### PR TITLE
feat(interactive): add Escape key navigation to submenus and selectors

### DIFF
--- a/src/commands/task/status.ts
+++ b/src/commands/task/status.ts
@@ -52,7 +52,11 @@ export async function taskStatusCommand(args: string[], options: TaskStatusOptio
   }
 
   // Interactive: select status if not provided
-  newStatus ??= await selectTaskStatus('Select new status:');
+  if (!newStatus) {
+    const selected = await selectTaskStatus('Select new status:');
+    if (!selected) return;
+    newStatus = selected;
+  }
 
   const result = TaskStatusSchema.safeParse(newStatus);
   if (!result.success) {

--- a/src/interactive/escapable.test.ts
+++ b/src/interactive/escapable.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock @inquirer/prompts before importing the module under test
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+}));
+
+import { select } from '@inquirer/prompts';
+import { escapableSelect } from './escapable.ts';
+
+const selectMock = vi.mocked(select);
+
+/** Create an error with a specific name, mimicking inquirer's error classes */
+function makeNamedError(name: string): Error {
+  const err = new Error(name);
+  err.name = name;
+  return err;
+}
+
+describe('escapableSelect', () => {
+  const config = {
+    message: 'Pick one',
+    choices: [
+      { name: 'A', value: 'a' as const },
+      { name: 'B', value: 'b' as const },
+    ],
+  };
+
+  it('returns the selected value on normal selection', async () => {
+    selectMock.mockResolvedValueOnce('a');
+
+    const result = await escapableSelect(config);
+
+    expect(result).toBe('a');
+    expect(selectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: config.message, choices: config.choices }),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('returns null when the prompt is aborted (Escape key)', async () => {
+    selectMock.mockRejectedValueOnce(makeNamedError('AbortPromptError'));
+
+    const result = await escapableSelect(config);
+
+    expect(result).toBeNull();
+  });
+
+  it('propagates ExitPromptError (Ctrl+C)', async () => {
+    const exitError = makeNamedError('ExitPromptError');
+    selectMock.mockRejectedValueOnce(exitError);
+
+    await expect(escapableSelect(config)).rejects.toThrow(exitError);
+  });
+
+  it('propagates unexpected errors', async () => {
+    selectMock.mockRejectedValueOnce(new Error('unexpected'));
+
+    await expect(escapableSelect(config)).rejects.toThrow('unexpected');
+  });
+
+  it('cleans up keypress listener after selection', async () => {
+    const removeSpy = vi.spyOn(process.stdin, 'removeListener');
+    selectMock.mockResolvedValueOnce('b');
+
+    await escapableSelect(config);
+
+    expect(removeSpy).toHaveBeenCalledWith('keypress', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it('cleans up keypress listener after abort', async () => {
+    const removeSpy = vi.spyOn(process.stdin, 'removeListener');
+    selectMock.mockRejectedValueOnce(makeNamedError('AbortPromptError'));
+
+    await escapableSelect(config);
+
+    expect(removeSpy).toHaveBeenCalledWith('keypress', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it('injects escape hint into theme keysHelpTip', async () => {
+    selectMock.mockResolvedValueOnce('a');
+
+    await escapableSelect(config);
+
+    const passedConfig = selectMock.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    const theme = passedConfig?.['theme'] as
+      | { style?: { keysHelpTip?: (keys: [string, string][]) => string } }
+      | undefined;
+    const keysHelpTip = theme?.style?.keysHelpTip;
+
+    expect(keysHelpTip).toBeTypeOf('function');
+
+    if (keysHelpTip) {
+      const result = keysHelpTip([['↑↓', 'navigate']]);
+      expect(result).toContain('esc');
+      expect(result).toContain('back');
+    }
+  });
+});

--- a/src/interactive/escapable.ts
+++ b/src/interactive/escapable.ts
@@ -1,0 +1,74 @@
+import readline from 'node:readline';
+import { select } from '@inquirer/prompts';
+import { bold, dim } from 'colorette';
+
+type SelectConfig<Value> = Parameters<typeof select<Value>>[0];
+
+/**
+ * Default keysHelpTip renderer matching @inquirer/select's built-in format.
+ * Used as fallback when the caller doesn't provide a custom keysHelpTip.
+ */
+function defaultKeysHelpTip(keys: [string, string][]): string {
+  return keys.map(([key, action]) => `${bold(key)} ${dim(action)}`).join(dim(' \u2022 '));
+}
+
+/**
+ * Augment a select config's theme to append an "esc back" hint to the key help line.
+ */
+type KeysHelpTip = (keys: [string, string][]) => string | undefined;
+
+function withEscapeHint<Value>(config: SelectConfig<Value>): SelectConfig<Value> {
+  const originalTip = config.theme?.style?.keysHelpTip as KeysHelpTip | undefined;
+
+  return {
+    ...config,
+    theme: {
+      ...config.theme,
+      style: {
+        ...config.theme?.style,
+        keysHelpTip: (keys: [string, string][]) => {
+          const allKeys: [string, string][] = [...keys, ['esc', 'back']];
+          return originalTip ? originalTip(allKeys) : defaultKeysHelpTip(allKeys);
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Escape-aware wrapper around @inquirer/prompts select().
+ *
+ * Listens for the Escape key and aborts the prompt, returning null.
+ * Ctrl+C (ExitPromptError) propagates unchanged so callers can handle it.
+ * Appends an "esc back" hint to the bottom help line.
+ *
+ * Uses duck-typing for AbortPromptError to avoid depending on @inquirer/core directly.
+ *
+ * @returns the selected value, or null if the user pressed Escape
+ */
+export async function escapableSelect<Value>(config: SelectConfig<Value>): Promise<Value | null> {
+  const controller = new AbortController();
+
+  // Ensure stdin emits 'keypress' events (idempotent — safe to call multiple times)
+  readline.emitKeypressEvents(process.stdin);
+
+  const onKeypress = (_ch: string, key: { name: string } | undefined) => {
+    if (key?.name === 'escape') {
+      controller.abort();
+    }
+  };
+
+  process.stdin.on('keypress', onKeypress);
+
+  try {
+    const result = await select(withEscapeHint(config), { signal: controller.signal });
+    return result;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortPromptError') {
+      return null;
+    }
+    throw err;
+  } finally {
+    process.stdin.removeListener('keypress', onKeypress);
+  }
+}

--- a/src/interactive/file-browser.ts
+++ b/src/interactive/file-browser.ts
@@ -1,9 +1,9 @@
 import { readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { select } from '@inquirer/prompts';
 import { emoji } from '@src/theme/ui.ts';
 import { muted } from '@src/theme/index.ts';
+import { escapableSelect } from './escapable.ts';
 
 interface BrowseChoice {
   name: string;
@@ -116,12 +116,16 @@ export async function browseDirectory(message = 'Browse to directory:', startPat
     });
 
     try {
-      const selected = await select({
+      const selected = await escapableSelect({
         message: `${emoji.donut} ${message}\n   ${muted(currentPath)}`,
         choices,
         pageSize: 15,
         loop: false,
       });
+
+      if (selected === null) {
+        return null;
+      }
 
       switch (selected) {
         case '__SELECT__':
@@ -139,7 +143,7 @@ export async function browseDirectory(message = 'Browse to directory:', startPat
           currentPath = selected;
       }
     } catch (err) {
-      // Handle Ctrl+C / escape
+      // Handle Ctrl+C
       if ((err as Error).name === 'ExitPromptError') {
         return null;
       }

--- a/src/interactive/index.ts
+++ b/src/interactive/index.ts
@@ -1,4 +1,3 @@
-import { select } from '@inquirer/prompts';
 import { clearScreen, emoji, log, printSeparator, showBanner } from '@src/theme/ui.ts';
 import { colors, getQuoteForContext } from '@src/theme/index.ts';
 import { buildMainMenu, buildSubMenu, isWorkflowAction, type MenuContext, type MenuItem } from './menu.ts';
@@ -9,6 +8,8 @@ import { listProjects } from '@src/store/project.ts';
 import { getTasks } from '@src/store/task.ts';
 import { getNextAction, type DashboardData } from './dashboard.ts';
 import { allRequirementsApproved, getPendingRequirements } from '@src/store/ticket.ts';
+import { select } from '@inquirer/prompts';
+import { escapableSelect } from './escapable.ts';
 
 // Command imports - project
 import { projectAddCommand } from '@src/commands/project/add.ts';
@@ -294,7 +295,7 @@ async function handleSubMenu(
   while (true) {
     try {
       log.newline();
-      const subCommand = await select({
+      const subCommand = await escapableSelect({
         message: `${emoji.donut} ${currentTitle}`,
         choices: currentItems,
         pageSize: 15,
@@ -302,7 +303,7 @@ async function handleSubMenu(
         theme: selectTheme,
       });
 
-      if (subCommand === 'back') {
+      if (subCommand === null || subCommand === 'back') {
         break;
       }
 

--- a/src/interactive/selectors.ts
+++ b/src/interactive/selectors.ts
@@ -1,4 +1,4 @@
-import { checkbox, confirm, input, select } from '@inquirer/prompts';
+import { checkbox, confirm, input } from '@inquirer/prompts';
 import { listProjects } from '@src/store/project.ts';
 import { listSprints } from '@src/store/sprint.ts';
 import { formatTicketDisplay, listTickets } from '@src/store/ticket.ts';
@@ -6,6 +6,7 @@ import { listTasks } from '@src/store/task.ts';
 import { emoji, formatSprintStatus, formatTaskStatus } from '@src/theme/ui.ts';
 import { muted } from '@src/theme/index.ts';
 import type { Repository, SprintStatus, TaskStatus } from '@src/schemas/index.ts';
+import { escapableSelect } from './escapable.ts';
 
 /**
  * Select a project from the list.
@@ -27,7 +28,7 @@ export async function selectProject(message = 'Select project:'): Promise<string
       if (updated.length === 0) return null;
       if (updated.length === 1 && updated[0]) return updated[0].name;
       // Fall through to selection below
-      return select({
+      return escapableSelect({
         message: `${emoji.donut} ${message}`,
         choices: updated.map((p) => ({
           name: p.displayName,
@@ -39,7 +40,7 @@ export async function selectProject(message = 'Select project:'): Promise<string
     return null;
   }
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: projects.map((p) => ({
       name: p.displayName,
@@ -62,12 +63,12 @@ export async function selectProjectRepository(message = 'Select repository:'): P
   }
 
   // Step 1: Select project (auto-select if only one)
-  let projectName: string;
+  let projectName: string | null;
   const firstProject = projects[0];
   if (projects.length === 1 && firstProject) {
     projectName = firstProject.name;
   } else {
-    projectName = await select({
+    projectName = await escapableSelect({
       message: `${emoji.donut} Select project:`,
       choices: projects.map((p) => ({
         name: p.displayName,
@@ -76,6 +77,8 @@ export async function selectProjectRepository(message = 'Select repository:'): P
       })),
     });
   }
+
+  if (!projectName) return null;
 
   const project = projects.find((p) => p.name === projectName);
   if (!project) {
@@ -88,7 +91,7 @@ export async function selectProjectRepository(message = 'Select repository:'): P
     return firstRepo.path;
   }
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: project.repositories.map((r) => ({
       name: r.name,
@@ -120,7 +123,7 @@ export async function selectSprint(message = 'Select sprint:', filter?: SprintSt
       const refiltered = filter ? updated.filter((s) => filter.includes(s.status)) : updated;
       if (refiltered.length === 0) return null;
       if (refiltered.length === 1 && refiltered[0]) return refiltered[0].id;
-      return select({
+      return escapableSelect({
         message: `${emoji.donut} ${message}`,
         choices: refiltered.map((s) => ({
           name: `${s.id} - ${s.name} (${formatSprintStatus(s.status)})`,
@@ -131,7 +134,7 @@ export async function selectSprint(message = 'Select sprint:', filter?: SprintSt
     return null;
   }
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: filtered.map((s) => ({
       name: `${s.id} - ${s.name} (${formatSprintStatus(s.status)})`,
@@ -159,7 +162,7 @@ export async function selectTicket(message = 'Select ticket:'): Promise<string |
       const updated = await listTickets();
       if (updated.length === 0) return null;
       if (updated.length === 1 && updated[0]) return updated[0].id;
-      return select({
+      return escapableSelect({
         message: `${emoji.donut} ${message}`,
         choices: updated.map((t) => ({
           name: formatTicketDisplay(t),
@@ -170,7 +173,7 @@ export async function selectTicket(message = 'Select ticket:'): Promise<string |
     return null;
   }
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: tickets.map((t) => ({
       name: formatTicketDisplay(t),
@@ -192,7 +195,7 @@ export async function selectTask(message = 'Select task:', filter?: TaskStatus[]
     return null;
   }
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: filtered.map((t) => ({
       name: `${formatTaskStatus(t.status)} ${t.name}`,
@@ -205,10 +208,10 @@ export async function selectTask(message = 'Select task:', filter?: TaskStatus[]
  * Select a task status.
  * @returns task status
  */
-export async function selectTaskStatus(message = 'Select status:'): Promise<TaskStatus> {
+export async function selectTaskStatus(message = 'Select status:'): Promise<TaskStatus | null> {
   const statuses: TaskStatus[] = ['todo', 'in_progress', 'done'];
 
-  return select({
+  return escapableSelect({
     message: `${emoji.donut} ${message}`,
     choices: statuses.map((s) => ({
       name: formatTaskStatus(s),


### PR DESCRIPTION
## Summary
- Add `escapableSelect` wrapper that intercepts Escape keypress to abort prompts and return `null`
- Apply to submenus, shared selectors, and file browser — Escape navigates back one level
- Main menu uses plain `select` so Escape does nothing at root (no parent to return to)
- Handle nullable returns in `selectTaskStatus` and downstream callers

## Test plan
- [ ] `pnpm dev` → press Escape at main menu → nothing happens, no "esc back" hint
- [ ] Enter a submenu → "esc back" hint visible → press Escape → returns to main menu
- [ ] Enter a submenu → pick an action with a selector → press Escape → cancels back to submenu
- [ ] File browser → press Escape → returns without selection
- [ ] `pnpm typecheck && pnpm lint && pnpm test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)