### PR TITLE
chore: prepare for open-source release (v0.0.3)

### DIFF
--- a/.claude/agent-memory/designer/MEMORY.md
+++ b/.claude/agent-memory/designer/MEMORY.md
@@ -266,4 +266,4 @@ log.newline();
 
 ### Real Example
 
-See `/Users/grigis/Workzone/grigis/ralphctl/src/commands/sprint/refine.ts` for the per-ticket refinement flow.
+See `src/commands/sprint/refine.ts` for the per-ticket refinement flow.

--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -10,7 +10,7 @@ src/
 ├── theme/             # UI helpers (index.ts = colors/quotes, ui.ts = formatting)
 ├── utils/             # Utilities (paths.ts, storage.ts, ids.ts, file-lock.ts)
 ├── interactive/       # Interactive mode (menu.ts, selectors.ts)
-└── claude/            # Claude integration (session.ts, executor.ts, runner.ts)
+└── ai/                # Claude integration (session.ts, executor.ts, runner.ts)
 ```
 
 ## TypeScript Patterns

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,6 @@ jobs:
             ${{ steps.notes.outputs.notes }}
 
             ---
-            **Full changelog:** https://github.com/${{ github.repository }}/compare/${{ steps.version.outputs.version }}...HEAD
+            **Full changelog:** https://github.com/${{ github.repository }}/compare/v${{ steps.version.outputs.version }}...HEAD
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to RalphCTL will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.3] - 2026-03-06
+
+### Changed
+
+- Normalized git author identity across commit history
+- Updated package metadata for open-source release (description, homepage, private flag)
+- Moved `tsx` from devDependencies to dependencies (runtime requirement for `bin/ralphctl`)
+- Fixed stale path references in SECURITY.md, CONTRIBUTING.md, and agent memory files
+- Fixed changelog compare link in release workflow to include `v` prefix
+- Corrected documentation table descriptions in README.md
+- Cleaned up stale `dist/` build artifacts
+- Edited documentation for public release
+
 ## [0.0.2] - 2026-03-03
 
 ### Added
@@ -15,9 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Draft re-plan** — running `sprint plan` on a draft with existing tasks passes all tickets + tasks as AI context for atomic replacement
 - **Check script model** — single idempotent `checkScript` per repo replaces old `setupScript`/`verifyScript`; runs at sprint start and as a post-task gate
 - **Lifecycle hooks** — `runLifecycleHook()` abstraction in `src/ai/lifecycle.ts` with `RALPHCTL_LIFECYCLE_EVENT` env var
-- **Ecosystem detection** — extensible `EcosystemDetector[]` registry (node, python, go, rust, gradle, maven, makefile) for check script suggestions during project setup
-- **Sprint health improvements** — duplicate task order and pending requirements diagnostics; branch consistency checks across repos
-- **Interactive mode enhancements** — Escape key navigation, styled section titles, flat workflow section, provider config in REPL, refined/planned counts in status header, guards for unrefined/unplanned tickets
+- **Ecosystem detection** — `EcosystemDetector[]` registry (node, python, go, rust, gradle, maven, makefile) for check script suggestions during project setup
+- **Sprint health** — duplicate task order and pending requirements diagnostics; branch consistency checks across repos
+- **Interactive mode** — Escape key navigation, styled section titles, flat workflow section, provider config in REPL, refined/planned counts in status header, guards for unrefined/unplanned tickets
 - **Inline multiline editor** — replaced with `@inquirer/editor` and configurable editor settings via `config set editor`
 - **CI/CD** — GitHub Actions pipeline with lint, typecheck, test, format check; Dependabot; automated GitHub Release pipeline
 - **Schema sync tests** — JSON schema ↔ Zod schema validation
@@ -36,13 +49,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Sanitize session IDs and harden file operations against path traversal
-- Pre-flight execution security and correctness hardening
+- Fixed pre-flight execution checks for security and correctness
 - Preserve error cause in re-thrown errors
 - Thread provider through `checkTaskPermissions()`
 - Branch management error handling and retry logic
 - Interactive mode duplicate quote, closed sprint status header, and dashboard duplication
 - ANSI code handling in CLI test field extraction
-- Redundant file reads eliminated in interactive menu context loading
+- Removed redundant file reads in interactive menu context loading
 
 ### Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ src/
 ├── commands/        # CLI command implementations
 ├── interactive/     # REPL/menu mode
 ├── store/           # Data persistence layer
-├── claude/          # Claude CLI integration
+├── ai/              # Claude CLI integration
 ├── theme/           # UI components and styling
 ├── schemas/         # Zod validation schemas
 └── utils/           # Pure utilities

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ ralphctl sprint start       # Headless (fully automated)
 
 ## AI Provider Configuration
 
-RalphCTL supports **Claude Code** and **GitHub Copilot** as AI backends. Both providers share the same prompt templates and workflow — just pick your preferred assistant.
+RalphCTL supports **Claude Code** and **GitHub Copilot** as AI backends. Both use the same prompt templates and workflow.
 
 > [!NOTE]
 > **GitHub Copilot provider is in public preview.** A warning is shown each time it is used. Some features work differently — see the table below.
@@ -252,13 +252,13 @@ Run `ralphctl <command> --help` for details on any command.
 
 ## Documentation
 
-| Document                                          | Description                                       |
-| ------------------------------------------------- | ------------------------------------------------- |
-| [REQUIREMENTS.md](./.claude/docs/REQUIREMENTS.md) | Feature rationale and design decisions            |
-| [ARCHITECTURE.md](./.claude/docs/ARCHITECTURE.md) | Technical architecture, data models, service APIs |
-| [CLAUDE.md](./CLAUDE.md)                          | Developer guide and Claude Code project config    |
-| [CONTRIBUTING.md](./CONTRIBUTING.md)              | How to contribute                                 |
-| [CHANGELOG.md](./CHANGELOG.md)                    | Version history                                   |
+| Document                                          | Description                                    |
+| ------------------------------------------------- | ---------------------------------------------- |
+| [REQUIREMENTS.md](./.claude/docs/REQUIREMENTS.md) | Acceptance criteria and feature requirements   |
+| [ARCHITECTURE.md](./.claude/docs/ARCHITECTURE.md) | Data models, file storage, and error reference |
+| [CLAUDE.md](./CLAUDE.md)                          | Developer guide and Claude Code project config |
+| [CONTRIBUTING.md](./CONTRIBUTING.md)              | How to contribute                              |
+| [CHANGELOG.md](./CHANGELOG.md)                    | Version history                                |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ If you discover a security vulnerability in RalphCTL, please report it through [
 
 RalphCTL is a local CLI tool. The main security considerations are:
 
-- **File system access** — ralphctl reads/writes to `ralphctl-data/` and project directories
+- **File system access** — ralphctl reads/writes to `~/.ralphctl/` and project directories
 - **Process spawning** — ralphctl spawns `claude` CLI processes with user-provided prompts
 - **No network access** — ralphctl itself makes no network requests (Claude CLI handles its own connections)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "ralphctl",
   "version": "0.0.0",
-  "description": "Sprint and task management CLI for AI-assisted coding with Claude",
+  "description": "Sprint and task management CLI for AI-assisted coding",
+  "private": true,
+  "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",
   "license": "MIT",
   "author": "Lukas Grigis",
@@ -49,6 +51,7 @@
     "gradient-string": "^3.0.0",
     "ora": "^9.3.0",
     "tabtab": "^3.0.2",
+    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -61,7 +64,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.1",
     "prettier": "^3.8.1",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       tabtab:
         specifier: ^3.0.2
         version: 3.0.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -57,9 +60,6 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Normalized git author identity across commit history (zuhlke + OpenClaw emails → single hotmail address)
- Fixed stale references: `ralphctl-data/` → `~/.ralphctl/`, `src/claude/` → `src/ai/`, personal paths in agent memory
- Fixed release workflow changelog compare link (missing `v` prefix)
- Updated package.json metadata: description, homepage, `private: true`, moved `tsx` to production dependencies
- Corrected README documentation table descriptions to match actual file contents
- Added v0.0.3 changelog entry
- Cleaned up AI writing patterns in human-facing documentation

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (519 tests)
- [x] No personal paths in tracked `.claude/agent-memory/` files
- [x] Git log shows normalized author emails