### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-17
+
 ### Housekeeping
 
 - Pruned dead code across the theme, prompts, runtime, and factories layers: deleted unused formatters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

Release 0.3.0 — bumps `package.json` and finalizes the `[Unreleased]` CHANGELOG section under `[0.3.0] - 2026-04-17`.

Highlights (see CHANGELOG for full list):
- Clean Architecture refactor + composable pipelines
- Ink TUI (bare `ralphctl`, `interactive`, `sprint start`)
- PromptPort / LoggerPort / SignalBusPort abstractions
- Structured harness signals, config schema as single source of truth, live config mid-execution
- Per-task sprint contracts + evaluator dimensions + plateau detection + session-id resume
- Branch management, management hotkeys
- BREAKING: sprints are now scoped to a single project (id-based FKs)

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green locally
- [ ] CI green
- [ ] Tag `v0.3.0` after merge to trigger release workflow