### PR TITLE
feat: next + task why, auto refine/plan, TUI execution polish

### DIFF
--- a/src/application/entrypoint.ts
+++ b/src/application/entrypoint.ts
@@ -9,6 +9,7 @@ import { registerDashboardCommands } from '@src/integration/cli/commands/dashboa
 import { registerConfigCommands } from '@src/integration/cli/commands/config/register.ts';
 import { registerCompletionCommands } from '@src/integration/cli/commands/completion/register.ts';
 import { registerDoctorCommands } from '@src/integration/cli/commands/doctor/register.ts';
+import { registerNextCommands } from '@src/integration/cli/commands/next/register.ts';
 import { error } from '@src/integration/ui/theme/theme.ts';
 import { cliMetadata } from '@src/domain/cli-metadata.ts';
 import { DomainError } from '@src/domain/errors.ts';
@@ -49,6 +50,18 @@ registerDashboardCommands(program);
 registerConfigCommands(program);
 registerCompletionCommands(program);
 registerDoctorCommands(program);
+registerNextCommands(program);
+
+/**
+ * Commands that opt out of the ASCII banner so their output is pipe-safe.
+ * `next --porcelain` / `next --json` are used in shell prompts and CI — a
+ * decorative banner would corrupt the single-line / JSON contract.
+ */
+function isQuietCommand(argv: string[]): boolean {
+  const cmd = argv[2];
+  if (cmd === 'next' && (argv.includes('--porcelain') || argv.includes('--json'))) return true;
+  return false;
+}
 
 async function main(): Promise<void> {
   // Shell completion: intercept before any output (banner, interactive mode)
@@ -104,7 +117,7 @@ async function main(): Promise<void> {
     }
   }
 
-  printBanner();
+  if (!isQuietCommand(argv)) printBanner();
   await program.parseAsync(argv);
 }
 

--- a/src/business/pipelines/execute.ts
+++ b/src/business/pipelines/execute.ts
@@ -726,9 +726,9 @@ function executeTasksStep(deps: ExecuteDeps, options: ExecuteOptions): PipelineS
         },
         onSettle: (task, result) => {
           if (result === 'success') {
-            // Purge session-id tracking — task done.
+            // Purge session-id tracking — task done. The success log line is
+            // owned by the `mark-done` per-task step.
             taskSessionIds.delete(task.id);
-            deps.logger.success(`Completed: ${task.name}`);
           }
         },
       },

--- a/src/business/pipelines/execute/per-task-pipeline.test.ts
+++ b/src/business/pipelines/execute/per-task-pipeline.test.ts
@@ -267,10 +267,11 @@ describe('createPerTaskPipeline', () => {
       'mark-done',
     ]);
 
-    // signal bus emits task-started (from mark-in-progress) then
-    // task-finished (from mark-done), in order.
-    const types = events.map((e) => e.type);
-    expect(types).toEqual(['task-started', 'task-finished']);
+    // signal bus emits task-started (from mark-in-progress) and task-finished
+    // (from mark-done), interleaved with per-step task-step trace events.
+    // Ignore the step-trace events here; their ordering is covered separately.
+    const lifecycleTypes = events.map((e) => e.type).filter((t) => t !== 'task-step');
+    expect(lifecycleTypes).toEqual(['task-started', 'task-finished']);
 
     expect(calls.executeOneTask).toHaveBeenCalledTimes(1);
     expect(calls.runPostTaskCheck).toHaveBeenCalledTimes(1);

--- a/src/business/pipelines/execute/per-task-pipeline.ts
+++ b/src/business/pipelines/execute/per-task-pipeline.ts
@@ -9,7 +9,9 @@ import type { LoggerPort } from '@src/business/ports/logger.ts';
 import type { ExternalPort } from '@src/business/ports/external.ts';
 import type { SignalBusPort } from '@src/business/ports/signal-bus.ts';
 import { pipeline } from '@src/business/pipelines/framework/helpers.ts';
-import type { PipelineDefinition } from '@src/business/pipelines/framework/types.ts';
+import type { PipelineDefinition, PipelineStep } from '@src/business/pipelines/framework/types.ts';
+import type { DomainResult } from '@src/domain/types.ts';
+import { Result } from '@src/domain/types.ts';
 import type { ExecuteTasksUseCase } from '@src/business/usecases/execute.ts';
 import type { PerTaskContext } from './per-task-context.ts';
 import { branchPreflight } from './steps/branch-preflight.ts';
@@ -88,25 +90,66 @@ export function createPerTaskPipeline(
   useCase: ExecuteTasksUseCase,
   options: ExecutionOptions = {}
 ): PipelineDefinition<PerTaskContext> {
+  const trace = withStepTrace(deps.signalBus);
   return pipeline<PerTaskContext>('per-task', [
-    branchPreflight({ external: deps.external, persistence: deps.persistence }),
-    contractNegotiate({ persistence: deps.persistence, fs: deps.fs }),
-    markInProgress({ persistence: deps.persistence, signalBus: deps.signalBus }),
-    executeTask({ useCase, options, taskSessionIds: deps.taskSessionIds, logger: deps.logger }),
-    storeVerification({ persistence: deps.persistence, logger: deps.logger }),
-    postTaskCheck({ useCase }),
-    evaluateTask({
-      persistence: deps.persistence,
-      fs: deps.fs,
-      aiSession: deps.aiSession,
-      promptBuilder: deps.promptBuilder,
-      parser: deps.parser,
-      ui: deps.ui,
-      logger: deps.logger,
-      external: deps.external,
-      useCase,
-      options,
-    }),
-    markDone({ persistence: deps.persistence, logger: deps.logger, signalBus: deps.signalBus }),
+    trace(branchPreflight({ external: deps.external, persistence: deps.persistence })),
+    trace(contractNegotiate({ persistence: deps.persistence, fs: deps.fs })),
+    trace(markInProgress({ persistence: deps.persistence, signalBus: deps.signalBus })),
+    trace(executeTask({ useCase, options, taskSessionIds: deps.taskSessionIds, logger: deps.logger })),
+    trace(storeVerification({ persistence: deps.persistence, logger: deps.logger })),
+    trace(postTaskCheck({ useCase })),
+    trace(
+      evaluateTask({
+        persistence: deps.persistence,
+        fs: deps.fs,
+        aiSession: deps.aiSession,
+        promptBuilder: deps.promptBuilder,
+        parser: deps.parser,
+        ui: deps.ui,
+        logger: deps.logger,
+        external: deps.external,
+        useCase,
+        options,
+      })
+    ),
+    trace(markDone({ persistence: deps.persistence, logger: deps.logger, signalBus: deps.signalBus })),
   ]);
+}
+
+/**
+ * Wrap a per-task step so it emits `task-step` bus events at start / finish.
+ * The dashboard uses these to render a live "current step" label per running
+ * task. Emission is best-effort and never affects step semantics.
+ */
+function withStepTrace(signalBus: SignalBusPort): (step: PipelineStep<PerTaskContext>) => PipelineStep<PerTaskContext> {
+  return (inner) => ({
+    name: inner.name,
+    execute: inner.execute,
+    hooks: {
+      pre: async (ctx): Promise<DomainResult<PerTaskContext>> => {
+        signalBus.emit({
+          type: 'task-step',
+          sprintId: ctx.sprint.id,
+          taskId: ctx.task.id,
+          stepName: inner.name,
+          phase: 'start',
+          timestamp: new Date(),
+        });
+        const prior = await inner.hooks?.pre?.(ctx);
+        return prior ?? Result.ok(ctx);
+      },
+      post: async (ctx, result): Promise<DomainResult<Partial<PerTaskContext>>> => {
+        const prior = await inner.hooks?.post?.(ctx, result);
+        signalBus.emit({
+          type: 'task-step',
+          sprintId: ctx.sprint.id,
+          taskId: ctx.task.id,
+          stepName: inner.name,
+          phase: 'finish',
+          timestamp: new Date(),
+        });
+        return prior ?? Result.ok({});
+      },
+    },
+  });
 }

--- a/src/business/ports/signal-bus.ts
+++ b/src/business/ports/signal-bus.ts
@@ -22,7 +22,15 @@ export type HarnessEvent =
   | { type: 'rate-limit-paused'; delayMs: number; timestamp: Date }
   | { type: 'rate-limit-resumed'; timestamp: Date }
   | { type: 'task-started'; sprintId: string; taskId: string; taskName: string; timestamp: Date }
-  | { type: 'task-finished'; sprintId: string; taskId: string; status: 'done' | 'blocked' | 'failed'; timestamp: Date };
+  | { type: 'task-finished'; sprintId: string; taskId: string; status: 'done' | 'blocked' | 'failed'; timestamp: Date }
+  | {
+      type: 'task-step';
+      sprintId: string;
+      taskId: string;
+      stepName: string;
+      phase: 'start' | 'finish';
+      timestamp: Date;
+    };
 
 export type Unsubscribe = () => void;
 

--- a/src/integration/cli/commands/next/next.test.ts
+++ b/src/integration/cli/commands/next/next.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createTestEnv } from '@src/test-utils/setup.ts';
+import { runCli } from '@src/test-utils/cli-runner.ts';
+
+let env: Record<string, string>;
+let cleanup: () => Promise<void>;
+
+describe('ralphctl next', { timeout: 5000 }, () => {
+  beforeAll(async () => {
+    const testEnv = await createTestEnv();
+    env = testEnv.env;
+    cleanup = testEnv.cleanup;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    // Each test starts with no current sprint by clearing config between scenarios.
+    // createTestEnv already registers a 'test-project', so we just reset sprint state.
+    const res = await runCli(['sprint', 'list'], env);
+    // Clean any draft created by a prior test (best-effort).
+    const ids = res.stdout.match(/\b\d{8}-\d{6}-[a-z0-9-]+/g) ?? [];
+    for (const id of ids) {
+      await runCli(['sprint', 'delete', id, '-y'], env);
+    }
+  });
+
+  it('suggests sprint create when no current sprint is set', async () => {
+    const json = await runCli(['next', '--json'], env);
+    expect(json.code).toBe(0);
+    const payload = JSON.parse(json.stdout.trim()) as {
+      sprint: unknown;
+      action: unknown;
+      reason: string;
+    };
+    expect(payload.reason).toBe('no-sprint');
+    expect(payload.sprint).toBeNull();
+    expect(payload.action).toBeNull();
+  });
+
+  it('--porcelain emits an empty line when nothing is actionable', async () => {
+    const res = await runCli(['next', '--porcelain'], env);
+    expect(res.code).toBe(0);
+    expect(res.stdout.trim()).toBe('');
+  });
+
+  it('suggests refine when a draft sprint has a pending ticket', async () => {
+    await runCli(['sprint', 'create', '-n', '--project', 'test-project', '--name', 'Next Test'], env);
+    await runCli(['ticket', 'add', '-n', '--title', 'Needs refinement'], env);
+
+    const porcelain = await runCli(['next', '--porcelain'], env);
+    expect(porcelain.code).toBe(0);
+    expect(porcelain.stdout.trim()).toBe('ralphctl sprint refine');
+
+    const json = await runCli(['next', '--json'], env);
+    const payload = JSON.parse(json.stdout.trim()) as {
+      reason: string;
+      action: { command: string } | null;
+    };
+    expect(payload.reason).toBe('action-ready');
+    expect(payload.action?.command).toBe('ralphctl sprint refine');
+  });
+});

--- a/src/integration/cli/commands/next/next.ts
+++ b/src/integration/cli/commands/next/next.ts
@@ -1,0 +1,104 @@
+import { getNextAction, loadDashboardData, type NextAction } from '@src/integration/ui/tui/views/dashboard-data.ts';
+import { colors } from '@src/integration/ui/theme/theme.ts';
+import { formatSprintStatus, icons, log } from '@src/integration/ui/theme/ui.ts';
+
+interface NextOptions {
+  porcelain?: boolean;
+  json?: boolean;
+}
+
+interface NextPayload {
+  sprint: { id: string; name: string; status: 'draft' | 'active' | 'closed' } | null;
+  action: { command: string; label: string; description: string } | null;
+  reason: 'no-sprint' | 'all-done' | 'action-ready' | 'sprint-closed';
+}
+
+function toCommand(action: NextAction): string {
+  return `ralphctl ${action.group} ${action.subCommand}`;
+}
+
+function computePayload(data: Awaited<ReturnType<typeof loadDashboardData>>): NextPayload {
+  if (!data) {
+    return { sprint: null, action: null, reason: 'no-sprint' };
+  }
+
+  const sprint = { id: data.sprint.id, name: data.sprint.name, status: data.sprint.status };
+
+  if (data.sprint.status === 'closed') {
+    return { sprint, action: null, reason: 'sprint-closed' };
+  }
+
+  const next = getNextAction(data);
+  if (!next) {
+    return { sprint, action: null, reason: 'all-done' };
+  }
+
+  return {
+    sprint,
+    action: { command: toCommand(next), label: next.label, description: next.description },
+    reason: 'action-ready',
+  };
+}
+
+function renderPorcelain(payload: NextPayload): void {
+  // Single line, zero chrome. Empty string means "nothing to do".
+  if (payload.action) {
+    console.log(payload.action.command);
+    return;
+  }
+  console.log('');
+}
+
+function renderHuman(payload: NextPayload): void {
+  log.newline();
+
+  if (payload.reason === 'no-sprint') {
+    console.log(`  ${colors.muted(icons.inactive)} ${colors.muted('No current sprint.')}`);
+    console.log(`  ${colors.muted(icons.tip)} ${colors.muted('Create one to get started:')}`);
+    console.log(`    ${colors.highlight('ralphctl sprint create')}`);
+    log.newline();
+    return;
+  }
+
+  if (!payload.sprint) return; // exhaustive safety, not reachable
+
+  const sprintLine = `${icons.sprint} ${colors.highlight(payload.sprint.name)}  ${formatSprintStatus(payload.sprint.status)}`;
+  console.log(`  ${sprintLine}`);
+
+  if (payload.reason === 'sprint-closed') {
+    console.log(`  ${colors.muted(icons.info)} ${colors.muted('Sprint is closed. Start a new one:')}`);
+    console.log(`    ${colors.highlight('ralphctl sprint create')}`);
+    log.newline();
+    return;
+  }
+
+  if (payload.reason === 'all-done') {
+    console.log(`  ${colors.success(icons.success)} ${colors.success('Nothing left to do.')}`);
+    log.newline();
+    return;
+  }
+
+  const action = payload.action;
+  if (!action) return;
+
+  console.log(`  ${colors.muted(icons.tip)} ${colors.muted(action.label + ':')} ${colors.muted(action.description)}`);
+  console.log(`    ${colors.highlight(action.command)}`);
+  log.newline();
+}
+
+export async function nextCommand(options: NextOptions = {}): Promise<void> {
+  const data = await loadDashboardData();
+  const payload = computePayload(data);
+
+  if (options.json) {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+
+  if (options.porcelain) {
+    renderPorcelain(payload);
+    return;
+  }
+
+  renderHuman(payload);
+}

--- a/src/integration/cli/commands/next/register.ts
+++ b/src/integration/cli/commands/next/register.ts
@@ -1,0 +1,18 @@
+import type { Command } from 'commander';
+import { nextCommand } from '@src/integration/cli/commands/next/next.ts';
+
+interface NextCliOptions {
+  porcelain?: boolean;
+  json?: boolean;
+}
+
+export function registerNextCommands(program: Command): void {
+  program
+    .command('next')
+    .description('Suggest the next workflow action for the current sprint')
+    .option('--porcelain', 'Print only the suggested command (for shell/tmux integration)')
+    .option('--json', 'Emit a machine-readable JSON payload')
+    .action(async (options: NextCliOptions) => {
+      await nextCommand(options);
+    });
+}

--- a/src/integration/cli/commands/sprint/refine.ts
+++ b/src/integration/cli/commands/sprint/refine.ts
@@ -17,6 +17,7 @@ import { executePipeline } from '@src/business/pipelines/framework/pipeline.ts';
 
 interface RefineOptions {
   project?: string;
+  auto?: boolean;
 }
 
 function parseArgs(args: string[]): { sprintId?: string; options: RefineOptions } {
@@ -30,6 +31,8 @@ function parseArgs(args: string[]): { sprintId?: string; options: RefineOptions 
     if (arg === '--project') {
       options.project = nextArg;
       i++;
+    } else if (arg === '--auto') {
+      options.auto = true;
     } else if (!arg?.startsWith('-')) {
       sprintId = arg;
     }
@@ -61,7 +64,7 @@ export async function sprintRefineCommand(args: string[]): Promise<void> {
   // → export-requirements). Pipeline owns orchestration; this command just
   // renders the result.
   const shared = getSharedDeps();
-  const pipeline = createRefinePipeline(shared, { project: options.project });
+  const pipeline = createRefinePipeline(shared, { project: options.project, auto: options.auto });
   const result = await executePipeline(pipeline, { sprintId: id });
 
   if (!result.ok) {

--- a/src/integration/cli/commands/sprint/register.ts
+++ b/src/integration/cli/commands/sprint/register.ts
@@ -85,10 +85,12 @@ Examples:
     .command('refine [id]')
     .description('Refine ticket specifications')
     .option('--project <name>', 'Only refine tickets for specific project')
-    .action(async (id?: string, opts?: { project?: string }) => {
+    .option('--auto', 'Run without approval prompts (AI drafts requirements autonomously)')
+    .action(async (id?: string, opts?: { project?: string; auto?: boolean }) => {
       const args: string[] = [];
       if (id) args.push(id);
       if (opts?.project) args.push('--project', opts.project);
+      if (opts?.auto) args.push('--auto');
       await sprintRefineCommand(args);
     });
 

--- a/src/integration/cli/commands/task/register.ts
+++ b/src/integration/cli/commands/task/register.ts
@@ -7,6 +7,7 @@ import { taskStatusCommand } from '@src/integration/cli/commands/task/status.ts'
 import { taskNextCommand } from '@src/integration/cli/commands/task/next.ts';
 import { taskReorderCommand } from '@src/integration/cli/commands/task/reorder.ts';
 import { taskImportCommand } from '@src/integration/cli/commands/task/import.ts';
+import { taskWhyCommand } from '@src/integration/cli/commands/task/why.ts';
 
 export function registerTaskCommands(program: Command): void {
   const task = program.command('task').description('Manage tasks');
@@ -107,6 +108,13 @@ Examples:
     });
 
   task.command('next').description('Get next task').action(taskNextCommand);
+
+  task
+    .command('why [id]')
+    .description('Explain why a task is blocked (walks the dependency chain)')
+    .action(async (id?: string) => {
+      await taskWhyCommand(id);
+    });
 
   task
     .command('reorder [id] [position]')

--- a/src/integration/cli/commands/task/why.test.ts
+++ b/src/integration/cli/commands/task/why.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createTestEnv } from '@src/test-utils/setup.ts';
+import { extractField, runCli } from '@src/test-utils/cli-runner.ts';
+
+let env: Record<string, string>;
+let cleanup: () => Promise<void>;
+
+describe('ralphctl task why', { timeout: 5000 }, () => {
+  beforeAll(async () => {
+    const testEnv = await createTestEnv();
+    env = testEnv.env;
+    cleanup = testEnv.cleanup;
+
+    await runCli(['sprint', 'create', '-n', '--project', 'test-project', '--name', 'Why Test'], env);
+    await runCli(['ticket', 'add', '-n', '--title', 'Why Ticket'], env);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('prints usage when task id is omitted', async () => {
+    const res = await runCli(['task', 'why'], env);
+    expect(res.stderr + res.stdout).toMatch(/Usage: ralphctl task why/);
+  });
+
+  it('reports "no blockers" for an independent task', async () => {
+    const add = await runCli(['task', 'add', '-n', '--name', 'Solo Task'], env);
+    expect(add.code).toBe(0);
+    const id = extractField(add.stdout, 'ID');
+    expect(id).toBeTruthy();
+    if (!id) throw new Error('missing id');
+
+    const why = await runCli(['task', 'why', id], env);
+    expect(why.code).toBe(0);
+    expect(why.stdout).toMatch(/No blockers|ready to execute/);
+  });
+
+  it('reports unknown task id with a clear error', async () => {
+    const why = await runCli(['task', 'why', '00000000'], env);
+    // Domain errors are printed to stderr or stdout depending on route; we just
+    // assert the message surfaces somewhere.
+    const combined = why.stdout + why.stderr;
+    expect(combined.toLowerCase()).toMatch(/not found|task/);
+  });
+});

--- a/src/integration/cli/commands/task/why.test.ts
+++ b/src/integration/cli/commands/task/why.test.ts
@@ -19,11 +19,6 @@ describe('ralphctl task why', { timeout: 5000 }, () => {
     await cleanup();
   });
 
-  it('prints usage when task id is omitted', async () => {
-    const res = await runCli(['task', 'why'], env);
-    expect(res.stderr + res.stdout).toMatch(/Usage: ralphctl task why/);
-  });
-
   it('reports "no blockers" for an independent task', async () => {
     const add = await runCli(['task', 'add', '-n', '--name', 'Solo Task'], env);
     expect(add.code).toBe(0);

--- a/src/integration/cli/commands/task/why.ts
+++ b/src/integration/cli/commands/task/why.ts
@@ -1,0 +1,121 @@
+import { getTasks } from '@src/integration/persistence/task.ts';
+import type { Task, Tasks } from '@src/domain/models.ts';
+import { TaskNotFoundError } from '@src/domain/errors.ts';
+import { colors } from '@src/integration/ui/theme/theme.ts';
+import { formatTaskStatus, icons, log, printHeader, showError, showNextStep } from '@src/integration/ui/theme/ui.ts';
+import { ensureError, wrapAsync } from '@src/integration/utils/result-helpers.ts';
+
+interface WhyNode {
+  task: Task;
+  depth: number;
+  missing: boolean;
+}
+
+/**
+ * Walk the blockedBy graph from `root`, producing a depth-first trail of blocker
+ * nodes. Cycles are protected by a visited set (architecturally tasks should not
+ * cycle — DependencyCycleError is raised at import — but defensive here).
+ */
+function collectBlockers(root: Task, byId: Map<string, Task>): WhyNode[] {
+  const out: WhyNode[] = [];
+  const visited = new Set<string>([root.id]);
+
+  function walk(task: Task, depth: number): void {
+    for (const blockerId of task.blockedBy) {
+      const blocker = byId.get(blockerId);
+      if (!blocker) {
+        out.push({
+          task: { id: blockerId, name: `(missing ${blockerId})`, status: 'todo' } as Task,
+          depth,
+          missing: true,
+        });
+        continue;
+      }
+      if (visited.has(blocker.id)) continue;
+      visited.add(blocker.id);
+      out.push({ task: blocker, depth, missing: false });
+      if (blocker.status !== 'done') walk(blocker, depth + 1);
+    }
+  }
+
+  walk(root, 0);
+  return out;
+}
+
+function renderBlockerLine(node: WhyNode): string {
+  const indent = '    ' + '  '.repeat(node.depth);
+  const connector = colors.muted(node.depth === 0 ? '├─' : '↳');
+  const idPart = colors.muted(node.task.id);
+  if (node.missing) {
+    return `${indent}${connector} ${colors.error(icons.error)} ${idPart}  ${colors.error('(referenced but missing)')}`;
+  }
+  const status = formatTaskStatus(node.task.status);
+  const marker = node.task.status === 'done' ? colors.success(icons.success) : colors.warning(icons.warning);
+  return `${indent}${connector} ${marker} ${idPart}  ${node.task.name}  ${status}`;
+}
+
+export async function taskWhyCommand(taskId: string | undefined): Promise<void> {
+  if (!taskId) {
+    showError('Usage: ralphctl task why <task-id>');
+    return;
+  }
+
+  const r = await wrapAsync<Tasks, Error>(() => getTasks(), ensureError);
+  if (!r.ok) {
+    showError(r.error.message);
+    return;
+  }
+
+  const tasks = r.value;
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  const root = byId.get(taskId);
+  if (!root) {
+    showError(new TaskNotFoundError(taskId).message);
+    return;
+  }
+
+  printHeader('Why blocked?');
+  log.newline();
+  console.log(`  ${icons.task} ${colors.highlight(root.name)}  ${formatTaskStatus(root.status)}`);
+  console.log(`  ${colors.muted('id:')} ${colors.muted(root.id)}`);
+  log.newline();
+
+  if (root.status === 'done') {
+    console.log(`  ${colors.success(icons.success)} ${colors.success('Task is done — nothing blocking it.')}`);
+    log.newline();
+    return;
+  }
+
+  if (root.blockedBy.length === 0) {
+    console.log(`  ${colors.success(icons.success)} ${colors.success('No blockers — ready to execute.')}`);
+    log.newline();
+    showNextStep(`ralphctl task status ${root.id} in_progress`, 'Start working on this task');
+    log.newline();
+    return;
+  }
+
+  const nodes = collectBlockers(root, byId);
+  const unmet = nodes.filter((n) => !n.missing && n.task.status !== 'done');
+  const leafUnmet = unmet.filter((n) => n.task.blockedBy.every((bid) => byId.get(bid)?.status === 'done'));
+
+  console.log(`  ${colors.muted('Dependency chain:')}`);
+  for (const node of nodes) console.log(renderBlockerLine(node));
+  log.newline();
+
+  if (unmet.length === 0) {
+    console.log(`  ${colors.success(icons.success)} ${colors.success('All blockers are done — ready to execute.')}`);
+    log.newline();
+    showNextStep(`ralphctl task status ${root.id} in_progress`, 'Start working on this task');
+    log.newline();
+    return;
+  }
+
+  const actionable = leafUnmet.length > 0 ? leafUnmet : unmet;
+  console.log(
+    `  ${colors.warning(icons.warning)} ${colors.warning(`Unblock by completing ${String(actionable.length)} task${actionable.length !== 1 ? 's' : ''} first:`)}`
+  );
+  for (const node of actionable) {
+    console.log(`    ${colors.muted('→')} ${colors.highlight(node.task.id)}  ${node.task.name}`);
+  }
+  log.newline();
+}

--- a/src/integration/cli/commands/task/why.ts
+++ b/src/integration/cli/commands/task/why.ts
@@ -4,6 +4,7 @@ import { TaskNotFoundError } from '@src/domain/errors.ts';
 import { colors } from '@src/integration/ui/theme/theme.ts';
 import { formatTaskStatus, icons, log, printHeader, showError, showNextStep } from '@src/integration/ui/theme/ui.ts';
 import { ensureError, wrapAsync } from '@src/integration/utils/result-helpers.ts';
+import { selectTask } from '@src/integration/cli/commands/shared/selectors.ts';
 
 interface WhyNode {
   task: Task;
@@ -54,10 +55,12 @@ function renderBlockerLine(node: WhyNode): string {
   return `${indent}${connector} ${marker} ${idPart}  ${node.task.name}  ${status}`;
 }
 
-export async function taskWhyCommand(taskId: string | undefined): Promise<void> {
-  if (!taskId) {
-    showError('Usage: ralphctl task why <task-id>');
-    return;
+export async function taskWhyCommand(taskId?: string): Promise<void> {
+  let id = taskId;
+  if (!id) {
+    const selected = await selectTask('Which task is blocked?');
+    if (!selected) return;
+    id = selected;
   }
 
   const r = await wrapAsync<Tasks, Error>(() => getTasks(), ensureError);
@@ -68,9 +71,9 @@ export async function taskWhyCommand(taskId: string | undefined): Promise<void> 
 
   const tasks = r.value;
   const byId = new Map(tasks.map((t) => [t.id, t]));
-  const root = byId.get(taskId);
+  const root = byId.get(id);
   if (!root) {
-    showError(new TaskNotFoundError(taskId).message);
+    showError(new TaskNotFoundError(id).message);
     return;
   }
 

--- a/src/integration/ui/prompts/confirm-prompt.tsx
+++ b/src/integration/ui/prompts/confirm-prompt.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Box, Text } from 'ink';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
 import { ConfirmInput } from '@inkjs/ui';
 import type { ConfirmOptions } from '@src/business/ports/prompt.ts';
 import { emoji, glyphs, inkColors, spacing } from '@src/integration/ui/theme/tokens.ts';
@@ -10,9 +10,48 @@ interface ConfirmPromptProps {
   onCancel: () => void;
 }
 
+// Rows reserved for the rest of the prompt (confirm line, hints, breadcrumb,
+// borders). Viewport = terminalRows - RESERVED_ROWS, clamped to a sane range.
+const RESERVED_ROWS = 10;
+const MIN_VIEWPORT = 6;
+const MAX_VIEWPORT = 40;
+
+function useTerminalRows(): number {
+  const { stdout } = useStdout();
+  const [rows, setRows] = useState(stdout.rows);
+  useEffect(() => {
+    const onResize = (): void => {
+      setRows(stdout.rows);
+    };
+    stdout.on('resize', onResize);
+    return () => {
+      stdout.off('resize', onResize);
+    };
+  }, [stdout]);
+  return rows;
+}
+
 export function ConfirmPrompt({ options, onSubmit }: ConfirmPromptProps): React.JSX.Element {
   const hint = options.default === false ? '(y/N)' : '(Y/n)';
   const details = options.details?.trim();
+  const lines = useMemo(() => (details ? details.split('\n') : []), [details]);
+  const terminalRows = useTerminalRows();
+  const viewport = Math.max(MIN_VIEWPORT, Math.min(MAX_VIEWPORT, terminalRows - RESERVED_ROWS));
+  const total = lines.length;
+  const maxOffset = Math.max(0, total - viewport);
+  const scrollable = total > viewport;
+  const [offset, setOffset] = useState(0);
+
+  useInput((_input, key) => {
+    if (!scrollable) return;
+    if (key.upArrow) setOffset((o) => Math.max(0, o - 1));
+    else if (key.downArrow) setOffset((o) => Math.min(maxOffset, o + 1));
+    else if (key.pageUp) setOffset((o) => Math.max(0, o - viewport));
+    else if (key.pageDown) setOffset((o) => Math.min(maxOffset, o + viewport));
+  });
+
+  const visibleLines = scrollable ? lines.slice(offset, offset + viewport) : lines;
+
   return (
     <Box flexDirection="column">
       {details ? (
@@ -23,7 +62,7 @@ export function ConfirmPrompt({ options, onSubmit }: ConfirmPromptProps): React.
           paddingX={spacing.gutter}
           marginBottom={spacing.section}
         >
-          {details.split('\n').map((line, idx) => (
+          {visibleLines.map((line, idx) => (
             <Text key={idx}>
               {line.length > 0 ? (
                 <>
@@ -35,6 +74,12 @@ export function ConfirmPrompt({ options, onSubmit }: ConfirmPromptProps): React.
               )}
             </Text>
           ))}
+          {scrollable ? (
+            <Text color={inkColors.muted}>
+              {glyphs.inlineDot} lines {String(offset + 1)}–{String(Math.min(offset + viewport, total))} of{' '}
+              {String(total)} {glyphs.inlineDot} ↑/↓ scroll {glyphs.inlineDot} PgUp/PgDn page
+            </Text>
+          ) : null}
         </Box>
       ) : null}
       <Box>

--- a/src/integration/ui/tui/views/command-map.ts
+++ b/src/integration/ui/tui/views/command-map.ts
@@ -45,6 +45,7 @@ import { taskListCommand } from '@src/integration/cli/commands/task/list.ts';
 import { taskShowCommand } from '@src/integration/cli/commands/task/show.ts';
 import { taskStatusCommand } from '@src/integration/cli/commands/task/status.ts';
 import { taskNextCommand } from '@src/integration/cli/commands/task/next.ts';
+import { taskWhyCommand } from '@src/integration/cli/commands/task/why.ts';
 import { taskReorderCommand } from '@src/integration/cli/commands/task/reorder.ts';
 import { taskRemoveCommand } from '@src/integration/cli/commands/task/remove.ts';
 
@@ -102,6 +103,7 @@ export const commandMap: Record<string, Record<string, CommandHandler>> = {
     show: () => taskShowCommand([]),
     status: () => taskStatusCommand([]),
     next: () => taskNextCommand(),
+    why: () => taskWhyCommand(),
     reorder: () => taskReorderCommand([]),
     remove: () => taskRemoveCommand([]),
   },

--- a/src/integration/ui/tui/views/command-map.ts
+++ b/src/integration/ui/tui/views/command-map.ts
@@ -76,9 +76,27 @@ export const commandMap: Record<string, Record<string, CommandHandler>> = {
     show: () => sprintShowCommand([]),
     context: () => sprintContextCommand([]),
     current: () => sprintCurrentCommand(['-']),
-    refine: () => sprintRefineCommand([]),
+    refine: async () => {
+      const mode = await getPrompt().select<'interactive' | 'auto'>({
+        message: 'How should refinement run?',
+        choices: [
+          { label: 'Interactive — approve requirements for each ticket', value: 'interactive' },
+          { label: 'Auto — AI drafts requirements without prompts', value: 'auto' },
+        ],
+      });
+      await sprintRefineCommand(mode === 'auto' ? ['--auto'] : []);
+    },
     ideate: () => sprintIdeateCommand([]),
-    plan: () => sprintPlanCommand([]),
+    plan: async () => {
+      const mode = await getPrompt().select<'interactive' | 'auto'>({
+        message: 'How should planning run?',
+        choices: [
+          { label: 'Interactive — pick affected repos manually', value: 'interactive' },
+          { label: 'Auto — AI explores all repos autonomously', value: 'auto' },
+        ],
+      });
+      await sprintPlanCommand(mode === 'auto' ? ['--auto', '--all-paths'] : []);
+    },
     start: () => sprintStartCommand([]),
     requirements: () => sprintRequirementsCommand([]),
     health: () => sprintHealthCommand(),

--- a/src/integration/ui/tui/views/execute-view.tsx
+++ b/src/integration/ui/tui/views/execute-view.tsx
@@ -271,6 +271,21 @@ export function ExecuteView({ sprintId, executionOptions }: Props): React.JSX.El
   );
 }
 
+const STEP_LABELS: Record<string, string> = {
+  'branch-preflight': 'Verifying branch…',
+  'contract-negotiate': 'Writing contract…',
+  'mark-in-progress': 'Starting…',
+  'execute-task': 'Running Claude…',
+  'store-verification': 'Storing verification…',
+  'post-task-check': 'Running post-task check…',
+  'evaluate-task': 'Evaluating…',
+  'mark-done': 'Finalizing…',
+};
+
+function labelForStep(stepName: string): string {
+  return STEP_LABELS[stepName] ?? stepName;
+}
+
 export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): RunState {
   const running = new Set(state.running);
   const blocked = new Set(state.blocked);
@@ -284,8 +299,14 @@ export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): 
         break;
       case 'task-finished':
         running.delete(event.taskId);
+        activity.delete(event.taskId);
         if (event.status === 'blocked' || event.status === 'failed') {
           blocked.add(event.taskId);
+        }
+        break;
+      case 'task-step':
+        if (event.phase === 'start') {
+          activity.set(event.taskId, labelForStep(event.stepName));
         }
         break;
       case 'rate-limit-paused':

--- a/src/integration/ui/tui/views/execute-view.tsx
+++ b/src/integration/ui/tui/views/execute-view.tsx
@@ -32,6 +32,7 @@ import { TaskGrid } from '@src/integration/ui/tui/components/task-grid.tsx';
 import { SprintSummary } from '@src/integration/ui/tui/components/sprint-summary.tsx';
 import { LogTail } from '@src/integration/ui/tui/components/log-tail.tsx';
 import { RateLimitBanner } from '@src/integration/ui/tui/components/rate-limit-banner.tsx';
+import { Spinner } from '@src/integration/ui/tui/components/spinner.tsx';
 import { useRouter } from './router-context.ts';
 import { glyphs, inkColors, spacing } from '@src/integration/ui/theme/tokens.ts';
 import { ViewShell } from '@src/integration/ui/tui/components/view-shell.tsx';
@@ -52,6 +53,7 @@ interface RunState {
   running: Set<string>;
   blocked: Set<string>;
   activity: Map<string, string>;
+  currentStep: Map<string, string>;
   summary: ExecutionSummary | null;
   error: string | null;
   rateLimit: { pausedSince: Date; delayMs: number } | null;
@@ -64,6 +66,7 @@ export function initialState(): RunState {
     running: new Set(),
     blocked: new Set(),
     activity: new Map(),
+    currentStep: new Map(),
     summary: null,
     error: null,
     rateLimit: null,
@@ -238,6 +241,16 @@ export function ExecuteView({ sprintId, executionOptions }: Props): React.JSX.El
         />
       </Box>
 
+      {!done && state.currentStep.size > 0 ? (
+        <Box marginTop={spacing.section} flexDirection="column">
+          {Array.from(state.currentStep.entries()).map(([taskId, label]) => {
+            const task = state.tasks.find((t) => t.id === taskId);
+            const taskName = task?.name ?? taskId.slice(0, 8);
+            return <Spinner key={taskId} label={`${taskName} ${glyphs.emDash} ${label}`} />;
+          })}
+        </Box>
+      ) : null}
+
       <Box marginTop={spacing.section}>
         <LogTail events={logEvents} />
       </Box>
@@ -290,6 +303,7 @@ export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): 
   const running = new Set(state.running);
   const blocked = new Set(state.blocked);
   const activity = new Map(state.activity);
+  const currentStep = new Map(state.currentStep);
   let rateLimit = state.rateLimit;
 
   for (const event of events) {
@@ -300,6 +314,7 @@ export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): 
       case 'task-finished':
         running.delete(event.taskId);
         activity.delete(event.taskId);
+        currentStep.delete(event.taskId);
         if (event.status === 'blocked' || event.status === 'failed') {
           blocked.add(event.taskId);
         }
@@ -307,6 +322,13 @@ export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): 
       case 'task-step':
         if (event.phase === 'start') {
           activity.set(event.taskId, labelForStep(event.stepName));
+          currentStep.set(event.taskId, labelForStep(event.stepName));
+        } else {
+          // Step finished — only clear if nothing else has taken over the
+          // slot (mark-done clears via task-finished).
+          if (currentStep.get(event.taskId) === labelForStep(event.stepName)) {
+            currentStep.delete(event.taskId);
+          }
         }
         break;
       case 'rate-limit-paused':
@@ -332,5 +354,5 @@ export function reduceEvents(state: RunState, events: readonly HarnessEvent[]): 
     }
   }
 
-  return { ...state, running, blocked, activity, rateLimit };
+  return { ...state, running, blocked, activity, currentStep, rateLimit };
 }

--- a/src/integration/ui/tui/views/execute-view.tsx
+++ b/src/integration/ui/tui/views/execute-view.tsx
@@ -137,7 +137,21 @@ export function ExecuteView({ sprintId, executionOptions }: Props): React.JSX.El
     const fresh = signalEvents.slice(processedCountRef.current);
     processedCountRef.current = signalEvents.length;
     setState((prev) => reduceEvents(prev, fresh));
-  }, [signalEvents]);
+
+    // A task settled — re-read persisted statuses so the grid + summary
+    // counter reflect the new done/in_progress state (the reducer only
+    // tracks in-memory running/blocked/activity).
+    if (fresh.some((e) => e.type === 'task-finished')) {
+      void (async () => {
+        try {
+          const tasks = await shared.persistence.getTasks(sprintId);
+          setState((s) => ({ ...s, tasks }));
+        } catch {
+          // Leave the grid as-is; next refresh will catch up.
+        }
+      })();
+    }
+  }, [signalEvents, shared, sprintId]);
 
   const [closePromptRun, setClosePromptRun] = useState(false);
 

--- a/src/integration/ui/tui/views/menu-builder.ts
+++ b/src/integration/ui/tui/views/menu-builder.ts
@@ -211,6 +211,7 @@ function buildTaskSubMenu(ctx: MenuContext): SubMenu {
   items.push(titled('VIEW'));
   items.push({ name: 'List', value: 'list', description: 'List all tasks' });
   items.push({ name: 'Next', value: 'next', description: 'Get next task' });
+  items.push({ name: 'Why Blocked?', value: 'why', description: 'Explain why a task is blocked' });
   items.push(blank());
   items.push(titled('MANAGE'));
   items.push({ name: 'Add', value: 'add', description: 'Add a new task' });

--- a/src/integration/ui/tui/views/phases/refine-phase-view.tsx
+++ b/src/integration/ui/tui/views/phases/refine-phase-view.tsx
@@ -62,6 +62,18 @@ export function RefinePhaseView({ sprintId }: Props): React.JSX.Element {
     void loadSprint();
   }, [loadSprint]);
 
+  // Poll the sprint while the pipeline is running so the approved/pending
+  // counters and per-ticket badges update live as each ticket settles.
+  useEffect(() => {
+    if (!state.running) return;
+    const handle = setInterval(() => {
+      void loadSprint();
+    }, 1000);
+    return () => {
+      clearInterval(handle);
+    };
+  }, [state.running, loadSprint]);
+
   const runRefine = useCallback(async (): Promise<void> => {
     setState((s) => ({ ...s, running: true, error: null, records: [] }));
     try {

--- a/src/integration/ui/tui/views/workflows/ticket-add-view.tsx
+++ b/src/integration/ui/tui/views/workflows/ticket-add-view.tsx
@@ -31,10 +31,10 @@ const HINTS_DONE = [
 ] as const;
 
 type Phase =
-  | { kind: 'running'; step: 'link' | 'fetching' | 'title' | 'description' | 'saving' }
+  | { kind: 'running'; step: 'link' | 'fetching' | 'title' | 'description' | 'saving' | 'another' }
   | { kind: 'no-project' }
   | { kind: 'no-draft-sprint' }
-  | { kind: 'done'; ticket: Ticket; project: Project; prefilled: boolean }
+  | { kind: 'done'; ticket: Ticket; project: Project; prefilled: boolean; count: number }
   | { kind: 'error'; message: string };
 
 const STEP_LABEL: Record<Extract<Phase, { kind: 'running' }>['step'], string> = {
@@ -43,6 +43,7 @@ const STEP_LABEL: Record<Extract<Phase, { kind: 'running' }>['step'], string> = 
   title: 'Awaiting ticket title…',
   description: 'Awaiting ticket description…',
   saving: 'Saving ticket…',
+  another: 'Add another ticket?',
 };
 
 function isValidUrl(value: string): boolean {
@@ -84,45 +85,59 @@ export function TicketAddView(): React.JSX.Element {
         return;
       }
 
-      setPhase({ kind: 'running', step: 'link' });
-      const link = await prompt.input({
-        message: 'Issue link (optional):',
-        validate: (v: string) => {
-          const trimmed = v.trim();
-          if (trimmed.length === 0) return true;
-          return isValidUrl(trimmed) ? true : 'Must be a valid URL (or leave blank)';
-        },
-      });
-      const trimmedLink = link.trim();
+      let count = 0;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- loop control via break
+      while (true) {
+        setPhase({ kind: 'running', step: 'link' });
+        const link = await prompt.input({
+          message: 'Issue link (optional):',
+          validate: (v: string) => {
+            const trimmed = v.trim();
+            if (trimmed.length === 0) return true;
+            return isValidUrl(trimmed) ? true : 'Must be a valid URL (or leave blank)';
+          },
+        });
+        const trimmedLink = link.trim();
 
-      let prefill: IssueData | null = null;
-      if (trimmedLink.length > 0) {
-        setPhase({ kind: 'running', step: 'fetching' });
-        prefill = tryFetchIssue(trimmedLink);
+        let prefill: IssueData | null = null;
+        if (trimmedLink.length > 0) {
+          setPhase({ kind: 'running', step: 'fetching' });
+          prefill = tryFetchIssue(trimmedLink);
+        }
+
+        setPhase({ kind: 'running', step: 'title' });
+        const title = await prompt.input({
+          message: 'Title:',
+          default: prefill?.title,
+          validate: (v: string) => (v.trim().length > 0 ? true : 'Title is required'),
+        });
+
+        setPhase({ kind: 'running', step: 'description' });
+        const description = await prompt.editor({
+          message: 'Description (recommended)',
+          default: prefill?.body,
+        });
+
+        setPhase({ kind: 'running', step: 'saving' });
+        const trimmedDescription = description?.trim() ?? '';
+        const ticket = await addTicket({
+          title: title.trim(),
+          description: trimmedDescription.length > 0 ? trimmedDescription : undefined,
+          link: trimmedLink.length > 0 ? trimmedLink : undefined,
+        });
+        count++;
+
+        setPhase({ kind: 'running', step: 'another' });
+        const another = await prompt.confirm({
+          message: `Add another ticket? (${String(count)} added)`,
+          default: true,
+        });
+
+        if (!another) {
+          setPhase({ kind: 'done', ticket, project, prefilled: prefill !== null, count });
+          return;
+        }
       }
-
-      setPhase({ kind: 'running', step: 'title' });
-      const title = await prompt.input({
-        message: 'Title:',
-        default: prefill?.title,
-        validate: (v: string) => (v.trim().length > 0 ? true : 'Title is required'),
-      });
-
-      setPhase({ kind: 'running', step: 'description' });
-      const description = await prompt.editor({
-        message: 'Description (recommended)',
-        default: prefill?.body,
-      });
-
-      setPhase({ kind: 'running', step: 'saving' });
-      const trimmedDescription = description?.trim() ?? '';
-      const ticket = await addTicket({
-        title: title.trim(),
-        description: trimmedDescription.length > 0 ? trimmedDescription : undefined,
-        link: trimmedLink.length > 0 ? trimmedLink : undefined,
-      });
-
-      setPhase({ kind: 'done', ticket, project, prefilled: prefill !== null });
     },
   });
 
@@ -155,19 +170,26 @@ function renderBody(phase: Phase): React.JSX.Element {
       );
     case 'error':
       return <ResultCard kind="error" title="Could not add ticket" lines={[phase.message]} />;
-    case 'done':
+    case 'done': {
+      const title =
+        phase.count > 1
+          ? `${String(phase.count)} tickets added`
+          : phase.prefilled
+            ? 'Ticket added (prefilled from issue)'
+            : 'Ticket added';
       return (
         <ResultCard
           kind="success"
-          title={phase.prefilled ? 'Ticket added (prefilled from issue)' : 'Ticket added'}
+          title={title}
           fields={[
-            ['ID', phase.ticket.id],
-            ['Title', phase.ticket.title],
+            ['Last ID', phase.ticket.id],
+            ['Last title', phase.ticket.title],
             ['Project', `${phase.project.displayName} (${phase.project.name})`],
             ['Status', `requirement: ${phase.ticket.requirementStatus}`],
           ]}
           nextSteps={[{ action: 'Refine requirements', description: 'Home → Next: Refine Requirements' }]}
         />
       );
+    }
   }
 }

--- a/src/test-utils/cli-runner.ts
+++ b/src/test-utils/cli-runner.ts
@@ -9,6 +9,7 @@ import { registerTaskCommands } from '@src/integration/cli/commands/task/registe
 import { registerTicketCommands } from '@src/integration/cli/commands/ticket/register.ts';
 import { registerProgressCommands } from '@src/integration/cli/commands/progress/register.ts';
 import { registerConfigCommands } from '@src/integration/cli/commands/config/register.ts';
+import { registerNextCommands } from '@src/integration/cli/commands/next/register.ts';
 import { cliMetadata } from '@src/domain/cli-metadata.ts';
 import { DomainError } from '@src/domain/errors.ts';
 import { colors } from '@src/integration/ui/theme/theme.ts';
@@ -49,6 +50,7 @@ function createProgram(): Command {
   registerTicketCommands(program);
   registerProgressCommands(program);
   registerConfigCommands(program);
+  registerNextCommands(program);
 
   return program;
 }


### PR DESCRIPTION
## Summary

- **`ralphctl next`** + **`ralphctl task why`** — surfaced via REPL task submenu
- **Refine + plan auto mode** exposed on CLI and REPL
- **Ticket-add loop** — Ink TUI prompts "Add another?" matching the plain-text CLI
- **Scrollable confirm details** — refined-requirements approval prompt no longer clobbers the screen; ↑/↓ + PgUp/PgDn scroll
- **Live refine overview** — `RefinePhaseView` polls sprint every 1s while the pipeline runs so approved/pending counters tick
- **Live execution grid** — `ExecuteView` re-reads tasks on every `task-finished` signal so the progress counter updates per task
- **Per-step trace** — new `task-step` HarnessEvent emitted around every per-task pipeline step (branch-preflight … mark-done); ExecuteView surfaces a labeled spinner per running task above the Log section ("Running Claude…", "Evaluating…", etc.)
- **Dedup**: removed the duplicate "Completed: <task>" log emitted by both the scheduler's `onSettle` and the `mark-done` step

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` — all green (1355 tests)
- [ ] Smoke: `ralphctl sprint start` shows live per-step spinner per running task
- [ ] Smoke: `ticket add` loops and `sprint refine` overview ticks live