### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-20
+
+### Fixed
+
+- **Dirty-tree leaks after task settlement** — tasks and end-of-sprint feedback iterations could
+  leave uncommitted changes in the repo if the generator skipped its commit step. Two-layer fix:
+  - `sprint-feedback` prompt now mandates a commit before completion; `task-evaluation` prompt
+    declares a read-only posture and requires a clean tree in Phase 1.
+  - New `recover-dirty-tree` pipeline step (between `evaluate-task` and `mark-done`) and matching
+    hook in the feedback loop. If the tree is still dirty at settlement, the harness warns, emits
+    a `Note` signal to `progress.md`, and auto-commits via a new `ExternalPort.autoCommit`.
+    Non-blocking — `mark-done` always runs, even if the auto-commit itself fails.
+
 ## [0.4.0] - 2026-04-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.4.1
- Changelog entry covering #73 (dirty-tree leak fix at task + feedback settlement)

## Test plan

- [x] CI green