### PR TITLE
audit: tighten prompt templates (closes #75)

### DIFF
--- a/.claude/docs/PROMPT-AUDIT.md
+++ b/.claude/docs/PROMPT-AUDIT.md
@@ -1,0 +1,107 @@
+# Prompt Template Audit — Issue #75
+
+Per-file audit of `src/integration/ai/prompts/*.md`. Prompts run in **downstream projects** (Node, Python, Go, Rust,
+Java, mixed), so they must be ecosystem-generic and free of ralphctl-specific leakage.
+
+**Columns:**
+
+- **Role** — clear one-line role + mission statement
+- **XML** — structural inputs sit inside XML tags (`<context>`, `<requirements>`, `<constraints>`, `<examples>`, …)
+- **Output** — output contract precise (either `{{SIGNALS}}` or a schema + example)
+- **Placeholder-safe** — conditional placeholders expand cleanly when empty (no orphan numbering, no double blanks)
+- **No ralphctl leak** — template does not name ralphctl, its repo layout, or its own subagents
+- **Ecosystem-generic** — no hardcoded `pnpm` / `npm` / `pip` / `cargo` outside `{{PROJECT_TOOLING}}` / `{{CHECK_GATE_EXAMPLE}}`
+- **Em-dash** — explanatory clauses use `—`, not `-`
+- **Absolute-rule-free** — "never" rules name their legitimate exception
+
+## Checkbox table
+
+| File                        | Role | XML | Output | Placeholder-safe | No ralphctl leak | Ecosystem-generic | Em-dash | Absolute-rule-free | Notes                                                                                                                 |
+| --------------------------- | :--: | :-: | :----: | :--------------: | :--------------: | :---------------: | :-----: | :----------------: | --------------------------------------------------------------------------------------------------------------------- |
+| `harness-context.md`        |  ✓   |  ✓  |  n/a   |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Single `<harness-context>` block, 3 lines.                                                                            |
+| `validation-checklist.md`   |  ✓   |  ✓  |  n/a   |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Wrapped in `<validation-checklist>`.                                                                                  |
+| `signals-task.md`           | n/a  |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | `<signals>` contract block.                                                                                           |
+| `signals-planning.md`       | n/a  |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | `<signals>` contract block.                                                                                           |
+| `signals-evaluation.md`     | n/a  |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | `<signals>` contract block.                                                                                           |
+| `plan-common.md`            | n/a  |  ✓  |  n/a   |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Shared planner partial; inlined inside callers' outer `<context>` block.                                              |
+| `plan-auto.md`              |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Sprint context wrapped in `<context>`.                                                                                |
+| `plan-interactive.md`       |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Sprint context wrapped in `<context>`; inline gate prose generalised.                                                 |
+| `ideate.md`                 |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Idea + repositories wrapped in `<context>`.                                                                           |
+| `ideate-auto.md`            |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Idea + repositories wrapped in `<context>`.                                                                           |
+| `ticket-refine.md`          |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | `{{TICKET}}` wrapped in `<task-specification>`; `{{ISSUE_CONTEXT}}` wrapped in `<context>`.                           |
+| `task-execution.md`         |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |        ✓\*        |    ✓    |         ✓          | Check-gate example via `{{CHECK_GATE_EXAMPLE}}`; `{{COMMIT_STEP}}` owns its own line (no indent artefact when empty). |
+| `task-evaluation.md`        |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | `<dimension name="…" floor="…">` blocks; `<examples>` around discovery file list + calibration.                       |
+| `task-evaluation-resume.md` |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Critique is the single input.                                                                                         |
+| `sprint-feedback.md`        |  ✓   |  ✓  |   ✓    |        ✓         |        ✓         |         ✓         |    ✓    |         ✓          | Human feedback wrapped in `<task-specification>` (canonical).                                                         |
+
+\*Pending smoke run — see Verification Log.
+
+## Canonical XML vocabulary
+
+Every structural input sits inside one of these tags. Adding a new tag requires a row below (and a docs update).
+
+| Tag                                          | Semantics                                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `<harness-context>`                          | Harness lifecycle hints (context compaction, session management).                                                   |
+| `<task-specification>`                       | The immutable contract under action — task name, steps, criteria. Do not paraphrase or weaken.                      |
+| `<context>`                                  | Environmental state — sprint, repositories, prior progress, project config pointers.                                |
+| `<requirements>`                             | Approved ticket requirements — implementation-agnostic WHAT.                                                        |
+| `<constraints>`                              | Do/don't rules with named exceptions.                                                                               |
+| `<examples>`                                 | Non-normative illustrations. Treat as examples, not mandates.                                                       |
+| `<dimension name="..." floor="true\|false">` | Evaluator rubric unit. `floor="true"` means grade every task; `floor="false"` means planner-emitted per-task extra. |
+| `<signals>`                                  | Output signal contract — the exhaustive list of structural tags the role may emit.                                  |
+| `<validation-checklist>`                     | Pre-output self-check list (only in `validation-checklist.md`).                                                     |
+
+## Anti-patterns locked in CI
+
+Enforced by `loader.test.ts` under the `prompt template generic-content audits` describe block:
+
+- No `ralphctl` string anywhere in any `.md` template.
+- No backtick-wrapped hardcoded subagent names (`` `auditor` ``, `` `reviewer` ``, …) — subagent catalogs come from
+  runtime detection, not prompt content.
+- No literal package-manager commands (`pnpm`, `npm`, `pip`, `cargo`, `go test`) in planner/execution/evaluator
+  renderings — they must flow through `{{PROJECT_TOOLING}}` or `{{CHECK_GATE_EXAMPLE}}`.
+- Every top-level input block in planner-role prompts sits inside a known XML tag from the vocabulary above.
+- Every conditional placeholder expands cleanly when empty (builds with `noCommit=true` and `extraDimensions=[]` leave
+  no orphan numbering or double blank lines).
+
+## Verification Log
+
+Last updated: 2026-04-20.
+
+**Structurally verified in CI:**
+
+- Byte-identical rendering across callers — `loader.ts` returns a plain `string` and has no branching on the calling
+  surface (Ink TUI vs plain-text CLI vs tests). The same inputs produce the same output everywhere.
+- Three anti-pattern guards in `loader.test.ts` — no `ralphctl` string, no hardcoded subagent names, no literal
+  package-manager commands in rendered planner / execution / evaluator prompts.
+- Structural XML wrapping — every planner-role rendered prompt matches the known-tag allowlist.
+- Placeholder hygiene — empty conditionals (`noCommit=true`, `extraDimensions=[]`) leave no orphan numbering, no
+  indented-only lines, no double-blank runs.
+- TUI-parity fixture — `prompt rendering is surface-agnostic (TUI parity)` asserts deterministic output and the
+  absence of ANSI escapes / Ink component tags across every builder.
+
+**Pending (recommended before tagging a release):**
+
+- **Manual smoke run across one Node + one Python repo.** Procedure: run `ralphctl sprint plan` on each; confirm
+  generated `tasks.json` does not embed Node-isms (`pnpm`, `npm run`, `package.json` scripts) inside tasks that
+  execute against a Python repo. The CI regex check catches package-manager commands in the _templates_; only a
+  live run against a real heterogeneous project catches leakage via `{{PROJECT_TOOLING}}` or `{{CONTEXT}}`. Log
+  results here when performed.
+
+## Follow-ups
+
+Separate tickets — tracked here so #75 can close cleanly.
+
+- **Dynamic `CHECK_GATE_EXAMPLE`.** The neutral example is substituted everywhere, including runtime task execution
+  where the real `Repository.checkScript` is already known. Consider splitting into a generic
+  `PLANNER_CHECK_GATE_EXAMPLE` (stays neutral for the planner) and a runtime-aware renderer that uses
+  `Repository.checkScript` when configured for `buildTaskExecutionPrompt`.
+- **`<thinking>` scratchpad for `task-evaluation.md`.** The evaluator is autonomous and performs multi-dimensional
+  grading — a structured scratchpad (the same pattern used in headless planners) could lift grading quality. Not
+  wired today.
+
+## Re-run before every release
+
+Run `pnpm test` — the audit suite (in `loader.test.ts`) must stay green. Visually re-check the table above when a
+template is added or when the canonical vocabulary grows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,19 @@ prompt files)
 **Workflow sync** - Prompt templates must match actual command flow (e.g., repo selection happens in command before
 Claude session starts)
 **Template builders** - `src/integration/ai/prompts/loader.ts` compiles `.md` templates with placeholder replacement
+**Canonical XML vocabulary** — structural inputs sit inside known tags (`<harness-context>`, `<task-specification>`,
+`<context>`, `<requirements>`, `<constraints>`, `<examples>`, `<dimension>`, `<signals>`). Full table in
+[.claude/docs/PROMPT-AUDIT.md](.claude/docs/PROMPT-AUDIT.md) — extend both the doc and the loader audit tests when
+adding a new tag.
+**No hardcoded package-manager commands** — prompts must not embed `pnpm`/`npm`/`pip`/`cargo`/`go test` outside the
+`{{PROJECT_TOOLING}}` or `{{CHECK_GATE_EXAMPLE}}` placeholders. Downstream ecosystems differ; the placeholders are the
+seam.
+**Conditional placeholders must not sit inside numbered lists** — when the substitution is empty the list must still
+read cleanly. Emit conditional content as a standalone bullet or paragraph, not as trailing prose in a numbered step.
+**Downstream `.claude/` is optional context** — many downstream repos have no `.claude/` directory. Reference it as
+"when present" rather than prescriptively; skip silently when absent.
+**Absolute rules name their exception** — `never`/`always` phrasing is fragile when legitimate exceptions exist. Name
+the exception inline (e.g. "Merge create+use — except when a stable contract makes them independently testable").
 
 ## Custom Agents
 

--- a/src/integration/ai/prompts/ideate-auto.md
+++ b/src/integration/ai/prompts/ideate-auto.md
@@ -11,6 +11,27 @@ When finished, emit a signal from the `<signals>` block below.
 
 ## Two-Phase Protocol
 
+### Phase 0: Think Before Writing
+
+Before emitting any JSON, write your reasoning in a `<thinking>…</thinking>` block. Use it to interrogate the idea —
+surface hidden assumptions, identify the real user problem, sketch requirements, and reason about which repositories
+and dependencies the work touches. Explicit reasoning produces sharper output than jumping straight to JSON.
+
+The harness's JSON extractor skips everything before the first `{`, so the `<thinking>` block is stripped
+automatically — but the JSON object itself must still be emitted without markdown fences or commentary after it.
+
+```
+<thinking>
+The idea says "webhook notifications" but doesn't say which events. Reviewing the API, the natural candidates are
+task-status transitions. Scope = status-change webhooks only; other event types are out of scope.
+Acceptance: POST to configured URL with JSON payload on task status change; retries on 5xx.
+…
+</thinking>
+{
+  … JSON object …
+}
+```
+
 ### Phase 1: Refine Requirements (WHAT)
 
 Analyze the idea and produce complete, implementation-agnostic requirements:
@@ -87,6 +108,8 @@ If you cannot produce a valid plan, signal the issue instead of outputting incom
 
 - `<planning-blocked>reason</planning-blocked>`
 
+<context>
+
 ## Idea to Implement
 
 **Title:** {{IDEA_TITLE}}
@@ -106,6 +129,8 @@ You have access to these repositories:
 ## Planning Common Context
 
 {{COMMON}}
+
+</context>
 
 {{VALIDATION}}
 
@@ -148,7 +173,7 @@ If you cannot produce a valid plan, output `<planning-blocked>reason</planning-b
         "Update src/repositories/export.ts findExports() to add WHERE clause for date filtering",
         "Add unit tests in src/schemas/__tests__/date-range.test.ts covering valid ranges, invalid formats, and reversed dates",
         "Add integration test in src/controllers/__tests__/export.test.ts for filtered and unfiltered queries",
-        "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
+        "{{CHECK_GATE_EXAMPLE}}"
       ],
       "verificationCriteria": [
         "TypeScript compiles with no errors",

--- a/src/integration/ai/prompts/ideate.md
+++ b/src/integration/ai/prompts/ideate.md
@@ -118,6 +118,8 @@ Focus: Determine HOW to implement the approved requirements
 
 {{VALIDATION}}
 
+<context>
+
 ## Idea to Refine and Plan
 
 **Title:** {{IDEA_TITLE}}
@@ -140,6 +142,8 @@ mention it as an observation.
 ## Planning Common Context
 
 {{COMMON}}
+
+</context>
 
 ## Output Format
 
@@ -169,7 +173,7 @@ Use this exact JSON Schema:
         "Update ExportController.getExport() in src/controllers/export.ts to parse and validate date range params",
         "Add date range filtering to ExportRepository.findRecords() in src/repositories/export.ts",
         "Write tests in src/controllers/__tests__/export.test.ts for: no dates, valid range, invalid range, start > end",
-        "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
+        "{{CHECK_GATE_EXAMPLE}}"
       ],
       "verificationCriteria": [
         "TypeScript compiles with no errors",

--- a/src/integration/ai/prompts/loader.test.ts
+++ b/src/integration/ai/prompts/loader.test.ts
@@ -33,6 +33,7 @@ const PARTIAL_MARKERS = {
   signalsTask: '<task-verified>',
   signalsPlanning: '<planning-blocked>',
   signalsEvaluation: '<evaluation-passed>',
+  planCommonExamples: 'Good Dependency Graph',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -165,6 +166,23 @@ describe('buildTaskExecutionPrompt', () => {
     it('includes commit constraint text', () => {
       const result = buildTaskExecutionPrompt(progressFile, false, contextFile);
       expect(result).toContain('Must commit');
+    });
+
+    it('renders Must commit as a peer constraint bullet at column 0, not a nested sub-bullet', () => {
+      // Regression guard for a Prettier-reflow bug: when {{COMMIT_CONSTRAINT}}
+      // sat indented under the preceding bullet's continuation, the rendered
+      // "- **Must commit**" read as a sub-bullet of "Leave CONTEXT_FILE alone".
+      // The placeholder must live at column 0 so the bullet is a sibling.
+      const result = buildTaskExecutionPrompt(progressFile, false, contextFile);
+      // Column-0 match (no leading whitespace) — the authoritative assertion.
+      expect(result).toMatch(/^- \*\*Must commit\*\*/m);
+      // And the indented form must not appear anywhere.
+      expect(result).not.toMatch(/^[ \t]+- \*\*Must commit\*\*/m);
+    });
+
+    it('places the closing </constraints> tag at column 0 (not indented under a bullet)', () => {
+      const result = buildTaskExecutionPrompt(progressFile, false, contextFile);
+      expect(result).toMatch(/^<\/constraints>/m);
     });
   });
 
@@ -397,33 +415,33 @@ describe('buildEvaluatorPrompt', () => {
   describe('extraDimensions', () => {
     it('renders only the four floor dimensions when extras is empty', () => {
       const result = buildEvaluatorPrompt(baseCtx);
-      expect(result).toContain('**Dimension 1 — Correctness**');
-      expect(result).toContain('**Dimension 2 — Completeness**');
-      expect(result).toContain('**Dimension 3 — Safety**');
-      expect(result).toContain('**Dimension 4 — Consistency**');
-      // No fifth dimension when no extras supplied.
-      expect(result).not.toContain('**Dimension 5');
+      expect(result).toContain('<dimension name="Correctness" floor="true">');
+      expect(result).toContain('<dimension name="Completeness" floor="true">');
+      expect(result).toContain('<dimension name="Safety" floor="true">');
+      expect(result).toContain('<dimension name="Consistency" floor="true">');
+      // No floor="false" (planner-emitted) dimension when no extras supplied.
+      expect(result).not.toContain('floor="false"');
     });
 
     it('renders an additional dimension block per extra entry', () => {
       const result = buildEvaluatorPrompt({ ...baseCtx, extraDimensions: ['Performance'] });
-      expect(result).toContain('**Dimension 5 — Performance**');
+      expect(result).toContain('<dimension name="Performance" floor="false">');
       // The four floor dimensions still come first.
-      expect(result).toContain('**Dimension 4 — Consistency**');
+      expect(result).toContain('<dimension name="Consistency" floor="true">');
       // Extra appears in the Pass Bar list and the Assessment templates.
       expect(result).toContain('- **Performance**');
       expect(result).toMatch(/\*\*Performance\*\*: PASS — \[one-line finding]/);
       expect(result).toMatch(/\*\*Performance\*\*: PASS\/FAIL — \[one-line finding]/);
     });
 
-    it('numbers extras consecutively starting from Dimension 5', () => {
+    it('emits one dimension tag per extra entry', () => {
       const result = buildEvaluatorPrompt({
         ...baseCtx,
         extraDimensions: ['Performance', 'Accessibility', 'MigrationSafety'],
       });
-      expect(result).toContain('**Dimension 5 — Performance**');
-      expect(result).toContain('**Dimension 6 — Accessibility**');
-      expect(result).toContain('**Dimension 7 — MigrationSafety**');
+      expect(result).toContain('<dimension name="Performance" floor="false">');
+      expect(result).toContain('<dimension name="Accessibility" floor="false">');
+      expect(result).toContain('<dimension name="MigrationSafety" floor="false">');
     });
 
     it('leaves no unrendered placeholders when extras is empty', () => {
@@ -630,6 +648,97 @@ describe('shared partial inlining', () => {
       expect(result).not.toContain(PARTIAL_MARKERS.validation);
     });
   });
+
+  describe('plan-common-examples partial (planner-role only)', () => {
+    it('is inlined into plan-auto', () => {
+      const result = buildAutoPrompt('ctx', '{}', '');
+      expect(result).toContain(PARTIAL_MARKERS.planCommonExamples);
+    });
+
+    it('is inlined into plan-interactive', () => {
+      const result = buildInteractivePrompt('ctx', '/out.json', '{}', '');
+      expect(result).toContain(PARTIAL_MARKERS.planCommonExamples);
+    });
+
+    it('is inlined into ideate', () => {
+      const result = buildIdeatePrompt('t', 'd', 'p', '/r', '/out.json', '{}', '');
+      expect(result).toContain(PARTIAL_MARKERS.planCommonExamples);
+    });
+
+    it('is inlined into ideate-auto', () => {
+      const result = buildIdeateAutoPrompt('t', 'd', 'p', '/r', '{}', '');
+      expect(result).toContain(PARTIAL_MARKERS.planCommonExamples);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TUI parity — prompts are surface-agnostic by construction
+// ---------------------------------------------------------------------------
+// loader.ts has no branching on whether the caller is the Ink TUI or the
+// plain-text CLI. A given input produces byte-identical output regardless of
+// surface. These assertions document that invariant and guard against a
+// future "just inject some Ink / ANSI for the dashboard" temptation. See
+// PROMPT-AUDIT.md § Verification Log for the full parity argument.
+// ---------------------------------------------------------------------------
+
+describe('prompt rendering is surface-agnostic (TUI parity)', () => {
+  // eslint-disable-next-line no-control-regex -- detecting the CSI prefix IS the point here
+  const ANSI_ESCAPE_RE = /\u001b\[/; // CSI sequence — ANSI colour / cursor control
+  const INK_COMPONENT_RE = /<(Box|Text|Spinner|Banner|SectionStamp)\b/;
+
+  it('buildAutoPrompt is deterministic across repeated calls with identical inputs', () => {
+    const a = buildAutoPrompt('ctx', '{"test":true}', '');
+    const b = buildAutoPrompt('ctx', '{"test":true}', '');
+    expect(a).toBe(b);
+  });
+
+  it('rendered prompts contain no ANSI escape sequences', () => {
+    const rendered: Record<string, string> = {
+      planAuto: buildAutoPrompt('## Sprint\n\nT', '{}', ''),
+      planInteractive: buildInteractivePrompt('## Sprint\n\nT', '/o', '{}', ''),
+      ideate: buildIdeatePrompt('t', 'd', 'p', '/r', '/o', '{}', ''),
+      ideateAuto: buildIdeateAutoPrompt('t', 'd', 'p', '/r', '{}', ''),
+      taskExecution: buildTaskExecutionPrompt('/p.md', false, 'ctx.md'),
+      taskEvaluation: buildEvaluatorPrompt({
+        taskName: 't',
+        taskDescription: '',
+        taskSteps: [],
+        verificationCriteria: [],
+        projectPath: '/tmp',
+        checkScriptSection: null,
+        projectToolingSection: '',
+        extraDimensions: [],
+      }),
+      ticketRefine: buildTicketRefinePrompt('## T\n\nx', '/o', '{}'),
+      evaluationResume: buildEvaluationResumePrompt({ critique: 'x', needsCommit: false }),
+    };
+    for (const [name, out] of Object.entries(rendered)) {
+      expect(out, `${name} must contain no ANSI escape sequences`).not.toMatch(ANSI_ESCAPE_RE);
+      expect(out, `${name} must contain no Ink component tags`).not.toMatch(INK_COMPONENT_RE);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain-of-Thought — <thinking> scratchpad scope
+// ---------------------------------------------------------------------------
+
+describe('headless planner <thinking> scratchpad', () => {
+  it('plan-auto instructs the planner to reason in a <thinking> block', () => {
+    const result = buildAutoPrompt('ctx', '{}', '');
+    expect(result).toContain('<thinking>');
+  });
+
+  it('ideate-auto instructs the planner to reason in a <thinking> block', () => {
+    const result = buildIdeateAutoPrompt('t', 'd', 'p', '/r', '{}', '');
+    expect(result).toContain('<thinking>');
+  });
+
+  it('interactive plan does NOT include a <thinking> directive (reasoning happens live with the user)', () => {
+    const result = buildInteractivePrompt('ctx', '/out.json', '{}', '');
+    expect(result).not.toContain('<thinking>');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -643,6 +752,7 @@ describe('prompt template generic-content audits', () => {
     'plan-auto',
     'plan-interactive',
     'plan-common',
+    'plan-common-examples',
     'ideate',
     'ideate-auto',
     'ticket-refine',
@@ -654,6 +764,7 @@ describe('prompt template generic-content audits', () => {
     'signals-planning',
     'signals-evaluation',
     'validation-checklist',
+    'sprint-feedback',
   ] as const;
 
   for (const name of TEMPLATE_NAMES) {
@@ -678,4 +789,123 @@ describe('prompt template generic-content audits', () => {
       });
     });
   }
+
+  // -------------------------------------------------------------------------
+  // Ecosystem-generic: no hardcoded package-manager commands in rendered
+  // prompts. All tool-specific content must flow through {{PROJECT_TOOLING}}
+  // or {{CHECK_GATE_EXAMPLE}} at runtime — the templates themselves must not
+  // embed `pnpm`, `npm`, `pip`, `cargo`, or `go test`. Legitimate prose uses
+  // of "npm" / "go" inside URLs or explanations are avoided by checking for
+  // command-shaped tokens (trailing space or end-of-line).
+  // -------------------------------------------------------------------------
+  it('no planner / execution / evaluator rendered prompt embeds a package-manager command', () => {
+    const rendered: Record<string, string> = {
+      planAuto: buildAutoPrompt('## Sprint Context\n\nTicket: x', '{"type":"array"}', ''),
+      planInteractive: buildInteractivePrompt('## Sprint Context\n\nTicket: x', '/out.json', '{"type":"array"}', ''),
+      ideate: buildIdeatePrompt('t', 'd', 'p', '/r', '/out.json', '{"type":"object"}', ''),
+      ideateAuto: buildIdeateAutoPrompt('t', 'd', 'p', '/r', '{"type":"object"}', ''),
+      taskExecution: buildTaskExecutionPrompt('/tmp/progress.md', false, 'ctx.md'),
+      taskEvaluation: buildEvaluatorPrompt({
+        taskName: 't',
+        taskDescription: '',
+        taskSteps: [],
+        verificationCriteria: [],
+        projectPath: '/tmp',
+        checkScriptSection: null,
+        projectToolingSection: '',
+        extraDimensions: [],
+      }),
+    };
+    // Command-shaped tokens: the literal followed by a space (an argument)
+    // or at end of a line. Avoids false positives from prose like "the
+    // go.mod file" or "an npm package".
+    const forbidden = [
+      /\bpnpm\s/,
+      /\bnpm\s+(run|test|install|ci|exec|publish)\b/,
+      /\bnpx\s/,
+      /\bpip\s+install\b/,
+      /\bcargo\s+(build|test|run)\b/,
+      /\bgo\s+test\b/,
+    ];
+    for (const [name, out] of Object.entries(rendered)) {
+      for (const rx of forbidden) {
+        expect(out, `${name} must not embed ${rx.source}`).not.toMatch(rx);
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Structural: every planner-role rendered prompt uses at least one of the
+  // canonical XML tags to wrap its top-level inputs. The vocabulary is fixed
+  // in PROMPT-AUDIT.md and CLAUDE.md; a new tag requires updating both docs
+  // AND expanding this allowlist.
+  // -------------------------------------------------------------------------
+  it('planner-role rendered prompts wrap top-level inputs inside a known XML tag', () => {
+    const plannerRendered: Record<string, string> = {
+      planAuto: buildAutoPrompt('## Sprint Context\n\nTicket: x', '{"type":"array"}', ''),
+      planInteractive: buildInteractivePrompt('## Sprint Context\n\nTicket: x', '/out.json', '{"type":"array"}', ''),
+      ideate: buildIdeatePrompt('t', 'd', 'p', '/r', '/out.json', '{"type":"object"}', ''),
+      ideateAuto: buildIdeateAutoPrompt('t', 'd', 'p', '/r', '{"type":"object"}', ''),
+      taskEvaluation: buildEvaluatorPrompt({
+        taskName: 't',
+        taskDescription: '',
+        taskSteps: [],
+        verificationCriteria: [],
+        projectPath: '/tmp',
+        checkScriptSection: null,
+        projectToolingSection: '',
+        extraDimensions: [],
+      }),
+    };
+    const knownTagRe =
+      /<(task-specification|context|requirements|constraints|examples|dimension|signals|validation-checklist|harness-context)\b/;
+    for (const [name, out] of Object.entries(plannerRendered)) {
+      expect(out, `${name} must wrap inputs in a known XML tag`).toMatch(knownTagRe);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Placeholder hygiene: conditional placeholders must expand cleanly when
+  // empty. Concretely:
+  //   - buildTaskExecutionPrompt(noCommit=true) → no orphan numbering (no
+  //     `1.\n\n3.` skip), no triple-newline runs, no trailing-space bullets.
+  //   - buildEvaluatorPrompt(extraDimensions=[]) → same guarantees around
+  //     the EXTRA_DIMENSIONS_* slots.
+  // -------------------------------------------------------------------------
+  it('conditional placeholders expand cleanly when empty', () => {
+    const taskExecEmpty = buildTaskExecutionPrompt('/tmp/progress.md', true, 'ctx.md');
+    // No orphan numbering in the Phase 3 list: step 2 must be directly
+    // followed by step 3, possibly with blank lines. Skipped numbers (e.g.
+    // "1." then "3." with no "2.") would indicate a swallowed conditional.
+    const phase3 = taskExecEmpty.split('## Phase 3: Completion')[1] ?? '';
+    expect(phase3, 'Phase 3 step 1 must be present').toMatch(/^\s*1\. /m);
+    expect(phase3, 'Phase 3 step 2 must be present').toMatch(/^\s*2\. /m);
+    expect(phase3, 'Phase 3 step 3 must be present').toMatch(/^\s*3\. /m);
+    // No unreplaced placeholders leaked through.
+    expect(taskExecEmpty).not.toMatch(/\{\{[A-Z_]+\}\}/);
+    // When noCommit is true the commit reminder is gone but Phase 3 stays
+    // intact.
+    expect(taskExecEmpty).not.toContain('Before continuing');
+    // And the swallowed conditional must not leave an indented-only line —
+    // that was the Phase 3 cosmetic nit called out in the prompt-audit review.
+    expect(taskExecEmpty, 'no line may contain only leading whitespace').not.toMatch(/^[ \t]+$/m);
+
+    const evalEmpty = buildEvaluatorPrompt({
+      taskName: 't',
+      taskDescription: '',
+      taskSteps: [],
+      verificationCriteria: [],
+      projectPath: '/tmp',
+      checkScriptSection: null,
+      projectToolingSection: '',
+      extraDimensions: [],
+    });
+    expect(evalEmpty).not.toMatch(/\{\{[A-Z_]+\}\}/);
+    // The Assessment output block still emits the four floor lines — an
+    // empty EXTRA_DIMENSIONS_ASSESSMENT_* slot must not swallow them.
+    expect(evalEmpty).toContain('**Correctness**: PASS — [one-line finding]');
+    expect(evalEmpty).toContain('**Consistency**: PASS/FAIL — [one-line finding]');
+    // No extra-dimension blocks leaked when extras is empty.
+    expect(evalEmpty).not.toContain('floor="false"');
+  });
 });

--- a/src/integration/ai/prompts/loader.ts
+++ b/src/integration/ai/prompts/loader.ts
@@ -49,13 +49,28 @@ function composePrompt(template: string, substitutions: Record<string, string>):
 }
 
 /**
- * Planner builders substitute `{{PROJECT_TOOLING}}` inside `plan-common`
- * first so the outer `composePrompt` can plug the result into `{{COMMON}}`
- * as opaque text.
+ * Neutral, ecosystem-agnostic check-gate example. Pre-expanded inside the
+ * planner partials so generated `steps` / `verificationCriteria` examples do
+ * not leak Node-specific commands (`pnpm test`, `npm run lint`) to prompts
+ * that run in Python / Go / Rust / Java / mixed repos. Downstream projects
+ * supply the real command via `{{PROJECT_TOOLING}}` at runtime.
+ */
+const CHECK_GATE_EXAMPLE =
+  "Run the project's check gate — all pass (omit this step when the project has no check script)";
+
+/**
+ * Planner builders substitute `{{PROJECT_TOOLING}}` and
+ * `{{CHECK_GATE_EXAMPLE}}` inside `plan-common` first so the outer
+ * `composePrompt` can plug the result into `{{COMMON}}` as opaque text.
  */
 function buildPlanCommon(projectToolingSection: string): string {
+  // PLAN_COMMON_EXAMPLES is substituted first so its embedded
+  // `{{CHECK_GATE_EXAMPLE}}` placeholder is caught by the subsequent
+  // iteration of composePrompt — order matters here.
   return composePrompt(loadPartial('plan-common'), {
+    PLAN_COMMON_EXAMPLES: loadPartial('plan-common-examples'),
     PROJECT_TOOLING: projectToolingSection,
+    CHECK_GATE_EXAMPLE,
   });
 }
 
@@ -69,12 +84,14 @@ function buildPlannerBase(projectToolingSection: string): {
   COMMON: string;
   VALIDATION: string;
   SIGNALS: string;
+  CHECK_GATE_EXAMPLE: string;
 } {
   return {
     HARNESS_CONTEXT: loadPartial('harness-context'),
     COMMON: buildPlanCommon(projectToolingSection),
     VALIDATION: loadPartial('validation-checklist'),
     SIGNALS: loadPartial('signals-planning'),
+    CHECK_GATE_EXAMPLE,
   };
 }
 
@@ -106,14 +123,23 @@ export function buildTaskExecutionPrompt(
   contextFileName: string,
   projectToolingSection = ''
 ): string {
-  const template = loadTemplate('task-execution');
-  // COMMIT_STEP renders as a sub-bullet under Phase 3 step 2 (verification). Keeping it
-  // as a nested list item avoids the list-gap anti-pattern: when noCommit is true, the
-  // substitution is the empty string and the surrounding numbered list stays intact.
+  let template = loadTemplate('task-execution');
+  // Prettier reflows markdown and re-indents continuation lines, so the
+  // template's indent around {{COMMIT_STEP}} / {{COMMIT_CONSTRAINT}} isn't
+  // stable. When noCommit is true, collapse the entire placeholder line
+  // (leading whitespace + placeholder + trailing newline) to a single newline
+  // so no indented-empty line survives. When false, keep the placeholder as
+  // a normal substitution — the inserted content is a peer bullet at column 0
+  // (the template surrounds the placeholder with blank lines so the bullet
+  // renders as a sibling of the other constraints, not a sub-bullet).
+  if (noCommit) {
+    template = template.replace(/^[ \t]*\{\{COMMIT_STEP\}\}\n/m, '\n');
+    template = template.replace(/^[ \t]*\{\{COMMIT_CONSTRAINT\}\}\n/m, '');
+  }
   const commitStep = noCommit
     ? ''
-    : '\n   - **Before continuing:** Create a git commit with a descriptive message for the changes made.';
-  const commitConstraint = noCommit ? '' : '- **Must commit** — Create a git commit before signaling completion.\n';
+    : '   - **Before continuing:** Create a git commit with a descriptive message for the changes made.';
+  const commitConstraint = noCommit ? '' : '- **Must commit** — Create a git commit before signaling completion.';
   return composePrompt(template, {
     HARNESS_CONTEXT: loadPartial('harness-context'),
     SIGNALS: loadPartial('signals-task'),
@@ -132,11 +158,15 @@ export function buildTicketRefinePrompt(
   issueContext = ''
 ): string {
   const template = loadTemplate('ticket-refine');
+  // Wrap non-empty issue context in <context>…</context> for canonical XML
+  // framing. Empty input stays empty — no orphan tag pair in the rendered
+  // output when the ticket carries no upstream issue link.
+  const issueContextSection = issueContext ? `<context>\n\n${issueContext}\n\n</context>` : '';
   return composePrompt(template, {
     TICKET: ticketContent,
     OUTPUT_FILE: outputFile,
     SCHEMA: schema,
-    ISSUE_CONTEXT: issueContext,
+    ISSUE_CONTEXT: issueContextSection,
   });
 }
 
@@ -221,8 +251,8 @@ function renderExtraDimensions(extras: string[]): {
 
   const section = extras
     .map(
-      (name, i) =>
-        `\n**Dimension ${String(5 + i)} — ${name}**\nAdditional task-specific dimension flagged by the planner. Apply judgment to whether the implementation satisfies this dimension given the task's verification criteria and steps.\n`
+      (name) =>
+        `\n<dimension name="${name}" floor="false">\nAdditional task-specific dimension flagged by the planner. Apply judgment to whether the implementation satisfies this dimension given the task's verification criteria and steps.\n</dimension>\n`
     )
     .join('');
 

--- a/src/integration/ai/prompts/plan-auto.md
+++ b/src/integration/ai/prompts/plan-auto.md
@@ -12,6 +12,27 @@ When finished, emit a signal from the `<signals>` block below.
 
 ## Protocol
 
+### Step 0: Think Before Writing
+
+Before emitting any JSON, write your reasoning in a `<thinking>…</thinking>` block. Use it to work through the problem
+— map tickets to repositories, reason about dependencies, identify risks, and decide on task boundaries. Explicit
+reasoning produces sharper plans than jumping straight to output.
+
+The harness's JSON extractor skips everything before the first `[`, so the `<thinking>` block is stripped
+automatically — but the JSON array itself must still be emitted without markdown fences or commentary after it.
+
+```
+<thinking>
+Ticket 1 touches both the API and the worker repo — split into two tasks with a blockedBy edge.
+The shared schema change must land first so the worker can import it.
+Verification criterion for the API task: a contract test against the new schema.
+…
+</thinking>
+[
+  { … JSON array … }
+]
+```
+
 ### Step 1: Explore the Project
 
 Scope exploration to what will change the plan — read instruction files first, then only the specific files you need
@@ -55,9 +76,13 @@ The sprint contains:
 - **Existing Tasks**: Tasks from a previous planning run (your output replaces all existing tasks)
 - **Projects**: Each ticket belongs to a project which may have multiple repository paths
 
+<context>
+
 {{CONTEXT}}
 
 {{COMMON}}
+
+</context>
 
 ### Step 5: Handle Blockers
 
@@ -72,6 +97,9 @@ If you cannot produce a valid task breakdown, signal the issue instead of output
 {{VALIDATION}}
 
 ## Output
+
+Your output MAY begin with a `<thinking>…</thinking>` block — the harness's JSON extractor skips everything before the
+first `[`. The JSON array itself must still be emitted without markdown fences or surrounding prose.
 
 Output only the JSON document matching the schema below — the harness parses your raw output directly as JSON, so emit
 it without markdown fences, commentary, or surrounding prose. If you cannot produce tasks, output a
@@ -102,7 +130,7 @@ JSON Schema:
     "steps": [
       "Create src/utils/validation.ts with validateEmail(), validatePhone(), validateDateRange()",
       "Add corresponding unit tests in src/utils/__tests__/validation.test.ts covering valid inputs, invalid inputs, and edge cases (empty strings, unicode)",
-      "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
+      "{{CHECK_GATE_EXAMPLE}}"
     ],
     "verificationCriteria": [
       "TypeScript compiles with no errors",
@@ -123,7 +151,7 @@ JSON Schema:
       "Wire up validation from src/utils/validation.ts with inline error messages",
       "Add form submission handler that calls POST /api/users",
       "Write component tests in src/components/__tests__/RegistrationForm.test.ts for valid submission, validation errors, and API failure",
-      "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
+      "{{CHECK_GATE_EXAMPLE}}"
     ],
     "verificationCriteria": [
       "TypeScript compiles with no errors",

--- a/src/integration/ai/prompts/plan-common-examples.md
+++ b/src/integration/ai/prompts/plan-common-examples.md
@@ -1,0 +1,82 @@
+<examples>
+
+The illustrations below are non-normative — they show good/bad shapes for the rules stated in `plan-common.md`. Use
+them as calibration, not templates to copy literally.
+
+## Verification Criteria — good vs bad
+
+> **Good criteria (verifiable, unambiguous):**
+>
+> - "TypeScript compiles with no errors"
+> - "All existing tests pass plus new tests for the added feature"
+> - "GET /api/users returns 200 with paginated user list"
+> - "GET /api/users?page=-1 returns 400 with validation error"
+> - "Component renders without console errors in browser"
+> - "Playwright e2e: login flow completes without errors" _(UI tasks with Playwright configured)_
+
+> **Bad criteria (vague, not independently verifiable):**
+>
+> - "Code is clean and well-structured"
+> - "Error handling is appropriate"
+> - "Performance is acceptable"
+
+## Dependency Graph — good vs bad
+
+### Good Dependency Graph
+
+```
+Task 1: Add shared validation utilities       (no deps)
+Task 2: Implement user registration form       (blockedBy: [1])
+Task 3: Implement user profile editor          (blockedBy: [1])
+Task 4: Add form submission analytics          (blockedBy: [2, 3])
+```
+
+Tasks 2 and 3 run in parallel (both depend only on 1). Task 4 waits for both.
+
+### Bad Dependency Graph
+
+```
+Task 1: Add validation utilities               (no deps)
+Task 2: Implement registration form            (blockedBy: [1])
+Task 3: Implement profile editor               (blockedBy: [2])  <-- WRONG
+Task 4: Add submission analytics               (blockedBy: [3])  <-- WRONG
+```
+
+Task 3 does not actually need Task 2 — it only needs Task 1. This creates a false serial chain that prevents parallel
+execution.
+
+## Precise Steps — good vs bad
+
+Bad — vague steps that force the agent to guess:
+
+```json
+{
+  "name": "Add user authentication",
+  "steps": ["Implement auth", "Add tests", "Update docs"]
+}
+```
+
+Good — precise steps with file paths and pattern references:
+
+```json
+{
+  "name": "Add user authentication",
+  "projectPath": "/Users/dev/my-app",
+  "steps": [
+    "Create auth service in src/services/auth.ts with login(), logout(), getCurrentUser() — follow the pattern in src/services/user.ts for error handling and return types",
+    "Add AuthContext provider in src/contexts/AuthContext.tsx wrapping the app — follow existing ThemeContext pattern",
+    "Create useAuth hook in src/hooks/useAuth.ts exposing auth state and actions",
+    "Add ProtectedRoute wrapper component in src/components/ProtectedRoute.tsx",
+    "Write unit tests in src/services/__tests__/auth.test.ts — follow test patterns in src/services/__tests__/user.test.ts",
+    "{{CHECK_GATE_EXAMPLE}}"
+  ],
+  "verificationCriteria": [
+    "TypeScript compiles with no errors",
+    "All existing tests pass plus new auth tests",
+    "ProtectedRoute redirects unauthenticated users to /login",
+    "useAuth hook exposes isAuthenticated, user, login, and logout"
+  ]
+}
+```
+
+</examples>

--- a/src/integration/ai/prompts/plan-common.md
+++ b/src/integration/ai/prompts/plan-common.md
@@ -1,16 +1,21 @@
 ## Project Resources
 
-Each repository may ship with project-specific instruction files at its root and a `.claude/` configuration directory.
-Read them during exploration and reference them throughout planning:
+During exploration, check for project instruction files if present. Treat whichever files exist as authoritative for
+that codebase; skip silently when absent.
 
-- **`CLAUDE.md` / `AGENTS.md`** — project-level rules, conventions, and persistent memory
-- **`.github/copilot-instructions.md`** — GitHub Copilot-specific repository instructions, when present
+**Instruction files (any ecosystem):**
+
+- **`CLAUDE.md` / `AGENTS.md`** — when present: project-level rules, conventions, and persistent memory
+- **`.github/copilot-instructions.md`** — when present: GitHub Copilot-specific repository instructions
+- **`README.md`** and manifest files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, …) — setup,
+  scripts, and dependencies
+
+**Claude-specific configuration (only when the repo has a `.claude/` directory):**
+
 - **`.mcp.json`** — MCP servers the project ships with (Playwright, database inspection, etc.)
 - **`.claude/agents/`** — subagent definitions for Task-tool delegation
 - **`.claude/skills/`** — custom skills invokable with the Skill tool for project-specific workflows
 - **`.claude/settings.json`** / **`.claude/settings.local.json`** — tool permissions, model preferences, hooks
-
-When repository instruction files exist, treat their instructions as authoritative for that codebase.
 
 ## What Makes a Great Task
 
@@ -63,6 +68,8 @@ Right size (one task covering the full change):
 
 ### Verification Criteria (The Evaluator Contract)
 
+_See the `<examples>` block at the end of this page for good/bad pairs._
+
 Every task must include a `verificationCriteria` array — these are the **done contract** between the generator (task
 executor) and the evaluator (independent reviewer). The evaluator grades each criterion as pass/fail across four
 floor dimensions: correctness, completeness, safety, and consistency. If ANY dimension fails, the task fails
@@ -86,21 +93,6 @@ Write criteria that are:
 - **Unambiguous** — two reviewers would agree on pass/fail
 - **Outcome-oriented** — describe WHAT is true when done, not HOW to get there
 
-> **Good criteria (verifiable, unambiguous):**
->
-> - "TypeScript compiles with no errors"
-> - "All existing tests pass plus new tests for the added feature"
-> - "GET /api/users returns 200 with paginated user list"
-> - "GET /api/users?page=-1 returns 400 with validation error"
-> - "Component renders without console errors in browser"
-> - "Playwright e2e: login flow completes without errors" _(UI tasks with Playwright configured)_
-
-> **Bad criteria (vague, not independently verifiable):**
->
-> - "Code is clean and well-structured"
-> - "Error handling is appropriate"
-> - "Performance is acceptable"
-
 Aim for 2-4 criteria per task. Include at least one criterion that is computationally checkable (test pass, type check,
 lint clean). For **UI/frontend tasks**, if the project has Playwright configured, add a browser-verifiable criterion —
 the evaluator will attempt visual verification using Playwright or browser tools when the project supports it.
@@ -108,7 +100,8 @@ the evaluator will attempt visual verification using Playwright or browser tools
 ### Guidelines
 
 1. **Outcome-oriented** — Each task delivers a testable result
-2. **Merge create+use** — Never separate "create X" from "use X" — that is one task
+2. **Merge create+use** — Keep "create X" and "use X" in one task — except when a stable contract makes them
+   independently testable (e.g. schema + migration lands first, consumer wiring lands after)
 3. **Let scope drive task count** — do not aim for a specific number. Fewer, larger coherent tasks beat many
    micro-tasks; split only when parallelism or a clean boundary justifies it
 4. **Merge serial chains** — If tasks only make sense when run in sequence, fold them into one task
@@ -134,6 +127,8 @@ the evaluator will attempt visual verification using Playwright or browser tools
 
 ## Dependency Graph
 
+_See the `<examples>` block at the end of this page for good/bad pairs._
+
 Tasks execute in dependency order — foundations before dependents.
 
 ### Guidelines
@@ -142,29 +137,6 @@ Tasks execute in dependency order — foundations before dependents.
 2. **Declare all dependencies** — Use `blockedBy` to enforce order. Do not rely on array position alone.
 3. **Maximize parallelism** — Only add `blockedBy` when there is a real code dependency
 4. **Validate the DAG** — No cycles; earlier tasks cannot depend on later ones
-
-### Good Dependency Graph
-
-```
-Task 1: Add shared validation utilities       (no deps)
-Task 2: Implement user registration form       (blockedBy: [1])
-Task 3: Implement user profile editor          (blockedBy: [1])
-Task 4: Add form submission analytics          (blockedBy: [2, 3])
-```
-
-Tasks 2 and 3 run in parallel (both depend only on 1). Task 4 waits for both.
-
-### Bad Dependency Graph
-
-```
-Task 1: Add validation utilities               (no deps)
-Task 2: Implement registration form            (blockedBy: [1])
-Task 3: Implement profile editor               (blockedBy: [2])  <-- WRONG
-Task 4: Add submission analytics               (blockedBy: [3])  <-- WRONG
-```
-
-Task 3 does not actually need Task 2 — it only needs Task 1. This creates a false serial chain that prevents parallel
-execution.
 
 **Dependency test**: For each `blockedBy` entry, ask: "Does this task literally use code produced by the blocker?" If
 not, remove the dependency.
@@ -177,9 +149,13 @@ Each task must specify which repository it executes in via `projectPath`:
 2. **Split by repo** — If a ticket affects multiple repos, create separate tasks per repo with dependencies
 3. **Use exact paths** — `projectPath` must be one of the absolute paths from the project's Repositories section
 
-Never create a task that modifies files in multiple repos — split it.
+Split cross-repo work into one task per repo with `blockedBy` — except when atomicity is genuinely required (a
+single commit must land in both repos to avoid broken state), in which case flag the task and surface the need for
+human coordination.
 
 ## Precise Step Declarations
+
+_See the `<examples>` block at the end of this page for good/bad pairs._
 
 Every task must include explicit, actionable steps — the implementation checklist.
 
@@ -194,38 +170,6 @@ Every task must include explicit, actionable steps — the implementation checkl
    instruction files
 5. **No ambiguity** — Another developer should be able to follow steps without guessing
 
-Bad — vague steps that force the agent to guess:
-
-```json
-{
-  "name": "Add user authentication",
-  "steps": ["Implement auth", "Add tests", "Update docs"]
-}
-```
-
-Good — precise steps with file paths and pattern references:
-
-```json
-{
-  "name": "Add user authentication",
-  "projectPath": "/Users/dev/my-app",
-  "steps": [
-    "Create auth service in src/services/auth.ts with login(), logout(), getCurrentUser() — follow the pattern in src/services/user.ts for error handling and return types",
-    "Add AuthContext provider in src/contexts/AuthContext.tsx wrapping the app — follow existing ThemeContext pattern",
-    "Create useAuth hook in src/hooks/useAuth.ts exposing auth state and actions",
-    "Add ProtectedRoute wrapper component in src/components/ProtectedRoute.tsx",
-    "Write unit tests in src/services/__tests__/auth.test.ts — follow test patterns in src/services/__tests__/user.test.ts",
-    "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
-  ],
-  "verificationCriteria": [
-    "TypeScript compiles with no errors",
-    "All existing tests pass plus new auth tests",
-    "ProtectedRoute redirects unauthenticated users to /login",
-    "useAuth hook exposes isAuthenticated, user, login, and logout"
-  ]
-}
-```
-
 Use actual file paths discovered during exploration. Reference the repository instruction files for verification
 commands.
 
@@ -233,6 +177,10 @@ commands.
 
 Start with an action verb (Add, Create, Update, Fix, Refactor, Remove, Migrate). Include the feature/concept, not files.
 Keep under 60 characters. Avoid vague verbs (Improve, Enhance, Handle).
+
+See `<examples>` below for concrete good/bad pairs.
+
+{{PLAN_COMMON_EXAMPLES}}
 
 ## Delegation to Available Tooling
 

--- a/src/integration/ai/prompts/plan-interactive.md
+++ b/src/integration/ai/prompts/plan-interactive.md
@@ -72,7 +72,7 @@ before the plan is finalized.
    **Steps:**
    1. Create src/utils/csvExport.ts with column formatters for date, number, and string types
    2. Add unit tests in src/utils/__tests__/csvExport.test.ts covering empty data, special characters, and large datasets
-   3. Run `pnpm typecheck && pnpm lint && pnpm test` — all pass
+   3. Run the project's check/test/build gate — all pass
    ```
 
 2. **Show the dependency graph** — Make it obvious which tasks run in parallel vs sequentially, and why each dependency
@@ -123,9 +123,13 @@ The sprint contains:
 - **Existing Tasks**: Tasks from a previous planning run (your output replaces all existing tasks)
 - **Projects**: Each ticket belongs to a project which may have multiple repository paths
 
+<context>
+
 {{CONTEXT}}
 
 {{COMMON}}
+
+</context>
 
 ### Repository Assignment
 
@@ -166,7 +170,7 @@ Use this exact JSON Schema:
     "Update ExportController.getExport() in src/controllers/export.ts to parse and validate date range params",
     "Add date range filtering to ExportRepository.findRecords() in src/repositories/export.ts",
     "Write tests in src/controllers/__tests__/export.test.ts for: no dates, valid range, invalid range, start > end",
-    "Run pnpm typecheck && pnpm lint && pnpm test — all pass"
+    "{{CHECK_GATE_EXAMPLE}}"
   ],
   "verificationCriteria": [
     "TypeScript compiles with no errors",

--- a/src/integration/ai/prompts/prompt-builder-adapter.test.ts
+++ b/src/integration/ai/prompts/prompt-builder-adapter.test.ts
@@ -111,14 +111,14 @@ describe('TextPromptBuilderAdapter', () => {
       // dropping the field on the floor.
       const taskWithExtras: Task = { ...task, extraDimensions: ['Performance'] };
       const out = adapter.buildTaskEvaluationPrompt(taskWithExtras, repoPath, null, '');
-      expect(out).toContain('**Dimension 5 — Performance**');
+      expect(out).toContain('<dimension name="Performance" floor="false">');
     });
 
     it('omits extra-dimension blocks when task.extraDimensions is undefined', () => {
       // `undefined` (not `[]`) is the floor-only case — the adapter
       // normalises it to an empty array so the loader renders nothing.
       const out = adapter.buildTaskEvaluationPrompt(task, repoPath, null, '');
-      expect(out).not.toContain('**Dimension 5');
+      expect(out).not.toContain('floor="false"');
     });
   });
 

--- a/src/integration/ai/prompts/sprint-feedback.md
+++ b/src/integration/ai/prompts/sprint-feedback.md
@@ -19,7 +19,11 @@ something entirely new (create a file, add a feature, tweak a script), do exactl
 
 ## User Feedback — Implement this
 
+<task-specification>
+
 {{FEEDBACK}}
+
+</task-specification>
 
 ## Protocol
 
@@ -27,8 +31,8 @@ something entirely new (create a file, add a feature, tweak a script), do exactl
    X. If it says "change Y", change Y. Do not ask for clarification unless the instruction is genuinely contradictory.
 2. **Implement the change** — Create or edit the files required to satisfy the feedback. Make the smallest change that
    fully carries out the instruction.
-3. **Run verification** — If the project has a check script (e.g., `pnpm test`, `pnpm typecheck`), run it and confirm
-   it passes. If no check script is configured, skip this step.
+3. **Run verification** — If the project has a check script (test, typecheck, lint, or build command), run it and
+   confirm it passes. If no check script is configured, skip this step.
 4. **Output verification results** — Wrap any verification output in `<task-verified>...</task-verified>`. If you
    skipped step 3, emit `<task-verified>no check script configured; change applied</task-verified>`.
 5. **Commit your work** — Stage the modified files and create a git commit with a descriptive message summarising the

--- a/src/integration/ai/prompts/task-evaluation.md
+++ b/src/integration/ai/prompts/task-evaluation.md
@@ -58,10 +58,16 @@ Now apply semantic judgment to what the computational checks cannot catch:
 2. **Read the changed files carefully** — understand the full implementation, not just the diff.
 3. **Read surrounding code** — check that the implementation follows existing patterns and conventions.
 4. **Augment the Project Tooling section above** — the section lists detected subagents, skills, and MCP servers.
-   Additionally skim `package.json` scripts, `playwright.config.*`, `cypress.config.*`, `vitest.config.*`, `.storybook/`,
-   `CLAUDE.md`, and `.github/copilot-instructions.md` for the test/verification stack and any conventions the section
-   didn't surface. Note which application type this is (backend API / CLI / frontend SPA / fullstack / library) — it
-   determines which verification methods apply.
+   Additionally skim repository config for the test/verification stack and any conventions the section didn't surface.
+   Note which application type this is (backend API / CLI / frontend SPA / fullstack / library) — it determines which
+   verification methods apply.
+
+   <examples>
+   Representative files to scan when present — not an exhaustive list, adapt to the ecosystem:
+   `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `playwright.config.*`, `cypress.config.*`,
+   `vitest.config.*`, `.storybook/`, `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`.
+   </examples>
+
 5. **Run extended verification when the detected tooling makes it cheap and deterministic:**
    - **Frontend/UI tasks** — if Playwright or Cypress is configured, run a targeted e2e test or use a browser MCP to
      verify the changed UI renders correctly (console errors, layout, interactive behaviour).
@@ -78,14 +84,15 @@ Evaluate the implementation across the dimensions below. Each dimension is pass/
 dimension fails, the overall evaluation fails. The first four are the floor — every task is graded on them. The
 planner may have flagged additional task-specific dimensions; when present, they are graded on top of the floor.
 
-**Dimension 1 — Correctness**
+<dimension name="Correctness" floor="true">
 Does the implementation do what the specification says? Check for:
 
 - Logical errors, off-by-one, race conditions, type issues
 - Behavior matches each verification criterion (grade each one explicitly)
 - Edge cases handled where specified
+  </dimension>
 
-**Dimension 2 — Completeness**
+<dimension name="Completeness" floor="true">
 Is the full specification implemented? Check for:
 
 - Every verification criterion is satisfied (not just most)
@@ -93,25 +100,29 @@ Is the full specification implemented? Check for:
 - No TODO/FIXME/HACK markers left behind that indicate unfinished work
 - Uncommitted changes that look like incomplete work (WIP diffs, stashed edits) — committing is expected unless the
   task's contract says otherwise
+  </dimension>
 
-**Dimension 3 — Safety**
+<dimension name="Safety" floor="true">
 Are there security or reliability issues? Check for:
 
 - Injection vulnerabilities (SQL, command, XSS)
 - Validation gaps on external input
 - Exposed secrets, hardcoded credentials
 - Unsafe error handling that leaks internals
+  </dimension>
 
-**Dimension 4 — Consistency**
+<dimension name="Consistency" floor="true">
 Does the implementation fit the codebase? Check for:
 
 - Follows existing patterns and conventions (naming, structure, error handling)
 - Uses existing utilities instead of reinventing them
 - No unnecessary changes outside the task scope — spec drift
 - Test patterns match the project's existing test style
+  </dimension>
   {{EXTRA_DIMENSIONS_SECTION}}
-  Evaluate only what was asked vs what was delivered — suggesting improvements beyond the task scope creates noise that
-  distracts from the actual pass/fail decision.
+
+Evaluate only what was asked vs what was delivered — suggesting improvements beyond the task scope creates noise that
+distracts from the actual pass/fail decision.
 
 ### Pass Bar
 
@@ -165,6 +176,8 @@ Each issue must reference which dimension it violates.]
 
 ### Calibration Examples
 
+<examples>
+
 **Example of a correct PASS:**
 
 > Task: "Add date validation to export endpoint"
@@ -192,6 +205,8 @@ Each issue must reference which dimension it violates.]
 >    unhandled exception. Add validation before query.
 > 2. [Safety] `src/repositories/users.ts:23` — `WHERE name LIKE '%${query}%'` is SQL injection. Use parameterized
 >    query: `WHERE name LIKE $1` with `%${query}%` as parameter.
+
+</examples>
 
 Be direct and specific — point to files, lines, and concrete problems.
 

--- a/src/integration/ai/prompts/task-execution.md
+++ b/src/integration/ai/prompts/task-execution.md
@@ -15,16 +15,17 @@ When finished, emit a signal from the `<signals>` block below.
 - **Respect task boundaries** — complete exactly the declared steps for this one task, then stop. Other agents may be
   working on neighboring tasks in parallel; skipping steps, improvising, or editing files outside the declared set
   causes merge conflicts with their work.
-- **Prefer fixing the code over the test** — a failing test usually indicates a bug in the implementation. Update a
-  test only when the declared steps intentionally change the behaviour it asserts (e.g. a regression fix, a contract
-  change). Do not remove, skip, or weaken a test to make a failure go away — that masks real bugs. If the right move
-  is genuinely ambiguous, signal `<task-blocked>` so a human can decide.
+- **Prefer fixing the code over the test** — a failing test usually indicates a bug in the implementation. Update
+  tests only when the declared steps intentionally change the asserted behaviour (e.g. a contract change, a regression
+  fix). If the right move is genuinely ambiguous, signal `<task-blocked>` so a human can decide — do not silently
+  weaken a test to make a failure go away.
 - **Verify before completing** — the harness runs a post-task check gate; unverified work will be caught and rejected.
 - **Append progress, never overwrite** — append each progress entry at the end of the progress file. Overwriting
   erases context that downstream tasks depend on.
 - **Leave {{CONTEXT_FILE}} and task definitions alone** — the context file is cleaned up by the harness (committing it
   pollutes the repo); the task name, description, steps, and other task files are immutable.
-  {{COMMIT_CONSTRAINT}}
+
+{{COMMIT_CONSTRAINT}}
 
 </constraints>
 
@@ -93,7 +94,8 @@ Complete these steps IN ORDER:
 1. **Confirm all steps done** — Every task step has been completed
 2. **Run ALL verification commands** — Execute every verification command (see Check Script section in the context file
    or project instructions). Fix any failures before proceeding. The harness runs the check script as a post-task
-   gate — your task is not marked done unless it passes.{{COMMIT_STEP}}
+   gate — your task is not marked done unless it passes.
+   {{COMMIT_STEP}}
 3. **Update progress file** — Append to {{PROGRESS_FILE}} using this format:
 
    ```markdown
@@ -142,17 +144,15 @@ Complete these steps IN ORDER:
    - The WHERE clause builder in src/repositories/base.ts can be extended for future filters
    ```
 
-4. **Output verification results:**
+4. **Output verification results** — use the actual commands the harness ran; the examples below are illustrative:
 
 <!-- prettier-ignore -->
 ```
 <task-verified>
-$ pnpm typecheck
-No type errors
-$ pnpm lint
-No lint errors
-$ pnpm test
-47 tests passed
+$ <check-command-1>
+<output>
+$ <check-command-2>
+<output>
 </task-verified>
 ```
 

--- a/src/integration/ai/prompts/ticket-refine.md
+++ b/src/integration/ai/prompts/ticket-refine.md
@@ -223,9 +223,13 @@ The `ref` field should match either:
 - The ticket's internal ID
 - The exact ticket title
 
+<task-specification>
+
 ## Ticket to Refine
 
 {{TICKET}}
+
+</task-specification>
 
 {{ISSUE_CONTEXT}}
 

--- a/src/integration/ai/prompts/validation-checklist.md
+++ b/src/integration/ai/prompts/validation-checklist.md
@@ -1,3 +1,5 @@
+<validation-checklist>
+
 ## Pre-Output Validation
 
 Before writing the JSON output, verify EVERY item:
@@ -12,3 +14,5 @@ Before writing the JSON output, verify EVERY item:
 8. **`projectPath` assigned** — every task uses a path from the available repositories
 9. **Verification criteria** — every task has 2-4 `verificationCriteria` that are testable and unambiguous
 10. **Raw JSON output** — the output is valid JSON matching the schema exactly; the harness parses the output directly as JSON, so emit it without markdown fences, commentary, or surrounding prose
+
+</validation-checklist>


### PR DESCRIPTION
## Summary

Tightens all 15 prompt templates under `src/integration/ai/prompts/*.md` to be ecosystem-generic (Node / Python / Go / Rust / Java) and structurally consistent per Anthropic's prompt-engineering guidance.

- Audit report at `.claude/docs/PROMPT-AUDIT.md` — per-file checklist, canonical XML vocabulary, CI-locked anti-patterns.
- De-Node-ified example JSON via `{{CHECK_GATE_EXAMPLE}}` placeholder; softened default so planners don't push a check-gate criterion on projects with no check script.
- Canonical XML vocabulary applied (`<context>`, `<requirements>`, `<constraints>`, `<examples>`, `<dimension>`, `<task-specification>`) — biggest structural win is the evaluator rubric.
- `<thinking>` scratchpads added to headless planners (`plan-auto`, `ideate-auto`) — evidence-backed CoT lift; parser already strips pre-JSON content.
- `plan-common.md` trimmed 263 → 197 lines by extracting illustrations into a new `<examples>`-wrapped partial — compounding savings across four inlined planner prompts.
- CI-locked anti-patterns in `loader.test.ts` + TUI-parity fixture asserting byte-identical output across callers.

## Commits

| SHA | Scope |
|---|---|
| `b807056` | `#75 docs(prompts): document prompt audit framework and canonical vocabulary` |
| `060ffd1` | `#75 feat(prompts): add thinking scratchpad to headless planners` |
| `18963c5` | `#75 refactor(prompts): extract plan-common examples into partial` |
| `4a06b2f` | `#75 fix(prompts): align templates with canonical XML vocabulary` |
| `a496fb4` | `#75 feat(prompts): soften CHECK_GATE_EXAMPLE and fix COMMIT_STEP rendering` |

## Acceptance criteria (#75)

- [x] Written audit report (checkbox table) covering all 15 files — `.claude/docs/PROMPT-AUDIT.md`
- [x] Concrete diff proposals per file — see commits
- [x] Loader tests still pass; step traces on pipeline integration tests unchanged
- [x] Anti-patterns documented back into `CLAUDE.md § Prompt Template Engineering`
- [x] TUI parity — prompts are surface-agnostic by construction; byte-identical output regardless of caller

## Candidate improvements from #75 — status

- [x] Wrap input context blocks in `<context>` / `<requirements>` / `<task-specification>` XML tags
- [x] Add a `<thinking>` scratchpad to `plan-auto.md` and `ideate-auto.md` (headless modes)
- [x] Trim `plan-common.md` — split into a compact required block + an optional `<examples>` partial
- [x] XML-structure the evaluator's four floor dimensions
- [x] `validation-checklist.md` confirmed load-bearing (inlined into every planner-role prompt)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 104 files / 1381 tests passing
- [ ] Smoke run across one Node + one Python repo (manual, post-merge)

## Follow-ups (not blocking merge)

- Dynamic `CHECK_GATE_EXAMPLE` expansion based on per-repo `checkScript` config — separate ticket.
- `<thinking>` scratchpad for `task-evaluation.md` evaluator — separate ticket.
- Few-shot `<examples>` injection in planners — needs a curated corpus (tracked in `ARCHITECTURE.md § Future Work`).

Closes #75.