### PR TITLE
chore: version-check TTL fix + merge-pr/release skills

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: merge-pr
+description: Land an open PR on this repo — wait for CI to finish, then merge with a merge commit using admin bypass. Use whenever the user says "merge this PR", "/merge-pr", "ship the PR", "land the PR", or asks to merge a specific PR number. Defaults to the PR opened from the current branch.
+when_to_use: After a PR is opened and CI is running (or done) and the user wants it landed. Also used as the merge step inside the `release` skill. Skip when the PR isn't open yet — open it first.
+allowed-tools: Bash
+---
+
+# Merge PR
+
+Standard end-of-PR landing flow for `lukas-grigis/ralphctl`.
+
+Repo + branch-protection facts that shape this flow (verified via `gh repo view` /
+`gh api .../branches/main/protection`):
+
+- Only **merge commits** allowed — squash and rebase are off. `gh pr merge --squash` would 422.
+- `deleteBranchOnMerge: true` — branches auto-delete after merge. **Do not pass `--delete-branch`.**
+- `main` requires 1 approving review. Solo maintainer can't self-approve, so admin bypass is the standard tool here.
+  `enforce_admins` is `false`, so the bypass is honored by the API.
+
+## Args
+
+- `<pr-number>` (optional) — when omitted, derive from the current branch via `gh pr view --json number,...`.
+
+## Flow
+
+1. **Resolve the PR.** If no number given:
+
+   ```bash
+   gh pr view --json number,title,state,headRefName,baseRefName,mergeable
+   ```
+
+   Bail if `state != OPEN` or `baseRefName != main`. Show the user `title` + `headRefName` so they see what they're
+   about to land.
+
+2. **Watch CI.** Block until checks finish:
+
+   ```bash
+   gh pr checks <num> --watch --fail-fast
+   ```
+
+   On failure: surface the failing check name + URL. **Do not retry, do not merge.** Hand back to the user — they decide
+   whether to push a fix or close the PR.
+
+3. **Merge with admin bypass.**
+
+   ```bash
+   gh pr merge <num> --merge --admin
+   ```
+
+   `--admin` is the load-bearing flag — it tells the GitHub API to use the caller's admin permissions to merge through
+   the required-review rule.
+
+4. **Confirm.** Print the merge commit SHA:
+
+   ```bash
+   gh pr view <num> --json mergeCommit -q .mergeCommit.oid
+   ```
+
+5. **Clean up the trailing branch.** The remote branch is gone (`deleteBranchOnMerge: true` handled it), but the local copy and stale remote-tracking ref still linger. Switch back to `main` and delete them:
+
+   ```bash
+   BRANCH="$(gh pr view <num> --json headRefName -q .headRefName)"
+   git checkout main
+   git pull --ff-only origin main           # fast-forward to the new merge commit
+   git fetch --prune                          # drop the stale `origin/<branch>` ref
+   git branch -D "$BRANCH" 2>/dev/null || true   # ok if it was never checked out locally
+   ```
+
+   If the local checkout has unpushed work that _isn't_ on the merged PR (rare, but possible if the user kept committing after pushing), `git branch -d` would refuse — `-D` is intentional here because the canonical history is now on `main` via the merge commit. Surface a warning if the deleted branch had commits not reachable from `main`.
+
+## Why these defaults
+
+- **`--merge`, not `--squash` / `--rebase`** — repo policy. The existing `chore(release): X.Y.Z (#NN)` commit subjects
+  on `main` are merge-commit subjects; preserving that shape keeps tags aligned with PR history.
+- **`--admin`** — the required-review rule exists for safety on multi-contributor PRs but blocks solo workflows. Admin
+  bypass is the explicit "I am the reviewer" escape hatch. Use it knowingly, not silently.
+- **No `--auto`** — `--watch` then merge is faster than the auto-merge queue and surfaces CI failures synchronously.
+
+## When NOT to use
+
+- **Stacked / dependent PRs** that need a specific merge order — sequence those manually, one `merge-pr` per stack tip.
+- **PRs targeting branches other than `main`** — admin bypass is configured for `main`'s protection rules; other
+  branches may have different rules and silently failing reviews shouldn't be papered over.
+- **PRs with unresolved review threads you actually care about** — `--admin` will merge through them. Address first;
+  don't bury them under the merge commit.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: release
+description:
+  Cut a new release of ralphctl — bumps `package.json`, promotes the `## [Unreleased]` CHANGELOG section to a dated `## [X.Y.Z]`, opens a `chore(release): X.Y.Z` PR, defers to `merge-pr` to wait for CI and merge with admin bypass, then tags the merge commit and pushes the tag (which fires the `release.yml` workflow → npm publish + GitHub Release). Use when the user says "/release X.Y.Z", "release X.Y.Z", "ship 1.2.3", "cut a new version", or otherwise asks to publish a new version of ralphctl.
+when_to_use: When the user explicitly asks to ship a release. Requires the version arg in semver form (e.g. `0.4.5`, no `v` prefix). Pre-conditions checked at runtime — clean working tree on `main`, no other release branch in flight, `## [Unreleased]` has content worth releasing.
+allowed-tools: Bash, Read, Edit
+---
+
+# Release
+
+End-to-end release flow for `lukas-grigis/ralphctl`. Mirrors the established pattern (v0.4.2 / v0.4.3 / v0.4.4):
+branch → bump → changelog → PR → CI → merge → tag → workflow.
+
+## Arg
+
+- `<version>` — semver, no `v` prefix (e.g. `0.4.5`, `1.0.0-rc.1`). Reject anything that doesn't match
+  `^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$`.
+
+## Pre-flight (stop on any failure — don't try to recover)
+
+```bash
+git rev-parse --abbrev-ref HEAD                   # must be `main`
+[ -z "$(git status --porcelain)" ]                # working tree clean
+git fetch origin && git pull --ff-only origin main
+node -p "require('./package.json').version"       # must be < <version>
+```
+
+If any check fails, surface the exact problem and stop. Don't stash, don't switch branches, don't auto-fix — the user
+wants to know.
+
+Also confirm `## [Unreleased]` in `CHANGELOG.md` has actual entries (not just the heading). If empty, stop and ask the
+user — there's nothing to release.
+
+## Steps
+
+1. **Branch.** `git checkout -b release/<version>`
+
+2. **Bump `package.json`.** Edit the `"version"` field directly. **Do not** use `npm version` / `pnpm version` — those
+   create a tag immediately, and we tag the _merge commit on `main`_, not the release-branch commit.
+
+3. **Promote the changelog.** In `CHANGELOG.md`, replace exactly:
+
+   ```
+   ## [Unreleased]
+   ```
+
+   with:
+
+   ```
+   ## [Unreleased]
+
+   ## [<version>] - <YYYY-MM-DD>
+   ```
+
+   Use today's UTC date in ISO format (`date -u +%Y-%m-%d`). Keep the existing entries where they are — they belong
+   under the new dated heading by virtue of position. The heading format is **load-bearing**: `release.yml` extracts the
+   GitHub Release body by `awk`-ing for `## [<version>]`, and a typo there silently falls back to a `git log` blob.
+
+4. **Local gate.** Run the project's full check sequence (same as the `verify` skill):
+
+   ```bash
+   pnpm typecheck && pnpm lint && pnpm test
+   ```
+
+   All three must pass. If anything fails, stop — fix on a separate branch first; don't pile fixes onto a release
+   branch.
+
+5. **Commit + push.**
+
+   ```bash
+   git add package.json CHANGELOG.md
+   git commit -m "chore(release): <version>"
+   git push -u origin release/<version>
+   ```
+
+6. **Open the PR.**
+
+   ```bash
+   gh pr create --base main \
+     --title "chore(release): <version>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+
+   - Bump version to <version>
+   - Promote `## [Unreleased]` CHANGELOG section to `## [<version>]`
+
+   ## Test plan
+
+   - [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
+   - [ ] CI green
+   EOF
+   )"
+   ```
+
+   Capture the PR number from the output URL.
+
+7. **Defer to `merge-pr`.** Follow the `merge-pr` skill with the new PR number — it `--watch`es CI, runs
+   `gh pr merge --merge --admin`, then **cleans up the trailing branch** (switches to `main`, fast-forwards, prunes the
+   stale remote-tracking ref, deletes the local `release/<version>`). The merge commit lands on `main` with subject
+   `chore(release): <version> (#NN)`. (See `.claude/skills/merge-pr/SKILL.md` for the why behind `--merge --admin`.)
+
+8. **Tag the merge commit.** `merge-pr` already left us on `main` at the merge commit, so just tag and push:
+
+   ```bash
+   git tag v<version>                        # tags HEAD = the merge commit
+   git push origin v<version>
+   ```
+
+9. **Watch the release workflow.** Tag push fires `.github/workflows/release.yml`:
+   - re-runs format / lint / typecheck / test / build
+   - verifies tag matches `package.json` version
+   - publishes to npm with `--provenance`
+   - creates a GitHub Release using the matching `## [<version>]` section as the body
+
+   ```bash
+   sleep 3   # let GH register the workflow run
+   gh run watch --exit-status \
+     "$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+   ```
+
+10. **Done.** Print:
+    - npm: `https://www.npmjs.com/package/ralphctl/v/<version>`
+    - Release: `https://github.com/lukas-grigis/ralphctl/releases/tag/v<version>`
+
+## Failure recovery
+
+- **Local gate red:** Stop. Fix on a non-release branch. Restart `release` once `main` is green again.
+- **CI red on the PR (step 7):** Don't merge. The branch is still a normal branch — push fixes, and `merge-pr`
+  re-watches.
+- **Workflow red after tag push (step 9):** The tag is already public. **Do not delete or move it** — npm provenance
+  will refuse to re-publish the same version, and consumers may have already pulled. Cut the next patch version with the
+  fix.
+- **Cold feet before merge:** `gh pr close <num>` (auto-deletes the branch). No tag has been pushed yet. The version
+  bump + changelog promotion exist only on the closed PR.
+
+## Why this shape
+
+- **Branch + PR (not direct push to `main`):** Branch protection requires a PR. Even with admin bypass, the audit trail
+  and the PR's CI run are valuable — the workflow re-runs everything, but the PR catches issues before tagging (and tags
+  are forever once published).
+- **Tag the merge commit, not the release-branch tip:** The published artifact must match what's actually on `main`.
+  Tagging the merge commit guarantees `git checkout v<version>` shows the same tree `main` had at release time.
+- **One source of truth for release notes:** The workflow extracts `## [<version>] - <YYYY-MM-DD>` from `CHANGELOG.md`.
+  Match the format exactly; otherwise the GitHub Release body silently falls back to a raw `git log` dump (still works,
+  but noisy).
+- **Admin bypass is loud, on purpose:** Each release surfaces the bypass via `--admin` rather than relying on auto-merge
+  with weakened protections. The protections stay strict; the bypass is invoked explicitly.

--- a/src/integration/external/version-check.test.ts
+++ b/src/integration/external/version-check.test.ts
@@ -90,14 +90,14 @@ describe('checkLatestVersion', () => {
     expect(existsSync(join(tempDir, 'version-check.json'))).toBe(false);
   });
 
-  it('refetches when cache is stale (>24h)', async () => {
+  it('refetches when cache is stale (>1h)', async () => {
     const { checkLatestVersion } = await load();
     const current = getCurrent();
     const stale = {
       current,
       latest: '1.0.0',
       updateAvailable: false,
-      checkedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+      checkedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
     };
     writeFileSync(join(tempDir, 'version-check.json'), JSON.stringify(stale), 'utf-8');
 

--- a/src/integration/external/version-check.ts
+++ b/src/integration/external/version-check.ts
@@ -19,7 +19,7 @@ export interface VersionCheck {
   readonly checkedAt: string; // ISO8601
 }
 
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1h
 const FETCH_TIMEOUT_MS = 3000;
 const REGISTRY_URL = 'https://registry.npmjs.org/ralphctl/latest';
 


### PR DESCRIPTION
## Summary

- Reduce version-check cache TTL from 24h to 1h so update notifications surface the same day a release lands.
- Add `/merge-pr` and `/release` skills under `.claude/skills/` to codify the end-of-PR and release flows.

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` all green
- [ ] Version-check test covers the 1h TTL refetch path