### PR TITLE
chore(release): 0.4.5

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,8 +28,34 @@ node -p "require('./package.json').version"       # must be < <version>
 If any check fails, surface the exact problem and stop. Don't stash, don't switch branches, don't auto-fix — the user
 wants to know.
 
-Also confirm `## [Unreleased]` in `CHANGELOG.md` has actual entries (not just the heading). If empty, stop and ask the
-user — there's nothing to release.
+### `## [Unreleased]` auto-draft
+
+Check whether `## [Unreleased]` has content. Grab the body between that heading and the next `## [` heading:
+
+```bash
+awk '/^## \[Unreleased\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md | sed '/^$/d'
+```
+
+**If empty,** auto-draft entries from the commit range since the last tag, **skipping contributor-side tooling that
+isn't shipped to npm** (`.claude/**`, `.github/**`, `CHANGELOG.md`, `CLAUDE.md`):
+
+```bash
+LAST_TAG="$(git describe --tags --abbrev=0)"
+git log --no-merges --pretty='- %s' "${LAST_TAG}..HEAD" -- \
+  ':!.claude' ':!.github' ':!CHANGELOG.md' ':!CLAUDE.md'
+```
+
+Group the surviving commit subjects by conventional-commit prefix into `### Added` (`feat:`), `### Fixed` (`fix:`),
+`### Changed` (`refactor:` / `perf:` / user-facing `chore:`). Write the result under `## [Unreleased]` in
+`CHANGELOG.md` (edit only — don't commit yet; the release commit in step 5 picks it up).
+
+**If the filtered `git log` is also empty,** there's nothing user-facing to release — stop and tell the user. Don't
+promote an empty section; `release.yml` would fall back to a raw `git log` dump and ship noise.
+
+**If the original `## [Unreleased]` had content,** skip the draft — the user already wrote what they want. Proceed.
+
+Surface the drafted entries back to the user before moving on so they can veto / rewrite in-place on the release
+branch if anything looks off.
 
 ## Steps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-04-24
+
+### Fixed
+
+- **Version-check cache TTL reduced from 24h to 1h** — update notifications now
+  surface the same day a release lands on npm rather than up to a day later.
+
 ## [0.4.4] - 2026-04-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.4.5
- Promote `## [Unreleased]` CHANGELOG section to `## [0.4.5]` — Fixed: version-check cache TTL reduced from 24h to 1h
- Teach `/release` skill to auto-draft `## [Unreleased]` from `git log` since the last tag when the section is empty (still stops if the filtered range yields nothing user-facing)

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (1540 tests)
- [ ] CI green