### PR TITLE
fix(execute): surface failure reason and stop truncating check output

### DIFF
--- a/src/business/pipelines/execute/executor-integration.test.ts
+++ b/src/business/pipelines/execute/executor-integration.test.ts
@@ -363,7 +363,7 @@ function buildDeps(scenario: Scenario = {}): {
     spawnInteractive: () => Promise.resolve(),
   } as unknown as AiSessionPort;
 
-  const runCheckScript = scenario.runCheckScript ?? vi.fn(() => ({ passed: true, output: '' }));
+  const runCheckScript = scenario.runCheckScript ?? vi.fn(() => Promise.resolve({ passed: true, output: '' }));
   const verifyBranch = scenario.verifyBranch ?? vi.fn(() => true);
   const hasUncommittedChanges = scenario.hasUncommittedChanges ?? (() => false);
 
@@ -557,8 +557,8 @@ describe('executeTasksStep via forEachTask — integration', () => {
     const task = makeTask();
     // runCheckScript: sprint-start passes, task-complete fails.
     const runCheckScript = vi.fn((_path: string, _script: string, phase: string) => {
-      if (phase === 'sprintStart') return { passed: true, output: '' };
-      return { passed: false, output: 'lint failed' };
+      if (phase === 'sprintStart') return Promise.resolve({ passed: true, output: '' });
+      return Promise.resolve({ passed: false, output: 'lint failed' });
     });
 
     const scenario = buildDeps({

--- a/src/business/pipelines/steps/run-check-scripts.test.ts
+++ b/src/business/pipelines/steps/run-check-scripts.test.ts
@@ -77,7 +77,7 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const sprint = makeSprint();
     const tasks = [makeTask('r-a'), makeTask('r-a', 'task2'), makeTask('r-b', 'task3')];
     const project = makeProject([makeRepo('r-a', '/a', 'echo ok'), makeRepo('r-b', '/b', 'echo ok2')]);
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(
       project,
@@ -95,7 +95,7 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const sprint = makeSprint({ checkRanAt: { 'r-a': '2020-01-01' } });
     const tasks = [makeTask('r-a')];
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check')]);
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -115,7 +115,9 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const tasks = [makeTask('r-a')];
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check')]);
     const saveSprint = vi.fn(() => Promise.resolve());
-    const external = { runCheckScript: vi.fn(() => ({ passed: true, output: 'ok' })) } as unknown as ExternalPort;
+    const external = {
+      runCheckScript: vi.fn(() => Promise.resolve({ passed: true, output: 'ok' })),
+    } as unknown as ExternalPort;
     const persistence = makePersistence(project, saveSprint);
 
     const step = runCheckScriptsStep<Ctx>(external, persistence, 'sprint-start');
@@ -132,7 +134,7 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const tasks = [makeTask('r-a')];
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check')]);
     const external = {
-      runCheckScript: vi.fn(() => ({ passed: false, output: 'linting failed' })),
+      runCheckScript: vi.fn(() => Promise.resolve({ passed: false, output: 'linting failed' })),
     } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -148,7 +150,7 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const sprint = makeSprint();
     const tasks = [makeTask('r-a')];
     const project = makeProject([makeRepo('r-a', '/a')]); // no script
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -163,7 +165,7 @@ describe('runCheckScriptsStep — sprint-start mode', () => {
     const sprint = makeSprint();
     const tasks = [makeTask('r-a', 'done-task', 'done'), makeTask('r-b')];
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check'), makeRepo('r-b', '/b', 'pnpm check')]);
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -188,7 +190,7 @@ describe('runCheckScriptsStep — post-task mode', () => {
   it('runs check for the target repo', async () => {
     const sprint = makeSprint();
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check')]);
-    const runCheck = vi.fn(() => ({ passed: true, output: 'ok' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: 'ok' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -204,7 +206,7 @@ describe('runCheckScriptsStep — post-task mode', () => {
     const sprint = makeSprint();
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check')]);
     const external = {
-      runCheckScript: vi.fn(() => ({ passed: false, output: 'test failure' })),
+      runCheckScript: vi.fn(() => Promise.resolve({ passed: false, output: 'test failure' })),
     } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -227,7 +229,7 @@ describe('runCheckScriptsStep — post-task mode', () => {
   it('treats missing check script as pass (no side effects)', async () => {
     const sprint = makeSprint();
     const project = makeProject([makeRepo('r-a', '/a')]); // no script
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 
@@ -241,7 +243,7 @@ describe('runCheckScriptsStep — post-task mode', () => {
   it('passes per-repo checkTimeout when configured', async () => {
     const sprint = makeSprint();
     const project = makeProject([makeRepo('r-a', '/a', 'pnpm check', 9999)]);
-    const runCheck = vi.fn(() => ({ passed: true, output: '' }));
+    const runCheck = vi.fn(() => Promise.resolve({ passed: true, output: '' }));
     const external = { runCheckScript: runCheck } as unknown as ExternalPort;
     const persistence = makePersistence(project);
 

--- a/src/business/pipelines/steps/run-check-scripts.ts
+++ b/src/business/pipelines/steps/run-check-scripts.ts
@@ -11,6 +11,19 @@ import { findProjectForRepoId, resolveCheckScriptForRepo } from './project-looku
 
 type CheckScriptsMode = 'sprint-start' | 'post-task';
 
+/** Lines of check-script output to include in the error message. Build tools
+ *  (Maven, pnpm) report the actual failure at the tail of their output, so
+ *  we keep the last N lines and drop the rest. The full output is still
+ *  retained in `checkResults[repoId].output` for downstream consumers. */
+const ERROR_OUTPUT_TAIL_LINES = 100;
+
+function tailOutput(output: string, maxLines = ERROR_OUTPUT_TAIL_LINES): string {
+  const lines = output.split('\n');
+  if (lines.length <= maxLines) return output;
+  const hidden = lines.length - maxLines;
+  return `[${String(hidden)} earlier line${hidden !== 1 ? 's' : ''} omitted]\n${lines.slice(-maxLines).join('\n')}`;
+}
+
 interface RunCheckScriptsOptions {
   /** Force re-running a check even if `sprint.checkRanAt` already has a
    *  timestamp for the repo. Only meaningful in `'sprint-start'` mode. */
@@ -69,7 +82,7 @@ export function runCheckScriptsStep<
           if (!resolved || !checkScript) continue;
 
           const { repo } = resolved;
-          const result = external.runCheckScript(repo.path, checkScript, 'sprintStart', repo.checkTimeout);
+          const result = await external.runCheckScript(repo.path, checkScript, 'sprintStart', repo.checkTimeout);
 
           if (!result.passed) {
             checkResults[repoId] = {
@@ -77,7 +90,9 @@ export function runCheckScriptsStep<
               success: false,
               output: result.output,
             };
-            return Result.error(new StorageError(`Check failed for ${repo.path}: ${checkScript}\n${result.output}`));
+            return Result.error(
+              new StorageError(`Check failed for ${repo.path}: ${checkScript}\n${tailOutput(result.output)}`)
+            );
           }
 
           const ranAt = new Date().toISOString();
@@ -108,7 +123,7 @@ export function runCheckScriptsStep<
         }
 
         const { repo } = resolved;
-        const result = external.runCheckScript(repo.path, checkScript, 'taskComplete', repo.checkTimeout);
+        const result = await external.runCheckScript(repo.path, checkScript, 'taskComplete', repo.checkTimeout);
 
         checkResults[targetRepoId] = {
           projectPath: repo.path,
@@ -118,7 +133,7 @@ export function runCheckScriptsStep<
 
         if (!result.passed) {
           return Result.error(
-            new StorageError(`Post-task check failed for ${repo.path}: ${checkScript}\n${result.output}`)
+            new StorageError(`Post-task check failed for ${repo.path}: ${checkScript}\n${tailOutput(result.output)}`)
           );
         }
       }

--- a/src/business/ports/execution-registry.test.ts
+++ b/src/business/ports/execution-registry.test.ts
@@ -325,5 +325,7 @@ describe('ExecutionRegistryPort contract', () => {
     await Promise.resolve();
 
     expect(statuses).toEqual(['running', 'failed']);
+    // The failure reason is carried on the snapshot so the UI can surface it.
+    expect(registry.get('exec-1')?.error?.message).toBe('boom');
   });
 });

--- a/src/business/ports/execution-registry.ts
+++ b/src/business/ports/execution-registry.ts
@@ -29,6 +29,12 @@ export type ExecutionStatus = 'running' | 'completed' | 'failed' | 'cancelled';
  * Public view of an in-flight or terminal execution. The registry stores a
  * private `Entry` per execution (see the in-memory adapter) and exposes only
  * this projection to callers so the UI never reaches into lifecycle internals.
+ *
+ * `error` is populated on `status === 'failed'` entries so the UI can surface
+ * the failure reason. It's a plain data shape — `Error`/`DomainError` instances
+ * are intentionally not leaked across the port. `stepName` is set when the
+ * caught error is a `StepError` (see `src/domain/errors.ts`) so the view can
+ * tell the user which pipeline step blew up.
  */
 export interface RunningExecution {
   id: string;
@@ -39,6 +45,7 @@ export interface RunningExecution {
   startedAt: Date;
   endedAt?: Date;
   summary?: ExecutionSummary;
+  error?: { message: string; stepName?: string };
 }
 
 /**

--- a/src/business/ports/external.ts
+++ b/src/business/ports/external.ts
@@ -26,7 +26,7 @@ export interface ExternalPort {
   // --- Check script execution ---
 
   /** Run a check/lifecycle script in a project directory */
-  runCheckScript(projectPath: string, script: string, phase: string, timeout?: number): CheckScriptResult;
+  runCheckScript(projectPath: string, script: string, phase: string, timeout?: number): Promise<CheckScriptResult>;
 
   // --- Git operations ---
 

--- a/src/business/usecases/execute.test.ts
+++ b/src/business/usecases/execute.test.ts
@@ -133,7 +133,7 @@ function buildFeedbackDeps(feedbackResponses: (string | null)[], spawnOutput = '
   for (const r of feedbackResponses) getFeedback.mockResolvedValueOnce(r);
 
   const spawnWithRetry = vi.fn().mockResolvedValue({ output: spawnOutput, sessionId: 'sid' });
-  const runCheckScript = vi.fn().mockReturnValue({ passed: true });
+  const runCheckScript = vi.fn().mockResolvedValue({ passed: true });
 
   const handleProgress = vi.fn().mockResolvedValue({ ok: true });
   const handleNote = vi.fn().mockResolvedValue({ ok: true });

--- a/src/business/usecases/execute.ts
+++ b/src/business/usecases/execute.ts
@@ -239,7 +239,7 @@ export class ExecuteTasksUseCase {
 
     this.logger.info(`Running post-task check: ${checkScript}`);
     const { repo } = resolved;
-    const result = this.external.runCheckScript(repo.path, checkScript, 'taskComplete', repo.checkTimeout);
+    const result = await this.external.runCheckScript(repo.path, checkScript, 'taskComplete', repo.checkTimeout);
 
     if (result.passed) {
       this.logger.success('Post-task check: passed');

--- a/src/integration/external/external-adapter.ts
+++ b/src/integration/external/external-adapter.ts
@@ -54,7 +54,7 @@ export class DefaultExternalAdapter implements ExternalPort {
 
   // --- Check script execution ---
 
-  runCheckScript(projectPath: string, script: string, phase: string, timeout?: number): CheckScriptResult {
+  runCheckScript(projectPath: string, script: string, phase: string, timeout?: number): Promise<CheckScriptResult> {
     return runLifecycleHook(projectPath, script, phase as LifecycleEvent, timeout);
   }
 

--- a/src/integration/external/lifecycle.test.ts
+++ b/src/integration/external/lifecycle.test.ts
@@ -1,21 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
-  return {
-    ...actual,
-    spawnSync: vi.fn(),
-  };
-});
+import { runLifecycleHook } from './lifecycle.ts';
 
 describe('runLifecycleHook', () => {
   let tempDir: string;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(join(tmpdir(), 'ralphctl-lifecycle-'));
   });
 
@@ -25,79 +17,46 @@ describe('runLifecycleHook', () => {
   });
 
   it('returns passed:true on exit 0', async () => {
-    const { spawnSync } = await import('node:child_process');
-    const { runLifecycleHook } = await import('./lifecycle.ts');
-
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: 'All tests passed',
-      stderr: '',
-      pid: 1,
-      output: [],
-      signal: null,
-    });
-
-    const result = runLifecycleHook(tempDir, 'pnpm test', 'taskComplete');
-
+    const result = await runLifecycleHook(tempDir, 'echo "All tests passed"', 'taskComplete');
     expect(result.passed).toBe(true);
     expect(result.output).toContain('All tests passed');
   });
 
   it('returns passed:false on non-zero exit', async () => {
-    const { spawnSync } = await import('node:child_process');
-    const { runLifecycleHook } = await import('./lifecycle.ts');
-
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 1,
-      stdout: '',
-      stderr: '3 tests failed',
-      pid: 1,
-      output: [],
-      signal: null,
-    });
-
-    const result = runLifecycleHook(tempDir, 'pnpm test', 'sprintStart');
-
+    const result = await runLifecycleHook(tempDir, 'echo "3 tests failed" >&2; exit 1', 'sprintStart');
     expect(result.passed).toBe(false);
     expect(result.output).toContain('3 tests failed');
   });
 
   it('captures both stdout and stderr in output', async () => {
-    const { spawnSync } = await import('node:child_process');
-    const { runLifecycleHook } = await import('./lifecycle.ts');
-
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: 'stdout content',
-      stderr: 'stderr content',
-      pid: 1,
-      output: [],
-      signal: null,
-    });
-
-    const result = runLifecycleHook(tempDir, 'pnpm test', 'taskComplete');
-
-    expect(result.output).toContain('stdout content');
-    expect(result.output).toContain('stderr content');
+    const result = await runLifecycleHook(tempDir, 'echo stdout-content; echo stderr-content >&2', 'taskComplete');
+    expect(result.output).toContain('stdout-content');
+    expect(result.output).toContain('stderr-content');
   });
 
-  it('uses RALPHCTL_SETUP_TIMEOUT_MS env var for timeout', async () => {
-    const { spawnSync } = await import('node:child_process');
-    const { runLifecycleHook } = await import('./lifecycle.ts');
+  it('captures >2MB of output without buffer overflow (regression for #maxBuffer)', async () => {
+    // Emit 2 MB of stdout synchronously via fs.writeSync. With the old
+    // spawnSync + default 1 MB maxBuffer, Node would kill the child with
+    // SIGTERM and status: null, making the check spuriously "fail" even
+    // though the script exited 0. fs.writeSync is used instead of
+    // process.stdout.write so the bytes flush before the child exits
+    // (process.stdout.write is asynchronous when stdio is piped).
+    const script = 'node -e "const fs=require(\\"fs\\"); fs.writeSync(1, \\"x\\".repeat(2*1024*1024))"';
+    const result = await runLifecycleHook(tempDir, script, 'sprintStart');
+    expect(result.passed).toBe(true);
+    expect(result.output.length).toBeGreaterThanOrEqual(2 * 1024 * 1024);
+  }, 15_000);
 
-    process.env['RALPHCTL_SETUP_TIMEOUT_MS'] = '30000';
+  it('kills the child and marks failed on timeout', async () => {
+    const result = await runLifecycleHook(tempDir, 'sleep 5', 'taskComplete', 200);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain('timeout exceeded after 200ms');
+  });
 
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: '',
-      stderr: '',
-      pid: 1,
-      output: [],
-      signal: null,
-    });
-
-    runLifecycleHook(tempDir, 'pnpm test', 'sprintStart');
-
-    expect(spawnSync).toHaveBeenCalledWith('pnpm test', expect.objectContaining({ timeout: 30000 }));
+  it('uses RALPHCTL_SETUP_TIMEOUT_MS env var when no explicit override given', async () => {
+    process.env['RALPHCTL_SETUP_TIMEOUT_MS'] = '150';
+    const result = await runLifecycleHook(tempDir, 'sleep 5', 'sprintStart');
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain('timeout exceeded after 150ms');
   });
 });

--- a/src/integration/external/lifecycle.ts
+++ b/src/integration/external/lifecycle.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { assertSafeCwd } from '@src/integration/persistence/paths.ts';
 
 /** Lifecycle events where hooks can fire. Extend this union for new phases. */
@@ -11,6 +11,17 @@ interface HookResult {
 
 /** Default timeout for lifecycle hooks: 5 minutes. Override via RALPHCTL_SETUP_TIMEOUT_MS. */
 const DEFAULT_HOOK_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Hard cap on combined stdout+stderr buffered in memory (50 MB).
+ *
+ * Replaces Node's silent 1 MB default on `spawnSync` / `execFile` — real-world
+ * check scripts like `mvn clean install` on a Spring/Hibernate backend can
+ * emit 5-10 MB legitimately. If the cap is hit we kill the child and surface
+ * an explicit truncation marker rather than letting the overflow manifest as
+ * a spurious "check failed".
+ */
+const MAX_OUTPUT_BYTES = 50 * 1024 * 1024;
 
 function getHookTimeoutMs(): number {
   const envVal = process.env['RALPHCTL_SETUP_TIMEOUT_MS'];
@@ -26,25 +37,81 @@ function getHookTimeoutMs(): number {
  *
  * Scripts are user-configured via `project add` or `project repo add` —
  * they are NOT arbitrary AI-generated commands.
+ *
+ * Streams stdout/stderr to in-memory buffers (no 1 MB `maxBuffer` cap from
+ * `spawnSync` — see `MAX_OUTPUT_BYTES`). Kills the child on timeout or when
+ * the output cap is exceeded and surfaces an explicit marker in `output`.
  */
 export function runLifecycleHook(
   projectPath: string,
   script: string,
   event: LifecycleEvent,
   timeoutOverrideMs?: number
-): HookResult {
+): Promise<HookResult> {
   assertSafeCwd(projectPath);
   const timeoutMs = timeoutOverrideMs ?? getHookTimeoutMs();
 
-  const result = spawnSync(script, {
-    cwd: projectPath,
-    shell: true,
-    stdio: ['pipe', 'pipe', 'pipe'],
-    encoding: 'utf-8',
-    timeout: timeoutMs,
-    env: { ...process.env, RALPHCTL_LIFECYCLE_EVENT: event },
-  });
+  return new Promise<HookResult>((resolve) => {
+    const child = spawn(script, {
+      cwd: projectPath,
+      shell: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, RALPHCTL_LIFECYCLE_EVENT: event },
+    });
 
-  const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
-  return { passed: result.status === 0, output };
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let timedOut = false;
+    let capExceeded = false;
+    let settled = false;
+
+    const appendChunk = (chunk: Buffer): void => {
+      if (capExceeded) return;
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_OUTPUT_BYTES) {
+        capExceeded = true;
+        child.kill('SIGTERM');
+        return;
+      }
+      chunks.push(chunk);
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      appendChunk(chunk);
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      appendChunk(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    const finish = (passed: boolean, suffix?: string): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const base = Buffer.concat(chunks).toString('utf-8').trim();
+      const output = suffix ? (base ? `${base}\n${suffix}` : suffix) : base;
+      resolve({ passed, output });
+    };
+
+    child.on('error', (err) => {
+      // Spawn failure (e.g. shell missing). Surface the error message.
+      finish(false, `[spawn error: ${err.message}]`);
+    });
+
+    child.on('close', (code) => {
+      if (timedOut) {
+        finish(false, `[timeout exceeded after ${String(timeoutMs)}ms]`);
+        return;
+      }
+      if (capExceeded) {
+        finish(false, `[output exceeded ${String(MAX_OUTPUT_BYTES)} byte cap — truncated]`);
+        return;
+      }
+      finish(code === 0);
+    });
+  });
 }

--- a/src/integration/external/lifecycle.ts
+++ b/src/integration/external/lifecycle.ts
@@ -52,12 +52,33 @@ export function runLifecycleHook(
   const timeoutMs = timeoutOverrideMs ?? getHookTimeoutMs();
 
   return new Promise<HookResult>((resolve) => {
+    // detached: true makes the child a process-group leader so SIGTERM to
+    // -pid reaches descendants (e.g. `sleep` spawned by `sh -c`). Without
+    // this, killing the shell on Linux leaves the grandchild holding stdio
+    // open and `close` never fires. Windows has no process groups.
     const child = spawn(script, {
       cwd: projectPath,
       shell: true,
+      detached: process.platform !== 'win32',
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, RALPHCTL_LIFECYCLE_EVENT: event },
     });
+
+    const killTree = (): void => {
+      if (process.platform !== 'win32' && typeof child.pid === 'number') {
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+          return;
+        } catch {
+          // Group already gone — fall through to direct kill.
+        }
+      }
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // Already dead — nothing to do.
+      }
+    };
 
     const chunks: Buffer[] = [];
     let totalBytes = 0;
@@ -70,7 +91,7 @@ export function runLifecycleHook(
       totalBytes += chunk.length;
       if (totalBytes > MAX_OUTPUT_BYTES) {
         capExceeded = true;
-        child.kill('SIGTERM');
+        killTree();
         return;
       }
       chunks.push(chunk);
@@ -85,7 +106,7 @@ export function runLifecycleHook(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
+      killTree();
     }, timeoutMs);
 
     const finish = (passed: boolean, suffix?: string): void => {

--- a/src/integration/runtime/execution-registry.test.ts
+++ b/src/integration/runtime/execution-registry.test.ts
@@ -9,7 +9,9 @@
 
 import { describe, expect, it } from 'vitest';
 import type { Project, Sprint } from '@src/domain/models.ts';
+import { StepError } from '@src/domain/errors.ts';
 import type { LoggerPort } from '@src/business/ports/logger.ts';
+import type { LogEvent } from '@src/business/ports/log-event-bus.ts';
 import type { PersistencePort } from '@src/business/ports/persistence.ts';
 import type { SignalBusPort } from '@src/business/ports/signal-bus.ts';
 import type { SharedDeps } from '@src/integration/shared-deps.ts';
@@ -170,5 +172,94 @@ describe('InMemoryExecutionRegistry — scope isolation', () => {
     await Promise.resolve();
 
     expect(registry.get('exec-1')?.status).toBe('completed');
+  });
+});
+
+describe('InMemoryExecutionRegistry — failure surface', () => {
+  async function startFailing(err: Error): Promise<InMemoryExecutionRegistry> {
+    const sprint = makeSprint('s', 'p');
+    const project = makeProject('p', 'alpha');
+    const persistence = makePersistence({ sprints: [sprint], projects: [project] });
+
+    const runner: PipelineRunner = () => Promise.reject(err);
+
+    const registry = new InMemoryExecutionRegistry({
+      baseShared: makeBaseShared(persistence),
+      runner,
+      generateId: () => 'exec-1',
+    });
+
+    await registry.start({ sprintId: 's' });
+    // Two microtask drains — one for the rejected runner, one for the catch
+    // block to run and call transition.
+    await Promise.resolve();
+    await Promise.resolve();
+    return registry;
+  }
+
+  it('failed status carries a plain-string error message when the runner throws a vanilla Error', async () => {
+    const registry = await startFailing(new Error('boom'));
+    const snapshot = registry.get('exec-1');
+    expect(snapshot?.status).toBe('failed');
+    expect(snapshot?.error?.message).toBe('boom');
+    expect(snapshot?.error?.stepName).toBeUndefined();
+  });
+
+  it('failed status round-trips stepName when the runner throws a StepError', async () => {
+    const registry = await startFailing(new StepError("Step 'load-sprint' failed: boom", 'load-sprint'));
+    const snapshot = registry.get('exec-1');
+    expect(snapshot?.status).toBe('failed');
+    expect(snapshot?.error?.message).toBe("Step 'load-sprint' failed: boom");
+    expect(snapshot?.error?.stepName).toBe('load-sprint');
+  });
+
+  it('emits an error-level log event on the scoped LogEventBus when the runner rejects', async () => {
+    const registry = await startFailing(new StepError("Step 'run-check-scripts' failed: exit 1", 'run-check-scripts'));
+    const bus = registry.getLogEventBus('exec-1');
+    if (!bus) throw new Error('expected scoped LogEventBus');
+
+    // The in-memory bus micro-batches on a timer; drain synchronously.
+    const captured: LogEvent[] = [];
+    bus.subscribe((batch) => {
+      for (const e of batch) captured.push(e);
+    });
+    // The default InMemoryLogEventBus exposes `flush` for tests; cast narrowly.
+    (bus as unknown as { flush: () => void }).flush();
+
+    const errorLog = captured.find((e) => e.kind === 'log' && e.level === 'error');
+    expect(errorLog).toBeDefined();
+    if (errorLog?.kind === 'log') {
+      expect(errorLog.message).toContain('run-check-scripts');
+      expect(errorLog.message).toContain('exit 1');
+    }
+  });
+
+  it('cancellation still reads as cancelled (no error forwarded)', async () => {
+    const sprint = makeSprint('s', 'p');
+    const project = makeProject('p', 'alpha');
+    const persistence = makePersistence({ sprints: [sprint], projects: [project] });
+
+    const runner: PipelineRunner = (_scopedShared, { abortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        abortSignal.addEventListener('abort', () => {
+          reject(new Error('interrupted'));
+        });
+      });
+    };
+
+    const registry = new InMemoryExecutionRegistry({
+      baseShared: makeBaseShared(persistence),
+      runner,
+      generateId: () => 'exec-1',
+    });
+
+    await registry.start({ sprintId: 's' });
+    registry.cancel('exec-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshot = registry.get('exec-1');
+    expect(snapshot?.status).toBe('cancelled');
+    expect(snapshot?.error).toBeUndefined();
   });
 });

--- a/src/integration/runtime/execution-registry.ts
+++ b/src/integration/runtime/execution-registry.ts
@@ -28,7 +28,7 @@ import type {
   StartExecutionParams,
   Unsubscribe,
 } from '@src/business/ports/execution-registry.ts';
-import { ExecutionAlreadyRunningError } from '@src/domain/errors.ts';
+import { ExecutionAlreadyRunningError, StepError } from '@src/domain/errors.ts';
 import type { ExecutionSummary } from '@src/business/usecases/execute.ts';
 import type { SignalBusPort } from '@src/business/ports/signal-bus.ts';
 import type { LogEventBus } from '@src/business/ports/log-event-bus.ts';
@@ -154,14 +154,31 @@ export class InMemoryExecutionRegistry implements ExecutionRegistryPort {
         this.transition(executionId, 'completed', summary ?? undefined);
       }
     } catch (err) {
-      void err;
       // A rejected pipeline after cancellation should still read as cancelled —
       // e.g. when the runner throws because the abort interrupted a step.
+      // Cancellation is not a failure: don't forward the error.
       if (abortSignal.aborted) {
         this.transition(executionId, 'cancelled');
-      } else {
-        this.transition(executionId, 'failed');
+        return;
       }
+
+      const errInfo: RunningExecution['error'] =
+        err instanceof StepError
+          ? { message: err.message, stepName: err.stepName }
+          : { message: err instanceof Error ? err.message : String(err) };
+
+      // Publish the error to the scoped LogEventBus so a live <LogTail />
+      // shows it alongside the terminal banner.
+      const entry = this.entries.get(executionId);
+      entry?.logEventBus.emit({
+        kind: 'log',
+        level: 'error',
+        message: errInfo.stepName ? `[${errInfo.stepName}] ${errInfo.message}` : errInfo.message,
+        context: {},
+        timestamp: new Date(),
+      });
+
+      this.transition(executionId, 'failed', undefined, errInfo);
     }
   }
 
@@ -195,7 +212,12 @@ export class InMemoryExecutionRegistry implements ExecutionRegistryPort {
     return this.entries.get(id)?.logEventBus ?? null;
   }
 
-  private transition(executionId: string, status: ExecutionStatus, summary?: ExecutionSummary): void {
+  private transition(
+    executionId: string,
+    status: ExecutionStatus,
+    summary?: ExecutionSummary,
+    error?: RunningExecution['error']
+  ): void {
     const entry = this.entries.get(executionId);
     if (!entry) return;
     if (entry.execution.status === status) return;
@@ -204,6 +226,7 @@ export class InMemoryExecutionRegistry implements ExecutionRegistryPort {
       status,
       endedAt: new Date(),
       summary: summary ?? entry.execution.summary,
+      error: error ?? entry.execution.error,
     };
     entry.execution = next;
     this.notify(next);

--- a/src/integration/ui/tui/components/log-tail.test.tsx
+++ b/src/integration/ui/tui/components/log-tail.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * LogTail tests — verify that:
+ *   (a) only `visibleLines` events render by default (cap enforcement)
+ *   (b) `scrollOffset > 0` slides the window up to show older events
+ *   (c) the "N hidden" indicator appears when the buffer exceeds the window
+ *   (d) "no activity yet" renders on an empty buffer
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { LogEvent } from '@src/business/ports/log-event-bus.ts';
+import { LogTail } from './log-tail.tsx';
+
+const EMPTY_CONTEXT = {} as import('@src/business/ports/logger.ts').LogContext;
+
+function logEvent(message: string): LogEvent {
+  return { kind: 'log', level: 'info', message, context: EMPTY_CONTEXT, timestamp: new Date() };
+}
+
+function makeEvents(count: number): LogEvent[] {
+  return Array.from({ length: count }, (_, i) => logEvent(`line ${String(i + 1)}`));
+}
+
+describe('LogTail', () => {
+  it('renders "no activity yet" for an empty event list', () => {
+    const { lastFrame } = render(<LogTail events={[]} />);
+    expect(lastFrame() ?? '').toContain('no activity yet');
+  });
+
+  it('renders all events when count is within visibleLines', () => {
+    const events = makeEvents(5);
+    const { lastFrame } = render(<LogTail events={events} visibleLines={10} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('line 1');
+    expect(frame).toContain('line 5');
+  });
+
+  it('only renders the last visibleLines events when buffer exceeds the cap', () => {
+    // Use padded labels so "event-005" cannot match "event-015".
+    const events = Array.from({ length: 25 }, (_, i): LogEvent => {
+      const n = i + 1;
+      const label = `event-${String(n).padStart(3, '0')}`;
+      return { kind: 'log', level: 'info', message: label, context: EMPTY_CONTEXT, timestamp: new Date() };
+    });
+    const { lastFrame } = render(<LogTail events={events} visibleLines={15} scrollOffset={0} />);
+    const frame = lastFrame() ?? '';
+    // Window should be events 11-25.
+    expect(frame).not.toContain('event-010');
+    expect(frame).toContain('event-011');
+    expect(frame).toContain('event-025');
+  });
+
+  it('shows a hidden-count indicator when buffer exceeds visibleLines', () => {
+    const events = makeEvents(20);
+    const { lastFrame } = render(<LogTail events={events} visibleLines={10} scrollOffset={0} />);
+    const frame = lastFrame() ?? '';
+    // At least "10 hidden" should appear somewhere
+    expect(frame).toMatch(/10 hidden/);
+  });
+
+  it('scrollOffset > 0 slides the window up to expose older events', () => {
+    // 25 padded events, window=10, offset=10 → shows events 006-015
+    const events = Array.from({ length: 25 }, (_, i): LogEvent => {
+      const n = i + 1;
+      return {
+        kind: 'log',
+        level: 'info',
+        message: `event-${String(n).padStart(3, '0')}`,
+        context: EMPTY_CONTEXT,
+        timestamp: new Date(),
+      };
+    });
+    const { lastFrame } = render(<LogTail events={events} visibleLines={10} scrollOffset={10} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('event-006');
+    expect(frame).toContain('event-015');
+    expect(frame).not.toContain('event-016');
+  });
+
+  it('clamps scrollOffset to maxOffset so the window never goes out of range', () => {
+    // offset=9999 on 5 events → clamps to show whatever is available
+    const events = makeEvents(5);
+    const { lastFrame } = render(<LogTail events={events} visibleLines={10} scrollOffset={9999} />);
+    const frame = lastFrame() ?? '';
+    // All 5 events are within the window even at max offset
+    expect(frame).toContain('line 1');
+    expect(frame).toContain('line 5');
+  });
+
+  it('shows lines-above indicator when scrollOffset is positive', () => {
+    const events = makeEvents(30);
+    const { lastFrame } = render(<LogTail events={events} visibleLines={10} scrollOffset={5} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('above');
+  });
+});

--- a/src/integration/ui/tui/components/log-tail.tsx
+++ b/src/integration/ui/tui/components/log-tail.tsx
@@ -1,9 +1,15 @@
 /**
- * LogTail — renders the last N log events emitted on `logEventBus`.
+ * LogTail — renders a scrollable window of log events emitted on `logEventBus`.
  *
  * The Ink sink translates LoggerPort calls into structured `LogEvent`s — this
  * component flattens each event into a single coloured line. Headers and
  * separators are kept compact so the tail stays readable in a small terminal.
+ *
+ * Scrolling:
+ *   - `scrollOffset = 0` means "stick to bottom" (default, live-update mode).
+ *   - `scrollOffset > 0` means the user has paged up; auto-scroll is frozen.
+ *   - The parent controls `scrollOffset` and passes it as a prop so key
+ *     handling lives in the view (which already owns `useInput`).
  */
 
 import React, { useMemo } from 'react';
@@ -14,7 +20,14 @@ import { Spinner } from '@src/integration/ui/tui/components/spinner.tsx';
 
 interface Props {
   events: readonly LogEvent[];
-  limit?: number;
+  /** How many lines to display at once. Defaults to 8. */
+  visibleLines?: number;
+  /**
+   * How many lines above the natural tail the user has scrolled.
+   * 0 = stick-to-bottom. Positive values show older events.
+   * Clamped internally so callers don't have to guard boundaries.
+   */
+  scrollOffset?: number;
 }
 
 function levelColor(level: LogEventLevel): string | undefined {
@@ -108,12 +121,20 @@ function renderLine(event: LogEvent, index: number, isActiveSpinner: boolean): R
   }
 }
 
-export function LogTail({ events, limit = 8 }: Props): React.JSX.Element {
-  const tail = events.slice(-limit);
+export function LogTail({ events, visibleLines = 8, scrollOffset = 0 }: Props): React.JSX.Element {
+  // Clamp offset so callers don't have to guard upper/lower bounds.
+  const maxOffset = Math.max(0, events.length - visibleLines);
+  const clampedOffset = Math.min(Math.max(0, scrollOffset), maxOffset);
+
+  // Slice the visible window. When offset=0 this is the tail; when offset>0
+  // we show older events above that tail.
+  const end = events.length - clampedOffset;
+  const start = Math.max(0, end - visibleLines);
+  const window = events.slice(start, end);
 
   // A spinner-start is "active" if no later event with the same id has
   // resolved it (succeed/fail/stop). Scan the full events array — not just
-  // the tail — so a spinner whose terminator got trimmed still counts as
+  // the window — so a spinner whose terminator got trimmed still counts as
   // resolved. Memoized because this runs on every ~16ms signal-bus flush.
   const resolvedIds = useMemo(() => {
     const ids = new Set<number>();
@@ -125,13 +146,30 @@ export function LogTail({ events, limit = 8 }: Props): React.JSX.Element {
     return ids;
   }, [events]);
 
+  const scrolledUp = clampedOffset > 0;
+  const hiddenAbove = start;
+  const hiddenBelow = events.length - end;
+
   return (
     <Box flexDirection="column">
-      <Text dimColor>── Log ─────────────────────────────</Text>
-      {tail.length === 0 ? (
+      <Box>
+        <Text dimColor>── Log ─────────────────────────────</Text>
+        {scrolledUp ? (
+          <Text dimColor>
+            {'  '}
+            {glyphs.arrowRight} {hiddenAbove} line{hiddenAbove !== 1 ? 's' : ''} above
+            {hiddenBelow > 0 ? ` · ${String(hiddenBelow)} below` : ''}
+          </Text>
+        ) : events.length > visibleLines ? (
+          <Text dimColor>
+            {'  '}({events.length - visibleLines} hidden)
+          </Text>
+        ) : null}
+      </Box>
+      {window.length === 0 ? (
         <Text dimColor>(no activity yet)</Text>
       ) : (
-        tail.map((event, i) => {
+        window.map((event, i) => {
           const active = event.kind === 'spinner-start' && !resolvedIds.has(event.id);
           return renderLine(event, i, active);
         })

--- a/src/integration/ui/tui/views/execute-view.test.tsx
+++ b/src/integration/ui/tui/views/execute-view.test.tsx
@@ -154,7 +154,7 @@ vi.mock('@src/integration/ui/prompts/hooks.ts', () => ({
   useCurrentPrompt: () => null,
 }));
 
-import { initialState, reduceEvents, ExecuteView } from './execute-view.tsx';
+import { initialState, reduceEvents, ExecuteView, buildErrorCard } from './execute-view.tsx';
 
 function renderWithRouter(element: React.ReactElement): ReturnType<typeof render> {
   return render(
@@ -275,5 +275,89 @@ describe('ExecuteView — attach / start behaviour', () => {
     await flush();
 
     expect(currentRegistry.cancelCalls).toContain('exec-cancel');
+  });
+
+  it('renders the failure reason when attaching to a failed execution', async () => {
+    const failed: RunningExecution = {
+      ...makeExecution('exec-fail', 'sprint-f', 'failed'),
+      endedAt: new Date(),
+      error: { message: 'sprint not found: sprint-f', stepName: 'load-sprint' },
+    };
+    currentRegistry = makeStubRegistry({ entry: failed });
+
+    const { lastFrame } = renderWithRouter(<ExecuteView sprintId="sprint-f" executionId="exec-fail" />);
+    await flush();
+    await flush();
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Execution failed');
+    expect(frame).toContain('sprint not found: sprint-f');
+    expect(frame).toContain('load-sprint');
+  });
+
+  it('renders the log tail before the failure card so the card is pinned at the bottom', async () => {
+    const failed: RunningExecution = {
+      ...makeExecution('exec-order', 'sprint-o', 'failed'),
+      endedAt: new Date(),
+      error: { message: 'build failed', stepName: 'run-check-scripts' },
+    };
+    currentRegistry = makeStubRegistry({ entry: failed });
+
+    const { lastFrame } = renderWithRouter(<ExecuteView sprintId="sprint-o" executionId="exec-order" />);
+    await flush();
+    await flush();
+
+    const frame = lastFrame() ?? '';
+    const errorIdx = frame.indexOf('Execution failed');
+    const logIdx = frame.indexOf('── Log');
+    // The log header must appear BEFORE the ResultCard title in the rendered
+    // output — this ensures the error card is pinned at the bottom of the
+    // viewport, not buried in terminal scrollback by a long log tail.
+    expect(errorIdx).toBeGreaterThanOrEqual(0);
+    expect(logIdx).toBeGreaterThanOrEqual(0);
+    expect(logIdx).toBeLessThan(errorIdx);
+  });
+
+  it('does not expose PgUp/PgDn/g/G scroll keys', () => {
+    // The hints arrays are module-level constants — we verify they contain
+    // only the keys the user asked to keep (c and Enter).
+    // We import the view file itself to check, but the simplest verification
+    // is that no hint entry in either hints set mentions those keys.
+    // Since the constants are not exported we read the rendered frame instead.
+    const running = makeExecution('exec-hints', 'sprint-h', 'running');
+    currentRegistry = makeStubRegistry({ entry: running });
+
+    const { lastFrame } = renderWithRouter(<ExecuteView sprintId="sprint-h" executionId="exec-hints" />);
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('PgUp');
+    expect(frame).not.toContain('PgDn');
+    // 'g' and 'G' as single-key bindings won't appear in the hint footer.
+    expect(frame).not.toContain('log top');
+    expect(frame).not.toContain('log bottom');
+  });
+});
+
+describe('buildErrorCard', () => {
+  it('returns all lines when message is short', () => {
+    const { lines, fields } = buildErrorCard({ message: 'line one\nline two', stepName: 'my-step' });
+    expect(lines).toEqual(['line one', 'line two']);
+    expect(fields).toEqual([['Step', 'my-step']]);
+  });
+
+  it('keeps the last 20 lines and prepends an omission marker — build-tool errors report at the tail', () => {
+    const longMessage = Array.from({ length: 30 }, (_, i) => `line ${String(i + 1)}`).join('\n');
+    const { lines } = buildErrorCard({ message: longMessage });
+    // Should have 1 omission marker + 20 content lines = 21 entries
+    expect(lines).toHaveLength(21);
+    expect(lines[0]).toContain('10 earlier line');
+    expect(lines[0]).toContain('omitted');
+    // First retained content line is line 11 (lines 1–10 dropped).
+    expect(lines[1]).toBe('line 11');
+    expect(lines[lines.length - 1]).toBe('line 30');
+  });
+
+  it('returns undefined fields when stepName is absent', () => {
+    const { fields } = buildErrorCard({ message: 'oops' });
+    expect(fields).toBeUndefined();
   });
 });

--- a/src/integration/ui/tui/views/execute-view.tsx
+++ b/src/integration/ui/tui/views/execute-view.tsx
@@ -22,7 +22,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useStdout } from 'ink';
 import type { HarnessEvent } from '@src/business/ports/signal-bus.ts';
 import type { RunningExecution } from '@src/business/ports/execution-registry.ts';
 import type { ExecutionOptions } from '@src/domain/context.ts';
@@ -46,6 +46,38 @@ import type { ExecutionSummary } from '@src/business/usecases/execute.ts';
 
 const EXECUTE_HINTS_RUNNING = [{ key: 'c', action: 'cancel' }] as const;
 const EXECUTE_HINTS_TERMINAL = [{ key: 'Enter', action: 'back' }] as const;
+
+/**
+ * Fixed row overhead consumed by the execute view's non-log chrome on a
+ * terminal-state screen (error card visible). Counted conservatively:
+ *
+ *   1  SectionStamp header
+ *   1  section margin (spacing.section = 1)
+ *   1  sprint name row
+ *   1  section margin
+ *   1  SprintSummary
+ *   1  section margin
+ *   5  TaskGrid (minimum rows assumed — variable, but we need a floor)
+ *   1  section margin
+ *   1  log "── Log ───" header row (inside LogTail)
+ *   3  error card minimum (glyph+title + step field + 1 msg line)
+ *   1  KeyboardHints row
+ *   1  StatusBar row
+ *   2  safety margin
+ *  ──
+ *  20  fixed overhead
+ *
+ * Remaining rows (`terminalRows - FIXED_OVERHEAD`) are given to the log tail.
+ * The floor of 3 ensures at least a sliver of context is visible even on tiny
+ * terminals.
+ */
+const LOG_TAIL_FIXED_OVERHEAD = 20;
+/** Minimum log lines shown even on very small terminals. */
+const LOG_TAIL_MIN_LINES = 3;
+/** Default when terminal height is unknown (non-TTY / tests). */
+const LOG_TAIL_DEFAULT_LINES = 8;
+/** Maximum characters from an error message before truncating in the ResultCard. */
+const ERROR_MESSAGE_MAX_LINES = 20;
 
 interface Props {
   sprintId: string;
@@ -102,6 +134,7 @@ export function ExecuteView({ sprintId, executionId, executionOptions }: Props):
   const registryEvents = useRegistryEvents(registry);
   const [attach, setAttach] = useState<AttachState>(initialAttach);
   const [state, setState] = useState(initialState);
+  const { stdout } = useStdout();
   const processedCountRef = useRef(0);
   const startedRef = useRef(false);
 
@@ -222,6 +255,14 @@ export function ExecuteView({ sprintId, executionId, executionOptions }: Props):
     }
   }, [signalEvents, shared, sprintId]);
 
+  // Derive how many log lines fit in the viewport. `stdout.rows` is the live
+  // terminal height (undefined in non-TTY / test environments). We subtract
+  // the fixed chrome budget to leave what's left for the log. The result is
+  // clamped to at least LOG_TAIL_MIN_LINES so tiny terminals still see context.
+  const logVisibleLines = stdout.rows
+    ? Math.max(LOG_TAIL_MIN_LINES, stdout.rows - LOG_TAIL_FIXED_OVERHEAD)
+    : LOG_TAIL_DEFAULT_LINES;
+
   const status = liveExecution?.status ?? 'running';
   const terminal = status === 'completed' || status === 'failed' || status === 'cancelled';
   const [closePromptRun, setClosePromptRun] = useState(false);
@@ -263,6 +304,10 @@ export function ExecuteView({ sprintId, executionId, executionOptions }: Props):
   // View-local keys:
   //   - `c` while running → cancel via the registry (keeps the user on-view)
   //   - Enter on a terminal execution → pop back to the previous frame
+  //
+  // Log scrolling is intentionally absent. The log auto-tails to its end so
+  // the user always sees the most recent events without any interaction.
+  // Full output is available in the sprint's progress.md.
   useInput((input, key) => {
     if (attach.kind === 'attached' && liveExecution?.status === 'running' && input === 'c') {
       registry.cancel(liveExecution.id);
@@ -314,6 +359,11 @@ export function ExecuteView({ sprintId, executionId, executionOptions }: Props):
     );
   }
 
+  // Build error card content — truncate very long messages so the ResultCard
+  // stays readable. The full output is always in the log tail below.
+  const errorCard =
+    terminal && liveExecution?.status === 'failed' && liveExecution.error ? buildErrorCard(liveExecution.error) : null;
+
   return (
     <ViewShell title="Execute">
       <Box>
@@ -357,24 +407,38 @@ export function ExecuteView({ sprintId, executionId, executionOptions }: Props):
         </Box>
       ) : null}
 
+      {/* Log tail — always rendered first (above the outcome card) so that on a
+          terminal transition the card lands at the bottom of the viewport, just
+          above the hints/status-bar chrome. The tail auto-sticks to its end so
+          the user sees the most-recent events with no key interaction needed.
+          `logVisibleLines` is computed from the live terminal height so the
+          log never pushes the card into terminal scrollback. */}
       <Box marginTop={spacing.section}>
-        <LogTail events={logEvents} />
+        <LogTail events={logEvents} visibleLines={logVisibleLines} scrollOffset={0} />
       </Box>
 
+      {/* Terminal outcome block — rendered AFTER the log tail so it is pinned
+          at the bottom of the viewport (just above hints) when a run finishes. */}
       {terminal && liveExecution ? (
         <Box marginTop={spacing.section} flexDirection="column">
-          <Text color={terminalColor(liveExecution.status)} bold>
-            {terminalGlyph(liveExecution.status)} Execution {liveExecution.status}
-          </Text>
-          {liveExecution.summary ? (
-            <Text dimColor>
-              {liveExecution.summary.completed} completed {glyphs.inlineDot} {liveExecution.summary.remaining} remaining{' '}
-              {glyphs.inlineDot} {liveExecution.summary.blocked} blocked
-              {'  ('}
-              {liveExecution.summary.stopReason}
-              {')'}
-            </Text>
-          ) : null}
+          {errorCard ? (
+            <ResultCard kind="error" title="Execution failed" fields={errorCard.fields} lines={errorCard.lines} />
+          ) : (
+            <>
+              <Text color={terminalColor(liveExecution.status)} bold>
+                {terminalGlyph(liveExecution.status)} Execution {liveExecution.status}
+              </Text>
+              {liveExecution.summary ? (
+                <Text dimColor>
+                  {liveExecution.summary.completed} completed {glyphs.inlineDot} {liveExecution.summary.remaining}{' '}
+                  remaining {glyphs.inlineDot} {liveExecution.summary.blocked} blocked
+                  {'  ('}
+                  {liveExecution.summary.stopReason}
+                  {')'}
+                </Text>
+              ) : null}
+            </>
+          )}
         </Box>
       ) : null}
     </ViewShell>
@@ -391,6 +455,31 @@ function terminalGlyph(status: RunningExecution['status']): string {
   if (status === 'completed') return glyphs.check;
   if (status === 'failed') return glyphs.cross;
   return glyphs.warningGlyph;
+}
+
+/**
+ * Build the fields + lines for a failure ResultCard. Truncates the error
+ * message to the LAST ERROR_MESSAGE_MAX_LINES lines — build tools (Maven,
+ * pnpm, etc.) report the actual failure at the tail of their output, so
+ * head-truncation would show only banners and dependency resolution noise.
+ *
+ * Exported for unit testing.
+ */
+export function buildErrorCard(error: NonNullable<RunningExecution['error']>): {
+  fields: [string, string][] | undefined;
+  lines: string[];
+} {
+  const fields: [string, string][] | undefined = error.stepName ? [['Step', error.stepName]] : undefined;
+  const rawLines = error.message.split('\n');
+  if (rawLines.length <= ERROR_MESSAGE_MAX_LINES) {
+    return { fields, lines: rawLines };
+  }
+  const hidden = rawLines.length - ERROR_MESSAGE_MAX_LINES;
+  const visibleLines = [
+    `(${String(hidden)} earlier line${hidden !== 1 ? 's' : ''} omitted)`,
+    ...rawLines.slice(-ERROR_MESSAGE_MAX_LINES),
+  ];
+  return { fields, lines: visibleLines };
 }
 
 interface CollisionProps {


### PR DESCRIPTION
## Summary

- Replace `spawnSync` with streaming `spawn` in lifecycle hooks — Node's silent 1 MB `maxBuffer` was killing real `mvn` builds mid-run; cap raised to 50 MB.
- Execution registry now forwards the full `StepError` (message + `stepName`) to `RunningExecution` and the scoped `LogEventBus` instead of swallowing it with `void err`.
- Execute view pins the failure `ResultCard` above the hints, auto-tails the log to terminal height, drops unused scroll keys.
- Check-script errors and the failure card now render the **last** lines of output — build tools report failures at the tail, not the head.

## Test plan

- [x] \`pnpm typecheck && pnpm lint && pnpm test\` green
- [ ] Manual: trigger a failing \`mvn\` build larger than 1 MB and confirm the dashboard shows the tail of the failure output, not a premature buffer-overflow error
- [ ] Manual: confirm the failure \`ResultCard\` stays pinned above the keyboard hints in the execute view