### PR TITLE
fix(0.6.2): entrypoint guard rejected the npm-installed ralphctl shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-04
+
+Hotfix on top of 0.6.1. The previous bundles silently no-op'd when invoked through the npm-installed
+`ralphctl` shim — so `npm i -g ralphctl && ralphctl --version` exited 0 with no output.
+
+### Fixed
+
+- `entrypoint.ts#shouldAutoInvoke` no longer rejects symlinked bins. The basename allowlist
+  (`cli.mjs` / `entrypoint.ts`) skipped `main()` when `process.argv[1]` was the npm-global
+  `<prefix>/bin/ralphctl` symlink. Replaced with the canonical "am I the entry module?" check —
+  resolve `argv[1]` through `realpathSync` and compare against `import.meta.url`. Added an e2e
+  regression that spawns `dist/cli.mjs` through a renamed symlink and asserts on the version output.
+
 ## [0.6.1] - 2026-05-04
 
 Quality follow-up to 0.6.0 — bumps the build chain to TypeScript 6, lifts a runtime patch on `zod`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",

--- a/src/__e2e__/cli.e2e.test.ts
+++ b/src/__e2e__/cli.e2e.test.ts
@@ -12,7 +12,7 @@
  * without a preceding manual build step.
  */
 import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -156,5 +156,34 @@ describe('CLI e2e smoke (built dist/cli.mjs)', () => {
     expect(r.status).not.toBe(0);
     // Commander emits "unknown command" to stderr by default.
     expect((r.stderr + r.stdout).toLowerCase()).toMatch(/unknown command|invalid|error/);
+  });
+
+  // Regression for the 0.6.0 / 0.6.1 entrypoint bug. `shouldAutoInvoke()`
+  // was basename-gated to `cli.mjs` / `entrypoint.ts`, so when npm linked
+  // `<prefix>/bin/ralphctl` → `dist/cli.mjs`, `process.argv[1]` was the
+  // shim path and the basename check rejected it — `main()` never ran and
+  // `ralphctl --version` exited 0 with no output.
+  it('runs main() when invoked via a renamed symlink (npm bin install path)', () => {
+    const linkPath = join(tmpRoot, 'ralphctl-bin-shim');
+    if (existsSync(linkPath)) rmSync(linkPath, { force: true });
+    symlinkSync(CLI_PATH, linkPath);
+    const parentEnv = { ...process.env };
+    delete parentEnv['VITEST'];
+    delete parentEnv['VITEST_POOL_ID'];
+    delete parentEnv['VITEST_WORKER_ID'];
+    const result = spawnSync(process.execPath, [linkPath, '--version'], {
+      encoding: 'utf-8',
+      env: {
+        ...parentEnv,
+        RALPHCTL_ROOT: tmpRoot,
+        RALPHCTL_NO_TUI: '1',
+        RALPHCTL_JSON: '1',
+        NO_COLOR: '1',
+        CI: '1',
+      },
+      timeout: 20_000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/src/application/cli/entrypoint.ts
+++ b/src/application/cli/entrypoint.ts
@@ -10,6 +10,8 @@
  * now, the entrypoint prints help. Non-TTY / piped invocations always
  * pick the plain-text path.
  */
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { Command } from 'commander';
 
 import { getSharedDeps } from '@src/application/bootstrap/get-shared-deps.ts';
@@ -249,20 +251,22 @@ function serialiseError(err: unknown): Record<string, unknown> {
 // `import.meta.url` against the process entry so tests that import this
 // module don't trigger a top-level CLI dispatch.
 //
-// When running under tsx, `process.argv[1]` is the source `.ts` file
-// (`entrypoint.ts`). When bundled via tsup, the entry is `dist/cli.mjs`
-// (the file name comes from `tsup.config.ts`'s `entry: { cli: ... }`).
-// Match either form, plus a generic `cli.{mjs,js}` for npm-installed
-// invocations under `node_modules/.bin/`.
+// Resolve `process.argv[1]` through realpath so symlinked bins (npm's
+// global install pattern — `<prefix>/bin/ralphctl` → `dist/cli.mjs`)
+// resolve back to this module. Compare against `import.meta.url` to
+// confirm we're the entry point. The earlier basename allowlist
+// (`entrypoint.ts` / `cli.mjs`) silently skipped main() when invoked
+// via the `ralphctl` shim, so 0.6.0 / 0.6.1 ran as no-ops on a fresh
+// `npm i -g ralphctl`.
 function shouldAutoInvoke(): boolean {
   if (process.env['VITEST'] !== undefined) return false;
   const entry = process.argv[1];
   if (entry === undefined) return false;
-  const base = entry.split('/').pop() ?? '';
-  // Accept `entrypoint.{ts,mjs,js}` (dev / direct invocation) and
-  // `cli.{mjs,js}` (the bundled binary name configured by tsup).
-  if (!/^(entrypoint|cli)\.(ts|mjs|js)$/.test(base)) return false;
-  return true;
+  try {
+    return pathToFileURL(realpathSync(entry)).href === import.meta.url;
+  } catch {
+    return false;
+  }
 }
 
 if (shouldAutoInvoke()) {


### PR DESCRIPTION
## Summary

Hotfix on top of 0.6.1. `npm i -g ralphctl && ralphctl --version` was silently exiting 0 with no output — the basename gate in `shouldAutoInvoke()` rejected the npm-bin symlink (`<prefix>/bin/ralphctl` → `dist/cli.mjs`) because basename was `ralphctl`, not `cli.mjs`.

## Root cause

`src/application/cli/entrypoint.ts#shouldAutoInvoke` checked `basename(process.argv[1])` against the regex `^(entrypoint|cli)\.(ts|mjs|js)$`. When invoked via the npm-bin symlink, `argv[1]` is the shim path. Basename `ralphctl` failed the regex → `main()` never ran.

## Fix

Replace the basename allowlist with the canonical "am I the entry module?" pattern: resolve `argv[1]` through `realpathSync` and compare `pathToFileURL(...).href` to `import.meta.url`. Dev (`tsx src/.../entrypoint.ts`) and direct (`node dist/cli.mjs`) both still pass; symlinked bins resolve through and pass too.

## Regression test

New e2e in `cli.e2e.test.ts` creates a renamed symlink to `dist/cli.mjs` (`tmpRoot/ralphctl-bin-shim`) and spawns it via `node`. Asserts the version lands on stdout. Prevents the silent-skip shape from regressing.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (231 files / 2218 tests)
- [x] Manual: rebuilt `dist/cli.mjs`, symlinked `/tmp/ralphctl-shim → dist/cli.mjs`, ran `node /tmp/ralphctl-shim --version` → printed `0.6.1` (the version of the local working tree at build time)
- [ ] CI green