### PR TITLE
refactor(evaluator): round-aware artefacts + per-task split-OnError

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -310,10 +310,11 @@ factory passes `SessionOptions.sessionMdPath`, the adapter brackets the spawn wi
 (provider / cwd / flags / prompt body) before the child boots and `writeSessionFinish` (model / sessionId / exitCode)
 after it settles. Writes are best-effort: any filesystem failure logs a warn through the adapter's `LoggerPort` and
 is otherwise swallowed so audit emission never fails a spawn. Path construction lives in the chain leaves — refine /
-plan / ideate stamp a single `<unit-root>/session.md` (overwritten on re-run); the per-task chain rotates through
-`session-N.md` via `nextSessionPath` so each execute attempt and each evaluator round get distinct files; standalone
-`sprint evaluate` writes `<sprintDir>/evaluations/session-<task-id>.md`; feedback writes
-`<sprintDir>/feedback/session-<iteration>.md`.
+plan / ideate stamp a single `<unit-root>/session.md` (overwritten on re-run); the per-task chain routes each
+generator and evaluator spawn into `rounds/<N>/{generator,evaluator}/session.md` via the `generatorRoundDir` /
+`evaluatorRoundDir` helpers (`src/integration/persistence/execution-unit-builder.ts`) so every execute attempt and
+each evaluator round get distinct files; standalone `sprint evaluate` writes
+`<sprintDir>/evaluations/session-<task-id>.md`; feedback writes `<sprintDir>/feedback/session-<iteration>.md`.
 
 `sprint requirements [--output <path>]` and `sprint context [--output <path>]` are markdown **exports**, not state.
 They default to the caller's `cwd` (`./<sprintId>-requirements.md` / `./<sprintId>-context.md`) and accept any

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -205,10 +205,9 @@ chains/
 │   │                               unlink-skills → summarise-execution
 │   └── per-task-flow.ts          ← per-task: branch-preflight (OnError → mark-blocked) →
 │                                   mark-in-progress → render-prompt-to-file →
+│                                   build-execution-unit (OnError → noop) →
 │                                   execute-task (Retry on rate-limit) → post-task-check →
-│                                   build-execution-unit → evaluate-task
-│                                   (build + loop wrapped in OnError catch-all except aborted) →
-│                                   commit-task → mark-done
+│                                   evaluate-task (OnError → noop) → commit-task → mark-done
 ├── evaluate/evaluate-flow.ts     ← load-sprint → assert-active → load-task →
 │                                   check-already-evaluated → render-prompt-to-file →
 │                                   evaluate-task → persist-evaluation
@@ -225,6 +224,14 @@ chains/
 CLI commands and TUI views invoke chain factories (`createXxxFlow(deps, opts)`) and launch via
 `SessionManager.start({ element, initialCtx, label })` — never `chain.execute()` directly. An ESLint
 `no-restricted-imports` fence prevents direct use-case imports from CLI commands and TUI views.
+
+**Split OnError fallbacks (per-task).** `build-execution-unit` and `evaluate-task` are wrapped in **two
+independent** `OnError` decorators, each with `catchIf: err => err.code !== 'aborted'` and a `noopLeaf`
+fallback (`per-task-flow.ts`). A builder failure (disk full, EPERM…) is absorbed and the chain proceeds:
+`execute-task` runs against `task.projectPath` as usual, and `evaluate-task` runs the multi-round loop
+**without** `ctx.executionUnitRoot` — `EvaluateAndFixLoopUseCase` handles the missing root gracefully, so
+the per-task chain still settles to `mark-done`. User-initiated cancellation (`code: 'aborted'`)
+propagates through both wraps so Ctrl+C mid-evaluator doesn't silently fall through to `mark-done`.
 
 Per-pipeline step traces are the architectural fence: each `<name>-flow.test.ts` asserts
 `trace.map(s => s.stepName)` on happy + failure paths, locking step order. Step-order regressions break the build.

--- a/src/__e2e__/cli.e2e.test.ts
+++ b/src/__e2e__/cli.e2e.test.ts
@@ -7,9 +7,10 @@
  * directly with a wired `SharedDeps`, these tests exercise the full bundled
  * artefact — the exact bytes published to npm.
  *
- * Auto-build: if `dist/cli.mjs` is missing when the suite starts, `beforeAll`
- * runs `pnpm build` synchronously so `pnpm test` works on a fresh checkout
- * without a preceding manual build step.
+ * Auto-build: `beforeAll` always runs `pnpm build` synchronously so the suite
+ * exercises the current source — not a stale `dist/cli.mjs` left over from
+ * an earlier branch. The build is ~1s and the reliability win is worth it
+ * (tests against a stale bundle masquerade as code regressions).
  */
 import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
@@ -60,21 +61,19 @@ describe('CLI e2e smoke (built dist/cli.mjs)', () => {
   let tmpRoot: string;
 
   beforeAll(() => {
+    const build = spawnSync('pnpm', ['build'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 60_000,
+    });
+    if (build.status !== 0) {
+      throw new Error(`pnpm build failed (status ${String(build.status ?? -1)}):\n${build.stdout}\n${build.stderr}`);
+    }
     if (!existsSync(CLI_PATH)) {
-      const build = spawnSync('pnpm', ['build'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf-8',
-        timeout: 60_000,
-      });
-      if (build.status !== 0) {
-        throw new Error(`pnpm build failed (status ${String(build.status ?? -1)}):\n${build.stdout}\n${build.stderr}`);
-      }
-      if (!existsSync(CLI_PATH)) {
-        throw new Error(`pnpm build completed but dist/cli.mjs is still missing at ${CLI_PATH}.`);
-      }
+      throw new Error(`pnpm build completed but dist/cli.mjs is still missing at ${CLI_PATH}.`);
     }
     tmpRoot = mkdtempSync(join(tmpdir(), 'ralphctl-e2e-'));
-  });
+  }, 60_000);
 
   afterAll(() => {
     rmSync(tmpRoot, { recursive: true, force: true });

--- a/src/_e2e/execute-golden-artefacts.e2e.test.tsx
+++ b/src/_e2e/execute-golden-artefacts.e2e.test.tsx
@@ -114,19 +114,19 @@ describe('e2e: execute golden-path artefacts', () => {
     });
   });
 
-  // ── 2. rounds/<N>/evaluator/evaluation.md + latest-evaluation.md ─────────
+  // ── 2. rounds/<N>/evaluator/evaluation.md ────────────────────────────────
 
   describe('evaluation artefact', () => {
-    it('writes rounds/1/evaluator/evaluation.md and latest-evaluation.md with the full critique', async () => {
+    it('writes rounds/1/evaluator/evaluation.md with the full critique and stamps that path on Task.evaluationFile', async () => {
       const sprint = makeArtefactSprint('eval');
       const task = makeTask({ name: 'eval-task', order: 1, projectPath: '/tmp/artefact-repo' });
 
-      // Compute the expected per-round + latest paths.
+      // Compute the expected per-round path. Each round path is unique,
+      // so the path itself is the canonical reference — no pointer file.
       const paths = resolveStoragePaths();
       const slug = unitSlug(String(task.id), task.name);
       const unitRoot = String(paths.executionUnitDir(sprint.id, slug));
       const round1VerdictPath = join(unitRoot, 'rounds', '1', 'evaluator', 'evaluation.md');
-      const latestPath = join(unitRoot, 'latest-evaluation.md');
       const progressPath = join(String(paths.sprintDir(sprint.id)), 'progress.md');
 
       // Use the real FileSystemSignalHandler so the per-task progress
@@ -134,8 +134,8 @@ describe('e2e: execute golden-path artefacts', () => {
       // builder adapter so the loop's `evaluateWorkspaceDir` resolves
       // to the actual `<sprintDir>/execution/<unit>/` path the test
       // asserts on. Use the real WriteContextFile adapter so the
-      // loop's per-round verdict + latest-evaluation.md writes hit
-      // disk (the default Fake just captures the calls).
+      // loop's per-round verdict writes hit disk (the default Fake
+      // just captures the calls).
       const signalHandler = new FileSystemSignalHandler(paths);
       const sessionFolderBuilder = new FileSessionFolderBuilderAdapter(paths);
       const writeContextFile = new FileWriteContextFileAdapter();
@@ -176,15 +176,12 @@ describe('e2e: execute golden-path artefacts', () => {
       if (!persisted.ok) throw new Error('taskRepo.findById failed');
       expect(persisted.value.status).toBe('done');
       expect(persisted.value.evaluationStatus).toBe('passed');
-      // `evaluationFile` points at the stable latest-evaluation.md pointer.
-      expect(persisted.value.evaluationFile).toContain('latest-evaluation.md');
+      // `evaluationFile` points at the FINAL round's verdict (round 1 here).
+      expect(persisted.value.evaluationFile).toBe(`execution/${slug}/rounds/1/evaluator/evaluation.md`);
 
-      // The loop wrote the full critique to the per-round file AND to the
-      // stable latest-evaluation.md pointer.
+      // The loop wrote the full critique to the per-round file.
       const round1Body = await readFile(round1VerdictPath, 'utf-8');
       expect(round1Body).toContain('eval round 1 raw critique body');
-      const latestBody = await readFile(latestPath, 'utf-8');
-      expect(latestBody).toBe(round1Body);
 
       // The signal handler still appends the one-line summary to
       // progress.md so the sprint timeline shows the verdict.

--- a/src/_e2e/execute-golden-artefacts.e2e.test.tsx
+++ b/src/_e2e/execute-golden-artefacts.e2e.test.tsx
@@ -9,11 +9,11 @@
  *      Requires `external.uncommitted: true` so `hasUncommittedChanges()`
  *      returns true and the leaf calls `commitChanges()`.
  *
- *   2. `evaluations/<task-id>.md` — written by `FileSystemSignalHandler` when
- *      the evaluator produces an `EvaluationSignal`. The harness default uses
- *      `NoopSignalHandler`; this test overrides it with the real
- *      `FileSystemSignalHandler`. Also asserts that the per-dimension
- *      `(score N/5)` marker introduced in the G2 contract appears in the file.
+ *   2. `rounds/<N>/evaluator/evaluation.md` — written by
+ *      `EvaluateAndFixLoopUseCase` via `WriteContextFilePort` after each
+ *      evaluator round, plus a stable copy at `<unit>/latest-evaluation.md`
+ *      that `Task.evaluationFile` points at. The handler appends a one-line
+ *      summary to `progress.md`; the loop owns the full critique.
  *
  *   3. `done-criteria.md` at the sprint root — written by the PLAN chain's
  *      `save-tasks` leaf and READ by the EXECUTE chain's `evaluate-task` leaf
@@ -35,6 +35,8 @@ import type { FakeExternalPort } from '@src/business/_test-fakes/fake-external-p
 import { FakePromptPort } from '@src/application/_test-fakes/fake-prompt-port.ts';
 import type { HarnessSignal } from '@src/domain/signals/harness-signal.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
+import { FileSessionFolderBuilderAdapter } from '@src/integration/persistence/session-folder-builder-adapter.ts';
+import { FileWriteContextFileAdapter } from '@src/integration/persistence/file-write-context-file-adapter.ts';
 import { FileSystemSignalHandler } from '@src/integration/signals/file-system-handler.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 import { renderDoneCriteria } from '@src/application/chains/leaves/save-tasks.ts';
@@ -112,26 +114,32 @@ describe('e2e: execute golden-path artefacts', () => {
     });
   });
 
-  // ── 2. evaluations/<task-id>.md with (score N/5) markers ─────────────────
+  // ── 2. rounds/<N>/evaluator/evaluation.md + latest-evaluation.md ─────────
 
   describe('evaluation artefact', () => {
-    it('writes evaluations/<task-id>.md with per-dimension (score N/5) markers', async () => {
+    it('writes rounds/1/evaluator/evaluation.md and latest-evaluation.md with the full critique', async () => {
       const sprint = makeArtefactSprint('eval');
       const task = makeTask({ name: 'eval-task', order: 1, projectPath: '/tmp/artefact-repo' });
 
-      // Compute the expected file path the signal handler will write to.
-      // FileSystemSignalHandler uses resolveStoragePaths() + unitSlug(taskId, taskName).
+      // Compute the expected per-round + latest paths.
       const paths = resolveStoragePaths();
       const slug = unitSlug(String(task.id), task.name);
-      const evalFilePath = join(String(paths.executionUnitDir(sprint.id, slug)), 'evaluation.md');
+      const unitRoot = String(paths.executionUnitDir(sprint.id, slug));
+      const round1VerdictPath = join(unitRoot, 'rounds', '1', 'evaluator', 'evaluation.md');
+      const latestPath = join(unitRoot, 'latest-evaluation.md');
+      const progressPath = join(String(paths.sprintDir(sprint.id)), 'progress.md');
 
-      // Ensure the parent directory exists so the handler can write.
-      await mkdir(join(String(paths.executionUnitDir(sprint.id, slug))), { recursive: true });
-
-      // Use the real FileSystemSignalHandler so the evaluation file lands on disk.
+      // Use the real FileSystemSignalHandler so the per-task progress
+      // summary lands in `progress.md`. Use the real session folder
+      // builder adapter so the loop's `evaluateWorkspaceDir` resolves
+      // to the actual `<sprintDir>/execution/<unit>/` path the test
+      // asserts on. Use the real WriteContextFile adapter so the
+      // loop's per-round verdict + latest-evaluation.md writes hit
+      // disk (the default Fake just captures the calls).
       const signalHandler = new FileSystemSignalHandler(paths);
+      const sessionFolderBuilder = new FileSessionFolderBuilderAdapter(paths);
+      const writeContextFile = new FileWriteContextFileAdapter();
 
-      // Evaluation signal with numeric per-dimension score (G2 contract).
       const evalPassed: HarnessSignal = {
         type: 'evaluation',
         status: 'passed',
@@ -148,11 +156,11 @@ describe('e2e: execute golden-path artefacts', () => {
         cwd: CWD,
         evaluationIterations: 1,
         external: { uncommitted: false },
-        overrides: { signalHandler },
+        overrides: { signalHandler, sessionFolderBuilder, writeContextFile },
         aiSession: {
           outcomes: [
             { kind: 'ok', result: { output: 'task done', sessionId: 'sess-exec' } },
-            { kind: 'ok', result: { output: 'eval round 1' } },
+            { kind: 'ok', result: { output: 'eval round 1 raw critique body' } },
           ],
         },
         signalParser: {
@@ -168,21 +176,21 @@ describe('e2e: execute golden-path artefacts', () => {
       if (!persisted.ok) throw new Error('taskRepo.findById failed');
       expect(persisted.value.status).toBe('done');
       expect(persisted.value.evaluationStatus).toBe('passed');
+      // `evaluationFile` points at the stable latest-evaluation.md pointer.
+      expect(persisted.value.evaluationFile).toContain('latest-evaluation.md');
 
-      // The signal handler wrote the evaluation file.
-      let evalBody: string;
-      try {
-        evalBody = await readFile(evalFilePath, 'utf-8');
-      } catch {
-        throw new Error(`evaluation file not found at ${evalFilePath}`);
-      }
+      // The loop wrote the full critique to the per-round file AND to the
+      // stable latest-evaluation.md pointer.
+      const round1Body = await readFile(round1VerdictPath, 'utf-8');
+      expect(round1Body).toContain('eval round 1 raw critique body');
+      const latestBody = await readFile(latestPath, 'utf-8');
+      expect(latestBody).toBe(round1Body);
 
-      // Per-dimension (score N/5) marker — the G2 contract.
-      expect(evalBody).toContain('(score 5/5)');
-      // Overall score line.
-      expect(evalBody).toContain('Overall score: 5/5');
-      // Status header.
-      expect(evalBody).toContain('# Evaluation — passed');
+      // The signal handler still appends the one-line summary to
+      // progress.md so the sprint timeline shows the verdict.
+      const progress = await readFile(progressPath, 'utf-8');
+      expect(progress).toContain('**Evaluation:** passed');
+      expect(progress).toContain('score 5/5');
     });
   });
 

--- a/src/application/_test-fakes/build-tui-deps.ts
+++ b/src/application/_test-fakes/build-tui-deps.ts
@@ -8,7 +8,6 @@
  * (`createTestDeps`) covers business-port fakes; this layer adds the
  * presentation-only ports views read from `getSharedDeps()`.
  */
-import { FakeSessionFolderBuilderPort } from '@src/business/_test-fakes/fake-session-folder-builder-port.ts';
 import { Result } from '@src/domain/result.ts';
 import { InMemorySignalBus } from '@src/integration/signals/bus.ts';
 import { InMemoryLogEventBus } from '@src/integration/logging/log-event-bus.ts';
@@ -65,6 +64,9 @@ export function buildTuiDeps(opts: TuiDepsOptions = {}): TuiTestDeps {
     prompt: inner.prompt,
     rateLimitCoordinator: inner.rateLimitCoordinator,
     writeContextFile: inner.writeContextFile,
-    sessionFolderBuilder: new FakeSessionFolderBuilderPort(),
+    // Forward the inner sessionFolderBuilder so callers that pass an
+    // override (e.g. e2e tests using the real `FileSessionFolderBuilderAdapter`)
+    // see their port flow through to the SharedDeps graph.
+    sessionFolderBuilder: inner.sessionFolderBuilder,
   };
 }

--- a/src/application/chains/evaluate/evaluate-flow.test.ts
+++ b/src/application/chains/evaluate/evaluate-flow.test.ts
@@ -29,7 +29,7 @@ function activateSprint(draft: ReturnType<typeof makeSprint>) {
 }
 
 describe('createEvaluateFlow', () => {
-  it('runs load-sprint → assert-active → load-task → check-already-evaluated → render-prompt-to-file → evaluate-task → persist-evaluation', async () => {
+  it('runs load-sprint → assert-active → load-task → render-prompt-to-file → evaluate-task → persist-evaluation', async () => {
     const sprint = activateSprint(makeSprint());
     const task = makeTask({ name: 'do thing' });
     const deps = createTestDeps({
@@ -54,7 +54,6 @@ describe('createEvaluateFlow', () => {
       'load-sprint',
       'assert-active',
       'load-task',
-      'check-already-evaluated',
       'render-prompt-to-file',
       'evaluate-task',
       'persist-evaluation',
@@ -120,24 +119,29 @@ describe('createEvaluateFlow', () => {
     expect(result.error.trace.some((t) => t.status === 'aborted')).toBe(true);
   });
 
-  it('short-circuits as a successful no-op when the task is already evaluated', async () => {
+  it('re-runs end-to-end when the task is already evaluated (re-runs are allowed)', async () => {
     // The evaluator never blocks (REQUIREMENTS.md). Re-running
     // `sprint evaluate <task>` on a task that already has a recorded
-    // verdict must complete successfully, not return an error. Every
-    // downstream leaf no-ops so the trace stays honest.
+    // verdict must complete successfully — and now runs the AI spawn
+    // again so a stale verdict can be refreshed. Each invocation lays
+    // down a fresh `rounds/standalone-<ISO>/` so prior verdicts persist
+    // as durable history.
     const sprint = activateSprint(makeSprint());
     const task0 = makeTask({ name: 'do thing' });
     const evaluated = task0.recordEvaluation({
       status: 'passed',
       output: 'prior critique',
-      file: 'evaluations/x.md',
+      file: 'execution/x/latest-evaluation.md',
     });
 
-    const aiSession = new FakeAiSessionPort();
+    const aiSession = new FakeAiSessionPort({
+      outcomes: [{ kind: 'ok', result: { output: 'fresh evaluator output' } }],
+    });
     const writeContextFile = new FakeWriteContextFilePort();
     const deps = createTestDeps({
       sprints: [sprint],
       tasks: [[sprint.id, [evaluated]]],
+      signalParser: { results: [[passSignal]] },
       overrides: { aiSession, writeContextFile },
     });
 
@@ -151,31 +155,21 @@ describe('createEvaluateFlow', () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    // Every step in the chain still ran (as a no-op for downstream
-    // leaves) so the trace remains the canonical step order.
     expect(result.value.trace.map((t) => t.stepName)).toStrictEqual([
       'load-sprint',
       'assert-active',
       'load-task',
-      'check-already-evaluated',
       'render-prompt-to-file',
       'evaluate-task',
       'persist-evaluation',
     ]);
-    // The task's recorded evaluation must be untouched — re-running
-    // shouldn't overwrite a prior verdict with a fresh spawn we never
-    // actually performed.
-    const reread = await deps.taskRepo.findById(sprint.id, evaluated.id);
-    if (!reread.ok) throw new Error('expected task');
-    expect(reread.value.evaluated).toBe(true);
-    expect(reread.value.evaluationStatus).toBe('passed');
-    expect(reread.value.evaluationOutput).toBe('prior critique');
-
-    // No AI spawn fired — the chain skipped evaluate-task as a no-op.
-    expect(aiSession.captured).toHaveLength(0);
-    // No prompt file was rendered — render-prompt-to-file honours the
-    // skip flag too.
-    expect(writeContextFile.writes).toHaveLength(0);
+    // A fresh AI spawn fires — the chain no longer short-circuits.
+    expect(aiSession.captured).toHaveLength(1);
+    // Prompt file was rendered to the standalone-round folder.
+    expect(writeContextFile.writes).toHaveLength(1);
+    expect(String(writeContextFile.writes[0]?.path)).toMatch(
+      /\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/prompt\.md$/
+    );
   });
 
   it('fails on assert-active when sprint is not active (draft)', async () => {

--- a/src/application/chains/evaluate/evaluate-flow.test.ts
+++ b/src/application/chains/evaluate/evaluate-flow.test.ts
@@ -221,11 +221,11 @@ describe('createEvaluateFlow', () => {
   });
 
   it('two same-process invocations land in distinct rounds/standalone-<ISO>/ folders', async () => {
-    // Module-level ISO caching previously made back-to-back evaluates of
-    // the same (sprint, task) collide on the same standalone-round folder
-    // — the second run silently overwrote the first. The fix scopes the
-    // ISO to a single chain-factory call so each `createEvaluateFlow(...)`
-    // invocation gets a fresh folder.
+    // Each `createEvaluateFlow(...)` call captures its own folder token
+    // (`<ISO>-<rand4>`). The 4-char random suffix means two back-to-back
+    // factory calls land in distinct folders even within the same
+    // millisecond — no `setTimeout` needed in this test, no race in
+    // production.
     const sprint = activateSprint(makeSprint());
     const task = makeTask({ name: 'do thing' });
 
@@ -243,11 +243,6 @@ describe('createEvaluateFlow', () => {
 
     const result1 = await flow1.execute({ sprintId: sprint.id, taskId: task.id, cwd: CWD });
     expect(result1.ok).toBe(true);
-
-    // Tiny delay ensures `IsoTimestamp.now()`'s millisecond precision
-    // produces a distinct value on the second factory call. Keeps the
-    // test deterministic without faking the clock.
-    await new Promise((r) => setTimeout(r, 5));
 
     const aiSession2 = new FakeAiSessionPort({
       outcomes: [{ kind: 'ok', result: { output: 'evaluator output 2' } }],

--- a/src/application/chains/evaluate/evaluate-flow.test.ts
+++ b/src/application/chains/evaluate/evaluate-flow.test.ts
@@ -171,16 +171,16 @@ describe('createEvaluateFlow', () => {
     ]);
     // A fresh AI spawn fires — the chain no longer short-circuits.
     expect(aiSession.captured).toHaveLength(1);
-    // Three writes routed via WriteContextFilePort: the rendered prompt
-    // for the standalone round, the per-round evaluation.md verdict, and
-    // the unit's stable latest-evaluation.md copy.
-    expect(writeContextFile.writes).toHaveLength(3);
+    // Two writes routed via WriteContextFilePort: the rendered prompt
+    // and the per-round evaluation.md verdict — both under the
+    // standalone-round folder. Each round path is unique, so no
+    // pointer file is needed.
+    expect(writeContextFile.writes).toHaveLength(2);
     const writtenPaths = writeContextFile.writes.map((w) => String(w.path));
     expect(writtenPaths).toStrictEqual(
       expect.arrayContaining([
         expect.stringMatching(/\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/prompt\.md$/),
         expect.stringMatching(/\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/evaluation\.md$/),
-        expect.stringMatching(/\/execution\/[^/]+\/latest-evaluation\.md$/),
       ])
     );
   });
@@ -271,12 +271,13 @@ describe('createEvaluateFlow', () => {
     expect(folder1).not.toBe(folder2);
   });
 
-  it('persists Task.evaluationFile as execution/<unit-slug>/latest-evaluation.md', async () => {
-    // The persisted relative path must use the unit slug
-    // (`<id>-<name-slug>`), not the bare task id — the slug is what the
-    // upstream evaluate-task leaf actually wrote to disk. With a name
-    // that produces a non-trivial slug, this catches the prior regression
-    // where the recorded path resolved to a non-existent file.
+  it('persists Task.evaluationFile as execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/evaluation.md', async () => {
+    // The persisted relative path must point at the verdict file the
+    // upstream evaluate-task leaf actually wrote — keyed on the unit
+    // slug (`<id>-<name-slug>`) and the standalone round's ISO. Each
+    // standalone-round path is unique, so the recorded value
+    // unambiguously locates THIS run's verdict — no pointer-file
+    // indirection, no stale references after a re-run.
     const sprint = activateSprint(makeSprint());
     const explicitId = taskId('abc123');
     const task = makeTask({ id: explicitId, name: 'My Cool Feature' });
@@ -297,16 +298,17 @@ describe('createEvaluateFlow', () => {
 
     const slug = unitSlug(String(task.id), task.name);
     expect(slug).toBe('abc123-my-cool-feature');
-    expect(reread.value.evaluationFile).toBe(`execution/${slug}/latest-evaluation.md`);
+    expect(reread.value.evaluationFile).toMatch(
+      new RegExp(`^execution/${slug}/rounds/standalone-[^/]+/evaluator/evaluation\\.md$`)
+    );
   });
 
   it('standalone evaluate write failures warn and never block the chain', async () => {
-    // Inject a fake writer that fails specifically on the verdict +
-    // latest-evaluation paths but lets the prompt write succeed. The
-    // chain must complete (Result.ok) and emit warn-level diagnostics
-    // referencing the failed paths — durable history is best-effort,
-    // and the in-memory critique still flows downstream to
-    // persist-evaluation.
+    // Inject a fake writer that fails specifically on the verdict path
+    // but lets the prompt write succeed. The chain must complete
+    // (Result.ok) and emit a warn-level diagnostic referencing the
+    // failed path — durable history is best-effort, and the in-memory
+    // critique still flows downstream to persist-evaluation.
     const sprint = activateSprint(makeSprint());
     const task = makeTask({ name: 'do thing' });
 
@@ -315,7 +317,7 @@ describe('createEvaluateFlow', () => {
       write(path, content) {
         this.writes.push({ path, content });
         const p = String(path);
-        if (p.endsWith('/evaluation.md') || p.endsWith('/latest-evaluation.md')) {
+        if (p.endsWith('/evaluation.md')) {
           return Promise.resolve(
             Result.error(new StorageError({ subCode: 'io', message: 'EACCES simulated', path: p }))
           );
@@ -338,13 +340,13 @@ describe('createEvaluateFlow', () => {
 
     expect(result.ok).toBe(true);
 
-    // At least one warn log references one of the failed paths.
+    // At least one warn log references the failed evaluation.md path.
     const warns = logger.entries.filter((e) => e.level === 'warn');
     expect(warns.length).toBeGreaterThanOrEqual(1);
     const warnedPaths = warns
       .map((w) => (typeof w.context['path'] === 'string' ? w.context['path'] : ''))
       .filter((p) => p.length > 0);
-    expect(warnedPaths.some((p) => p.endsWith('/evaluation.md') || p.endsWith('/latest-evaluation.md'))).toBe(true);
+    expect(warnedPaths.some((p) => p.endsWith('/evaluation.md'))).toBe(true);
 
     // Persist-evaluation still ran with the in-memory critique.
     const reread = await deps.taskRepo.findById(sprint.id, task.id);

--- a/src/application/chains/evaluate/evaluate-flow.test.ts
+++ b/src/application/chains/evaluate/evaluate-flow.test.ts
@@ -3,8 +3,14 @@ import { describe, expect, it } from 'vitest';
 
 import type { EvaluationSignal } from '@src/domain/signals/harness-signal.ts';
 import { FakeAiSessionPort } from '@src/business/_test-fakes/fake-ai-session-port.ts';
+import { FakeLoggerPort } from '@src/business/_test-fakes/fake-logger-port.ts';
 import { FakeWriteContextFilePort } from '@src/business/_test-fakes/fake-write-context-file-port.ts';
-import { T0, abs, makeSprint, makeTask } from '@src/application/_test-fakes/fixtures.ts';
+import type { WriteContextFilePort } from '@src/business/ports/write-context-file-port.ts';
+import { StorageError } from '@src/domain/errors/storage-error.ts';
+import { Result } from '@src/domain/result.ts';
+import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
+import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
+import { T0, abs, makeSprint, makeTask, taskId } from '@src/application/_test-fakes/fixtures.ts';
 import { createTestDeps } from '@src/application/_test-fakes/create-test-deps.ts';
 import { createEvaluateFlow } from './evaluate-flow.ts';
 
@@ -165,10 +171,17 @@ describe('createEvaluateFlow', () => {
     ]);
     // A fresh AI spawn fires — the chain no longer short-circuits.
     expect(aiSession.captured).toHaveLength(1);
-    // Prompt file was rendered to the standalone-round folder.
-    expect(writeContextFile.writes).toHaveLength(1);
-    expect(String(writeContextFile.writes[0]?.path)).toMatch(
-      /\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/prompt\.md$/
+    // Three writes routed via WriteContextFilePort: the rendered prompt
+    // for the standalone round, the per-round evaluation.md verdict, and
+    // the unit's stable latest-evaluation.md copy.
+    expect(writeContextFile.writes).toHaveLength(3);
+    const writtenPaths = writeContextFile.writes.map((w) => String(w.path));
+    expect(writtenPaths).toStrictEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/prompt\.md$/),
+        expect.stringMatching(/\/execution\/[^/]+\/rounds\/standalone-[^/]+\/evaluator\/evaluation\.md$/),
+        expect.stringMatching(/\/execution\/[^/]+\/latest-evaluation\.md$/),
+      ])
     );
   });
 
@@ -206,4 +219,150 @@ describe('createEvaluateFlow', () => {
     // The error code must identify the state violation.
     expect(result.error.error.code).toBe('invalid-state');
   });
+
+  it('two same-process invocations land in distinct rounds/standalone-<ISO>/ folders', async () => {
+    // Module-level ISO caching previously made back-to-back evaluates of
+    // the same (sprint, task) collide on the same standalone-round folder
+    // — the second run silently overwrote the first. The fix scopes the
+    // ISO to a single chain-factory call so each `createEvaluateFlow(...)`
+    // invocation gets a fresh folder.
+    const sprint = activateSprint(makeSprint());
+    const task = makeTask({ name: 'do thing' });
+
+    const aiSession1 = new FakeAiSessionPort({
+      outcomes: [{ kind: 'ok', result: { output: 'evaluator output 1' } }],
+    });
+    const writer1 = new FakeWriteContextFilePort();
+    const deps1 = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      signalParser: { results: [[passSignal]] },
+      overrides: { aiSession: aiSession1, writeContextFile: writer1 },
+    });
+    const flow1 = createEvaluateFlow(deps1);
+
+    const result1 = await flow1.execute({ sprintId: sprint.id, taskId: task.id, cwd: CWD });
+    expect(result1.ok).toBe(true);
+
+    // Tiny delay ensures `IsoTimestamp.now()`'s millisecond precision
+    // produces a distinct value on the second factory call. Keeps the
+    // test deterministic without faking the clock.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const aiSession2 = new FakeAiSessionPort({
+      outcomes: [{ kind: 'ok', result: { output: 'evaluator output 2' } }],
+    });
+    const writer2 = new FakeWriteContextFilePort();
+    const deps2 = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      signalParser: { results: [[passSignal]] },
+      overrides: { aiSession: aiSession2, writeContextFile: writer2 },
+    });
+    const flow2 = createEvaluateFlow(deps2);
+
+    const result2 = await flow2.execute({ sprintId: sprint.id, taskId: task.id, cwd: CWD });
+    expect(result2.ok).toBe(true);
+
+    const folder1 = extractStandaloneFolder(writer1.writes.map((w) => String(w.path)));
+    const folder2 = extractStandaloneFolder(writer2.writes.map((w) => String(w.path)));
+    expect(folder1).toBeDefined();
+    expect(folder2).toBeDefined();
+    expect(folder1).not.toBe(folder2);
+  });
+
+  it('persists Task.evaluationFile as execution/<unit-slug>/latest-evaluation.md', async () => {
+    // The persisted relative path must use the unit slug
+    // (`<id>-<name-slug>`), not the bare task id — the slug is what the
+    // upstream evaluate-task leaf actually wrote to disk. With a name
+    // that produces a non-trivial slug, this catches the prior regression
+    // where the recorded path resolved to a non-existent file.
+    const sprint = activateSprint(makeSprint());
+    const explicitId = taskId('abc123');
+    const task = makeTask({ id: explicitId, name: 'My Cool Feature' });
+
+    const deps = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      aiSession: { outcomes: [{ kind: 'ok', result: { output: 'evaluator output' } }] },
+      signalParser: { results: [[passSignal]] },
+    });
+
+    const flow = createEvaluateFlow(deps);
+    const result = await flow.execute({ sprintId: sprint.id, taskId: task.id, cwd: CWD });
+    expect(result.ok).toBe(true);
+
+    const reread = await deps.taskRepo.findById(sprint.id, task.id);
+    if (!reread.ok) throw new Error('expected task');
+
+    const slug = unitSlug(String(task.id), task.name);
+    expect(slug).toBe('abc123-my-cool-feature');
+    expect(reread.value.evaluationFile).toBe(`execution/${slug}/latest-evaluation.md`);
+  });
+
+  it('standalone evaluate write failures warn and never block the chain', async () => {
+    // Inject a fake writer that fails specifically on the verdict +
+    // latest-evaluation paths but lets the prompt write succeed. The
+    // chain must complete (Result.ok) and emit warn-level diagnostics
+    // referencing the failed paths — durable history is best-effort,
+    // and the in-memory critique still flows downstream to
+    // persist-evaluation.
+    const sprint = activateSprint(makeSprint());
+    const task = makeTask({ name: 'do thing' });
+
+    const writer: WriteContextFilePort = {
+      writes: [] as { path: AbsolutePath; content: string }[],
+      write(path, content) {
+        this.writes.push({ path, content });
+        const p = String(path);
+        if (p.endsWith('/evaluation.md') || p.endsWith('/latest-evaluation.md')) {
+          return Promise.resolve(
+            Result.error(new StorageError({ subCode: 'io', message: 'EACCES simulated', path: p }))
+          );
+        }
+        return Promise.resolve(Result.ok());
+      },
+    } as WriteContextFilePort & { writes: { path: AbsolutePath; content: string }[] };
+
+    const logger = new FakeLoggerPort();
+    const deps = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      aiSession: { outcomes: [{ kind: 'ok', result: { output: 'evaluator output' } }] },
+      signalParser: { results: [[passSignal]] },
+      overrides: { writeContextFile: writer, logger },
+    });
+
+    const flow = createEvaluateFlow(deps);
+    const result = await flow.execute({ sprintId: sprint.id, taskId: task.id, cwd: CWD });
+
+    expect(result.ok).toBe(true);
+
+    // At least one warn log references one of the failed paths.
+    const warns = logger.entries.filter((e) => e.level === 'warn');
+    expect(warns.length).toBeGreaterThanOrEqual(1);
+    const warnedPaths = warns
+      .map((w) => (typeof w.context['path'] === 'string' ? w.context['path'] : ''))
+      .filter((p) => p.length > 0);
+    expect(warnedPaths.some((p) => p.endsWith('/evaluation.md') || p.endsWith('/latest-evaluation.md'))).toBe(true);
+
+    // Persist-evaluation still ran with the in-memory critique.
+    const reread = await deps.taskRepo.findById(sprint.id, task.id);
+    if (!reread.ok) throw new Error('expected task');
+    expect(reread.value.evaluated).toBe(true);
+  });
 });
+
+/**
+ * Extract the `rounds/standalone-<iso>/` segment from any of the per-run
+ * write paths. Returns `undefined` when no path matches, which the test
+ * assertion catches.
+ */
+function extractStandaloneFolder(paths: readonly string[]): string | undefined {
+  const re = /\/(rounds\/standalone-[^/]+)\//;
+  for (const p of paths) {
+    const m = re.exec(p);
+    if (m && typeof m[1] === 'string') return m[1];
+  }
+  return undefined;
+}

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -4,8 +4,8 @@
  *
  * Steps (happy path):
  *
- *   load-sprint → assert-active → load-task → check-already-evaluated →
- *     render-prompt-to-file → evaluate-task → persist-evaluation
+ *   load-sprint → assert-active → load-task → render-prompt-to-file →
+ *     evaluate-task → persist-evaluation
  *
  * Used standalone by the `sprint evaluate` command. The per-task
  * chain inside `executeFlow` runs the multi-round
@@ -13,16 +13,22 @@
  * prompt rendering); this chain is the single-round equivalent for
  * one-shot evaluator runs.
  *
- * `render-prompt-to-file` writes the FULL evaluator prompt (task body,
- * verification criteria, harness context, signal vocabulary) to
- * `<sprintDir>/contexts/evaluate-<task-id>.md`. The downstream
- * `evaluate-task` leaf hands the AI a thin wrapper pointing at that
- * file.
+ * Re-runs are allowed: every invocation creates a fresh
+ * `<sprintDir>/execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/`
+ * folder so prior verdicts are preserved as durable history. The latest
+ * verdict still wins for `Task.evaluationFile` via a copy at
+ * `<unit>/latest-evaluation.md`.
+ *
+ * `render-prompt-to-file` writes the evaluator prompt to the standalone
+ * round's `prompt.md`. The downstream `evaluate-task` leaf hands the AI
+ * a thin wrapper pointing at that file.
  *
  * The use case **never blocks**: a malformed / failed evaluation still
  * resolves successfully so the surrounding chain can continue. The
  * `persist-evaluation` step records the verdict on the task entity.
  */
+import { join } from 'node:path';
+
 import { Result } from '@src/domain/result.ts';
 
 import { EvaluateTaskUseCase, type EvaluationOutcome } from '@src/business/usecases/evaluate/evaluate-task.ts';
@@ -31,7 +37,8 @@ import type { Task } from '@src/domain/entities/task.ts';
 import type { Element } from '@src/kernel/chain/element.ts';
 import { Leaf } from '@src/kernel/chain/leaf.ts';
 import { Sequential } from '@src/kernel/chain/sequential.ts';
-import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
+import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/values/iso-timestamp.ts';
 import type { SprintId } from '@src/domain/values/sprint-id.ts';
 import type { TaskId } from '@src/domain/values/task-id.ts';
 import type { ChainSharedDeps } from '@src/application/chains/chain-deps.ts';
@@ -40,6 +47,9 @@ import { loadSprintLeaf } from '@src/application/chains/leaves/load-sprint.ts';
 import { renderPromptToFileLeaf } from '@src/application/chains/leaves/render-prompt-to-file.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
+import { latestEvaluationPath, standaloneRoundDir } from '@src/integration/persistence/execution-unit-builder.ts';
+import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
+import { mkdir, writeFile } from 'node:fs/promises';
 
 export interface EvaluateCtx {
   readonly sprintId: SprintId;
@@ -55,17 +65,6 @@ export interface EvaluateCtx {
    * consumed by `evaluate-task`.
    */
   readonly promptFilePath?: AbsolutePath;
-  /**
-   * Set to `true` by `check-already-evaluated` when the task already
-   * carries a recorded verdict. Every downstream leaf (render-prompt,
-   * evaluate-task, persist-evaluation) checks the flag and short-circuits
-   * as a no-op so the chain trace stays honest while skipping the work.
-   *
-   * The evaluator never blocks (REQUIREMENTS.md): re-running
-   * `sprint evaluate <task>` on an already-evaluated task must complete
-   * successfully, not return a `NotFoundError`.
-   */
-  readonly skipEvaluation?: boolean;
 }
 
 export function createEvaluateFlow(
@@ -88,11 +87,17 @@ export function createEvaluateFlow(
     {
       flowName: 'evaluate',
       identifier: (ctx) => String(ctx.taskId),
-      // `check-already-evaluated` may flip `skipEvaluation: true` upstream
-      // when the task carries a recorded verdict. The render-prompt-to-file
-      // leaf honours the flag — no point writing an evaluator prompt we
-      // never plan to spawn.
-      skip: (ctx) => ctx.skipEvaluation === true,
+      // Standalone evaluate routes the prompt under the standalone-round
+      // folder so each invocation lays down a fresh, distinct artefact
+      // pack alongside its prior siblings. `WriteContextFilePort.write`
+      // mkdir's its parent directory, so we only need to compute the
+      // path here.
+      path: (ctx) => {
+        if (!ctx.sprint) throw new Error('render-prompt-to-file: ctx.sprint must be loaded first');
+        if (!ctx.task) throw new Error('render-prompt-to-file: ctx.task must be loaded first');
+        const dir = standaloneEvaluatorDir(ctx.sprint.id, ctx.task);
+        return AbsolutePath.trustString(join(dir, 'prompt.md'));
+      },
       buildPrompt: async (ctx) => {
         if (!ctx.sprint) throw new Error('render-prompt-to-file: ctx.sprint must be loaded first');
         if (!ctx.task) throw new Error('render-prompt-to-file: ctx.task must be loaded first');
@@ -115,11 +120,37 @@ export function createEvaluateFlow(
     loadSprintLeaf<EvaluateCtx>({ sprintRepo: deps.sprintRepo }),
     assertActiveLeaf<EvaluateCtx>('evaluate'),
     loadTaskLeaf(deps),
-    checkAlreadyEvaluatedLeaf(),
     renderPromptStep,
     evaluateTaskLeaf(useCase),
     persistEvaluationLeaf(deps),
   ]);
+}
+
+/**
+ * Resolve the standalone-round evaluator folder for this invocation.
+ * Each `sprint evaluate <task>` call gets a fresh
+ * `<unit>/rounds/standalone-<ISO>/evaluator/` subtree so prior
+ * verdicts persist as durable history. The ISO is cached per
+ * (sprintId, taskId) so `render-prompt-to-file` and `evaluate-task`
+ * resolve identical paths within a single chain run.
+ *
+ * Pure path computation — `WriteContextFilePort` and the AI session
+ * adapter both mkdir their parent dirs, so the caller does not need
+ * to ensure the directory before writing.
+ */
+const standaloneRoundCache = new Map<string, string>();
+
+function standaloneEvaluatorDir(sprintId: SprintId, task: Task): string {
+  const storage = resolveStoragePaths();
+  const slug = unitSlug(String(task.id), task.name);
+  const unitRoot = String(storage.executionUnitDir(sprintId, slug));
+  const cacheKey = `${String(sprintId)}::${String(task.id)}`;
+  let iso = standaloneRoundCache.get(cacheKey);
+  if (iso === undefined) {
+    iso = String(IsoTimestamp.now()).replace(/[:.]/g, '-');
+    standaloneRoundCache.set(cacheKey, iso);
+  }
+  return join(standaloneRoundDir(unitRoot, iso), 'evaluator');
 }
 
 /** Build a load-task leaf for the evaluate flow's per-task pipeline. */
@@ -135,35 +166,6 @@ function loadTaskLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element<Evaluate
   });
 }
 
-/**
- * Skip-out leaf — flips `ctx.skipEvaluation = true` when the task already
- * carries a recorded verdict so downstream leaves no-op as a courtesy.
- * Re-running `sprint evaluate <task>` on an already-evaluated task must
- * complete successfully (REQUIREMENTS.md: the evaluator never blocks),
- * not abort with a `NotFoundError`.
- *
- * The trace still records the step so callers can see why the rest of
- * the chain skipped its work — every downstream leaf still emits its
- * own trace entry as a no-op.
- */
-function checkAlreadyEvaluatedLeaf(): Element<EvaluateCtx> {
-  return new Leaf<EvaluateCtx, { readonly task: Task }, { readonly skipEvaluation: boolean }>(
-    'check-already-evaluated',
-    {
-      useCase: {
-        async execute(input) {
-          return Promise.resolve(Result.ok({ skipEvaluation: input.task.evaluated }));
-        },
-      },
-      input: (ctx) => {
-        if (!ctx.task) throw new Error('check-already-evaluated: ctx.task must be loaded');
-        return { task: ctx.task };
-      },
-      output: (ctx, out) => ({ ...ctx, skipEvaluation: out.skipEvaluation }),
-    }
-  );
-}
-
 function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
   return new Leaf<
     EvaluateCtx,
@@ -172,33 +174,22 @@ function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
       readonly task: Task;
       readonly cwd: AbsolutePath;
       readonly promptFilePath?: AbsolutePath;
-      readonly skipEvaluation: boolean;
     },
     { readonly outcome?: EvaluationOutcome; readonly fullCritique?: string }
   >('evaluate-task', {
     useCase: {
       async execute(input) {
-        // No-op when an upstream `check-already-evaluated` flagged the
-        // task as already evaluated. Re-running `sprint evaluate` on a
-        // settled task must complete successfully without burning a
-        // fresh AI spawn (REQUIREMENTS.md: evaluator never blocks).
-        if (input.skipEvaluation) {
-          return Result.ok({});
-        }
         if (!input.promptFilePath) {
           throw new Error('evaluate-task: ctx.promptFilePath must be set by render-prompt-to-file');
         }
-        // Standalone evaluate has no per-task execution unit folder
-        // (the per-task chain inside executeFlow owns that folder), so
-        // we derive a stable session.md path under the sprint dir
-        // keyed on the task id. Each invocation of
-        // `sprint evaluate <task>` overwrites the prior file; the
-        // standalone command is a one-shot, not a loop.
-        const { resolveStoragePaths } = await import('@src/integration/persistence/storage-paths.ts');
-        const { join } = await import('node:path');
-        const sprintDir = resolveStoragePaths().sprintDir(input.sprint.id);
-        const { AbsolutePath: APV } = await import('@src/domain/values/absolute-path.ts');
-        const sessionMdPath = APV.trustString(join(sprintDir, 'evaluations', `session-${String(input.task.id)}.md`));
+        // Route every per-spawn artefact (session.md, evaluation.md,
+        // and a copy at the unit's `latest-evaluation.md`) under the
+        // standalone-round folder this chain run owns. The AI session
+        // adapter mkdir's the parent of `sessionMdPath`; explicit
+        // mkdir here covers the verdict + latest-evaluation paths.
+        const evaluatorDir = standaloneEvaluatorDir(input.sprint.id, input.task);
+        await mkdir(evaluatorDir, { recursive: true });
+        const sessionMdPath = AbsolutePath.trustString(join(evaluatorDir, 'session.md'));
         const result = await useCase.execute({
           sprint: input.sprint,
           task: input.task,
@@ -207,6 +198,16 @@ function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
           sessionMdPath,
         });
         if (!result.ok) return Result.error(result.error);
+        // Persist the verdict per-round AND copy to the unit's stable
+        // `latest-evaluation.md` so `Task.evaluationFile` always points
+        // at the most recent run's body.
+        const verdictPath = join(evaluatorDir, 'evaluation.md');
+        await writeFile(verdictPath, result.value.fullCritique, 'utf-8');
+        const storage = resolveStoragePaths();
+        const slug = unitSlug(String(input.task.id), input.task.name);
+        const unitRoot = String(storage.executionUnitDir(input.sprint.id, slug));
+        await mkdir(unitRoot, { recursive: true });
+        await writeFile(latestEvaluationPath(unitRoot), result.value.fullCritique, 'utf-8');
         return Result.ok({ outcome: result.value.outcome, fullCritique: result.value.fullCritique });
       },
     },
@@ -218,7 +219,6 @@ function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
         task: ctx.task,
         cwd: ctx.cwd,
         ...(ctx.promptFilePath !== undefined ? { promptFilePath: ctx.promptFilePath } : {}),
-        skipEvaluation: ctx.skipEvaluation === true,
       };
     },
     output: (ctx, out) =>
@@ -236,9 +236,10 @@ const MAX_PREVIEW_CHARS = 2000;
 
 /**
  * Persist the evaluator outcome on the Task aggregate. Records the
- * preview (≤2000 chars) plus the resolved verdict; full critique would
- * be persisted to a sidecar file by an integration adapter outside this
- * chain (the legacy `evaluations/<taskId>.md` writer).
+ * preview (≤2000 chars) plus the resolved verdict. The full critique is
+ * persisted under `execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/
+ * evaluation.md` (and copied to `latest-evaluation.md`) by the upstream
+ * evaluate-task leaf — `Task.evaluationFile` points at the stable copy.
  */
 function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element<EvaluateCtx> {
   return new Leaf<
@@ -248,22 +249,18 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
       readonly task: Task;
       readonly outcome?: EvaluationOutcome;
       readonly critique: string;
-      readonly skipEvaluation: boolean;
     },
     void
   >('persist-evaluation', {
     useCase: {
       async execute(input) {
-        // No-op when the task was already evaluated upstream — there's
-        // no fresh verdict to persist.
-        if (input.skipEvaluation) return Result.ok(undefined);
         if (input.outcome === undefined) {
           throw new Error('persist-evaluation: ctx.evaluationOutcome must be set');
         }
         const recorded = input.task.recordEvaluation({
           status: input.outcome,
           output: input.critique.slice(0, MAX_PREVIEW_CHARS),
-          file: `execution/${String(input.task.id)}/evaluation.md`,
+          file: `execution/${String(input.task.id)}/latest-evaluation.md`,
         });
         return deps.taskRepo.update(input.sprintId, recorded);
       },
@@ -275,7 +272,6 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
         task: ctx.task,
         ...(ctx.evaluationOutcome !== undefined ? { outcome: ctx.evaluationOutcome } : {}),
         critique: ctx.evaluationCritique ?? '',
-        skipEvaluation: ctx.skipEvaluation === true,
       };
     },
     output: (ctx) => ctx,

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -49,7 +49,6 @@ import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criter
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
 import { latestEvaluationPath, standaloneRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
-import { mkdir, writeFile } from 'node:fs/promises';
 
 export interface EvaluateCtx {
   readonly sprintId: SprintId;
@@ -81,6 +80,32 @@ export function createEvaluateFlow(
   >
 ): Element<EvaluateCtx> {
   const useCase = new EvaluateTaskUseCase(deps.aiSession, deps.signalParser, deps.logger, deps.signalHandler);
+
+  // One ISO per chain factory call → one folder per `sprint evaluate <task>`
+  // invocation. Two same-process invocations land in distinct folders.
+  // Computed eagerly so `render-prompt-to-file` and `evaluate-task` resolve
+  // to the same path within this run.
+  const iso = String(IsoTimestamp.now()).replace(/[:.]/g, '-');
+
+  /**
+   * Resolve the standalone-round evaluator folder for this invocation.
+   * Each `sprint evaluate <task>` call gets a fresh
+   * `<unit>/rounds/standalone-<ISO>/evaluator/` subtree so prior
+   * verdicts persist as durable history. `iso` is captured per chain
+   * factory call so `render-prompt-to-file` and `evaluate-task` resolve
+   * identical paths within a single run, and a fresh factory call gives
+   * a fresh `iso`.
+   *
+   * Pure path computation — `WriteContextFilePort` and the AI session
+   * adapter both mkdir their parent dirs, so the caller does not need
+   * to ensure the directory before writing.
+   */
+  const standaloneEvaluatorDir = (sprintId: SprintId, task: Task): string => {
+    const storage = resolveStoragePaths();
+    const slug = unitSlug(String(task.id), task.name);
+    const unitRoot = String(storage.executionUnitDir(sprintId, slug));
+    return join(standaloneRoundDir(unitRoot, iso), 'evaluator');
+  };
 
   const renderPromptStep = renderPromptToFileLeaf<EvaluateCtx>(
     { writeContextFile: deps.writeContextFile },
@@ -121,36 +146,9 @@ export function createEvaluateFlow(
     assertActiveLeaf<EvaluateCtx>('evaluate'),
     loadTaskLeaf(deps),
     renderPromptStep,
-    evaluateTaskLeaf(useCase),
+    evaluateTaskLeaf(deps, useCase, standaloneEvaluatorDir),
     persistEvaluationLeaf(deps),
   ]);
-}
-
-/**
- * Resolve the standalone-round evaluator folder for this invocation.
- * Each `sprint evaluate <task>` call gets a fresh
- * `<unit>/rounds/standalone-<ISO>/evaluator/` subtree so prior
- * verdicts persist as durable history. The ISO is cached per
- * (sprintId, taskId) so `render-prompt-to-file` and `evaluate-task`
- * resolve identical paths within a single chain run.
- *
- * Pure path computation — `WriteContextFilePort` and the AI session
- * adapter both mkdir their parent dirs, so the caller does not need
- * to ensure the directory before writing.
- */
-const standaloneRoundCache = new Map<string, string>();
-
-function standaloneEvaluatorDir(sprintId: SprintId, task: Task): string {
-  const storage = resolveStoragePaths();
-  const slug = unitSlug(String(task.id), task.name);
-  const unitRoot = String(storage.executionUnitDir(sprintId, slug));
-  const cacheKey = `${String(sprintId)}::${String(task.id)}`;
-  let iso = standaloneRoundCache.get(cacheKey);
-  if (iso === undefined) {
-    iso = String(IsoTimestamp.now()).replace(/[:.]/g, '-');
-    standaloneRoundCache.set(cacheKey, iso);
-  }
-  return join(standaloneRoundDir(unitRoot, iso), 'evaluator');
 }
 
 /** Build a load-task leaf for the evaluate flow's per-task pipeline. */
@@ -166,7 +164,11 @@ function loadTaskLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element<Evaluate
   });
 }
 
-function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
+function evaluateTaskLeaf(
+  deps: Pick<ChainSharedDeps, 'writeContextFile' | 'logger'>,
+  useCase: EvaluateTaskUseCase,
+  standaloneEvaluatorDir: (sprintId: SprintId, task: Task) => string
+): Element<EvaluateCtx> {
   return new Leaf<
     EvaluateCtx,
     {
@@ -185,10 +187,10 @@ function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
         // Route every per-spawn artefact (session.md, evaluation.md,
         // and a copy at the unit's `latest-evaluation.md`) under the
         // standalone-round folder this chain run owns. The AI session
-        // adapter mkdir's the parent of `sessionMdPath`; explicit
-        // mkdir here covers the verdict + latest-evaluation paths.
+        // adapter mkdir's the parent of `sessionMdPath`, and
+        // `WriteContextFilePort.write` mkdir's its parent — no explicit
+        // mkdir needed here.
         const evaluatorDir = standaloneEvaluatorDir(input.sprint.id, input.task);
-        await mkdir(evaluatorDir, { recursive: true });
         const sessionMdPath = AbsolutePath.trustString(join(evaluatorDir, 'session.md'));
         const result = await useCase.execute({
           sprint: input.sprint,
@@ -198,16 +200,37 @@ function evaluateTaskLeaf(useCase: EvaluateTaskUseCase): Element<EvaluateCtx> {
           sessionMdPath,
         });
         if (!result.ok) return Result.error(result.error);
-        // Persist the verdict per-round AND copy to the unit's stable
-        // `latest-evaluation.md` so `Task.evaluationFile` always points
-        // at the most recent run's body.
-        const verdictPath = join(evaluatorDir, 'evaluation.md');
-        await writeFile(verdictPath, result.value.fullCritique, 'utf-8');
+
+        // Per-round verdict + latest-evaluation copy — both best-effort.
+        // "Evaluator never blocks": the Task entity carries the critique in
+        // memory already (returned in `result.value.fullCritique`), so a
+        // write failure here is observable warn-level noise but doesn't
+        // fail the chain.
+        const verdictPath = AbsolutePath.trustString(join(evaluatorDir, 'evaluation.md'));
+        const verdictWritten = await deps.writeContextFile.write(verdictPath, result.value.fullCritique);
+        if (!verdictWritten.ok) {
+          deps.logger.warn('failed to persist standalone evaluator verdict', {
+            sprintId: String(input.sprint.id),
+            taskId: String(input.task.id),
+            path: String(verdictPath),
+            error: verdictWritten.error.message,
+          });
+        }
+
         const storage = resolveStoragePaths();
         const slug = unitSlug(String(input.task.id), input.task.name);
         const unitRoot = String(storage.executionUnitDir(input.sprint.id, slug));
-        await mkdir(unitRoot, { recursive: true });
-        await writeFile(latestEvaluationPath(unitRoot), result.value.fullCritique, 'utf-8');
+        const latestPath = AbsolutePath.trustString(latestEvaluationPath(unitRoot));
+        const latestWritten = await deps.writeContextFile.write(latestPath, result.value.fullCritique);
+        if (!latestWritten.ok) {
+          deps.logger.warn('failed to persist standalone latest-evaluation copy', {
+            sprintId: String(input.sprint.id),
+            taskId: String(input.task.id),
+            path: String(latestPath),
+            error: latestWritten.error.message,
+          });
+        }
+
         return Result.ok({ outcome: result.value.outcome, fullCritique: result.value.fullCritique });
       },
     },
@@ -257,10 +280,15 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
         if (input.outcome === undefined) {
           throw new Error('persist-evaluation: ctx.evaluationOutcome must be set');
         }
+        // Resolve the relative path the same way the upstream
+        // `evaluate-task` leaf resolves the on-disk write target — keyed
+        // on `unitSlug(taskId, taskName)` — so the recorded
+        // `Task.evaluationFile` reliably points at the file that exists.
+        const slug = unitSlug(String(input.task.id), input.task.name);
         const recorded = input.task.recordEvaluation({
           status: input.outcome,
           output: input.critique.slice(0, MAX_PREVIEW_CHARS),
-          file: `execution/${String(input.task.id)}/latest-evaluation.md`,
+          file: `execution/${slug}/latest-evaluation.md`,
         });
         return deps.taskRepo.update(input.sprintId, recorded);
       },

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -90,11 +90,14 @@ export function createEvaluateFlow(
 ): Element<EvaluateCtx> {
   const useCase = new EvaluateTaskUseCase(deps.aiSession, deps.signalParser, deps.logger, deps.signalHandler);
 
-  // One ISO per chain factory call → one folder per `sprint evaluate <task>`
-  // invocation. Two same-process invocations land in distinct folders.
-  // Computed eagerly so `render-prompt-to-file` and `evaluate-task` resolve
-  // to the same path within this run.
-  const iso = String(IsoTimestamp.now()).replace(/[:.]/g, '-');
+  // One folder-token per chain factory call → one folder per
+  // `sprint evaluate <task>` invocation. The token is `<ISO>-<rand4>`
+  // — millisecond ISO plus a 4-char random suffix so two same-process
+  // invocations within the same millisecond can't collide on the same
+  // `rounds/standalone-<token>/` folder. Computed eagerly so
+  // `render-prompt-to-file` and `evaluate-task` resolve to the same path
+  // within this run.
+  const iso = `${String(IsoTimestamp.now()).replace(/[:.]/g, '-')}-${randomSuffix()}`;
 
   /**
    * Resolve the standalone-round evaluator folder for this invocation.
@@ -313,4 +316,21 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
     },
     output: (ctx) => ctx,
   });
+}
+
+/**
+ * 4-char alphanumeric suffix appended to the standalone-round token so
+ * two same-process `sprint evaluate <task>` invocations within the same
+ * millisecond land in distinct folders. Uses lower-case alphanumerics
+ * for filesystem-safety; collision odds at 36^4 ≈ 1 in 1.7M per
+ * collision-window are well below the noise floor for human-driven
+ * evaluator runs.
+ */
+function randomSuffix(): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let out = '';
+  for (let i = 0; i < 4; i += 1) {
+    out += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
+  }
+  return out;
 }

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -28,6 +28,7 @@
  * resolves successfully so the surrounding chain can continue. The
  * `persist-evaluation` step records the verdict on the task entity.
  */
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 
 import { Result } from '@src/domain/result.ts';
@@ -48,7 +49,10 @@ import { loadSprintLeaf } from '@src/application/chains/leaves/load-sprint.ts';
 import { renderPromptToFileLeaf } from '@src/application/chains/leaves/render-prompt-to-file.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
-import { standaloneRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
+import {
+  standaloneEvaluatorVerdictSprintRelative,
+  standaloneRoundDir,
+} from '@src/kernel/algorithms/execution-round-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 
 export interface EvaluateCtx {
@@ -92,12 +96,15 @@ export function createEvaluateFlow(
 
   // One folder-token per chain factory call → one folder per
   // `sprint evaluate <task>` invocation. The token is `<ISO>-<rand4>`
-  // — millisecond ISO plus a 4-char random suffix so two same-process
-  // invocations within the same millisecond can't collide on the same
-  // `rounds/standalone-<token>/` folder. Computed eagerly so
-  // `render-prompt-to-file` and `evaluate-task` resolve to the same path
-  // within this run.
-  const iso = `${String(IsoTimestamp.now()).replace(/[:.]/g, '-')}-${randomSuffix()}`;
+  // — millisecond ISO plus a 4-hex-char random suffix so two
+  // same-process invocations within the same millisecond can't collide
+  // on the same `rounds/standalone-<token>/` folder. Computed eagerly
+  // so `render-prompt-to-file` and `evaluate-task` resolve to the same
+  // path within this run. Suffix entropy is 16⁴ ≈ 65k — collision odds
+  // are well below the noise floor for human-driven evaluator runs and
+  // `randomBytes` keeps us off `Math.random` for consistency with the
+  // rest of the codebase.
+  const iso = `${String(IsoTimestamp.now()).replace(/[:.]/g, '-')}-${randomBytes(2).toString('hex')}`;
 
   /**
    * Resolve the standalone-round evaluator folder for this invocation.
@@ -235,7 +242,7 @@ function evaluateTaskLeaf(
           });
         }
 
-        const evaluationFile = `execution/${slug}/rounds/standalone-${iso}/evaluator/evaluation.md`;
+        const evaluationFile = standaloneEvaluatorVerdictSprintRelative(slug, iso);
         return Result.ok({
           outcome: result.value.outcome,
           fullCritique: result.value.fullCritique,
@@ -316,21 +323,4 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
     },
     output: (ctx) => ctx,
   });
-}
-
-/**
- * 4-char alphanumeric suffix appended to the standalone-round token so
- * two same-process `sprint evaluate <task>` invocations within the same
- * millisecond land in distinct folders. Uses lower-case alphanumerics
- * for filesystem-safety; collision odds at 36^4 ≈ 1 in 1.7M per
- * collision-window are well below the noise floor for human-driven
- * evaluator runs.
- */
-function randomSuffix(): string {
-  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
-  let out = '';
-  for (let i = 0; i < 4; i += 1) {
-    out += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
-  }
-  return out;
 }

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -15,9 +15,10 @@
  *
  * Re-runs are allowed: every invocation creates a fresh
  * `<sprintDir>/execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/`
- * folder so prior verdicts are preserved as durable history. The latest
- * verdict still wins for `Task.evaluationFile` via a copy at
- * `<unit>/latest-evaluation.md`.
+ * folder so prior verdicts are preserved as durable history. Each
+ * standalone-round path is unique by ISO, so `Task.evaluationFile` is
+ * stamped to the verdict file inside the current run's folder — no
+ * pointer-file indirection needed.
  *
  * `render-prompt-to-file` writes the evaluator prompt to the standalone
  * round's `prompt.md`. The downstream `evaluate-task` leaf hands the AI
@@ -47,7 +48,7 @@ import { loadSprintLeaf } from '@src/application/chains/leaves/load-sprint.ts';
 import { renderPromptToFileLeaf } from '@src/application/chains/leaves/render-prompt-to-file.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
-import { latestEvaluationPath, standaloneRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
+import { standaloneRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 
 export interface EvaluateCtx {
@@ -64,6 +65,14 @@ export interface EvaluateCtx {
    * consumed by `evaluate-task`.
    */
   readonly promptFilePath?: AbsolutePath;
+  /**
+   * Relative path (under the sprint dir) of the verdict file this run
+   * wrote on disk — `execution/<unit-slug>/rounds/standalone-<ISO>/
+   * evaluator/evaluation.md`. Stamped by `evaluate-task` and read by
+   * `persist-evaluation` so the recorded `Task.evaluationFile`
+   * reliably points at a file that exists.
+   */
+  readonly evaluationFile?: string;
 }
 
 export function createEvaluateFlow(
@@ -146,7 +155,7 @@ export function createEvaluateFlow(
     assertActiveLeaf<EvaluateCtx>('evaluate'),
     loadTaskLeaf(deps),
     renderPromptStep,
-    evaluateTaskLeaf(deps, useCase, standaloneEvaluatorDir),
+    evaluateTaskLeaf(deps, useCase, iso),
     persistEvaluationLeaf(deps),
   ]);
 }
@@ -167,7 +176,7 @@ function loadTaskLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element<Evaluate
 function evaluateTaskLeaf(
   deps: Pick<ChainSharedDeps, 'writeContextFile' | 'logger'>,
   useCase: EvaluateTaskUseCase,
-  standaloneEvaluatorDir: (sprintId: SprintId, task: Task) => string
+  iso: string
 ): Element<EvaluateCtx> {
   return new Leaf<
     EvaluateCtx,
@@ -177,20 +186,25 @@ function evaluateTaskLeaf(
       readonly cwd: AbsolutePath;
       readonly promptFilePath?: AbsolutePath;
     },
-    { readonly outcome?: EvaluationOutcome; readonly fullCritique?: string }
+    {
+      readonly outcome?: EvaluationOutcome;
+      readonly fullCritique?: string;
+      readonly evaluationFile?: string;
+    }
   >('evaluate-task', {
     useCase: {
       async execute(input) {
         if (!input.promptFilePath) {
           throw new Error('evaluate-task: ctx.promptFilePath must be set by render-prompt-to-file');
         }
-        // Route every per-spawn artefact (session.md, evaluation.md,
-        // and a copy at the unit's `latest-evaluation.md`) under the
-        // standalone-round folder this chain run owns. The AI session
-        // adapter mkdir's the parent of `sessionMdPath`, and
+        // Route every per-spawn artefact (session.md, evaluation.md)
+        // under the standalone-round folder this chain run owns. The AI
+        // session adapter mkdir's the parent of `sessionMdPath`, and
         // `WriteContextFilePort.write` mkdir's its parent — no explicit
         // mkdir needed here.
-        const evaluatorDir = standaloneEvaluatorDir(input.sprint.id, input.task);
+        const slug = unitSlug(String(input.task.id), input.task.name);
+        const unitRoot = String(resolveStoragePaths().executionUnitDir(input.sprint.id, slug));
+        const evaluatorDir = join(standaloneRoundDir(unitRoot, iso), 'evaluator');
         const sessionMdPath = AbsolutePath.trustString(join(evaluatorDir, 'session.md'));
         const result = await useCase.execute({
           sprint: input.sprint,
@@ -201,11 +215,12 @@ function evaluateTaskLeaf(
         });
         if (!result.ok) return Result.error(result.error);
 
-        // Per-round verdict + latest-evaluation copy — both best-effort.
-        // "Evaluator never blocks": the Task entity carries the critique in
-        // memory already (returned in `result.value.fullCritique`), so a
-        // write failure here is observable warn-level noise but doesn't
-        // fail the chain.
+        // Per-round verdict — best-effort. "Evaluator never blocks":
+        // the Task entity carries the critique in memory already
+        // (returned in `result.value.fullCritique`), so a write failure
+        // here is observable warn-level noise but doesn't fail the
+        // chain. The relative path is plumbed through ctx so
+        // `persist-evaluation` records the same path that was written.
         const verdictPath = AbsolutePath.trustString(join(evaluatorDir, 'evaluation.md'));
         const verdictWritten = await deps.writeContextFile.write(verdictPath, result.value.fullCritique);
         if (!verdictWritten.ok) {
@@ -217,21 +232,12 @@ function evaluateTaskLeaf(
           });
         }
 
-        const storage = resolveStoragePaths();
-        const slug = unitSlug(String(input.task.id), input.task.name);
-        const unitRoot = String(storage.executionUnitDir(input.sprint.id, slug));
-        const latestPath = AbsolutePath.trustString(latestEvaluationPath(unitRoot));
-        const latestWritten = await deps.writeContextFile.write(latestPath, result.value.fullCritique);
-        if (!latestWritten.ok) {
-          deps.logger.warn('failed to persist standalone latest-evaluation copy', {
-            sprintId: String(input.sprint.id),
-            taskId: String(input.task.id),
-            path: String(latestPath),
-            error: latestWritten.error.message,
-          });
-        }
-
-        return Result.ok({ outcome: result.value.outcome, fullCritique: result.value.fullCritique });
+        const evaluationFile = `execution/${slug}/rounds/standalone-${iso}/evaluator/evaluation.md`;
+        return Result.ok({
+          outcome: result.value.outcome,
+          fullCritique: result.value.fullCritique,
+          evaluationFile,
+        });
       },
     },
     input: (ctx) => {
@@ -251,6 +257,7 @@ function evaluateTaskLeaf(
             ...ctx,
             evaluationOutcome: out.outcome,
             evaluationCritique: out.fullCritique ?? '',
+            ...(out.evaluationFile !== undefined ? { evaluationFile: out.evaluationFile } : {}),
           },
   });
 }
@@ -261,8 +268,10 @@ const MAX_PREVIEW_CHARS = 2000;
  * Persist the evaluator outcome on the Task aggregate. Records the
  * preview (≤2000 chars) plus the resolved verdict. The full critique is
  * persisted under `execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/
- * evaluation.md` (and copied to `latest-evaluation.md`) by the upstream
- * evaluate-task leaf — `Task.evaluationFile` points at the stable copy.
+ * evaluation.md` by the upstream evaluate-task leaf, which also stamps
+ * the relative path of that file onto `ctx.evaluationFile` so this leaf
+ * records the exact path that was written — no path duplication, no
+ * drift between writer and recorder.
  */
 function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element<EvaluateCtx> {
   return new Leaf<
@@ -272,6 +281,7 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
       readonly task: Task;
       readonly outcome?: EvaluationOutcome;
       readonly critique: string;
+      readonly evaluationFile?: string;
     },
     void
   >('persist-evaluation', {
@@ -280,15 +290,13 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
         if (input.outcome === undefined) {
           throw new Error('persist-evaluation: ctx.evaluationOutcome must be set');
         }
-        // Resolve the relative path the same way the upstream
-        // `evaluate-task` leaf resolves the on-disk write target — keyed
-        // on `unitSlug(taskId, taskName)` — so the recorded
-        // `Task.evaluationFile` reliably points at the file that exists.
-        const slug = unitSlug(String(input.task.id), input.task.name);
+        if (input.evaluationFile === undefined) {
+          throw new Error('persist-evaluation: ctx.evaluationFile must be set by evaluate-task');
+        }
         const recorded = input.task.recordEvaluation({
           status: input.outcome,
           output: input.critique.slice(0, MAX_PREVIEW_CHARS),
-          file: `execution/${slug}/latest-evaluation.md`,
+          file: input.evaluationFile,
         });
         return deps.taskRepo.update(input.sprintId, recorded);
       },
@@ -300,6 +308,7 @@ function persistEvaluationLeaf(deps: Pick<ChainSharedDeps, 'taskRepo'>): Element
         task: ctx.task,
         ...(ctx.evaluationOutcome !== undefined ? { outcome: ctx.evaluationOutcome } : {}),
         critique: ctx.evaluationCritique ?? '',
+        ...(ctx.evaluationFile !== undefined ? { evaluationFile: ctx.evaluationFile } : {}),
       };
     },
     output: (ctx) => ctx,

--- a/src/application/chains/evaluate/evaluate-flow.ts
+++ b/src/application/chains/evaluate/evaluate-flow.ts
@@ -47,7 +47,7 @@ import { loadSprintLeaf } from '@src/application/chains/leaves/load-sprint.ts';
 import { renderPromptToFileLeaf } from '@src/application/chains/leaves/render-prompt-to-file.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
-import { latestEvaluationPath, standaloneRoundDir } from '@src/integration/persistence/execution-unit-builder.ts';
+import { latestEvaluationPath, standaloneRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 import { mkdir, writeFile } from 'node:fs/promises';
 

--- a/src/application/chains/execute/per-task-flow.test.ts
+++ b/src/application/chains/execute/per-task-flow.test.ts
@@ -97,14 +97,14 @@ describe('createPerTaskFlow', () => {
     const idx = (n: string): number => stepNames.indexOf(n);
     expect(idx('branch-preflight')).toBeLessThan(idx('mark-in-progress'));
     expect(idx('mark-in-progress')).toBeLessThan(idx('render-prompt-to-file'));
-    expect(idx('render-prompt-to-file')).toBeLessThan(idx('execute-task'));
+    expect(idx('render-prompt-to-file')).toBeLessThan(idx('build-execution-unit'));
+    // build-execution-unit MUST run BEFORE execute-task so the initial
+    // generator's `session.md` audit lands in `rounds/1/generator/`.
+    // Reordering this is a contract change — the round-aware audit
+    // layout depends on it.
+    expect(idx('build-execution-unit')).toBeLessThan(idx('execute-task'));
     expect(idx('execute-task')).toBeLessThan(idx('post-task-check'));
-    // build-execution-unit + evaluate-task are wrapped together in
-    // an OnError-Sequential so they're adjacent in the trace, with
-    // build coming first to lay down the contract pack the evaluator
-    // reads.
-    expect(idx('post-task-check')).toBeLessThan(idx('build-execution-unit'));
-    expect(idx('build-execution-unit')).toBeLessThan(idx('evaluate-task'));
+    expect(idx('post-task-check')).toBeLessThan(idx('evaluate-task'));
     // commit-task sits AFTER the evaluator (so the evaluator's git status
     // sees the dirty tree as designed) and BEFORE mark-done.
     expect(idx('evaluate-task')).toBeLessThan(idx('commit-task'));
@@ -797,10 +797,11 @@ describe('createPerTaskFlow', () => {
   });
 
   it('build-execution-unit failure absorbed by OnError, task continues to mark-done', async () => {
-    // The OnError wrapper around the evaluator pack catches unit-build
-    // failures (disk full, EPERM, ...) so they don't gate task
-    // completion — the task still proceeds to `done`. The evaluator
-    // simply runs without addDirs, falling back to current behaviour.
+    // build-execution-unit has its own OnError wrap so a builder failure
+    // (disk full, EPERM, ...) does NOT gate task completion — the task
+    // still proceeds to `done`. The evaluator runs without an
+    // executionUnitRoot in ctx (no unit was materialised), which is the
+    // standalone-evaluate fallback path.
     const sprint = makeSprint();
     const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });
     const failure = new StorageError({ subCode: 'io', message: 'no disk space' });
@@ -812,14 +813,22 @@ describe('createPerTaskFlow', () => {
       aiSession: {
         outcomes: [
           { kind: 'ok', result: { output: 'done' } }, // execute-task
-          // Note: evaluator does NOT spawn — the unit build
-          // failure trips the OnError fallback BEFORE reaching the
-          // evaluator. With evaluator disabled by the swallow, only
-          // execute-task spawns.
+          { kind: 'ok', result: { output: 'evaluated' } }, // evaluator (no unit, no addDirs)
         ],
       },
       signalParser: {
-        results: [[taskCompleteSignal]],
+        results: [
+          [taskCompleteSignal],
+          [
+            {
+              type: 'evaluation',
+              status: 'passed',
+              dimensions: [],
+              critique: '',
+              timestamp: '2026-04-29T12:00:00Z' as never,
+            },
+          ],
+        ],
       },
       overrides: { sessionFolderBuilder },
     });
@@ -838,16 +847,15 @@ describe('createPerTaskFlow', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const stepNames = result.value.trace.map((t) => t.stepName.replace(/#attempt-\d+$/, ''));
+    // The OnError fallback's noop step records the swallowed failure.
     expect(stepNames).toContain('build-execution-unit');
-    expect(stepNames).toContain('evaluate-task-noop');
+    expect(stepNames).toContain('build-execution-unit-noop');
     expect(stepNames).toContain('mark-done');
 
     // Task is done despite the workspace build failure.
     const reread = await deps.taskRepo.findById(sprint.id, task.id);
     if (!reread.ok) throw new Error('expected task');
     expect(reread.value.status).toBe('done');
-    // Evaluator did not run, so `evaluated` stays false.
-    expect(reread.value.evaluated).toBe(false);
   });
 
   it('Copilot path: evaluator cwd is the workspace root (mirror lives there)', async () => {

--- a/src/application/chains/execute/per-task-flow.test.ts
+++ b/src/application/chains/execute/per-task-flow.test.ts
@@ -638,6 +638,75 @@ describe('createPerTaskFlow', () => {
     expect(coordinator.isPaused()).toBe(true);
   });
 
+  it('retry preserves the initial generator audit at session.md and routes the retry to session-attempt-2.md', async () => {
+    // The Retry(maxAttempts: 2, retryOn: 'rate-limited') decorator
+    // re-invokes execute-task on the same leaf instance. Without a
+    // per-leaf attempt counter the second attempt would overwrite
+    // `rounds/1/generator/session.md` and lose the first attempt's
+    // audit body. The fix keeps attempt 1 at the documented filename
+    // and routes attempt 2 to `session-attempt-2.md`.
+    const sprint = makeSprint();
+    const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });
+
+    const rl = new StorageError({ subCode: 'io', message: 'spawn failed: 429 too many requests' });
+    const ai = new FakeAiSessionPort({
+      outcomes: [
+        // Attempt 1: rate-limited spawn → use case classifies as
+        // 'rate-limited' → execute-task converts to a kernel error →
+        // Retry fires another attempt.
+        { kind: 'error', error: rl },
+        // Attempt 2: ok, signals carry task-complete so the chain
+        // proceeds.
+        { kind: 'ok', result: { output: 'done' } },
+        // Evaluator spawn (post-task-check passes by default).
+        { kind: 'ok', result: { output: 'evaluated' } },
+      ],
+    });
+
+    const deps = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      signalParser: {
+        results: [
+          [taskCompleteSignal],
+          [
+            {
+              type: 'evaluation',
+              status: 'passed',
+              dimensions: [],
+              critique: '',
+              timestamp: '2026-04-29T12:00:00Z' as never,
+            },
+          ],
+        ],
+      },
+      overrides: { aiSession: ai },
+    });
+
+    const flow = createPerTaskFlow(deps, { task, sprint });
+    const result = await flow.execute({
+      sprintId: sprint.id,
+      sprint,
+      task,
+      tasks: [task],
+      cwd: abs('/tmp/demo-repo'),
+      expectedBranch: '',
+    });
+
+    expect(result.ok).toBe(true);
+
+    // Spawns 1 + 2 are the generator (attempt 1 then retry); spawn 3 is
+    // the evaluator. The audit paths must point to the round-1 generator
+    // folder, with attempt 1 keeping the bare `session.md` filename and
+    // attempt 2 routed to `session-attempt-2.md`.
+    expect(ai.captured.length).toBeGreaterThanOrEqual(2);
+    const path1 = String(ai.captured[0]?.options.sessionMdPath ?? '');
+    const path2 = String(ai.captured[1]?.options.sessionMdPath ?? '');
+    expect(path1).toMatch(/\/rounds\/1\/generator\/session\.md$/);
+    expect(path2).toMatch(/\/rounds\/1\/generator\/session-attempt-2\.md$/);
+    expect(path1).not.toBe(path2);
+  });
+
   it('use case forwards every parsed signal to the signal bus during execute-task', async () => {
     const sprint = makeSprint();
     const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -62,7 +62,7 @@
  * the surrounding chain frame so `mark-done` still runs. (See the
  * `OnError(catchIf: () => true)` wrapper below.)
  */
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { Result } from '@src/domain/result.ts';
 import { evaluatorRoundDir, generatorRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
@@ -152,13 +152,6 @@ export interface PerTaskCtx {
    * real `task.projectPath`.
    */
   readonly executionSessionCwd?: AbsolutePath;
-  /**
-   * `<executionUnitRoot>/latest-evaluation.md` — stable pointer to the
-   * most recent evaluator critique. Stamped on `Task.evaluationFile` after
-   * each successful round; the per-round `rounds/<N>/evaluator/evaluation.md`
-   * artefacts remain on disk as the durable history.
-   */
-  readonly executionLatestEvaluationMdPath?: AbsolutePath;
   /**
    * Full sprint task list. Used by `build-execution-unit` to derive
    * `priorEvaluations` and to populate `tasks.md` / `tasks.json` inside
@@ -445,6 +438,10 @@ function executeTaskLeaf(useCase: ExecuteSingleTaskUseCase): Element<PerTaskCtx>
   // first attempt's audit body. Naming scheme: attempt 1 keeps the
   // documented happy-path filename; attempts 2+ get an `-attempt-N`
   // suffix so every retry's audit pack survives on disk.
+  //
+  // Safe because `createPerTaskFlow` is invoked per-task and the leaf
+  // instance is never shared across runs — a future refactor that
+  // memoises leaves across tasks would re-introduce the bug.
   let attempt = 0;
 
   return new Leaf<
@@ -678,7 +675,6 @@ function evaluateLoopLeaf(
       readonly executionUnitRoot?: AbsolutePath;
       readonly executionAddDirs?: readonly AbsolutePath[];
       readonly executionSessionCwd?: AbsolutePath;
-      readonly executionLatestEvaluationMdPath?: AbsolutePath;
     },
     { readonly evaluation?: EvaluateAndFixLoopOutput; readonly task: Task }
   >('evaluate-task', {
@@ -687,15 +683,14 @@ function evaluateLoopLeaf(
         if (input.taskBlocked) {
           return Result.ok({ task: input.task });
         }
-        // Read the per-task bullet from the execution unit's done-criteria.md.
-        // Best-effort — returns '' when absent or unreadable.
-        const doneCriteriaBullet =
-          input.executionUnitRoot !== undefined
-            ? await readDoneCriteriaBullet(
-                join(String(input.executionUnitRoot), 'done-criteria.md'),
-                String(input.task.id)
-              )
-            : '';
+        // No execution unit → the build leaf was swallowed by OnError
+        // upstream. The loop's contract requires an evaluate workspace
+        // for archival writes, so skip the loop entirely rather than
+        // invoking it without a target. The task still proceeds to
+        // mark-done; `evaluated` stays false so consumers can tell.
+        if (input.executionUnitRoot === undefined) {
+          return Result.ok({ task: input.task });
+        }
         // Programmer-error guard — the upstream `render-prompt-to-file`
         // leaf must have set this. The fix-and-reeval loop re-spawns
         // the generator, which needs the same execute-prompt file path.
@@ -705,64 +700,57 @@ function evaluateLoopLeaf(
             message: 'evaluate-task: promptFilePath is missing — render-prompt-to-file must run first',
           });
         }
-        // The render-prompt-to-file leaf already wrote the execute prompt
-        // under `<sprintDir>/contexts/`; derive the directory from the
-        // stamped path so the chain doesn't re-resolve storage paths.
-        const contextsDir = AbsolutePath.trustString(dirname(String(input.promptFilePath)));
+        const unitRoot = input.executionUnitRoot;
 
-        // Build a `refreshWorkspace` closure when an evaluate workspace
-        // was mounted upstream. The closure recomputes `priorEvaluations`
-        // from the live task list each call so a sibling that finishes
-        // mid-sprint surfaces in the next round's contract pack. When
-        // the workspace wasn't mounted (e.g. `build-evaluate-workspace`
-        // failed and the OnError wrapper is about to swallow this leaf
-        // anyway, or the standalone evaluate chain), refresh is a no-op
-        // and the loop skips it. The workspace root is captured by
-        // value — refresh works against the root that was already laid
-        // down, which is the contract for `refreshEvaluateWorkspace`.
-        const unitMounted = input.executionUnitRoot !== undefined;
-        const refreshWorkspace = unitMounted
-          ? async (): Promise<Result<void, DomainError>> => {
-              await deps.aiSession.ensureReady();
-              const aiProvider = deps.aiSession.getProviderName();
-              const priorEvaluations = collectPriorEvaluations(input.tasks);
-              return deps.sessionFolderBuilder.refreshExecutionUnit({
-                sprint: input.sprint,
-                tasks: input.tasks,
-                task: input.task,
-                aiProvider,
-                priorEvaluations,
-              });
-            }
-          : undefined;
+        // Read the per-task bullet from the execution unit's done-criteria.md.
+        // Best-effort — returns '' when absent or unreadable.
+        const doneCriteriaBullet = await readDoneCriteriaBullet(
+          join(String(unitRoot), 'done-criteria.md'),
+          String(input.task.id)
+        );
+
+        // `refreshWorkspace` recomputes `priorEvaluations` from the live
+        // task list each call so a sibling that finishes mid-sprint
+        // surfaces in the next round's contract pack. The workspace
+        // root is captured by value — refresh works against the root
+        // that was already laid down.
+        const refreshWorkspace = async (): Promise<Result<void, DomainError>> => {
+          await deps.aiSession.ensureReady();
+          const aiProvider = deps.aiSession.getProviderName();
+          const priorEvaluations = collectPriorEvaluations(input.tasks);
+          return deps.sessionFolderBuilder.refreshExecutionUnit({
+            sprint: input.sprint,
+            tasks: input.tasks,
+            task: input.task,
+            aiProvider,
+            priorEvaluations,
+          });
+        };
 
         // Per-spawn `session.md` audit path provider for the multi-round
         // loop. Each round routes its own audit under
         // `rounds/<round>/{generator,evaluator}/session.md` so the user
-        // can audit every round and every kind independently. When no
-        // unit folder was materialised (build failed) the closure
-        // returns undefined and audit is skipped.
-        const unitRoot = input.executionUnitRoot;
-        const nextSessionMdPath = unitRoot
-          ? (kind: 'generator' | 'evaluator', round: number): Promise<AbsolutePath | undefined> => {
-              const dir = kind === 'generator' ? generatorRoundDir : evaluatorRoundDir;
-              return Promise.resolve(AbsolutePath.trustString(join(dir(String(unitRoot), round), 'session.md')));
-            }
-          : undefined;
+        // can audit every round and every kind independently.
+        const nextSessionMdPath = (
+          kind: 'generator' | 'evaluator',
+          round: number
+        ): Promise<AbsolutePath | undefined> => {
+          const dir = kind === 'generator' ? generatorRoundDir : evaluatorRoundDir;
+          return Promise.resolve(AbsolutePath.trustString(join(dir(String(unitRoot), round), 'session.md')));
+        };
 
         const result = await loop.execute({
           task: input.task,
           sprint: input.sprint,
           cwd: input.cwd,
           executePromptFilePath: String(input.promptFilePath),
-          contextsDir,
+          evaluateWorkspaceDir: String(unitRoot),
+          refreshWorkspace,
+          nextSessionMdPath,
           ...(input.checkScript !== undefined ? { checkScript: input.checkScript } : {}),
           ...(input.resumeSessionId !== undefined ? { resumeSessionId: input.resumeSessionId } : {}),
           ...(input.executionAddDirs !== undefined ? { addDirs: input.executionAddDirs } : {}),
           ...(input.executionSessionCwd !== undefined ? { evaluateSessionCwd: input.executionSessionCwd } : {}),
-          ...(input.executionUnitRoot !== undefined ? { evaluateWorkspaceDir: String(input.executionUnitRoot) } : {}),
-          ...(refreshWorkspace !== undefined ? { refreshWorkspace } : {}),
-          ...(nextSessionMdPath !== undefined ? { nextSessionMdPath } : {}),
           ...(doneCriteriaBullet.length > 0 ? { doneCriteriaBullet } : {}),
         });
         if (!result.ok) return Result.error(result.error);
@@ -771,17 +759,19 @@ function evaluateLoopLeaf(
         // evaluator was disabled (rounds === 0) — the task entity's
         // `evaluated` flag stays false so consumers can tell.
         if (result.value.rounds > 0 && result.value.finalSignal !== null) {
-          // Evaluation file lives at `execution/<unit-slug>/latest-evaluation.md`.
-          // Persist the absolute path stamped by the build leaf when present;
-          // fall back to a best-effort relative path keyed on the task id
-          // when no unit was mounted (e.g. standalone evaluate chain).
+          // The verdict file lives at the FINAL round's per-round path —
+          // each round path is unique, so the highest N is unambiguously
+          // the most recent verdict. Recorded as a relative path under
+          // the sprint dir (`execution/<slug>/rounds/<N>/evaluator/
+          // evaluation.md`) so the value is portable across moved data
+          // dirs and machines.
+          const finalRound = result.value.rounds;
+          const slug = unitSlug(String(input.task.id), input.task.name);
+          const file = `execution/${slug}/rounds/${String(finalRound)}/evaluator/evaluation.md`;
           const recorded = input.task.recordEvaluation({
             status: result.value.finalSignal.status,
             output: result.value.finalCritique.slice(0, MAX_PREVIEW_CHARS),
-            file:
-              input.executionLatestEvaluationMdPath !== undefined
-                ? String(input.executionLatestEvaluationMdPath)
-                : `execution/${String(input.task.id)}/latest-evaluation.md`,
+            file,
           });
           const saved = await deps.taskRepo.update(input.sprintId, recorded);
           if (!saved.ok) return Result.error(saved.error);
@@ -803,9 +793,6 @@ function evaluateLoopLeaf(
       ...(ctx.executionUnitRoot !== undefined ? { executionUnitRoot: ctx.executionUnitRoot } : {}),
       ...(ctx.executionAddDirs !== undefined ? { executionAddDirs: ctx.executionAddDirs } : {}),
       ...(ctx.executionSessionCwd !== undefined ? { executionSessionCwd: ctx.executionSessionCwd } : {}),
-      ...(ctx.executionLatestEvaluationMdPath !== undefined
-        ? { executionLatestEvaluationMdPath: ctx.executionLatestEvaluationMdPath }
-        : {}),
     }),
     // Push the recorded task back onto the context so the downstream
     // `mark-done` leaf carries the evaluation forward when it flips

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -438,6 +438,15 @@ function markInProgressLeaf(deps: Pick<ChainSharedDeps, 'taskRepo' | 'signalBus'
 }
 
 function executeTaskLeaf(useCase: ExecuteSingleTaskUseCase): Element<PerTaskCtx> {
+  // Closure-scoped attempt counter: increments each time the leaf runs.
+  // The surrounding `Retry(maxAttempts: 2, retryOn: 'rate-limited')`
+  // re-invokes execute() against the same leaf instance, which would
+  // otherwise overwrite `rounds/1/generator/session.md` and lose the
+  // first attempt's audit body. Naming scheme: attempt 1 keeps the
+  // documented happy-path filename; attempts 2+ get an `-attempt-N`
+  // suffix so every retry's audit pack survives on disk.
+  let attempt = 0;
+
   return new Leaf<
     PerTaskCtx,
     {
@@ -467,18 +476,23 @@ function executeTaskLeaf(useCase: ExecuteSingleTaskUseCase): Element<PerTaskCtx>
             message: 'execute-task: promptFilePath is missing — render-prompt-to-file must run first',
           });
         }
+        attempt += 1;
         // Per-spawn `session.md` audit path. The initial generator
         // spawn is always round 1 — it lands at
         // `<unit>/rounds/1/generator/session.md` so the audit history
         // is round-aware from the very first attempt. Subsequent
         // generator (re-)spawns from the evaluate-and-fix loop go to
-        // `rounds/<round>/generator/session.md`. Best-effort: if the
-        // unit folder wasn't materialised (build leaf failed and the
-        // OnError above is about to swallow the result anyway), audit
-        // is silently skipped.
+        // `rounds/<round>/generator/session.md`. Retries from the
+        // surrounding `Retry` decorator land at
+        // `rounds/1/generator/session-attempt-<N>.md` so the first
+        // attempt's audit body is preserved across rate-limit retries.
+        // Best-effort: if the unit folder wasn't materialised (build
+        // leaf failed and the OnError above is about to swallow the
+        // result anyway), audit is silently skipped.
+        const filename = attempt === 1 ? 'session.md' : `session-attempt-${String(attempt)}.md`;
         const sessionMdPath =
           input.executionUnitRoot !== undefined
-            ? AbsolutePath.trustString(join(generatorRoundDir(String(input.executionUnitRoot), 1), 'session.md'))
+            ? AbsolutePath.trustString(join(generatorRoundDir(String(input.executionUnitRoot), 1), filename))
             : undefined;
         const result = await useCase.execute({
           sprint: input.sprint,

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -65,7 +65,7 @@
 import { dirname, join } from 'node:path';
 
 import { Result } from '@src/domain/result.ts';
-import { nextSessionPath } from '@src/integration/persistence/session-md-writer.ts';
+import { evaluatorRoundDir, generatorRoundDir } from '@src/integration/persistence/execution-unit-builder.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 
 import { BranchPreflightUseCase } from '@src/business/usecases/execute/branch-preflight.ts';
@@ -152,8 +152,13 @@ export interface PerTaskCtx {
    * real `task.projectPath`.
    */
   readonly executionSessionCwd?: AbsolutePath;
-  /** `<executionUnitRoot>/evaluation.md` — durable evaluator critique sink. */
-  readonly executionEvaluationMdPath?: AbsolutePath;
+  /**
+   * `<executionUnitRoot>/latest-evaluation.md` — stable pointer to the
+   * most recent evaluator critique. Stamped on `Task.evaluationFile` after
+   * each successful round; the per-round `rounds/<N>/evaluator/evaluation.md`
+   * artefacts remain on disk as the durable history.
+   */
+  readonly executionLatestEvaluationMdPath?: AbsolutePath;
   /**
    * Full sprint task list. Used by `build-execution-unit` to derive
    * `priorEvaluations` and to populate `tasks.md` / `tasks.json` inside
@@ -462,16 +467,18 @@ function executeTaskLeaf(useCase: ExecuteSingleTaskUseCase): Element<PerTaskCtx>
             message: 'execute-task: promptFilePath is missing — render-prompt-to-file must run first',
           });
         }
-        // Per-spawn `session.md` audit path. Each retry attempt OR
-        // resume on rate-limit recovery counts as its own round and
-        // gets its own `session-N.md` under the execution unit folder
-        // so the audit history shows each attempt distinctly. Best-
-        // effort: if the unit folder wasn't materialised (build leaf
-        // failed and the OnError above this leaf is about to swallow
-        // the result anyway), audit is silently skipped.
+        // Per-spawn `session.md` audit path. The initial generator
+        // spawn is always round 1 — it lands at
+        // `<unit>/rounds/1/generator/session.md` so the audit history
+        // is round-aware from the very first attempt. Subsequent
+        // generator (re-)spawns from the evaluate-and-fix loop go to
+        // `rounds/<round>/generator/session.md`. Best-effort: if the
+        // unit folder wasn't materialised (build leaf failed and the
+        // OnError above is about to swallow the result anyway), audit
+        // is silently skipped.
         const sessionMdPath =
           input.executionUnitRoot !== undefined
-            ? AbsolutePath.trustString(await nextSessionPath(String(input.executionUnitRoot)))
+            ? AbsolutePath.trustString(join(generatorRoundDir(String(input.executionUnitRoot), 1), 'session.md'))
             : undefined;
         const result = await useCase.execute({
           sprint: input.sprint,
@@ -657,7 +664,7 @@ function evaluateLoopLeaf(
       readonly executionUnitRoot?: AbsolutePath;
       readonly executionAddDirs?: readonly AbsolutePath[];
       readonly executionSessionCwd?: AbsolutePath;
-      readonly executionEvaluationMdPath?: AbsolutePath;
+      readonly executionLatestEvaluationMdPath?: AbsolutePath;
     },
     { readonly evaluation?: EvaluateAndFixLoopOutput; readonly task: Task }
   >('evaluate-task', {
@@ -716,20 +723,17 @@ function evaluateLoopLeaf(
           : undefined;
 
         // Per-spawn `session.md` audit path provider for the multi-round
-        // loop. Both evaluator and generator (fix-attempt) rounds get
-        // their own `session-N.md` under the per-task execution unit
-        // folder so the user can audit every round individually. The
-        // file basename is monotonic across kinds — interleaving the
-        // counter is an explicit decision so chronological order is
-        // preserved on disk; the frontmatter records `provider`/`flags`
-        // and the body shows the prompt, which together disambiguate
-        // generator vs evaluator without filename suffixes. When no
+        // loop. Each round routes its own audit under
+        // `rounds/<round>/{generator,evaluator}/session.md` so the user
+        // can audit every round and every kind independently. When no
         // unit folder was materialised (build failed) the closure
         // returns undefined and audit is skipped.
         const unitRoot = input.executionUnitRoot;
         const nextSessionMdPath = unitRoot
-          ? async (): Promise<AbsolutePath | undefined> =>
-              AbsolutePath.trustString(await nextSessionPath(String(unitRoot)))
+          ? (kind: 'generator' | 'evaluator', round: number): Promise<AbsolutePath | undefined> => {
+              const dir = kind === 'generator' ? generatorRoundDir : evaluatorRoundDir;
+              return Promise.resolve(AbsolutePath.trustString(join(dir(String(unitRoot), round), 'session.md')));
+            }
           : undefined;
 
         const result = await loop.execute({
@@ -753,7 +757,7 @@ function evaluateLoopLeaf(
         // evaluator was disabled (rounds === 0) — the task entity's
         // `evaluated` flag stays false so consumers can tell.
         if (result.value.rounds > 0 && result.value.finalSignal !== null) {
-          // Evaluation file lives at `execution/<unit-slug>/evaluation.md`.
+          // Evaluation file lives at `execution/<unit-slug>/latest-evaluation.md`.
           // Persist the absolute path stamped by the build leaf when present;
           // fall back to a best-effort relative path keyed on the task id
           // when no unit was mounted (e.g. standalone evaluate chain).
@@ -761,9 +765,9 @@ function evaluateLoopLeaf(
             status: result.value.finalSignal.status,
             output: result.value.finalCritique.slice(0, MAX_PREVIEW_CHARS),
             file:
-              input.executionEvaluationMdPath !== undefined
-                ? String(input.executionEvaluationMdPath)
-                : `execution/${String(input.task.id)}/evaluation.md`,
+              input.executionLatestEvaluationMdPath !== undefined
+                ? String(input.executionLatestEvaluationMdPath)
+                : `execution/${String(input.task.id)}/latest-evaluation.md`,
           });
           const saved = await deps.taskRepo.update(input.sprintId, recorded);
           if (!saved.ok) return Result.error(saved.error);
@@ -785,8 +789,8 @@ function evaluateLoopLeaf(
       ...(ctx.executionUnitRoot !== undefined ? { executionUnitRoot: ctx.executionUnitRoot } : {}),
       ...(ctx.executionAddDirs !== undefined ? { executionAddDirs: ctx.executionAddDirs } : {}),
       ...(ctx.executionSessionCwd !== undefined ? { executionSessionCwd: ctx.executionSessionCwd } : {}),
-      ...(ctx.executionEvaluationMdPath !== undefined
-        ? { executionEvaluationMdPath: ctx.executionEvaluationMdPath }
+      ...(ctx.executionLatestEvaluationMdPath !== undefined
+        ? { executionLatestEvaluationMdPath: ctx.executionLatestEvaluationMdPath }
         : {}),
     }),
     // Push the recorded task back onto the context so the downstream

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -65,7 +65,11 @@
 import { join } from 'node:path';
 
 import { Result } from '@src/domain/result.ts';
-import { evaluatorRoundDir, generatorRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
+import {
+  evaluatorRoundDir,
+  evaluatorVerdictSprintRelative,
+  generatorRoundDir,
+} from '@src/kernel/algorithms/execution-round-paths.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 
 import { BranchPreflightUseCase } from '@src/business/usecases/execute/branch-preflight.ts';
@@ -761,13 +765,12 @@ function evaluateLoopLeaf(
         if (result.value.rounds > 0 && result.value.finalSignal !== null) {
           // The verdict file lives at the FINAL round's per-round path —
           // each round path is unique, so the highest N is unambiguously
-          // the most recent verdict. Recorded as a relative path under
-          // the sprint dir (`execution/<slug>/rounds/<N>/evaluator/
-          // evaluation.md`) so the value is portable across moved data
-          // dirs and machines.
+          // the most recent verdict. The kernel helper centralises the
+          // relative-path layout so this and the standalone-evaluate
+          // chain don't drift on a future folder rename.
           const finalRound = result.value.rounds;
           const slug = unitSlug(String(input.task.id), input.task.name);
-          const file = `execution/${slug}/rounds/${String(finalRound)}/evaluator/evaluation.md`;
+          const file = evaluatorVerdictSprintRelative(slug, finalRound);
           const recorded = input.task.recordEvaluation({
             status: result.value.finalSignal.status,
             output: result.value.finalCritique.slice(0, MAX_PREVIEW_CHARS),

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -6,7 +6,8 @@
  * Steps (happy path):
  *
  *   branch-preflight → mark-in-progress → render-prompt-to-file →
- *     execute-task → post-task-check → evaluate-task → mark-done
+ *     build-execution-unit → execute-task → post-task-check →
+ *     evaluate-task → commit-task → mark-done
  *
  * The chain does NOT auto-commit a dirty tree after the generator. The
  * evaluator runs `git status` as part of its read-only checks and treats
@@ -251,26 +252,36 @@ export function createPerTaskFlow(
     fallback: markCancelledFallbackLeaf(deps),
   });
 
-  // The evaluator pack: `build-evaluate-workspace` lays down the per-task
-  // contract files, then `evaluate-task` runs the multi-round loop and
-  // reads them via the workspace root. Wrap BOTH together so a workspace
-  // builder failure (disk full, EPERM, ...) ALSO doesn't block task
-  // completion — the task should still proceed to `mark-done`. The
-  // existing "evaluator never gates mark-done" contract extends to the
-  // workspace setup that feeds it. User-initiated cancellation
-  // (`code: 'aborted'`) propagates so Ctrl+C mid-evaluator doesn't
-  // silently fall through to mark-done.
-  const buildEvalWorkspaceStep = buildExecutionUnitLeaf<PerTaskCtx>({
-    sessionFolderBuilder: deps.sessionFolderBuilder,
-    aiSession: deps.aiSession,
-  });
-  const evaluatorAsLeaf = new OnError<PerTaskCtx>(
-    new Sequential<PerTaskCtx>('evaluate', [buildEvalWorkspaceStep, evaluateLoopLeaf(deps, evaluateLoop)]),
+  // The evaluator pack is split across two outer-Sequential steps:
+  //
+  //   1. `buildEvalWorkspaceStep` lays down the per-task contract files
+  //      BEFORE `execute-task` runs so the initial generator's
+  //      `session.md` audit lands in `rounds/1/generator/`.
+  //   2. `evaluateLoopStep` runs the multi-round loop AFTER the
+  //      `post-task-check` gate, reading the contract files via the
+  //      workspace root and writing per-round artefacts under
+  //      `rounds/<N>/{generator,evaluator}/`.
+  //
+  // Each step has its OWN OnError wrap so a builder failure (disk full,
+  // EPERM, …) OR an evaluator failure ALSO doesn't block task completion
+  // — the task should still proceed to `mark-done`. User-initiated
+  // cancellation (`code: 'aborted'`) propagates so Ctrl+C mid-evaluator
+  // doesn't silently fall through to mark-done.
+  const buildEvalWorkspaceStep = new OnError<PerTaskCtx>(
+    buildExecutionUnitLeaf<PerTaskCtx>({
+      sessionFolderBuilder: deps.sessionFolderBuilder,
+      aiSession: deps.aiSession,
+    }),
     {
       catchIf: (err) => err.code !== 'aborted',
-      fallback: noopLeaf<PerTaskCtx>('evaluate-task-noop'),
+      fallback: noopLeaf<PerTaskCtx>('build-execution-unit-noop'),
     }
   );
+
+  const evaluateLoopStep = new OnError<PerTaskCtx>(evaluateLoopLeaf(deps, evaluateLoop), {
+    catchIf: (err) => err.code !== 'aborted',
+    fallback: noopLeaf<PerTaskCtx>('evaluate-task-noop'),
+  });
 
   // Conditionally include post-task-check only when a check script is
   // configured. Tasks with no check script (e.g. polyglot subdirs) skip
@@ -306,9 +317,10 @@ export function createPerTaskFlow(
     branchPreflightStep,
     markInProgressLeaf(deps),
     renderPromptStep,
+    buildEvalWorkspaceStep,
     executeTaskStep,
     postTaskStep,
-    evaluatorAsLeaf,
+    evaluateLoopStep,
     commitTaskLeaf(deps),
     markDoneLeaf(deps),
   ]);

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -65,7 +65,7 @@
 import { dirname, join } from 'node:path';
 
 import { Result } from '@src/domain/result.ts';
-import { evaluatorRoundDir, generatorRoundDir } from '@src/integration/persistence/execution-unit-builder.ts';
+import { evaluatorRoundDir, generatorRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
 import { readDoneCriteriaBullet } from '@src/integration/persistence/done-criteria-reader.ts';
 
 import { BranchPreflightUseCase } from '@src/business/usecases/execute/branch-preflight.ts';

--- a/src/application/chains/leaves/build-execution-unit.test.ts
+++ b/src/application/chains/leaves/build-execution-unit.test.ts
@@ -33,7 +33,7 @@ describe('buildExecutionUnitLeaf', () => {
       expect(call?.priorEvaluations.size).toBe(0);
     });
 
-    it('stamps the returned paths onto ctx as executionUnitRoot / executionAddDirs / executionSessionCwd / executionEvaluationMdPath', async () => {
+    it('stamps the returned paths onto ctx as executionUnitRoot / executionAddDirs / executionSessionCwd / executionLatestEvaluationMdPath', async () => {
       const sessionFolderBuilder = new FakeSessionFolderBuilderPort({ rootPrefix: '/fake-units' });
       const aiSession = new FakeAiSessionPort({ providerName: 'claude' });
       const leaf = buildExecutionUnitLeaf<BuildExecutionUnitCtx>({ sessionFolderBuilder, aiSession });
@@ -50,7 +50,7 @@ describe('buildExecutionUnitLeaf', () => {
       expect(ctx.executionUnitRoot).toBeDefined();
       expect(ctx.executionAddDirs).toBeDefined();
       expect(ctx.executionSessionCwd).toBeDefined();
-      expect(ctx.executionEvaluationMdPath).toBeDefined();
+      expect(ctx.executionLatestEvaluationMdPath).toBeDefined();
     });
 
     it('preserves extra ctx fields on output', async () => {

--- a/src/application/chains/leaves/build-execution-unit.test.ts
+++ b/src/application/chains/leaves/build-execution-unit.test.ts
@@ -33,7 +33,7 @@ describe('buildExecutionUnitLeaf', () => {
       expect(call?.priorEvaluations.size).toBe(0);
     });
 
-    it('stamps the returned paths onto ctx as executionUnitRoot / executionAddDirs / executionSessionCwd / executionLatestEvaluationMdPath', async () => {
+    it('stamps the returned paths onto ctx as executionUnitRoot / executionAddDirs / executionSessionCwd', async () => {
       const sessionFolderBuilder = new FakeSessionFolderBuilderPort({ rootPrefix: '/fake-units' });
       const aiSession = new FakeAiSessionPort({ providerName: 'claude' });
       const leaf = buildExecutionUnitLeaf<BuildExecutionUnitCtx>({ sessionFolderBuilder, aiSession });
@@ -50,7 +50,6 @@ describe('buildExecutionUnitLeaf', () => {
       expect(ctx.executionUnitRoot).toBeDefined();
       expect(ctx.executionAddDirs).toBeDefined();
       expect(ctx.executionSessionCwd).toBeDefined();
-      expect(ctx.executionLatestEvaluationMdPath).toBeDefined();
     });
 
     it('preserves extra ctx fields on output', async () => {

--- a/src/application/chains/leaves/build-execution-unit.ts
+++ b/src/application/chains/leaves/build-execution-unit.ts
@@ -34,7 +34,7 @@ export interface BuildExecutionUnitCtx {
   readonly executionUnitRoot?: AbsolutePath;
   readonly executionAddDirs?: readonly AbsolutePath[];
   readonly executionSessionCwd?: AbsolutePath;
-  readonly executionEvaluationMdPath?: AbsolutePath;
+  readonly executionLatestEvaluationMdPath?: AbsolutePath;
 }
 
 export interface BuildExecutionUnitLeafDeps {
@@ -58,7 +58,7 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
       readonly root: AbsolutePath;
       readonly addDirs: readonly AbsolutePath[];
       readonly sessionCwd: AbsolutePath;
-      readonly evaluationMdPath: AbsolutePath;
+      readonly latestEvaluationMdPath: AbsolutePath;
     }
   >(name, {
     useCase: {
@@ -68,7 +68,7 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
             readonly root: AbsolutePath;
             readonly addDirs: readonly AbsolutePath[];
             readonly sessionCwd: AbsolutePath;
-            readonly evaluationMdPath: AbsolutePath;
+            readonly latestEvaluationMdPath: AbsolutePath;
           },
           DomainError
         >
@@ -104,7 +104,7 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
       executionUnitRoot: out.root,
       executionAddDirs: out.addDirs,
       executionSessionCwd: out.sessionCwd,
-      executionEvaluationMdPath: out.evaluationMdPath,
+      executionLatestEvaluationMdPath: out.latestEvaluationMdPath,
     }),
   });
 }

--- a/src/application/chains/leaves/build-execution-unit.ts
+++ b/src/application/chains/leaves/build-execution-unit.ts
@@ -34,7 +34,6 @@ export interface BuildExecutionUnitCtx {
   readonly executionUnitRoot?: AbsolutePath;
   readonly executionAddDirs?: readonly AbsolutePath[];
   readonly executionSessionCwd?: AbsolutePath;
-  readonly executionLatestEvaluationMdPath?: AbsolutePath;
 }
 
 export interface BuildExecutionUnitLeafDeps {
@@ -58,7 +57,6 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
       readonly root: AbsolutePath;
       readonly addDirs: readonly AbsolutePath[];
       readonly sessionCwd: AbsolutePath;
-      readonly latestEvaluationMdPath: AbsolutePath;
     }
   >(name, {
     useCase: {
@@ -68,7 +66,6 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
             readonly root: AbsolutePath;
             readonly addDirs: readonly AbsolutePath[];
             readonly sessionCwd: AbsolutePath;
-            readonly latestEvaluationMdPath: AbsolutePath;
           },
           DomainError
         >
@@ -104,7 +101,6 @@ export function buildExecutionUnitLeaf<TCtx extends BuildExecutionUnitCtx>(
       executionUnitRoot: out.root,
       executionAddDirs: out.addDirs,
       executionSessionCwd: out.sessionCwd,
-      executionLatestEvaluationMdPath: out.latestEvaluationMdPath,
     }),
   });
 }

--- a/src/business/_test-fakes/fake-session-folder-builder-port.ts
+++ b/src/business/_test-fakes/fake-session-folder-builder-port.ts
@@ -134,7 +134,7 @@ export class FakeSessionFolderBuilderPort implements SessionFolderBuilderPort {
         root,
         addDirs: isCopilot ? [] : [root],
         sessionCwd: isCopilot ? root : input.task.projectPath,
-        evaluationMdPath: this.path(input.sprint.id, 'execution', slug, 'evaluation.md'),
+        latestEvaluationMdPath: this.path(input.sprint.id, 'execution', slug, 'latest-evaluation.md'),
       })
     );
   }

--- a/src/business/_test-fakes/fake-session-folder-builder-port.ts
+++ b/src/business/_test-fakes/fake-session-folder-builder-port.ts
@@ -134,7 +134,6 @@ export class FakeSessionFolderBuilderPort implements SessionFolderBuilderPort {
         root,
         addDirs: isCopilot ? [] : [root],
         sessionCwd: isCopilot ? root : input.task.projectPath,
-        latestEvaluationMdPath: this.path(input.sprint.id, 'execution', slug, 'latest-evaluation.md'),
       })
     );
   }

--- a/src/business/ports/prompt-builder-port.ts
+++ b/src/business/ports/prompt-builder-port.ts
@@ -130,7 +130,7 @@ export interface PromptBuilderPort {
    * lands its contract pack on disk). When set, the rendered prompt
    * includes a `Contract files` section pointing the AI at upstream
    * artefacts (`requirements/`, `tasks.md`, `dimensions.md`,
-   * `evaluations/`, `project-context.md`). When unset, the section
+   * `prior-evaluations/`, `project-context.md`). When unset, the section
    * collapses — used by the standalone `sprint evaluate` chain which
    * has no workspace.
    */

--- a/src/business/ports/session-folder-builder-port.ts
+++ b/src/business/ports/session-folder-builder-port.ts
@@ -82,15 +82,6 @@ export interface ExecutionUnitPaths {
    * `<root>/repo/`.
    */
   readonly sessionCwd: AbsolutePath;
-  /**
-   * `<root>/latest-evaluation.md` — stable pointer to the most recent
-   * evaluator critique. Updated by the evaluate-and-fix loop after every
-   * round (a copy of `rounds/<N>/evaluator/evaluation.md`). Stamped on
-   * `Task.evaluationFile` so consumers always have a single, canonical
-   * place to read the latest verdict; the `rounds/<N>/evaluator/…`
-   * artefacts remain the durable per-round history.
-   */
-  readonly latestEvaluationMdPath: AbsolutePath;
 }
 
 export interface SessionFolderBuilderPort {

--- a/src/business/ports/session-folder-builder-port.ts
+++ b/src/business/ports/session-folder-builder-port.ts
@@ -21,8 +21,8 @@
  *
  * **Refresh semantics:** `refreshExecutionUnit` overwrites only the
  * volatile per-task files (`task.md`, `tasks.md`, `tasks.json`,
- * `project-context.md`, `evaluations/`). Static files written by the
- * initial `buildExecutionUnit` (`requirements/`, `dimensions.md`,
+ * `project-context.md`, `prior-evaluations/`). Static files written by
+ * the initial `buildExecutionUnit` (`requirements/`, `dimensions.md`,
  * the root context file) are left untouched.
  */
 import type { AiProvider } from '@src/business/ports/ai-session-port.ts';
@@ -82,8 +82,15 @@ export interface ExecutionUnitPaths {
    * `<root>/repo/`.
    */
   readonly sessionCwd: AbsolutePath;
-  /** `<root>/evaluation.md` — durable evaluator critique sink (overwritten per round). */
-  readonly evaluationMdPath: AbsolutePath;
+  /**
+   * `<root>/latest-evaluation.md` — stable pointer to the most recent
+   * evaluator critique. Updated by the evaluate-and-fix loop after every
+   * round (a copy of `rounds/<N>/evaluator/evaluation.md`). Stamped on
+   * `Task.evaluationFile` so consumers always have a single, canonical
+   * place to read the latest verdict; the `rounds/<N>/evaluator/…`
+   * artefacts remain the durable per-round history.
+   */
+  readonly latestEvaluationMdPath: AbsolutePath;
 }
 
 export interface SessionFolderBuilderPort {
@@ -123,8 +130,8 @@ export interface SessionFolderBuilderPort {
    * Build a per-task execution unit folder. Writes both static files
    * (`requirements/`, `dimensions.md`, the root context file) and the
    * volatile per-task files (`task.md`, `tasks.md`, `tasks.json`,
-   * `project-context.md`, `evaluations/`). For Copilot, mirrors the
-   * task's `projectPath` into `<root>/repo/`.
+   * `project-context.md`, `prior-evaluations/`). For Copilot, mirrors
+   * the task's `projectPath` into `<root>/repo/`.
    */
   buildExecutionUnit(input: {
     readonly sprint: Sprint;

--- a/src/business/ports/signal-bus-port.ts
+++ b/src/business/ports/signal-bus-port.ts
@@ -1,9 +1,10 @@
 /**
  * `SignalBusPort` — observable signal stream parallel to
  * `SignalHandlerPort`. Where the handler writes signals to durable storage
- * (progress.md, evaluations/, tasks.json), the bus broadcasts the same
- * signals + synthetic lifecycle events to in-memory subscribers (the live
- * TUI dashboard, log tails, etc.). Two sinks, one source.
+ * (progress.md summaries; the evaluator's full critique is persisted by
+ * `EvaluateAndFixLoopUseCase`), the bus broadcasts the same signals plus
+ * synthetic lifecycle events to in-memory subscribers (the live TUI
+ * dashboard, log tails, etc.). Two sinks, one source.
  *
  * Subscribers receive events in emission order. A failing listener does
  * NOT stall delivery to other listeners — adapters wrap each invocation

--- a/src/business/usecases/_shared/file-handoff-wrapper.test.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.test.ts
@@ -92,4 +92,27 @@ describe('renderFixHandoffWrapper', () => {
     const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
     expect(result.endsWith('\n')).toBe(false);
   });
+
+  it('escapes embedded </evaluator-critique> tags in the critique body so the wrapper boundary stays unambiguous', () => {
+    // The evaluator AI could quote the tag (it's named in dimensions.md)
+    // and a literal closing tag inside the body would close the wrapper
+    // early. Replace it with a backslash-escaped form that the resumed
+    // generator can still read but doesn't terminate the wrapper.
+    const adversarial = [
+      'A naive evaluator might emit </evaluator-critique> mid-body.',
+      'Even </evaluator-critique> appearing at column 0 must not close the wrapper early.',
+    ].join('\n');
+    const result = renderFixHandoffWrapper(FAKE_PATH, adversarial);
+    // The body's closing tags are escaped — exactly one un-escaped
+    // `</evaluator-critique>` remains: the wrapper's own closing tag.
+    const unescapedCloses = result.split('</evaluator-critique>').length - 1;
+    expect(unescapedCloses).toBe(1);
+    // The escaped form appears in the body so the generator still
+    // sees the literal mention.
+    expect(result).toContain('<\\/evaluator-critique>');
+    // The escaped-form count matches the number of adversarial close
+    // tags we injected (two).
+    const escapedCloses = result.split('<\\/evaluator-critique>').length - 1;
+    expect(escapedCloses).toBe(2);
+  });
 });

--- a/src/business/usecases/_shared/file-handoff-wrapper.test.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.test.ts
@@ -3,8 +3,16 @@ import { describe, expect, it } from 'vitest';
 import { renderFileHandoffWrapper, renderFixHandoffWrapper } from './file-handoff-wrapper.ts';
 
 const FAKE_PATH = '/home/user/.ralphctl/data/sprints/20260429-120000-demo/contexts/execute-task-abc.md';
-const CRITIQUE_PATH =
-  '/home/user/.ralphctl/data/sprints/20260429-120000-demo/execution/abc-task/rounds/1/evaluator/evaluation.md';
+const CRITIQUE_BODY = [
+  '# Evaluation — failed',
+  '',
+  '## Dimensions',
+  '- **correctness** (score 2/5): FAIL — null-input branch returns undefined.',
+  '- **completeness** (score 4/5): PASS — covers the happy path.',
+  '',
+  '## Notes',
+  'Fix the null-input handling and add a regression test.',
+].join('\n');
 
 describe('renderFileHandoffWrapper', () => {
   it('embeds the absolute promptFilePath verbatim inside the wrapper body', () => {
@@ -36,18 +44,29 @@ describe('renderFileHandoffWrapper', () => {
 });
 
 describe('renderFixHandoffWrapper', () => {
-  it('embeds both the critique path and the spec path', () => {
-    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+  it('inlines the critique body verbatim and embeds the spec path', () => {
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
+    expect(result).toContain(CRITIQUE_BODY);
     expect(result).toContain(FAKE_PATH);
-    expect(result).toContain(CRITIQUE_PATH);
+  });
+
+  it('wraps the critique in <evaluator-critique> tags so the AI can locate it unambiguously', () => {
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
+    expect(result).toContain('<evaluator-critique>');
+    expect(result).toContain('</evaluator-critique>');
+    const openIdx = result.indexOf('<evaluator-critique>');
+    const bodyIdx = result.indexOf(CRITIQUE_BODY);
+    const closeIdx = result.indexOf('</evaluator-critique>');
+    expect(openIdx).toBeLessThan(bodyIdx);
+    expect(bodyIdx).toBeLessThan(closeIdx);
   });
 
   it('orders the critique BEFORE the spec — read-critique-first contract', () => {
     // The whole point of this wrapper: the resumed generator must
     // read the verdict before re-reading the spec, otherwise the fix
     // round is a blind retry.
-    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
-    const critiqueIdx = result.indexOf(CRITIQUE_PATH);
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
+    const critiqueIdx = result.indexOf(CRITIQUE_BODY);
     const specIdx = result.indexOf(FAKE_PATH);
     expect(critiqueIdx).toBeGreaterThanOrEqual(0);
     expect(specIdx).toBeGreaterThanOrEqual(0);
@@ -55,7 +74,7 @@ describe('renderFixHandoffWrapper', () => {
   });
 
   it('mentions the harness, fix-round framing, and the <task-complete> closing signal', () => {
-    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
     const lower = result.toLowerCase();
     expect(lower).toContain('ralphctl');
     expect(lower).toContain('harness');
@@ -64,13 +83,13 @@ describe('renderFixHandoffWrapper', () => {
   });
 
   it('produces a distinct body from the plain wrapper', () => {
-    const fix = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const fix = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
     const plain = renderFileHandoffWrapper(FAKE_PATH);
     expect(fix).not.toBe(plain);
   });
 
   it('does not include any trailing newline', () => {
-    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_BODY);
     expect(result.endsWith('\n')).toBe(false);
   });
 });

--- a/src/business/usecases/_shared/file-handoff-wrapper.test.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderFileHandoffWrapper } from './file-handoff-wrapper.ts';
+import { renderFileHandoffWrapper, renderFixHandoffWrapper } from './file-handoff-wrapper.ts';
 
 const FAKE_PATH = '/home/user/.ralphctl/data/sprints/20260429-120000-demo/contexts/execute-task-abc.md';
+const CRITIQUE_PATH =
+  '/home/user/.ralphctl/data/sprints/20260429-120000-demo/execution/abc-task/rounds/1/evaluator/evaluation.md';
 
 describe('renderFileHandoffWrapper', () => {
   it('embeds the absolute promptFilePath verbatim inside the wrapper body', () => {
@@ -29,6 +31,46 @@ describe('renderFileHandoffWrapper', () => {
 
   it('does not include any trailing newline', () => {
     const result = renderFileHandoffWrapper(FAKE_PATH);
+    expect(result.endsWith('\n')).toBe(false);
+  });
+});
+
+describe('renderFixHandoffWrapper', () => {
+  it('embeds both the critique path and the spec path', () => {
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    expect(result).toContain(FAKE_PATH);
+    expect(result).toContain(CRITIQUE_PATH);
+  });
+
+  it('orders the critique BEFORE the spec — read-critique-first contract', () => {
+    // The whole point of this wrapper: the resumed generator must
+    // read the verdict before re-reading the spec, otherwise the fix
+    // round is a blind retry.
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const critiqueIdx = result.indexOf(CRITIQUE_PATH);
+    const specIdx = result.indexOf(FAKE_PATH);
+    expect(critiqueIdx).toBeGreaterThanOrEqual(0);
+    expect(specIdx).toBeGreaterThanOrEqual(0);
+    expect(critiqueIdx).toBeLessThan(specIdx);
+  });
+
+  it('mentions the harness, fix-round framing, and the <task-complete> closing signal', () => {
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const lower = result.toLowerCase();
+    expect(lower).toContain('ralphctl');
+    expect(lower).toContain('harness');
+    expect(lower).toContain('fix round');
+    expect(result).toContain('<task-complete>');
+  });
+
+  it('produces a distinct body from the plain wrapper', () => {
+    const fix = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
+    const plain = renderFileHandoffWrapper(FAKE_PATH);
+    expect(fix).not.toBe(plain);
+  });
+
+  it('does not include any trailing newline', () => {
+    const result = renderFixHandoffWrapper(FAKE_PATH, CRITIQUE_PATH);
     expect(result.endsWith('\n')).toBe(false);
   });
 });

--- a/src/business/usecases/_shared/file-handoff-wrapper.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.ts
@@ -39,9 +39,17 @@ export function renderFileHandoffWrapper(promptFilePath: string): string {
  * `rounds/<N>/evaluator/evaluation.md` remains for archival, written by
  * the surrounding loop.
  *
+ * **Delimiter safety.** The critique body is an AI emission and could
+ * theoretically contain a literal `</evaluator-critique>` (the tag is
+ * named in `dimensions.md` and the evaluator may quote it). We escape
+ * any embedded closing tag in the inlined body so the resumed generator
+ * can locate the wrapper boundary unambiguously even when the critique
+ * mentions the tag verbatim.
+ *
  * Pure string. No IO.
  */
 export function renderFixHandoffWrapper(promptFilePath: string, critique: string): string {
+  const safeCritique = critique.replace(/<\/evaluator-critique>/g, '<\\/evaluator-critique>');
   return [
     'You are an agent under the ralphctl harness — resuming on a fix round.',
     '',
@@ -49,7 +57,7 @@ export function renderFixHandoffWrapper(promptFilePath: string, critique: string
     'Its critique follows verbatim — read it FIRST, before doing anything else:',
     '',
     '<evaluator-critique>',
-    critique,
+    safeCritique,
     '</evaluator-critique>',
     '',
     `Then re-read the task spec at \`${promptFilePath}\` to refresh the success criteria.`,

--- a/src/business/usecases/_shared/file-handoff-wrapper.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.ts
@@ -31,20 +31,26 @@ export function renderFileHandoffWrapper(promptFilePath: string): string {
  * The evaluator runs in a separate AI session, so its critique is NOT in
  * the generator's chat history; without an explicit pointer the resumed
  * generator never sees the verdict and the fix attempt is a blind retry.
- * This wrapper hands the generator the on-disk path of the prior round's
- * evaluation.md and instructs it to read the verdict FIRST, then
- * re-read the spec, then address every flagged dimension without
- * regressing the passed ones — the read-critique-first contract.
+ * This wrapper inlines the verdict body directly in the resume turn so
+ * the generator reads it without a tool round-trip — the critique is
+ * bounded (a few KB) and already lives in memory at the call site, so a
+ * file-handoff buys nothing here and adds two failure modes (file
+ * missing / unreadable). The on-disk copy at
+ * `rounds/<N>/evaluator/evaluation.md` remains for archival, written by
+ * the surrounding loop.
  *
- * Pure string. No IO. The chain layer is responsible for ensuring the
- * file at `critiqueFilePath` exists before the generator spawns.
+ * Pure string. No IO.
  */
-export function renderFixHandoffWrapper(promptFilePath: string, critiqueFilePath: string): string {
+export function renderFixHandoffWrapper(promptFilePath: string, critique: string): string {
   return [
     'You are an agent under the ralphctl harness — resuming on a fix round.',
     '',
-    `Read the evaluator critique at \`${critiqueFilePath}\` FIRST.`,
-    'It lists which evaluation dimensions failed in the previous round and why.',
+    'The evaluator from the previous round flagged the work as not yet complete.',
+    'Its critique follows verbatim — read it FIRST, before doing anything else:',
+    '',
+    '<evaluator-critique>',
+    critique,
+    '</evaluator-critique>',
     '',
     `Then re-read the task spec at \`${promptFilePath}\` to refresh the success criteria.`,
     '',

--- a/src/business/usecases/_shared/file-handoff-wrapper.ts
+++ b/src/business/usecases/_shared/file-handoff-wrapper.ts
@@ -23,3 +23,32 @@ export function renderFileHandoffWrapper(promptFilePath: string): string {
     'Follow the protocol in that file exactly.',
   ].join('\n');
 }
+
+/**
+ * `renderFixHandoffWrapper` — critique-aware variant of the file-handoff
+ * wrapper used when the harness resumes the generator on a fix round.
+ *
+ * The evaluator runs in a separate AI session, so its critique is NOT in
+ * the generator's chat history; without an explicit pointer the resumed
+ * generator never sees the verdict and the fix attempt is a blind retry.
+ * This wrapper hands the generator the on-disk path of the prior round's
+ * evaluation.md and instructs it to read the verdict FIRST, then
+ * re-read the spec, then address every flagged dimension without
+ * regressing the passed ones — the read-critique-first contract.
+ *
+ * Pure string. No IO. The chain layer is responsible for ensuring the
+ * file at `critiqueFilePath` exists before the generator spawns.
+ */
+export function renderFixHandoffWrapper(promptFilePath: string, critiqueFilePath: string): string {
+  return [
+    'You are an agent under the ralphctl harness — resuming on a fix round.',
+    '',
+    `Read the evaluator critique at \`${critiqueFilePath}\` FIRST.`,
+    'It lists which evaluation dimensions failed in the previous round and why.',
+    '',
+    `Then re-read the task spec at \`${promptFilePath}\` to refresh the success criteria.`,
+    '',
+    'Address every dimension flagged failed. Do not regress the dimensions that already passed.',
+    'When the work is complete, emit `<task-complete>` per the spec.',
+  ].join('\n');
+}

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
@@ -681,6 +681,61 @@ describe('EvaluateAndFixLoopUseCase', () => {
     expect(latestWrites[1]?.content).toBe('eval-1');
   });
 
+  it('hands the round-2 generator a critique-aware wrapper pointing at rounds/1/evaluator/evaluation.md', async () => {
+    // The fix-round resume must reference the prior round's verdict on
+    // disk so the generator reads the critique BEFORE re-reading the
+    // spec. Without this the resumed session never sees the evaluator's
+    // findings.
+    const { loop, ai } = buildLoop({
+      iterations: 3,
+      evalSignals: [[failSignal()], [passSignal()]],
+    });
+
+    await loop.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
+      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
+    });
+
+    // Spawn 1 = generator fix; the wrapper text is captured as the
+    // `prompt` passed into the spawn. The fix wrapper embeds both the
+    // critique path and the spec path.
+    const fixPrompt = ai.captured[1]?.prompt ?? '';
+    expect(fixPrompt).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/evaluation.md');
+    expect(fixPrompt).toContain('/tmp/sprints/a/contexts/execute-task.md');
+    // It identifies itself as a fix round so the generator picks the
+    // critique-first reading order.
+    expect(fixPrompt.toLowerCase()).toContain('fix round');
+  });
+
+  it('does NOT pass fixContext when no evaluate workspace is mounted (defensive)', async () => {
+    // Standalone evaluate / no workspace → the loop has nowhere to
+    // point the generator at, so fall back to the plain wrapper. The
+    // fix branch only fires on iterations >= 2, so we exercise the
+    // multi-round path without `evaluateWorkspaceDir`.
+    const { loop, ai } = buildLoop({
+      iterations: 3,
+      evalSignals: [[failSignal()], [passSignal()]],
+    });
+
+    await loop.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
+      contextsDir: path('/tmp/sprints/a/contexts'),
+      // intentionally no evaluateWorkspaceDir
+    });
+
+    const fixPrompt = ai.captured[1]?.prompt ?? '';
+    // The plain wrapper does NOT reference a critique file path.
+    expect(fixPrompt.toLowerCase()).not.toContain('fix round');
+    expect(fixPrompt).not.toContain('evaluation.md');
+  });
+
   it('threads `round` into nextSessionMdPath so generator/evaluator audits land per-round', async () => {
     const calls: { kind: string; round: number }[] = [];
     const nextSessionMdPath = (kind: 'generator' | 'evaluator', round: number): Promise<undefined> => {

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
@@ -191,7 +191,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -217,7 +217,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -240,7 +240,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -263,7 +263,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -290,7 +290,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -313,7 +313,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -335,7 +335,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -363,7 +363,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       resumeSessionId: 'initial-gen',
     });
 
@@ -388,7 +388,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -407,7 +407,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -427,7 +427,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       checkScript: 'pnpm test',
     });
 
@@ -450,7 +450,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -470,7 +470,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     const roundComplete = logger.entries.find((e) => e.message.startsWith('evaluator round complete'));
@@ -497,7 +497,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);
@@ -519,7 +519,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       addDirs: [path('/tmp/sprints/a/workspaces/evaluate')],
     });
 
@@ -548,7 +548,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       evaluateSessionCwd: path('/tmp/sprints/a/workspaces/evaluate'),
     });
 
@@ -568,7 +568,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(String(ai.captured[0]?.options.cwd)).toBe('/repos/demo');
@@ -585,7 +585,6 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
       evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
@@ -612,7 +611,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       refreshWorkspace,
     });
 
@@ -637,7 +636,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       refreshWorkspace,
     });
 
@@ -651,7 +650,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
     expect(logger.hasMessage('warn', 'refresh evaluate workspace')).toBe(true);
   });
 
-  it('writes the per-round verdict to rounds/<N>/evaluator/evaluation.md and updates latest-evaluation.md', async () => {
+  it('writes the per-round verdict to rounds/<N>/evaluator/evaluation.md (one file per round, no pointer)', async () => {
     const { loop, writeContextFile } = buildLoop({
       iterations: 3,
       evalSignals: [[failSignal()], [passSignal()]],
@@ -662,30 +661,27 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
       evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     const writePaths = writeContextFile.writes.map((w) => String(w.path));
-    // Per-round prompt + verdict for both rounds.
+    // Per-round prompt + verdict for both rounds — each round path is unique,
+    // so the highest-N verdict is unambiguously the most recent.
     expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/prompt.md');
     expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/evaluation.md');
     expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/2/evaluator/prompt.md');
     expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/2/evaluator/evaluation.md');
-    // latest-evaluation.md is updated after every round.
-    const latestWrites = writeContextFile.writes.filter(
-      (w) => String(w.path) === '/tmp/sprints/a/workspaces/evaluate/latest-evaluation.md'
-    );
-    expect(latestWrites).toHaveLength(2);
-    // The most recent latest write is round 2's body.
-    expect(latestWrites[1]?.content).toBe('eval-1');
+    // No `latest-evaluation.md` pointer file is written — the per-round
+    // path itself is the canonical reference.
+    expect(writePaths).not.toContain('/tmp/sprints/a/workspaces/evaluate/latest-evaluation.md');
   });
 
-  it('hands the round-2 generator a critique-aware wrapper pointing at rounds/1/evaluator/evaluation.md', async () => {
-    // The fix-round resume must reference the prior round's verdict on
-    // disk so the generator reads the critique BEFORE re-reading the
-    // spec. Without this the resumed session never sees the evaluator's
-    // findings.
+  it('hands the round-2 generator a critique-aware wrapper that inlines the round-1 verdict body', async () => {
+    // The fix-round resume must include the prior round's verdict so the
+    // generator reads the critique BEFORE re-reading the spec. The
+    // critique is inlined in the wrapper turn rather than handed off
+    // via a file pointer — bounded body, already in memory, no extra
+    // tool round-trip.
     const { loop, ai } = buildLoop({
       iterations: 3,
       evalSignals: [[failSignal()], [passSignal()]],
@@ -696,44 +692,17 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
       evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
-    // Spawn 1 = generator fix; the wrapper text is captured as the
-    // `prompt` passed into the spawn. The fix wrapper embeds both the
-    // critique path and the spec path.
+    // Spawn 1 = round 1→2 fix attempt. The wrapper inlines the round-1
+    // evaluator stdout (`eval-0` per buildLoop's canonical script) and
+    // references the spec by path; it identifies itself as a fix round.
     const fixPrompt = ai.captured[1]?.prompt ?? '';
-    expect(fixPrompt).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/evaluation.md');
+    expect(fixPrompt).toContain('eval-0');
+    expect(fixPrompt).toContain('<evaluator-critique>');
     expect(fixPrompt).toContain('/tmp/sprints/a/contexts/execute-task.md');
-    // It identifies itself as a fix round so the generator picks the
-    // critique-first reading order.
     expect(fixPrompt.toLowerCase()).toContain('fix round');
-  });
-
-  it('does NOT pass fixContext when no evaluate workspace is mounted (defensive)', async () => {
-    // Standalone evaluate / no workspace → the loop has nowhere to
-    // point the generator at, so fall back to the plain wrapper. The
-    // fix branch only fires on iterations >= 2, so we exercise the
-    // multi-round path without `evaluateWorkspaceDir`.
-    const { loop, ai } = buildLoop({
-      iterations: 3,
-      evalSignals: [[failSignal()], [passSignal()]],
-    });
-
-    await loop.execute({
-      task: aTask(),
-      sprint: aSprint(),
-      cwd: path('/repos/demo'),
-      executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
-      // intentionally no evaluateWorkspaceDir
-    });
-
-    const fixPrompt = ai.captured[1]?.prompt ?? '';
-    // The plain wrapper does NOT reference a critique file path.
-    expect(fixPrompt.toLowerCase()).not.toContain('fix round');
-    expect(fixPrompt).not.toContain('evaluation.md');
   });
 
   it('threads `round` into nextSessionMdPath so generator/evaluator audits land per-round', async () => {
@@ -753,7 +722,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
       nextSessionMdPath,
     });
 
@@ -785,7 +754,7 @@ describe('EvaluateAndFixLoopUseCase', () => {
       sprint: aSprint(),
       cwd: path('/repos/demo'),
       executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
-      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
     });
 
     expect(result.ok).toBe(true);

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.test.ts
@@ -651,6 +651,66 @@ describe('EvaluateAndFixLoopUseCase', () => {
     expect(logger.hasMessage('warn', 'refresh evaluate workspace')).toBe(true);
   });
 
+  it('writes the per-round verdict to rounds/<N>/evaluator/evaluation.md and updates latest-evaluation.md', async () => {
+    const { loop, writeContextFile } = buildLoop({
+      iterations: 3,
+      evalSignals: [[failSignal()], [passSignal()]],
+    });
+
+    await loop.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
+      contextsDir: path('/tmp/sprints/a/contexts'),
+      evaluateWorkspaceDir: '/tmp/sprints/a/workspaces/evaluate',
+    });
+
+    const writePaths = writeContextFile.writes.map((w) => String(w.path));
+    // Per-round prompt + verdict for both rounds.
+    expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/prompt.md');
+    expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/1/evaluator/evaluation.md');
+    expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/2/evaluator/prompt.md');
+    expect(writePaths).toContain('/tmp/sprints/a/workspaces/evaluate/rounds/2/evaluator/evaluation.md');
+    // latest-evaluation.md is updated after every round.
+    const latestWrites = writeContextFile.writes.filter(
+      (w) => String(w.path) === '/tmp/sprints/a/workspaces/evaluate/latest-evaluation.md'
+    );
+    expect(latestWrites).toHaveLength(2);
+    // The most recent latest write is round 2's body.
+    expect(latestWrites[1]?.content).toBe('eval-1');
+  });
+
+  it('threads `round` into nextSessionMdPath so generator/evaluator audits land per-round', async () => {
+    const calls: { kind: string; round: number }[] = [];
+    const nextSessionMdPath = (kind: 'generator' | 'evaluator', round: number): Promise<undefined> => {
+      calls.push({ kind, round });
+      return Promise.resolve(undefined);
+    };
+
+    const { loop } = buildLoop({
+      iterations: 3,
+      evalSignals: [[failSignal()], [passSignal()]],
+    });
+
+    await loop.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      executePromptFilePath: '/tmp/sprints/a/contexts/execute-task.md',
+      contextsDir: path('/tmp/sprints/a/contexts'),
+      nextSessionMdPath,
+    });
+
+    // Round 1 evaluator → generator fix (round 2 in the upcoming sense)
+    // → round 2 evaluator.
+    expect(calls).toStrictEqual([
+      { kind: 'evaluator', round: 1 },
+      { kind: 'generator', round: 2 },
+      { kind: 'evaluator', round: 2 },
+    ]);
+  });
+
   it('honors a config raise mid-loop (re-read picks up the new ceiling)', async () => {
     // Round 1: cap=1, evaluator fails. After the fail check, cap is
     // raised to 3, so a fix attempt + round 2 should run.

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
@@ -22,14 +22,26 @@
  * on every loop tick so a settings-panel edit mid-execution applies to the
  * next round (REQ-12).
  *
- * **Prompt file rendering** — each evaluator round writes a fresh
- * evaluator prompt to `<sprintDir>/contexts/evaluate-<task-id>.md`,
- * overwriting the prior round's body so the AI always reads the
- * current critique. The generator's prompt at
- * `<sprintDir>/contexts/execute-<task-id>.md` is rendered once by the
- * chain layer's `render-prompt-to-file` leaf and reused across fix
- * rounds (Claude resumes via `--resume <session-id>` so the original
- * file body remains in scope).
+ * **Per-round on-disk layout** — when an `evaluateWorkspaceDir` is set,
+ * the loop writes one folder per round under
+ * `<workspace>/rounds/<N>/evaluator/`:
+ *
+ *   - `prompt.md` — the evaluator prompt rendered for THIS round.
+ *   - `evaluation.md` — the full critique (`fullCritique` from the
+ *     `EvaluateTaskUseCase` result), stamped after the round settles.
+ *   - `session.md` — the audit pack written by the AI session adapter.
+ *
+ * Generator (re-)spawns land their `session.md` audit at
+ * `rounds/<N>/generator/session.md`. After every successful round the
+ * loop also copies the verdict to `<workspace>/latest-evaluation.md`
+ * — a stable pointer for `Task.evaluationFile`, while the per-round
+ * `evaluation.md` files remain the durable history.
+ *
+ * The generator's prompt at the chain-supplied
+ * `executePromptFilePath` is rendered once by the
+ * `render-prompt-to-file` leaf and reused across fix rounds (Claude
+ * resumes via `--resume <session-id>` so the original file body
+ * remains in scope).
  *
  * **Never blocks** — the loop **always** returns `Result.ok(...)`. A
  * failed / malformed / plateau outcome is signalled via the structured
@@ -55,6 +67,21 @@ import type { PostTaskCheckUseCase } from '@src/business/usecases/execute/post-t
 import type { EvaluateTaskUseCase } from './evaluate-task.ts';
 import { type EvaluationOutcome } from './evaluate-task.ts';
 import { dimensionsEqual } from './plateau-detection.ts';
+
+/**
+ * Pure path helpers — the loop knows the per-round layout under an
+ * execution unit folder. Mirror of the integration-layer helpers in
+ * `src/integration/persistence/execution-unit-builder.ts`; kept inline
+ * here so the business layer doesn't import from integration. Both
+ * sites must agree on the layout.
+ */
+function evaluatorRoundDirInline(workspaceDir: string, round: number): string {
+  return join(workspaceDir, 'rounds', String(round), 'evaluator');
+}
+
+function latestEvaluationPathInline(workspaceDir: string): string {
+  return join(workspaceDir, 'latest-evaluation.md');
+}
 
 /**
  * Narrow shape this use case needs from a live-config provider — only the
@@ -139,17 +166,18 @@ export interface EvaluateAndFixLoopInput {
   /**
    * Optional per-spawn `session.md` path provider. The loop calls this
    * before each generator (`{ kind: 'generator' }`) and evaluator
-   * (`{ kind: 'evaluator' }`) spawn to obtain a fresh audit path; it
-   * threads the result into the spawn's `SessionOptions` so the AI
-   * session adapter brackets the spawn with `writeSessionStart` /
-   * `writeSessionFinish`. Returning `undefined` skips the audit for
-   * that round. Implementations typically use {@link nextSessionPath}
-   * over the per-task execution unit root.
+   * (`{ kind: 'evaluator' }`) spawn to obtain an audit path keyed on
+   * `round`; it threads the result into the spawn's `SessionOptions`
+   * so the AI session adapter brackets the spawn with
+   * `writeSessionStart` / `writeSessionFinish`. Returning `undefined`
+   * skips the audit for that round. The chain layer's implementation
+   * routes `'evaluator'` to `rounds/<round>/evaluator/session.md` and
+   * `'generator'` to `rounds/<round>/generator/session.md`.
    *
    * Lives in `business/` so the use case stays IO-free; the chain
    * leaf injects an integration-side closure.
    */
-  readonly nextSessionMdPath?: (kind: 'generator' | 'evaluator') => Promise<AbsolutePath | undefined>;
+  readonly nextSessionMdPath?: (kind: 'generator' | 'evaluator', round: number) => Promise<AbsolutePath | undefined>;
   readonly abortSignal?: AbortSignal;
 }
 
@@ -202,12 +230,6 @@ export class EvaluateAndFixLoopUseCase {
       });
     }
 
-    const evaluatorPromptPath = AbsolutePathVO.trustString(
-      input.evaluateWorkspaceDir !== undefined
-        ? join(input.evaluateWorkspaceDir, 'evaluator-prompt.md')
-        : join(String(input.contextsDir), `evaluate-${String(input.task.id)}.md`)
-    );
-
     const history: EvaluationRound[] = [];
     let previousSignal: EvaluationSignal | undefined;
     let previousCritique: string | undefined;
@@ -250,6 +272,19 @@ export class EvaluateAndFixLoopUseCase {
         }
       }
 
+      // ── Per-round evaluator paths.
+      //    When an evaluate workspace is mounted, route the prompt + verdict
+      //    + session.md under `rounds/<round>/evaluator/` so each round's
+      //    artefacts persist independently. Without a workspace (the
+      //    standalone evaluate chain doesn't mount one), fall back to the
+      //    sprint-level contexts/ folder so plain-text invocations still
+      //    write somewhere meaningful.
+      const evaluatorPromptPath = AbsolutePathVO.trustString(
+        input.evaluateWorkspaceDir !== undefined
+          ? join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'prompt.md')
+          : join(String(input.contextsDir), `evaluate-${String(input.task.id)}.md`)
+      );
+
       // ── Render the evaluator prompt to file (per-round; the
       //    `previousCritique` slot changes between rounds). Overwriting
       //    is intentional — the AI reads the FRESH version each time.
@@ -266,7 +301,9 @@ export class EvaluateAndFixLoopUseCase {
 
       // ── Evaluator round ─────────────────────────────────────────
       const evaluatorCwd = input.evaluateSessionCwd ?? input.cwd;
-      const evaluatorSessionMdPath = input.nextSessionMdPath ? await input.nextSessionMdPath('evaluator') : undefined;
+      const evaluatorSessionMdPath = input.nextSessionMdPath
+        ? await input.nextSessionMdPath('evaluator', round)
+        : undefined;
       const evalResult = await this.evaluator.execute({
         task: input.task,
         sprint: input.sprint,
@@ -280,6 +317,32 @@ export class EvaluateAndFixLoopUseCase {
 
       const { outcome, signal, fullCritique } = evalResult.value;
       history.push({ round, outcome, signal, critique: fullCritique });
+
+      // ── Persist the verdict to disk: per-round file + stable
+      //    `latest-evaluation.md` pointer. Best-effort: a write failure
+      //    surfaces as a warning so the round result is still usable
+      //    by the chain (the verdict is in `fullCritique` on the result
+      //    object regardless). Skipped when no workspace is mounted.
+      if (input.evaluateWorkspaceDir !== undefined) {
+        const verdictPath = AbsolutePathVO.trustString(
+          join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'evaluation.md')
+        );
+        const verdictWritten = await this.writeContextFile.write(verdictPath, fullCritique);
+        if (!verdictWritten.ok) {
+          log.warn('failed to persist per-round evaluator verdict', {
+            round,
+            error: verdictWritten.error.message,
+          });
+        }
+        const latestPath = AbsolutePathVO.trustString(latestEvaluationPathInline(input.evaluateWorkspaceDir));
+        const latestWritten = await this.writeContextFile.write(latestPath, fullCritique);
+        if (!latestWritten.ok) {
+          log.warn('failed to update latest-evaluation.md pointer', {
+            round,
+            error: latestWritten.error.message,
+          });
+        }
+      }
 
       log.info(`evaluator round complete for task ${String(input.task.id)}`, { round, outcome });
 
@@ -319,9 +382,14 @@ export class EvaluateAndFixLoopUseCase {
       // ── Generator fix round ─────────────────────────────────────
       // The generator resumes the same session, so the original
       // execute prompt file at `input.executePromptFilePath` is
-      // already in scope. No re-render needed.
+      // already in scope. No re-render needed. The next round's
+      // index is `round + 1` — `nextSessionMdPath` is keyed on it
+      // so the generator's audit lands in `rounds/<round + 1>/generator/`.
       log.info('resuming generator with critique', { round });
-      const generatorSessionMdPath = input.nextSessionMdPath ? await input.nextSessionMdPath('generator') : undefined;
+      const fixRound = round + 1;
+      const generatorSessionMdPath = input.nextSessionMdPath
+        ? await input.nextSessionMdPath('generator', fixRound)
+        : undefined;
       const fixResult = await this.generator.execute({
         task: input.task,
         sprint: input.sprint,

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
@@ -39,9 +39,10 @@
  *
  * The generator's prompt at the chain-supplied
  * `executePromptFilePath` is rendered once by the
- * `render-prompt-to-file` leaf and reused across fix rounds (Claude
- * resumes via `--resume <session-id>` so the original file body
- * remains in scope).
+ * `render-prompt-to-file` leaf and reused across fix rounds. On round
+ * `>= 2` the loop additionally hands the generator a critique-aware
+ * wrapper pointing at `rounds/<N-1>/evaluator/evaluation.md` so the
+ * fix attempt can read the verdict before re-reading the spec.
  *
  * **Never blocks** — the loop **always** returns `Result.ok(...)`. A
  * failed / malformed / plateau outcome is signalled via the structured
@@ -382,14 +383,22 @@ export class EvaluateAndFixLoopUseCase {
       // ── Generator fix round ─────────────────────────────────────
       // The generator resumes the same session, so the original
       // execute prompt file at `input.executePromptFilePath` is
-      // already in scope. No re-render needed. The next round's
-      // index is `round + 1` — `nextSessionMdPath` is keyed on it
-      // so the generator's audit lands in `rounds/<round + 1>/generator/`.
+      // already in scope. The fix wrapper is critique-aware: it
+      // points at the prior round's `evaluation.md` so the generator
+      // re-reads the verdict before re-reading the spec. The next
+      // round's index is `round + 1`; the critique under review was
+      // produced THIS round at `rounds/<round>/evaluator/evaluation.md`.
       log.info('resuming generator with critique', { round });
       const fixRound = round + 1;
       const generatorSessionMdPath = input.nextSessionMdPath
         ? await input.nextSessionMdPath('generator', fixRound)
         : undefined;
+      const fixContext =
+        input.evaluateWorkspaceDir !== undefined
+          ? {
+              critiqueFilePath: join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'evaluation.md'),
+            }
+          : undefined;
       const fixResult = await this.generator.execute({
         task: input.task,
         sprint: input.sprint,
@@ -397,6 +406,7 @@ export class EvaluateAndFixLoopUseCase {
         promptFilePath: input.executePromptFilePath,
         ...(resumeSessionId !== undefined ? { resumeSessionId } : {}),
         ...(generatorSessionMdPath !== undefined ? { sessionMdPath: generatorSessionMdPath } : {}),
+        ...(fixContext !== undefined ? { fixContext } : {}),
         ...(input.abortSignal !== undefined ? { abortSignal: input.abortSignal } : {}),
       });
       if (!fixResult.ok) return Result.error(fixResult.error);

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
@@ -60,6 +60,7 @@ import { Result } from '@src/domain/result.ts';
 import type { EvaluationSignal } from '@src/domain/signals/harness-signal.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import { AbsolutePath as AbsolutePathVO } from '@src/domain/values/absolute-path.ts';
+import { evaluatorRoundDir, latestEvaluationPath } from '@src/kernel/algorithms/execution-round-paths.ts';
 import type { LoggerPort } from '@src/business/ports/logger-port.ts';
 import type { PromptBuilderPort } from '@src/business/ports/prompt-builder-port.ts';
 import type { WriteContextFilePort } from '@src/business/ports/write-context-file-port.ts';
@@ -68,21 +69,6 @@ import type { PostTaskCheckUseCase } from '@src/business/usecases/execute/post-t
 import type { EvaluateTaskUseCase } from './evaluate-task.ts';
 import { type EvaluationOutcome } from './evaluate-task.ts';
 import { dimensionsEqual } from './plateau-detection.ts';
-
-/**
- * Pure path helpers — the loop knows the per-round layout under an
- * execution unit folder. Mirror of the integration-layer helpers in
- * `src/integration/persistence/execution-unit-builder.ts`; kept inline
- * here so the business layer doesn't import from integration. Both
- * sites must agree on the layout.
- */
-function evaluatorRoundDirInline(workspaceDir: string, round: number): string {
-  return join(workspaceDir, 'rounds', String(round), 'evaluator');
-}
-
-function latestEvaluationPathInline(workspaceDir: string): string {
-  return join(workspaceDir, 'latest-evaluation.md');
-}
 
 /**
  * Narrow shape this use case needs from a live-config provider — only the
@@ -282,7 +268,7 @@ export class EvaluateAndFixLoopUseCase {
       //    write somewhere meaningful.
       const evaluatorPromptPath = AbsolutePathVO.trustString(
         input.evaluateWorkspaceDir !== undefined
-          ? join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'prompt.md')
+          ? join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'prompt.md')
           : join(String(input.contextsDir), `evaluate-${String(input.task.id)}.md`)
       );
 
@@ -326,7 +312,7 @@ export class EvaluateAndFixLoopUseCase {
       //    object regardless). Skipped when no workspace is mounted.
       if (input.evaluateWorkspaceDir !== undefined) {
         const verdictPath = AbsolutePathVO.trustString(
-          join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'evaluation.md')
+          join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'evaluation.md')
         );
         const verdictWritten = await this.writeContextFile.write(verdictPath, fullCritique);
         if (!verdictWritten.ok) {
@@ -335,7 +321,7 @@ export class EvaluateAndFixLoopUseCase {
             error: verdictWritten.error.message,
           });
         }
-        const latestPath = AbsolutePathVO.trustString(latestEvaluationPathInline(input.evaluateWorkspaceDir));
+        const latestPath = AbsolutePathVO.trustString(latestEvaluationPath(input.evaluateWorkspaceDir));
         const latestWritten = await this.writeContextFile.write(latestPath, fullCritique);
         if (!latestWritten.ok) {
           log.warn('failed to update latest-evaluation.md pointer', {
@@ -396,7 +382,7 @@ export class EvaluateAndFixLoopUseCase {
       const fixContext =
         input.evaluateWorkspaceDir !== undefined
           ? {
-              critiqueFilePath: join(evaluatorRoundDirInline(input.evaluateWorkspaceDir, round), 'evaluation.md'),
+              critiqueFilePath: join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'evaluation.md'),
             }
           : undefined;
       const fixResult = await this.generator.execute({

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
@@ -22,7 +22,7 @@
  * on every loop tick so a settings-panel edit mid-execution applies to the
  * next round (REQ-12).
  *
- * **Per-round on-disk layout** — when an `evaluateWorkspaceDir` is set,
+ * **Per-round on-disk layout** — `evaluateWorkspaceDir` is required;
  * the loop writes one folder per round under
  * `<workspace>/rounds/<N>/evaluator/`:
  *
@@ -32,17 +32,17 @@
  *   - `session.md` — the audit pack written by the AI session adapter.
  *
  * Generator (re-)spawns land their `session.md` audit at
- * `rounds/<N>/generator/session.md`. After every successful round the
- * loop also copies the verdict to `<workspace>/latest-evaluation.md`
- * — a stable pointer for `Task.evaluationFile`, while the per-round
- * `evaluation.md` files remain the durable history.
+ * `rounds/<N>/generator/session.md`. Each round path is unique, so
+ * "the most recent verdict" is unambiguously the highest-N
+ * `evaluation.md`; the chain layer records that path on
+ * `Task.evaluationFile` directly — no pointer file is needed.
  *
  * The generator's prompt at the chain-supplied
  * `executePromptFilePath` is rendered once by the
  * `render-prompt-to-file` leaf and reused across fix rounds. On round
- * `>= 2` the loop additionally hands the generator a critique-aware
- * wrapper pointing at `rounds/<N-1>/evaluator/evaluation.md` so the
- * fix attempt can read the verdict before re-reading the spec.
+ * `>= 2` the loop hands the generator a critique-aware wrapper that
+ * inlines the prior round's verdict body directly in the resume turn
+ * so the fix attempt reads the critique without a tool round-trip.
  *
  * **Never blocks** — the loop **always** returns `Result.ok(...)`. A
  * failed / malformed / plateau outcome is signalled via the structured
@@ -60,7 +60,7 @@ import { Result } from '@src/domain/result.ts';
 import type { EvaluationSignal } from '@src/domain/signals/harness-signal.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import { AbsolutePath as AbsolutePathVO } from '@src/domain/values/absolute-path.ts';
-import { evaluatorRoundDir, latestEvaluationPath } from '@src/kernel/algorithms/execution-round-paths.ts';
+import { evaluatorRoundDir } from '@src/kernel/algorithms/execution-round-paths.ts';
 import type { LoggerPort } from '@src/business/ports/logger-port.ts';
 import type { PromptBuilderPort } from '@src/business/ports/prompt-builder-port.ts';
 import type { WriteContextFilePort } from '@src/business/ports/write-context-file-port.ts';
@@ -93,12 +93,6 @@ export interface EvaluateAndFixLoopInput {
    */
   readonly executePromptFilePath: string;
   /**
-   * Absolute path to the sprint dir's contexts/ folder. The loop
-   * writes per-round evaluator prompts under
-   * `<contextsDir>/evaluate-<task-id>.md`, overwriting on each round.
-   */
-  readonly contextsDir: AbsolutePath;
-  /**
    * Resolved check script for the post-task gate after a generator fix
    * round. When omitted, the post-task gate is skipped between rounds.
    */
@@ -126,13 +120,21 @@ export interface EvaluateAndFixLoopInput {
    */
   readonly evaluateSessionCwd?: AbsolutePath;
   /**
-   * Absolute path of the evaluate workspace root, embedded into the
-   * evaluator prompt's `Contract files` section so the AI knows where
-   * to read upstream contracts (refined requirements, full task plan,
-   * dimension definitions, prior sibling evaluations). When undefined
-   * the section renders empty (standalone `sprint evaluate`).
+   * Absolute path of the evaluate workspace root. Two roles:
+   *  - Embedded into the evaluator prompt's `Contract files` section so
+   *    the AI knows where to read upstream contracts (refined
+   *    requirements, full task plan, dimension definitions, prior
+   *    sibling evaluations).
+   *  - Anchors the per-round on-disk artefact pack at
+   *    `<workspace>/rounds/<N>/evaluator/{prompt.md, evaluation.md,
+   *    session.md}` plus the stable `<workspace>/latest-evaluation.md`.
+   *
+   * Required: production callers (the per-task chain) always provide
+   * one. Callers that lack a workspace (build-execution-unit failed)
+   * must SKIP the loop entirely rather than invoke it with no
+   * archival target — the chain layer owns that decision.
    */
-  readonly evaluateWorkspaceDir?: string;
+  readonly evaluateWorkspaceDir: string;
   /**
    * The single `done-criteria.md` bullet for this task — e.g.
    * `- **Task name** (\`<id>\`) — <criteria>`. Threaded through to
@@ -260,16 +262,12 @@ export class EvaluateAndFixLoopUseCase {
       }
 
       // ── Per-round evaluator paths.
-      //    When an evaluate workspace is mounted, route the prompt + verdict
-      //    + session.md under `rounds/<round>/evaluator/` so each round's
-      //    artefacts persist independently. Without a workspace (the
-      //    standalone evaluate chain doesn't mount one), fall back to the
-      //    sprint-level contexts/ folder so plain-text invocations still
-      //    write somewhere meaningful.
+      //    Each round's prompt + verdict + session.md live under
+      //    `<workspace>/rounds/<round>/evaluator/` so artefacts persist
+      //    independently. The workspace is contractually required —
+      //    callers that don't have one must skip the loop.
       const evaluatorPromptPath = AbsolutePathVO.trustString(
-        input.evaluateWorkspaceDir !== undefined
-          ? join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'prompt.md')
-          : join(String(input.contextsDir), `evaluate-${String(input.task.id)}.md`)
+        join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'prompt.md')
       );
 
       // ── Render the evaluator prompt to file (per-round; the
@@ -278,8 +276,8 @@ export class EvaluateAndFixLoopUseCase {
       const evalPromptResult = await this.prompts.buildEvaluatePrompt({
         task: input.task,
         sprint: input.sprint,
+        evaluateWorkspaceDir: input.evaluateWorkspaceDir,
         ...(previousCritique !== undefined ? { previousCritique } : {}),
-        ...(input.evaluateWorkspaceDir !== undefined ? { evaluateWorkspaceDir: input.evaluateWorkspaceDir } : {}),
         ...(input.doneCriteriaBullet !== undefined ? { doneCriteriaBullet: input.doneCriteriaBullet } : {}),
       });
       if (!evalPromptResult.ok) return Result.error(evalPromptResult.error);
@@ -305,30 +303,21 @@ export class EvaluateAndFixLoopUseCase {
       const { outcome, signal, fullCritique } = evalResult.value;
       history.push({ round, outcome, signal, critique: fullCritique });
 
-      // ── Persist the verdict to disk: per-round file + stable
-      //    `latest-evaluation.md` pointer. Best-effort: a write failure
-      //    surfaces as a warning so the round result is still usable
-      //    by the chain (the verdict is in `fullCritique` on the result
-      //    object regardless). Skipped when no workspace is mounted.
-      if (input.evaluateWorkspaceDir !== undefined) {
-        const verdictPath = AbsolutePathVO.trustString(
-          join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'evaluation.md')
-        );
-        const verdictWritten = await this.writeContextFile.write(verdictPath, fullCritique);
-        if (!verdictWritten.ok) {
-          log.warn('failed to persist per-round evaluator verdict', {
-            round,
-            error: verdictWritten.error.message,
-          });
-        }
-        const latestPath = AbsolutePathVO.trustString(latestEvaluationPath(input.evaluateWorkspaceDir));
-        const latestWritten = await this.writeContextFile.write(latestPath, fullCritique);
-        if (!latestWritten.ok) {
-          log.warn('failed to update latest-evaluation.md pointer', {
-            round,
-            error: latestWritten.error.message,
-          });
-        }
+      // ── Persist the verdict to disk under the per-round folder.
+      //    Each round gets its own unique path (`rounds/<N>/evaluator/
+      //    evaluation.md`), so "the most recent" is unambiguously the
+      //    highest N — no pointer file needed. Best-effort: a write
+      //    failure surfaces as a warning, the verdict is still in
+      //    `fullCritique` on the result object regardless.
+      const verdictPath = AbsolutePathVO.trustString(
+        join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'evaluation.md')
+      );
+      const verdictWritten = await this.writeContextFile.write(verdictPath, fullCritique);
+      if (!verdictWritten.ok) {
+        log.warn('failed to persist per-round evaluator verdict', {
+          round,
+          error: verdictWritten.error.message,
+        });
       }
 
       log.info(`evaluator round complete for task ${String(input.task.id)}`, { round, outcome });
@@ -369,22 +358,16 @@ export class EvaluateAndFixLoopUseCase {
       // ── Generator fix round ─────────────────────────────────────
       // The generator resumes the same session, so the original
       // execute prompt file at `input.executePromptFilePath` is
-      // already in scope. The fix wrapper is critique-aware: it
-      // points at the prior round's `evaluation.md` so the generator
-      // re-reads the verdict before re-reading the spec. The next
-      // round's index is `round + 1`; the critique under review was
-      // produced THIS round at `rounds/<round>/evaluator/evaluation.md`.
+      // already in scope. The fix wrapper inlines the verdict body
+      // (`fullCritique`) directly in the resume turn so the generator
+      // reads it without a tool round-trip — the critique is bounded
+      // and already in memory; an on-disk handoff would only add
+      // failure modes. The next round's index is `round + 1`.
       log.info('resuming generator with critique', { round });
       const fixRound = round + 1;
       const generatorSessionMdPath = input.nextSessionMdPath
         ? await input.nextSessionMdPath('generator', fixRound)
         : undefined;
-      const fixContext =
-        input.evaluateWorkspaceDir !== undefined
-          ? {
-              critiqueFilePath: join(evaluatorRoundDir(input.evaluateWorkspaceDir, round), 'evaluation.md'),
-            }
-          : undefined;
       const fixResult = await this.generator.execute({
         task: input.task,
         sprint: input.sprint,
@@ -392,7 +375,7 @@ export class EvaluateAndFixLoopUseCase {
         promptFilePath: input.executePromptFilePath,
         ...(resumeSessionId !== undefined ? { resumeSessionId } : {}),
         ...(generatorSessionMdPath !== undefined ? { sessionMdPath: generatorSessionMdPath } : {}),
-        ...(fixContext !== undefined ? { fixContext } : {}),
+        fixContext: { critique: fullCritique },
         ...(input.abortSignal !== undefined ? { abortSignal: input.abortSignal } : {}),
       });
       if (!fixResult.ok) return Result.error(fixResult.error);

--- a/src/business/usecases/evaluate/evaluate-task.ts
+++ b/src/business/usecases/evaluate/evaluate-task.ts
@@ -66,7 +66,11 @@ export interface EvaluateTaskOutput {
   readonly outcome: EvaluationOutcome;
   /** The evaluation signal — synthesised as malformed when none was emitted. */
   readonly signal: EvaluationSignal;
-  /** Raw evaluator stdout — chain persists this to `evaluations/<taskId>.md`. */
+  /**
+   * Raw evaluator stdout — the chain layer persists this under
+   * `rounds/<N>/evaluator/evaluation.md` (per-round) and
+   * `latest-evaluation.md` (stable pointer). This use case stays IO-free.
+   */
   readonly fullCritique: string;
 }
 

--- a/src/business/usecases/execute/execute-single-task.test.ts
+++ b/src/business/usecases/execute/execute-single-task.test.ts
@@ -448,13 +448,13 @@ describe('ExecuteSingleTaskUseCase', () => {
     expect(coordinator.isPaused()).toBe(true);
   });
 
-  it('uses the critique-aware wrapper when fixContext is set; references both paths', async () => {
+  it('uses the critique-aware wrapper when fixContext is set; inlines the critique body', async () => {
     const ai = new FakeAiSessionPort({
       outcomes: [{ kind: 'ok', result: { output: 'fix done', sessionId: 'after-fix' } }],
     });
     const parser = new FakeSignalParserPort({ results: [[completeSignal()]] });
     const uc = new ExecuteSingleTaskUseCase(ai, parser, new FakeLoggerPort());
-    const critiquePath = '/tmp/sprints/a/execution/abc-task/rounds/1/evaluator/evaluation.md';
+    const critique = '# Evaluation — failed\n\n- correctness: FAIL — null branch returns undefined';
 
     await uc.execute({
       task: aTask(),
@@ -462,11 +462,14 @@ describe('ExecuteSingleTaskUseCase', () => {
       cwd: path('/repos/demo'),
       promptFilePath: CONTEXT_FILE,
       resumeSessionId: 'session-before-fix',
-      fixContext: { critiqueFilePath: critiquePath },
+      fixContext: { critique },
     });
 
     const wrapper = ai.captured[0]?.prompt ?? '';
-    expect(wrapper).toContain(critiquePath);
+    // Critique body is inlined verbatim, wrapped in <evaluator-critique> tags.
+    expect(wrapper).toContain(critique);
+    expect(wrapper).toContain('<evaluator-critique>');
+    expect(wrapper).toContain('</evaluator-critique>');
     expect(wrapper).toContain(CONTEXT_FILE);
     // The critique-aware wrapper identifies itself.
     expect(wrapper.toLowerCase()).toContain('fix round');
@@ -490,7 +493,7 @@ describe('ExecuteSingleTaskUseCase', () => {
     expect(wrapper).toContain(CONTEXT_FILE);
     // The plain wrapper does NOT reference any critique.
     expect(wrapper.toLowerCase()).not.toContain('fix round');
-    expect(wrapper).not.toContain('evaluation.md');
+    expect(wrapper).not.toContain('<evaluator-critique>');
   });
 
   it('does not emit signals or call coordinator when neither is provided', async () => {

--- a/src/business/usecases/execute/execute-single-task.test.ts
+++ b/src/business/usecases/execute/execute-single-task.test.ts
@@ -448,6 +448,51 @@ describe('ExecuteSingleTaskUseCase', () => {
     expect(coordinator.isPaused()).toBe(true);
   });
 
+  it('uses the critique-aware wrapper when fixContext is set; references both paths', async () => {
+    const ai = new FakeAiSessionPort({
+      outcomes: [{ kind: 'ok', result: { output: 'fix done', sessionId: 'after-fix' } }],
+    });
+    const parser = new FakeSignalParserPort({ results: [[completeSignal()]] });
+    const uc = new ExecuteSingleTaskUseCase(ai, parser, new FakeLoggerPort());
+    const critiquePath = '/tmp/sprints/a/execution/abc-task/rounds/1/evaluator/evaluation.md';
+
+    await uc.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      promptFilePath: CONTEXT_FILE,
+      resumeSessionId: 'session-before-fix',
+      fixContext: { critiqueFilePath: critiquePath },
+    });
+
+    const wrapper = ai.captured[0]?.prompt ?? '';
+    expect(wrapper).toContain(critiquePath);
+    expect(wrapper).toContain(CONTEXT_FILE);
+    // The critique-aware wrapper identifies itself.
+    expect(wrapper.toLowerCase()).toContain('fix round');
+  });
+
+  it('falls back to the plain wrapper when fixContext is absent — no critique reference', async () => {
+    const ai = new FakeAiSessionPort({
+      outcomes: [{ kind: 'ok', result: { output: 'done' } }],
+    });
+    const parser = new FakeSignalParserPort({ results: [[completeSignal()]] });
+    const uc = new ExecuteSingleTaskUseCase(ai, parser, new FakeLoggerPort());
+
+    await uc.execute({
+      task: aTask(),
+      sprint: aSprint(),
+      cwd: path('/repos/demo'),
+      promptFilePath: CONTEXT_FILE,
+    });
+
+    const wrapper = ai.captured[0]?.prompt ?? '';
+    expect(wrapper).toContain(CONTEXT_FILE);
+    // The plain wrapper does NOT reference any critique.
+    expect(wrapper.toLowerCase()).not.toContain('fix round');
+    expect(wrapper).not.toContain('evaluation.md');
+  });
+
   it('does not emit signals or call coordinator when neither is provided', async () => {
     const ai = new FakeAiSessionPort({
       outcomes: [{ kind: 'ok', result: { output: 'done' } }],

--- a/src/business/usecases/execute/execute-single-task.ts
+++ b/src/business/usecases/execute/execute-single-task.ts
@@ -46,7 +46,10 @@ import type { AiSessionPort } from '@src/business/ports/ai-session-port.ts';
 import type { LoggerPort } from '@src/business/ports/logger-port.ts';
 import type { SignalBusPort } from '@src/business/ports/signal-bus-port.ts';
 import type { SignalParserPort } from '@src/business/ports/signal-parser-port.ts';
-import { renderFileHandoffWrapper } from '@src/business/usecases/_shared/file-handoff-wrapper.ts';
+import {
+  renderFileHandoffWrapper,
+  renderFixHandoffWrapper,
+} from '@src/business/usecases/_shared/file-handoff-wrapper.ts';
 import type { RateLimitCoordinator } from '@src/kernel/algorithms/rate-limit-coordinator.ts';
 
 /** Possible outcomes of a single-task execution attempt. */
@@ -67,11 +70,25 @@ export interface ExecuteSingleTaskInput {
   readonly resumeSessionId?: string;
   /**
    * Optional absolute path the AI session adapter writes a `session.md`
-   * audit record to. Set per execution round to a `session-N.md` under
-   * the per-task execution unit folder. Best-effort — write failures
-   * never fail the spawn.
+   * audit record to. Set per execution round to a `session.md` under
+   * the per-task execution unit folder's `rounds/<N>/{generator,evaluator}/`
+   * subtree. Best-effort — write failures never fail the spawn.
    */
   readonly sessionMdPath?: AbsolutePath;
+  /**
+   * Optional fix-round context. When set, the use case hands the AI a
+   * critique-aware wrapper (`renderFixHandoffWrapper`) pointing at the
+   * prior round's evaluator verdict so the resumed generator reads the
+   * critique FIRST, then re-reads the spec, then addresses every flagged
+   * dimension. When undefined, the standard `renderFileHandoffWrapper`
+   * is used — the spec-only first-round contract.
+   *
+   * Orthogonal to `resumeSessionId`: the resume id drives spawn vs
+   * resume; `fixContext` drives wrapper choice. A fix round typically
+   * has both; they're decoupled so a future use case can ship either
+   * independently.
+   */
+  readonly fixContext?: { readonly critiqueFilePath: string };
   /** Optional cooperative cancellation. */
   readonly abortSignal?: AbortSignal;
 }
@@ -136,8 +153,13 @@ export class ExecuteSingleTaskUseCase {
 
     // The full prompt is on disk at `input.promptFilePath`. Hand the AI
     // a thin wrapper pointing at it — the AI reads the file as its
-    // first action.
-    const wrapper = renderFileHandoffWrapper(input.promptFilePath);
+    // first action. On a fix round (`fixContext` set), use the
+    // critique-aware variant so the resumed generator reads the prior
+    // round's verdict before re-reading the spec.
+    const wrapper =
+      input.fixContext !== undefined
+        ? renderFixHandoffWrapper(input.promptFilePath, input.fixContext.critiqueFilePath)
+        : renderFileHandoffWrapper(input.promptFilePath);
 
     log.info(`executing task ${String(input.task.id)}${formatNameSuffix(input.task.name)}`);
 

--- a/src/business/usecases/execute/execute-single-task.ts
+++ b/src/business/usecases/execute/execute-single-task.ts
@@ -77,7 +77,7 @@ export interface ExecuteSingleTaskInput {
   readonly sessionMdPath?: AbsolutePath;
   /**
    * Optional fix-round context. When set, the use case hands the AI a
-   * critique-aware wrapper (`renderFixHandoffWrapper`) pointing at the
+   * critique-aware wrapper (`renderFixHandoffWrapper`) that inlines the
    * prior round's evaluator verdict so the resumed generator reads the
    * critique FIRST, then re-reads the spec, then addresses every flagged
    * dimension. When undefined, the standard `renderFileHandoffWrapper`
@@ -88,7 +88,7 @@ export interface ExecuteSingleTaskInput {
    * has both; they're decoupled so a future use case can ship either
    * independently.
    */
-  readonly fixContext?: { readonly critiqueFilePath: string };
+  readonly fixContext?: { readonly critique: string };
   /** Optional cooperative cancellation. */
   readonly abortSignal?: AbortSignal;
 }
@@ -158,7 +158,7 @@ export class ExecuteSingleTaskUseCase {
     // round's verdict before re-reading the spec.
     const wrapper =
       input.fixContext !== undefined
-        ? renderFixHandoffWrapper(input.promptFilePath, input.fixContext.critiqueFilePath)
+        ? renderFixHandoffWrapper(input.promptFilePath, input.fixContext.critique)
         : renderFileHandoffWrapper(input.promptFilePath);
 
     log.info(`executing task ${String(input.task.id)}${formatNameSuffix(input.task.name)}`);

--- a/src/integration/ai/prompts/prompt-renderers.ts
+++ b/src/integration/ai/prompts/prompt-renderers.ts
@@ -98,7 +98,7 @@ export function renderEvaluateWorkspaceSection(workspaceDir: string | undefined)
     '- `tasks.md` / `tasks.json` — the full task plan, for cross-task consistency checks',
     "- `project-context.md` — the project's CLAUDE.md / .github/copilot-instructions.md (when present in the target repo)",
     '- `dimensions.md` — the four floor dimensions plus any extra dimensions the planner emitted on this task',
-    '- `evaluations/<task-id>.md` — prior task evaluations from earlier in this sprint (the quality bar so far)',
+    '- `prior-evaluations/<task-id>.md` — prior sibling task evaluations from earlier in this sprint (the quality bar so far)',
   ].join('\n');
 }
 

--- a/src/integration/ai/session/provider-ai-session-adapter.ts
+++ b/src/integration/ai/session/provider-ai-session-adapter.ts
@@ -28,10 +28,11 @@
  * audit "where Claude was started, why, and with what permissions"
  * without reading code. Writes are best-effort: a write failure logs
  * a warn through the injected `LoggerPort` and the spawn proceeds
- * unchanged. For execution rounds the chain leaf rotates through
- * `session-1.md`, `session-2.md`, …  via {@link nextSessionPath}; for
- * single-shot AI rounds (refine / plan / ideate / feedback / evaluate)
- * a single `session.md` per unit folder is overwritten on re-run.
+ * unchanged. For execution rounds the chain leaf routes audits through
+ * round-aware paths (`rounds/<N>/{generator,evaluator}/session.md`) so
+ * each round's audit lives independently; for single-shot AI rounds
+ * (refine / plan / ideate / feedback / standalone evaluate) a single
+ * `session.md` per unit folder is overwritten on re-run.
  */
 import { RateLimitError } from '@src/domain/errors/rate-limit-error.ts';
 import { StorageError } from '@src/domain/errors/storage-error.ts';

--- a/src/integration/ai/session/provider-ai-session-adapter.ts
+++ b/src/integration/ai/session/provider-ai-session-adapter.ts
@@ -261,6 +261,10 @@ export class ProviderAiSessionAdapter implements AiSessionPort {
    * The actual provider exit code isn't surfaced through the runner's
    * typed Result — `1` is a faithful "spawn failed" stand-in for audit
    * purposes; the underlying error's message is already in the logs.
+   *
+   * `model` is the first audit hint we have for headless spawns where
+   * the runner picks the model — `writeSessionFinish` merges it into
+   * the frontmatter alongside the other finish fields in a single write.
    */
   private async writeSessionMdFinishHeadless(
     options: SessionOptions,
@@ -269,26 +273,19 @@ export class ProviderAiSessionAdapter implements AiSessionPort {
     const path = options.sessionMdPath;
     if (path === undefined) return;
     const sessionId = result.ok ? result.value.sessionId : undefined;
+    const model = result.ok ? result.value.model : undefined;
     const written = await writeSessionFinish({
       path: String(path),
       finished: new Date().toISOString(),
       exitCode: result.ok ? 0 : 1,
       ...(sessionId !== undefined ? { sessionId } : {}),
+      ...(model !== undefined ? { model } : {}),
     });
     if (!written.ok) {
       this.opts.logger?.warn('failed to write session.md (finish) — spawn already settled', {
         path: String(path),
         error: written.error.message,
       });
-      return;
-    }
-    // Append model when surfaced (writeSessionFinish only carries the
-    // standard finish fields; model lives in the start frontmatter for
-    // pre-spawn sessions, but a successful headless run is the first
-    // chance we have to learn the resolved model identifier — patch it
-    // in by re-rendering with the merged field set).
-    if (result.ok && result.value.model !== undefined) {
-      await this.patchSessionMdModel(String(path), result.value.model);
     }
   }
 
@@ -309,39 +306,6 @@ export class ProviderAiSessionAdapter implements AiSessionPort {
       this.opts.logger?.warn('failed to write session.md (finish) — spawn already settled', {
         path: String(path),
         error: written.error.message,
-      });
-    }
-  }
-
-  /**
-   * Patch the resolved `model` into an existing `session.md`. Reuses
-   * `writeSessionFinish` to round-trip frontmatter without touching the
-   * prompt body. Best-effort — write failures log a warn.
-   *
-   * Implementation note: `writeSessionFinish` was scoped to the
-   * standard finish fields only. The narrow `model` patch here goes
-   * through `writeSessionStart` would clobber the body, so we re-read,
-   * splice the field, and re-emit via the same writer surface. This
-   * keeps the YAML-handling logic in one place (`session-md-writer`)
-   * even at the cost of a second IO round-trip — the audit pack is
-   * cold-path and we'd rather centralise format knowledge.
-   */
-  private async patchSessionMdModel(path: string, model: string): Promise<void> {
-    try {
-      const fs = await import('node:fs/promises');
-      const existing = await fs.readFile(path, 'utf-8');
-      // Surgical: rewrite the first `---`-delimited frontmatter block
-      // with `model:` either inserted (if missing) or replaced. Done
-      // inline because `session-md-writer` keeps its parser private —
-      // reaching for it here would expand the public surface for one
-      // post-hoc patch.
-      const patched = upsertFrontmatterField(existing, 'model', model);
-      if (patched === existing) return;
-      await fs.writeFile(path, patched, { encoding: 'utf-8', mode: 0o600 });
-    } catch (err) {
-      this.opts.logger?.warn('failed to patch session.md model field', {
-        path,
-        error: err instanceof Error ? err.message : String(err),
       });
     }
   }
@@ -408,34 +372,4 @@ function stripTrailingPromptSlot(args: readonly string[]): readonly string[] {
   // Drop a trailing `--` separator if it's now exposed.
   if (end > 0 && args[end - 1] === '--') end -= 1;
   return args.slice(0, end);
-}
-
-/**
- * Upsert a single key into a YAML-ish frontmatter block. The block is
- * the first `---`-delimited section at the top of the file. If `key`
- * already appears, its value is replaced; otherwise the new line is
- * inserted just before the closing `---`. Handles only flat string
- * values — sufficient for the `model` patch the adapter performs.
- */
-function upsertFrontmatterField(content: string, key: string, value: string): string {
-  const lines = content.split('\n');
-  if (lines[0]?.trim() !== '---') return content;
-  let closeIdx = -1;
-  for (let i = 1; i < lines.length; i += 1) {
-    if (lines[i]?.trim() === '---') {
-      closeIdx = i;
-      break;
-    }
-  }
-  if (closeIdx < 0) return content;
-  const keyRegex = new RegExp(`^${key}\\s*:`);
-  for (let i = 1; i < closeIdx; i += 1) {
-    const line = lines[i] ?? '';
-    if (keyRegex.test(line.trim())) {
-      lines[i] = `${key}: ${value}`;
-      return lines.join('\n');
-    }
-  }
-  lines.splice(closeIdx, 0, `${key}: ${value}`);
-  return lines.join('\n');
 }

--- a/src/integration/persistence/execution-unit-builder.test.ts
+++ b/src/integration/persistence/execution-unit-builder.test.ts
@@ -121,22 +121,4 @@ describe('buildExecutionUnit — prior-evaluations directory', () => {
     // The legacy `evaluations/` folder must NOT exist.
     await expect(stat(join(unitRoot, 'evaluations'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
-
-  it('latestEvaluationMdPath points at <unit>/latest-evaluation.md', async () => {
-    const sprint = makeSprint();
-    const task = makeTask({ name: 'current task', projectPath: '/tmp' });
-
-    const storage = resolveStoragePaths();
-    const result = await buildExecutionUnit(storage, {
-      sprint,
-      tasks: [task],
-      task,
-      aiProvider: 'claude',
-      priorEvaluations: new Map(),
-    });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(String(result.value.latestEvaluationMdPath)).toBe(join(String(result.value.root), 'latest-evaluation.md'));
-  });
 });

--- a/src/integration/persistence/execution-unit-builder.test.ts
+++ b/src/integration/persistence/execution-unit-builder.test.ts
@@ -1,17 +1,18 @@
 /**
- * `buildExecutionUnit` integration tests — focused on the `done-criteria.md`
- * copy added as part of Wave 4 G3.
+ * `buildExecutionUnit` integration tests — covers the `done-criteria.md`
+ * copy and the renamed `prior-evaluations/` subtree.
  *
  * `buildExecutionUnit` is an IO-heavy function — these tests write to a real
  * tmp directory. Each test gets its own isolated root via a unique prefix.
  */
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, stat, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { resolveStoragePaths, resetEnsureLayoutDirsCache } from '@src/integration/persistence/storage-paths.ts';
 import { makeSprint, makeTask } from '@src/application/_test-fakes/fixtures.ts';
+import { TaskId } from '@src/domain/values/task-id.ts';
 import { buildExecutionUnit } from './execution-unit-builder.ts';
 
 function uniqueRoot(): string {
@@ -88,5 +89,54 @@ describe('buildExecutionUnit — done-criteria.md', () => {
     // A warning must be emitted so callers can surface it.
     expect(warnings.length).toBeGreaterThan(0);
     expect(warnings[0]).toContain('done-criteria.md not found');
+  });
+});
+
+describe('buildExecutionUnit — prior-evaluations directory', () => {
+  it('writes prior sibling critiques to <unit>/prior-evaluations/<task-id>.md (renamed from evaluations/)', async () => {
+    const sprint = makeSprint();
+    const task = makeTask({ name: 'current task', projectPath: '/tmp' });
+    const priorId = TaskId.trustString('aaaaaaaa');
+    const priorBody = '# Prior critique\n\n- correctness PASS';
+
+    const storage = resolveStoragePaths();
+    const result = await buildExecutionUnit(storage, {
+      sprint,
+      tasks: [task],
+      task,
+      aiProvider: 'claude',
+      priorEvaluations: new Map([[priorId, priorBody]]),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const unitRoot = String(result.value.root);
+    // The renamed folder receives prior siblings.
+    const priorPath = join(unitRoot, 'prior-evaluations', `${String(priorId)}.md`);
+    const body = await readFile(priorPath, 'utf-8');
+    expect(body).toContain('Prior critique');
+    expect(body).toContain('correctness PASS');
+
+    // The legacy `evaluations/` folder must NOT exist.
+    await expect(stat(join(unitRoot, 'evaluations'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('latestEvaluationMdPath points at <unit>/latest-evaluation.md', async () => {
+    const sprint = makeSprint();
+    const task = makeTask({ name: 'current task', projectPath: '/tmp' });
+
+    const storage = resolveStoragePaths();
+    const result = await buildExecutionUnit(storage, {
+      sprint,
+      tasks: [task],
+      task,
+      aiProvider: 'claude',
+      priorEvaluations: new Map(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(String(result.value.latestEvaluationMdPath)).toBe(join(String(result.value.root), 'latest-evaluation.md'));
   });
 });

--- a/src/integration/persistence/execution-unit-builder.ts
+++ b/src/integration/persistence/execution-unit-builder.ts
@@ -20,8 +20,9 @@
  *     - `rounds/<N>/generator/session.md` — generator (re-)spawn audit
  *     - `rounds/<N>/evaluator/{prompt.md, evaluation.md, session.md}` — per-round evaluator artefacts
  *     - `rounds/standalone-<ISO>/evaluator/…` — out-of-band `sprint evaluate` runs
- *     - `latest-evaluation.md` — copy of the most recent round's verdict; canonical
- *       path stamped on `Task.evaluationFile` (a stable pointer, not a round-specific file)
+ *     - `Task.evaluationFile` is stamped to point at the FINAL round's
+ *       `rounds/<N>/evaluator/evaluation.md` — each round path is unique,
+ *       so the highest N is unambiguously the most recent verdict.
  *
  *   Copilot only (mirrored at build time):
  *     - `repo/` — mirror of `task.projectPath`
@@ -39,7 +40,6 @@ import { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
 import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import type { TaskId } from '@src/domain/values/task-id.ts';
-import { latestEvaluationPath } from '@src/kernel/algorithms/execution-round-paths.ts';
 import type { StoragePaths } from '@src/integration/persistence/storage-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 import {
@@ -55,8 +55,8 @@ import {
 /**
  * Integration-local helper for the per-task `prior-evaluations/` folder.
  * The round-aware helpers (`roundDir`, `generatorRoundDir`,
- * `evaluatorRoundDir`, `latestEvaluationPath`, `standaloneRoundDir`) live
- * in `@src/kernel/algorithms/execution-round-paths.ts` so the business
+ * `evaluatorRoundDir`, `standaloneRoundDir`) live in
+ * `@src/kernel/algorithms/execution-round-paths.ts` so the business
  * layer can use them without importing from integration.
  */
 export function priorEvaluationsDir(unitRoot: string): string {
@@ -387,7 +387,6 @@ export async function buildExecutionUnit(
     root,
     addDirs,
     sessionCwd,
-    latestEvaluationMdPath: AbsolutePath.trustString(latestEvaluationPath(root)),
   });
 }
 

--- a/src/integration/persistence/execution-unit-builder.ts
+++ b/src/integration/persistence/execution-unit-builder.ts
@@ -39,6 +39,7 @@ import { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
 import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import type { TaskId } from '@src/domain/values/task-id.ts';
+import { latestEvaluationPath } from '@src/kernel/algorithms/execution-round-paths.ts';
 import type { StoragePaths } from '@src/integration/persistence/storage-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 import {
@@ -52,37 +53,14 @@ import {
 // ─────────────────────── round-aware path helpers ────────────────────────
 
 /**
- * Pure string helpers that compute the canonical sub-paths inside an
- * execution unit folder. Centralising them here means callers (chain
- * leaves, the evaluate-and-fix loop, tests) never hand-roll `join` on
- * the layout — a future folder rename is a single edit.
- *
- * All helpers return plain `string`s; callers wrap with
- * `AbsolutePath.trustString` only at the boundary where the value is
- * surfaced as a domain value.
+ * Integration-local helper for the per-task `prior-evaluations/` folder.
+ * The round-aware helpers (`roundDir`, `generatorRoundDir`,
+ * `evaluatorRoundDir`, `latestEvaluationPath`, `standaloneRoundDir`) live
+ * in `@src/kernel/algorithms/execution-round-paths.ts` so the business
+ * layer can use them without importing from integration.
  */
-export function roundDir(unitRoot: string, round: number): string {
-  return join(unitRoot, 'rounds', String(round));
-}
-
-export function generatorRoundDir(unitRoot: string, round: number): string {
-  return join(roundDir(unitRoot, round), 'generator');
-}
-
-export function evaluatorRoundDir(unitRoot: string, round: number): string {
-  return join(roundDir(unitRoot, round), 'evaluator');
-}
-
 export function priorEvaluationsDir(unitRoot: string): string {
   return join(unitRoot, 'prior-evaluations');
-}
-
-export function latestEvaluationPath(unitRoot: string): string {
-  return join(unitRoot, 'latest-evaluation.md');
-}
-
-export function standaloneRoundDir(unitRoot: string, iso: string): string {
-  return join(unitRoot, 'rounds', `standalone-${iso}`);
 }
 
 // ──────────────────────── evaluation rubric ──────────────────────────────

--- a/src/integration/persistence/execution-unit-builder.ts
+++ b/src/integration/persistence/execution-unit-builder.ts
@@ -14,13 +14,17 @@
  *     - `tasks.md` — full task plan as markdown
  *     - `tasks.json` — machine-readable task list
  *     - `project-context.md` — copy of the target repo's context file
- *     - `evaluations/<task-id>.md` — prior evaluation critiques
+ *     - `prior-evaluations/<task-id>.md` — prior sibling evaluation critiques
+ *
+ *   Per-round (written by the evaluate-and-fix loop, never by this module):
+ *     - `rounds/<N>/generator/session.md` — generator (re-)spawn audit
+ *     - `rounds/<N>/evaluator/{prompt.md, evaluation.md, session.md}` — per-round evaluator artefacts
+ *     - `rounds/standalone-<ISO>/evaluator/…` — out-of-band `sprint evaluate` runs
+ *     - `latest-evaluation.md` — copy of the most recent round's verdict; canonical
+ *       path stamped on `Task.evaluationFile` (a stable pointer, not a round-specific file)
  *
  *   Copilot only (mirrored at build time):
  *     - `repo/` — mirror of `task.projectPath`
- *
- * Note: `evaluation.md` (the live evaluator output sink) is NOT written
- * here — `ProviderAiSessionAdapter` writes it per-round.
  */
 import { readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -44,6 +48,42 @@ import {
   writeContextFile,
   writeFileSafe,
 } from '@src/integration/persistence/session-folder-helpers.ts';
+
+// ─────────────────────── round-aware path helpers ────────────────────────
+
+/**
+ * Pure string helpers that compute the canonical sub-paths inside an
+ * execution unit folder. Centralising them here means callers (chain
+ * leaves, the evaluate-and-fix loop, tests) never hand-roll `join` on
+ * the layout — a future folder rename is a single edit.
+ *
+ * All helpers return plain `string`s; callers wrap with
+ * `AbsolutePath.trustString` only at the boundary where the value is
+ * surfaced as a domain value.
+ */
+export function roundDir(unitRoot: string, round: number): string {
+  return join(unitRoot, 'rounds', String(round));
+}
+
+export function generatorRoundDir(unitRoot: string, round: number): string {
+  return join(roundDir(unitRoot, round), 'generator');
+}
+
+export function evaluatorRoundDir(unitRoot: string, round: number): string {
+  return join(roundDir(unitRoot, round), 'evaluator');
+}
+
+export function priorEvaluationsDir(unitRoot: string): string {
+  return join(unitRoot, 'prior-evaluations');
+}
+
+export function latestEvaluationPath(unitRoot: string): string {
+  return join(unitRoot, 'latest-evaluation.md');
+}
+
+export function standaloneRoundDir(unitRoot: string, iso: string): string {
+  return join(unitRoot, 'rounds', `standalone-${iso}`);
+}
 
 // ──────────────────────── evaluation rubric ──────────────────────────────
 
@@ -267,23 +307,23 @@ export async function writeExecutionVolatile(args: {
   const projectCtxFile = await writeFileSafe(join(args.root, 'project-context.md'), projectContext);
   if (!projectCtxFile.ok) return Result.error(projectCtxFile.error);
 
-  const evaluationsDir = join(args.root, 'evaluations');
+  const priorEvaluationsDirPath = priorEvaluationsDir(args.root);
   try {
-    await rm(evaluationsDir, { recursive: true, force: true });
+    await rm(priorEvaluationsDirPath, { recursive: true, force: true });
   } catch (err) {
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `failed to clear ${evaluationsDir}: ${err instanceof Error ? err.message : String(err)}`,
-        path: evaluationsDir,
+        message: `failed to clear ${priorEvaluationsDirPath}: ${err instanceof Error ? err.message : String(err)}`,
+        path: priorEvaluationsDirPath,
         cause: err,
       })
     );
   }
-  const ensureEvals = await ensureDirSafe(evaluationsDir);
+  const ensureEvals = await ensureDirSafe(priorEvaluationsDirPath);
   if (!ensureEvals.ok) return Result.error(ensureEvals.error);
   for (const [taskId, body] of args.priorEvaluations) {
-    const w = await writeFileSafe(join(evaluationsDir, `${taskId}.md`), body);
+    const w = await writeFileSafe(join(priorEvaluationsDirPath, `${taskId}.md`), body);
     if (!w.ok) return Result.error(w.error);
   }
   return Result.ok();
@@ -341,7 +381,7 @@ export async function buildExecutionUnit(
     }
   }
 
-  // Volatile: task.md, tasks.md, tasks.json, project-context.md, evaluations/.
+  // Volatile: task.md, tasks.md, tasks.json, project-context.md, prior-evaluations/.
   const volatile = await writeExecutionVolatile({
     root,
     sprint: input.sprint,
@@ -369,7 +409,7 @@ export async function buildExecutionUnit(
     root,
     addDirs,
     sessionCwd,
-    evaluationMdPath: AbsolutePath.trustString(join(root, 'evaluation.md')),
+    latestEvaluationMdPath: AbsolutePath.trustString(latestEvaluationPath(root)),
   });
 }
 

--- a/src/integration/persistence/file-write-context-file-adapter.ts
+++ b/src/integration/persistence/file-write-context-file-adapter.ts
@@ -4,9 +4,9 @@
  *
  * Mirrors the same `mkdir -p` + `writeFile` pattern used by
  * {@link FileSystemSignalHandler} so per-task context files land alongside
- * `progress.md` and `evaluations/<task-id>.md` under the same
- * `<sprintDir>/` tree with consistent permissions (0o600 — user-only,
- * matches the project context file conventions).
+ * `progress.md` under the same `<sprintDir>/` tree with consistent
+ * permissions (0o600 — user-only, matches the project context file
+ * conventions).
  *
  * Failures wrap the underlying `NodeJS.ErrnoException` in a
  * `StorageError(subCode: 'io')` carrying the path so callers can route

--- a/src/integration/persistence/session-folder-helpers.ts
+++ b/src/integration/persistence/session-folder-helpers.ts
@@ -66,7 +66,7 @@ function renderInputsLine(phase: Phase): string {
   if (phase === 'plan')
     return '- Inputs: per-ticket refined requirements live alongside this folder under `../refinement/<unit>/requirements.json`. Write your generated `tasks.json` to `./tasks.json` in this folder.\n';
   // evaluate
-  return '- Inputs are in `./task.md` (the task under review), `./tasks.md` / `./tasks.json` (full task plan), `./requirements/` (per-ticket requirements), `./project-context.md` (target repo context), `./dimensions.md` (grading rubric), and `./evaluations/` (prior evaluations from this sprint).\n';
+  return '- Inputs are in `./task.md` (the task under review), `./tasks.md` / `./tasks.json` (full task plan), `./requirements/` (per-ticket requirements), `./project-context.md` (target repo context), `./dimensions.md` (grading rubric), and `./prior-evaluations/` (prior sibling evaluations from this sprint).\n';
 }
 
 function renderRepoLine(phase: Phase, affectedRepos: readonly AbsolutePath[], copilot: boolean): string {

--- a/src/integration/persistence/session-md-writer.test.ts
+++ b/src/integration/persistence/session-md-writer.test.ts
@@ -133,4 +133,47 @@ describe('writeSessionFinish', () => {
     const body = await readFile(path, 'utf-8');
     expect(body).toContain('exitCode: null');
   });
+
+  it('merges model into the frontmatter on finish (single-write replacement for the legacy patch path)', async () => {
+    // Headless spawns learn the resolved model identifier only after the
+    // runner returns, so the adapter passes it through SessionFinishArgs.
+    // The prior implementation did a second read+regex-rewrite to splice
+    // model in; this test pins that the merge happens in one write and
+    // co-exists with the standard finish fields.
+    const path = join(dir, 'session.md');
+    await writeSessionStart({
+      path,
+      provider: 'claude',
+      cwd: '/tmp',
+      flags: [],
+      started: '2026-05-04T10:00:00Z',
+      promptBody: 'X',
+    });
+    await writeSessionFinish({
+      path,
+      finished: '2026-05-04T10:01:00Z',
+      exitCode: 0,
+      sessionId: 'sess-merge',
+      model: 'claude-opus-4-7',
+    });
+    const body = await readFile(path, 'utf-8');
+    expect(body).toContain('model: claude-opus-4-7');
+    expect(body).toContain('sessionId: sess-merge');
+    expect(body).toContain('exitCode: 0');
+    // Body still preserved.
+    expect(body).toContain('## Prompt\n\nX');
+  });
+
+  it('includes model in the finish-only stub when no prior file exists', async () => {
+    const path = join(dir, 'session.md');
+    await writeSessionFinish({
+      path,
+      finished: '2026-05-04T10:00:00Z',
+      exitCode: 0,
+      model: 'claude-opus-4-7',
+    });
+    const body = await readFile(path, 'utf-8');
+    expect(body).toContain('model: claude-opus-4-7');
+    expect(body).toContain('finished: 2026-05-04T10:00:00Z');
+  });
 });

--- a/src/integration/persistence/session-md-writer.test.ts
+++ b/src/integration/persistence/session-md-writer.test.ts
@@ -1,9 +1,9 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { nextSessionPath, writeSessionFinish, writeSessionStart } from './session-md-writer.ts';
+import { writeSessionFinish, writeSessionStart } from './session-md-writer.ts';
 
 let dir: string;
 
@@ -132,33 +132,5 @@ describe('writeSessionFinish', () => {
     await writeSessionFinish({ path, finished: '2026-05-04T10:01:00Z', exitCode: null });
     const body = await readFile(path, 'utf-8');
     expect(body).toContain('exitCode: null');
-  });
-});
-
-describe('nextSessionPath', () => {
-  it('returns session-1.md when the dir is empty', async () => {
-    const p = await nextSessionPath(dir);
-    expect(p).toBe(join(dir, 'session-1.md'));
-  });
-
-  it('returns session-1.md when the dir does not exist', async () => {
-    const missing = join(dir, 'does-not-exist');
-    const p = await nextSessionPath(missing);
-    expect(p).toBe(join(missing, 'session-1.md'));
-  });
-
-  it('increments past existing session-N.md files', async () => {
-    await writeFile(join(dir, 'session-1.md'), 'a');
-    await writeFile(join(dir, 'session-2.md'), 'b');
-    await writeFile(join(dir, 'session-5.md'), 'c'); // skipped numbers tolerated
-    const p = await nextSessionPath(dir);
-    expect(p).toBe(join(dir, 'session-6.md'));
-  });
-
-  it('ignores files that do not match the session pattern', async () => {
-    await writeFile(join(dir, 'random.md'), 'x');
-    await writeFile(join(dir, 'session.md'), 'y'); // no number — ignored
-    const p = await nextSessionPath(dir);
-    expect(p).toBe(join(dir, 'session-1.md'));
   });
 });

--- a/src/integration/persistence/session-md-writer.ts
+++ b/src/integration/persistence/session-md-writer.ts
@@ -50,6 +50,13 @@ export interface SessionFinishArgs {
   readonly exitCode: number | null;
   /** New session id assigned by the provider, when surfaced. */
   readonly sessionId?: string;
+  /**
+   * Resolved model identifier from the provider, when surfaced. Merged
+   * into the frontmatter at finish time — the start half doesn't know
+   * the model for headless spawns where the runner picks it. Optional
+   * because interactive spawns don't surface a model identifier.
+   */
+  readonly model?: string;
 }
 
 const FRONTMATTER_DELIM = '---';
@@ -151,6 +158,7 @@ export async function writeSessionFinish(args: SessionFinishArgs): Promise<Resul
       finished: args.finished,
       exitCode: args.exitCode,
       sessionId: args.sessionId,
+      model: args.model,
     });
     return writeFileSafe(args.path, `${fm}\n\n## Prompt\n\n_(no prompt recorded — session finish without start)_\n`);
   }
@@ -160,6 +168,7 @@ export async function writeSessionFinish(args: SessionFinishArgs): Promise<Resul
   merged['finished'] = args.finished;
   merged['exitCode'] = args.exitCode;
   if (args.sessionId !== undefined) merged['sessionId'] = args.sessionId;
+  if (args.model !== undefined) merged['model'] = args.model;
 
   const fm = renderFrontmatter(merged);
   const content = `${fm}\n\n${body}`;

--- a/src/integration/persistence/session-md-writer.ts
+++ b/src/integration/persistence/session-md-writer.ts
@@ -2,10 +2,11 @@
  * `session-md-writer` — write per-AI-session markdown files with a YAML
  * frontmatter header and a `## Prompt` body.
  *
- * Each AI session under a per-unit folder gets a `session.md` (or
- * `session-N.md` for execution rounds) so the user can audit exactly
- * what the harness handed the model and how the spawn settled. Two
- * write phases:
+ * Each AI session under a per-unit folder gets a `session.md` (refine /
+ * plan / ideate stamp a single one at the unit root; the per-task chain
+ * routes each spawn into `rounds/<N>/{generator,evaluator}/session.md`)
+ * so the user can audit exactly what the harness handed the model and
+ * how the spawn settled. Two write phases:
  *
  *  - {@link writeSessionStart} — called immediately before the spawn.
  *    Writes provider / model / cwd / flags / sessionId / started + the
@@ -22,8 +23,7 @@
  * be overkill for these few keys.
  */
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 
 import { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
@@ -217,27 +217,4 @@ function unquote(s: string): string {
     return s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
   }
   return s;
-}
-
-/**
- * Scan `unitDir` for `session-N.md` files and return the next number's
- * absolute path (`session-1.md` if none exist). Used by execution units
- * which spawn one AI session per evaluator round.
- */
-export async function nextSessionPath(unitDir: string): Promise<string> {
-  let entries: string[];
-  try {
-    entries = await readdir(unitDir);
-  } catch {
-    // Directory doesn't exist yet — start at 1.
-    return join(unitDir, 'session-1.md');
-  }
-  let max = 0;
-  for (const entry of entries) {
-    const m = /^session-(\d+)\.md$/.exec(entry);
-    if (!m) continue;
-    const n = Number(m[1]);
-    if (Number.isFinite(n) && n > max) max = n;
-  }
-  return join(unitDir, `session-${String(max + 1)}.md`);
 }

--- a/src/integration/signals/file-system-handler.test.ts
+++ b/src/integration/signals/file-system-handler.test.ts
@@ -106,7 +106,12 @@ describe('FileSystemSignalHandler', () => {
     expect(lines[1]).toContain('second');
   });
 
-  it('writes evaluation full critique to execution/<unit>/evaluation.md and a summary to progress.md', async () => {
+  it('appends an evaluation summary to progress.md without writing the full critique sidecar', async () => {
+    // The full critique is persisted by `EvaluateAndFixLoopUseCase`
+    // under `rounds/<N>/evaluator/evaluation.md` — this handler only
+    // emits a one-line summary into the sprint timeline. Asserting the
+    // sidecar is intentionally absent prevents a regression that would
+    // re-introduce the dual-write path.
     const signal: HarnessSignal = {
       type: 'evaluation',
       status: 'failed',
@@ -122,45 +127,15 @@ describe('FileSystemSignalHandler', () => {
     });
     expect(r.ok).toBe(true);
 
-    const sidecar = await readFile(
-      join(paths.sprintDir(SPRINT_ID), 'execution', `${TASK_ID}-sample-task`, 'evaluation.md'),
-      'utf-8'
-    );
-    expect(sidecar).toContain('# Evaluation — failed');
-    expect(sidecar).toContain('**correctness** (score 2/5): FAIL');
-    expect(sidecar).toContain('Overall score: 2/5');
-    expect(sidecar).toContain('The implementation does not handle null input.');
+    // No sidecar — the loop owns critique persistence now.
+    await expect(
+      readFile(join(paths.sprintDir(SPRINT_ID), 'execution', `${TASK_ID}-sample-task`, 'evaluation.md'), 'utf-8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
 
     const progress = await readFile(join(paths.sprintDir(SPRINT_ID), 'progress.md'), 'utf-8');
     expect(progress).toContain('**Evaluation:** failed');
     expect(progress).toContain('score 2/5');
-  });
-
-  it('overwrites the evaluation sidecar on subsequent calls (atomic per-task)', async () => {
-    const first: HarnessSignal = {
-      type: 'evaluation',
-      status: 'failed',
-      dimensions: [{ dimension: 'correctness', score: 1, passed: false, finding: 'broken' }],
-      overallScore: 1,
-      critique: 'first run',
-      timestamp: NOW,
-    };
-    const second: HarnessSignal = {
-      type: 'evaluation',
-      status: 'passed',
-      dimensions: [{ dimension: 'correctness', score: 5, passed: true, finding: 'all good' }],
-      overallScore: 5,
-      timestamp: NOW,
-    };
-    await handler.handle(first, { sprintId: SPRINT_ID, taskId: TASK_ID, taskName: 'Sample Task' });
-    await handler.handle(second, { sprintId: SPRINT_ID, taskId: TASK_ID, taskName: 'Sample Task' });
-
-    const sidecar = await readFile(
-      join(paths.sprintDir(SPRINT_ID), 'execution', `${TASK_ID}-sample-task`, 'evaluation.md'),
-      'utf-8'
-    );
-    expect(sidecar).toContain('# Evaluation — passed');
-    expect(sidecar).not.toContain('first run');
+    expect(progress).toContain('1 dimension(s)');
   });
 
   it('returns an error when an evaluation signal arrives without taskId', async () => {

--- a/src/integration/signals/file-system-handler.ts
+++ b/src/integration/signals/file-system-handler.ts
@@ -6,10 +6,15 @@
  *  - `progress` / `note` / `task-blocked` → append timestamped markdown
  *    line to `<sprintDir>/progress.md` (under file lock to prevent
  *    concurrent corruption when parallel tasks emit simultaneously).
- *  - `evaluation` → write full critique to the per-task execution unit's
- *    `evaluation.md` (`<sprintDir>/execution/<unit-slug>/evaluation.md`)
- *    and append a one-line summary to `progress.md`. Requires `taskId`
- *    plus `taskName` in the meta so the unit slug can be derived.
+ *  - `evaluation` → append a one-line summary to `progress.md`. The
+ *    full critique is persisted by `EvaluateAndFixLoopUseCase` via
+ *    `WriteContextFilePort` (per-round file under
+ *    `rounds/<N>/evaluator/evaluation.md` plus a stable
+ *    `latest-evaluation.md` pointer) — this handler does NOT write
+ *    the critique itself. Requires `taskId` plus `taskName` in the
+ *    meta only for ergonomic logging; both fields remain validated
+ *    so future per-task summary detail has a place to land without
+ *    a contract change.
  *  - `task-verified` / `task-complete` → no durable write (use case layer
  *    owns task lifecycle in `tasks.json`).
  *  - `check-script-discovery` / `agents-md-proposal` etc → setup-time
@@ -18,26 +23,20 @@
  * All writes are append-only or atomic-overwrite — a crash mid-write
  * leaves prior entries intact (resumability invariant).
  */
-import { appendFile, mkdir, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 
 import type { SignalHandlerMeta, SignalHandlerPort } from '@src/business/ports/signal-handler-port.ts';
 import { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
 import type { HarnessSignal } from '@src/domain/signals/harness-signal.ts';
-import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
+import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import type { SprintId } from '@src/domain/values/sprint-id.ts';
 import { FileLocker } from '@src/integration/persistence/file-locker.ts';
 import type { StoragePaths } from '@src/integration/persistence/storage-paths.ts';
-import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
 
 function progressPath(paths: StoragePaths, sprintId: SprintId): AbsolutePath {
   return paths.progressFile(sprintId);
-}
-
-function evaluationPath(paths: StoragePaths, sprintId: SprintId, taskId: string, taskName: string): AbsolutePath {
-  const slug = unitSlug(taskId, taskName);
-  return AbsolutePath.trustString(join(paths.executionUnitDir(sprintId, slug), 'evaluation.md'));
 }
 
 async function appendLine(path: AbsolutePath, line: string): Promise<Result<void, StorageError>> {
@@ -50,26 +49,6 @@ async function appendLine(path: AbsolutePath, line: string): Promise<Result<void
       new StorageError({
         subCode: 'io',
         message: `failed to append to ${path}: ${err instanceof Error ? err.message : String(err)}`,
-        path,
-        cause: err,
-      })
-    );
-  }
-}
-
-async function writeText(path: AbsolutePath, body: string): Promise<Result<void, StorageError>> {
-  try {
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, body.endsWith('\n') ? body : `${body}\n`, {
-      encoding: 'utf-8',
-      mode: 0o600,
-    });
-    return Result.ok();
-  } catch (err) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: `failed to write ${path}: ${err instanceof Error ? err.message : String(err)}`,
         path,
         cause: err,
       })
@@ -110,14 +89,15 @@ export class FileSystemSignalHandler implements SignalHandlerPort {
           return Result.error(
             new StorageError({
               subCode: 'io',
-              message: 'evaluation signal requires taskName in meta to derive the execution unit slug',
+              message: 'evaluation signal requires taskName in meta',
             })
           );
         }
-        const file = evaluationPath(this.paths, meta.sprintId, String(meta.taskId), meta.taskName);
-        const body = renderEvaluationBody(signal);
-        const w = await writeText(file, body);
-        if (!w.ok) return w;
+        // The full critique is persisted by `EvaluateAndFixLoopUseCase`
+        // under `rounds/<N>/evaluator/evaluation.md` (plus a stable
+        // `latest-evaluation.md` pointer). This handler only appends a
+        // one-line summary to `progress.md` so the user can scan
+        // verdicts in the sprint timeline without opening every round.
         const scoreSuffix = signal.overallScore !== undefined ? `, score ${String(signal.overallScore)}/5` : '';
         return this.appendProgress(
           meta.sprintId,
@@ -161,43 +141,4 @@ export class FileSystemSignalHandler implements SignalHandlerPort {
 function formatProgress(timestamp: string, message: string, files?: readonly string[]): string {
   const filesSuffix = files !== undefined && files.length > 0 ? ` (files: ${files.join(', ')})` : '';
   return `- ${timestamp} — ${message}${filesSuffix}`;
-}
-
-function renderEvaluationBody(signal: {
-  readonly status: 'passed' | 'failed' | 'malformed';
-  readonly dimensions: readonly {
-    readonly dimension: string;
-    readonly score?: number;
-    readonly passed: boolean;
-    readonly finding: string;
-  }[];
-  readonly overallScore?: number;
-  readonly critique?: string;
-  readonly timestamp: string;
-}): string {
-  const lines: string[] = [];
-  lines.push(`# Evaluation — ${signal.status}`);
-  lines.push('');
-  lines.push(`Recorded: ${signal.timestamp}`);
-  if (signal.overallScore !== undefined) {
-    lines.push(`Overall score: ${String(signal.overallScore)}/5`);
-  }
-  lines.push('');
-  if (signal.dimensions.length > 0) {
-    lines.push('## Dimensions');
-    lines.push('');
-    for (const d of signal.dimensions) {
-      const verdict = d.passed ? 'PASS' : 'FAIL';
-      const scoreLabel = d.score !== undefined ? ` (score ${String(d.score)}/5)` : '';
-      lines.push(`- **${d.dimension}**${scoreLabel}: ${verdict} — ${d.finding}`);
-    }
-    lines.push('');
-  }
-  if (signal.critique !== undefined && signal.critique.length > 0) {
-    lines.push('## Critique');
-    lines.push('');
-    lines.push(signal.critique);
-    lines.push('');
-  }
-  return lines.join('\n');
 }

--- a/src/kernel/algorithms/execution-round-paths.test.ts
+++ b/src/kernel/algorithms/execution-round-paths.test.ts
@@ -2,13 +2,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import {
-  evaluatorRoundDir,
-  generatorRoundDir,
-  latestEvaluationPath,
-  roundDir,
-  standaloneRoundDir,
-} from './execution-round-paths.ts';
+import { evaluatorRoundDir, generatorRoundDir, roundDir, standaloneRoundDir } from './execution-round-paths.ts';
 
 const UNIT_ROOT = '/tmp/sprint/execution/task-001-do-the-thing';
 
@@ -28,12 +22,6 @@ describe('execution-round-paths', () => {
   describe('evaluatorRoundDir', () => {
     it('joins unitRoot with rounds/<round>/evaluator', () => {
       expect(evaluatorRoundDir(UNIT_ROOT, 3)).toBe(join(UNIT_ROOT, 'rounds', '3', 'evaluator'));
-    });
-  });
-
-  describe('latestEvaluationPath', () => {
-    it('joins unitRoot with latest-evaluation.md', () => {
-      expect(latestEvaluationPath(UNIT_ROOT)).toBe(join(UNIT_ROOT, 'latest-evaluation.md'));
     });
   });
 

--- a/src/kernel/algorithms/execution-round-paths.test.ts
+++ b/src/kernel/algorithms/execution-round-paths.test.ts
@@ -1,0 +1,46 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluatorRoundDir,
+  generatorRoundDir,
+  latestEvaluationPath,
+  roundDir,
+  standaloneRoundDir,
+} from './execution-round-paths.ts';
+
+const UNIT_ROOT = '/tmp/sprint/execution/task-001-do-the-thing';
+
+describe('execution-round-paths', () => {
+  describe('roundDir', () => {
+    it('joins unitRoot with rounds/<round>', () => {
+      expect(roundDir(UNIT_ROOT, 1)).toBe(join(UNIT_ROOT, 'rounds', '1'));
+    });
+  });
+
+  describe('generatorRoundDir', () => {
+    it('joins unitRoot with rounds/<round>/generator', () => {
+      expect(generatorRoundDir(UNIT_ROOT, 2)).toBe(join(UNIT_ROOT, 'rounds', '2', 'generator'));
+    });
+  });
+
+  describe('evaluatorRoundDir', () => {
+    it('joins unitRoot with rounds/<round>/evaluator', () => {
+      expect(evaluatorRoundDir(UNIT_ROOT, 3)).toBe(join(UNIT_ROOT, 'rounds', '3', 'evaluator'));
+    });
+  });
+
+  describe('latestEvaluationPath', () => {
+    it('joins unitRoot with latest-evaluation.md', () => {
+      expect(latestEvaluationPath(UNIT_ROOT)).toBe(join(UNIT_ROOT, 'latest-evaluation.md'));
+    });
+  });
+
+  describe('standaloneRoundDir', () => {
+    it('joins unitRoot with rounds/standalone-<iso>', () => {
+      const iso = '2026-05-05T12-34-56-789Z';
+      expect(standaloneRoundDir(UNIT_ROOT, iso)).toBe(join(UNIT_ROOT, 'rounds', `standalone-${iso}`));
+    });
+  });
+});

--- a/src/kernel/algorithms/execution-round-paths.test.ts
+++ b/src/kernel/algorithms/execution-round-paths.test.ts
@@ -2,7 +2,14 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { evaluatorRoundDir, generatorRoundDir, roundDir, standaloneRoundDir } from './execution-round-paths.ts';
+import {
+  evaluatorRoundDir,
+  evaluatorVerdictSprintRelative,
+  generatorRoundDir,
+  roundDir,
+  standaloneEvaluatorVerdictSprintRelative,
+  standaloneRoundDir,
+} from './execution-round-paths.ts';
 
 const UNIT_ROOT = '/tmp/sprint/execution/task-001-do-the-thing';
 
@@ -29,6 +36,23 @@ describe('execution-round-paths', () => {
     it('joins unitRoot with rounds/standalone-<iso>', () => {
       const iso = '2026-05-05T12-34-56-789Z';
       expect(standaloneRoundDir(UNIT_ROOT, iso)).toBe(join(UNIT_ROOT, 'rounds', `standalone-${iso}`));
+    });
+  });
+
+  describe('evaluatorVerdictSprintRelative', () => {
+    it('builds execution/<slug>/rounds/<round>/evaluator/evaluation.md', () => {
+      expect(evaluatorVerdictSprintRelative('abc123-do-thing', 2)).toBe(
+        join('execution', 'abc123-do-thing', 'rounds', '2', 'evaluator', 'evaluation.md')
+      );
+    });
+  });
+
+  describe('standaloneEvaluatorVerdictSprintRelative', () => {
+    it('builds execution/<slug>/rounds/standalone-<iso>/evaluator/evaluation.md', () => {
+      const iso = '2026-05-05T12-34-56-789Z-abcd';
+      expect(standaloneEvaluatorVerdictSprintRelative('abc123-do-thing', iso)).toBe(
+        join('execution', 'abc123-do-thing', 'rounds', `standalone-${iso}`, 'evaluator', 'evaluation.md')
+      );
     });
   });
 });

--- a/src/kernel/algorithms/execution-round-paths.ts
+++ b/src/kernel/algorithms/execution-round-paths.ts
@@ -45,3 +45,28 @@ export function evaluatorRoundDir(unitRoot: string, round: number): string {
 export function standaloneRoundDir(unitRoot: string, iso: string): string {
   return join(unitRoot, 'rounds', `standalone-${iso}`);
 }
+
+/**
+ * Sprint-relative path of a per-round verdict file:
+ * `execution/<slug>/rounds/<round>/evaluator/evaluation.md`.
+ *
+ * Stamped on `Task.evaluationFile` so the recorded value remains
+ * portable across moved data dirs / machines. Single source of truth
+ * for the layout — call this instead of hand-rolling the relative
+ * path so a future folder rename is one edit.
+ */
+export function evaluatorVerdictSprintRelative(slug: string, round: number): string {
+  return join('execution', slug, 'rounds', String(round), 'evaluator', 'evaluation.md');
+}
+
+/**
+ * Sprint-relative path of a standalone-round verdict file:
+ * `execution/<slug>/rounds/standalone-<iso>/evaluator/evaluation.md`.
+ *
+ * Mirror of {@link evaluatorVerdictSprintRelative} for the
+ * `sprint evaluate` re-run path; kept symmetric so neither call site
+ * needs to encode the layout itself.
+ */
+export function standaloneEvaluatorVerdictSprintRelative(slug: string, iso: string): string {
+  return join('execution', slug, 'rounds', `standalone-${iso}`, 'evaluator', 'evaluation.md');
+}

--- a/src/kernel/algorithms/execution-round-paths.ts
+++ b/src/kernel/algorithms/execution-round-paths.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure path helpers that compute the canonical sub-paths inside a per-task
+ * execution unit folder (`<sprintDir>/execution/<unit-slug>/`).
+ *
+ * Single source of truth — every caller (chain leaves, the multi-round
+ * evaluate-and-fix loop in `business/`, tests) routes through these helpers
+ * so a future folder rename is a single edit and the business layer can
+ * compute paths without importing from `integration/`.
+ *
+ * All helpers return plain `string`s; callers wrap with
+ * `AbsolutePath.trustString` only at the boundary where the value is
+ * surfaced as a domain value. Zero IO; zero deps beyond `node:path`.
+ */
+import { join } from 'node:path';
+
+/**
+ * Per-round root folder: `<unitRoot>/rounds/<round>/`.
+ */
+export function roundDir(unitRoot: string, round: number): string {
+  return join(unitRoot, 'rounds', String(round));
+}
+
+/**
+ * Generator audit folder for a round: `<unitRoot>/rounds/<round>/generator/`.
+ * The per-task chain stamps `session.md` (and retry-suffixed siblings) here.
+ */
+export function generatorRoundDir(unitRoot: string, round: number): string {
+  return join(roundDir(unitRoot, round), 'generator');
+}
+
+/**
+ * Evaluator artefacts for a round: `<unitRoot>/rounds/<round>/evaluator/`.
+ * The evaluate-and-fix loop writes `prompt.md`, `evaluation.md`, and
+ * `session.md` under this folder.
+ */
+export function evaluatorRoundDir(unitRoot: string, round: number): string {
+  return join(roundDir(unitRoot, round), 'evaluator');
+}
+
+/**
+ * Stable pointer to the most recent verdict: `<unitRoot>/latest-evaluation.md`.
+ * `Task.evaluationFile` references this path (relative to the sprint dir) so
+ * the latest critique is always reachable without inspecting per-round folders.
+ */
+export function latestEvaluationPath(unitRoot: string): string {
+  return join(unitRoot, 'latest-evaluation.md');
+}
+
+/**
+ * Per-invocation folder for the standalone `sprint evaluate` command:
+ * `<unitRoot>/rounds/standalone-<iso>/`. Each invocation lays down a
+ * fresh, distinct artefact pack alongside its prior siblings.
+ */
+export function standaloneRoundDir(unitRoot: string, iso: string): string {
+  return join(unitRoot, 'rounds', `standalone-${iso}`);
+}

--- a/src/kernel/algorithms/execution-round-paths.ts
+++ b/src/kernel/algorithms/execution-round-paths.ts
@@ -38,15 +38,6 @@ export function evaluatorRoundDir(unitRoot: string, round: number): string {
 }
 
 /**
- * Stable pointer to the most recent verdict: `<unitRoot>/latest-evaluation.md`.
- * `Task.evaluationFile` references this path (relative to the sprint dir) so
- * the latest critique is always reachable without inspecting per-round folders.
- */
-export function latestEvaluationPath(unitRoot: string): string {
-  return join(unitRoot, 'latest-evaluation.md');
-}
-
-/**
  * Per-invocation folder for the standalone `sprint evaluate` command:
  * `<unitRoot>/rounds/standalone-<iso>/`. Each invocation lays down a
  * fresh, distinct artefact pack alongside its prior siblings.


### PR DESCRIPTION
## Summary

15 commits on top of `main` reshaping the evaluator + per-task chain around a round-aware on-disk layout. Each evaluator round and each generator (re-)spawn now writes its artefacts under `<unit>/rounds/<N>/{generator,evaluator}/`, the per-task chain wraps the workspace build and the multi-round loop in **two independent** `OnError` frames (so a builder failure or evaluator failure no longer gates task completion, but `code: 'aborted'` still propagates), and the `latest-evaluation.md` pointer is gone — each round path is unique, so `Task.evaluationFile` points directly at the final round's verdict.

- **`feat(evaluator)`** — per-round `prompt.md` + `evaluation.md` + `session.md` under `rounds/<N>/evaluator/`; generator (re-)spawns route their audit to `rounds/<N>/generator/session.md`; standalone `sprint evaluate <task>` re-runs land in `rounds/standalone-<ISO>-<rand>/` (millisecond-ISO + 4-hex random suffix prevents same-process collisions); fix-round wrapper inlines the prior critique body so the resumed generator reads it before re-reading the spec (no file round-trip).
- **`refactor(per-task)`** — `build-execution-unit` moved AHEAD of `execute-task` so the initial generator's `session.md` audit lands in `rounds/1/generator/`. Wrapped in its own `OnError(catchIf: code !== 'aborted', fallback: noop)`; `evaluate-task` wrapped in a separate `OnError` with the same shape. Either failure mode is absorbed; user-initiated cancel propagates so Ctrl+C mid-evaluator no longer silently flips the task to done.
- **`refactor(kernel)`** — new `kernel/algorithms/execution-round-paths.ts` is the single source of truth for round-folder path math (`roundDir`, `generatorRoundDir`, `evaluatorRoundDir`, `standaloneRoundDir`) and the sprint-relative verdict path helpers (`evaluatorVerdictSprintRelative`, `standaloneEvaluatorVerdictSprintRelative`) so business and integration consume one definition.
- **`fix(execute)`** — generator audit preserved across rate-limit retries (attempt 1 keeps `session.md`, attempts 2+ get `session-attempt-N.md`) so the forensic trail of what the AI saw before the 429 isn't overwritten.
- **`fix(evaluate)`** — standalone evaluate correctness pass: closure-scoped folder token (was a process-level memo cache), `Task.evaluationFile` uses the unit slug (was bare task id), verdict + pointer writes routed through `WriteContextFilePort` so transient EACCES warns instead of breaking the "evaluator never blocks" contract.
- **`refactor(evaluator) — review fixes`** (final commit) — `SessionFinishArgs.model` so headless-spawn finish writes the resolved model in a single write (drops `patchSessionMdModel` + `upsertFrontmatterField`); `</evaluator-critique>` escaped in the inlined critique body so an evaluator that quotes the tag can't terminate the wrapper early; `Math.random()` → `randomBytes(2).toString('hex')` for the standalone-round suffix.
- **`fix(test)`** — e2e suite always rebuilds `dist/` so the bundled-CLI tests assert against current source, not a stale artefact.
- **`docs(architecture)`** — ARCHITECTURE.md trace order matches the implementation; the split-OnError per-task chain and the missing-root evaluator fallback are documented as authoritative.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 232 files / 2238 tests pass
- [x] Per-task chain step-order fence pins `branch-preflight → mark-in-progress → render-prompt-to-file → build-execution-unit → execute-task → post-task-check → evaluate-task → commit-task → mark-done`
- [x] Standalone `sprint evaluate <task>` re-run lands in a fresh `rounds/standalone-<ISO>-<rand>/` folder; prior verdicts preserved
- [x] Rate-limit retry audit: attempt 1 at `rounds/1/generator/session.md`, attempt 2 at `rounds/1/generator/session-attempt-2.md`
- [x] Ctrl+C during evaluator round propagates `code: 'aborted'` and does NOT mark the task done
- [x] `build-execution-unit` failure absorbed by `OnError`; chain still settles to `mark-done`
- [ ] CI green