### PR TITLE
fix(tui): cap live step trace to prevent OOM on long sprint runs

### DIFF
--- a/src/application/tui/components/execute/step-trace.test.tsx
+++ b/src/application/tui/components/execute/step-trace.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import React from 'react';
 import { render, cleanup } from 'ink-testing-library';
-import { StepTrace, CompactStepSummary, type LiveStep } from './step-trace.tsx';
+import { StepTrace, CompactStepSummary, MAX_RENDERED_STEPS, type LiveStep } from './step-trace.tsx';
 
 afterEach(() => {
   cleanup();
@@ -48,6 +48,38 @@ describe('StepTrace', () => {
     const frame = lastFrame() ?? '';
     expect(frame).toContain('bad-step');
     expect(frame).toContain('something went wrong');
+  });
+
+  it('caps rendered rows when steps exceed MAX_RENDERED_STEPS and shows an elision row', () => {
+    // Drive Ink with a large step list — without the cap this would render
+    // thousands of <Box> children and (combined with re-render heartbeats)
+    // OOM Node on long-running sprints. The cap keeps the parent's child
+    // count bounded.
+    const total = 5000;
+    const steps: LiveStep[] = Array.from({ length: total }, (_, i) => step(`step-${String(i)}`, 'completed', 10));
+    const { lastFrame } = render(<StepTrace steps={steps} isRunning={false} />);
+    const frame = lastFrame() ?? '';
+
+    expect(frame).toContain(`… ${String(total - MAX_RENDERED_STEPS)} earlier steps`);
+    // The earliest non-elided step is at index `total - MAX_RENDERED_STEPS`.
+    expect(frame).toContain(`step-${String(total - MAX_RENDERED_STEPS)}`);
+    expect(frame).toContain(`step-${String(total - 1)}`);
+    // Anything older than the visible window is gone.
+    expect(frame).not.toContain('step-0 ');
+    expect(frame).not.toContain(`step-${String(total - MAX_RENDERED_STEPS - 1)} `);
+
+    // Defensive bound on rendered rows: elision line + visible steps.
+    const lines = frame.split('\n').filter((line) => line.trim().length > 0);
+    expect(lines.length).toBeLessThanOrEqual(MAX_RENDERED_STEPS + 1);
+  });
+
+  it('renders all rows when steps fit under MAX_RENDERED_STEPS without an elision row', () => {
+    const steps: LiveStep[] = Array.from({ length: 10 }, (_, i) => step(`step-${String(i)}`));
+    const { lastFrame } = render(<StepTrace steps={steps} isRunning={false} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('earlier steps');
+    expect(frame).toContain('step-0');
+    expect(frame).toContain('step-9');
   });
 });
 

--- a/src/application/tui/components/execute/step-trace.tsx
+++ b/src/application/tui/components/execute/step-trace.tsx
@@ -76,15 +76,24 @@ function stepGlyph(status: ChainTraceEntry['status'] | undefined, spinnerFrame: 
   );
 }
 
+// Cap visible rows so a long-running chain (hundreds of per-task leaves)
+// can't grow the parent <Box>'s childNodes into the thousands. Ink calls
+// `[...childNodes].reverse()` per render; with a 90 ms spinner heartbeat
+// driving re-renders, an unbounded child list thrashes the heap to OOM.
+export const MAX_RENDERED_STEPS = 50;
+
 export function StepTrace({ steps, isRunning }: StepTraceProps): React.JSX.Element {
   const spinnerFrame = useSpinnerFrame();
   if (steps.length === 0) {
     if (isRunning) return <Spinner label="Starting…" />;
     return <Text dimColor>No steps recorded.</Text>;
   }
+  const visible = steps.length > MAX_RENDERED_STEPS ? steps.slice(-MAX_RENDERED_STEPS) : steps;
+  const elided = steps.length - visible.length;
   return (
     <Box flexDirection="column">
-      {steps.map((step, i) => (
+      {elided > 0 ? <Text dimColor>{`… ${String(elided)} earlier steps`}</Text> : null}
+      {visible.map((step, i) => (
         <Box key={i}>
           {stepGlyph(step.status, spinnerFrame)}
           <Text bold={step.status === undefined}>{`  ${step.name}`}</Text>

--- a/src/application/tui/views/execute-view.tsx
+++ b/src/application/tui/views/execute-view.tsx
@@ -78,6 +78,15 @@ function isTaskStep(name: string): boolean {
   return /^task-[a-zA-Z0-9_-]+$/.test(name);
 }
 
+// Cap accumulated step state. A long `sprint start` (200+ tasks × ~10 inner
+// leaves each) would otherwise grow `steps` into the thousands; combined with
+// the 80–120 ms spinner heartbeats, Ink's per-render `[...childNodes].reverse()`
+// allocates a fresh array per tick and OOMs the process. Safe because each
+// leaf's "started" / "settled" pair fires synchronously inside one
+// `Element.execute()` settle, so by the time the head is evicted nothing
+// in the discarded prefix is still in-flight for the findIndex match below.
+const MAX_LIVE_STEPS = 200;
+
 // ── Props ─────────────────────────────────────────────────────────────────────
 
 interface Props {
@@ -182,12 +191,14 @@ export function ExecuteView({ sessionId, sessionManager, signalBus }: Props): Re
             durationMs: entry.durationMs,
             errorMessage: entry.error?.message,
           };
+          let next: LiveStep[];
           if (idx >= 0) {
-            const next = [...prev];
+            next = [...prev];
             next[idx] = settled;
-            return next;
+          } else {
+            next = [...prev, settled];
           }
-          return [...prev, settled];
+          return next.length > MAX_LIVE_STEPS ? next.slice(-MAX_LIVE_STEPS) : next;
         });
         // Rate-limit heuristic fallback when no signalBus is wired.
         if (signalBus === undefined || signalBus === null) {


### PR DESCRIPTION
## Summary

- Cap `steps` state in `execute-view.tsx` at 200 entries (FIFO eviction).
- Slice `StepTrace` render to last 50 with an elision row above for the rest.
- Add regression tests covering both the cap and the under-cap path.

## Why

After ~15h of `ralphctl sprint start` Node V8 hit `Ineffective mark-compacts near heap limit Allocation failed` and aborted at ~4 GB. The native stack trace's smoking gun was `Builtins_ArrayPrototypeReverse` fired from `uv__run_check` → `Environment::CheckImmediate` — the only `.reverse()` reachable from React's commit phase is Ink's `[...node.childNodes].reverse()` in `render-node-to-output.js:42`.

Tracing the React tree pointed at one consumer: `execute-view.tsx`'s `steps` state subscriber appended every `step` event without a cap, and `StepTrace` rendered `steps.map(...)` without a slice. A 200-task sprint × ~10 inner leaves per task yielded thousands of entries; combined with 80–120 ms spinner heartbeats in `spinner.tsx` / `header-heartbeat.tsx` / `task-execution-list.tsx` / `step-trace.tsx`, Ink reconciled and re-`reverse()`-ed the giant child list every tick.

Capping at the consumer (not in `kernel/`) preserves the canonical chain trace asserted by every `<flow>-flow.test.ts` step-order test — the leak is renderer allocation churn, not data retention.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 232 files / 2240 tests pass
- [x] New tests in `step-trace.test.tsx`: 5000-entry cap and 10-entry under-cap path
- [ ] Manual: `pnpm dev sprint start` against a long sprint, watch RSS plateau instead of growing