### PR TITLE
feat(execute): split setup/check scripts; auto-source per-task gate

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -200,7 +200,7 @@ chains/
 │   │                               reset-stale-in-progress → assert-tasks-not-empty →
 │   │                               assert-tasks-blocked-by-resolvable → assert-tasks-acyclic →
 │   │                               resolve-branch → dirty-tree-preflight →
-│   │                               check-scripts-sprint-start → link-skills → execute-tasks
+│   │                               setup-scripts-sprint-start → link-skills → execute-tasks
 │   │                               (Sequential of topologically-ordered per-task chains) →
 │   │                               unlink-skills → summarise-execution
 │   └── per-task-flow.ts          ← per-task: branch-preflight (OnError → mark-blocked) →
@@ -336,10 +336,15 @@ and the mutators that are not obvious from the field names.
 - **`Project`** (`project.ts`) — identified by branded `ProjectName` slug; owns `≥1 Repository` (unique by path).
 - **`Repository`** (`repository.ts`) — identified by `AbsolutePath`; carries `setupScript`, `checkScript`,
   `checkTimeout`, `onboardedAt`. Mutators: `markOnboarded(now)`, `clearOnboarded()`, `withSetupScript(script)`.
+  `setupScript` runs **once** at sprint start (`setup-scripts-sprint-start` chain leaf, via
+  `ExternalPort.runSetupScript`) and a non-zero exit hard-aborts before any task runs. `checkScript` is the
+  per-task verification gate run after every AI task and inside the feedback loop. Both share the same shell-runner
+  but are emitted at different lifecycle hooks; do not conflate them.
 - **`Sprint`** (`sprint.ts`) — identified by `SprintId` (`YYYYMMDD-HHmmss-<slug>`); lifecycle
   `draft → active → closed`; owns nested `Ticket[]`; carries `projectName`, `branch`, `pullRequestUrl`,
-  `affectedRepositories`, `checkRanAt`. Mutators: `rename(name)`, `clearBranch()`, `recordPullRequestUrl(url)`,
-  `setAffectedRepositories(paths)`.
+  `affectedRepositories`, `setupRanAt`. Mutators: `rename(name)`, `clearBranch()`, `recordPullRequestUrl(url)`,
+  `setAffectedRepositories(paths)`, `recordSetupRun(repo, at)`. `setupRanAt` is the audit map
+  (`Map<AbsolutePath, IsoTimestamp>`) of sprint-start setup-script runs; cleared on `close()`.
 - **`Ticket`** (`ticket.ts`) — nested in Sprint; identified by `TicketId`; `requirementStatus: pending → approved`
   set by `sprint refine`.
 - **`Task`** (`task.ts`) — identified by `TaskId`; status `todo | in_progress | done | blocked`; references

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -200,8 +200,9 @@ chains/
 │   │                               reset-stale-in-progress → assert-tasks-not-empty →
 │   │                               assert-tasks-blocked-by-resolvable → assert-tasks-acyclic →
 │   │                               resolve-branch → dirty-tree-preflight →
-│   │                               setup-scripts-sprint-start → link-skills → execute-tasks
-│   │                               (Sequential of topologically-ordered per-task chains) →
+│   │                               resolve-check-scripts → setup-scripts-sprint-start →
+│   │                               link-skills → execute-tasks (Sequential of
+│   │                               topologically-ordered per-task chains) →
 │   │                               unlink-skills → summarise-execution
 │   └── per-task-flow.ts          ← per-task: branch-preflight (OnError → mark-blocked) →
 │                                   mark-in-progress → render-prompt-to-file →
@@ -338,8 +339,13 @@ and the mutators that are not obvious from the field names.
   `checkTimeout`, `onboardedAt`. Mutators: `markOnboarded(now)`, `clearOnboarded()`, `withSetupScript(script)`.
   `setupScript` runs **once** at sprint start (`setup-scripts-sprint-start` chain leaf, via
   `ExternalPort.runSetupScript`) and a non-zero exit hard-aborts before any task runs. `checkScript` is the
-  per-task verification gate run after every AI task and inside the feedback loop. Both share the same shell-runner
-  but are emitted at different lifecycle hooks; do not conflate them.
+  per-task verification gate run after every AI task and inside the feedback loop — auto-sourced by the
+  `resolve-check-scripts` chain leaf, which walks the sprint's project at sprint start and stuffs each
+  affected repo's configured script into `ctx.checkScripts` so the per-task bridge can fire the gate
+  without the user passing `--check-script`. The CLI flag overrides the auto-source globally when set.
+  Both scripts share the same shell-runner but are emitted at different lifecycle hooks; do not conflate
+  them — setup is the deterministic baseline so Claude departs reliably; check is the step-to-step gate
+  so follow-up tasks may succeed.
 - **`Sprint`** (`sprint.ts`) — identified by `SprintId` (`YYYYMMDD-HHmmss-<slug>`); lifecycle
   `draft → active → closed`; owns nested `Ticket[]`; carries `projectName`, `branch`, `pullRequestUrl`,
   `affectedRepositories`, `setupRanAt`. Mutators: `rename(name)`, `clearBranch()`, `recordPullRequestUrl(url)`,

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -97,8 +97,8 @@ save-sprint → save-tasks`
 - [ ] `createExecuteFlow(deps, opts)` returns an `Element<ExecuteCtx>`
 - [ ] Outer step trace: `load-sprint → assert-active → load-tasks → reset-stale-in-progress →
 assert-tasks-not-empty → assert-tasks-blocked-by-resolvable → assert-tasks-acyclic → resolve-branch →
-dirty-tree-preflight → check-scripts-sprint-start → link-skills → execute-tasks (Sequential) →
-unlink-skills → summarise-execution`
+dirty-tree-preflight → resolve-check-scripts → setup-scripts-sprint-start → link-skills →
+execute-tasks (Sequential) → unlink-skills → summarise-execution`
 - [ ] `execute-tasks` is a `Sequential` whose children are `createPerTaskFlow(deps, { task, sprint })` instances,
       one per runnable task in topological order
 - [ ] Tasks already in `done` / `blocked` are filtered out at construction time so resumed sprints skip them
@@ -242,9 +242,13 @@ confirm-setup-script → confirm-verify-script → confirm-context-file → writ
 - [ ] Completion signals parsed correctly
 - [ ] Blocked tasks short-circuit the rest of the per-task chain via `taskBlocked`; the outer Sequential continues
       with the next task
-- [x] `checkScript` runs at sprint start (per repo, idempotent via `sprint.checkRanAt`)
+- [x] `setupScript` runs at sprint start (per repo, audit-stamped on `sprint.setupRanAt`); first red exit
+      hard-aborts the chain naming the failing repo
+- [x] Per-task `checkScript` is auto-sourced from each repo's `Repository.checkScript` via the
+      `resolve-check-scripts` leaf; `--check-script` (CLI) overrides for every task when set
 - [x] `checkScript` runs after every task completion as a post-task gate
-- [x] Task not marked done if check gate fails
+- [x] Task not marked done if check gate fails (transitions to `blocked` via the inner `OnError(catchIf:
+code === 'check-failed')` wrap)
 - [ ] Rate-limited tasks auto-resume via session ID through `Retry(retryOn: 'rate-limited')`; `RateLimitCoordinator`
       bridges pause/resume to the signal bus for the dashboard's `RateLimitBanner`
 

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -242,9 +242,9 @@ confirm-setup-script → confirm-verify-script → confirm-context-file → writ
 - [ ] Completion signals parsed correctly
 - [ ] Blocked tasks short-circuit the rest of the per-task chain via `taskBlocked`; the outer Sequential continues
       with the next task
-- [ ] `checkScript` runs at sprint start (per repo, idempotent via `sprint.checkRanAt`)
-- [ ] `checkScript` runs after every task completion as a post-task gate
-- [ ] Task not marked done if check gate fails
+- [x] `checkScript` runs at sprint start (per repo, idempotent via `sprint.checkRanAt`)
+- [x] `checkScript` runs after every task completion as a post-task gate
+- [x] Task not marked done if check gate fails
 - [ ] Rate-limited tasks auto-resume via session ID through `Retry(retryOn: 'rate-limited')`; `RateLimitCoordinator`
       bridges pause/resume to the signal bus for the dashboard's `RateLimitBanner`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,30 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Setup ≠ check.** Sprint start now runs each repo's configured `setupScript` (the deterministic
+  baseline so Claude departs reliably) via the renamed `setup-scripts-sprint-start` chain leaf,
+  iterating `sprint.affectedRepositories` and stamping `Sprint.setupRanAt[repoPath]`. The first red
+  exit hard-aborts the chain naming the failing repo. The per-task prompt's `{{ENVIRONMENT_STATUS}}`
+  slot renders "Setup script ran at <ISO>" instead of the old "Pre-task environment check passed at"
+  string.
+- **Per-task `checkScript` is auto-sourced.** A new `resolve-check-scripts` chain leaf (runs in the
+  initialize phase before setup) walks the sprint's project once and populates `ctx.checkScripts`
+  with each affected repo's configured `Repository.checkScript`. The per-task bridge seeds the gate
+  per-task without the user passing `--check-script`. The CLI flag stays as a global override
+  (and its help text now says so).
+
 ### Fixed
 
-- **Sprint-start green baseline** — `check-scripts-sprint-start` now iterates `sprint.affectedRepositories`,
-  runs each repo's configured `checkScript` exactly once, and stamps `Sprint.checkRanAt[repoPath]`. The
-  first red exit hard-aborts the chain naming the failing repo; the per-task prompt's
-  `{{ENVIRONMENT_STATUS}}` slot now renders "Pre-task environment check passed at <ISO>" instead of
-  "Not run.".
-- **Per-task verification gate** — `PostTaskCheckUseCase` now returns `Result.error(CheckFailedError)`
-  on a non-zero exit. The per-task chain wraps it in `OnError(catchIf: code === 'check-failed')` and
-  transitions the task to `'blocked'` (reason: "post-task check failed") instead of letting `mark-done`
-  proceed.
-- **Spawn-level errors degrade gracefully** — both check gates wrap the inner leaf in a soft `OnError`
-  that absorbs anything except `aborted` and the gate's own hard error code, so a missing binary /
-  EPERM doesn't strand a sprint or a task.
+- **Per-task verification gate is a hard fence.** `PostTaskCheckUseCase` returns
+  `Result.error(CheckFailedError)` on a non-zero exit. The per-task chain wraps it in
+  `OnError(catchIf: code === 'check-failed')` and transitions the task to `'blocked'` (reason:
+  "post-task check failed") instead of letting `mark-done` proceed.
+- **Spawn-level errors degrade gracefully.** Both gates wrap the inner leaf in a soft `OnError` that
+  absorbs anything except `aborted` and the gate's own hard error code, so a missing binary / EPERM
+  doesn't strand a sprint or a task. `resolve-check-scripts` runs BEFORE the soft-wrapped setup so
+  the per-task gate keeps its check-script map even when setup degrades.
 
 ## [0.6.2] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sprint-start green baseline** — `check-scripts-sprint-start` now iterates `sprint.affectedRepositories`,
+  runs each repo's configured `checkScript` exactly once, and stamps `Sprint.checkRanAt[repoPath]`. The
+  first red exit hard-aborts the chain naming the failing repo; the per-task prompt's
+  `{{ENVIRONMENT_STATUS}}` slot now renders "Pre-task environment check passed at <ISO>" instead of
+  "Not run.".
+- **Per-task verification gate** — `PostTaskCheckUseCase` now returns `Result.error(CheckFailedError)`
+  on a non-zero exit. The per-task chain wraps it in `OnError(catchIf: code === 'check-failed')` and
+  transitions the task to `'blocked'` (reason: "post-task check failed") instead of letting `mark-done`
+  proceed.
+- **Spawn-level errors degrade gracefully** — both check gates wrap the inner leaf in a soft `OnError`
+  that absorbs anything except `aborted` and the gate's own hard error code, so a missing binary /
+  EPERM doesn't strand a sprint or a task.
+
 ## [0.6.2] - 2026-05-04
 
 Hotfix on top of 0.6.1. The previous bundles silently no-op'd when invoked through the npm-installed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,14 @@ Before committing any code change, run `/verify` (wraps `pnpm typecheck && pnpm 
 - **Check scripts come ONLY from explicit repo config** — set during `project add` or `project repo add`. Heuristic
   detection in `src/integration/external/` is used only as editable suggestions during project setup, never as
   a runtime fallback.
-- **`RALPHCTL_SETUP_TIMEOUT_MS`** — env var to override the 5-minute default timeout for check scripts
+- **`RALPHCTL_SETUP_TIMEOUT_MS`** — env var to override the 5-minute default timeout for setup AND check scripts (they
+  share the runner)
+- **`setupScript` ≠ `checkScript`** — two distinct lifecycle hooks on every `Repository`. `setupScript` is the
+  one-shot "prepare the env" command (e.g. `pnpm install`); it runs once per affected repo at sprint start, in the
+  `setup-scripts-sprint-start` chain leaf, and a non-zero exit hard-aborts before any task runs. `checkScript` is the
+  per-task verification gate; it runs after every AI task and inside the feedback loop. Both are collected during
+  `project onboard` and persisted on the `Repository` entity. Don't conflate them — a passing setup does not imply
+  the codebase compiles, and a passing check does not imply the env was prepared.
 - **Post-task gate** — the per-task chain runs the configured `checkScript` after every AI task; the task is not marked
   done if the gate fails (see `business/usecases/execute/post-task-check.ts`)
 - **Branch management** — `sprint start` prompts for branch strategy on first run; `sprint.branch` persists the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,9 @@ Before committing any code change, run `/verify` (wraps `pnpm typecheck && pnpm 
   `project onboard` and persisted on the `Repository` entity. Don't conflate them — a passing setup does not imply
   the codebase compiles, and a passing check does not imply the env was prepared.
 - **Post-task gate** — the per-task chain runs the configured `checkScript` after every AI task; the task is not marked
-  done if the gate fails (see `business/usecases/execute/post-task-check.ts`)
+  done if the gate fails (see `business/usecases/execute/post-task-check.ts`). The script is auto-sourced from each
+  repo's `Repository.checkScript` by the `resolve-check-scripts` chain leaf (run at sprint start); `sprint start
+--check-script <cmd>` overrides this for every task when set.
 - **Branch management** — `sprint start` prompts for branch strategy on first run; `sprint.branch` persists the
   choice; branches created in all repos with tasks; pre-flight verifies correct branch before each task; `--branch`
   auto-generates `ralphctl/<sprint-id>`; `--branch-name <name>` for custom names; `sprint close --create-pr` creates PRs

--- a/src/application/chains/execute/execute-flow.test.ts
+++ b/src/application/chains/execute/execute-flow.test.ts
@@ -19,7 +19,7 @@ const taskCompleteSignal: HarnessSignal = {
 };
 
 describe('createExecuteFlow', () => {
-  it('runs load-sprint → assert-active → load-tasks → reset-stale-in-progress → assert-tasks-not-empty → assert-tasks-blocked-by-resolvable → assert-tasks-acyclic → [initialize: resolve-branch → dirty-tree-preflight → check-scripts-sprint-start] → link-skills → execute-tasks → unlink-skills → summarise-execution', async () => {
+  it('runs load-sprint → assert-active → load-tasks → reset-stale-in-progress → assert-tasks-not-empty → assert-tasks-blocked-by-resolvable → assert-tasks-acyclic → [initialize: resolve-branch → dirty-tree-preflight → setup-scripts-sprint-start] → link-skills → execute-tasks → unlink-skills → summarise-execution', async () => {
     const sprint0 = makeSprint();
     const ticket = makeApprovedTicket();
     const withTicket = sprint0.addTicket(ticket);
@@ -78,7 +78,7 @@ describe('createExecuteFlow', () => {
     // The kernel's Sequential flattens child traces: a nested Sequential's
     // own name never appears as a trace entry — only Leaf entries do.
     // So `'initialize'` (which wraps resolve-branch → dirty-tree-preflight →
-    // check-scripts-sprint-start) and `'execute-tasks'` (which wraps the
+    // setup-scripts-sprint-start) and `'execute-tasks'` (which wraps the
     // per-task bridges) do NOT appear in headlineSteps; their children surface
     // flatly in the same order as before.
     const headlineSteps = [
@@ -91,7 +91,7 @@ describe('createExecuteFlow', () => {
       'assert-tasks-acyclic',
       'resolve-branch',
       'dirty-tree-preflight',
-      'check-scripts-sprint-start',
+      'setup-scripts-sprint-start',
       'link-skills',
       'unlink-skills',
       'summarise-execution',
@@ -109,13 +109,13 @@ describe('createExecuteFlow', () => {
     expect(trace.slice(linkIdx + 1, unlinkIdx)).toContain(`task-${task.id}`);
   });
 
-  // ── sprint-start green baseline (REQ check gate) ───────────────────
+  // ── sprint-start setup execution (REQ setup hook) ──────────────────
 
-  describe('check-scripts-sprint-start', () => {
-    function buildProject(repoPath: string, checkScript: string | undefined): Project {
+  describe('setup-scripts-sprint-start', () => {
+    function buildProject(repoPath: string, setupScript: string | undefined): Project {
       const repoCreate =
-        checkScript !== undefined
-          ? Repository.create({ path: abs(repoPath), name: 'demo-repo', checkScript })
+        setupScript !== undefined
+          ? Repository.create({ path: abs(repoPath), name: 'demo-repo', setupScript })
           : Repository.create({ path: abs(repoPath), name: 'demo-repo' });
       if (!repoCreate.ok) throw new Error('precondition: repo');
       const projectName = ProjectName.parse('demo');
@@ -145,12 +145,12 @@ describe('createExecuteFlow', () => {
       return { sprint: affected.value };
     }
 
-    it("runs each affected repo's checkScript and stamps checkRanAt on success", async () => {
+    it("runs each affected repo's setupScript and stamps setupRanAt on success", async () => {
       const repoPath = '/tmp/demo-repo';
-      const { sprint } = setupActive({ branch: 'ralphctl/check-ok', affectedRepoPath: repoPath });
-      const project = buildProject(repoPath, 'pnpm test');
+      const { sprint } = setupActive({ branch: 'ralphctl/setup-ok', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm install');
       const task = makeTask({ name: 'do work', projectPath: repoPath });
-      const external = new FakeExternalPort({ checkScriptOutcomes: [{ passed: true, output: '' }] });
+      const external = new FakeExternalPort({ setupScriptOutcomes: [{ passed: true, output: '' }] });
 
       const deps = createTestDeps({
         sprints: [sprint],
@@ -182,7 +182,7 @@ describe('createExecuteFlow', () => {
       const flow = createExecuteFlow(deps, {
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-ok',
+        expectedBranch: 'ralphctl/setup-ok',
         tasks: [task],
         sprint,
       });
@@ -190,36 +190,35 @@ describe('createExecuteFlow', () => {
       const result = await flow.execute({
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-ok',
+        expectedBranch: 'ralphctl/setup-ok',
       });
 
       expect(result.ok).toBe(true);
-      // The repo's check script ran exactly once during sprint-start.
-      const sprintStartCalls = external.checkScriptCalls.filter((c) => c.phase === 'sprint-start');
-      expect(sprintStartCalls).toHaveLength(1);
-      expect(String(sprintStartCalls[0]?.projectPath)).toBe(repoPath);
-      expect(sprintStartCalls[0]?.script).toBe('pnpm test');
+      // The repo's setup script ran exactly once during sprint-start.
+      expect(external.setupScriptCalls).toHaveLength(1);
+      expect(String(external.setupScriptCalls[0]?.projectPath)).toBe(repoPath);
+      expect(external.setupScriptCalls[0]?.script).toBe('pnpm install');
 
-      // checkRanAt is populated on the persisted sprint.
+      // setupRanAt is persisted on the on-disk sprint by the leaf so
+      // the per-task prompt builder can read it.
       const reread = await deps.sprintRepo.findById(sprint.id);
       expect(reread.ok).toBe(true);
-      // The bridge propagates the stamped sprint forward — but we
-      // don't write it to disk in this leaf, so the on-disk sprint
-      // doesn't carry checkRanAt yet. Trace assertion is the durable
-      // contract for now.
+      if (reread.ok) {
+        expect(reread.value.setupRanAt.get(abs(repoPath))).toBeDefined();
+      }
       if (!result.ok) return;
       const trace = result.value.trace.map((t) => t.stepName);
-      expect(trace).toContain('check-scripts-sprint-start');
+      expect(trace).toContain('setup-scripts-sprint-start');
     });
 
-    it('hard-aborts when a repo check script exits non-zero (red baseline)', async () => {
+    it('hard-aborts when a repo setup script exits non-zero (red baseline)', async () => {
       const repoPath = '/tmp/demo-repo';
-      const { sprint } = setupActive({ branch: 'ralphctl/check-red', affectedRepoPath: repoPath });
-      const project = buildProject(repoPath, 'pnpm test');
+      const { sprint } = setupActive({ branch: 'ralphctl/setup-red', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm install');
       const task = makeTask({ name: 'do work', projectPath: repoPath });
-      // Red baseline.
+      // Red baseline — setup script fails.
       const external = new FakeExternalPort({
-        checkScriptOutcomes: [{ passed: false, output: 'baseline tests failing' }],
+        setupScriptOutcomes: [{ passed: false, output: 'install failing' }],
       });
 
       const deps = createTestDeps({
@@ -232,7 +231,7 @@ describe('createExecuteFlow', () => {
       const flow = createExecuteFlow(deps, {
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-red',
+        expectedBranch: 'ralphctl/setup-red',
         tasks: [task],
         sprint,
       });
@@ -240,7 +239,7 @@ describe('createExecuteFlow', () => {
       const result = await flow.execute({
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-red',
+        expectedBranch: 'ralphctl/setup-red',
       });
 
       expect(result.ok).toBe(false);
@@ -250,7 +249,7 @@ describe('createExecuteFlow', () => {
       // The leaf surfaces an `invalid-state` error which the OnError
       // wrap explicitly LETS THROUGH (catchIf excludes invalid-state).
       // The Sequential records the failed step and aborts the rest.
-      expect(failed?.stepName).toBe('check-scripts-sprint-start');
+      expect(failed?.stepName).toBe('setup-scripts-sprint-start');
       expect(result.error.error.code).toBe('invalid-state');
       // No per-task bridge ran — tasks must NOT have started.
       expect(trace.some((n) => n.startsWith('task-'))).toBe(false);
@@ -260,15 +259,15 @@ describe('createExecuteFlow', () => {
 
     it('soft-degrades on a spawn-level error (e.g. missing binary): noop in trace, chain continues', async () => {
       const repoPath = '/tmp/demo-repo';
-      const { sprint } = setupActive({ branch: 'ralphctl/check-spawn', affectedRepoPath: repoPath });
-      const project = buildProject(repoPath, 'pnpm test');
+      const { sprint } = setupActive({ branch: 'ralphctl/setup-spawn', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm install');
       const task = makeTask({ name: 'do work', projectPath: repoPath });
 
-      // External whose runCheckScript throws — mimics ENOENT / EPERM.
+      // External whose runSetupScript throws — mimics ENOENT / EPERM.
       const baseExternal = new FakeExternalPort();
       const throwingExternal = new Proxy(baseExternal, {
         get(target, prop, receiver) {
-          if (prop === 'runCheckScript') {
+          if (prop === 'runSetupScript') {
             return (): Promise<never> => Promise.reject(new Error('ENOENT: no such file or directory'));
           }
           return Reflect.get(target, prop, receiver) as unknown;
@@ -305,7 +304,7 @@ describe('createExecuteFlow', () => {
       const flow = createExecuteFlow(deps, {
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-spawn',
+        expectedBranch: 'ralphctl/setup-spawn',
         tasks: [task],
         sprint,
       });
@@ -313,7 +312,7 @@ describe('createExecuteFlow', () => {
       const result = await flow.execute({
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/check-spawn',
+        expectedBranch: 'ralphctl/setup-spawn',
       });
 
       // Chain still resolves OK — spawn error swallowed by the outer OnError.
@@ -321,12 +320,12 @@ describe('createExecuteFlow', () => {
       if (!result.ok) return;
       const trace = result.value.trace.map((t) => t.stepName);
       // The OnError fallback's noop step records the swallow.
-      expect(trace).toContain('check-scripts-sprint-start-noop');
+      expect(trace).toContain('setup-scripts-sprint-start-noop');
       // The per-task bridge ran (Sequential flattens; bridges surface as `task-<id>`).
       expect(trace.some((n) => n.startsWith('task-'))).toBe(true);
     });
 
-    it('skips repos without a checkScript and short-circuits cleanly when affectedRepositories is empty', async () => {
+    it('skips repos without a setupScript and short-circuits cleanly when affectedRepositories is empty', async () => {
       // Direct-task path: no `sprint plan` ran so affectedRepositories
       // is empty. The leaf must still appear in the trace as a
       // completed step (no-op) rather than crashing or trying to
@@ -384,9 +383,8 @@ describe('createExecuteFlow', () => {
       });
 
       expect(result.ok).toBe(true);
-      // No check script invocations — the leaf short-circuited.
-      const sprintStartCalls = external.checkScriptCalls.filter((c) => c.phase === 'sprint-start');
-      expect(sprintStartCalls).toHaveLength(0);
+      // No setup script invocations — the leaf short-circuited.
+      expect(external.setupScriptCalls).toHaveLength(0);
     });
   });
 
@@ -522,12 +520,12 @@ describe('createExecuteFlow', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     // The new step landed in the trace between resolve-branch and
-    // check-scripts-sprint-start. Failure is the dirty-tree-preflight step
+    // setup-scripts-sprint-start. Failure is the dirty-tree-preflight step
     // itself; subsequent steps are kernel-skipped (status 'skipped').
     const failed = result.error.trace.find((t) => t.status === 'failed');
     expect(failed?.stepName).toBe('dirty-tree-preflight');
-    const checkSprintStart = result.error.trace.find((t) => t.stepName === 'check-scripts-sprint-start');
-    expect(checkSprintStart?.status).toBe('skipped');
+    const setupSprintStart = result.error.trace.find((t) => t.stepName === 'setup-scripts-sprint-start');
+    expect(setupSprintStart?.status).toBe('skipped');
     const executeTasks = result.error.trace.find((t) => t.stepName === 'execute-tasks');
     expect(executeTasks?.status).toBe('skipped');
     // No stash / reset calls when the user cancelled.

--- a/src/application/chains/execute/execute-flow.test.ts
+++ b/src/application/chains/execute/execute-flow.test.ts
@@ -19,7 +19,7 @@ const taskCompleteSignal: HarnessSignal = {
 };
 
 describe('createExecuteFlow', () => {
-  it('runs load-sprint → assert-active → load-tasks → reset-stale-in-progress → assert-tasks-not-empty → assert-tasks-blocked-by-resolvable → assert-tasks-acyclic → [initialize: resolve-branch → dirty-tree-preflight → setup-scripts-sprint-start] → link-skills → execute-tasks → unlink-skills → summarise-execution', async () => {
+  it('runs load-sprint → assert-active → load-tasks → reset-stale-in-progress → assert-tasks-not-empty → assert-tasks-blocked-by-resolvable → assert-tasks-acyclic → [initialize: resolve-branch → dirty-tree-preflight → resolve-check-scripts → setup-scripts-sprint-start] → link-skills → execute-tasks → unlink-skills → summarise-execution', async () => {
     const sprint0 = makeSprint();
     const ticket = makeApprovedTicket();
     const withTicket = sprint0.addTicket(ticket);
@@ -78,9 +78,10 @@ describe('createExecuteFlow', () => {
     // The kernel's Sequential flattens child traces: a nested Sequential's
     // own name never appears as a trace entry — only Leaf entries do.
     // So `'initialize'` (which wraps resolve-branch → dirty-tree-preflight →
-    // setup-scripts-sprint-start) and `'execute-tasks'` (which wraps the
-    // per-task bridges) do NOT appear in headlineSteps; their children surface
-    // flatly in the same order as before.
+    // resolve-check-scripts → setup-scripts-sprint-start) and
+    // `'execute-tasks'` (which wraps the per-task bridges) do NOT appear in
+    // headlineSteps; their children surface flatly in the same order as
+    // before.
     const headlineSteps = [
       'load-sprint',
       'assert-active',
@@ -91,6 +92,7 @@ describe('createExecuteFlow', () => {
       'assert-tasks-acyclic',
       'resolve-branch',
       'dirty-tree-preflight',
+      'resolve-check-scripts',
       'setup-scripts-sprint-start',
       'link-skills',
       'unlink-skills',
@@ -388,6 +390,177 @@ describe('createExecuteFlow', () => {
     });
   });
 
+  // ── per-task gate auto-source (resolve-check-scripts → bridge) ─────
+
+  describe('resolve-check-scripts', () => {
+    function buildProjectWithCheck(repoPath: string, checkScript: string | undefined): Project {
+      const repoCreate =
+        checkScript !== undefined
+          ? Repository.create({ path: abs(repoPath), name: 'demo-repo', checkScript })
+          : Repository.create({ path: abs(repoPath), name: 'demo-repo' });
+      if (!repoCreate.ok) throw new Error('precondition: repo');
+      const projectName = ProjectName.parse('demo');
+      if (!projectName.ok) throw new Error('precondition: project name');
+      const project = Project.create({
+        name: projectName.value,
+        displayName: 'Demo',
+        repositories: [repoCreate.value],
+      });
+      if (!project.ok) throw new Error('precondition: project');
+      return project.value;
+    }
+
+    function setupActive(opts: { branch: string; affectedRepoPath: string }): {
+      sprint: ReturnType<typeof makeSprint>;
+    } {
+      const sprint0 = makeSprint();
+      const ticket = makeApprovedTicket();
+      const withTicket = sprint0.addTicket(ticket);
+      if (!withTicket.ok) throw new Error('precondition');
+      const activated = withTicket.value.activate(sprint0.createdAt);
+      if (!activated.ok) throw new Error('precondition');
+      const branched = activated.value.setBranch(opts.branch);
+      if (!branched.ok) throw new Error('precondition');
+      const affected = branched.value.setAffectedRepositories([abs(opts.affectedRepoPath)]);
+      if (!affected.ok) throw new Error('precondition');
+      return { sprint: affected.value };
+    }
+
+    it('auto-sources `Repository.checkScript` so the per-task gate fires per repo without --check-script', async () => {
+      // Design intent: setup at sprint start = baseline; check per task =
+      // step-to-step gate. The per-task gate must fire automatically from
+      // each repo's `Repository.checkScript` without the user passing
+      // `--check-script` to `sprint start`.
+      const repoPath = '/tmp/demo-repo';
+      const { sprint } = setupActive({ branch: 'ralphctl/check-auto', affectedRepoPath: repoPath });
+      const project = buildProjectWithCheck(repoPath, 'pnpm test');
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+      const external = new FakeExternalPort({
+        // First call is the post-task gate (passes).
+        checkScriptOutcomes: [{ passed: true, output: 'OK' }],
+      });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      // No `checkScript` opt — auto-source must populate the gate.
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-auto',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-auto',
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // The post-task gate fired with the repo's configured script.
+      expect(external.checkScriptCalls).toHaveLength(1);
+      expect(external.checkScriptCalls[0]?.script).toBe('pnpm test');
+      expect(external.checkScriptCalls[0]?.phase).toBe('post-task');
+      expect(String(external.checkScriptCalls[0]?.projectPath)).toBe(repoPath);
+
+      // resolve-check-scripts shows up in the trace before setup-scripts-sprint-start.
+      const trace = result.value.trace.map((t) => t.stepName);
+      const resolveIdx = trace.indexOf('resolve-check-scripts');
+      const setupIdx = trace.indexOf('setup-scripts-sprint-start');
+      expect(resolveIdx).toBeGreaterThan(-1);
+      expect(setupIdx).toBeGreaterThan(resolveIdx);
+    });
+
+    it('CLI --check-script (opts.checkScript) overrides the per-repo auto-source', async () => {
+      // Operator override: when the user passes `--check-script` to
+      // `sprint start`, that command runs as the post-task gate for
+      // every task regardless of the repo's own configured script.
+      const repoPath = '/tmp/demo-repo';
+      const { sprint } = setupActive({ branch: 'ralphctl/check-override', affectedRepoPath: repoPath });
+      const project = buildProjectWithCheck(repoPath, 'pnpm test'); // would normally fire
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+      const external = new FakeExternalPort({
+        checkScriptOutcomes: [{ passed: true, output: 'OK' }],
+      });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-override',
+        tasks: [task],
+        sprint,
+        checkScript: 'override-check.sh',
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-override',
+        checkScript: 'override-check.sh',
+      });
+
+      expect(result.ok).toBe(true);
+      // Override wins — the repo's `pnpm test` was NOT invoked.
+      expect(external.checkScriptCalls).toHaveLength(1);
+      expect(external.checkScriptCalls[0]?.script).toBe('override-check.sh');
+    });
+  });
+
   it('fails at assert-active when the sprint is still draft', async () => {
     const sprint = makeSprint();
     const task = makeTask({ name: 'do work' });
@@ -520,10 +693,13 @@ describe('createExecuteFlow', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     // The new step landed in the trace between resolve-branch and
-    // setup-scripts-sprint-start. Failure is the dirty-tree-preflight step
-    // itself; subsequent steps are kernel-skipped (status 'skipped').
+    // resolve-check-scripts / setup-scripts-sprint-start. Failure is
+    // the dirty-tree-preflight step itself; subsequent steps are
+    // kernel-skipped (status 'skipped').
     const failed = result.error.trace.find((t) => t.status === 'failed');
     expect(failed?.stepName).toBe('dirty-tree-preflight');
+    const resolveCheckScripts = result.error.trace.find((t) => t.stepName === 'resolve-check-scripts');
+    expect(resolveCheckScripts?.status).toBe('skipped');
     const setupSprintStart = result.error.trace.find((t) => t.stepName === 'setup-scripts-sprint-start');
     expect(setupSprintStart?.status).toBe('skipped');
     const executeTasks = result.error.trace.find((t) => t.stepName === 'execute-tasks');

--- a/src/application/chains/execute/execute-flow.test.ts
+++ b/src/application/chains/execute/execute-flow.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it } from 'vitest';
 import { FakeExternalPort } from '@src/business/_test-fakes/fake-external-port.ts';
 import { FakePromptPort } from '@src/application/_test-fakes/fake-prompt-port.ts';
 import type { HarnessSignal } from '@src/domain/signals/harness-signal.ts';
+import { Project } from '@src/domain/entities/project.ts';
+import { Repository } from '@src/domain/entities/repository.ts';
+import { ProjectName } from '@src/domain/values/project-name.ts';
 import { abs, makeApprovedTicket, makeSprint, makeTask, taskId } from '@src/application/_test-fakes/fixtures.ts';
 import { createTestDeps } from '@src/application/_test-fakes/create-test-deps.ts';
 import { createExecuteFlow } from './execute-flow.ts';
@@ -104,6 +107,287 @@ describe('createExecuteFlow', () => {
     expect(linkIdx).toBeGreaterThan(-1);
     expect(unlinkIdx).toBeGreaterThan(linkIdx);
     expect(trace.slice(linkIdx + 1, unlinkIdx)).toContain(`task-${task.id}`);
+  });
+
+  // ── sprint-start green baseline (REQ check gate) ───────────────────
+
+  describe('check-scripts-sprint-start', () => {
+    function buildProject(repoPath: string, checkScript: string | undefined): Project {
+      const repoCreate =
+        checkScript !== undefined
+          ? Repository.create({ path: abs(repoPath), name: 'demo-repo', checkScript })
+          : Repository.create({ path: abs(repoPath), name: 'demo-repo' });
+      if (!repoCreate.ok) throw new Error('precondition: repo');
+      const projectName = ProjectName.parse('demo');
+      if (!projectName.ok) throw new Error('precondition: project name');
+      const project = Project.create({
+        name: projectName.value,
+        displayName: 'Demo',
+        repositories: [repoCreate.value],
+      });
+      if (!project.ok) throw new Error('precondition: project');
+      return project.value;
+    }
+
+    function setupActive(opts: { branch: string; affectedRepoPath: string }): {
+      sprint: ReturnType<typeof makeSprint>;
+    } {
+      const sprint0 = makeSprint();
+      const ticket = makeApprovedTicket();
+      const withTicket = sprint0.addTicket(ticket);
+      if (!withTicket.ok) throw new Error('precondition');
+      const activated = withTicket.value.activate(sprint0.createdAt);
+      if (!activated.ok) throw new Error('precondition');
+      const branched = activated.value.setBranch(opts.branch);
+      if (!branched.ok) throw new Error('precondition');
+      const affected = branched.value.setAffectedRepositories([abs(opts.affectedRepoPath)]);
+      if (!affected.ok) throw new Error('precondition');
+      return { sprint: affected.value };
+    }
+
+    it("runs each affected repo's checkScript and stamps checkRanAt on success", async () => {
+      const repoPath = '/tmp/demo-repo';
+      const { sprint } = setupActive({ branch: 'ralphctl/check-ok', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm test');
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+      const external = new FakeExternalPort({ checkScriptOutcomes: [{ passed: true, output: '' }] });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-ok',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-ok',
+      });
+
+      expect(result.ok).toBe(true);
+      // The repo's check script ran exactly once during sprint-start.
+      const sprintStartCalls = external.checkScriptCalls.filter((c) => c.phase === 'sprint-start');
+      expect(sprintStartCalls).toHaveLength(1);
+      expect(String(sprintStartCalls[0]?.projectPath)).toBe(repoPath);
+      expect(sprintStartCalls[0]?.script).toBe('pnpm test');
+
+      // checkRanAt is populated on the persisted sprint.
+      const reread = await deps.sprintRepo.findById(sprint.id);
+      expect(reread.ok).toBe(true);
+      // The bridge propagates the stamped sprint forward — but we
+      // don't write it to disk in this leaf, so the on-disk sprint
+      // doesn't carry checkRanAt yet. Trace assertion is the durable
+      // contract for now.
+      if (!result.ok) return;
+      const trace = result.value.trace.map((t) => t.stepName);
+      expect(trace).toContain('check-scripts-sprint-start');
+    });
+
+    it('hard-aborts when a repo check script exits non-zero (red baseline)', async () => {
+      const repoPath = '/tmp/demo-repo';
+      const { sprint } = setupActive({ branch: 'ralphctl/check-red', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm test');
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+      // Red baseline.
+      const external = new FakeExternalPort({
+        checkScriptOutcomes: [{ passed: false, output: 'baseline tests failing' }],
+      });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-red',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-red',
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const trace = result.error.trace.map((t) => t.stepName);
+      const failed = result.error.trace.find((t) => t.status === 'failed');
+      // The leaf surfaces an `invalid-state` error which the OnError
+      // wrap explicitly LETS THROUGH (catchIf excludes invalid-state).
+      // The Sequential records the failed step and aborts the rest.
+      expect(failed?.stepName).toBe('check-scripts-sprint-start');
+      expect(result.error.error.code).toBe('invalid-state');
+      // No per-task bridge ran — tasks must NOT have started.
+      expect(trace.some((n) => n.startsWith('task-'))).toBe(false);
+      // The error message names the failing repo.
+      expect(result.error.error.message).toContain(repoPath);
+    });
+
+    it('soft-degrades on a spawn-level error (e.g. missing binary): noop in trace, chain continues', async () => {
+      const repoPath = '/tmp/demo-repo';
+      const { sprint } = setupActive({ branch: 'ralphctl/check-spawn', affectedRepoPath: repoPath });
+      const project = buildProject(repoPath, 'pnpm test');
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+
+      // External whose runCheckScript throws — mimics ENOENT / EPERM.
+      const baseExternal = new FakeExternalPort();
+      const throwingExternal = new Proxy(baseExternal, {
+        get(target, prop, receiver) {
+          if (prop === 'runCheckScript') {
+            return (): Promise<never> => Promise.reject(new Error('ENOENT: no such file or directory'));
+          }
+          return Reflect.get(target, prop, receiver) as unknown;
+        },
+      });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external: throwingExternal },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-spawn',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/check-spawn',
+      });
+
+      // Chain still resolves OK — spawn error swallowed by the outer OnError.
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const trace = result.value.trace.map((t) => t.stepName);
+      // The OnError fallback's noop step records the swallow.
+      expect(trace).toContain('check-scripts-sprint-start-noop');
+      // The per-task bridge ran (Sequential flattens; bridges surface as `task-<id>`).
+      expect(trace.some((n) => n.startsWith('task-'))).toBe(true);
+    });
+
+    it('skips repos without a checkScript and short-circuits cleanly when affectedRepositories is empty', async () => {
+      // Direct-task path: no `sprint plan` ran so affectedRepositories
+      // is empty. The leaf must still appear in the trace as a
+      // completed step (no-op) rather than crashing or trying to
+      // resolve a project that may not exist.
+      const sprint0 = makeSprint();
+      const ticket = makeApprovedTicket();
+      const withTicket = sprint0.addTicket(ticket);
+      if (!withTicket.ok) throw new Error('precondition');
+      const activated = withTicket.value.activate(sprint0.createdAt);
+      if (!activated.ok) throw new Error('precondition');
+      const branched = activated.value.setBranch('ralphctl/empty-affected');
+      if (!branched.ok) throw new Error('precondition');
+      const sprint = branched.value;
+      const task = makeTask({ name: 'do work', projectPath: '/tmp/demo-repo' });
+
+      const external = new FakeExternalPort();
+      const deps = createTestDeps({
+        sprints: [sprint],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/empty-affected',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/empty-affected',
+      });
+
+      expect(result.ok).toBe(true);
+      // No check script invocations — the leaf short-circuited.
+      const sprintStartCalls = external.checkScriptCalls.filter((c) => c.phase === 'sprint-start');
+      expect(sprintStartCalls).toHaveLength(0);
+    });
   });
 
   it('fails at assert-active when the sprint is still draft', async () => {

--- a/src/application/chains/execute/execute-flow.ts
+++ b/src/application/chains/execute/execute-flow.ts
@@ -96,8 +96,29 @@ export interface ExecuteCtx {
    * propagates correctly.
    */
   readonly expectedBranch: string;
-  /** Resolved check script (per-repo lookup happens at the caller). */
+  /**
+   * Global override for the per-task check script. When set (typically
+   * via the CLI `--check-script` flag), this command runs as the
+   * post-task gate for EVERY task, regardless of which repo the task
+   * targets. When unset, the per-task bridge falls back to
+   * {@link checkScripts}`.get(task.projectPath)` — the repo's own
+   * configured `checkScript`.
+   */
   readonly checkScript?: string;
+  /**
+   * Per-repo check-script lookup, populated by the
+   * `resolve-check-scripts` leaf at sprint start by reading the sprint's
+   * project's `Repository.checkScript` for every entry on
+   * `sprint.affectedRepositories`. The per-task bridge uses this map to
+   * auto-source the post-task gate's command per-task; {@link checkScript}
+   * (the global override) wins when both are present.
+   *
+   * Stays undefined when the resolve leaf was skipped (missing project
+   * record, empty `affectedRepositories`, etc.) — downstream leaves
+   * tolerate the absence by falling back to {@link checkScript} or
+   * skipping the gate cleanly.
+   */
+  readonly checkScripts?: ReadonlyMap<AbsolutePath, string>;
   readonly sprint?: Sprint;
   readonly tasks?: readonly Task[];
   /** Outcome of the dirty-tree pre-flight (set by `dirty-tree-preflight`). */
@@ -206,18 +227,34 @@ export function createExecuteFlow(
   // runs. Grouped separately from the CONTRACT validation above (assert-*)
   // and from the execution phase (link-skills → execute-tasks).
   //
-  // The sprint-start check leaf is wrapped in an `OnError` that absorbs
+  // Order:
+  //   - `resolve-branch` / `dirty-tree-preflight` — git plumbing
+  //   - `resolve-check-scripts` — pure project read; fills
+  //     `ctx.checkScripts` so the per-task bridge can auto-source the
+  //     post-task gate's command from each repo's own configuration
+  //   - `setup-scripts-sprint-start` — runs the configured `setupScript`
+  //     once per affected repo so Claude departs from a deterministic
+  //     baseline
+  //
+  // `resolve-check-scripts` runs BEFORE the setup leaf so even if
+  // setup's outer `OnError` swallows a spawn-level error, the per-task
+  // gate still has its check-script map. (See the user-stated design:
+  // setup ≠ check; setup is the one-shot baseline, check is the
+  // step-to-step gate so follow-up tasks can succeed.)
+  //
+  // The sprint-start setup leaf is wrapped in an `OnError` that absorbs
   // SPAWN-LEVEL errors (missing binary, EPERM, …) but lets:
   //   - `aborted` (user-initiated cancel) propagate, and
   //   - `invalid-state` (a real red baseline) propagate
   // through unchanged. Only those two reach the outer chain and stop
   // it; transient environment hiccups degrade to a noop so a sprint
   // isn't stranded by a flaky CI shell. The trace surfaces
-  // `check-scripts-sprint-start-noop` when the soft path fires so a
-  // post-mortem can tell why no checks ran.
+  // `setup-scripts-sprint-start-noop` when the soft path fires so a
+  // post-mortem can tell why no setup scripts ran.
   const initializeStep = new Sequential<ExecuteCtx>('initialize', [
     resolveBranchLeaf(deps),
     dirtyTreePreflightLeaf(deps, opts),
+    resolveCheckScriptsLeaf(deps),
     new OnError<ExecuteCtx>(setupScriptsSprintStartLeaf(deps), {
       catchIf: (err) => err.code !== 'aborted' && err.code !== 'invalid-state',
       fallback: noopLeafExec<ExecuteCtx>('setup-scripts-sprint-start-noop'),
@@ -541,6 +578,12 @@ function bridgePerTaskChain(
         // populated yet — load-sprint always runs first, so this is
         // belt-and-suspenders.
         const liveSprint = input.sprint ?? opts.sprint;
+        // Resolve the per-task check script. The CLI's `--check-script`
+        // global override (input.checkScript) wins; otherwise we fall
+        // back to the per-repo map populated by `resolve-check-scripts`
+        // at sprint start. When neither is set the gate skips silently
+        // — same policy as before this branch's auto-source.
+        const resolvedCheckScript = input.checkScript ?? input.checkScripts?.get(task.projectPath);
         const innerCtx: PerTaskCtx = {
           sprintId: input.sprintId,
           sprint: liveSprint,
@@ -548,7 +591,7 @@ function bridgePerTaskChain(
           tasks: liveTasks,
           cwd: task.projectPath,
           expectedBranch: input.expectedBranch,
-          ...(input.checkScript !== undefined ? { checkScript: input.checkScript } : {}),
+          ...(resolvedCheckScript !== undefined ? { checkScript: resolvedCheckScript } : {}),
           ...(input.noCommit === true ? { noCommit: true } : {}),
         };
         const innerResult = await inner.execute(innerCtx);
@@ -688,6 +731,64 @@ function assertTasksAcyclicLeaf(sortResult: ReturnType<typeof topologicalReorder
     },
     input: () => undefined,
     output: (ctx) => ctx,
+  });
+}
+
+/**
+ * Sprint-start check-script resolution — pure read. Walks
+ * `sprint.affectedRepositories`, looks each repo up on the sprint's
+ * project, and stuffs `Repository.checkScript` (when configured) into a
+ * `ReadonlyMap<AbsolutePath, string>` on `ctx.checkScripts`. The
+ * per-task bridge later seeds each per-task chain's `checkScript` from
+ * this map, so the post-task gate fires automatically per repo without
+ * the user having to pass `--check-script` to `sprint start`.
+ *
+ * Distinct leaf (rather than a side-effect of `setup-scripts-sprint-start`)
+ * because this read is pure and must succeed even when setup spawns are
+ * shaky: running it FIRST means a flaky setup script that gets
+ * absorbed by the soft `OnError` still leaves a populated
+ * `ctx.checkScripts` for the per-task gate.
+ *
+ * Soft-fails on missing project / missing repo / unset `checkScript`:
+ * the affected repo simply doesn't appear in the output map. An empty
+ * `affectedRepositories` short-circuits cleanly — many sprints (direct
+ * `task add` path) never run `sprint plan`, so this is the common case.
+ */
+function resolveCheckScriptsLeaf(deps: Pick<ChainSharedDeps, 'projectRepo' | 'logger'>): Element<ExecuteCtx> {
+  return new Leaf<ExecuteCtx, { readonly sprint: Sprint }, ReadonlyMap<AbsolutePath, string>>('resolve-check-scripts', {
+    useCase: {
+      async execute(input) {
+        const map = new Map<AbsolutePath, string>();
+        const repoPaths = input.sprint.affectedRepositories;
+        if (repoPaths.length === 0) {
+          return Result.ok(map);
+        }
+        const project = await deps.projectRepo.findByName(input.sprint.projectName);
+        if (!project.ok) {
+          // Same "let the user fix config without aborting" policy as
+          // `setup-scripts-sprint-start`. Logged so the trace shows why
+          // the per-task gates skipped.
+          deps.logger.warn(
+            `resolve-check-scripts: project ${String(input.sprint.projectName)} not found — per-task gate will skip`,
+            { error: project.error.message }
+          );
+          return Result.ok(map);
+        }
+        for (const repoPath of repoPaths) {
+          const repo = project.value.repositories.find((r) => r.path === repoPath);
+          if (repo === undefined) continue;
+          const script = repo.checkScript;
+          if (script === undefined || script.length === 0) continue;
+          map.set(repoPath, script);
+        }
+        return Result.ok(map);
+      },
+    },
+    input: (ctx) => {
+      if (!ctx.sprint) throw new Error('resolve-check-scripts: ctx.sprint must be loaded first');
+      return { sprint: ctx.sprint };
+    },
+    output: (ctx, checkScripts) => ({ ...ctx, checkScripts }),
   });
 }
 

--- a/src/application/chains/execute/execute-flow.ts
+++ b/src/application/chains/execute/execute-flow.ts
@@ -66,11 +66,13 @@ import {
 import type { Sprint } from '@src/domain/entities/sprint.ts';
 import type { Task } from '@src/domain/entities/task.ts';
 import { InvalidStateError } from '@src/domain/errors/invalid-state-error.ts';
-import type { Element } from '@src/kernel/chain/element.ts';
+import type { Element, KernelError } from '@src/kernel/chain/element.ts';
 import { Leaf } from '@src/kernel/chain/leaf.ts';
+import { OnError } from '@src/kernel/chain/on-error.ts';
 import { Sequential } from '@src/kernel/chain/sequential.ts';
 import { topologicalReorder } from '@src/kernel/algorithms/dependency-reorder.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/values/iso-timestamp.ts';
 import type { SprintId } from '@src/domain/values/sprint-id.ts';
 import type { ChainSharedDeps } from '@src/application/chains/chain-deps.ts';
 import { assertActiveLeaf } from '@src/application/chains/leaves/assert-active.ts';
@@ -140,6 +142,7 @@ export function createExecuteFlow(
   deps: Pick<
     ChainSharedDeps,
     | 'sprintRepo'
+    | 'projectRepo'
     | 'taskRepo'
     | 'aiSession'
     | 'prompts'
@@ -202,10 +205,23 @@ export function createExecuteFlow(
   // Initializer phase: environment SETUP that must succeed before any task
   // runs. Grouped separately from the CONTRACT validation above (assert-*)
   // and from the execution phase (link-skills → execute-tasks).
+  //
+  // The sprint-start check leaf is wrapped in an `OnError` that absorbs
+  // SPAWN-LEVEL errors (missing binary, EPERM, …) but lets:
+  //   - `aborted` (user-initiated cancel) propagate, and
+  //   - `invalid-state` (a real red baseline) propagate
+  // through unchanged. Only those two reach the outer chain and stop
+  // it; transient environment hiccups degrade to a noop so a sprint
+  // isn't stranded by a flaky CI shell. The trace surfaces
+  // `check-scripts-sprint-start-noop` when the soft path fires so a
+  // post-mortem can tell why no checks ran.
   const initializeStep = new Sequential<ExecuteCtx>('initialize', [
     resolveBranchLeaf(deps),
     dirtyTreePreflightLeaf(deps, opts),
-    checkScriptsSprintStartLeaf(deps),
+    new OnError<ExecuteCtx>(checkScriptsSprintStartLeaf(deps), {
+      catchIf: (err) => err.code !== 'aborted' && err.code !== 'invalid-state',
+      fallback: noopLeafExec<ExecuteCtx>('check-scripts-sprint-start-noop'),
+    }),
   ]);
 
   return new Sequential<ExecuteCtx>('execute', [
@@ -519,9 +535,15 @@ function bridgePerTaskChain(
         // when the repo read fails.
         const fresh = await taskRepo.findBySprintId(input.sprintId);
         const liveTasks = fresh.ok ? fresh.value : (input.tasks ?? opts.tasks);
+        // Prefer the freshly-stamped sprint from ctx (the sprint-start
+        // check leaf updates `checkRanAt` and threads it forward). Fall
+        // back to the factory-time snapshot when ctx hasn't been
+        // populated yet — load-sprint always runs first, so this is
+        // belt-and-suspenders.
+        const liveSprint = input.sprint ?? opts.sprint;
         const innerCtx: PerTaskCtx = {
           sprintId: input.sprintId,
-          sprint: opts.sprint,
+          sprint: liveSprint,
           task,
           tasks: liveTasks,
           cwd: task.projectPath,
@@ -670,38 +692,100 @@ function assertTasksAcyclicLeaf(sortResult: ReturnType<typeof topologicalReorder
 }
 
 /**
- * Sprint-start check execution — runs the project check script once
- * before any tasks fan out, surfacing a hard failure if the baseline
- * environment is broken. Skipped when no check script is configured.
+ * Sprint-start green baseline. Walks `sprint.affectedRepositories`,
+ * looks up each path's `Repository` on the sprint's `Project`, and
+ * runs that repo's `checkScript` exactly once. The first red exit
+ * hard-aborts the chain via `InvalidStateError({ currentState:
+ * 'check-failed' })` (the outer `OnError` lets that error code
+ * propagate so the sprint stops cleanly with a "fix the baseline
+ * first" message naming the failing repo). Repos without a
+ * `checkScript` configured are skipped silently.
+ *
+ * On success, stamps `Sprint.checkRanAt[repoPath] = now` for each
+ * repo and threads the updated sprint forward via the leaf output so
+ * the per-task bridge sees populated `checkRanAt` and the prompt
+ * builder can render `Pre-task environment check passed at <ISO>`
+ * instead of `Not run.`.
+ *
+ * Stale paths (a repo that was on `affectedRepositories` at plan time
+ * but has since been removed from the project) are silently skipped —
+ * same policy as `resolve-branch` which also tolerates partial repo
+ * state.
+ *
+ * Spawn-level errors (missing binary, EPERM, …) propagate as whatever
+ * the `ExternalPort` adapter throws; the outer `OnError` (in the
+ * `initializeStep` Sequential) absorbs them so a flaky environment
+ * doesn't strand the sprint.
  */
-function checkScriptsSprintStartLeaf(deps: Pick<ChainSharedDeps, 'external'>): Element<ExecuteCtx> {
-  return new Leaf<ExecuteCtx, { readonly cwd: AbsolutePath; readonly checkScript?: string }, void>(
-    'check-scripts-sprint-start',
-    {
-      useCase: {
-        async execute(input) {
-          if (input.checkScript === undefined || input.checkScript.length === 0) {
-            return Promise.resolve(Result.ok(undefined));
-          }
-          const r = await deps.external.runCheckScript(input.cwd, input.checkScript, 'sprint-start');
-          if (!r.passed) {
+function checkScriptsSprintStartLeaf(deps: Pick<ChainSharedDeps, 'external' | 'projectRepo'>): Element<ExecuteCtx> {
+  return new Leaf<ExecuteCtx, { readonly sprint: Sprint }, Sprint>('check-scripts-sprint-start', {
+    useCase: {
+      async execute(input) {
+        const repoPaths = input.sprint.affectedRepositories;
+        // Empty `affectedRepositories` (e.g. direct-task path that
+        // never ran `sprint plan`) — nothing to verify, leave the
+        // sprint untouched.
+        if (repoPaths.length === 0) {
+          return Result.ok(input.sprint);
+        }
+
+        // Look up the project once so we can resolve each affected
+        // path to its configured `checkScript` / `checkTimeout`.
+        const projectResult = await deps.projectRepo.findByName(input.sprint.projectName);
+        if (!projectResult.ok) return Result.error(projectResult.error);
+        const project = projectResult.value;
+
+        let updated = input.sprint;
+        for (const repoPath of repoPaths) {
+          const repo = project.repositories.find((r) => r.path === repoPath);
+          if (repo === undefined) continue; // stale: repo removed post-plan
+          if (repo.checkScript === undefined || repo.checkScript.length === 0) continue;
+          const result = await deps.external.runCheckScript(
+            repoPath,
+            repo.checkScript,
+            'sprint-start',
+            repo.checkTimeout
+          );
+          if (!result.passed) {
             return Result.error(
               new InvalidStateError({
                 entity: 'sprint',
                 currentState: 'check-failed',
                 attemptedAction: 'execute',
-                message: 'sprint-start check script failed',
+                message: `sprint-start check script failed in ${String(repoPath)}`,
+                hint: 'Fix the failing check script before starting execution.',
               })
             );
           }
-          return Result.ok(undefined);
-        },
+          updated = updated.recordCheckRun(repoPath, IsoTimestamp.now());
+        }
+        return Result.ok(updated);
       },
-      input: (ctx) => ({
-        cwd: ctx.cwd,
-        ...(ctx.checkScript !== undefined ? { checkScript: ctx.checkScript } : {}),
-      }),
-      output: (ctx) => ctx,
-    }
-  );
+    },
+    input: (ctx) => {
+      if (!ctx.sprint) throw new Error('check-scripts-sprint-start: ctx.sprint must be loaded first');
+      return { sprint: ctx.sprint };
+    },
+    // Thread the (possibly stamped) sprint forward — every per-task
+    // bridge reads `ctx.sprint`, and the prompt builder reads
+    // `sprint.checkRanAt` to decide whether to render "passed at <ISO>"
+    // vs "Not run.".
+    output: (ctx, sprint) => ({ ...ctx, sprint }),
+  });
+}
+
+/**
+ * Identity leaf — local to execute-flow so the sprint-start `OnError`
+ * fallback has a typed noop without pulling per-task-flow's helper.
+ */
+function noopLeafExec<TCtx>(name: string): Element<TCtx> {
+  return new Leaf<TCtx, TCtx, TCtx>(name, {
+    useCase: {
+      execute(input) {
+        return Promise.resolve(Result.ok(input)) as Promise<Result<TCtx, KernelError>>;
+      },
+    },
+    input: (ctx) => ctx,
+    output: (_, ctx) => ctx,
+  });
 }

--- a/src/application/chains/execute/execute-flow.ts
+++ b/src/application/chains/execute/execute-flow.ts
@@ -7,7 +7,8 @@
  *     assert-tasks-not-empty → assert-tasks-blocked-by-resolvable →
  *     assert-tasks-acyclic →
  *     [initialize]:
- *       resolve-branch → dirty-tree-preflight → setup-scripts-sprint-start →
+ *       resolve-branch → dirty-tree-preflight → resolve-check-scripts →
+ *       setup-scripts-sprint-start →
  *     link-skills →
  *     execute-tasks (Sequential of topologically-ordered per-task chains) →
  *     unlink-skills → summarise-execution
@@ -21,13 +22,13 @@
  *
  * ## Initializer phase (`Sequential('initialize', [...])`)
  *
- * The three SETUP leaves — `resolve-branch`, `dirty-tree-preflight`, and
- * `setup-scripts-sprint-start` — are grouped into an inner Sequential named
- * `'initialize'`. This separates CONTRACT validation (the `assert-*` leaves
- * above) from environment SETUP (the initializer) from execution (the
- * per-task fan-out). Because `Sequential` flattens child traces, the
- * `'initialize'` name itself does NOT appear as a trace entry; the three
- * leaf names surface flatly just as they did before. The grouping is purely
+ * The four SETUP leaves — `resolve-branch`, `dirty-tree-preflight`,
+ * `resolve-check-scripts`, and `setup-scripts-sprint-start` — are grouped
+ * into an inner Sequential named `'initialize'`. This separates CONTRACT
+ * validation (the `assert-*` leaves above) from environment SETUP (the
+ * initializer) from execution (the per-task fan-out). Because `Sequential`
+ * flattens child traces, the `'initialize'` name itself does NOT appear as
+ * a trace entry; the four leaf names surface flatly. The grouping is purely
  * structural: it makes the chain definition self-documenting and keeps the
  * phase separation explicit for future additions.
  *

--- a/src/application/chains/execute/execute-flow.ts
+++ b/src/application/chains/execute/execute-flow.ts
@@ -7,7 +7,7 @@
  *     assert-tasks-not-empty → assert-tasks-blocked-by-resolvable →
  *     assert-tasks-acyclic →
  *     [initialize]:
- *       resolve-branch → dirty-tree-preflight → check-scripts-sprint-start →
+ *       resolve-branch → dirty-tree-preflight → setup-scripts-sprint-start →
  *     link-skills →
  *     execute-tasks (Sequential of topologically-ordered per-task chains) →
  *     unlink-skills → summarise-execution
@@ -22,7 +22,7 @@
  * ## Initializer phase (`Sequential('initialize', [...])`)
  *
  * The three SETUP leaves — `resolve-branch`, `dirty-tree-preflight`, and
- * `check-scripts-sprint-start` — are grouped into an inner Sequential named
+ * `setup-scripts-sprint-start` — are grouped into an inner Sequential named
  * `'initialize'`. This separates CONTRACT validation (the `assert-*` leaves
  * above) from environment SETUP (the initializer) from execution (the
  * per-task fan-out). Because `Sequential` flattens child traces, the
@@ -218,9 +218,9 @@ export function createExecuteFlow(
   const initializeStep = new Sequential<ExecuteCtx>('initialize', [
     resolveBranchLeaf(deps),
     dirtyTreePreflightLeaf(deps, opts),
-    new OnError<ExecuteCtx>(checkScriptsSprintStartLeaf(deps), {
+    new OnError<ExecuteCtx>(setupScriptsSprintStartLeaf(deps), {
       catchIf: (err) => err.code !== 'aborted' && err.code !== 'invalid-state',
-      fallback: noopLeafExec<ExecuteCtx>('check-scripts-sprint-start-noop'),
+      fallback: noopLeafExec<ExecuteCtx>('setup-scripts-sprint-start-noop'),
     }),
   ]);
 
@@ -536,7 +536,7 @@ function bridgePerTaskChain(
         const fresh = await taskRepo.findBySprintId(input.sprintId);
         const liveTasks = fresh.ok ? fresh.value : (input.tasks ?? opts.tasks);
         // Prefer the freshly-stamped sprint from ctx (the sprint-start
-        // check leaf updates `checkRanAt` and threads it forward). Fall
+        // setup leaf updates `setupRanAt` and threads it forward). Fall
         // back to the factory-time snapshot when ctx hasn't been
         // populated yet — load-sprint always runs first, so this is
         // belt-and-suspenders.
@@ -692,86 +692,109 @@ function assertTasksAcyclicLeaf(sortResult: ReturnType<typeof topologicalReorder
 }
 
 /**
- * Sprint-start green baseline. Walks `sprint.affectedRepositories`,
- * looks up each path's `Repository` on the sprint's `Project`, and
- * runs that repo's `checkScript` exactly once. The first red exit
- * hard-aborts the chain via `InvalidStateError({ currentState:
- * 'check-failed' })` (the outer `OnError` lets that error code
- * propagate so the sprint stops cleanly with a "fix the baseline
- * first" message naming the failing repo). Repos without a
- * `checkScript` configured are skipped silently.
+ * Sprint-start setup execution — runs the configured `setupScript` for
+ * every repo on `sprint.affectedRepositories` once before any tasks fan
+ * out. Setup is the one-shot "prepare the environment" hook (e.g. `pnpm
+ * install`) collected during `project onboard`; it is distinct from the
+ * per-task `checkScript` gate which lives in the per-task chain.
  *
- * On success, stamps `Sprint.checkRanAt[repoPath] = now` for each
- * repo and threads the updated sprint forward via the leaf output so
- * the per-task bridge sees populated `checkRanAt` and the prompt
- * builder can render `Pre-task environment check passed at <ISO>`
- * instead of `Not run.`.
+ * Behaviour:
+ *  - Repos with no `setupScript` configured are skipped silently (same
+ *    policy as the per-task gate's no-`checkScript` skip).
+ *  - Empty `sprint.affectedRepositories` short-circuits cleanly.
+ *  - On the first failing setup script, the leaf returns
+ *    `InvalidStateError({ currentState: 'setup-failed' })` and the chain
+ *    aborts before any task runs — a broken baseline environment must
+ *    not be papered over by the per-task gate.
+ *  - On success, `sprint.recordSetupRun(repoPath, now)` audit-stamps the
+ *    sprint entity (persisted via the sprint repo) so the per-task
+ *    prompt builder can surface "Setup script ran at <ISO>." to the AI.
  *
- * Stale paths (a repo that was on `affectedRepositories` at plan time
- * but has since been removed from the project) are silently skipped —
- * same policy as `resolve-branch` which also tolerates partial repo
- * state.
+ * Project-repo lookup: `setupScript` lives on the `Repository` entity
+ * inside the sprint's `Project`. We load the project once and resolve
+ * each affected path by walking `project.repositories`. A missing
+ * project (rare — usually means the user removed the project after
+ * planning) skips the phase silently rather than failing — the user can
+ * fix it without re-planning.
  *
  * Spawn-level errors (missing binary, EPERM, …) propagate as whatever
  * the `ExternalPort` adapter throws; the outer `OnError` (in the
- * `initializeStep` Sequential) absorbs them so a flaky environment
- * doesn't strand the sprint.
+ * `initializeStep` Sequential) absorbs them via the
+ * `setup-scripts-sprint-start-noop` fallback so a flaky environment
+ * doesn't strand the sprint. Real `setup-failed` (`code: 'invalid-state'`)
+ * propagates so the user sees the failing repo by name.
  */
-function checkScriptsSprintStartLeaf(deps: Pick<ChainSharedDeps, 'external' | 'projectRepo'>): Element<ExecuteCtx> {
-  return new Leaf<ExecuteCtx, { readonly sprint: Sprint }, Sprint>('check-scripts-sprint-start', {
-    useCase: {
-      async execute(input) {
-        const repoPaths = input.sprint.affectedRepositories;
-        // Empty `affectedRepositories` (e.g. direct-task path that
-        // never ran `sprint plan`) — nothing to verify, leave the
-        // sprint untouched.
-        if (repoPaths.length === 0) {
-          return Result.ok(input.sprint);
-        }
-
-        // Look up the project once so we can resolve each affected
-        // path to its configured `checkScript` / `checkTimeout`.
-        const projectResult = await deps.projectRepo.findByName(input.sprint.projectName);
-        if (!projectResult.ok) return Result.error(projectResult.error);
-        const project = projectResult.value;
-
-        let updated = input.sprint;
-        for (const repoPath of repoPaths) {
-          const repo = project.repositories.find((r) => r.path === repoPath);
-          if (repo === undefined) continue; // stale: repo removed post-plan
-          if (repo.checkScript === undefined || repo.checkScript.length === 0) continue;
-          const result = await deps.external.runCheckScript(
-            repoPath,
-            repo.checkScript,
-            'sprint-start',
-            repo.checkTimeout
-          );
-          if (!result.passed) {
-            return Result.error(
-              new InvalidStateError({
-                entity: 'sprint',
-                currentState: 'check-failed',
-                attemptedAction: 'execute',
-                message: `sprint-start check script failed in ${String(repoPath)}`,
-                hint: 'Fix the failing check script before starting execution.',
-              })
-            );
+function setupScriptsSprintStartLeaf(
+  deps: Pick<ChainSharedDeps, 'external' | 'projectRepo' | 'sprintRepo' | 'logger'>
+): Element<ExecuteCtx> {
+  return new Leaf<ExecuteCtx, { readonly sprintId: SprintId; readonly sprint: Sprint }, void>(
+    'setup-scripts-sprint-start',
+    {
+      useCase: {
+        async execute(input) {
+          const repoPaths = input.sprint.affectedRepositories;
+          if (repoPaths.length === 0) {
+            return Result.ok(undefined);
           }
-          updated = updated.recordCheckRun(repoPath, IsoTimestamp.now());
-        }
-        return Result.ok(updated);
+          const project = await deps.projectRepo.findByName(input.sprint.projectName);
+          if (!project.ok) {
+            // Missing project — skip silently and let the user repair the
+            // config without blocking. Logged so it's visible in the trace.
+            deps.logger.warn(
+              `setup-scripts-sprint-start: project ${String(input.sprint.projectName)} not found — skipping setup`,
+              { error: project.error.message }
+            );
+            return Result.ok(undefined);
+          }
+          let sprint = input.sprint;
+          const now = IsoTimestamp.trustString(new Date().toISOString());
+          for (const repoPath of repoPaths) {
+            const repo = project.value.repositories.find((r) => r.path === repoPath);
+            if (repo === undefined) {
+              // Sprint references a repo that no longer exists on the
+              // project — skip silently for the same "let the user fix
+              // config" reason as a missing project.
+              continue;
+            }
+            const script = repo.setupScript;
+            if (script === undefined || script.length === 0) {
+              continue; // No setup script for this repo — skip.
+            }
+            const r = await deps.external.runSetupScript(repoPath, script, repo.checkTimeout);
+            if (!r.passed) {
+              return Result.error(
+                new InvalidStateError({
+                  entity: 'sprint',
+                  currentState: 'setup-failed',
+                  attemptedAction: 'execute',
+                  message: `sprint-start setup script failed in ${String(repoPath)}`,
+                  hint: 'Fix the setup script (configured via `project onboard` / `project repo add`) and retry. Setup runs once at sprint start; the per-task `checkScript` is a separate gate.',
+                })
+              );
+            }
+            sprint = sprint.recordSetupRun(repoPath, now);
+          }
+          // Persist the audit stamps so the per-task prompt sees them.
+          // Best-effort: a save failure logs a warning but does not block
+          // sprint start — the setup actually ran successfully.
+          if (sprint !== input.sprint) {
+            const saved = await deps.sprintRepo.save(sprint);
+            if (!saved.ok) {
+              deps.logger.warn('setup-scripts-sprint-start: failed to persist setup audit stamps', {
+                error: saved.error.message,
+              });
+            }
+          }
+          return Result.ok(undefined);
+        },
       },
-    },
-    input: (ctx) => {
-      if (!ctx.sprint) throw new Error('check-scripts-sprint-start: ctx.sprint must be loaded first');
-      return { sprint: ctx.sprint };
-    },
-    // Thread the (possibly stamped) sprint forward — every per-task
-    // bridge reads `ctx.sprint`, and the prompt builder reads
-    // `sprint.checkRanAt` to decide whether to render "passed at <ISO>"
-    // vs "Not run.".
-    output: (ctx, sprint) => ({ ...ctx, sprint }),
-  });
+      input: (ctx) => {
+        if (!ctx.sprint) throw new Error('setup-scripts-sprint-start: ctx.sprint must be loaded first');
+        return { sprintId: ctx.sprintId, sprint: ctx.sprint };
+      },
+      output: (ctx) => ctx,
+    }
+  );
 }
 
 /**

--- a/src/application/chains/execute/per-task-flow.test.ts
+++ b/src/application/chains/execute/per-task-flow.test.ts
@@ -309,6 +309,152 @@ describe('createPerTaskFlow', () => {
     expect(reread.value.evaluationStatus).toBeUndefined();
   });
 
+  it('post-task check fails (red script): inner OnError marks task blocked, downstream leaves no-op', async () => {
+    // The post-task gate is wrapped in two nested OnError decorators.
+    // The inner one catches `code: 'check-failed'` (the loud signal the
+    // PostTaskCheckUseCase now surfaces on a red exit) and runs the
+    // mark-blocked-check fallback. Downstream leaves still emit trace
+    // entries (kept honest) but no-op via `taskBlocked: true` — the
+    // task does NOT advance to `done`.
+    const sprint = makeSprint();
+    const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });
+    // checkScriptOutcomes: first run fails — that's the post-task gate.
+    const external = new FakeExternalPort({
+      checkScriptOutcomes: [{ passed: false, output: '3 tests failing' }],
+    });
+    const deps = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      aiSession: {
+        outcomes: [
+          { kind: 'ok', result: { output: 'done' } }, // execute-task
+          { kind: 'ok', result: { output: 'evaluated' } }, // evaluator (no-op when blocked)
+        ],
+      },
+      signalParser: {
+        results: [
+          [taskCompleteSignal],
+          [
+            {
+              type: 'evaluation',
+              status: 'passed',
+              dimensions: [],
+              critique: '',
+              timestamp: '2026-04-29T12:00:00Z' as never,
+            },
+          ],
+        ],
+      },
+      overrides: { external },
+    });
+
+    const flow = createPerTaskFlow(deps, { task, sprint });
+    const result = await flow.execute({
+      sprintId: sprint.id,
+      sprint,
+      task,
+      tasks: [task],
+      cwd: abs('/tmp/demo-repo'),
+      expectedBranch: '',
+      checkScript: 'pnpm test',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const stepNames = result.value.trace.map((t) => t.stepName.replace(/#attempt-\d+$/, ''));
+    expect(stepNames).toContain('post-task-check');
+    // Inner OnError fallback fired.
+    expect(stepNames).toContain('mark-blocked-check');
+    // Outer (soft) noop must NOT fire — the inner wrap absorbed the error.
+    expect(stepNames).not.toContain('post-task-check-noop');
+    // Downstream leaves still emit trace entries (no-op via taskBlocked).
+    expect(stepNames).toContain('evaluate-task');
+    expect(stepNames).toContain('mark-done');
+
+    // Task is persisted as blocked with the post-task reason.
+    const reread = await deps.taskRepo.findById(sprint.id, task.id);
+    if (!reread.ok) throw new Error('expected task');
+    expect(reread.value.status).toBe('blocked');
+    expect(reread.value.blockedReason).toBe('post-task check failed');
+  });
+
+  it('post-task check spawn error (e.g. ENOENT): outer OnError swallows, task still completes', async () => {
+    // A spawn-level failure (missing binary, EPERM, …) surfaces from
+    // the ExternalPort as a thrown exception. The outer (soft) OnError
+    // wrap catches anything except `aborted` / `check-failed`, so the
+    // task still proceeds to `mark-done`. This preserves the
+    // "transient environment hiccup shouldn't strand a task" semantics
+    // while keeping `check-failed` a genuine block.
+    const sprint = makeSprint();
+    const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });
+
+    // Custom external that throws ENOENT from runCheckScript — mimics
+    // the script binary missing or unreadable.
+    const baseExternal = new FakeExternalPort();
+    const throwingExternal = new Proxy(baseExternal, {
+      get(target, prop, receiver) {
+        if (prop === 'runCheckScript') {
+          return (): Promise<never> => Promise.reject(new Error('ENOENT: no such file or directory'));
+        }
+        return Reflect.get(target, prop, receiver) as unknown;
+      },
+    });
+
+    const deps = createTestDeps({
+      sprints: [sprint],
+      tasks: [[sprint.id, [task]]],
+      aiSession: {
+        outcomes: [
+          { kind: 'ok', result: { output: 'done' } }, // execute-task
+          { kind: 'ok', result: { output: 'evaluated' } }, // evaluator
+        ],
+      },
+      signalParser: {
+        results: [
+          [taskCompleteSignal],
+          [
+            {
+              type: 'evaluation',
+              status: 'passed',
+              dimensions: [],
+              critique: '',
+              timestamp: '2026-04-29T12:00:00Z' as never,
+            },
+          ],
+        ],
+      },
+      overrides: { external: throwingExternal },
+    });
+
+    const flow = createPerTaskFlow(deps, { task, sprint });
+    const result = await flow.execute({
+      sprintId: sprint.id,
+      sprint,
+      task,
+      tasks: [task],
+      cwd: abs('/tmp/demo-repo'),
+      expectedBranch: '',
+      checkScript: 'pnpm test',
+    });
+
+    // Chain still resolves OK — spawn error swallowed by outer wrap.
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const stepNames = result.value.trace.map((t) => t.stepName.replace(/#attempt-\d+$/, ''));
+    expect(stepNames).toContain('post-task-check');
+    // Outer noop fired; inner block fallback did NOT (no `check-failed` to catch).
+    expect(stepNames).toContain('post-task-check-noop');
+    expect(stepNames).not.toContain('mark-blocked-check');
+    expect(stepNames).toContain('mark-done');
+
+    // Task still flips to done — the spawn error didn't gate completion.
+    const reread = await deps.taskRepo.findById(sprint.id, task.id);
+    if (!reread.ok) throw new Error('expected task');
+    expect(reread.value.status).toBe('done');
+  });
+
   it('on user-initiated abort during execute-task: marks task blocked with reason "cancelled by user", short-circuits the rest of the chain', async () => {
     const sprint = makeSprint();
     const task = makeTask({ name: 'do thing', projectPath: '/tmp/demo-repo' });

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -285,10 +285,34 @@ export function createPerTaskFlow(
     fallback: noopLeaf<PerTaskCtx>('evaluate-task-noop'),
   });
 
-  // Conditionally include post-task-check only when a check script is
-  // configured. Tasks with no check script (e.g. polyglot subdirs) skip
-  // the gate cleanly.
-  const postTaskStep = postTaskCheckLeaf(postCheck);
+  // Post-task check is the per-task verification gate — REQUIREMENTS.md.
+  // Wrapped in TWO nested OnError decorators:
+  //
+  //   1. Inner (hard gate): catches `code: 'check-failed'` (the use case
+  //      surfaces this when the script exits non-zero) and runs the
+  //      block-fallback so the task is marked `blocked` instead of
+  //      proceeding to `mark-done`. Sets `taskBlocked: true` so every
+  //      downstream leaf (evaluate-task, commit-task, mark-done) no-ops.
+  //
+  //   2. Outer (soft safety net): catches any OTHER error except
+  //      `aborted` (user cancellation must propagate) and `check-failed`
+  //      (already handled by the inner wrap). Spawn-level breakage —
+  //      missing binary, EPERM, etc. — degrades to a noop so a flaky
+  //      environment doesn't strand the task.
+  //
+  // Nesting order matters: inner-hard, outer-soft. Reversing would let
+  // the outer wrap absorb `check-failed` and silently fall through to
+  // mark-done — exactly the regression this fix addresses.
+  const postTaskStep = new OnError<PerTaskCtx>(
+    new OnError<PerTaskCtx>(postTaskCheckLeaf(postCheck), {
+      catchIf: (err) => err.code === 'check-failed',
+      fallback: postTaskCheckBlockedFallbackLeaf(deps),
+    }),
+    {
+      catchIf: (err) => err.code !== 'aborted' && err.code !== 'check-failed',
+      fallback: noopLeaf<PerTaskCtx>('post-task-check-noop'),
+    }
+  );
 
   // The render-prompt-to-file leaf writes the FULL execute prompt (with
   // task body, harness context, signal vocabulary, project tooling) to
@@ -382,6 +406,38 @@ function markBlockedFallbackLeaf(deps: Pick<ChainSharedDeps, 'taskRepo' | 'signa
     // chain knows to short-circuit. Every downstream leaf checks the flag
     // and no-ops without doing any work — the chain trace still records
     // each step (kept honest) but no further side effects fire.
+    output: (ctx, task) => ({ ...ctx, task, taskBlocked: true }),
+  });
+}
+
+/**
+ * `post-task-check` `OnError` fallback. Reached when the inner check leaf
+ * returned `code: 'check-failed'` — i.e. the configured `checkScript`
+ * exited non-zero AFTER the AI session reported done. Transitions the
+ * task to `'blocked'` with a generic reason; the full failing output
+ * has already been logged at WARN level by `PostTaskCheckUseCase`
+ * (which the durable signal handler tees into `progress.md`), so no
+ * need to duplicate it on the entity. Sets `taskBlocked: true` so every
+ * downstream leaf (evaluate-task, commit-task, mark-done) no-ops.
+ *
+ * Distinct from `markBlockedFallbackLeaf` (branch preflight): different
+ * blocked reason and a separate trace step name (`mark-blocked-check`)
+ * so a sprint with both kinds of blocks is diagnosable from the trace
+ * alone.
+ */
+function postTaskCheckBlockedFallbackLeaf(deps: Pick<ChainSharedDeps, 'taskRepo' | 'signalBus'>): Element<PerTaskCtx> {
+  return new Leaf<PerTaskCtx, { readonly sprintId: SprintId; readonly task: Task }, Task>('mark-blocked-check', {
+    useCase: {
+      async execute(input) {
+        const transitioned = input.task.markBlocked('post-task check failed');
+        if (!transitioned.ok) return Result.error(transitioned.error);
+        const saved = await deps.taskRepo.update(input.sprintId, transitioned.value);
+        if (!saved.ok) return Result.error(saved.error);
+        deps.signalBus.emit({ type: 'task-finished', taskId: transitioned.value.id, status: 'blocked' });
+        return Result.ok(transitioned.value);
+      },
+    },
+    input: (ctx) => ({ sprintId: ctx.sprintId, task: ctx.task }),
     output: (ctx, task) => ({ ...ctx, task, taskBlocked: true }),
   });
 }

--- a/src/application/cli/commands/sprint-start.ts
+++ b/src/application/cli/commands/sprint-start.ts
@@ -59,7 +59,10 @@ export function attachSprintStart(group: Command, deps: SharedDeps): void {
     .option('--cwd <abs>', 'working directory for AI sessions', process.cwd())
     .option('--branch', 'auto-generate sprint branch name (`ralphctl/<sprint-id>`)')
     .option('--branch-name <name>', 'use a custom branch name')
-    .option('--check-script <cmd>', 'sprint-start check script')
+    .option(
+      '--check-script <cmd>',
+      'override the post-task check script for every task (otherwise auto-sourced from each repo)'
+    )
     .option('--no-commit', 'do not auto-commit each task after the evaluator round')
     .action(async (opts: SprintStartFlags) => {
       const code = await runSprintStart(deps, opts);

--- a/src/business/_test-fakes/fake-external-port.ts
+++ b/src/business/_test-fakes/fake-external-port.ts
@@ -25,6 +25,8 @@ export interface FakeExternalPortOptions {
   readonly currentBranch?: string;
   /** When set, `hasUncommittedChanges` returns this — otherwise `false`. */
   readonly uncommitted?: boolean;
+  /** Outcomes for `runSetupScript`, FIFO. Defaults to one passing run. */
+  readonly setupScriptOutcomes?: readonly CheckScriptResult[];
   /** Outcomes for `runCheckScript`, FIFO. Defaults to one passing run. */
   readonly checkScriptOutcomes?: readonly CheckScriptResult[];
   /** Outcomes for `stashChanges`, FIFO. Defaults to one ok. */
@@ -42,6 +44,12 @@ export interface FakeExternalPortOptions {
    * a deterministic SHA derived from the call index.
    */
   readonly commitChangesOutcomes?: readonly Result<string, StorageError>[];
+}
+
+export interface CapturedSetupScript {
+  readonly projectPath: AbsolutePath;
+  readonly script: string;
+  readonly timeout?: number;
 }
 
 export interface CapturedCheckScript {
@@ -67,6 +75,7 @@ export interface CapturedCommit {
 }
 
 export class FakeExternalPort implements ExternalPort {
+  readonly setupScriptCalls: CapturedSetupScript[] = [];
   readonly checkScriptCalls: CapturedCheckScript[] = [];
   readonly stashCalls: CapturedStash[] = [];
   readonly hardResetCalls: AbsolutePath[] = [];
@@ -78,6 +87,7 @@ export class FakeExternalPort implements ExternalPort {
   private readonly branchOk: boolean;
   private readonly currentBranch: string;
   private readonly uncommitted: boolean;
+  private readonly setupScriptOutcomes: CheckScriptResult[];
   private readonly checkScriptOutcomes: CheckScriptResult[];
   private readonly stashOutcomes: Result<void, StorageError>[];
   private readonly hardResetOutcomes: Result<void, StorageError>[];
@@ -90,6 +100,7 @@ export class FakeExternalPort implements ExternalPort {
     this.branchOk = opts?.branchOk ?? true;
     this.currentBranch = opts?.currentBranch ?? 'main';
     this.uncommitted = opts?.uncommitted ?? false;
+    this.setupScriptOutcomes = opts?.setupScriptOutcomes === undefined ? [] : [...opts.setupScriptOutcomes];
     this.checkScriptOutcomes = opts?.checkScriptOutcomes === undefined ? [] : [...opts.checkScriptOutcomes];
     this.stashOutcomes = opts?.stashOutcomes === undefined ? [] : [...opts.stashOutcomes];
     this.hardResetOutcomes = opts?.hardResetOutcomes === undefined ? [] : [...opts.hardResetOutcomes];
@@ -111,7 +122,17 @@ export class FakeExternalPort implements ExternalPort {
     return '';
   }
 
-  // --- Check script ---
+  // --- Setup / check script ---
+
+  runSetupScript(projectPath: AbsolutePath, script: string, timeout?: number): Promise<CheckScriptResult> {
+    this.setupScriptCalls.push({
+      projectPath,
+      script,
+      ...(timeout !== undefined ? { timeout } : {}),
+    });
+    const next = this.setupScriptOutcomes.shift();
+    return Promise.resolve(next ?? { passed: true, output: '' });
+  }
 
   runCheckScript(
     projectPath: AbsolutePath,

--- a/src/business/ports/external-port.ts
+++ b/src/business/ports/external-port.ts
@@ -33,7 +33,7 @@ export interface CheckScriptResult {
 }
 
 /** Phase tag describing which lifecycle hook the check script was invoked from. */
-export type CheckScriptPhase = 'sprint-start' | 'post-task' | 'feedback';
+export type CheckScriptPhase = 'post-task' | 'feedback';
 
 /** Inputs for {@link ExternalPort.createPullRequest}. */
 export interface CreatePullRequestInput {
@@ -70,7 +70,18 @@ export interface ExternalPort {
   /** Format issue data as context for AI prompts. */
   formatIssueContext(issue: ExternalIssue): string;
 
-  // --- Check script execution ---
+  // --- Setup / check script execution ---
+
+  /**
+   * Run a one-shot environment setup script (e.g. `pnpm install`) in a
+   * project directory once at sprint start. Distinct from
+   * {@link ExternalPort.runCheckScript} — setup prepares the environment;
+   * check verifies the working tree after a task. They share the same
+   * underlying shell-execution machinery but are emitted at different
+   * lifecycle hooks. `timeout` overrides the default
+   * `RALPHCTL_SETUP_TIMEOUT_MS`.
+   */
+  runSetupScript(projectPath: AbsolutePath, script: string, timeout?: number): Promise<CheckScriptResult>;
 
   /**
    * Run a check / lifecycle script in a project directory.

--- a/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
+++ b/src/business/usecases/evaluate/evaluate-and-fix-loop.ts
@@ -384,13 +384,20 @@ export class EvaluateAndFixLoopUseCase {
       }
 
       // ── Post-task check between rounds ──────────────────────────
+      // The check runner now surfaces a red script via
+      // `Result.error(CheckFailedError)` so the per-task chain's outer
+      // gate can block the task. Inside the fix-and-reevaluate loop we
+      // intentionally tolerate a red check — the next evaluator round
+      // will re-grade — so we treat `code: 'check-failed'` as a warning
+      // and keep iterating. Any other error (StorageError, etc.) is
+      // propagated.
       if (input.checkScript !== undefined && input.checkScript.length > 0) {
         const checkResult = await this.checkRunner.execute({
           projectPath: input.cwd,
           checkScript: input.checkScript,
         });
-        if (!checkResult.ok) return Result.error(checkResult.error);
-        if (!checkResult.value.passed) {
+        if (!checkResult.ok) {
+          if (checkResult.error.code !== 'check-failed') return Result.error(checkResult.error);
           log.warn('post-task check failed after fix attempt — re-evaluating anyway', { round });
         }
       }

--- a/src/business/usecases/execute/post-task-check.test.ts
+++ b/src/business/usecases/execute/post-task-check.test.ts
@@ -31,7 +31,7 @@ describe('PostTaskCheckUseCase', () => {
     expect(external.checkScriptCalls[0]?.phase).toBe('post-task');
   });
 
-  it('reports failed when the check script fails', async () => {
+  it('returns Result.error(CheckFailedError) when the check script fails', async () => {
     const external = new FakeExternalPort({
       checkScriptOutcomes: [{ passed: false, output: '3 tests failing' }],
     });
@@ -43,10 +43,14 @@ describe('PostTaskCheckUseCase', () => {
       checkScript: 'pnpm test',
     });
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.passed).toBe(false);
-    expect(result.value.output).toBe('3 tests failing');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('check-failed');
+    // The captured stdout/stderr round-trips on the error.
+    if (result.error.code === 'check-failed') {
+      expect(result.error.output).toBe('3 tests failing');
+    }
+    // The use case still warns through the logger so progress.md captures it.
     expect(logger.hasMessage('warn', 'post-task check failed')).toBe(true);
   });
 

--- a/src/business/usecases/execute/post-task-check.ts
+++ b/src/business/usecases/execute/post-task-check.ts
@@ -3,12 +3,22 @@
  * task settles. Returns a structured result the chain layer uses to decide
  * whether to mark the task done.
  *
+ * Hard-failure contract: when the script exits non-zero, the use case
+ * surfaces a {@link CheckFailedError} via `Result.error` so the chain's
+ * outer `OnError(catchIf: code === 'check-failed', fallback: markBlocked)`
+ * can transition the task to `'blocked'` instead of letting `mark-done`
+ * proceed. Spawn-level errors (missing binary, EPERM, …) propagate as
+ * whatever the `ExternalPort` adapter throws — usually `StorageError` —
+ * and are absorbed by the chain's outer (soft) `OnError` wrap so a flaky
+ * environment doesn't strand a whole task.
+ *
  * Skip optimisation: when the caller passes `changedFilesSinceBaseline` and
  * the list is empty, the gate short-circuits with `skipped: true`. A task
  * that left no artefacts cannot have broken anything, and shaving the check
  * (typically a multi-minute install + lint + test) on those tasks compounds
  * across long sprints.
  */
+import { CheckFailedError } from '@src/domain/errors/check-failed-error.ts';
 import type { DomainError } from '@src/domain/errors/domain-error.ts';
 import { Result } from '@src/domain/result.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
@@ -59,11 +69,12 @@ export class PostTaskCheckUseCase {
     );
 
     if (!result.passed) {
-      log.warn('post-task check failed');
+      log.warn('post-task check failed', { output: result.output });
+      return Result.error(new CheckFailedError({ output: result.output }));
     }
 
     return Result.ok({
-      passed: result.passed,
+      passed: true,
       output: result.output,
       skipped: false,
     });

--- a/src/business/usecases/sprint/close-sprint.ts
+++ b/src/business/usecases/sprint/close-sprint.ts
@@ -13,7 +13,7 @@ export interface CloseSprintInput {
 
 /**
  * `CloseSprintUseCase` — load an active sprint, close it via
- * {@link Sprint.close} (which clears `checkRanAt`), and persist.
+ * {@link Sprint.close} (which clears `setupRanAt`), and persist.
  */
 export class CloseSprintUseCase {
   constructor(private readonly sprints: SprintRepository) {}

--- a/src/domain/entities/sprint.test.ts
+++ b/src/domain/entities/sprint.test.ts
@@ -59,7 +59,7 @@ describe('Sprint.create', () => {
     expect(s.tickets).toStrictEqual([]);
     expect(s.activatedAt).toBeNull();
     expect(s.closedAt).toBeNull();
-    expect(s.checkRanAt.size).toBe(0);
+    expect(s.setupRanAt.size).toBe(0);
     expect(s.branch).toBeNull();
     expect(s.createdAt).toBe(T0);
     expect(s.id).toMatch(/^\d{8}-\d{6}-my-sprint$/);
@@ -136,18 +136,18 @@ describe('Sprint.activate', () => {
 });
 
 describe('Sprint.close', () => {
-  it('moves active → closed, stamps closedAt, and clears checkRanAt', () => {
+  it('moves active → closed, stamps closedAt, and clears setupRanAt', () => {
     const a = draft().activate(T1);
     if (!a.ok) throw new Error('precondition failed');
-    const stamped = a.value.recordCheckRun(path('/abs/repo'), T1);
-    expect(stamped.checkRanAt.size).toBe(1);
+    const stamped = a.value.recordSetupRun(path('/abs/repo'), T1);
+    expect(stamped.setupRanAt.size).toBe(1);
 
     const c = stamped.close(T2);
     expect(c.ok).toBe(true);
     if (!c.ok) return;
     expect(c.value.status).toBe('closed');
     expect(c.value.closedAt).toBe(T2);
-    expect(c.value.checkRanAt.size).toBe(0);
+    expect(c.value.setupRanAt.size).toBe(0);
   });
 
   it('refuses to close a draft', () => {
@@ -340,23 +340,23 @@ describe('Sprint.clearBranch', () => {
   });
 });
 
-describe('Sprint.recordCheckRun', () => {
+describe('Sprint.recordSetupRun', () => {
   it('stamps a repo with the timestamp', () => {
-    const s = draft().recordCheckRun(path('/abs/r'), T1);
-    expect(s.checkRanAt.get(path('/abs/r'))).toBe(T1);
+    const s = draft().recordSetupRun(path('/abs/r'), T1);
+    expect(s.setupRanAt.get(path('/abs/r'))).toBe(T1);
   });
 
   it('overwrites a prior entry for the same repo', () => {
-    const s1 = draft().recordCheckRun(path('/abs/r'), T1);
-    const s2 = s1.recordCheckRun(path('/abs/r'), T2);
-    expect(s2.checkRanAt.size).toBe(1);
-    expect(s2.checkRanAt.get(path('/abs/r'))).toBe(T2);
+    const s1 = draft().recordSetupRun(path('/abs/r'), T1);
+    const s2 = s1.recordSetupRun(path('/abs/r'), T2);
+    expect(s2.setupRanAt.size).toBe(1);
+    expect(s2.setupRanAt.get(path('/abs/r'))).toBe(T2);
   });
 
   it('does not mutate the original map', () => {
-    const s1 = draft().recordCheckRun(path('/abs/r'), T1);
-    s1.recordCheckRun(path('/abs/r'), T2);
-    expect(s1.checkRanAt.get(path('/abs/r'))).toBe(T1);
+    const s1 = draft().recordSetupRun(path('/abs/r'), T1);
+    s1.recordSetupRun(path('/abs/r'), T2);
+    expect(s1.setupRanAt.get(path('/abs/r'))).toBe(T1);
   });
 });
 

--- a/src/domain/entities/sprint.ts
+++ b/src/domain/entities/sprint.ts
@@ -38,7 +38,7 @@ export interface SprintCreateInput {
 /**
  * `Sprint` — aggregate root containing the tickets users add during the
  * `draft` phase. Once `activated`, ticket edits are locked. Once `closed`,
- * everything is locked and `checkRanAt` is cleared.
+ * everything is locked and `setupRanAt` is cleared.
  *
  * Mutators return new instances; the class is structurally immutable.
  * Lifecycle invariants live here, not at the use-case layer — the entity
@@ -52,7 +52,12 @@ export class Sprint {
   readonly activatedAt: IsoTimestamp | null;
   readonly closedAt: IsoTimestamp | null;
   readonly tickets: readonly Ticket[];
-  readonly checkRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
+  /**
+   * Audit trail of sprint-start setup-script runs, keyed by repo path.
+   * Filled in by the `setup-scripts-sprint-start` chain leaf. Cleared on
+   * sprint close so a re-opened sprint starts a fresh setup record.
+   */
+  readonly setupRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
   readonly branch: string | null;
   /**
    * Pull / merge request URL recorded after `sprint create-pr` runs.
@@ -81,7 +86,7 @@ export class Sprint {
     activatedAt: IsoTimestamp | null;
     closedAt: IsoTimestamp | null;
     tickets: readonly Ticket[];
-    checkRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
+    setupRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
     branch: string | null;
     pullRequestUrl: string | null;
     projectName: ProjectName;
@@ -94,7 +99,7 @@ export class Sprint {
     this.activatedAt = props.activatedAt;
     this.closedAt = props.closedAt;
     this.tickets = props.tickets;
-    this.checkRanAt = props.checkRanAt;
+    this.setupRanAt = props.setupRanAt;
     this.branch = props.branch;
     this.pullRequestUrl = props.pullRequestUrl;
     this.projectName = props.projectName;
@@ -122,7 +127,7 @@ export class Sprint {
         activatedAt: null,
         closedAt: null,
         tickets: [],
-        checkRanAt: new Map(),
+        setupRanAt: new Map(),
         branch: null,
         pullRequestUrl: null,
         projectName: input.projectName,
@@ -162,7 +167,7 @@ export class Sprint {
       this.with({
         status: 'closed',
         closedAt: now,
-        checkRanAt: new Map<AbsolutePath, IsoTimestamp>(),
+        setupRanAt: new Map<AbsolutePath, IsoTimestamp>(),
       })
     );
   }
@@ -202,7 +207,7 @@ export class Sprint {
         activatedAt: this.activatedAt,
         closedAt: this.closedAt,
         tickets: this.tickets,
-        checkRanAt: this.checkRanAt,
+        setupRanAt: this.setupRanAt,
         branch: this.branch,
         pullRequestUrl: this.pullRequestUrl,
         projectName: this.projectName,
@@ -306,13 +311,13 @@ export class Sprint {
   }
 
   /**
-   * Stamp a check-script run for one repo. Never fails — the harness owns
+   * Stamp a setup-script run for one repo. Never fails — the harness owns
    * this audit trail and the entity should not gate it.
    */
-  recordCheckRun(repo: AbsolutePath, at: IsoTimestamp): Sprint {
-    const next = new Map(this.checkRanAt);
+  recordSetupRun(repo: AbsolutePath, at: IsoTimestamp): Sprint {
+    const next = new Map(this.setupRanAt);
     next.set(repo, at);
-    return this.with({ checkRanAt: next });
+    return this.with({ setupRanAt: next });
   }
 
   /**
@@ -402,7 +407,7 @@ export class Sprint {
       activatedAt: IsoTimestamp | null;
       closedAt: IsoTimestamp | null;
       tickets: readonly Ticket[];
-      checkRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
+      setupRanAt: ReadonlyMap<AbsolutePath, IsoTimestamp>;
       branch: string | null;
       pullRequestUrl: string | null;
       affectedRepositories: readonly AbsolutePath[];
@@ -416,7 +421,7 @@ export class Sprint {
       activatedAt: 'activatedAt' in partial ? (partial.activatedAt ?? null) : this.activatedAt,
       closedAt: 'closedAt' in partial ? (partial.closedAt ?? null) : this.closedAt,
       tickets: partial.tickets ?? this.tickets,
-      checkRanAt: partial.checkRanAt ?? this.checkRanAt,
+      setupRanAt: partial.setupRanAt ?? this.setupRanAt,
       branch: 'branch' in partial ? (partial.branch ?? null) : this.branch,
       pullRequestUrl: 'pullRequestUrl' in partial ? (partial.pullRequestUrl ?? null) : this.pullRequestUrl,
       projectName: this.projectName,

--- a/src/domain/errors/check-failed-error.test.ts
+++ b/src/domain/errors/check-failed-error.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { CheckFailedError } from './check-failed-error.ts';
+
+describe('CheckFailedError', () => {
+  it('has the kebab-case discriminator code', () => {
+    const err = new CheckFailedError({ output: '3 tests failing' });
+    expect(err.code).toBe('check-failed');
+  });
+
+  it('builds a default message when none is provided', () => {
+    const err = new CheckFailedError({ output: '' });
+    expect(err.message).toBe('post-task check script failed');
+  });
+
+  it('honours an explicit message override', () => {
+    const err = new CheckFailedError({ output: 'oops', message: 'lint failed' });
+    expect(err.message).toBe('lint failed');
+  });
+
+  it('preserves the captured output', () => {
+    const err = new CheckFailedError({ output: 'FAIL src/foo.test.ts' });
+    expect(err.output).toBe('FAIL src/foo.test.ts');
+    expect(err.name).toBe('CheckFailedError');
+  });
+
+  it('is an instance of Error and structurally a KernelError', () => {
+    const err = new CheckFailedError({ output: 'x' });
+    expect(err).toBeInstanceOf(Error);
+    expect(typeof err.code).toBe('string');
+    expect(typeof err.message).toBe('string');
+  });
+
+  it('attaches an optional cause', () => {
+    const root = new Error('exit 1');
+    const err = new CheckFailedError({ output: '', cause: root });
+    expect((err as { cause?: unknown }).cause).toBe(root);
+  });
+});

--- a/src/domain/errors/check-failed-error.ts
+++ b/src/domain/errors/check-failed-error.ts
@@ -1,0 +1,45 @@
+/**
+ * `CheckFailedError` — raised by the post-task check gate when a configured
+ * `checkScript` exits non-zero. The error is the explicit signal that the
+ * AI's work failed verification — distinct from spawn-level breakage
+ * (missing binary, EPERM, …) which surfaces as a `StorageError` and is
+ * absorbed by an outer `OnError` so a flaky environment doesn't strand a
+ * task.
+ *
+ * The discriminator `code: 'check-failed'` lets the per-task chain's
+ * `OnError.catchIf` discriminate hard-gate failures from any other kernel
+ * error without scanning message strings.
+ *
+ * Sibling note: `InvalidStateError({ currentState: 'check-failed' })` at
+ * `execute-flow.ts` is the SPRINT-START hard-abort path — distinct from
+ * this per-task signal. Keeping them on different classes preserves the
+ * "abort vs. block one task" semantics at the type level.
+ *
+ * Structurally compatible with the kernel's `KernelError` shape
+ * (`{ code, message, cause? }`) so chain elements can propagate it without
+ * translation.
+ */
+export interface CheckFailedErrorOptions {
+  /** Captured stdout/stderr from the failing check script. */
+  readonly output: string;
+  /** Optional override for the default message. */
+  readonly message?: string;
+  /** Optional underlying cause (e.g. the script's exit metadata). */
+  readonly cause?: unknown;
+}
+
+export class CheckFailedError extends Error {
+  /** Discriminator. `as const` keeps it narrow at the type level. */
+  readonly code = 'check-failed' as const;
+  /** Captured output of the failing script — surfaced to logs / progress. */
+  readonly output: string;
+
+  constructor(opts: CheckFailedErrorOptions) {
+    super(opts.message ?? 'post-task check script failed');
+    this.name = 'CheckFailedError';
+    this.output = opts.output;
+    if (opts.cause !== undefined) {
+      (this as { cause?: unknown }).cause = opts.cause;
+    }
+  }
+}

--- a/src/domain/errors/domain-error.ts
+++ b/src/domain/errors/domain-error.ts
@@ -17,6 +17,7 @@
  * shape (`{ code, message, cause? }`) — the kernel layer can propagate
  * any `DomainError` without translation.
  */
+import type { CheckFailedError } from './check-failed-error.ts';
 import type { ConflictError } from './conflict-error.ts';
 import type { InvalidStateError } from './invalid-state-error.ts';
 import type { NotFoundError } from './not-found-error.ts';
@@ -32,4 +33,5 @@ export type DomainError =
   | NotFoundError
   | ParseError
   | RateLimitError
-  | StorageError;
+  | StorageError
+  | CheckFailedError;

--- a/src/integration/ai/prompts/prompt-builder-adapter.test.ts
+++ b/src/integration/ai/prompts/prompt-builder-adapter.test.ts
@@ -391,6 +391,29 @@ describe('TextPromptBuilderAdapter — execute', () => {
     expect(r.value).toContain('No check script configured for this repo.');
     expect(r.value).not.toContain('See the project documentation');
   });
+
+  it('renders "Pre-task environment check passed at <ISO>" when sprint.checkRanAt has an entry for task.projectPath', async () => {
+    // Regression guard: the sprint-start green baseline leaf stamps
+    // `Sprint.checkRanAt[repoPath] = now` for each repo whose
+    // checkScript passed. The execute prompt must surface that
+    // timestamp via {{ENVIRONMENT_STATUS}} so the agent knows the
+    // baseline was verified — not the old "Not run." string.
+    const loader = new StubTemplateLoader({
+      'task-execution': 'ENV:{{ENVIRONMENT_STATUS}}:END',
+      'harness-context': 'H',
+      'signals-task': 'S',
+    });
+    const adapter = new TextPromptBuilderAdapter(loader);
+    const task = makeTask();
+    // Stamp checkRanAt for the same path the task points at.
+    const stamped = makeSprint().recordCheckRun(task.projectPath, '2026-05-05T10:00:00Z' as IsoTimestamp);
+    const r = await adapter.buildExecutePrompt({ task, sprint: stamped });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toContain('Pre-task environment check passed at');
+    expect(r.value).toContain('2026-05-05T10:00:00Z');
+    expect(r.value).not.toContain('Not run.');
+  });
 });
 
 describe('TextPromptBuilderAdapter — evaluate', () => {

--- a/src/integration/ai/prompts/prompt-builder-adapter.test.ts
+++ b/src/integration/ai/prompts/prompt-builder-adapter.test.ts
@@ -392,12 +392,14 @@ describe('TextPromptBuilderAdapter — execute', () => {
     expect(r.value).not.toContain('See the project documentation');
   });
 
-  it('renders "Pre-task environment check passed at <ISO>" when sprint.checkRanAt has an entry for task.projectPath', async () => {
-    // Regression guard: the sprint-start green baseline leaf stamps
-    // `Sprint.checkRanAt[repoPath] = now` for each repo whose
-    // checkScript passed. The execute prompt must surface that
+  it('renders "Setup script ran at <ISO>" when sprint.setupRanAt has an entry for task.projectPath', async () => {
+    // Regression guard: the sprint-start setup leaf stamps
+    // `Sprint.setupRanAt[repoPath] = now` for each repo whose
+    // setupScript passed. The execute prompt must surface that
     // timestamp via {{ENVIRONMENT_STATUS}} so the agent knows the
-    // baseline was verified — not the old "Not run." string.
+    // env was prepared — not the old "Not run." string. The wording
+    // matters: "setup ran" ≠ "tests pass" — the per-task `checkScript`
+    // is the gate, not this stamp.
     const loader = new StubTemplateLoader({
       'task-execution': 'ENV:{{ENVIRONMENT_STATUS}}:END',
       'harness-context': 'H',
@@ -405,12 +407,12 @@ describe('TextPromptBuilderAdapter — execute', () => {
     });
     const adapter = new TextPromptBuilderAdapter(loader);
     const task = makeTask();
-    // Stamp checkRanAt for the same path the task points at.
-    const stamped = makeSprint().recordCheckRun(task.projectPath, '2026-05-05T10:00:00Z' as IsoTimestamp);
+    // Stamp setupRanAt for the same path the task points at.
+    const stamped = makeSprint().recordSetupRun(task.projectPath, '2026-05-05T10:00:00Z' as IsoTimestamp);
     const r = await adapter.buildExecutePrompt({ task, sprint: stamped });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.value).toContain('Pre-task environment check passed at');
+    expect(r.value).toContain('Setup script ran at');
     expect(r.value).toContain('2026-05-05T10:00:00Z');
     expect(r.value).not.toContain('Not run.');
   });

--- a/src/integration/ai/prompts/prompt-builder-adapter.ts
+++ b/src/integration/ai/prompts/prompt-builder-adapter.ts
@@ -215,11 +215,9 @@ export class TextPromptBuilderAdapter implements PromptBuilderPort {
     // "no check script configured" — never the old "see docs" boilerplate.
     const checkScriptSection = renderCheckScriptSection(input.checkScript);
 
-    const checkRanAtForRepo = input.sprint.checkRanAt.get(input.task.projectPath);
+    const setupRanAtForRepo = input.sprint.setupRanAt.get(input.task.projectPath);
     const environmentStatus =
-      checkRanAtForRepo !== undefined
-        ? `Pre-task environment check passed at ${String(checkRanAtForRepo)}.`
-        : 'Not run.';
+      setupRanAtForRepo !== undefined ? `Setup script ran at ${String(setupRanAtForRepo)}.` : 'Not run.';
 
     const rendered = substitute(tpl.value, {
       TASK_NAME: input.task.name,

--- a/src/integration/ai/prompts/prompt-completeness.smoke.test.ts
+++ b/src/integration/ai/prompts/prompt-completeness.smoke.test.ts
@@ -320,20 +320,21 @@ describe('prompt completeness — no unresolved {{PLACEHOLDER}} in rendered outp
     expect(r.value).toContain('ralphctl/sprint-a');
   });
 
-  it('execute — with checkRanAt populated (renders non-generic ENVIRONMENT_STATUS)', async () => {
-    // When the harness has already run the check script for a repo, it
-    // stamps `checkRanAt` on the sprint; the execute prompt renders the
+  it('execute — with setupRanAt populated (renders non-generic ENVIRONMENT_STATUS)', async () => {
+    // When the harness has already run the setup script for a repo, it
+    // stamps `setupRanAt` on the sprint; the execute prompt renders the
     // timestamp instead of the generic "Not run." fallback.
     const base = makeSprint();
-    const withCheck = base.recordCheckRun(path('/tmp/repo'), T0);
+    const withSetup = base.recordSetupRun(path('/tmp/repo'), T0);
     const r = await adapter.buildExecutePrompt({
       task: makeTask(),
-      sprint: withCheck,
+      sprint: withSetup,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    assertNoUnresolvedPlaceholders(r.value, 'buildExecutePrompt(with-checkRanAt)');
+    assertNoUnresolvedPlaceholders(r.value, 'buildExecutePrompt(with-setupRanAt)');
     expect(r.value).toContain('2026-04-29T12:00:00Z');
+    expect(r.value).toContain('Setup script ran at');
     expect(r.value).not.toContain('Not run.');
   });
 

--- a/src/integration/external/check-script-runner.test.ts
+++ b/src/integration/external/check-script-runner.test.ts
@@ -16,7 +16,7 @@ describe('CheckScriptRunner', () => {
   it('returns passed=true when the script exits zero', async () => {
     const cwd = await tmpAbs();
     const runner = new CheckScriptRunner();
-    const r = await runner.run(cwd, 'echo hello', 'sprint-start');
+    const r = await runner.run(cwd, 'echo hello', 'setup');
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.value.passed).toBe(true);
@@ -55,7 +55,7 @@ describe('CheckScriptRunner', () => {
     const cwd = await tmpAbs();
     const runner = new CheckScriptRunner();
     // 50ms timeout, script sleeps 5s — should be killed.
-    const r = await runner.run(cwd, 'sleep 5', 'sprint-start', 50);
+    const r = await runner.run(cwd, 'sleep 5', 'setup', 50);
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.value.passed).toBe(false);
@@ -69,7 +69,7 @@ describe('CheckScriptRunner', () => {
     // Non-existent command — shell exits 127. Not a system error —
     // a missing tool is a config issue the harness should surface as a
     // failed gate, not a crash.
-    const r = await runner.run(cwd, 'definitely-not-a-real-binary-xyz', 'sprint-start');
+    const r = await runner.run(cwd, 'definitely-not-a-real-binary-xyz', 'setup');
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.value.passed).toBe(false);
   });
@@ -83,7 +83,7 @@ describe('CheckScriptRunner', () => {
     const runner = new CheckScriptRunner();
     // Emit 2 MB via node (fs.writeSync is synchronous so bytes flush before exit).
     const script = 'node -e "const fs=require(\\"fs\\"); fs.writeSync(1, \\"x\\".repeat(2*1024*1024))"';
-    const r = await runner.run(cwd, script, 'sprint-start');
+    const r = await runner.run(cwd, script, 'setup');
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.value.passed).toBe(true);
@@ -97,7 +97,7 @@ describe('CheckScriptRunner', () => {
     if (process.platform === 'win32') return; // skip on Windows
     const cwd = await tmpAbs();
     const runner = new CheckScriptRunner();
-    const r = await runner.run(cwd, 'sleep 5', 'sprint-start', 100);
+    const r = await runner.run(cwd, 'sleep 5', 'setup', 100);
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.value.passed).toBe(false);

--- a/src/integration/external/check-script-runner.ts
+++ b/src/integration/external/check-script-runner.ts
@@ -34,7 +34,14 @@ import { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 
-export type CheckScriptPhase = 'sprint-start' | 'post-task' | 'feedback';
+/**
+ * Phase tag for the underlying shell run. Mirrors the lifecycle hooks in
+ * {@link ExternalPort} plus the dedicated `'setup'` phase used by
+ * `runSetupScript` (sprint-start environment prep). Surfaces to user
+ * scripts via the `RALPHCTL_LIFECYCLE_EVENT` env var so a single shell
+ * command can branch on what phase invoked it.
+ */
+export type CheckScriptPhase = 'setup' | 'post-task' | 'feedback';
 
 export interface CheckScriptResult {
   readonly passed: boolean;

--- a/src/integration/external/external-adapter.test.ts
+++ b/src/integration/external/external-adapter.test.ts
@@ -59,9 +59,23 @@ describe('DefaultExternalAdapter (composition smoke)', () => {
 
   it('runCheckScript surfaces a real script result (echo passes)', async () => {
     const a = buildAdapter(new FakeGitRunner());
-    const r = await a.runCheckScript(AbsolutePath.trustString(process.cwd()), 'echo ok', 'sprint-start');
+    const r = await a.runCheckScript(AbsolutePath.trustString(process.cwd()), 'echo ok', 'post-task');
     expect(r.passed).toBe(true);
     expect(r.output).toContain('ok');
+  });
+
+  it('runSetupScript surfaces a real script result (echo passes)', async () => {
+    const a = buildAdapter(new FakeGitRunner());
+    const r = await a.runSetupScript(AbsolutePath.trustString(process.cwd()), 'echo prepared');
+    expect(r.passed).toBe(true);
+    expect(r.output).toContain('prepared');
+  });
+
+  it('runSetupScript exposes the lifecycle phase to the script via RALPHCTL_LIFECYCLE_EVENT', async () => {
+    const a = buildAdapter(new FakeGitRunner());
+    const r = await a.runSetupScript(AbsolutePath.trustString(process.cwd()), 'echo "$RALPHCTL_LIFECYCLE_EVENT"');
+    expect(r.passed).toBe(true);
+    expect(r.output).toContain('setup');
   });
 
   it('createPullRequest delegates to PullRequestRunner using the resolved remote', async () => {

--- a/src/integration/external/external-adapter.ts
+++ b/src/integration/external/external-adapter.ts
@@ -46,7 +46,19 @@ export class DefaultExternalAdapter implements ExternalPort {
     return this.issues.format(issue);
   }
 
-  // --- Check script execution -----------------------------------------
+  // --- Setup / check script execution ---------------------------------
+
+  async runSetupScript(projectPath: AbsolutePath, script: string, timeout?: number): Promise<CheckScriptResult> {
+    // Setup scripts run once per affected repo at sprint start. We
+    // delegate to the same runner as `runCheckScript` — the underlying
+    // mechanism (shell command, capture, return passed/output) is
+    // identical — but tag the lifecycle event as `'setup'` so user
+    // scripts branching on `RALPHCTL_LIFECYCLE_EVENT` can tell setup
+    // from a per-task check.
+    const r = await this.checkScripts.run(projectPath, script, 'setup', timeout);
+    if (r.ok) return r.value;
+    return { passed: false, output: `[setup-script error: ${r.error.message}]` };
+  }
 
   async runCheckScript(
     projectPath: AbsolutePath,

--- a/src/integration/persistence/schemas/sprint-schema.test.ts
+++ b/src/integration/persistence/schemas/sprint-schema.test.ts
@@ -44,7 +44,7 @@ describe('sprint-schema', () => {
     expect(back.value.status).toBe('draft');
     expect(back.value.tickets).toHaveLength(0);
     expect(back.value.branch).toBeNull();
-    expect(back.value.checkRanAt.size).toBe(0);
+    expect(back.value.setupRanAt.size).toBe(0);
     expect(String(back.value.projectName)).toBe('demo-project');
     expect(back.value.affectedRepositories).toStrictEqual([]);
   });
@@ -89,9 +89,9 @@ describe('sprint-schema', () => {
     expect(back.value.closedAt).toBe('2026-04-29T02:00:00.000Z');
   });
 
-  it('preserves checkRanAt entries', () => {
+  it('preserves setupRanAt entries', () => {
     const draft = makeDraftSprint();
-    const stamped = draft.recordCheckRun(
+    const stamped = draft.recordSetupRun(
       AbsolutePath.trustString('/repo/a'),
       IsoTimestamp.trustString('2026-04-29T03:00:00.000Z')
     );
@@ -99,8 +99,8 @@ describe('sprint-schema', () => {
     const back = toSprint(sprintJsonSchema.parse(json));
     expect(back.ok).toBe(true);
     if (!back.ok) return;
-    expect(back.value.checkRanAt.size).toBe(1);
-    expect(back.value.checkRanAt.get(AbsolutePath.trustString('/repo/a'))).toBe('2026-04-29T03:00:00.000Z');
+    expect(back.value.setupRanAt.size).toBe(1);
+    expect(back.value.setupRanAt.get(AbsolutePath.trustString('/repo/a'))).toBe('2026-04-29T03:00:00.000Z');
   });
 
   it('preserves branch when set', () => {
@@ -148,7 +148,7 @@ describe('sprint-schema', () => {
       closedAt: null,
       branch: null,
       pullRequestUrl: null,
-      checkRanAt: {},
+      setupRanAt: {},
       tickets: [
         {
           id: 'aaaaaaaa',

--- a/src/integration/persistence/schemas/sprint-schema.ts
+++ b/src/integration/persistence/schemas/sprint-schema.ts
@@ -45,7 +45,7 @@ export const sprintJsonSchema = z.object({
   // to `[]` on a fresh draft sprint, populated post-plan).
   affectedRepositories: z.array(z.string()),
   // `Map<AbsolutePath, IsoTimestamp>` — serialised as a plain object map.
-  checkRanAt: z.record(z.string(), z.string()),
+  setupRanAt: z.record(z.string(), z.string()),
   tickets: z.array(ticketJsonSchema),
 });
 
@@ -77,9 +77,9 @@ export function toSprint(parsed: SprintJson): Result<Sprint, StorageError> {
     tickets.push(r.value);
   }
 
-  const checkRanAt = new Map<AbsolutePath, IsoTimestamp>();
-  for (const [k, v] of Object.entries(parsed.checkRanAt)) {
-    checkRanAt.set(AbsolutePath.trustString(k), IsoTimestamp.trustString(v));
+  const setupRanAt = new Map<AbsolutePath, IsoTimestamp>();
+  for (const [k, v] of Object.entries(parsed.setupRanAt)) {
+    setupRanAt.set(AbsolutePath.trustString(k), IsoTimestamp.trustString(v));
   }
 
   const created = Sprint.create({
@@ -119,11 +119,11 @@ export function toSprint(parsed: SprintJson): Result<Sprint, StorageError> {
     if (r.ok) s = r.value;
   }
 
-  // Apply check stamps after lifecycle so a closed sprint still preserves
+  // Apply setup stamps after lifecycle so a closed sprint still preserves
   // any persisted entries (defensive — closed sprints normally have empty
-  // checkRanAt because `close()` clears them).
-  for (const [path, at] of checkRanAt) {
-    s = s.recordCheckRun(path, at);
+  // setupRanAt because `close()` clears them).
+  for (const [path, at] of setupRanAt) {
+    s = s.recordSetupRun(path, at);
   }
 
   if (parsed.branch !== null) {
@@ -147,9 +147,9 @@ export function toSprint(parsed: SprintJson): Result<Sprint, StorageError> {
 
 /** Reverse direction — Sprint entity → JSON-shaped object. */
 export function fromSprint(sprint: Sprint): SprintJson {
-  const checkRanAt: Record<string, string> = {};
-  for (const [k, v] of sprint.checkRanAt) {
-    checkRanAt[k] = v;
+  const setupRanAt: Record<string, string> = {};
+  for (const [k, v] of sprint.setupRanAt) {
+    setupRanAt[k] = v;
   }
   return {
     id: sprint.id,
@@ -162,7 +162,7 @@ export function fromSprint(sprint: Sprint): SprintJson {
     pullRequestUrl: sprint.pullRequestUrl,
     projectName: sprint.projectName,
     affectedRepositories: [...sprint.affectedRepositories],
-    checkRanAt,
+    setupRanAt,
     tickets: sprint.tickets.map(fromTicket),
   };
 }


### PR DESCRIPTION
## Summary

- **Setup ≠ check.** Sprint start now runs each repo's configured `setupScript` (the deterministic baseline so Claude departs reliably) via the renamed `setup-scripts-sprint-start` chain leaf — iterates `sprint.affectedRepositories`, stamps `Sprint.setupRanAt[repoPath]`, hard-aborts on the first red exit naming the failing repo. The per-task `{{ENVIRONMENT_STATUS}}` slot now renders "Setup script ran at <ISO>".
- **Per-task `checkScript` is auto-sourced from each repo's config.** A new `resolve-check-scripts` chain leaf (runs in the initialize phase before setup) walks the sprint's project once and populates `ctx.checkScripts`. The per-task bridge seeds the gate per-task without `--check-script`. The CLI flag stays as a global override (help text updated).
- **Post-task gate is a hard fence.** `PostTaskCheckUseCase` returns `Result.error(CheckFailedError)` on red; `OnError(catchIf: code === 'check-failed')` transitions the task to `blocked` instead of letting `mark-done` proceed. Spawn-level errors (missing binary, EPERM) degrade to a noop via a soft outer `OnError` so a flaky env never strands a sprint or task.
- **Doc/changelog/comment sync.** REQUIREMENTS, ARCHITECTURE, CLAUDE.md, CHANGELOG, top-of-file docstring, and CLI flag help text all updated to match.

## Pipeline (post-merge)

```
sprint start
  resolve-branch
  dirty-tree-preflight
  resolve-check-scripts        ← NEW (pure read; populates ctx.checkScripts)
  setup-scripts-sprint-start   ← deterministic baseline (red exit aborts)
loop per task:
  branch-preflight
  execute-task
  post-task-check              ← auto-fires from repo.checkScript;
                                  red → mark blocked → downstream no-ops
  evaluate-task                ← skipped if blocked
  mark-done
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 233 files, 2257 tests pass (incl. 2 new auto-source / override-wins tests)
- [x] Step-trace fences updated for the new outer trace
- [ ] Manual smoke: `ralphctl sprint start <id>` on a repo with `setupScript` + `checkScript` configured — confirm setup runs once, check runs after every task
- [ ] Manual smoke: red `setupScript` aborts the chain naming the failing repo
- [ ] Manual smoke: red `checkScript` after a task transitions the task to `blocked` (not `done`); subsequent tasks still execute
- [ ] Manual smoke: `--check-script <cmd>` global override fires for every task instead of the per-repo config