### PR TITLE
refactor(execute): execution-unit cleanup + release-readiness fixes

### DIFF
--- a/.claude/agent-memory/tester/MEMORY.md
+++ b/.claude/agent-memory/tester/MEMORY.md
@@ -229,7 +229,7 @@ Four leaves directly unit-tested in `src/application/chains/leaves/`:
 - Asserts `/\{\{[A-Z_]+\}\}/g` matches nothing after substitution.
 - **8 new tests added** covering optional-field branches not previously exercised:
   - `buildRefinePrompt` — pre-fetched `issueContext` text (wraps in `<context>` block)
-  - `buildExecutePrompt` — with `checkScript` (fenced shell block rendered); sprint with `branch` set (BRANCH_LINE populated); sprint with `checkRanAt` stamped (ENVIRONMENT_STATUS shows timestamp not "Not run.")
+  - `buildExecutePrompt` — with `checkScript` (fenced shell block rendered); sprint with `branch` set (BRANCH_LINE populated); sprint with `setupRanAt` stamped (ENVIRONMENT_STATUS shows timestamp not "Not run.")
   - `buildEvaluatePrompt` — with `evaluateWorkspaceDir` (Contract files section rendered)
   - `buildFeedbackPrompt` — sprint without a branch (BRANCH_SECTION collapses to empty string)
   - `buildPlanPrompt` — sprint with `affectedRepositories` set (repos in CONTEXT block)

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -339,8 +339,10 @@ and the mutators that are not obvious from the field names.
 - **`Repository`** (`repository.ts`) — identified by `AbsolutePath`; carries `setupScript`, `checkScript`,
   `checkTimeout`, `onboardedAt`. Mutators: `markOnboarded(now)`, `clearOnboarded()`, `withSetupScript(script)`.
   `setupScript` runs **once** at sprint start (`setup-scripts-sprint-start` chain leaf, via
-  `ExternalPort.runSetupScript`) and a non-zero exit hard-aborts before any task runs. `checkScript` is the
-  per-task verification gate run after every AI task and inside the feedback loop — auto-sourced by the
+  `ExternalPort.runSetupScript`) and any failure (non-zero exit OR spawn-level error) hard-aborts the chain
+  naming the failing repo before any task runs. The leaf skips repos already stamped on `Sprint.setupRanAt`
+  so resumes don't re-run setup. `checkScript` is the per-task verification gate run after every AI task
+  and inside the feedback loop — auto-sourced by the
   `resolve-check-scripts` chain leaf, which walks the sprint's project at sprint start and stuffs each
   affected repo's configured script into `ctx.checkScripts` so the per-task bridge can fire the gate
   without the user passing `--check-script`. The CLI flag overrides the auto-source globally when set.

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -297,7 +297,7 @@ throw domain errors for bottom-of-the-stack failures — the use-case layer wrap
 │   │       ├── evaluation.md          ← evaluator critique (overwritten per round)
 │   │       ├── done-criteria.md       ← copy of sprint-level done-criteria.md; evaluator per-task reference
 │   │       └── (CLAUDE.md, .claude/skills/, repo/ for Copilot,
-│   │           requirements/, dimensions.md, tasks.md, tasks.json, project-context.md, evaluations/)
+│   │           requirements/, dimensions.md, tasks.md, project-context.md)
 │   └── insights/<sprint-id>.md
 ├── cache/                           ← transient, safe to delete
 │   └── prompts-compiled/            ← optional (skills are now copied per-session, not cached)

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -321,8 +321,9 @@ is otherwise swallowed so audit emission never fails a spawn. Path construction 
 plan / ideate stamp a single `<unit-root>/session.md` (overwritten on re-run); the per-task chain routes each
 generator and evaluator spawn into `rounds/<N>/{generator,evaluator}/session.md` via the `generatorRoundDir` /
 `evaluatorRoundDir` helpers (`src/integration/persistence/execution-unit-builder.ts`) so every execute attempt and
-each evaluator round get distinct files; standalone `sprint evaluate` writes
-`<sprintDir>/evaluations/session-<task-id>.md`; feedback writes `<sprintDir>/feedback/session-<iteration>.md`.
+each evaluator round get distinct files; standalone `sprint evaluate` writes into
+`<sprintDir>/execution/<unit-slug>/rounds/standalone-<ISO>/evaluator/` (one folder per invocation, ISO-stamped so
+prior verdicts are preserved as durable history); feedback writes `<sprintDir>/feedback/session-<iteration>.md`.
 
 `sprint requirements [--output <path>]` and `sprint context [--output <path>]` are markdown **exports**, not state.
 They default to the caller's `cwd` (`./<sprintId>-requirements.md` / `./<sprintId>-context.md`) and accept any
@@ -366,19 +367,19 @@ Fixed discriminated union in `src/domain/signals/harness-signal.ts`. Adding a va
 every `switch` on `HarnessSignal['type']` is exhaustiveness-checked by the compiler via
 `const _exhaustive: never = signal`.
 
-| Signal                       | Parsed from                                                        | Durable handler                                                                              |
-| ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `ProgressSignal`             | `<progress><summary>…</summary>…</progress>`                       | Append to `progress.md`                                                                      |
-| `EvaluationSignal`           | `<evaluation-passed>` / `<evaluation-failed>…</evaluation-failed>` | Sidecar (`evaluations/<task-id>.md`) + `tasks.json` preview                                  |
-| `TaskCompleteSignal`         | `<task-complete>`                                                  | None (per-task chain owns task lifecycle)                                                    |
-| `TaskVerifiedSignal`         | `<task-verified>output</task-verified>`                            | None (use case sets `verified` on the task entity)                                           |
-| `TaskBlockedSignal`          | `<task-blocked>reason</task-blocked>`                              | Record blocker in `progress.md`                                                              |
-| `NoteSignal`                 | `<note>text</note>`                                                | Append to `progress.md`                                                                      |
-| `CheckScriptDiscoverySignal` | `<check-script>command</check-script>`                             | None — consumed inline by setup flow (`project add` / `project repo add`)                    |
-| `AgentsMdProposalSignal`     | `<agents-md>…</agents-md>`                                         | None — consumed inline by `project onboard`; harness writes the provider-native file         |
-| `SetupScriptSignal`          | `<setup-script>command</setup-script>`                             | None — consumed inline by `project onboard`; persisted on `Repository.setupScript`           |
-| `VerifyScriptSignal`         | `<verify-script>command</verify-script>`                           | None — consumed inline by `project onboard`; persisted on `Repository.checkScript`           |
-| `SkillSuggestionsSignal`     | `<skill-suggestions>name1, name2, …</skill-suggestions>`           | None — consumed inline by `project onboard`; user-accepted subset linked via the skills port |
+| Signal                       | Parsed from                                                        | Durable handler                                                                                                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ProgressSignal`             | `<progress><summary>…</summary>…</progress>`                       | Append to `progress.md`                                                                                                                                                                                  |
+| `EvaluationSignal`           | `<evaluation-passed>` / `<evaluation-failed>…</evaluation-failed>` | `tasks.json` preview update (`Task.evaluationOutput` 2000-char truncation); full critique written per-round by `EvaluateAndFixLoopUseCase` to `execution/<unit-slug>/rounds/<N>/evaluator/evaluation.md` |
+| `TaskCompleteSignal`         | `<task-complete>`                                                  | None (per-task chain owns task lifecycle)                                                                                                                                                                |
+| `TaskVerifiedSignal`         | `<task-verified>output</task-verified>`                            | None (use case sets `verified` on the task entity)                                                                                                                                                       |
+| `TaskBlockedSignal`          | `<task-blocked>reason</task-blocked>`                              | Record blocker in `progress.md`                                                                                                                                                                          |
+| `NoteSignal`                 | `<note>text</note>`                                                | Append to `progress.md`                                                                                                                                                                                  |
+| `CheckScriptDiscoverySignal` | `<check-script>command</check-script>`                             | None — consumed inline by setup flow (`project add` / `project repo add`)                                                                                                                                |
+| `AgentsMdProposalSignal`     | `<agents-md>…</agents-md>`                                         | None — consumed inline by `project onboard`; harness writes the provider-native file                                                                                                                     |
+| `SetupScriptSignal`          | `<setup-script>command</setup-script>`                             | None — consumed inline by `project onboard`; persisted on `Repository.setupScript`                                                                                                                       |
+| `VerifyScriptSignal`         | `<verify-script>command</verify-script>`                           | None — consumed inline by `project onboard`; persisted on `Repository.checkScript`                                                                                                                       |
+| `SkillSuggestionsSignal`     | `<skill-suggestions>name1, name2, …</skill-suggestions>`           | None — consumed inline by `project onboard`; user-accepted subset linked via the skills port                                                                                                             |
 
 Plus synthetic bus events emitted by the per-task chain (not parsed from AI output): `rate-limit-paused`,
 `rate-limit-resumed`, `task-started`, `task-finished`. The `InMemorySignalBus` micro-batches emissions at ~16ms

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -242,12 +242,14 @@ confirm-setup-script → confirm-verify-script → confirm-context-file → writ
 - [ ] Completion signals parsed correctly
 - [ ] Blocked tasks short-circuit the rest of the per-task chain via `taskBlocked`; the outer Sequential continues
       with the next task
-- [x] `setupScript` runs at sprint start (per repo, audit-stamped on `sprint.setupRanAt`); first red exit
-      hard-aborts the chain naming the failing repo
-- [x] Per-task `checkScript` is auto-sourced from each repo's `Repository.checkScript` via the
+- [ ] `setupScript` runs at sprint start (per repo, audit-stamped on `sprint.setupRanAt`); any setup
+      failure (non-zero exit or spawn-level error — missing binary / EPERM / ENOENT) hard-aborts the chain
+      naming the failing repo. Repos already stamped on `setupRanAt` are skipped on resume so the chain
+      reaches per-task fan-out without re-running setup.
+- [ ] Per-task `checkScript` is auto-sourced from each repo's `Repository.checkScript` via the
       `resolve-check-scripts` leaf; `--check-script` (CLI) overrides for every task when set
-- [x] `checkScript` runs after every task completion as a post-task gate
-- [x] Task not marked done if check gate fails (transitions to `blocked` via the inner `OnError(catchIf:
+- [ ] `checkScript` runs after every task completion as a post-task gate
+- [ ] Task not marked done if check gate fails (transitions to `blocked` via the inner `OnError(catchIf:
 code === 'check-failed')` wrap)
 - [ ] Rate-limited tasks auto-resume via session ID through `Retry(retryOn: 'rate-limited')`; `RateLimitCoordinator`
       bridges pause/resume to the signal bus for the dashboard's `RateLimitBanner`

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -34,8 +34,8 @@ done; when a behaviour regresses, untick it.
 - [ ] Harness signals — see [ARCHITECTURE.md § Harness Signals](./ARCHITECTURE.md). Acceptance: union
       exhaustiveness enforced via `const _exhaustive: never = signal`; unrecognised signals log a warning and
       continue.
-- [ ] Harness-owned output writes — `progress.md`, `evaluations/<taskId>.md`, `tasks.json` are written by the
-      harness, never by the AI. Append-only, file-locked via `FileLocker`.
+- [ ] Harness-owned output writes — `progress.md`, `execution/<unit-slug>/rounds/<N>/evaluator/evaluation.md`,
+      `tasks.json` are written by the harness, never by the AI. Append-only, file-locked via `FileLocker`.
 - [ ] Logger sinks (`PlainTextSink` / `JsonLogger` / `InkSink` / `JsonlSink` / `FanOutLogger`) — see
       [ARCHITECTURE.md § Composition root](./ARCHITECTURE.md). Acceptance: console + JSONL receive identical
       streams; `RALPHCTL_LOG_LEVEL` filters everywhere; `VITEST=1` silences info / warn.
@@ -263,7 +263,8 @@ code === 'check-failed')` wrap)
 - [ ] `createEvaluateFlow` (standalone factory) runs ONE round per invocation; the multi-round loop is
       `EvaluateAndFixLoopUseCase` inside the per-task chain only
 - [ ] Evaluator **never blocks** — task always proceeds to `done` (or `blocked` via mark-blocked when branch-preflight
-      fails), even on `failed` / `malformed` outcomes; full critique persists to `evaluations/<taskId>.md`
+      fails), even on `failed` / `malformed` outcomes; full critique persists per-round to
+      `execution/<unit-slug>/rounds/<N>/evaluator/evaluation.md`; `Task.evaluationFile` points at the final round
 - [ ] `--no-evaluate` flag skips evaluation for a single run
 - [ ] Session/interactive mode disables evaluation
 - [ ] `evaluationOutput` truncated to 2000 chars before persisting on the `Task` entity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ to [Semantic Versioning](https://semver.org/).
 
 - **Setup ≠ check.** Sprint start now runs each repo's configured `setupScript` (the deterministic
   baseline so Claude departs reliably) via the renamed `setup-scripts-sprint-start` chain leaf,
-  iterating `sprint.affectedRepositories` and stamping `Sprint.setupRanAt[repoPath]`. The first red
-  exit hard-aborts the chain naming the failing repo. The per-task prompt's `{{ENVIRONMENT_STATUS}}`
-  slot renders "Setup script ran at <ISO>" instead of the old "Pre-task environment check passed at"
-  string.
+  iterating `sprint.affectedRepositories` and stamping `Sprint.setupRanAt[repoPath]`. Any setup
+  failure — non-zero exit OR spawn-level error (missing binary, EPERM, ENOENT, …) — hard-aborts
+  the chain as `InvalidStateError({ currentState: 'setup-failed' })` naming the failing repo. The
+  per-task prompt's `{{ENVIRONMENT_STATUS}}` slot renders "Setup script ran at <ISO>" instead of
+  the old "Pre-task environment check passed at" string.
+- **Sprint resume skips already-stamped repos.** The `setup-scripts-sprint-start` leaf no-ops per
+  repo when `Sprint.setupRanAt[repoPath]` already carries a timestamp, so a sprint killed mid-run
+  reaches the per-task fan-out without re-running setup. The existing stamp is preserved.
 - **Per-task `checkScript` is auto-sourced.** A new `resolve-check-scripts` chain leaf (runs in the
   initialize phase before setup) walks the sprint's project once and populates `ctx.checkScripts`
   with each affected repo's configured `Repository.checkScript`. The per-task bridge seeds the gate
@@ -29,10 +33,14 @@ to [Semantic Versioning](https://semver.org/).
   `Result.error(CheckFailedError)` on a non-zero exit. The per-task chain wraps it in
   `OnError(catchIf: code === 'check-failed')` and transitions the task to `'blocked'` (reason:
   "post-task check failed") instead of letting `mark-done` proceed.
-- **Spawn-level errors degrade gracefully.** Both gates wrap the inner leaf in a soft `OnError` that
-  absorbs anything except `aborted` and the gate's own hard error code, so a missing binary / EPERM
-  doesn't strand a sprint or a task. `resolve-check-scripts` runs BEFORE the soft-wrapped setup so
-  the per-task gate keeps its check-script map even when setup degrades.
+- **Per-task spawn-level errors degrade gracefully.** The post-task `checkScript` gate, the
+  execution-unit builder, and the evaluator each wrap their inner leaf in a soft `OnError` that
+  absorbs anything except `aborted` and the gate's own hard error code, so a missing binary /
+  EPERM doesn't strand a task. `resolve-check-scripts` runs before the setup leaf so the per-task
+  gate keeps its check-script map even when sprint-start setup hard-aborts.
+- **Legacy `sprint.json` files load.** Sprint files written by v0.6.2 (carrying `checkRanAt: {}`
+  with no `setupRanAt` key) parse successfully; the legacy key is silently dropped on the next
+  save, so the file self-cleans without a migration step.
 
 ## [0.6.2] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to [Semantic Versioning](https://semver.org/).
   with each affected repo's configured `Repository.checkScript`. The per-task bridge seeds the gate
   per-task without the user passing `--check-script`. The CLI flag stays as a global override
   (and its help text now says so).
+- `execution/<unit-slug>/` slimmed: dropped per-unit `tasks.json` and `prior-evaluations/`; sibling
+  evaluator output now renders inline inside `tasks.md`.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Before committing any code change, run `/verify` (wraps `pnpm typecheck && pnpm 
   - Claude uses a model ladder (Opus→Sonnet, Sonnet→Haiku, Haiku→Haiku); Copilot uses the same model (no control).
   - Evaluator grades four floor dimensions (Correctness / Completeness / Safety / Consistency) plus optional
     `extraDimensions` emitted per-task by the planner.
-  - Full critique persists to `<sprintDir>/evaluations/<taskId>.md`; `tasks.json` keeps a 2000-char preview + status.
+  - Full critique persists per-round to `execution/<unit-slug>/rounds/<N>/evaluator/evaluation.md`; `Task.evaluationFile` points at the final round's file; `tasks.json` keeps a 2000-char preview on `Task.evaluationOutput`.
   - Evaluator **never blocks** — evaluator spawn / parse failures are wrapped in
     `OnError(catchIf: err => err.code !== 'aborted', fallback: noop)` in the per-task chain, so the task always
     proceeds to `done` (or `blocked` via `markBlocked` when branch-preflight fails) and the chain continues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,12 @@ Before committing any code change, run `/verify` (wraps `pnpm typecheck && pnpm 
   share the runner)
 - **`setupScript` ≠ `checkScript`** — two distinct lifecycle hooks on every `Repository`. `setupScript` is the
   one-shot "prepare the env" command (e.g. `pnpm install`); it runs once per affected repo at sprint start, in the
-  `setup-scripts-sprint-start` chain leaf, and a non-zero exit hard-aborts before any task runs. `checkScript` is the
-  per-task verification gate; it runs after every AI task and inside the feedback loop. Both are collected during
-  `project onboard` and persisted on the `Repository` entity. Don't conflate them — a passing setup does not imply
-  the codebase compiles, and a passing check does not imply the env was prepared.
+  `setup-scripts-sprint-start` chain leaf, and any setup failure (non-zero exit OR spawn-level error — missing binary,
+  EPERM, ENOENT) hard-aborts the chain naming the failing repo before any task runs. The leaf skips repos already
+  stamped on `Sprint.setupRanAt` so resumes are fast. `checkScript` is the per-task verification gate; it runs after
+  every AI task and inside the feedback loop. Both are collected during `project onboard` and persisted on the
+  `Repository` entity. Don't conflate them — a passing setup does not imply the codebase compiles, and a passing
+  check does not imply the env was prepared.
 - **Post-task gate** — the per-task chain runs the configured `checkScript` after every AI task; the task is not marked
   done if the gate fails (see `business/usecases/execute/post-task-check.ts`). The script is auto-sourced from each
   repo's `Repository.checkScript` by the `resolve-check-scripts` chain leaf (run at sprint start); `sprint start

--- a/src/application/chains/execute/execute-flow.test.ts
+++ b/src/application/chains/execute/execute-flow.test.ts
@@ -259,7 +259,11 @@ describe('createExecuteFlow', () => {
       expect(result.error.error.message).toContain(repoPath);
     });
 
-    it('soft-degrades on a spawn-level error (e.g. missing binary): noop in trace, chain continues', async () => {
+    it('hard-aborts on a spawn-level setup error (e.g. missing binary)', async () => {
+      // Spawn errors (ENOENT / EPERM / missing binary) must abort the chain
+      // identically to a non-zero exit. A broken baseline environment
+      // surfaces as `InvalidStateError({ currentState: 'setup-failed' })`
+      // naming the failing repo so the user can fix it before retrying.
       const repoPath = '/tmp/demo-repo';
       const { sprint } = setupActive({ branch: 'ralphctl/setup-spawn', affectedRepoPath: repoPath });
       const project = buildProject(repoPath, 'pnpm install');
@@ -281,6 +285,155 @@ describe('createExecuteFlow', () => {
         projects: [project],
         tasks: [[sprint.id, [task]]],
         overrides: { external: throwingExternal },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/setup-spawn',
+        tasks: [task],
+        sprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: sprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/setup-spawn',
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const trace = result.error.trace.map((t) => t.stepName);
+      const failed = result.error.trace.find((t) => t.status === 'failed');
+      expect(failed?.stepName).toBe('setup-scripts-sprint-start');
+      expect(result.error.error.code).toBe('invalid-state');
+      // Error message names the failing repo and the underlying cause.
+      expect(result.error.error.message).toContain(repoPath);
+      expect(result.error.error.message).toContain('ENOENT');
+      // No per-task bridge ran — tasks must NOT have started.
+      expect(trace.some((n) => n.startsWith('task-'))).toBe(false);
+      // No soft-fallback step in the trace — the wrap was removed.
+      expect(trace).not.toContain('setup-scripts-sprint-start-noop');
+      expect(trace).not.toContain('setup-scripts-sprint-start-degraded');
+    });
+
+    it('skips repos already stamped on sprint.setupRanAt (resume case)', async () => {
+      // Resume scenario: a prior `sprint start` ran setup successfully,
+      // got killed mid-task, and the user re-runs. The sprint already
+      // carries a `setupRanAt` stamp for the affected repo; the leaf
+      // must NOT re-invoke the setup script.
+      const repoPath = '/tmp/demo-repo';
+      const { sprint: freshSprint } = setupActive({ branch: 'ralphctl/setup-resume', affectedRepoPath: repoPath });
+      const stampedSprint = freshSprint.recordSetupRun(abs(repoPath), '2026-05-06T08:00:00.000Z' as never);
+      const project = buildProject(repoPath, 'pnpm install');
+      const task = makeTask({ name: 'do work', projectPath: repoPath });
+      const external = new FakeExternalPort();
+
+      const deps = createTestDeps({
+        sprints: [stampedSprint],
+        projects: [project],
+        tasks: [[stampedSprint.id, [task]]],
+        overrides: { external },
+        aiSession: {
+          outcomes: [
+            { kind: 'ok', result: { output: 'done' } },
+            { kind: 'ok', result: { output: 'evaluated' } },
+          ],
+        },
+        signalParser: {
+          results: [
+            [taskCompleteSignal],
+            [
+              {
+                type: 'evaluation',
+                status: 'passed',
+                dimensions: [],
+                critique: '',
+                timestamp: '2026-04-29T12:00:00Z' as never,
+              },
+            ],
+          ],
+        },
+      });
+
+      const flow = createExecuteFlow(deps, {
+        sprintId: stampedSprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/setup-resume',
+        tasks: [task],
+        sprint: stampedSprint,
+      });
+
+      const result = await flow.execute({
+        sprintId: stampedSprint.id,
+        cwd: CWD,
+        expectedBranch: 'ralphctl/setup-resume',
+      });
+
+      expect(result.ok).toBe(true);
+      // The stamped repo is skipped — no setup script invocations.
+      expect(external.setupScriptCalls).toHaveLength(0);
+      // Existing stamp is preserved (no re-stamping; no entity churn).
+      const reread = await deps.sprintRepo.findById(stampedSprint.id);
+      expect(reread.ok).toBe(true);
+      if (reread.ok) {
+        expect(reread.value.setupRanAt.get(abs(repoPath))).toBe('2026-05-06T08:00:00.000Z');
+      }
+      if (!result.ok) return;
+      // The leaf still appears in the trace as a completed step (skip
+      // is silent at the per-repo level, not the leaf level).
+      const trace = result.value.trace.map((t) => t.stepName);
+      expect(trace).toContain('setup-scripts-sprint-start');
+    });
+
+    it('runs setup for un-stamped repos when only some repos in affectedRepositories carry stamps', async () => {
+      // Mixed case: two repos, one already stamped, one fresh. The leaf
+      // must skip the stamped one and call the setup script exactly once
+      // for the fresh repo.
+      const stampedPath = '/tmp/demo-repo-stamped';
+      const freshPath = '/tmp/demo-repo-fresh';
+      const sprint0 = makeSprint();
+      const ticket = makeApprovedTicket();
+      const withTicket = sprint0.addTicket(ticket);
+      if (!withTicket.ok) throw new Error('precondition');
+      const activated = withTicket.value.activate(sprint0.createdAt);
+      if (!activated.ok) throw new Error('precondition');
+      const branched = activated.value.setBranch('ralphctl/setup-mixed');
+      if (!branched.ok) throw new Error('precondition');
+      const affected = branched.value.setAffectedRepositories([abs(stampedPath), abs(freshPath)]);
+      if (!affected.ok) throw new Error('precondition');
+      const sprint = affected.value.recordSetupRun(abs(stampedPath), '2026-05-06T08:00:00.000Z' as never);
+
+      // Build a project carrying both repos with setup scripts.
+      const stampedRepo = Repository.create({
+        path: abs(stampedPath),
+        name: 'stamped-repo',
+        setupScript: 'pnpm install',
+      });
+      if (!stampedRepo.ok) throw new Error('precondition: stamped repo');
+      const freshRepo = Repository.create({
+        path: abs(freshPath),
+        name: 'fresh-repo',
+        setupScript: 'pnpm install',
+      });
+      if (!freshRepo.ok) throw new Error('precondition: fresh repo');
+      const projectName = ProjectName.parse('demo');
+      if (!projectName.ok) throw new Error('precondition: project name');
+      const project = Project.create({
+        name: projectName.value,
+        displayName: 'Demo',
+        repositories: [stampedRepo.value, freshRepo.value],
+      });
+      if (!project.ok) throw new Error('precondition: project');
+
+      const task = makeTask({ name: 'do work', projectPath: freshPath });
+      const external = new FakeExternalPort({ setupScriptOutcomes: [{ passed: true, output: '' }] });
+
+      const deps = createTestDeps({
+        sprints: [sprint],
+        projects: [project.value],
+        tasks: [[sprint.id, [task]]],
+        overrides: { external },
         aiSession: {
           outcomes: [
             { kind: 'ok', result: { output: 'done' } },
@@ -306,7 +459,7 @@ describe('createExecuteFlow', () => {
       const flow = createExecuteFlow(deps, {
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/setup-spawn',
+        expectedBranch: 'ralphctl/setup-mixed',
         tasks: [task],
         sprint,
       });
@@ -314,17 +467,13 @@ describe('createExecuteFlow', () => {
       const result = await flow.execute({
         sprintId: sprint.id,
         cwd: CWD,
-        expectedBranch: 'ralphctl/setup-spawn',
+        expectedBranch: 'ralphctl/setup-mixed',
       });
 
-      // Chain still resolves OK — spawn error swallowed by the outer OnError.
       expect(result.ok).toBe(true);
-      if (!result.ok) return;
-      const trace = result.value.trace.map((t) => t.stepName);
-      // The OnError fallback's noop step records the swallow.
-      expect(trace).toContain('setup-scripts-sprint-start-noop');
-      // The per-task bridge ran (Sequential flattens; bridges surface as `task-<id>`).
-      expect(trace.some((n) => n.startsWith('task-'))).toBe(true);
+      // Setup ran exactly once — for the un-stamped repo only.
+      expect(external.setupScriptCalls).toHaveLength(1);
+      expect(String(external.setupScriptCalls[0]?.projectPath)).toBe(freshPath);
     });
 
     it('skips repos without a setupScript and short-circuits cleanly when affectedRepositories is empty', async () => {

--- a/src/application/chains/execute/execute-flow.ts
+++ b/src/application/chains/execute/execute-flow.ts
@@ -67,9 +67,8 @@ import {
 import type { Sprint } from '@src/domain/entities/sprint.ts';
 import type { Task } from '@src/domain/entities/task.ts';
 import { InvalidStateError } from '@src/domain/errors/invalid-state-error.ts';
-import type { Element, KernelError } from '@src/kernel/chain/element.ts';
+import type { Element } from '@src/kernel/chain/element.ts';
 import { Leaf } from '@src/kernel/chain/leaf.ts';
-import { OnError } from '@src/kernel/chain/on-error.ts';
 import { Sequential } from '@src/kernel/chain/sequential.ts';
 import { topologicalReorder } from '@src/kernel/algorithms/dependency-reorder.ts';
 import type { AbsolutePath } from '@src/domain/values/absolute-path.ts';
@@ -237,29 +236,25 @@ export function createExecuteFlow(
   //     once per affected repo so Claude departs from a deterministic
   //     baseline
   //
-  // `resolve-check-scripts` runs BEFORE the setup leaf so even if
-  // setup's outer `OnError` swallows a spawn-level error, the per-task
-  // gate still has its check-script map. (See the user-stated design:
-  // setup ≠ check; setup is the one-shot baseline, check is the
-  // step-to-step gate so follow-up tasks can succeed.)
+  // `resolve-check-scripts` runs BEFORE the setup leaf so the per-task
+  // gate's check-script map is populated before the setup script can
+  // hard-abort the chain. (See the user-stated design: setup ≠ check;
+  // setup is the one-shot baseline, check is the step-to-step gate so
+  // follow-up tasks can succeed.)
   //
-  // The sprint-start setup leaf is wrapped in an `OnError` that absorbs
-  // SPAWN-LEVEL errors (missing binary, EPERM, …) but lets:
-  //   - `aborted` (user-initiated cancel) propagate, and
-  //   - `invalid-state` (a real red baseline) propagate
-  // through unchanged. Only those two reach the outer chain and stop
-  // it; transient environment hiccups degrade to a noop so a sprint
-  // isn't stranded by a flaky CI shell. The trace surfaces
-  // `setup-scripts-sprint-start-noop` when the soft path fires so a
-  // post-mortem can tell why no setup scripts ran.
+  // The sprint-start setup leaf is intentionally NOT wrapped in an
+  // `OnError`. Both red exits and spawn-level errors (missing binary,
+  // EPERM, ENOENT, etc.) surface as
+  // `InvalidStateError({ currentState: 'setup-failed' })` from the leaf
+  // and abort the chain naming the failing repo. A broken environment
+  // baseline must fail loudly — papering over it with a soft fallback
+  // means task fan-out runs on top of a half-installed dependency tree
+  // and every downstream check is suspect.
   const initializeStep = new Sequential<ExecuteCtx>('initialize', [
     resolveBranchLeaf(deps),
     dirtyTreePreflightLeaf(deps, opts),
     resolveCheckScriptsLeaf(deps),
-    new OnError<ExecuteCtx>(setupScriptsSprintStartLeaf(deps), {
-      catchIf: (err) => err.code !== 'aborted' && err.code !== 'invalid-state',
-      fallback: noopLeafExec<ExecuteCtx>('setup-scripts-sprint-start-noop'),
-    }),
+    setupScriptsSprintStartLeaf(deps),
   ]);
 
   return new Sequential<ExecuteCtx>('execute', [
@@ -745,10 +740,9 @@ function assertTasksAcyclicLeaf(sortResult: ReturnType<typeof topologicalReorder
  * the user having to pass `--check-script` to `sprint start`.
  *
  * Distinct leaf (rather than a side-effect of `setup-scripts-sprint-start`)
- * because this read is pure and must succeed even when setup spawns are
- * shaky: running it FIRST means a flaky setup script that gets
- * absorbed by the soft `OnError` still leaves a populated
- * `ctx.checkScripts` for the per-task gate.
+ * because this read is pure and must succeed before the setup leaf can
+ * hard-abort: running it FIRST keeps `ctx.checkScripts` populated for
+ * the per-task gate even on sprints that bail out at sprint-start setup.
  *
  * Soft-fails on missing project / missing repo / unset `checkScript`:
  * the affected repo simply doesn't appear in the output map. An empty
@@ -803,14 +797,19 @@ function resolveCheckScriptsLeaf(deps: Pick<ChainSharedDeps, 'projectRepo' | 'lo
  * Behaviour:
  *  - Repos with no `setupScript` configured are skipped silently (same
  *    policy as the per-task gate's no-`checkScript` skip).
+ *  - Repos already stamped on `sprint.setupRanAt` are skipped silently
+ *    (resume case — setup already ran successfully on a prior launch).
  *  - Empty `sprint.affectedRepositories` short-circuits cleanly.
- *  - On the first failing setup script, the leaf returns
- *    `InvalidStateError({ currentState: 'setup-failed' })` and the chain
- *    aborts before any task runs — a broken baseline environment must
- *    not be papered over by the per-task gate.
+ *  - On the first failing setup script — exit non-zero OR a spawn-level
+ *    error (missing binary, EPERM, ENOENT, …) — the leaf returns
+ *    `InvalidStateError({ currentState: 'setup-failed' })` naming the
+ *    failing repo and the chain aborts before any task runs. A broken
+ *    baseline environment must fail loudly so the user fixes setup
+ *    rather than letting task fan-out run on a half-installed tree.
  *  - On success, `sprint.recordSetupRun(repoPath, now)` audit-stamps the
  *    sprint entity (persisted via the sprint repo) so the per-task
- *    prompt builder can surface "Setup script ran at <ISO>." to the AI.
+ *    prompt builder can surface "Setup script ran at <ISO>." to the AI
+ *    and so resumes skip already-stamped repos on the next launch.
  *
  * Project-repo lookup: `setupScript` lives on the `Repository` entity
  * inside the sprint's `Project`. We load the project once and resolve
@@ -818,13 +817,6 @@ function resolveCheckScriptsLeaf(deps: Pick<ChainSharedDeps, 'projectRepo' | 'lo
  * project (rare — usually means the user removed the project after
  * planning) skips the phase silently rather than failing — the user can
  * fix it without re-planning.
- *
- * Spawn-level errors (missing binary, EPERM, …) propagate as whatever
- * the `ExternalPort` adapter throws; the outer `OnError` (in the
- * `initializeStep` Sequential) absorbs them via the
- * `setup-scripts-sprint-start-noop` fallback so a flaky environment
- * doesn't strand the sprint. Real `setup-failed` (`code: 'invalid-state'`)
- * propagates so the user sees the failing repo by name.
  */
 function setupScriptsSprintStartLeaf(
   deps: Pick<ChainSharedDeps, 'external' | 'projectRepo' | 'sprintRepo' | 'logger'>
@@ -851,6 +843,16 @@ function setupScriptsSprintStartLeaf(
           let sprint = input.sprint;
           const now = IsoTimestamp.trustString(new Date().toISOString());
           for (const repoPath of repoPaths) {
+            // Resume: a prior launch already ran setup successfully for
+            // this repo. Preserve the stamp and skip — no re-run, no
+            // re-stamp, no log noise (debug only).
+            if (input.sprint.setupRanAt.has(repoPath)) {
+              const stampedAt = input.sprint.setupRanAt.get(repoPath);
+              deps.logger.debug(
+                `setup-scripts-sprint-start: skipping ${String(repoPath)} — already stamped at ${String(stampedAt)}`
+              );
+              continue;
+            }
             const repo = project.value.repositories.find((r) => r.path === repoPath);
             if (repo === undefined) {
               // Sprint references a repo that no longer exists on the
@@ -862,8 +864,26 @@ function setupScriptsSprintStartLeaf(
             if (script === undefined || script.length === 0) {
               continue; // No setup script for this repo — skip.
             }
-            const r = await deps.external.runSetupScript(repoPath, script, repo.checkTimeout);
-            if (!r.passed) {
+            // Wrap the spawn so a thrown rejection (ENOENT / EPERM and
+            // friends — adapters that bypass the normal `passed: false`
+            // conversion) surfaces as the same `setup-failed` invalid-
+            // state error as a non-zero exit. Either way, a broken
+            // baseline must abort the chain naming the failing repo.
+            let outcome;
+            try {
+              outcome = await deps.external.runSetupScript(repoPath, script, repo.checkTimeout);
+            } catch (err) {
+              return Result.error(
+                new InvalidStateError({
+                  entity: 'sprint',
+                  currentState: 'setup-failed',
+                  attemptedAction: 'execute',
+                  message: `sprint-start setup script failed in ${String(repoPath)}: ${err instanceof Error ? err.message : String(err)}`,
+                  hint: 'Fix the setup script (configured via `project onboard` / `project repo add`) and retry. Setup runs once at sprint start; the per-task `checkScript` is a separate gate.',
+                })
+              );
+            }
+            if (!outcome.passed) {
               return Result.error(
                 new InvalidStateError({
                   entity: 'sprint',
@@ -897,20 +917,4 @@ function setupScriptsSprintStartLeaf(
       output: (ctx) => ctx,
     }
   );
-}
-
-/**
- * Identity leaf — local to execute-flow so the sprint-start `OnError`
- * fallback has a typed noop without pulling per-task-flow's helper.
- */
-function noopLeafExec<TCtx>(name: string): Element<TCtx> {
-  return new Leaf<TCtx, TCtx, TCtx>(name, {
-    useCase: {
-      execute(input) {
-        return Promise.resolve(Result.ok(input)) as Promise<Result<TCtx, KernelError>>;
-      },
-    },
-    input: (ctx) => ctx,
-    output: (_, ctx) => ctx,
-  });
 }

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -89,13 +89,14 @@ import type { DomainError } from '@src/domain/errors/domain-error.ts';
 import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import type { SprintId } from '@src/domain/values/sprint-id.ts';
 import type { TaskId } from '@src/domain/values/task-id.ts';
-import type { Element, KernelError } from '@src/kernel/chain/element.ts';
+import type { Element } from '@src/kernel/chain/element.ts';
 import { Leaf } from '@src/kernel/chain/leaf.ts';
 import { OnError } from '@src/kernel/chain/on-error.ts';
 import { Retry } from '@src/kernel/chain/retry.ts';
 import { Sequential } from '@src/kernel/chain/sequential.ts';
 import type { ChainSharedDeps } from '@src/application/chains/chain-deps.ts';
 import { buildExecutionUnitLeaf } from '@src/application/chains/leaves/build-execution-unit.ts';
+import { noopLeaf } from '@src/application/chains/leaves/noop-leaf.ts';
 import { renderPromptToFileLeaf } from '@src/application/chains/leaves/render-prompt-to-file.ts';
 import { resolveStoragePaths } from '@src/integration/persistence/storage-paths.ts';
 import { unitSlug } from '@src/integration/persistence/unit-slug.ts';
@@ -964,22 +965,5 @@ function commitTaskLeaf(deps: Pick<ChainSharedDeps, 'taskRepo' | 'external' | 'l
       noCommit: ctx.noCommit === true,
     }),
     output: (ctx, task) => ({ ...ctx, task }),
-  });
-}
-
-/**
- * Identity leaf — used as an `OnError` fallback so an evaluator failure
- * resolves the chain step with the original context. The evaluator
- * never blocks task completion (REQUIREMENTS.md).
- */
-function noopLeaf<TCtx>(name: string): Element<TCtx> {
-  return new Leaf<TCtx, TCtx, TCtx>(name, {
-    useCase: {
-      execute(input) {
-        return Promise.resolve(Result.ok(input)) as Promise<Result<TCtx, KernelError>>;
-      },
-    },
-    input: (ctx) => ctx,
-    output: (_, ctx) => ctx,
   });
 }

--- a/src/application/chains/execute/per-task-flow.ts
+++ b/src/application/chains/execute/per-task-flow.ts
@@ -158,8 +158,8 @@ export interface PerTaskCtx {
   readonly executionSessionCwd?: AbsolutePath;
   /**
    * Full sprint task list. Used by `build-execution-unit` to derive
-   * `priorEvaluations` and to populate `tasks.md` / `tasks.json` inside
-   * the unit folder. Stamped onto the ctx by the outer `executeFlow`'s
+   * `priorEvaluations` and to populate `tasks.md` inside the unit
+   * folder. Stamped onto the ctx by the outer `executeFlow`'s
    * `load-tasks` leaf via the per-task chain construction; we expose
    * it on the per-task ctx so the build leaf can read it without
    * threading a separate input.

--- a/src/application/chains/leaves/build-execution-unit.ts
+++ b/src/application/chains/leaves/build-execution-unit.ts
@@ -5,9 +5,10 @@
  *
  * The execution unit is the EVALUATOR'S cwd (or `--add-dir` mount,
  * for Claude). The generator session itself runs inside `task.projectPath`
- * — the unit folder only carries evaluator inputs (task.md, tasks plan,
- * project context, prior evaluations) plus the `evaluation.md` sink the
- * signal handler writes critiques to.
+ * — the unit folder only carries evaluator inputs (task.md, tasks plan
+ * with sibling evaluator output rendered inline in `tasks.md`, project
+ * context) plus the `evaluation.md` sink the signal handler writes
+ * critiques to.
  *
  * Position in the chain: AFTER `mark-in-progress` and BEFORE the
  * evaluator round runs. The per-task chain wraps this leaf together

--- a/src/application/chains/leaves/noop-leaf.ts
+++ b/src/application/chains/leaves/noop-leaf.ts
@@ -1,0 +1,26 @@
+/**
+ * `noopLeaf` — identity Leaf factory used as `OnError` fallbacks.
+ *
+ * Returns the input context unchanged via `Result.ok`, emits a single trace
+ * entry under the supplied step name. Every consumer that needs a soft
+ * fallback for `OnError(catchIf, fallback)` shares this implementation —
+ * keeping the helper in one place stops the local copies from drifting.
+ *
+ * Generic over the chain context shape so per-task and outer execute chains
+ * (and any future workflow) can reuse it without bespoke wrappers.
+ */
+import { Result } from '@src/domain/result.ts';
+import type { Element, KernelError } from '@src/kernel/chain/element.ts';
+import { Leaf } from '@src/kernel/chain/leaf.ts';
+
+export function noopLeaf<TCtx>(name: string): Element<TCtx> {
+  return new Leaf<TCtx, TCtx, TCtx>(name, {
+    useCase: {
+      execute(input) {
+        return Promise.resolve(Result.ok(input)) as Promise<Result<TCtx, KernelError>>;
+      },
+    },
+    input: (ctx) => ctx,
+    output: (_, ctx) => ctx,
+  });
+}

--- a/src/business/ports/prompt-builder-port.ts
+++ b/src/business/ports/prompt-builder-port.ts
@@ -129,10 +129,10 @@ export interface PromptBuilderPort {
    * workspace (set by the per-task chain after `buildEvaluateWorkspace`
    * lands its contract pack on disk). When set, the rendered prompt
    * includes a `Contract files` section pointing the AI at upstream
-   * artefacts (`requirements/`, `tasks.md`, `dimensions.md`,
-   * `prior-evaluations/`, `project-context.md`). When unset, the section
-   * collapses — used by the standalone `sprint evaluate` chain which
-   * has no workspace.
+   * artefacts (`requirements/`, `tasks.md` with sibling evaluator output
+   * rendered inline, `dimensions.md`, `project-context.md`). When unset,
+   * the section collapses — used by the standalone `sprint evaluate`
+   * chain which has no workspace.
    */
   buildEvaluatePrompt(input: {
     task: Task;

--- a/src/business/ports/session-folder-builder-port.ts
+++ b/src/business/ports/session-folder-builder-port.ts
@@ -20,10 +20,11 @@
  * `.claude/skills/` inside each folder at chain run time.
  *
  * **Refresh semantics:** `refreshExecutionUnit` overwrites only the
- * volatile per-task files (`task.md`, `tasks.md`, `tasks.json`,
- * `project-context.md`, `prior-evaluations/`). Static files written by
- * the initial `buildExecutionUnit` (`requirements/`, `dimensions.md`,
- * the root context file) are left untouched.
+ * volatile per-task files (`task.md`, `tasks.md`, `project-context.md`).
+ * Static files written by the initial `buildExecutionUnit`
+ * (`requirements/`, `dimensions.md`, the root context file) are left
+ * untouched. Sibling evaluator output is rendered inline inside
+ * `tasks.md` — there is no separate `prior-evaluations/` directory.
  */
 import type { AiProvider } from '@src/business/ports/ai-session-port.ts';
 import type { Sprint } from '@src/domain/entities/sprint.ts';
@@ -120,15 +121,21 @@ export interface SessionFolderBuilderPort {
   /**
    * Build a per-task execution unit folder. Writes both static files
    * (`requirements/`, `dimensions.md`, the root context file) and the
-   * volatile per-task files (`task.md`, `tasks.md`, `tasks.json`,
-   * `project-context.md`, `prior-evaluations/`). For Copilot, mirrors
-   * the task's `projectPath` into `<root>/repo/`.
+   * volatile per-task files (`task.md`, `tasks.md`, `project-context.md`).
+   * Sibling evaluator output (`priorEvaluations`) is rendered inline
+   * inside `tasks.md` rather than written to a separate directory.
+   * For Copilot, mirrors the task's `projectPath` into `<root>/repo/`.
    */
   buildExecutionUnit(input: {
     readonly sprint: Sprint;
     readonly tasks: readonly Task[];
     readonly task: Task;
     readonly aiProvider: AiProvider;
+    /**
+     * Sibling task verdicts (taskId → 2000-char preview from
+     * `Task.evaluationOutput`). Rendered inline inside `tasks.md`
+     * under each completed sibling's `### Evaluator output` block.
+     */
     readonly priorEvaluations: ReadonlyMap<TaskId, string>;
   }): Promise<Result<ExecutionUnitPaths, DomainError>>;
 
@@ -142,6 +149,7 @@ export interface SessionFolderBuilderPort {
     readonly tasks: readonly Task[];
     readonly task: Task;
     readonly aiProvider: AiProvider;
+    /** See {@link SessionFolderBuilderPort.buildExecutionUnit}. */
     readonly priorEvaluations: ReadonlyMap<TaskId, string>;
   }): Promise<Result<void, DomainError>>;
 }

--- a/src/integration/ai/prompts/prompt-renderers.ts
+++ b/src/integration/ai/prompts/prompt-renderers.ts
@@ -80,11 +80,12 @@ export function renderCheckScriptSection(checkScript: string | undefined): strin
 /**
  * Render the evaluator prompt's `{{EVALUATE_WORKSPACE}}` section. When
  * the per-task chain laid down an evaluate workspace (refined
- * requirements, full task plan, dimensions, project context, prior
- * evaluations), the section points the evaluator at the on-disk paths
- * so the AI reads them via its file-read tool — cheaper per round than
- * inlining everything into the prompt. When undefined (standalone
- * `sprint evaluate` with no workspace), the section collapses to ''.
+ * requirements, full task plan with sibling verdicts inlined,
+ * dimensions, project context), the section points the evaluator at the
+ * on-disk paths so the AI reads them via its file-read tool — cheaper
+ * per round than inlining everything into the prompt. When undefined
+ * (standalone `sprint evaluate` with no workspace), the section
+ * collapses to ''.
  */
 export function renderEvaluateWorkspaceSection(workspaceDir: string | undefined): string {
   if (workspaceDir === undefined || workspaceDir.trim().length === 0) return '';
@@ -95,10 +96,9 @@ export function renderEvaluateWorkspaceSection(workspaceDir: string | undefined)
     '',
     '- `task.md` — the current task being evaluated (description, steps, verification criteria, status)',
     '- `requirements/<ticket-id>.md` — the refined requirements + raw ticket text that motivated this task',
-    '- `tasks.md` / `tasks.json` — the full task plan, for cross-task consistency checks',
+    "- `tasks.md` — the full task plan, including any sibling tasks' evaluator output rendered inline where present (cross-task consistency + quality bar so far)",
     "- `project-context.md` — the project's CLAUDE.md / .github/copilot-instructions.md (when present in the target repo)",
     '- `dimensions.md` — the four floor dimensions plus any extra dimensions the planner emitted on this task',
-    '- `prior-evaluations/<task-id>.md` — prior sibling task evaluations from earlier in this sprint (the quality bar so far)',
   ].join('\n');
 }
 

--- a/src/integration/persistence/execution-unit-builder.test.ts
+++ b/src/integration/persistence/execution-unit-builder.test.ts
@@ -1,6 +1,7 @@
 /**
  * `buildExecutionUnit` integration tests — covers the `done-criteria.md`
- * copy and the renamed `prior-evaluations/` subtree.
+ * copy and the inline rendering of sibling evaluator output inside
+ * `tasks.md`.
  *
  * `buildExecutionUnit` is an IO-heavy function — these tests write to a real
  * tmp directory. Each test gets its own isolated root via a unique prefix.
@@ -12,7 +13,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { resolveStoragePaths, resetEnsureLayoutDirsCache } from '@src/integration/persistence/storage-paths.ts';
 import { makeSprint, makeTask } from '@src/application/_test-fakes/fixtures.ts';
-import { TaskId } from '@src/domain/values/task-id.ts';
 import { buildExecutionUnit } from './execution-unit-builder.ts';
 
 function uniqueRoot(): string {
@@ -92,33 +92,65 @@ describe('buildExecutionUnit — done-criteria.md', () => {
   });
 });
 
-describe('buildExecutionUnit — prior-evaluations directory', () => {
-  it('writes prior sibling critiques to <unit>/prior-evaluations/<task-id>.md (renamed from evaluations/)', async () => {
+describe('buildExecutionUnit — tasks.md inline prior evaluations', () => {
+  it('renders sibling evaluator output as a fenced ### Evaluator output block inside tasks.md', async () => {
     const sprint = makeSprint();
-    const task = makeTask({ name: 'current task', projectPath: '/tmp' });
-    const priorId = TaskId.trustString('aaaaaaaa');
+    // The current task is the one under review; the sibling carries the
+    // prior evaluation that should surface inside `tasks.md`.
+    const sibling = makeTask({ name: 'sibling task', projectPath: '/tmp', order: 1 });
+    const current = makeTask({ name: 'current task', projectPath: '/tmp', order: 2 });
     const priorBody = '# Prior critique\n\n- correctness PASS';
 
     const storage = resolveStoragePaths();
     const result = await buildExecutionUnit(storage, {
       sprint,
-      tasks: [task],
-      task,
+      tasks: [sibling, current],
+      task: current,
       aiProvider: 'claude',
-      priorEvaluations: new Map([[priorId, priorBody]]),
+      priorEvaluations: new Map([[sibling.id, priorBody]]),
     });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
     const unitRoot = String(result.value.root);
-    // The renamed folder receives prior siblings.
-    const priorPath = join(unitRoot, 'prior-evaluations', `${String(priorId)}.md`);
-    const body = await readFile(priorPath, 'utf-8');
-    expect(body).toContain('Prior critique');
-    expect(body).toContain('correctness PASS');
+    const tasksMd = await readFile(join(unitRoot, 'tasks.md'), 'utf-8');
+    // Sibling section carries the verdict heading + fenced body.
+    expect(tasksMd).toContain('## 1. sibling task');
+    expect(tasksMd).toContain('### Evaluator output');
+    expect(tasksMd).toContain('```text');
+    expect(tasksMd).toContain('Prior critique');
+    expect(tasksMd).toContain('correctness PASS');
 
-    // The legacy `evaluations/` folder must NOT exist.
-    await expect(stat(join(unitRoot, 'evaluations'))).rejects.toMatchObject({ code: 'ENOENT' });
+    // Per-unit tasks.json is gone — only the canonical sprint-root copy
+    // remains (untouched by this builder).
+    await expect(stat(join(unitRoot, 'tasks.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    // Per-unit prior-evaluations/ directory is gone too.
+    await expect(stat(join(unitRoot, 'prior-evaluations'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('omits the ### Evaluator output heading for tasks without a prior evaluation', async () => {
+    const sprint = makeSprint();
+    const onlyTask = makeTask({ name: 'lonely task', projectPath: '/tmp' });
+
+    const storage = resolveStoragePaths();
+    const result = await buildExecutionUnit(storage, {
+      sprint,
+      tasks: [onlyTask],
+      task: onlyTask,
+      aiProvider: 'claude',
+      priorEvaluations: new Map(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const unitRoot = String(result.value.root);
+    const tasksMd = await readFile(join(unitRoot, 'tasks.md'), 'utf-8');
+    expect(tasksMd).toContain('## 1. lonely task');
+    expect(tasksMd).not.toContain('### Evaluator output');
+
+    // Per-unit tasks.json is gone unconditionally.
+    await expect(stat(join(unitRoot, 'tasks.json'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/src/integration/persistence/execution-unit-builder.ts
+++ b/src/integration/persistence/execution-unit-builder.ts
@@ -11,10 +11,11 @@
  *
  *   Volatile (overwritten by both `buildExecutionUnit` and `refreshExecutionUnit`):
  *     - `task.md` — the single task under review
- *     - `tasks.md` — full task plan as markdown
- *     - `tasks.json` — machine-readable task list
+ *     - `tasks.md` — full task plan as markdown; sibling evaluator output
+ *       (the 2000-char preview from `Task.evaluationOutput`) is rendered
+ *       inline under each completed task as a `### Evaluator output` block,
+ *       so the evaluator gets cross-task verdicts next to the task body.
  *     - `project-context.md` — copy of the target repo's context file
- *     - `prior-evaluations/<task-id>.md` — prior sibling evaluation critiques
  *
  *   Per-round (written by the evaluate-and-fix loop, never by this module):
  *     - `rounds/<N>/generator/session.md` — generator (re-)spawn audit
@@ -27,7 +28,7 @@
  *   Copilot only (mirrored at build time):
  *     - `repo/` — mirror of `task.projectPath`
  */
-import { readFile, rm } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { AiProvider } from '@src/business/ports/ai-session-port.ts';
@@ -36,7 +37,7 @@ import type { Sprint } from '@src/domain/entities/sprint.ts';
 import type { Task } from '@src/domain/entities/task.ts';
 import type { Ticket } from '@src/domain/entities/ticket.ts';
 import type { DomainError } from '@src/domain/errors/domain-error.ts';
-import { StorageError } from '@src/domain/errors/storage-error.ts';
+import type { StorageError } from '@src/domain/errors/storage-error.ts';
 import { Result } from '@src/domain/result.ts';
 import { AbsolutePath } from '@src/domain/values/absolute-path.ts';
 import type { TaskId } from '@src/domain/values/task-id.ts';
@@ -50,18 +51,10 @@ import {
   writeFileSafe,
 } from '@src/integration/persistence/session-folder-helpers.ts';
 
-// ─────────────────────── round-aware path helpers ────────────────────────
-
-/**
- * Integration-local helper for the per-task `prior-evaluations/` folder.
- * The round-aware helpers (`roundDir`, `generatorRoundDir`,
- * `evaluatorRoundDir`, `standaloneRoundDir`) live in
- * `@src/kernel/algorithms/execution-round-paths.ts` so the business
- * layer can use them without importing from integration.
- */
-export function priorEvaluationsDir(unitRoot: string): string {
-  return join(unitRoot, 'prior-evaluations');
-}
+// The round-aware helpers (`roundDir`, `generatorRoundDir`,
+// `evaluatorRoundDir`, `standaloneRoundDir`) live in
+// `@src/kernel/algorithms/execution-round-paths.ts` so the business
+// layer can use them without importing from integration.
 
 // ──────────────────────── evaluation rubric ──────────────────────────────
 
@@ -150,9 +143,12 @@ function renderTaskInput(task: Task): string {
 
 /**
  * Render `tasks.md` — the full task plan as one markdown section per
- * task, sorted by `order`.
+ * task, sorted by `order`. When `priorEvaluations` carries an entry for
+ * a task, its body (the 2000-char `Task.evaluationOutput` preview) is
+ * rendered inline as a fenced block under a `### Evaluator output`
+ * heading. Tasks without a prior evaluation get no heading — no stub.
  */
-function renderTasksList(tasks: readonly Task[]): string {
+function renderTasksList(tasks: readonly Task[], priorEvaluations: ReadonlyMap<TaskId, string>): string {
   const ordered = [...tasks].sort((a, b) => a.order - b.order);
   const lines: string[] = ['# Task plan', ''];
   for (const t of ordered) {
@@ -175,6 +171,10 @@ function renderTasksList(tasks: readonly Task[]): string {
       lines.push('### Verification criteria', '');
       for (const c of t.verificationCriteria) lines.push(`- ${c}`);
       lines.push('');
+    }
+    const priorEval = priorEvaluations.get(t.id);
+    if (priorEval !== undefined && priorEval.length > 0) {
+      lines.push('### Evaluator output', '', '```text', priorEval, '```', '');
     }
   }
   return lines.join('\n');
@@ -233,33 +233,14 @@ async function readProjectContext(repoPath: AbsolutePath, provider: AiProvider):
   }
 }
 
-/**
- * Stable, JSON-friendly snapshot of a task list.
- */
-function serialiseTasks(tasks: readonly Task[]): readonly Record<string, unknown>[] {
-  return [...tasks]
-    .sort((a, b) => a.order - b.order)
-    .map((t) => ({
-      id: t.id,
-      name: t.name,
-      description: t.description,
-      steps: t.steps,
-      verificationCriteria: t.verificationCriteria,
-      status: t.status,
-      order: t.order,
-      ticketId: t.ticketId,
-      blockedBy: t.blockedBy,
-      projectPath: t.projectPath,
-      extraDimensions: t.extraDimensions,
-    }));
-}
-
 // ────────────────────────── volatile writer ───────────────────────────────
 
 /**
  * Write (or overwrite) the volatile per-task files inside an execution unit
  * folder. Called by both `buildExecutionUnit` (initial build) and
- * `refreshExecutionUnit` (between evaluator rounds).
+ * `refreshExecutionUnit` (between evaluator rounds). Sibling evaluator
+ * output (`priorEvaluations`) is rendered inline inside `tasks.md` —
+ * there is no separate per-unit `prior-evaluations/` directory.
  */
 export async function writeExecutionVolatile(args: {
   root: AbsolutePath;
@@ -272,38 +253,13 @@ export async function writeExecutionVolatile(args: {
   const taskMd = await writeFileSafe(join(args.root, 'task.md'), renderTaskInput(args.task));
   if (!taskMd.ok) return Result.error(taskMd.error);
 
-  const tasksMd = await writeFileSafe(join(args.root, 'tasks.md'), renderTasksList(args.tasks));
+  const tasksMd = await writeFileSafe(join(args.root, 'tasks.md'), renderTasksList(args.tasks, args.priorEvaluations));
   if (!tasksMd.ok) return Result.error(tasksMd.error);
-
-  const tasksJson = await writeFileSafe(
-    join(args.root, 'tasks.json'),
-    JSON.stringify(serialiseTasks(args.tasks), null, 2)
-  );
-  if (!tasksJson.ok) return Result.error(tasksJson.error);
 
   const projectContext = await readProjectContext(args.task.projectPath, args.aiProvider);
   const projectCtxFile = await writeFileSafe(join(args.root, 'project-context.md'), projectContext);
   if (!projectCtxFile.ok) return Result.error(projectCtxFile.error);
 
-  const priorEvaluationsDirPath = priorEvaluationsDir(args.root);
-  try {
-    await rm(priorEvaluationsDirPath, { recursive: true, force: true });
-  } catch (err) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: `failed to clear ${priorEvaluationsDirPath}: ${err instanceof Error ? err.message : String(err)}`,
-        path: priorEvaluationsDirPath,
-        cause: err,
-      })
-    );
-  }
-  const ensureEvals = await ensureDirSafe(priorEvaluationsDirPath);
-  if (!ensureEvals.ok) return Result.error(ensureEvals.error);
-  for (const [taskId, body] of args.priorEvaluations) {
-    const w = await writeFileSafe(join(priorEvaluationsDirPath, `${taskId}.md`), body);
-    if (!w.ok) return Result.error(w.error);
-  }
   return Result.ok();
 }
 
@@ -359,7 +315,7 @@ export async function buildExecutionUnit(
     }
   }
 
-  // Volatile: task.md, tasks.md, tasks.json, project-context.md, prior-evaluations/.
+  // Volatile: task.md, tasks.md (with sibling evaluator output rendered inline), project-context.md.
   const volatile = await writeExecutionVolatile({
     root,
     sprint: input.sprint,

--- a/src/integration/persistence/schemas/sprint-schema.test.ts
+++ b/src/integration/persistence/schemas/sprint-schema.test.ts
@@ -194,4 +194,43 @@ describe('sprint-schema', () => {
     if (!back.ok) return;
     expect(back.value.pullRequestUrl).toBeNull();
   });
+
+  it('loads legacy v0.6.2 sprint.json with checkRanAt instead of setupRanAt', () => {
+    // v0.6.2 wrote the audit map under the legacy key `checkRanAt`. On the
+    // next save we drop the legacy key and emit `setupRanAt: {}` — Zod
+    // silently strips unknown keys, so a stale audit trail under the wrong
+    // key is forfeit (worst case: one extra setup run on first resume).
+    const original = makeDraftSprint();
+    const legacy = { ...fromSprint(original) } as Record<string, unknown>;
+    delete legacy['setupRanAt'];
+    legacy['checkRanAt'] = {};
+    const parsed = sprintJsonSchema.safeParse(legacy);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const back = toSprint(parsed.data);
+    expect(back.ok).toBe(true);
+    if (!back.ok) return;
+    expect(back.value.setupRanAt.size).toBe(0);
+
+    // Round-trip: re-emitted JSON carries `setupRanAt: {}` and no
+    // `checkRanAt` key, so the next save self-cleans.
+    const reEmitted = fromSprint(back.value) as unknown as Record<string, unknown>;
+    expect(reEmitted['setupRanAt']).toStrictEqual({});
+    expect(reEmitted).not.toHaveProperty('checkRanAt');
+  });
+
+  it('loads legacy sprint.json with no audit-map key at all (defaults to empty)', () => {
+    // Some older drafts may have predated the audit map entirely. The
+    // schema must accept the absence and default to an empty Map.
+    const original = makeDraftSprint();
+    const legacy = { ...fromSprint(original) } as Record<string, unknown>;
+    delete legacy['setupRanAt'];
+    const parsed = sprintJsonSchema.safeParse(legacy);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const back = toSprint(parsed.data);
+    expect(back.ok).toBe(true);
+    if (!back.ok) return;
+    expect(back.value.setupRanAt.size).toBe(0);
+  });
 });

--- a/src/integration/persistence/schemas/sprint-schema.ts
+++ b/src/integration/persistence/schemas/sprint-schema.ts
@@ -45,7 +45,13 @@ export const sprintJsonSchema = z.object({
   // to `[]` on a fresh draft sprint, populated post-plan).
   affectedRepositories: z.array(z.string()),
   // `Map<AbsolutePath, IsoTimestamp>` — serialised as a plain object map.
-  setupRanAt: z.record(z.string(), z.string()),
+  // Backwards-compat: v0.6.2 wrote this audit map under the legacy key
+  // `checkRanAt` and may not have emitted any key at all on older drafts.
+  // `.optional().default({})` accepts both shapes; Zod silently strips the
+  // legacy `checkRanAt` payload on the next save (a stale audit trail under
+  // the wrong key has no migration value — the worst case is one extra
+  // setup run on first resume).
+  setupRanAt: z.record(z.string(), z.string()).optional().default({}),
   tickets: z.array(ticketJsonSchema),
 });
 

--- a/src/integration/persistence/session-folder-helpers.ts
+++ b/src/integration/persistence/session-folder-helpers.ts
@@ -66,7 +66,7 @@ function renderInputsLine(phase: Phase): string {
   if (phase === 'plan')
     return '- Inputs: per-ticket refined requirements live alongside this folder under `../refinement/<unit>/requirements.json`. Write your generated `tasks.json` to `./tasks.json` in this folder.\n';
   // evaluate
-  return '- Inputs are in `./task.md` (the task under review), `./tasks.md` / `./tasks.json` (full task plan), `./requirements/` (per-ticket requirements), `./project-context.md` (target repo context), `./dimensions.md` (grading rubric), and `./prior-evaluations/` (prior sibling evaluations from this sprint).\n';
+  return '- Inputs are in `./task.md` (the task under review), `./tasks.md` (full task plan including any sibling evaluator output), `./requirements/` (per-ticket requirements), `./project-context.md` (target repo context), and `./dimensions.md` (grading rubric).\n';
 }
 
 function renderRepoLine(phase: Phase, affectedRepos: readonly AbsolutePath[], copilot: boolean): string {


### PR DESCRIPTION
## Summary

Three commits on the back of the v0.6.2 setup/check-split branch:

- **`refactor(execute): slim per-task execution unit folder`** — drops per-unit `tasks.json` and `prior-evaluations/`; the canonical sprint-root copy + the inline `### Evaluator output` block in `tasks.md` cover both.
- **`docs: replace stale evaluations/<taskId>.md path with per-round truth`** — CLAUDE.md / ARCHITECTURE.md / REQUIREMENTS.md now point at `execution/<unit-slug>/rounds/<N>/evaluator/evaluation.md` (the actual file `EvaluateAndFixLoopUseCase` writes) instead of the legacy sidecar path.
- **`fix(execute): release-readiness fixes for setup/check split`** — six audit findings against `0b6eece4..HEAD` so v0.6.2 users can upgrade without losing sprints and the chain trace + adapter contracts match the tests that fence them.

## Release-readiness fixes (last commit)

- **Legacy `sprint.json` files load.** Zod schema defaults `setupRanAt` to `{}`; v0.6.2 files carrying `checkRanAt` (the legacy key) parse successfully and self-clean on the next save. Two new sprint-schema tests cover the round-trip and the no-audit-key-at-all variant.
- **Spawn-level setup failures hard-abort.** `setup-scripts-sprint-start` now wraps the `runSetupScript` call in `try/catch`; ENOENT, EPERM, missing binary all surface as `InvalidStateError({ currentState: 'setup-failed' })` naming the failing repo — identical to a non-zero exit. The soft `OnError` fallback (`setup-scripts-sprint-start-noop`) is gone — a broken baseline must fail loudly.
- **Sprint resume skips already-stamped repos.** The leaf no-ops per repo when `Sprint.setupRanAt[repoPath]` already carries a timestamp; the existing stamp is preserved.
- **Identity-leaf helper consolidated.** Single shared `noopLeaf<TCtx>(name)` at `src/application/chains/leaves/noop-leaf.ts`; the duplicate `noopLeafExec` / `noopLeaf` definitions in `execute-flow.ts` and `per-task-flow.ts` are removed.
- **Tester agent memory** line 232 references `setupRanAt` (post-rename field).
- **Docs synced** — CHANGELOG Unreleased, CLAUDE.md, ARCHITECTURE.md, REQUIREMENTS.md.

## Pipeline (post-merge)

```
sprint start
  resolve-branch
  dirty-tree-preflight
  resolve-check-scripts
  setup-scripts-sprint-start    ← now hard-aborts on ANY setup failure
                                   (red exit OR spawn-level error);
                                   skips repos already stamped on
                                   sprint.setupRanAt (resume case)
loop per task:
  branch-preflight
  execute-task
  post-task-check
  evaluate-task
  mark-done
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 233 files, 2262 tests pass (4 new: legacy-checkRanAt round-trip, no-audit-key fallback, hard-aborts on spawn error, skip-if-stamped + mixed-stamps)
- [x] `grep -rn "function noopLeaf" src/` returns exactly one match (the new shared module)
- [x] `grep -rn "setup-scripts-sprint-start-noop" src/` returns only the negative-assertion lines in the new test
- [ ] Manual smoke — `RALPHCTL_ROOT=/tmp/legacy ralphctl sprint show` against a hand-crafted v0.6.2 `sprint.json` with `checkRanAt: {}`: should load without error
- [ ] Manual smoke — kill `sprint start` mid-task, re-run: setup script does NOT re-execute on the stamped repo
- [ ] Manual smoke — point `setupScript` at a non-existent binary: chain hard-aborts naming the failing repo