### PR TITLE
chore(release): 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-06
+
 ### Changed
 
 - **Setup ≠ check.** Sprint start now runs each repo's configured `setupScript` (the deterministic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.6.3
- Promote `## [Unreleased]` CHANGELOG section to `## [0.6.3]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green