### PR TITLE
fix(ai,tui): plug onto the repo + doctor/log-level/detect-prompts

### DIFF
--- a/.claude/docs/KERNEL-DESIGN.md
+++ b/.claude/docs/KERNEL-DESIGN.md
@@ -215,41 +215,47 @@ The final returned `Trace` is the union of those emissions. Live UIs subscribe v
 sequential('refine', [
   loadSprintLeaf,
   assertDraftLeaf,
-  linkSkillsLeaf,
   sequential(
     'per-ticket',
     tickets.map((t) =>
       sequential(`ticket-${t.id}`, [
         buildUnitLeaf(/* refinement/<ticket-slug>/ */),
+        installSkillsLeaf({ name: `install-skills-${t.id}` }),
         renderPromptToFileLeaf,
         callRefineInteractiveLeaf, // reads <unit-root>/requirements.md, updates ticket
         saveSprintLeaf,
+        uninstallSkillsLeaf({ name: `uninstall-skills-${t.id}` }),
       ])
     )
   ),
   exportRequirementsLeaf,
-  unlinkSkillsLeaf,
 ]);
 ```
 
 ### implementFlow (per-task gen-eval loop)
 
 ```ts
-const perTask = sequential('per-task', [
-  preflightTaskLeaf,
+const perTask = sequential('task-<id>', [
+  branchPreflightLeaf,
+  buildTaskWorkspaceLeaf,
+  installSkillsLeaf, // copies bundled skills into <repo>; git-excludes via ralphctl-*
   startAttemptLeaf,
-  withRepoLock(
-    sequential('attempt', [
-      buildTaskWorkspaceLeaf,
-      loop('gen-eval', sequential('round', [generatorLeaf, evaluatorLeaf, finalizeGenEvalLeaf]), {
-        shouldStop: (ctx) => ctx.attempt.evaluation?.passed === true,
-        maxIterations: ctx.task.maxAttempts ?? settings.harness.maxAttempts,
-      }),
-      postTaskCheckLeaf,
-      commitTaskLeaf,
-    ])
+  loop(
+    'gen-eval-<id>',
+    sequential('gen-eval-turn-<id>', [
+      generatorLeaf,
+      guard('evaluator-guard-<id>', (ctx) => ctx.lastExit === undefined, evaluatorLeaf),
+    ]),
+    {
+      shouldStop: (ctx) => ctx.lastExit !== undefined,
+      maxIterations: settings.harness.maxTurns,
+    }
   ),
+  finalizeGenEvalLeaf,
+  postTaskCheckLeaf,
+  guard('commit-task-guard-<id>', (ctx) => ctx.lastBlockReason === undefined, commitTaskLeaf),
   settleAttemptLeaf,
+  uninstallSkillsLeaf, // removes harness-installed ralphctl-* skills from <repo>
 ]);
 
 // Linearise tasks via topologicalReorder over `task.blockedBy` and feed
@@ -262,13 +268,11 @@ sequential('implement', [
   resolveBranchLeaf,
   ensureProgressFileLeaf,
   setupScriptRunnerLeaf,
-  linkSkillsLeaf,
   sequential(
     'execute-tasks',
-    orderedTasks.map(() => perTask)
+    orderedTasks.map(() => perTask) // each perTask brackets with install-skills-<id> / uninstall-skills-<id>
   ),
   flushProgressSinkLeaf,
-  unlinkSkillsLeaf,
   transitionSprintToReviewLeaf,
 ]);
 ```

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -134,8 +134,10 @@ Status flow: `draft → active → review → done`.
 - [ ] **Exponential backoff** — rate-limit retries use `rate-limit-backoff.ts` (`integration/ai/providers/_engine/`).
 - [ ] **Interactive variant** — `InteractiveAiProvider` hands over the terminal (alt-screen swap to the AI's
       own UI); the TUI restores its alt-screen state on the way back.
-- [ ] **Bundled skills** — `linkSkillsLeaf` / `unlinkSkillsLeaf` bracket every AI session that benefits from
-      defaults. Project skills always win over bundled ones. Adapter is no-op for Codex / Copilot today.
+- [ ] **Bundled skills** — `installSkillsLeaf` / `uninstallSkillsLeaf` bracket every AI session that benefits
+      from defaults. Skills are copied into `<repo>/<parentDir>/skills/ralphctl-<name>/` and git-excluded via a
+      single `ralphctl-*` wildcard appended to `.git/info/exclude`. Project skills always win over bundled ones.
+      Adapter is no-op for Codex / Copilot today.
 - [ ] **Provider-native context file** — `readiness` flow writes `CLAUDE.md` (Claude),
       `.github/copilot-instructions.md` (Copilot), or `AGENTS.md` (Codex) based on `settings.ai.provider`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,10 +193,14 @@ fenced from business code by the layer rules.
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
 or fallback catches errors, it MUST exempt `AbortError`.
 
-**AI sessions run in sandbox folders** under `<sprintDir>/<flow>/<unit-slug>/`. The `refine` / `plan` /
-`ideate` / `implement` flows pre-stage `prompt.md`, the provider-native context file, bundled skills, and
-contract files there. Affected repos are exposed via `--add-dir` (Claude) or mirrored under `<unit>/repos/`
-(Copilot / Codex). Never run an AI session in a user repo — the sandbox keeps writes auditable.
+**AI sessions plug onto the repo.** Cwd is the user's repo (multi-repo flows pick `repositories[0]`);
+the per-flow sandbox under `<sprintDir>/<flow>/<unit-slug>/` is mounted via `--add-dir` so `prompt.md`,
+`done-criteria.md`, and `signals.json` round-trip through harness-controlled paths. Cwd is the repo because
+Claude / Copilot / Codex only auto-discover their context file (`CLAUDE.md` / `.github/copilot-instructions.md`
+/ `AGENTS.md`), skills (`.claude/skills/` / `.github/skills/` / `.agents/skills/`), agents, and `.mcp.json`
+from cwd — not from `--add-dir` roots. Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-*/`
+and the skills adapter appends one wildcard line to `.git/info/exclude` on first install so they never appear
+in `git status` or `git add -A`.
 
 **Bundled skills always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already exists, the
 bundled copy is skipped and the project copy is left untouched. The skills adapter

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -266,7 +266,7 @@ export const wire = (opts: WireOptions): AppDeps => {
       currentVersion: CLI_METADATA.currentVersion,
       packageName: CLI_METADATA.packageName,
     }),
-    skillsAdapter: createSkillsAdapter({ provider: opts.settings.ai.provider }),
+    skillsAdapter: createSkillsAdapter({ provider: opts.settings.ai.provider, logger }),
     skillSource: createBundledSkillSource(),
   };
 };

--- a/src/application/flows/_shared/skills/install-skills.ts
+++ b/src/application/flows/_shared/skills/install-skills.ts
@@ -1,9 +1,9 @@
 /**
- * `linkSkillsLeaf` — install bundled skills into the AI session's sandbox before the session
+ * `installSkillsLeaf` — install bundled skills into the AI session's sandbox before the session
  * runs.
  *
- * Pairs with {@link unlinkSkillsLeaf}. The flow brackets every AI step with
- * `link → … → unlink`; both leaves dispatch through the wired {@link SkillsAdapter}, which
+ * Pairs with {@link uninstallSkillsLeaf}. The flow brackets every AI step with
+ * `install → … → uninstall`; both leaves dispatch through the wired {@link SkillsAdapter}, which
  * is provider-aware (Claude writes to `.claude/skills/`, Copilot / Codex log + no-op).
  *
  * The leaf does not throw if the skill source has no skills configured for the flow — an
@@ -23,12 +23,12 @@ import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-po
 import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
 
-export interface LinkSkillsDeps {
+export interface InstallSkillsDeps {
   readonly skillsAdapter: SkillsAdapter;
   readonly skillSource: SkillSource;
 }
 
-export interface LinkSkillsOptions<TCtx> {
+export interface InstallSkillsOptions<TCtx> {
   readonly name?: string;
   readonly flowId: FlowId;
   /** Project the chain context to the AI session's cwd. Throws if the upstream leaves haven't
@@ -36,8 +36,8 @@ export interface LinkSkillsOptions<TCtx> {
   readonly cwdPicker: (ctx: TCtx) => AbsolutePath;
 }
 
-export const linkSkillsLeaf = <TCtx>(deps: LinkSkillsDeps, opts: LinkSkillsOptions<TCtx>): Element<TCtx> => {
-  const name = opts.name ?? 'link-skills';
+export const installSkillsLeaf = <TCtx>(deps: InstallSkillsDeps, opts: InstallSkillsOptions<TCtx>): Element<TCtx> => {
+  const name = opts.name ?? 'install-skills';
   return leaf<TCtx, { readonly cwd: AbsolutePath }, void>(name, {
     useCase: {
       async execute(input): Promise<Result<void, DomainError>> {

--- a/src/application/flows/_shared/skills/uninstall-skills.ts
+++ b/src/application/flows/_shared/skills/uninstall-skills.ts
@@ -1,5 +1,5 @@
 /**
- * `unlinkSkillsLeaf` — uninstall bundled skills the matching {@link linkSkillsLeaf} placed
+ * `uninstallSkillsLeaf` — uninstall bundled skills the matching {@link installSkillsLeaf} placed
  * into the sandbox.
  *
  * Idempotent: dispatching to an adapter that never saw an install (or has already been
@@ -13,19 +13,22 @@ import { leaf } from '@src/application/chain/build/leaf.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
-export interface UnlinkSkillsDeps {
+export interface UninstallSkillsDeps {
   readonly skillsAdapter: SkillsAdapter;
 }
 
-export interface UnlinkSkillsOptions<TCtx> {
+export interface UninstallSkillsOptions<TCtx> {
   readonly name?: string;
-  /** Same picker as the matching `linkSkillsLeaf` — ensures install/uninstall target the
+  /** Same picker as the matching `installSkillsLeaf` — ensures install/uninstall target the
    * same sandbox even when the chain has multiple AI sub-sessions per run. */
   readonly cwdPicker: (ctx: TCtx) => AbsolutePath;
 }
 
-export const unlinkSkillsLeaf = <TCtx>(deps: UnlinkSkillsDeps, opts: UnlinkSkillsOptions<TCtx>): Element<TCtx> => {
-  const name = opts.name ?? 'unlink-skills';
+export const uninstallSkillsLeaf = <TCtx>(
+  deps: UninstallSkillsDeps,
+  opts: UninstallSkillsOptions<TCtx>
+): Element<TCtx> => {
+  const name = opts.name ?? 'uninstall-skills';
   return leaf<TCtx, { readonly cwd: AbsolutePath }, void>(name, {
     useCase: {
       execute: async (input) => deps.skillsAdapter.uninstall(input.cwd),

--- a/src/application/flows/detect-scripts/leaves/propose.ts
+++ b/src/application/flows/detect-scripts/leaves/propose.ts
@@ -14,7 +14,8 @@ import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { buildDetectScriptsPrompt } from '@src/integration/ai/prompts/detect-scripts/definition.ts';
 import { consumeSignals } from '@src/integration/ai/signals/_engine/consume-signals.ts';
-import { withSignalsTempPath } from '@src/integration/ai/signals/_engine/temp-signals-file.ts';
+import { withSignalsTempPath, allocSignalsTempPath } from '@src/integration/ai/signals/_engine/temp-signals-file.ts';
+import { removeFile } from '@src/integration/io/fs.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 import type { DetectScriptsCtx } from '@src/application/flows/detect-scripts/ctx.ts';
 
@@ -23,13 +24,15 @@ export const detectScriptsSession = (
   repository: Repository,
   prompt: Prompt,
   model: string,
-  signalsFile: AbsolutePath
+  signalsFile: AbsolutePath,
+  bodyFile?: AbsolutePath
 ): AiSession => ({
   prompt,
   cwd: repository.path,
   model,
   permissions: READ_ONLY,
   signalsFile,
+  ...(bodyFile !== undefined ? { bodyFile } : {}),
 });
 
 export interface ProposeDetectScriptsLeafDeps {
@@ -74,38 +77,58 @@ const proposeUseCase = async (
   });
   if (!prompt.ok) return Result.error(prompt.error);
 
-  return withSignalsTempPath('detect-scripts', async (signalsFile) => {
-    const signals = await consumeSignals(
-      deps.provider,
-      detectScriptsSession(input.repository, prompt.value, deps.model, signalsFile),
-      deps.signals
-    );
-    if (!signals.ok) {
-      log.error(`provider failed for repo ${input.repository.name}`, {
+  // Allocate a sibling body file for diagnostic capture. When the AI returns no proposals,
+  // the operator can inspect this file to see what the assistant actually emitted.
+  // Only the Claude adapter implements bodyFile; other adapters silently no-op.
+  const bodyPathResult = allocSignalsTempPath('detect-scripts-body');
+  const bodyFile = bodyPathResult.ok ? bodyPathResult.value : undefined;
+
+  try {
+    return await withSignalsTempPath('detect-scripts', async (signalsFile) => {
+      const signals = await consumeSignals(
+        deps.provider,
+        detectScriptsSession(input.repository, prompt.value, deps.model, signalsFile, bodyFile),
+        deps.signals
+      );
+      if (!signals.ok) {
+        log.error(`provider failed for repo ${input.repository.name}`, {
+          repositoryId: String(input.repository.id),
+          error: signals.error.message,
+        });
+        return Result.error(signals.error);
+      }
+
+      const setupScript = signals.value.find(
+        (s: HarnessSignal): s is SetupScriptSignal => s.type === 'setup-script'
+      )?.command;
+      const verifyScript = signals.value.find(
+        (s: HarnessSignal): s is VerifyScriptSignal => s.type === 'verify-script'
+      )?.command;
+
+      if (setupScript === undefined && verifyScript === undefined && bodyFile !== undefined) {
+        log.debug(`AI returned no proposals for repo ${input.repository.name} — inspect body file for raw response`, {
+          repositoryId: String(input.repository.id),
+          bodyFile: String(bodyFile),
+        });
+      }
+
+      log.info(`proposal ready for repo ${input.repository.name}`, {
         repositoryId: String(input.repository.id),
-        error: signals.error.message,
+        hasSetupScript: setupScript !== undefined,
+        hasVerifyScript: verifyScript !== undefined,
       });
-      return Result.error(signals.error);
+
+      return Result.ok({
+        ...(setupScript !== undefined ? { proposedSetupScript: setupScript } : {}),
+        ...(verifyScript !== undefined ? { proposedVerifyScript: verifyScript } : {}),
+      });
+    });
+  } finally {
+    // Best-effort cleanup of the diagnostic body file. Orphan tempfiles are bounded by os.tmpdir() rotation.
+    if (bodyFile !== undefined) {
+      await removeFile(String(bodyFile));
     }
-
-    const setupScript = signals.value.find(
-      (s: HarnessSignal): s is SetupScriptSignal => s.type === 'setup-script'
-    )?.command;
-    const verifyScript = signals.value.find(
-      (s: HarnessSignal): s is VerifyScriptSignal => s.type === 'verify-script'
-    )?.command;
-
-    log.info(`proposal ready for repo ${input.repository.name}`, {
-      repositoryId: String(input.repository.id),
-      hasSetupScript: setupScript !== undefined,
-      hasVerifyScript: verifyScript !== undefined,
-    });
-
-    return Result.ok({
-      ...(setupScript !== undefined ? { proposedSetupScript: setupScript } : {}),
-      ...(verifyScript !== undefined ? { proposedVerifyScript: verifyScript } : {}),
-    });
-  });
+  }
 };
 
 export const proposeDetectScriptsLeaf = (deps: ProposeDetectScriptsLeafDeps): Element<DetectScriptsCtx> =>

--- a/src/application/flows/detect-skills/leaves/propose.ts
+++ b/src/application/flows/detect-skills/leaves/propose.ts
@@ -14,7 +14,8 @@ import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { buildDetectSkillsPrompt } from '@src/integration/ai/prompts/detect-skills/definition.ts';
 import { consumeSignals } from '@src/integration/ai/signals/_engine/consume-signals.ts';
-import { withSignalsTempPath } from '@src/integration/ai/signals/_engine/temp-signals-file.ts';
+import { withSignalsTempPath, allocSignalsTempPath } from '@src/integration/ai/signals/_engine/temp-signals-file.ts';
+import { removeFile } from '@src/integration/io/fs.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { DetectSkillsCtx } from '@src/application/flows/detect-skills/ctx.ts';
@@ -24,13 +25,15 @@ export const detectSkillsSession = (
   repository: Repository,
   prompt: Prompt,
   model: string,
-  signalsFile: AbsolutePath
+  signalsFile: AbsolutePath,
+  bodyFile?: AbsolutePath
 ): AiSession => ({
   prompt,
   cwd: repository.path,
   model,
   permissions: READ_ONLY,
   signalsFile,
+  ...(bodyFile !== undefined ? { bodyFile } : {}),
 });
 
 export interface ProposeDetectSkillsLeafDeps {
@@ -73,40 +76,60 @@ const proposeUseCase = async (
   });
   if (!prompt.ok) return Result.error(prompt.error);
 
-  return withSignalsTempPath('detect-skills', async (signalsFile) => {
-    const signals = await consumeSignals(
-      deps.provider,
-      detectSkillsSession(input.repository, prompt.value, deps.model, signalsFile),
-      deps.signals
-    );
-    if (!signals.ok) {
-      log.error(`provider failed for repo ${input.repository.name}`, {
+  // Allocate a sibling body file for diagnostic capture. When the AI returns no proposals,
+  // the operator can inspect this file to see what the assistant actually emitted.
+  // Only the Claude adapter implements bodyFile; other adapters silently no-op.
+  const bodyPathResult = allocSignalsTempPath('detect-skills-body');
+  const bodyFile = bodyPathResult.ok ? bodyPathResult.value : undefined;
+
+  try {
+    return await withSignalsTempPath('detect-skills', async (signalsFile) => {
+      const signals = await consumeSignals(
+        deps.provider,
+        detectSkillsSession(input.repository, prompt.value, deps.model, signalsFile, bodyFile),
+        deps.signals
+      );
+      if (!signals.ok) {
+        log.error(`provider failed for repo ${input.repository.name}`, {
+          repositoryId: String(input.repository.id),
+          error: signals.error.message,
+        });
+        return Result.error(signals.error);
+      }
+
+      const setupSkill = signals.value.find(
+        (s: HarnessSignal): s is SetupSkillProposalSignal => s.type === 'setup-skill-proposal'
+      )?.content;
+      const verifySkill = signals.value.find(
+        (s: HarnessSignal): s is VerifySkillProposalSignal => s.type === 'verify-skill-proposal'
+      )?.content;
+
+      if (setupSkill === undefined && verifySkill === undefined && bodyFile !== undefined) {
+        log.debug(`AI returned no proposals for repo ${input.repository.name} — inspect body file for raw response`, {
+          repositoryId: String(input.repository.id),
+          bodyFile: String(bodyFile),
+        });
+      }
+
+      log.info(`proposal ready for repo ${input.repository.name}`, {
         repositoryId: String(input.repository.id),
-        error: signals.error.message,
+        hasSetupSkill: setupSkill !== undefined,
+        hasVerifySkill: verifySkill !== undefined,
+        setupLength: setupSkill?.length ?? 0,
+        verifyLength: verifySkill?.length ?? 0,
       });
-      return Result.error(signals.error);
+
+      return Result.ok({
+        ...(setupSkill !== undefined ? { proposedSetupSkill: setupSkill } : {}),
+        ...(verifySkill !== undefined ? { proposedVerifySkill: verifySkill } : {}),
+      });
+    });
+  } finally {
+    // Best-effort cleanup of the diagnostic body file. Orphan tempfiles are bounded by os.tmpdir() rotation.
+    if (bodyFile !== undefined) {
+      await removeFile(String(bodyFile));
     }
-
-    const setupSkill = signals.value.find(
-      (s: HarnessSignal): s is SetupSkillProposalSignal => s.type === 'setup-skill-proposal'
-    )?.content;
-    const verifySkill = signals.value.find(
-      (s: HarnessSignal): s is VerifySkillProposalSignal => s.type === 'verify-skill-proposal'
-    )?.content;
-
-    log.info(`proposal ready for repo ${input.repository.name}`, {
-      repositoryId: String(input.repository.id),
-      hasSetupSkill: setupSkill !== undefined,
-      hasVerifySkill: verifySkill !== undefined,
-      setupLength: setupSkill?.length ?? 0,
-      verifyLength: verifySkill?.length ?? 0,
-    });
-
-    return Result.ok({
-      ...(setupSkill !== undefined ? { proposedSetupSkill: setupSkill } : {}),
-      ...(verifySkill !== undefined ? { proposedVerifySkill: verifySkill } : {}),
-    });
-  });
+  }
 };
 
 export const proposeDetectSkillsLeaf = (deps: ProposeDetectSkillsLeafDeps): Element<DetectSkillsCtx> =>

--- a/src/application/flows/ideate/flow.ts
+++ b/src/application/flows/ideate/flow.ts
@@ -101,10 +101,9 @@ export const createIdeateFlow = (deps: IdeateDeps, opts: CreateIdeateFlowOpts): 
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       {
         flowId: 'ideate',
-        cwdPicker: (ctx) => {
-          if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          return ctx.currentUnitRoot;
-        },
+        // Skills land in the AI session's cwd (the repo) — the provider-native conventions
+        // only auto-discover skills from cwd, not from `--add-dir` roots.
+        cwdPicker: () => opts.cwd,
       }
     ),
     ideateAndPlanLeaf({
@@ -113,15 +112,7 @@ export const createIdeateFlow = (deps: IdeateDeps, opts: CreateIdeateFlowOpts): 
       logger: deps.logger,
       model: opts.model,
     }),
-    unlinkSkillsLeaf<IdeateCtx>(
-      { skillsAdapter: deps.skillsAdapter },
-      {
-        cwdPicker: (ctx) => {
-          if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          return ctx.currentUnitRoot;
-        },
-      }
-    ),
+    unlinkSkillsLeaf<IdeateCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
     saveSprintLeaf<IdeateCtx>({ sprintRepo: deps.sprintRepo }),
     saveTasksLeaf<IdeateCtx>({ taskRepo: deps.taskRepo }),
   ]);

--- a/src/application/flows/ideate/flow.ts
+++ b/src/application/flows/ideate/flow.ts
@@ -15,8 +15,8 @@ import { buildIdeatePrompt } from '@src/integration/ai/prompts/ideate/definition
 import type { IdeateCtx } from '@src/application/flows/ideate/ctx.ts';
 import type { IdeateDeps } from '@src/application/flows/ideate/deps.ts';
 import { ideateAndPlanLeaf } from '@src/application/flows/ideate/leaves/ideate-and-plan.ts';
-import { linkSkillsLeaf } from '@src/application/flows/_shared/skills/link-skills.ts';
-import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-skills.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 
 export interface CreateIdeateFlowOpts {
   readonly sprintId: SprintId;
@@ -97,7 +97,7 @@ export const createIdeateFlow = (deps: IdeateDeps, opts: CreateIdeateFlowOpts): 
         write: (ctx, path) => ({ ...ctx, currentPromptFile: path }),
       }
     ),
-    linkSkillsLeaf<IdeateCtx>(
+    installSkillsLeaf<IdeateCtx>(
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       {
         flowId: 'ideate',
@@ -112,7 +112,7 @@ export const createIdeateFlow = (deps: IdeateDeps, opts: CreateIdeateFlowOpts): 
       logger: deps.logger,
       model: opts.model,
     }),
-    unlinkSkillsLeaf<IdeateCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
+    uninstallSkillsLeaf<IdeateCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
     saveSprintLeaf<IdeateCtx>({ sprintRepo: deps.sprintRepo }),
     saveTasksLeaf<IdeateCtx>({ taskRepo: deps.taskRepo }),
   ]);

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -33,8 +33,8 @@ import { startAttemptLeaf } from '@src/application/flows/implement/leaves/start-
 import { buildTaskWorkspaceLeaf } from '@src/application/flows/implement/leaves/build-task-workspace.ts';
 import { transitionSprintToReviewLeaf } from '@src/application/flows/implement/leaves/transition-sprint-to-review.ts';
 import { withRepoLock } from '@src/application/flows/implement/leaves/with-repo-lock.ts';
-import { linkSkillsLeaf } from '@src/application/flows/_shared/skills/link-skills.ts';
-import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-skills.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 
 /**
  * Per-task subchain's terminal leaf — the leaf that marks "this task is fully settled" for the
@@ -44,7 +44,7 @@ import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-s
  * detection. Keep this in sync with the actual final element name returned from
  * `perTaskSubChain` below.
  */
-export const IMPLEMENT_TASK_TERMINAL_LEAF = 'unlink-skills';
+export const IMPLEMENT_TASK_TERMINAL_LEAF = 'uninstall-skills';
 
 /**
  * Per-repository execution config — path + the scripts the chain runs against that repo. The
@@ -111,13 +111,13 @@ export interface CreateImplementFlowOpts {
  *           sequential('task-<id>', [
  *             branch-preflight-<id>,       // halt if working tree drifted off the sprint branch
  *             build-task-workspace-<id>,
- *             link-skills-<id>,            // → <sprintDir>/implement/<task-id>/.claude/skills/
+ *             install-skills-<id>,         // → <sprintDir>/implement/<task-id>/.claude/skills/
  *             start-attempt-<id>,
  *             gen-eval-loop-<id>,
  *             commit-task-<id>,
  *             post-task-check,
  *             settle-attempt-<id>,
- *             unlink-skills-<id>,
+ *             uninstall-skills-<id>,
  *           ]),
  *           ...
  *         ]),
@@ -136,7 +136,7 @@ export interface CreateImplementFlowOpts {
  * Preflight rationale: the dirty-tree check is a precondition for the whole invocation, not for
  * each task. Between tasks the tree is clean (commit-task commits each task's work), so a
  * per-task check just re-asserts what's already known. Running preflight ONCE at the outer level
- * also lets `link-skills` materialise its files afterwards without tripping the check.
+ * also lets `install-skills` materialise its files afterwards without tripping the check.
  *
  * Branch preflight rationale: the dirty-tree check is one-shot but the branch can drift mid-run
  * (an AI generator turn with shell access could `git checkout` away). `resolve-branch` pins the
@@ -218,7 +218,7 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
   });
   const signalsBroadcast = broadcastSink<HarnessSignal>([deps.signals, progressSink]);
 
-  // `linkSkillsLeaf` writes the bundled skill set to `<repo>/<parentDir>/skills/ralphctl-*/`.
+  // `installSkillsLeaf` writes the bundled skill set to `<repo>/<parentDir>/skills/ralphctl-*/`.
   // Pointing it at `repo.path` is what makes per-repo project skills, `.mcp.json`, and the
   // provider-native context file (CLAUDE.md / .github/copilot-instructions.md / AGENTS.md)
   // visible to the running AI — those are only auto-discovered from cwd, not from `--add-dir`
@@ -255,9 +255,9 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
         },
         taskId
       ),
-      linkSkillsLeaf<ImplementCtx>(
+      installSkillsLeaf<ImplementCtx>(
         { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
-        { name: `link-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
+        { name: `install-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
       ),
       startAttemptLeaf({ taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger }, taskId),
       // Composite: per-turn generator + evaluator, repeated until a terminal exit is set on ctx
@@ -306,7 +306,7 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
         { cwd: repo.path },
         taskId
       ),
-      unlinkSkillsLeaf<ImplementCtx>(
+      uninstallSkillsLeaf<ImplementCtx>(
         { skillsAdapter: deps.skillsAdapter },
         { name: `${IMPLEMENT_TASK_TERMINAL_LEAF}-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
       ),

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -127,9 +127,11 @@ export interface CreateImplementFlowOpts {
  *     ),
  *   ])
  *
- * Skills are linked into the per-task workspace under our data root, NOT the user's repo —
- * the AI session uses that workspace as its `cwd` and mounts the user's repo as `--add-dir`.
- * The user's git status stays clean of harness-managed context.
+ * Skills are linked into the user's repo at `<repo>/<parentDir>/skills/ralphctl-<name>/` — the
+ * provider-native conventions (`.claude/skills`, `.github/skills`, `.agents/skills`) only
+ * auto-discover from cwd, so the AI session uses the repo as its `cwd` and the per-task
+ * workspace as `--add-dir`. The `ralphctl-` prefix combined with one wildcard line in
+ * `.git/info/exclude` keeps `git status` clean of harness-managed context.
  *
  * Preflight rationale: the dirty-tree check is a precondition for the whole invocation, not for
  * each task. Between tasks the tree is clean (commit-task commits each task's work), so a
@@ -216,16 +218,13 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
   });
   const signalsBroadcast = broadcastSink<HarnessSignal>([deps.signals, progressSink]);
 
-  // `linkSkillsLeaf` writes the bundled skill set to `<sessionDir>/.claude/skills/`. Pointing
-  // it at `ctx.taskWorkspaceRoot` keeps that managed context inside the harness dir; the user's
-  // repo never sees a `.claude/skills/` write, so `git add -A` can't accidentally commit them.
-  // The implement session uses the same workspace as its cwd and mounts the repo via
-  // `--add-dir`, so the AI still has full access to repo-specific `.claude/`, `.mcp.json`,
-  // `agents/`, etc.
-  const taskWorkspaceCwdPicker = (ctx: ImplementCtx): AbsolutePath => {
-    if (ctx.taskWorkspaceRoot === undefined) throw new Error('taskWorkspaceRoot missing');
-    return ctx.taskWorkspaceRoot;
-  };
+  // `linkSkillsLeaf` writes the bundled skill set to `<repo>/<parentDir>/skills/ralphctl-*/`.
+  // Pointing it at `repo.path` is what makes per-repo project skills, `.mcp.json`, and the
+  // provider-native context file (CLAUDE.md / .github/copilot-instructions.md / AGENTS.md)
+  // visible to the running AI — those are only auto-discovered from cwd, not from `--add-dir`
+  // roots. The `ralphctl-` prefix + the wildcard line the skills adapter appends to
+  // `.git/info/exclude` keeps the harness-authored copies out of the user's git tree.
+  const repoCwdPicker = (repoPath: AbsolutePath) => (): AbsolutePath => repoPath;
 
   const perTaskSubChain = (task: Task): Element<ImplementCtx> => {
     const taskId = task.id;
@@ -258,7 +257,7 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
       ),
       linkSkillsLeaf<ImplementCtx>(
         { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
-        { name: `link-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: taskWorkspaceCwdPicker }
+        { name: `link-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
       ),
       startAttemptLeaf({ taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger }, taskId),
       // Composite: per-turn generator + evaluator, repeated until a terminal exit is set on ctx
@@ -309,7 +308,7 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
       ),
       unlinkSkillsLeaf<ImplementCtx>(
         { skillsAdapter: deps.skillsAdapter },
-        { name: `${IMPLEMENT_TASK_TERMINAL_LEAF}-${String(taskId)}`, cwdPicker: taskWorkspaceCwdPicker }
+        { name: `${IMPLEMENT_TASK_TERMINAL_LEAF}-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
       ),
     ]);
   };

--- a/src/application/flows/implement/leaves/implement-session.ts
+++ b/src/application/flows/implement/leaves/implement-session.ts
@@ -4,20 +4,25 @@ import { FULL_AUTO } from '@src/integration/ai/providers/_engine/session-permiss
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 
 /**
- * Per-call AiSession profile for implement and evaluate calls. Two-tier mount layout:
+ * Per-call AiSession profile for implement and evaluate calls. The session "plugs onto" the
+ * repo: the user's repo is the foundation; the harness extends it with the per-task sandbox.
  *
- *  - `sandboxCwd` is the AI session's working directory. The per-task workspace under
- *    `<sprintDir>/implement/<task-id>/` is the harness's territory — `linkSkillsLeaf` writes
- *    `.claude/skills/` here, prompt.md / done-criteria.md / rounds/N/* already live here.
- *    Putting the AI session's cwd inside the harness dir means our managed context never
- *    enters the user's repo, never shows up in `git status`, never gets `git add -A`'d into
- *    a task commit.
+ *  - `repoPath` is the AI session's working directory. Claude / Copilot / Codex only
+ *    auto-discover their context files (`CLAUDE.md` / `.github/copilot-instructions.md` /
+ *    `AGENTS.md`), skills (`.claude/skills` / `.github/skills` / `.agents/skills`), agents,
+ *    and `.mcp.json` from cwd — not from `--add-dir` roots. Putting cwd at the repo means
+ *    per-repo project guidance is visible to the running AI.
  *
- *  - `repoPath` is mounted as an additional root with `--add-dir`. The AI reads / edits the
- *    user's repo via that path; per-repo `.claude/skills/`, `.mcp.json`, `agents/`, and
- *    whatever else lives there is reachable on top of the harness-linked context. Git
- *    operations (`commit-task`, `branch-preflight`, `post-task-check`) keep targeting this
- *    path — "AI cwd" and "git working tree" are separate concepts.
+ *  - `sandboxCwd` is mounted as an additional root with `--add-dir`. The per-task workspace
+ *    under `<sprintDir>/implement/<task-id>/` carries the harness's handoff files
+ *    (`prompt.md`, `done-criteria.md`, `rounds/<N>/…/signals.json`); the AI reads / writes
+ *    them via that path. Git operations (`commit-task`, `branch-preflight`, `post-task-check`)
+ *    keep targeting `repoPath` — "AI cwd" and "git working tree" are now the same path.
+ *
+ * Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-<name>/` (the
+ * `ralphctl-` prefix is set in the bundled / project skill sources). The skills adapter
+ * appends one wildcard line to `.git/info/exclude` on first install so they never show up
+ * in `git status` or `git add -A`.
  *
  * Both calls run full-auto; the harness's branch / dirty-tree / post-task-check layer is the
  * safety gate, not Claude's per-tool prompts.
@@ -30,8 +35,8 @@ export const implementSession = (
   signalsFile: AbsolutePath
 ): AiSession => ({
   prompt,
-  cwd: sandboxCwd,
-  additionalRoots: [repoPath],
+  cwd: repoPath,
+  additionalRoots: [sandboxCwd],
   model,
   permissions: FULL_AUTO,
   signalsFile,

--- a/src/application/flows/plan/flow.ts
+++ b/src/application/flows/plan/flow.ts
@@ -16,8 +16,8 @@ import { buildPlanPrompt } from '@src/integration/ai/prompts/plan/definition.ts'
 import type { PlanCtx } from '@src/application/flows/plan/ctx.ts';
 import type { PlanDeps } from '@src/application/flows/plan/deps.ts';
 import { callPlannerInteractiveLeaf } from '@src/application/flows/plan/leaves/call-planner-interactive.ts';
-import { linkSkillsLeaf } from '@src/application/flows/_shared/skills/link-skills.ts';
-import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-skills.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 
 export interface CreatePlanFlowOpts {
   readonly sprintId: SprintId;
@@ -106,7 +106,7 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
         write: (ctx, path) => ({ ...ctx, currentPromptFile: path }),
       }
     ),
-    linkSkillsLeaf<PlanCtx>(
+    installSkillsLeaf<PlanCtx>(
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       {
         flowId: 'plan',
@@ -127,7 +127,7 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
         : {}),
       ...(deps.reviewBeforeApprove !== undefined ? { reviewBeforeApprove: deps.reviewBeforeApprove } : {}),
     }),
-    unlinkSkillsLeaf<PlanCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
+    uninstallSkillsLeaf<PlanCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
     saveTasksLeaf<PlanCtx>({ taskRepo: deps.taskRepo }),
     saveSprintLeaf<PlanCtx>({ sprintRepo: deps.sprintRepo }),
   ]);

--- a/src/application/flows/plan/flow.ts
+++ b/src/application/flows/plan/flow.ts
@@ -110,10 +110,9 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       {
         flowId: 'plan',
-        cwdPicker: (ctx) => {
-          if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          return ctx.currentUnitRoot;
-        },
+        // Skills land in the AI session's cwd (the repo) — the provider-native conventions
+        // only auto-discover skills from cwd, not from `--add-dir` roots.
+        cwdPicker: () => opts.cwd,
       }
     ),
     callPlannerInteractiveLeaf({
@@ -128,15 +127,7 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
         : {}),
       ...(deps.reviewBeforeApprove !== undefined ? { reviewBeforeApprove: deps.reviewBeforeApprove } : {}),
     }),
-    unlinkSkillsLeaf<PlanCtx>(
-      { skillsAdapter: deps.skillsAdapter },
-      {
-        cwdPicker: (ctx) => {
-          if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          return ctx.currentUnitRoot;
-        },
-      }
-    ),
+    unlinkSkillsLeaf<PlanCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
     saveTasksLeaf<PlanCtx>({ taskRepo: deps.taskRepo }),
     saveSprintLeaf<PlanCtx>({ sprintRepo: deps.sprintRepo }),
   ]);

--- a/src/application/flows/readiness/flow.ts
+++ b/src/application/flows/readiness/flow.ts
@@ -11,8 +11,8 @@ import { pickToolLeaf } from '@src/application/flows/readiness/leaves/pick-tool.
 import { probeReadinessLeaf } from '@src/application/flows/readiness/leaves/probe.ts';
 import { proposeReadinessLeaf } from '@src/application/flows/readiness/leaves/propose.ts';
 import { writeReadinessLeaf } from '@src/application/flows/readiness/leaves/write.ts';
-import { linkSkillsLeaf } from '@src/application/flows/_shared/skills/link-skills.ts';
-import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-skills.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 
 export interface CreateReadinessFlowOpts {
   readonly projectId: ProjectId;
@@ -55,7 +55,7 @@ export const createReadinessFlow = (deps: SetupReadinessDeps, opts: CreateReadin
     ),
     pickToolLeaf({ interactive: deps.interactive }),
     probeReadinessLeaf({ probes: deps.probes, clock: deps.clock }),
-    linkSkillsLeaf<ReadinessCtx>(
+    installSkillsLeaf<ReadinessCtx>(
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       { flowId: 'readiness', cwdPicker: () => opts.cwd }
     ),
@@ -67,7 +67,7 @@ export const createReadinessFlow = (deps: SetupReadinessDeps, opts: CreateReadin
       cwd: opts.cwd,
       model: opts.model,
     }),
-    unlinkSkillsLeaf<ReadinessCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
+    uninstallSkillsLeaf<ReadinessCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
     confirmReadinessLeaf({ interactive: deps.interactive }),
     writeReadinessLeaf({ writeFile: deps.writeFile, logger: deps.logger, clock: deps.clock }),
   ]);

--- a/src/application/flows/refine/flow.ts
+++ b/src/application/flows/refine/flow.ts
@@ -118,10 +118,9 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
         {
           name: `link-skills-${String(ticket.id)}`,
           flowId: 'refine',
-          cwdPicker: (ctx) => {
-            if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-            return ctx.currentUnitRoot;
-          },
+          // Skills land in the AI session's cwd (the repo) — the provider-native conventions
+          // only auto-discover skills from cwd, not from `--add-dir` roots.
+          cwdPicker: () => opts.cwd,
         }
       ),
       refineTicketInteractiveLeaf(
@@ -139,13 +138,7 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
       ),
       unlinkSkillsLeaf<RefineCtx>(
         { skillsAdapter: deps.skillsAdapter },
-        {
-          name: `unlink-skills-${String(ticket.id)}`,
-          cwdPicker: (ctx) => {
-            if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-            return ctx.currentUnitRoot;
-          },
-        }
+        { name: `unlink-skills-${String(ticket.id)}`, cwdPicker: () => opts.cwd }
       ),
       saveSprintLeaf<RefineCtx>({ sprintRepo: deps.sprintRepo }, `save-after-${String(ticket.id)}`),
     ])

--- a/src/application/flows/refine/flow.ts
+++ b/src/application/flows/refine/flow.ts
@@ -15,8 +15,8 @@ import type { RefineDeps } from '@src/application/flows/refine/deps.ts';
 import { fetchIssueContextLeaf } from '@src/application/flows/refine/leaves/fetch-issue-context.ts';
 import { refineTicketInteractiveLeaf } from '@src/application/flows/refine/leaves/refine-ticket-interactive.ts';
 import { buildRefinePrompt } from '@src/integration/ai/prompts/refine/definition.ts';
-import { linkSkillsLeaf } from '@src/application/flows/_shared/skills/link-skills.ts';
-import { unlinkSkillsLeaf } from '@src/application/flows/_shared/skills/unlink-skills.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 
 export interface CreateRefineFlowOpts {
   readonly sprintId: SprintId;
@@ -113,10 +113,10 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
           write: (ctx, path) => ({ ...ctx, currentPromptFile: path }),
         }
       ),
-      linkSkillsLeaf<RefineCtx>(
+      installSkillsLeaf<RefineCtx>(
         { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
         {
-          name: `link-skills-${String(ticket.id)}`,
+          name: `install-skills-${String(ticket.id)}`,
           flowId: 'refine',
           // Skills land in the AI session's cwd (the repo) — the provider-native conventions
           // only auto-discover skills from cwd, not from `--add-dir` roots.
@@ -136,9 +136,9 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
         },
         ticket
       ),
-      unlinkSkillsLeaf<RefineCtx>(
+      uninstallSkillsLeaf<RefineCtx>(
         { skillsAdapter: deps.skillsAdapter },
-        { name: `unlink-skills-${String(ticket.id)}`, cwdPicker: () => opts.cwd }
+        { name: `uninstall-skills-${String(ticket.id)}`, cwdPicker: () => opts.cwd }
       ),
       saveSprintLeaf<RefineCtx>({ sprintRepo: deps.sprintRepo }, `save-after-${String(ticket.id)}`),
     ])

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -200,7 +200,7 @@ export const launchFlow = async (
     eventBus: deps.app.eventBus,
   });
   const interactiveAi = createInteractiveAiProvider({ ai: settings.ai, eventBus: deps.app.eventBus });
-  const skillsAdapter = createSkillsAdapter({ provider: settings.ai.provider });
+  const skillsAdapter = createSkillsAdapter({ provider: settings.ai.provider, logger: deps.app.logger });
 
   // Compose the static bundled skill source with a project-scoped source that emits per-repo
   // setup / verify skills authored via the detect-skills flow. The project-source closure reads

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -204,7 +204,7 @@ export const launchFlow = async (
 
   // Compose the static bundled skill source with a project-scoped source that emits per-repo
   // setup / verify skills authored via the detect-skills flow. The project-source closure reads
-  // through `snapshot.project` so every link-skills leaf during this chain run sees the latest
+  // through `snapshot.project` so every install-skills leaf during this chain run sees the latest
   // skills as of launch time. Flows that run without a project (none today) fall back cleanly
   // to bundled-only.
   const projectSource = createProjectSkillSource({ getProject: () => snapshot.project });

--- a/src/application/ui/tui/App.tsx
+++ b/src/application/ui/tui/App.tsx
@@ -15,6 +15,7 @@ import type { TuiBuses } from '@src/application/ui/tui/runtime/sinks-context.tsx
 import type { SessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import type { PromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+import type { LogLevelGate } from '@src/business/observability/log-level-filter.ts';
 import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { StorageProvider } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { BusesProvider } from '@src/application/ui/tui/runtime/sinks-context.tsx';
@@ -25,6 +26,7 @@ import { HintsProvider } from '@src/application/ui/tui/runtime/use-view-hints.ts
 import { SelectionProvider, type SelectionSeed } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { SystemStatusProvider } from '@src/application/ui/tui/runtime/system-status-context.tsx';
+import { LogLevelProvider } from '@src/application/ui/tui/runtime/log-level-context.tsx';
 import { renderView } from '@src/application/ui/tui/views/view-registry.tsx';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
@@ -36,6 +38,11 @@ export interface AppProps {
   readonly buses: TuiBuses;
   readonly sessions: SessionManager;
   readonly queue: PromptQueue;
+  /**
+   * Mutable holder for the active log-level floor. The TUI's `EventBus -> logBus` forwarder
+   * reads it on every event; the Settings view writes to it when the user changes log level.
+   */
+  readonly logLevelGate: LogLevelGate;
   /**
    * Initial view to mount. Production launches with `{ id: 'welcome' }` on first run (no
    * settings file yet) and `{ id: 'home' }` otherwise; tests can pass anything.
@@ -59,6 +66,7 @@ export const App = ({
   buses,
   sessions,
   queue,
+  logLevelGate,
   initialView,
   initialSelection,
   onSelectionChange,
@@ -74,11 +82,13 @@ export const App = ({
                   {...(initialSelection !== undefined ? { seed: initialSelection } : {})}
                   {...(onSelectionChange !== undefined ? { onChange: onSelectionChange } : {})}
                 >
-                  <SystemStatusProvider>
-                    <RouterProvider initial={initialView}>
-                      {(current) => <Layout>{renderView(current)}</Layout>}
-                    </RouterProvider>
-                  </SystemStatusProvider>
+                  <LogLevelProvider gate={logLevelGate}>
+                    <SystemStatusProvider>
+                      <RouterProvider initial={initialView}>
+                        {(current) => <Layout>{renderView(current)}</Layout>}
+                      </RouterProvider>
+                    </SystemStatusProvider>
+                  </LogLevelProvider>
                 </SelectionProvider>
               </HintsProvider>
             </UiStateProvider>

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -29,6 +29,7 @@ import { setRunInTerminal } from '@src/application/ui/tui/runtime/run-in-termina
 import { App } from '@src/application/ui/tui/App.tsx';
 import { resolveInitialState } from '@src/application/ui/tui/launch-routing.ts';
 import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
+import { createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
 
 interface Bootstrapped {
   readonly app: Parameters<typeof App>[0];
@@ -69,8 +70,13 @@ const bootstrap = async (): Promise<Bootstrapped> => {
   // launchTui's finally on Ink shutdown) can release the listener — otherwise a re-launched
   // TUI in the same Node process would stack a fresh forwarder on top of the dead one and
   // each 'log' event would publish twice (or N times after N relaunches).
+  //
+  // Log-level gate is a small mutable holder seeded from `settings.logging.level`. The
+  // forwarder reads `gate.get()` on every event so the Settings view can swap the floor at
+  // runtime by calling `gate.set(newLevel)` via the LogLevelContext.
+  const logLevelGate = createLogLevelGate(settings.value.logging.level);
   const unsubLogForward = deps.eventBus.subscribe((event) => {
-    if (event.type === 'log') logBus.emit(event);
+    if (event.type === 'log' && passesLogLevel(event.level, logLevelGate.get())) logBus.emit(event);
   });
 
   const sessions = createSessionManager();
@@ -101,6 +107,7 @@ const bootstrap = async (): Promise<Bootstrapped> => {
       buses: { harness: harnessBus, log: logBus },
       sessions,
       queue,
+      logLevelGate,
       initialView,
       ...(initialSelection !== undefined ? { initialSelection } : {}),
       onSelectionChange: (next): void => {

--- a/src/application/ui/tui/runtime/bucket-task-signals.ts
+++ b/src/application/ui/tui/runtime/bucket-task-signals.ts
@@ -18,8 +18,8 @@
  * per-task substep trace alone:
  *
  *  - any substep failed/aborted (terminally) → that status (last-wins for failed-vs-aborted)
- *  - last expected substep (`unlink-skills-<id>`) recorded → `completed`
- *  - any substep recorded, but not yet `unlink-skills` → `running`
+ *  - last expected substep (`uninstall-skills-<id>`) recorded → `completed`
+ *  - any substep recorded, but not yet `uninstall-skills` → `running`
  *  - no substeps recorded → `pending`
  *
  * The function is pure and total — empty inputs yield `{ tasks: [], orphanSignals: [] }`.
@@ -46,7 +46,7 @@ export const isPerTaskLeaf = (name: string): boolean => TOP_LEVEL_TASK_REGEX.tes
  * overall status flips to `completed`. Matches the implement flow. Flows with a different
  * terminal leaf override via {@link BucketOptions.terminalSubstepName}.
  */
-const DEFAULT_TERMINAL_SUBSTEP = 'unlink-skills';
+const DEFAULT_TERMINAL_SUBSTEP = 'uninstall-skills';
 
 export type TaskBucketStatus = TraceStatus | 'running' | 'pending';
 
@@ -258,7 +258,7 @@ export interface BucketOptions {
   readonly maxTurns?: number;
   /**
    * Name of the per-task subchain's final leaf — when it appears in the trace the task flips to
-   * `completed`. Defaults to `'unlink-skills'` (the implement flow's terminal leaf). Decoupling
+   * `completed`. Defaults to `'uninstall-skills'` (the implement flow's terminal leaf). Decoupling
    * this from a hard-coded constant means a flow that renames its terminal leaf can override
    * via the launcher without breaking the UI.
    */

--- a/src/application/ui/tui/runtime/log-level-context.tsx
+++ b/src/application/ui/tui/runtime/log-level-context.tsx
@@ -1,0 +1,43 @@
+/**
+ * Wraps a {@link LogLevelGate} in React state so the Settings view's `logging.level` write path
+ * can update the live floor used by the TUI's `EventBus -> logBus` forwarder. The forwarder
+ * keeps a stable reference to the gate (initialised in `launch.ts`) and reads the current floor
+ * on every event; this context exposes a `setLevel` to mutate that gate plus a React-tracked
+ * mirror so views can render the current value without subscribing to the gate directly.
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { LogLevel } from '@src/domain/value/log-level.ts';
+import type { LogLevelGate } from '@src/business/observability/log-level-filter.ts';
+
+export interface LogLevelContextValue {
+  readonly level: LogLevel;
+  readonly setLevel: (level: LogLevel) => void;
+}
+
+const LogLevelContext = createContext<LogLevelContextValue | undefined>(undefined);
+
+export const useLogLevel = (): LogLevelContextValue => {
+  const ctx = useContext(LogLevelContext);
+  if (!ctx) throw new Error('useLogLevel: must be used inside <LogLevelProvider>');
+  return ctx;
+};
+
+export const LogLevelProvider = ({
+  gate,
+  children,
+}: {
+  readonly gate: LogLevelGate;
+  readonly children: React.ReactNode;
+}): React.JSX.Element => {
+  const [level, setLevelState] = useState<LogLevel>(gate.get());
+  const setLevel = useCallback(
+    (next: LogLevel): void => {
+      gate.set(next);
+      setLevelState(next);
+    },
+    [gate]
+  );
+  const value = useMemo<LogLevelContextValue>(() => ({ level, setLevel }), [level, setLevel]);
+  return <LogLevelContext.Provider value={value}>{children}</LogLevelContext.Provider>;
+};

--- a/src/application/ui/tui/runtime/session-manager.ts
+++ b/src/application/ui/tui/runtime/session-manager.ts
@@ -38,7 +38,7 @@ export interface SessionDescriptor {
    */
   readonly plannedLeaves?: readonly string[];
   /**
-   * Name of the per-task subchain's final leaf (`'unlink-skills'` for the implement flow). When
+   * Name of the per-task subchain's final leaf (`'uninstall-skills'` for the implement flow). When
    * the bucketing sees this leaf for a task id it flips the task to `completed`. Threaded from
    * the launcher so flows with a different terminal leaf — or future renames — don't break the
    * UI silently.

--- a/src/application/ui/tui/runtime/system-status-context.tsx
+++ b/src/application/ui/tui/runtime/system-status-context.tsx
@@ -1,14 +1,16 @@
 /**
  * Shared system-status context — surfaces the doctor probe and the npm version check to any
- * component that wants to render them (currently the StatusBar's footer info row).
+ * component that wants to render them (currently the StatusBar's footer info row and the
+ * Doctor view).
  *
- * Both fetches kick off once on app mount and live for the whole session: doctor is cheap but
- * not instant, and the version check hits the network. Re-running them on every view mount
- * would mean a spinner flash + stale-frame rewrites every time the user navigates. The TUI
- * surfaces a manual reload via the `!` doctor view when freshness matters.
+ * Doctor + version probes are run lazily on first mount of the provider so the rest of the UI
+ * doesn't pay the cost on every view change. The doctor probe can be re-run on demand via
+ * `refreshDoctor()` — both the Doctor view's `r` keybind and any future "rerun health checks"
+ * affordance call the same callback so the StatusBar footer and the Doctor view always reflect
+ * the same single source of truth.
  */
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { createDoctorFlow } from '@src/application/flows/doctor/flow.ts';
@@ -23,6 +25,12 @@ export interface SystemStatus {
   readonly doctorLoading: boolean;
   /** `null` while pending or when no update is available; the check otherwise. */
   readonly version: VersionCheck | null;
+  /**
+   * Re-runs the doctor probes and updates {@link doctor} / {@link doctorLoading} in place.
+   * Both the StatusBar footer and the Doctor view subscribe to the same state, so calling
+   * this from one surface reflects in every other surface automatically.
+   */
+  readonly refreshDoctor: () => Promise<void>;
 }
 
 const SystemStatusContext = createContext<SystemStatus | undefined>(undefined);
@@ -47,43 +55,42 @@ export const SystemStatusProvider = ({ children }: { readonly children: React.Re
   const [doctorLoading, setDoctorLoading] = useState<boolean>(!testEnv);
   const [version, setVersion] = useState<VersionCheck | null>(null);
 
-  // Doctor + version probes can't be hard-aborted: the `DoctorFlow` leaf and `VersionChecker`
-  // port don't accept an `AbortSignal`. The `cancelled` flag is therefore a state-write gate,
-  // not a true cancellation — in-flight async work completes but its result is dropped. This
-  // is acceptable because the provider mounts once per app lifecycle and only unmounts at app
-  // exit (process is dying anyway). If/when those ports gain signal support, plumb an
-  // AbortController through here.
-  useEffect(() => {
-    if (testEnv) return undefined;
-    let cancelled = false;
+  // The doctor flow + `VersionChecker` port don't accept an `AbortSignal`, so we can't
+  // hard-cancel in-flight work — the no-op callback below is a state-write gate, not a true
+  // cancellation. Acceptable: probes are short and the provider only unmounts at app exit.
+  //
+  // `refreshDoctor` itself always runs — the test-env gate only suppresses the *initial*
+  // auto-fire so unrelated view tests don't pay for the doctor flow on every harness mount.
+  // The Doctor view explicitly calls `refreshDoctor()` on mount, so opening it (even in tests)
+  // runs the probes deterministically.
+  const refreshDoctor = useCallback(async (): Promise<void> => {
     setDoctorLoading(true);
-    void (async (): Promise<void> => {
-      try {
-        const flow = createDoctorFlow({
-          projectRepo: deps.projectRepo,
-          sprintRepo: deps.sprintRepo,
-          sprintExecutionRepo: deps.sprintExecutionRepo,
-          settingsRepo: deps.settingsRepo,
-          commandExists,
-          runCommand,
-          nodeVersion: process.version,
-        });
-        const report = await flow.execute({
-          input: { dataRoot: storage.dataRoot, configRoot: storage.configRoot },
-        });
-        if (cancelled) return;
-        if (report.ok) setDoctorReport(report.value.ctx.output!);
-      } catch {
-        // Doctor is best-effort decoration on the status bar. Tests with partial deps stubs
-        // can throw inside the probe; swallow so the rest of the UI keeps rendering.
-      } finally {
-        if (!cancelled) setDoctorLoading(false);
-      }
-    })();
-    return (): void => {
-      cancelled = true;
-    };
-  }, [deps, storage, testEnv]);
+    try {
+      const flow = createDoctorFlow({
+        projectRepo: deps.projectRepo,
+        sprintRepo: deps.sprintRepo,
+        sprintExecutionRepo: deps.sprintExecutionRepo,
+        settingsRepo: deps.settingsRepo,
+        commandExists,
+        runCommand,
+        nodeVersion: process.version,
+      });
+      const report = await flow.execute({
+        input: { dataRoot: storage.dataRoot, configRoot: storage.configRoot },
+      });
+      if (report.ok) setDoctorReport(report.value.ctx.output!);
+    } catch {
+      // Doctor is best-effort decoration on the status bar. Tests with partial deps stubs
+      // can throw inside the probe; swallow so the rest of the UI keeps rendering.
+    } finally {
+      setDoctorLoading(false);
+    }
+  }, [deps, storage]);
+
+  useEffect(() => {
+    if (testEnv) return;
+    void refreshDoctor();
+  }, [refreshDoctor, testEnv]);
 
   useEffect(() => {
     if (testEnv) return undefined;
@@ -102,7 +109,7 @@ export const SystemStatusProvider = ({ children }: { readonly children: React.Re
   }, [deps, testEnv]);
 
   return (
-    <SystemStatusContext.Provider value={{ doctor: doctorReport, doctorLoading, version }}>
+    <SystemStatusContext.Provider value={{ doctor: doctorReport, doctorLoading, version, refreshDoctor }}>
       {children}
     </SystemStatusContext.Provider>
   );

--- a/src/application/ui/tui/views/doctor-view.tsx
+++ b/src/application/ui/tui/views/doctor-view.tsx
@@ -4,23 +4,23 @@
  *
  * Probes are bucketed by their `group` field and rendered under section headers. Probes
  * without a group fall under a "General" section.
+ *
+ * The view reads the doctor report from {@link useSystemStatus} so the StatusBar footer and
+ * the view share a single source of truth — pressing `r` here also refreshes the footer's
+ * "X doctor warnings" indicator.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { StatusChip } from '@src/application/ui/tui/components/status-chip.tsx';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
-import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
-import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { glyphs, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useSystemStatus } from '@src/application/ui/tui/runtime/system-status-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
-import { createDoctorFlow } from '@src/application/flows/doctor/flow.ts';
 import type { ProbeGroup, ProbeResult } from '@src/application/flows/doctor/ctx.ts';
-import { commandExists } from '@src/integration/io/command-exists.ts';
-import { runCommand } from '@src/integration/io/run-command.ts';
 import { inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 
 const GROUP_ORDER: ReadonlyArray<ProbeGroup | 'other'> = [
@@ -46,43 +46,36 @@ const GROUP_LABEL: Record<ProbeGroup | 'other', string> = {
 };
 
 export const DoctorView = (): React.JSX.Element => {
-  const deps = useDeps();
-  const storage = useStorage();
   const ui = useUiState();
-  const [results, setResults] = useState<readonly ProbeResult[] | undefined>(undefined);
+  const system = useSystemStatus();
+  const results = system.doctor?.probes;
   useViewHints([{ keys: 'r', label: 'reload' }]);
 
-  const runProbes = useCallback(async (): Promise<void> => {
-    setResults(undefined);
-    const flow = createDoctorFlow({
-      projectRepo: deps.projectRepo,
-      sprintRepo: deps.sprintRepo,
-      sprintExecutionRepo: deps.sprintExecutionRepo,
-      settingsRepo: deps.settingsRepo,
-      commandExists,
-      runCommand,
-      nodeVersion: process.version,
-    });
-    const report = await flow.execute({
-      input: { dataRoot: storage.dataRoot, configRoot: storage.configRoot },
-    });
-    if (report.ok) setResults(report.value.ctx.output!.probes);
-  }, [deps, storage]);
-
+  // Trigger a refresh on first mount when the shared provider hasn't auto-fired yet (e.g. the
+  // test-env gate suppressed the boot-time probe). A ref guards against re-firing if the
+  // refreshDoctor callback identity changes mid-life. Explicit re-runs go through the `r`
+  // keybind below.
+  const refreshDoctor = system.refreshDoctor;
+  const triggered = React.useRef(false);
   useEffect(() => {
-    void runProbes();
-  }, [runProbes]);
+    if (triggered.current) return;
+    if (results !== undefined || system.doctorLoading) return;
+    triggered.current = true;
+    void refreshDoctor();
+  }, [refreshDoctor, results, system.doctorLoading]);
 
   useInput((input) => {
     if (ui.helpOpen || ui.promptActive) return;
-    if (input === 'r') void runProbes();
+    if (input === 'r') void system.refreshDoctor();
   });
+
+  const showSpinner = system.doctorLoading || results === undefined;
 
   return (
     <ViewShell title="Doctor" subtitle="sanity probes">
       {ui.helpOpen ? (
         <HelpOverlay />
-      ) : results === undefined ? (
+      ) : showSpinner ? (
         <Box paddingX={spacing.indent}>
           <Spinner label="Running probes…" />
         </Box>

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -21,6 +21,7 @@ import { TextPrompt } from '@src/application/ui/tui/prompts/text-prompt.tsx';
 import { SelectPrompt } from '@src/application/ui/tui/prompts/select-prompt.tsx';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
+import { useLogLevel } from '@src/application/ui/tui/runtime/log-level-context.tsx';
 import { spacing, inkColors, glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
@@ -30,6 +31,7 @@ import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.
 import { createSettingsSetProviderFlow } from '@src/application/flows/settings-set-provider/flow.ts';
 import { applySettingsKey } from '@src/business/settings/apply-key.ts';
 import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
+import type { LogLevel } from '@src/domain/value/log-level.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
@@ -114,6 +116,7 @@ export const SettingsView = (): React.JSX.Element => {
   const deps = useDeps();
   const storage = useStorage();
   const ui = useUiState();
+  const logLevel = useLogLevel();
   const [settings, setSettings] = useState<Settings | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | undefined>(undefined);
   const [cursor, setCursor] = useState(0);
@@ -209,6 +212,12 @@ export const SettingsView = (): React.JSX.Element => {
       setFeedback({ tone: 'error', text: saved.error.error.message });
       closeEditor();
       return;
+    }
+    // Mirror persisted log-level into the live forwarder gate so the floor takes effect
+    // immediately — otherwise the recent-events panel would keep using the boot-time level
+    // until the TUI restarts.
+    if (field.key === 'logging.level') {
+      logLevel.setLevel(next.value.logging.level satisfies LogLevel);
     }
     setFeedback({ tone: 'ok', text: `${field.label} = ${raw}` });
     closeEditor();

--- a/src/business/observability/log-level-filter.ts
+++ b/src/business/observability/log-level-filter.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure log-level filter shared between every place that needs to gate {@link LogEvent}s on a
+ * user-chosen floor (currently the TUI's `EventBus -> logBus` forwarder; future JSONL sinks and
+ * webhook subscribers can reuse it). Lives in business/ because it consumes the domain's
+ * `LogLevel` and is layer-pure (zero IO, zero React).
+ *
+ * Ordering — most → least severe:
+ *
+ *     silent (∞) > error > warn > info > debug
+ *
+ * `silent` is a synthetic floor that filters everything; a {@link LogEvent}'s own `level` is
+ * narrowed to `Exclude<LogLevel, 'silent'>` (see `events.ts`) so we never have to invent a
+ * severity for the silent variant on the event side.
+ */
+
+import type { LogLevel } from '@src/domain/value/log-level.ts';
+
+type EventLogLevel = Exclude<LogLevel, 'silent'>;
+
+/**
+ * Numeric severity for ordering — higher = more severe. `silent` sits above `error` so any
+ * event level compared against it returns `false` (nothing passes a silent floor).
+ */
+const SEVERITY: Readonly<Record<LogLevel, number>> = {
+  silent: 100,
+  error: 40,
+  warn: 30,
+  info: 20,
+  debug: 10,
+};
+
+/**
+ * Returns true when an event at {@link eventLevel} should be emitted given a configured
+ * {@link floor}. A `silent` floor filters everything; otherwise the event passes when its
+ * severity is at or above the floor.
+ */
+export const passesLogLevel = (eventLevel: EventLogLevel, floor: LogLevel): boolean => {
+  if (floor === 'silent') return false;
+  return SEVERITY[eventLevel] >= SEVERITY[floor];
+};
+
+/**
+ * Small mutable holder for the current log-level floor. The TUI forwarder reads via `get()` on
+ * each event; the settings view writes via `set()` when the user changes log level so live
+ * updates take effect without restarting the TUI.
+ */
+export interface LogLevelGate {
+  readonly get: () => LogLevel;
+  readonly set: (level: LogLevel) => void;
+}
+
+export const createLogLevelGate = (initial: LogLevel): LogLevelGate => {
+  let current = initial;
+  return {
+    get: (): LogLevel => current,
+    set: (level: LogLevel): void => {
+      current = level;
+    },
+  };
+};

--- a/src/integration/ai/prompts/detect-scripts/template.md
+++ b/src/integration/ai/prompts/detect-scripts/template.md
@@ -1,58 +1,80 @@
 # Repository Script Detection Protocol
 
-You are a senior engineer inventorying a single repository so the harness can run the right shell commands at
-sprint start (setup) and after every task (verification). You propose two single-line shell commands; both are
-optional — omit a tag entirely when there is no honest answer.
+You are a senior engineer inventorying a single repository so the harness can run the right shell
+commands at sprint start (setup) and after every task (verification). For any repo that has a
+manifest or a coding-agent context file, you should typically emit both tags — silence is reserved
+for repos where the project itself is silent on those topics.
 
-1. **`<setup-script>`** — one shell line the harness runs **once** before each sprint to prepare the working tree
-   (typically dependency install via whichever package manager / build tool the project actually uses). Omit
-   when the project needs nothing — fabrications are worse than silence.
-2. **`<verify-script>`** — one shell line the harness runs as the **post-task gate**. Chain the typecheck / lint
-   / test commands the project actually exposes using `&&` so the harness sees the first failure. Omit when the
-   project exposes none of them.
+1. **`<setup-script>`** — one shell line the harness runs **once** before each sprint to prepare
+   the working tree (typically dependency install via whichever package manager / build tool the
+   project actually uses). Omit only when the project itself documents no setup step.
+2. **`<verify-script>`** — one shell line the harness runs as the **post-task gate**. Chain the
+   typecheck / lint / test commands the project actually exposes using `&&` so the harness sees
+   the first failure. Omit only when the project documents no such commands at all.
 
 {{HARNESS_CONTEXT}}
 
 <constraints>
 
-**This invocation is read-only.** Do not modify the working tree, do not create files, do not run commands. The
-harness owns execution; the user reviews your proposal before anything runs.
+**This invocation is read-only.** Do not modify the working tree, do not create files, do not run
+commands. The harness owns execution; the user reviews your proposal before anything runs.
 
-**Read project context first.** Before any manifest, look for coding-agent context files (`CLAUDE.md`,
-`AGENTS.md`, `.cursor/rules/*.md`, `.github/copilot-instructions.md`, etc.), human onboarding docs (`README.md`,
-`CONTRIBUTING.md`), and explicit task runners (`Makefile`, `justfile`, `Taskfile.yml`). Whichever your provider
-ships are the authoritative source — they often spell out the exact build / test commands the project uses. If
-any of them gives a clear setup / verify command, prefer it verbatim over an inferred guess.
+**Coding-agent context files are the strongest evidence.** Before any manifest, look for
+`CLAUDE.md`, `AGENTS.md`, `.cursor/rules/*.md`, `.github/copilot-instructions.md`, and human
+onboarding docs (`README.md`, `CONTRIBUTING.md`). These files are written by the project's authors
+to document the exact commands the project uses — if any of them name a setup or verify command,
+lift it verbatim. Prefer this over any inference from manifest scripts.
 
-**Inspection scope.** Beyond the context files above, read only configuration and metadata files (manifests,
-lockfiles, build descriptors, tool-version pins, CI workflows, top-level `scripts/` entries). **Monorepos**:
-inspect the **root** manifest and at least one or two representative sub-modules to confirm the stack, then
-propose root-level commands that build/verify the whole tree.
+**Read manifests and metadata next.** Beyond context files, read configuration and metadata files
+(manifests, lockfiles, build descriptors, tool-version pins, CI workflows, top-level `scripts/`
+entries). **Monorepos**: inspect the root manifest and one or two representative sub-modules to
+confirm the stack, then propose root-level commands that build/verify the whole tree.
 
-**Polyglot monorepos** — when sub-trees use different toolchains, chain each sub-tree's command so the harness
-prepares / verifies every half from the repo root. Use `&&` so the first failure stops the chain. Prefer each
-tool's own directory flag over `cd … &&` so the line stays portable; fall back to a `(cd <path> && …)` subshell
-when no such flag exists. Do not crawl source trees, tests, or vendored directories.
+**Polyglot monorepos.** When sub-trees use different toolchains, chain each sub-tree's command so
+the harness prepares / verifies every half from the repo root. Use `&&` so the first failure stops
+the chain. Prefer each tool's own directory flag over `cd … &&` so the line stays portable; fall
+back to a `(cd <path> && …)` subshell when no such flag exists. Do not crawl source trees, tests,
+or vendored directories.
 
-**Evidence rule (the most important rule).** Every command must resolve in this repo. Cite a command only when
-the manifest, wrapper, or coding-agent context file that proves it will run is present in the working tree. A
-coding-agent context file (`CLAUDE.md`, `AGENTS.md`, etc.) that names a command IS valid evidence on its own —
-the project's authors documented it deliberately. If you cannot point to either a context file or a manifest
-that proves the command will work, omit the tag entirely — guessing is worse than silence.
+**Emit when documented, omit when silent.** When the manifest or context files name a class of
+commands, emit the tag — even when multiple candidates exist, pick the one most consistent with
+what the project documented. Omit a tag only when the project's own files are silent on that class
+entirely.
 
-**Verify-script composition.** Combine commands the project already exposes, in the order an experienced
-contributor would run them locally. Use `&&` not `;`, so the first failure stops the chain. Skip slow commands
-that don't carry signal (e.g. e2e suites keyed off a separate flag).
+**Script safety.** Reject pipe-to-shell shapes (`curl … | sh`, `wget -O- … | bash`), `eval`, and
+`rm -rf`. One shell line per script — multi-line bodies, sub-shells, and heredocs are out of
+contract; the harness collapses whitespace before execution.
 
-**Script safety.** Reject pipe-to-shell shapes (`curl … | sh`, `wget -O- … | bash`), `eval`, and `rm -rf`. One
-shell line per script — multi-line bodies, sub-shells, and heredocs are out of contract; the harness collapses
-whitespace before execution.
+**Idempotence.** Prefer commands that are safe to re-run (e.g. the plain install invocation for
+the project's package manager rather than a frozen-lockfile / production-only variant, unless the
+project's docs specifically call for the latter). The harness may invoke setup multiple times
+across a sprint.
 
-**Idempotence.** Prefer commands that are safe to re-run (`pnpm install` over `pnpm install --frozen-lockfile
---prod`, unless the project's docs specifically call for the latter). The harness may invoke setup multiple
-times across a sprint.
+**Verify-script composition.** Combine commands the project already exposes, in the order an
+experienced contributor would run them locally. Use `&&` not `;`. Include test commands when the
+project's docs name them as part of the verification gate.
 
 </constraints>
+
+<example>
+When `CLAUDE.md` (or equivalent) contains "Verification: `<tool> typecheck && <tool> lint &&
+<tool> test`" and `package.json` (or equivalent manifest) declares those scripts:
+
+```
+<setup-script><tool> install</setup-script>
+<verify-script><tool> typecheck && <tool> lint && <tool> test</verify-script>
+<note>Commands lifted verbatim from CLAUDE.md.</note>
+```
+
+When only a manifest exists with install + test scripts and no context file:
+
+```
+<setup-script><tool> install</setup-script>
+<verify-script><tool> test</verify-script>
+<note>No context file found; commands inferred from package.json scripts.</note>
+```
+
+</example>
 
 ## Repository Context
 
@@ -64,30 +86,33 @@ times across a sprint.
 
 Open with a `<thinking>...</thinking>` block. Cover, in order:
 
-1. The coding-agent context files you found and the commands they explicitly name, if any.
-2. The manifest(s) you read, and the package manager / language toolchain each implies.
-3. The **shape** of the repo: single-stack, single-language monorepo, or **polyglot** monorepo (sub-trees with
-   different toolchains). For polyglot layouts, name each sub-tree's path and toolchain — the verify / setup
-   chain must cover ALL halves.
-4. The candidate setup / verify commands you'd consider, with the file or doc that proves each one resolves.
+1. The coding-agent context files you found and the commands they explicitly name. These are your
+   primary evidence source — list them before anything else.
+2. The manifest(s) you read, the package manager / language toolchain each implies, and the
+   `scripts` / task aliases it exposes.
+3. The shape of the repo: single-stack, single-language monorepo, or polyglot monorepo. For
+   polyglot layouts, name each sub-tree's path and toolchain.
+4. The candidate setup / verify commands, each with the file that documents it.
 
-The harness strips thinking blocks before persisting; explicit reasoning produces sharper, more selective
-proposals than jumping straight to drafting.
+The harness strips thinking blocks before persisting; explicit reasoning produces sharper proposals.
 
-Then read only the configuration and metadata files in scope above. Do NOT read source trees, tests, vendored
-directories, or generated output.
+Then read only the configuration and metadata files in scope above. Do NOT read source trees,
+tests, vendored directories, or generated output.
 
 ### Phase 2 — Drafting
 
-For each candidate command, apply the evidence rule: which file in this repo proves it will run? If you cannot
-name one, drop the candidate. For `<verify-script>`, prefer chaining the project's own task scripts over
-re-spelling the underlying tools — the project's scripts are the documented contract.
+For each candidate command, confirm the file that documents it. When a context file and a manifest
+both name the same command, the context file wins (it's deliberate author intent). For
+`<verify-script>`, prefer chaining the project's own task scripts over re-spelling the underlying
+tools — the project's scripts are the documented contract.
 
 ### Phase 3 — Output
 
-Emit the elements below, each on its own line, no preamble, no commentary, no markdown fences around the tags:
+Emit the elements below, each on its own line, no preamble, no commentary, no markdown fences
+around the tags:
 
-1. `<setup-script>…single shell line…</setup-script>` — optional. Omit entirely when the repo needs no prep.
-2. `<verify-script>…single shell line…</verify-script>` — optional. Omit entirely when the project exposes no
-   typecheck / lint / test commands worth chaining.
-3. `<note>…</note>` — optional, one short observation that helps the human reviewer judge your choices.
+1. `<setup-script>…single shell line…</setup-script>` — omit only when the project documents no
+   setup step.
+2. `<verify-script>…single shell line…</verify-script>` — omit only when the project documents no
+   verification commands.
+3. `<note>…</note>` — optional, one short observation naming the source file(s) you relied on.

--- a/src/integration/ai/prompts/detect-skills/template.md
+++ b/src/integration/ai/prompts/detect-skills/template.md
@@ -1,20 +1,22 @@
 # Per-Repository Skill Authoring Protocol
 
-You are a senior engineer authoring two short coding-agent skills for a single repository, so future
-AI sessions on this repo have stack-aware guidance baked in. You produce two markdown bodies; either is
-optional — omit the tag entirely when there is no honest content to write.
+You are a senior engineer authoring two short coding-agent skills for a single repository, so
+future AI sessions on this repo have stack-aware guidance baked in. For any repo that has a
+manifest or coding-agent context file, you should typically emit both skills — silence is reserved
+for repos where an existing skill already covers the same intent.
 
-1. **`<setup-skill>`** — a few paragraphs of markdown explaining how this repo should be prepared at
-   the start of a sprint. Covers the package manager / build tool actually in use, any environment or
-   tool-version pins, and quirks the AI must respect (monorepo sub-tree ordering, lockfile policies,
-   network access, …). The reader is an AI session about to spend the next several turns editing this
-   repo; teach it what it needs to know up front. Omit when the project is so standard the bundled
-   guidance suffices.
-2. **`<verify-skill>`** — a few paragraphs explaining how to **verify changes** in this repo: which
-   commands gate correctness, where the signal lives (test output, type errors, lint reports), and how
-   to interpret common failure modes for this stack. The reader will run the verify-script (a single
-   shell line elsewhere on the repo entity) and needs to know how to read its output. Omit when the
-   project exposes no verification at all.
+1. **`<setup-skill>`** — a few paragraphs of markdown explaining how this repo should be prepared
+   at the start of a sprint. Covers the package manager / build tool actually in use, any
+   environment or tool-version pins, and quirks the AI must respect (monorepo sub-tree ordering,
+   lockfile policies, network access, …). The reader is an AI session about to spend the next
+   several turns editing this repo; teach it what it needs to know up front. Omit when an
+   existing project skill at the convention path already covers sprint setup for this repo.
+2. **`<verify-skill>`** — a few paragraphs explaining how to **verify changes** in this repo:
+   which commands gate correctness, where the signal lives (test output, type errors, lint
+   reports), and how to interpret common failure modes for this stack. The reader will run the
+   verify-script (a single shell line elsewhere on the repo entity) and needs to know how to read
+   its output. Omit when an existing project skill already covers post-task verification for this
+   repo.
 
 {{HARNESS_CONTEXT}}
 
@@ -25,41 +27,69 @@ commands. The harness owns execution; the user reviews your proposal before anyt
 
 **Read project context first.** Before any manifest, look for the coding-agent context files your
 provider knows about, human onboarding docs (`README.md`, `CONTRIBUTING.md`), and explicit task
-runners (`Makefile`, `justfile`, `Taskfile.yml`). Whichever your provider ships are the
-authoritative source — they often describe the project's setup and verify conventions directly. If
-they do, write your skill bodies in terms of what those files say, not what you would do yourself.
+runners (`Makefile`, `justfile`, `Taskfile.yml`). These are the authoritative source — they often
+describe the project's setup and verify conventions directly. If they do, write your skill bodies
+in terms of what those files say.
 
-**Check existing skills before drafting.** Many repositories already ship per-repo skills with
-similar intent. Use the convention below to list and inspect them. If an existing skill already
-covers the sprint-setup or post-task-verification responsibility for this repo — even partially —
-do not duplicate: omit the relevant tag entirely and call this out in `<note>` so the human reviewer
-can decide whether to refine the existing skill manually. Only write a body when there is no
-existing skill that covers the same ground.
+**Check existing skills before drafting — but treat their absence as normal.** Use the convention
+below to list and inspect existing per-repo skills. If a skill already covers the sprint-setup or
+post-task-verification responsibility for this repo — even partially — omit the relevant tag and
+note it in `<note>` so the human reviewer can decide. Most repos will not have existing skills;
+the absence of a match is not a reason to omit — it is the reason to emit.
 
 <skills-convention>
 {{SKILLS_CONVENTION}}
 </skills-convention>
 
-**Inspection scope.** Beyond the context files above, read only configuration and metadata files
-(manifests, lockfiles, build descriptors, tool-version pins, CI workflows, top-level `scripts/`
-entries). For monorepos, inspect the root and one or two representative sub-modules so the skill
-bodies describe the whole tree, not just the root. Do not crawl source trees, tests, or vendored
-directories.
+**Inspection scope.** Beyond context files, read only configuration and metadata files (manifests,
+lockfiles, build descriptors, tool-version pins, CI workflows, top-level `scripts/` entries). For
+monorepos, inspect the root and one or two representative sub-modules so skill bodies describe the
+whole tree, not just the root. Do not crawl source trees, tests, or vendored directories.
 
 **Evidence rule.** Every concrete claim in a skill body (a tool name, a flag, a directory) must be
-backed by something you read in the repo or in a context file. Don't recite generic advice from
-training data; the value here is repo-specific grounding. If you cannot tie a claim to a file, drop
-it.
+backed by something you read in the repo or a context file. Don't recite generic advice from
+training data; the value is repo-specific grounding. If you cannot tie a claim to a file, drop it.
+
+**Emit when there is any stack-specific quirk.** If the repo has a non-default tool chain, a
+tool-version pin, a lockfile policy, a monorepo sub-tree ordering dependency, or anything else that
+would trip up a generic AI session — emit the skill and document it. Omit only when an existing
+skill already covers it.
 
 **Voice and length.** Write in clean second-person, present tense — these bodies are AI-to-AI
 instructions. Aim for 4–10 short paragraphs per skill. No headings inside the body (the harness
-wraps each one in its own `# Setup` / `# Verify` section). No code fences around the tags
-themselves; code fences inside the body are fine.
+wraps each in its own `# Setup` / `# Verify` section). No code fences around the tags themselves;
+code fences inside the body are fine.
 
-**Skill content must be useful, not aspirational.** "Run `pnpm test`" is useful. "Be careful with
-edge cases" is noise. If a paragraph would apply to any project, delete it.
+**Skill content must be useful, not aspirational.** "Run `<tool> test`" is useful. "Be careful
+with edge cases" is noise. If a paragraph would apply to any project, delete it.
 
 </constraints>
+
+<example>
+When `CLAUDE.md` (or equivalent) documents the verify command and `mise.toml` (or equivalent)
+pins tool versions:
+
+```
+<setup-skill>
+This repo pins tool versions with `mise`. Before editing anything, run `mise install` to activate
+the exact versions declared in `mise.toml`. Then run the project's install command (documented in
+`CLAUDE.md`) to hydrate the dependency tree.
+
+The lockfile is committed — do not pass flags that skip it or downgrade to production-only deps
+unless `CLAUDE.md` explicitly asks for that variant. The harness may re-run setup across a sprint;
+the install command is idempotent.
+</setup-skill>
+<verify-skill>
+Verification runs three gates in sequence (documented in `CLAUDE.md`): typecheck, lint, then tests.
+A failure in any gate stops the chain; read the first failing gate's output — later gates haven't
+run yet. Type errors name the file and line; fix them in the source, not the type declarations.
+Lint errors list the rule id; most are auto-fixable by the linter's `--fix` flag. Test failures
+show the failing assertion and the diff.
+</verify-skill>
+<note>Skills authored from CLAUDE.md and mise.toml.</note>
+```
+
+</example>
 
 ## Repository Context
 
@@ -73,15 +103,15 @@ Open with a `<thinking>...</thinking>` block. Cover, in order:
 
 1. Existing skills you found at the convention path above and, for each, the responsibility it
    already covers. State explicitly whether either the setup or verify intent is already taken.
+   When no existing skills exist, note that — it means you should emit both.
 2. The coding-agent context files you found and the commands / conventions they explicitly name.
 3. The manifest(s) you read and what stack each implies. For monorepos, name the sub-trees.
 4. The single most important thing the next AI session would NOT know without this skill —
    the asymmetry between what's documented in the repo and what's load-bearing for real work.
 5. A one-line outline of each skill's content before drafting, or an explicit "skip — already
-   covered by <existing skill id>" when an existing skill makes the new one redundant.
+   covered by `<existing skill id>`" when an existing skill makes the new one redundant.
 
-The harness strips thinking blocks before persisting; explicit reasoning produces sharper, more
-selective bodies than jumping straight to drafting.
+The harness strips thinking blocks before persisting; explicit reasoning produces sharper bodies.
 
 Then read only the configuration and metadata files in scope above. Do NOT read source trees,
 tests, vendored directories, or generated output.
@@ -90,16 +120,17 @@ tests, vendored directories, or generated output.
 
 Write each body with the evidence rule in mind. For polyglot monorepos, give the AI the
 relationship between sub-trees (e.g. "the frontend depends on a build artifact produced by the
-backend"); generic boilerplate adds no value.
+backend"). Generic boilerplate adds no value — every sentence should earn its place by being
+specific to this repo.
 
 ### Phase 3 — Output
 
 Emit the elements below, each as a single block, no preamble, no commentary, no markdown fences
 around the tags themselves:
 
-1. `<setup-skill>…multi-paragraph markdown body…</setup-skill>` — optional. Omit entirely when
-   the repo's setup is too generic to warrant per-repo guidance.
-2. `<verify-skill>…multi-paragraph markdown body…</verify-skill>` — optional. Omit when the
-   project exposes no verification worth describing.
-3. `<note>…</note>` — optional, one short observation that helps the human reviewer judge your
-   choices.
+1. `<setup-skill>…multi-paragraph markdown body…</setup-skill>` — omit only when an existing
+   project skill already covers sprint setup for this repo.
+2. `<verify-skill>…multi-paragraph markdown body…</verify-skill>` — omit only when an existing
+   project skill already covers post-task verification for this repo.
+3. `<note>…</note>` — optional, one short observation naming the source file(s) relied on, or
+   noting which existing skill made a tag redundant.

--- a/src/integration/ai/providers/_engine/ai-session.ts
+++ b/src/integration/ai/providers/_engine/ai-session.ts
@@ -45,4 +45,16 @@ export interface AiSession {
    * regardless of which custom tags they consume.
    */
   readonly signalsFile: AbsolutePath;
+  /**
+   * Optional path where the provider mirrors the raw assistant response body (plain text).
+   * Intended for diagnostic use in one-shot flows (detect-scripts, detect-skills) where an
+   * empty signal set may mean the AI responded but emitted no recognised tags. When set,
+   * the body is written here after `signalsFile` is written; the file is owned and cleaned
+   * up by the caller. Adapters that do not support this field MUST silently ignore it —
+   * never surface an error for an unset optional diagnostic path.
+   *
+   * Only the Claude adapter currently implements this field. Copilot and Codex support is
+   * deferred; they will silently no-op when `bodyFile` is present.
+   */
+  readonly bodyFile?: AbsolutePath;
 }

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -19,7 +19,7 @@ import {
   delayForRetry,
   sleepCancellable,
 } from '@src/integration/ai/providers/_engine/rate-limit-backoff.ts';
-import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { writeJsonAtomic, writeTextAtomic } from '@src/integration/io/fs.ts';
 
 /**
  * Real {@link HeadlessAiProvider} backed by the Claude Code CLI.
@@ -275,6 +275,20 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     const signals = parseHarnessSignals(envelope.body, IsoTimestamp.now());
     const wrote = await writeJsonAtomic(String(session.signalsFile), signals);
     if (!wrote.ok) return { kind: 'error', error: wrote.error };
+    // Mirror raw body for diagnostic capture (detect-scripts / detect-skills empty-proposal
+    // debugging). Best-effort: a write failure here is logged but does not fail the session.
+    if (session.bodyFile !== undefined) {
+      const bodyWrote = await writeTextAtomic(String(session.bodyFile), envelope.body);
+      if (!bodyWrote.ok) {
+        deps.eventBus.publish({
+          type: 'log',
+          level: 'warn',
+          message: `claude-provider: failed to write body file — diagnostic capture skipped`,
+          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
+          at: IsoTimestamp.now(),
+        });
+      }
+    }
     return {
       kind: 'success',
       output: {

--- a/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
+++ b/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
@@ -25,6 +25,8 @@ import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
 import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
@@ -38,6 +40,12 @@ export interface FilesystemSkillsAdapterDeps {
   readonly parentDir: string;
   /** Markdown sentence returned from {@link SkillsAdapter.describeSkillsConvention}. */
   readonly convention: string;
+  /**
+   * Optional logger — used to warn when the best-effort `.git/info/exclude` write fails.
+   * Skills install still succeeds in that case; the user just sees harness-authored
+   * `ralphctl-*` folders in `git status` until the exclude lands manually.
+   */
+  readonly logger?: Logger;
 }
 
 /**
@@ -65,7 +73,12 @@ export const createFilesystemSkillsAdapter = (deps: FilesystemSkillsAdapterDeps)
   // Per-sessionDir manifest of skill names this adapter created at install time. Cleared on
   // a successful uninstall. Not promised across crashed runs — the cleanup is best-effort.
   const installed = new Map<string, Set<string>>();
+  // Per-sessionDir flag tracking whether we've already attempted to append the wildcard
+  // exclude. Idempotent against the file regardless, but the in-memory check avoids re-
+  // reading the file on every install call across a long-running session.
+  const excludeAttempted = new Set<string>();
   const skillsSubdir = join(deps.parentDir, 'skills');
+  const excludePattern = `${skillsSubdir}/ralphctl-*`;
 
   // Self-healing prune: drop manifest entries whose sessionDir no longer exists on disk. The
   // typical leak path is the per-task subchain failing BETWEEN `linkSkills` and `unlinkSkills`
@@ -109,6 +122,21 @@ export const createFilesystemSkillsAdapter = (deps: FilesystemSkillsAdapterDeps)
       }
 
       if (tracked.size > 0) installed.set(String(sessionDir), tracked);
+
+      // Best-effort: append a single wildcard line to <sessionDir>/.git/info/exclude so
+      // every `ralphctl-*` skill we manage stays out of `git status`. A non-git tree, a
+      // worktree, or a write-protected `.git/info/exclude` all collapse to "warn and
+      // proceed" — the skill install itself already succeeded.
+      if (!excludeAttempted.has(String(sessionDir))) {
+        excludeAttempted.add(String(sessionDir));
+        const excluded = await ensureGitExcludeWildcard(sessionDir, excludePattern);
+        if (!excluded.ok) {
+          deps.logger
+            ?.named('skills.exclude')
+            .warn(`${deps.providerId}: failed to update .git/info/exclude: ${excluded.error.message}`);
+        }
+      }
+
       return Result.ok(undefined);
     },
 

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -20,11 +20,11 @@ export type FlowId = 'refine' | 'plan' | 'implement' | 'readiness' | 'ideate';
 
 /** Skill ids referenced below — must each exist as `src/ai/skills/bundled/<id>/SKILL.md`. */
 export const FLOW_SKILLS: Record<FlowId, readonly string[]> = {
-  refine: ['alignment', 'iterative-review', 'abstraction-first'],
-  plan: ['alignment', 'iterative-review', 'abstraction-first'],
-  implement: ['alignment', 'iterative-review', 'abstraction-first'],
-  readiness: ['alignment', 'iterative-review', 'abstraction-first'],
-  ideate: ['alignment', 'iterative-review', 'abstraction-first'],
+  refine: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
+  plan: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
+  implement: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
+  readiness: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
+  ideate: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
 };
 
 /** Type-safe lookup. Returns the configured skill ids or an empty list. */

--- a/src/integration/ai/skills/adapter-factory.ts
+++ b/src/integration/ai/skills/adapter-factory.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import { createClaudeSkillsAdapter } from '@src/integration/ai/skills/claude/adapter.ts';
 import { createCodexSkillsAdapter } from '@src/integration/ai/skills/codex/adapter.ts';
@@ -20,15 +21,18 @@ import { createCopilotSkillsAdapter } from '@src/integration/ai/skills/copilot/a
 
 export interface SkillsAdapterFactoryDeps {
   readonly provider: AiProvider;
+  /** Optional logger — surfaces best-effort `.git/info/exclude` write failures as warnings. */
+  readonly logger?: Logger;
 }
 
 export const createSkillsAdapter = (deps: SkillsAdapterFactoryDeps): SkillsAdapter => {
+  const logger = deps.logger;
   switch (deps.provider) {
     case 'claude-code':
-      return createClaudeSkillsAdapter();
+      return createClaudeSkillsAdapter(logger !== undefined ? { logger } : undefined);
     case 'github-copilot':
-      return createCopilotSkillsAdapter();
+      return createCopilotSkillsAdapter(logger !== undefined ? { logger } : undefined);
     case 'openai-codex':
-      return createCodexSkillsAdapter();
+      return createCodexSkillsAdapter(logger !== undefined ? { logger } : undefined);
   }
 };

--- a/src/integration/ai/skills/bundled/ralphctl-abstraction-first/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-abstraction-first/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: abstraction-first
+name: ralphctl-abstraction-first
 description: Cross-phase skill — design the shape of the change (entities, boundaries, seams) before generating code, tasks, or acceptance criteria. Failure mode is "big blob" output that obscures the core change.
 ---
 

--- a/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: alignment
+name: ralphctl-alignment
 description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output. Restate the input back to the user; surface assumptions; agree before you write.
 ---
 

--- a/src/integration/ai/skills/bundled/ralphctl-iterative-review/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-iterative-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: iterative-review
+name: ralphctl-iterative-review
 description: Cross-phase skill — treat AI output as a controlled feedback loop, not a one-shot generation. Run the cheap check after each meaningful change; re-read your own output before signalling completion.
 ---
 

--- a/src/integration/ai/skills/claude/adapter.ts
+++ b/src/integration/ai/skills/claude/adapter.ts
@@ -8,6 +8,7 @@
  * skills adapters, which only differ in `parentDir` and the convention text.
  */
 
+import type { Logger } from '@src/business/observability/logger.ts';
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
@@ -18,9 +19,14 @@ const CONVENTION = [
   'whose `name` or `description` hints at sprint setup or post-task verification.',
 ].join(' ');
 
-export const createClaudeSkillsAdapter = (): SkillsAdapter =>
+export interface CreateClaudeSkillsAdapterDeps {
+  readonly logger?: Logger;
+}
+
+export const createClaudeSkillsAdapter = (deps: CreateClaudeSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'claude-code',
     parentDir: '.claude',
     convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/ai/skills/codex/adapter.ts
+++ b/src/integration/ai/skills/codex/adapter.ts
@@ -7,6 +7,7 @@
  * {@link createFilesystemSkillsAdapter} — shared with the claude and copilot variants.
  */
 
+import type { Logger } from '@src/business/observability/logger.ts';
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
@@ -17,9 +18,14 @@ const CONVENTION = [
   'whose `name` or `description` hints at sprint setup or post-task verification.',
 ].join(' ');
 
-export const createCodexSkillsAdapter = (): SkillsAdapter =>
+export interface CreateCodexSkillsAdapterDeps {
+  readonly logger?: Logger;
+}
+
+export const createCodexSkillsAdapter = (deps: CreateCodexSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'openai-codex',
     parentDir: '.agents',
     convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/ai/skills/copilot/adapter.ts
+++ b/src/integration/ai/skills/copilot/adapter.ts
@@ -11,6 +11,7 @@
  * is the canonical Copilot-native location and what the CLI's docs steer authors toward.
  */
 
+import type { Logger } from '@src/business/observability/logger.ts';
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
@@ -21,9 +22,14 @@ const CONVENTION = [
   'whose `name` or `description` hints at sprint setup or post-task verification.',
 ].join(' ');
 
-export const createCopilotSkillsAdapter = (): SkillsAdapter =>
+export interface CreateCopilotSkillsAdapterDeps {
+  readonly logger?: Logger;
+}
+
+export const createCopilotSkillsAdapter = (deps: CreateCopilotSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'github-copilot',
     parentDir: '.github',
     convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/ai/skills/project/source.ts
+++ b/src/integration/ai/skills/project/source.ts
@@ -1,7 +1,7 @@
 /**
  * `createProjectSkillSource` — a {@link SkillSource} that materialises per-repository skills
  * stored on the {@link Project} aggregate. Pairs with the bundled source via
- * {@link composeSkillSources} so the same `linkSkillsLeaf` installs both flows of skills
+ * {@link composeSkillSources} so the same `installSkillsLeaf` installs both flows of skills
  * without each leaf having to know about the project.
  *
  * Each repository on the project may contribute up to two skills:

--- a/src/integration/ai/skills/project/source.ts
+++ b/src/integration/ai/skills/project/source.ts
@@ -9,7 +9,10 @@
  *  - `verify` → from `Repository.verifySkill` (if set)
  *
  * Skill names are namespaced per repository so two repos with their own setup skills don't
- * collide in `<sessionDir>/.claude/skills/<name>/`: `<repo-slug>-setup`, `<repo-slug>-verify`.
+ * collide in `<sessionDir>/.claude/skills/<name>/`: `ralphctl-<repo-slug>-setup`,
+ * `ralphctl-<repo-slug>-verify`. The `ralphctl-` prefix lets the wildcard exclude in
+ * `.git/info/exclude` (`<parentDir>/skills/ralphctl-*`) hide these from `git status`
+ * alongside the bundled skills.
  *
  * The source is project-aware but flow-agnostic — every flow that links skills installs the
  * same set. Reason: setup + verify guidance is load-bearing across refine (understand the
@@ -38,14 +41,14 @@ const projectSkillsFor = (project: Project): readonly Skill[] => {
   for (const repo of project.repositories) {
     if (repo.setupSkill !== undefined && repo.setupSkill.trim().length > 0) {
       skills.push({
-        name: `${String(repo.slug)}-setup`,
+        name: `ralphctl-${String(repo.slug)}-setup`,
         description: `Setup guidance for ${repo.name}: how to prepare the working tree at sprint start.`,
         content: `# Setup — ${repo.name}\n\n${repo.setupSkill}`,
       });
     }
     if (repo.verifySkill !== undefined && repo.verifySkill.trim().length > 0) {
       skills.push({
-        name: `${String(repo.slug)}-verify`,
+        name: `ralphctl-${String(repo.slug)}-verify`,
         description: `Verify guidance for ${repo.name}: how to interpret the post-task verification gate.`,
         content: `# Verify — ${repo.name}\n\n${repo.verifySkill}`,
       });

--- a/src/integration/io/git-exclude.ts
+++ b/src/integration/io/git-exclude.ts
@@ -1,0 +1,95 @@
+import { promises as fs } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { writeTextAtomic } from '@src/integration/io/fs.ts';
+
+/**
+ * Append a wildcard pattern to `<repoRoot>/.git/info/exclude` if (and only if) the same
+ * line isn't already there. Idempotent — repeated calls with the same pattern leave the
+ * file with a single entry. Used by the filesystem skills adapter on first install to
+ * hide harness-authored `ralphctl-*` skill folders from `git status` forever.
+ *
+ * Handles the three layouts git can present:
+ *  - Plain repo:  `<repoRoot>/.git/info/exclude` exists (or its parent dir does).
+ *  - Worktree:    `<repoRoot>/.git` is a FILE whose contents are `gitdir: <path>`. The
+ *    real `info/exclude` lives under that resolved path.
+ *  - Not a git repo / `.git` missing: there's no exclude file to write; return Ok and
+ *    skip silently. The caller (skills install) wants best-effort behaviour here — a
+ *    non-git working tree is a legitimate place to run ralphctl.
+ *
+ * Line-equality match ignores leading/trailing whitespace so a hand-edited `exclude`
+ * with the same pattern but trailing spaces is detected as already-present.
+ */
+export const ensureGitExcludeWildcard = async (
+  repoRoot: AbsolutePath,
+  pattern: string
+): Promise<Result<void, StorageError>> => {
+  const resolved = await resolveExcludePath(String(repoRoot));
+  if (resolved === undefined) return Result.ok(undefined);
+
+  let existing = '';
+  try {
+    existing = await fs.readFile(resolved, 'utf8');
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) {
+      // No exclude file yet — fall through to the write path with an empty body.
+    } else {
+      return Result.error(
+        new StorageError({
+          subCode: 'io',
+          message: `failed to read ${resolved}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          path: resolved,
+          cause,
+        })
+      );
+    }
+  }
+
+  const trimmedPattern = pattern.trim();
+  const present = existing.split('\n').some((line) => line.trim() === trimmedPattern);
+  if (present) return Result.ok(undefined);
+
+  // Preserve any existing terminating newline; append exactly one if missing.
+  const separator = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  const next = `${existing}${separator}${trimmedPattern}\n`;
+  return writeTextAtomic(resolved, next);
+};
+
+/**
+ * Resolve the path of the writable `info/exclude` file for a working tree. Returns
+ * `undefined` when no `.git` marker exists (the working tree isn't tracked by git) —
+ * the caller treats that as a no-op rather than an error.
+ */
+const resolveExcludePath = async (repoRoot: string): Promise<string | undefined> => {
+  const gitMarker = join(repoRoot, '.git');
+  let stat;
+  try {
+    stat = await fs.stat(gitMarker);
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return undefined;
+    throw cause;
+  }
+  if (stat.isDirectory()) {
+    return join(gitMarker, 'info', 'exclude');
+  }
+  if (!stat.isFile()) return undefined;
+
+  // Worktree: `.git` is a pointer file like `gitdir: /abs/path/.git/worktrees/<name>`.
+  // The pointer's path may be relative to repoRoot; resolve accordingly.
+  let pointer: string;
+  try {
+    pointer = await fs.readFile(gitMarker, 'utf8');
+  } catch {
+    return undefined;
+  }
+  const match = /^gitdir:\s*(.+)\s*$/m.exec(pointer);
+  if (match === null) return undefined;
+  const gitdir = match[1]!.trim();
+  const absoluteGitdir = isAbsolute(gitdir) ? gitdir : join(repoRoot, gitdir);
+  return join(absoluteGitdir, 'info', 'exclude');
+};
+
+const isNodeErrnoCode = (cause: unknown, code: string): boolean =>
+  typeof cause === 'object' && cause !== null && (cause as { code?: unknown }).code === code;

--- a/tests/e2e/flows/readiness.test.ts
+++ b/tests/e2e/flows/readiness.test.ts
@@ -193,9 +193,9 @@ describe('createReadinessFlow', () => {
       'pick-repository',
       'pick-tool',
       'probe',
-      'link-skills',
+      'install-skills',
       'propose',
-      'unlink-skills',
+      'uninstall-skills',
       'confirm',
       'write',
     ]);

--- a/tests/integration/ai/prompts/detect-scripts/definition.test.ts
+++ b/tests/integration/ai/prompts/detect-scripts/definition.test.ts
@@ -86,7 +86,9 @@ describe('detect-scripts template — detection guidance', () => {
 
   it('instructs the AI to read coding-agent context files first', async () => {
     const body = await renderedBody();
-    expect(body).toMatch(/Read project context first/i);
+    // The constraint block must explicitly position coding-agent context files as the primary
+    // (strongest) evidence source — before manifests.
+    expect(body).toMatch(/Coding-agent context files are the strongest evidence/i);
     // The two canonical coding-agent context filenames must be named explicitly.
     expect(body).toMatch(/CLAUDE\.md/);
     expect(body).toMatch(/AGENTS\.md/);
@@ -94,10 +96,11 @@ describe('detect-scripts template — detection guidance', () => {
 
   it('treats a coding-agent context file as valid standalone evidence', async () => {
     const body = await renderedBody();
-    // The evidence rule must explicitly allow a context file as standalone evidence — without
-    // this carve-out the AI can only cite manifest files and would dismiss `CLAUDE.md`-stated
-    // commands as inferred guesses.
-    expect(body).toMatch(/coding-agent context file.*valid evidence on its own/i);
+    // The constraint block must explicitly elevate context files over manifest inference —
+    // without this the AI dismisses CLAUDE.md-stated commands as inferred guesses.
+    expect(body).toMatch(/lift it verbatim/i);
+    // Must also instruct the AI to prefer context files over manifest inference.
+    expect(body).toMatch(/Prefer this over any inference from manifest/i);
   });
 
   it('does not bias the scope toward a specific stack family', async () => {
@@ -130,13 +133,15 @@ describe('detect-scripts template — detection guidance', () => {
     const body = await renderedBody();
     expect(body).toMatch(/read-only/i);
     expect(body).toMatch(/Do not modify the working tree/);
-    expect(body).toMatch(/do not run commands/i);
+    // "do not run commands" may span a soft line-wrap in the template source.
+    expect(body).toMatch(/do not run[\s\S]{0,5}commands/i);
   });
 
   it('mandates an evidence-or-omit rule on every proposed command', async () => {
     const body = await renderedBody();
-    expect(body).toMatch(/Evidence rule/);
-    expect(body).toMatch(/omit the tag entirely/i);
-    expect(body).toMatch(/guessing is worse than silence/i);
+    // The template must state explicitly when to emit vs omit — framed as "emit when
+    // documented, omit when silent" rather than a blanket silence-is-safer rule.
+    expect(body).toMatch(/Emit when documented, omit when silent/i);
+    expect(body).toMatch(/omit.*when the project.*files are silent/i);
   });
 });

--- a/tests/integration/ai/skills/bundled/source.test.ts
+++ b/tests/integration/ai/skills/bundled/source.test.ts
@@ -13,17 +13,17 @@ describe('createBundledSkillSource (production root)', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const names = result.value.map((s) => s.name);
-    expect(names).toContain('alignment');
-    expect(names).toContain('abstraction-first');
-    expect(names).toContain('iterative-review');
+    expect(names).toContain('ralphctl-alignment');
+    expect(names).toContain('ralphctl-abstraction-first');
+    expect(names).toContain('ralphctl-iterative-review');
   });
 
   it('reads name + description from frontmatter', async () => {
     const result = await source.getForFlow('refine');
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const alignment = result.value.find((s) => s.name === 'alignment');
-    expect(alignment?.name).toBe('alignment');
+    const alignment = result.value.find((s) => s.name === 'ralphctl-alignment');
+    expect(alignment?.name).toBe('ralphctl-alignment');
     expect(alignment?.description.length).toBeGreaterThan(0);
     expect(alignment?.content).toContain('# Alignment');
   });
@@ -50,12 +50,12 @@ describe('createBundledSkillSource (custom root)', () => {
 
   it('rejects malformed frontmatter with a parse error', async () => {
     const root = await mkdtemp(join(tmpdir(), 'bundled-source-'));
-    const skillDir = join(root, 'alignment');
+    const skillDir = join(root, 'ralphctl-alignment');
     await mkdir(skillDir, { recursive: true });
     // Frontmatter missing the required `name` field.
     await writeFile(join(skillDir, 'SKILL.md'), '---\ndescription: only description\n---\n\n# body\n', 'utf-8');
     // Need the other two too so the loop reaches alignment cleanly.
-    for (const id of ['abstraction-first', 'iterative-review']) {
+    for (const id of ['ralphctl-abstraction-first', 'ralphctl-iterative-review']) {
       const dir = join(root, id);
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, 'SKILL.md'), `---\nname: ${id}\ndescription: ok\n---\nbody\n`, 'utf-8');
@@ -69,11 +69,11 @@ describe('createBundledSkillSource (custom root)', () => {
 
   it('requires frontmatter name to match the folder name', async () => {
     const root = await mkdtemp(join(tmpdir(), 'bundled-source-'));
-    const alignDir = join(root, 'alignment');
+    const alignDir = join(root, 'ralphctl-alignment');
     await mkdir(alignDir, { recursive: true });
-    // Frontmatter name does not match the folder ('alignment' vs. 'mismatch').
+    // Frontmatter name does not match the folder ('ralphctl-alignment' vs. 'mismatch').
     await writeFile(join(alignDir, 'SKILL.md'), `---\nname: mismatch\ndescription: ok\n---\n\nbody\n`, 'utf-8');
-    for (const name of ['abstraction-first', 'iterative-review']) {
+    for (const name of ['ralphctl-abstraction-first', 'ralphctl-iterative-review']) {
       const dir = join(root, name);
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: ok\n---\nbody\n`, 'utf-8');

--- a/tests/integration/ai/skills/claude/adapter.test.ts
+++ b/tests/integration/ai/skills/claude/adapter.test.ts
@@ -111,3 +111,42 @@ describe('createClaudeSkillsAdapter — install / uninstall', () => {
     expect(existsSync(join(String(session), '.claude/CLAUDE.md'))).toBe(true);
   });
 });
+
+describe('createClaudeSkillsAdapter — .git/info/exclude wildcard', () => {
+  it('appends the .claude/skills/ralphctl-* line on first install', async () => {
+    const session = await makeSession();
+    await mkdir(join(String(session), '.git/info'), { recursive: true });
+    await writeFile(join(String(session), '.git/info/exclude'), '# default\n', 'utf-8');
+
+    const adapter = createClaudeSkillsAdapter();
+    await adapter.install(session, [skill('ralphctl-alignment', '# A')]);
+
+    const content = await readFile(join(String(session), '.git/info/exclude'), 'utf-8');
+    expect(content).toContain('.claude/skills/ralphctl-*');
+  });
+
+  it('does not duplicate the wildcard on repeated installs', async () => {
+    const session = await makeSession();
+    await mkdir(join(String(session), '.git/info'), { recursive: true });
+    await writeFile(join(String(session), '.git/info/exclude'), '', 'utf-8');
+
+    const adapter = createClaudeSkillsAdapter();
+    await adapter.install(session, [skill('ralphctl-alignment', '# A')]);
+    await adapter.install(session, [skill('ralphctl-iterative-review', '# B')]);
+
+    const content = await readFile(join(String(session), '.git/info/exclude'), 'utf-8');
+    const matches = content.split('\n').filter((l) => l.trim() === '.claude/skills/ralphctl-*');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('install proceeds when .git is missing (non-git working tree)', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeSkillsAdapter();
+    const result = await adapter.install(session, [skill('ralphctl-alignment', '# A')]);
+    expect(result.ok).toBe(true);
+
+    const installed = await readFile(join(String(session), '.claude/skills/ralphctl-alignment/SKILL.md'), 'utf-8');
+    expect(installed).toContain('# A');
+    expect(existsSync(join(String(session), '.git'))).toBe(false);
+  });
+});

--- a/tests/integration/ai/skills/project/source.test.ts
+++ b/tests/integration/ai/skills/project/source.test.ts
@@ -49,7 +49,11 @@ describe('createProjectSkillSource', () => {
     if (!r.ok) return;
     expect(r.value).toHaveLength(3);
     const names = r.value.map((s) => s.name);
-    expect(names).toEqual([`${String(a.slug)}-setup`, `${String(b.slug)}-setup`, `${String(b.slug)}-verify`]);
+    expect(names).toEqual([
+      `ralphctl-${String(a.slug)}-setup`,
+      `ralphctl-${String(b.slug)}-setup`,
+      `ralphctl-${String(b.slug)}-verify`,
+    ]);
     expect(r.value[0]!.content).toContain('# Setup — api');
     expect(r.value[0]!.content).toContain(SETUP_BODY);
     expect(r.value[2]!.content).toContain('# Verify — web-ui');

--- a/tests/integration/application/ui/tui/_harness.tsx
+++ b/tests/integration/application/ui/tui/_harness.tsx
@@ -25,9 +25,11 @@ import { PromptQueueProvider } from '@src/application/ui/tui/prompts/prompt-cont
 import { StorageProvider } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { BusesProvider, type TuiBuses } from '@src/application/ui/tui/runtime/sinks-context.tsx';
 import { SystemStatusProvider } from '@src/application/ui/tui/runtime/system-status-context.tsx';
+import { LogLevelProvider } from '@src/application/ui/tui/runtime/log-level-context.tsx';
 import { createBusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
 import { createSessionManager, type SessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { createPromptQueue, type PromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
+import { createLogLevelGate } from '@src/business/observability/log-level-filter.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import type { LogEvent } from '@src/business/observability/events.ts';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
@@ -98,15 +100,17 @@ export const renderView = (child: React.ReactNode, opts: HarnessOptions): Harnes
                 <HintsProvider>
                   <SelectionProvider>
                     {opts.selection !== undefined && <SeedSelection seed={opts.selection} />}
-                    <SystemStatusProvider>
-                      <RouterProvider initial={opts.initial}>
-                        {(current): React.ReactNode => {
-                          routes.push(current);
-                          opts.onRoute?.(current);
-                          return child;
-                        }}
-                      </RouterProvider>
-                    </SystemStatusProvider>
+                    <LogLevelProvider gate={createLogLevelGate('info')}>
+                      <SystemStatusProvider>
+                        <RouterProvider initial={opts.initial}>
+                          {(current): React.ReactNode => {
+                            routes.push(current);
+                            opts.onRoute?.(current);
+                            return child;
+                          }}
+                        </RouterProvider>
+                      </SystemStatusProvider>
+                    </LogLevelProvider>
                   </SelectionProvider>
                 </HintsProvider>
               </UiStateProvider>

--- a/tests/integration/application/ui/tui/views/execute-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view.test.tsx
@@ -121,7 +121,7 @@ describe('ExecuteView', () => {
       title: 'Implement — Rounds',
       taskNames,
       maxTurns: 10,
-      terminalSubstepName: 'unlink-skills',
+      terminalSubstepName: 'uninstall-skills',
     });
 
     // Seed 5 generator entries — round counter should read 5.
@@ -146,7 +146,7 @@ describe('ExecuteView', () => {
     expect(traceArray.length).toBe(2);
     // Trigger a re-render by mutating something the descriptor exposes. Easiest:
     // emit another step-style change by pushing a different leaf.
-    traceArray.push({ elementName: `unlink-skills-${TASK}`, status: 'completed', durationMs: 1 });
+    traceArray.push({ elementName: `uninstall-skills-${TASK}`, status: 'completed', durationMs: 1 });
     // Force the descriptor to update so the view re-renders.
     // The session-manager subscribes to runner events; we can't easily fire one against the
     // fake runner. Re-render by re-registering a new sessions object isn't right either.

--- a/tests/unit/application/ui/tui/runtime/bucket-task-signals.test.ts
+++ b/tests/unit/application/ui/tui/runtime/bucket-task-signals.test.ts
@@ -38,7 +38,7 @@ describe('bucketTaskSignals — binary-search attribution', () => {
     const trace: Trace = [{ elementName: `generator-${TASK}`, status: 'completed', durationMs: 10 }];
     const events: AppEvent[] = [
       stepCompleted(`build-task-workspace-${TASK}`, '2026-05-09T10:00:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
     ];
     const signals: HarnessSignal[] = [note('2026-05-09T10:00:30.000Z')];
     const result = bucketTaskSignals(trace, events, signals);
@@ -50,7 +50,7 @@ describe('bucketTaskSignals — binary-search attribution', () => {
   it('attributes a signal at the exact startedAt boundary to the matching window', () => {
     const events: AppEvent[] = [
       stepCompleted(`build-task-workspace-${TASK}`, '2026-05-09T10:00:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
     ];
     const trace: Trace = [{ elementName: `generator-${TASK}`, status: 'completed', durationMs: 10 }];
     const signals: HarnessSignal[] = [note('2026-05-09T10:00:00.000Z', 'at-start')];
@@ -62,7 +62,7 @@ describe('bucketTaskSignals — binary-search attribution', () => {
   it('attributes a signal at the exact endedAt boundary to the matching window', () => {
     const events: AppEvent[] = [
       stepCompleted(`build-task-workspace-${TASK}`, '2026-05-09T10:00:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
     ];
     const trace: Trace = [{ elementName: `generator-${TASK}`, status: 'completed', durationMs: 10 }];
     const signals: HarnessSignal[] = [note('2026-05-09T10:01:00.000Z', 'at-end')];
@@ -85,7 +85,7 @@ describe('bucketTaskSignals — binary-search attribution', () => {
     // and there's no later task to inherit it — must orphan.
     const events: AppEvent[] = [
       stepCompleted(`build-task-workspace-${TASK}`, '2026-05-09T10:00:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
     ];
     const trace: Trace = [{ elementName: `generator-${TASK}`, status: 'completed', durationMs: 10 }];
     const signals: HarnessSignal[] = [note('2026-05-09T10:01:30.000Z', 'after-task-1')];
@@ -96,9 +96,9 @@ describe('bucketTaskSignals — binary-search attribution', () => {
   it('routes signals to the right task across two non-overlapping windows', () => {
     const events: AppEvent[] = [
       stepCompleted(`build-task-workspace-${TASK}`, '2026-05-09T10:00:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK}`, '2026-05-09T10:01:00.000Z'),
       stepCompleted(`build-task-workspace-${TASK2}`, '2026-05-09T10:02:00.000Z'),
-      stepCompleted(`unlink-skills-${TASK2}`, '2026-05-09T10:03:00.000Z'),
+      stepCompleted(`uninstall-skills-${TASK2}`, '2026-05-09T10:03:00.000Z'),
     ];
     const trace: Trace = [
       { elementName: `generator-${TASK}`, status: 'completed', durationMs: 10 },
@@ -121,7 +121,7 @@ describe('bucketTaskSignals — status derivation', () => {
   it('flips a task to completed when the default terminal substep appears', () => {
     const trace: Trace = [
       { elementName: `generator-${TASK}`, status: 'completed', durationMs: 1 },
-      { elementName: `unlink-skills-${TASK}`, status: 'completed', durationMs: 1 },
+      { elementName: `uninstall-skills-${TASK}`, status: 'completed', durationMs: 1 },
     ];
     const result = bucketTaskSignals(trace, [], []);
     expect(result.tasks[0]?.status).toBe('completed');
@@ -130,7 +130,7 @@ describe('bucketTaskSignals — status derivation', () => {
   it('respects a custom terminalSubstepName when the flow uses a different terminal leaf', () => {
     const trace: Trace = [
       { elementName: `generator-${TASK}`, status: 'completed', durationMs: 1 },
-      { elementName: `unlink-skills-${TASK}`, status: 'completed', durationMs: 1 },
+      { elementName: `uninstall-skills-${TASK}`, status: 'completed', durationMs: 1 },
       { elementName: `custom-final-${TASK}`, status: 'completed', durationMs: 1 },
     ];
     const result = bucketTaskSignals(trace, [], [], { terminalSubstepName: 'custom-final' });
@@ -146,7 +146,7 @@ describe('bucketTaskSignals — status derivation', () => {
   it('lets a failed substep override a later completed terminal substep', () => {
     const trace: Trace = [
       { elementName: `generator-${TASK}`, status: 'failed', durationMs: 1 },
-      { elementName: `unlink-skills-${TASK}`, status: 'completed', durationMs: 1 },
+      { elementName: `uninstall-skills-${TASK}`, status: 'completed', durationMs: 1 },
     ];
     const result = bucketTaskSignals(trace, [], []);
     expect(result.tasks[0]?.status).toBe('failed');

--- a/tests/unit/business/observability/log-level-filter.test.ts
+++ b/tests/unit/business/observability/log-level-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
+
+describe('passesLogLevel', () => {
+  // Truth table: rows = event level, columns = floor.
+  // `true` means the event passes; `false` means it is dropped.
+  const cases: ReadonlyArray<{
+    readonly event: 'debug' | 'info' | 'warn' | 'error';
+    readonly floor: 'silent' | 'debug' | 'info' | 'warn' | 'error';
+    readonly expected: boolean;
+  }> = [
+    // floor=silent — everything dropped
+    { event: 'debug', floor: 'silent', expected: false },
+    { event: 'info', floor: 'silent', expected: false },
+    { event: 'warn', floor: 'silent', expected: false },
+    { event: 'error', floor: 'silent', expected: false },
+    // floor=error — only error passes
+    { event: 'debug', floor: 'error', expected: false },
+    { event: 'info', floor: 'error', expected: false },
+    { event: 'warn', floor: 'error', expected: false },
+    { event: 'error', floor: 'error', expected: true },
+    // floor=warn — warn + error pass
+    { event: 'debug', floor: 'warn', expected: false },
+    { event: 'info', floor: 'warn', expected: false },
+    { event: 'warn', floor: 'warn', expected: true },
+    { event: 'error', floor: 'warn', expected: true },
+    // floor=info — info, warn, error pass; debug dropped
+    { event: 'debug', floor: 'info', expected: false },
+    { event: 'info', floor: 'info', expected: true },
+    { event: 'warn', floor: 'info', expected: true },
+    { event: 'error', floor: 'info', expected: true },
+    // floor=debug — everything passes
+    { event: 'debug', floor: 'debug', expected: true },
+    { event: 'info', floor: 'debug', expected: true },
+    { event: 'warn', floor: 'debug', expected: true },
+    { event: 'error', floor: 'debug', expected: true },
+  ];
+
+  for (const { event, floor, expected } of cases) {
+    it(`event=${event} floor=${floor} -> ${String(expected)}`, () => {
+      expect(passesLogLevel(event, floor)).toBe(expected);
+    });
+  }
+});
+
+describe('createLogLevelGate', () => {
+  it('starts at the initial level and reflects writes through get()', () => {
+    const gate = createLogLevelGate('info');
+    expect(gate.get()).toBe('info');
+    gate.set('debug');
+    expect(gate.get()).toBe('debug');
+    gate.set('silent');
+    expect(gate.get()).toBe('silent');
+  });
+
+  it('feeds passesLogLevel — flipping the floor changes the verdict mid-stream', () => {
+    const gate = createLogLevelGate('info');
+    expect(passesLogLevel('debug', gate.get())).toBe(false);
+    gate.set('debug');
+    expect(passesLogLevel('debug', gate.get())).toBe(true);
+    gate.set('silent');
+    expect(passesLogLevel('error', gate.get())).toBe(false);
+  });
+});

--- a/tests/unit/integration/ai/skills/registry.test.ts
+++ b/tests/unit/integration/ai/skills/registry.test.ts
@@ -32,6 +32,16 @@ describe('skillsForFlow', () => {
   it('returns the configured ids for a known flow', () => {
     const ids = skillsForFlow('refine');
     expect(ids.length).toBeGreaterThan(0);
-    expect(ids).toContain('alignment');
+    expect(ids).toContain('ralphctl-alignment');
+  });
+
+  it('namespaces every bundled skill id with the ralphctl- prefix', () => {
+    const allSkillIds = new Set<string>();
+    for (const ids of Object.values(FLOW_SKILLS)) {
+      for (const id of ids) allSkillIds.add(id);
+    }
+    for (const id of allSkillIds) {
+      expect(id.startsWith('ralphctl-'), `bundled skill id missing prefix: ${id}`).toBe(true);
+    }
   });
 });

--- a/tests/unit/integration/io/git-exclude.test.ts
+++ b/tests/unit/integration/io/git-exclude.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
+
+const makeRoot = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'git-exclude-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const PATTERN = '.claude/skills/ralphctl-*';
+
+describe('ensureGitExcludeWildcard', () => {
+  it('is a no-op when .git is missing (non-git working tree)', async () => {
+    const root = await makeRoot();
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+  });
+
+  it('appends the pattern to a plain-repo .git/info/exclude', async () => {
+    const root = await makeRoot();
+    await mkdir(join(String(root), '.git/info'), { recursive: true });
+    await writeFile(join(String(root), '.git/info/exclude'), '# default\n', 'utf8');
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
+    expect(content).toBe(`# default\n${PATTERN}\n`);
+  });
+
+  it('creates the info/exclude file when only .git/ exists with no info/ subdir', async () => {
+    const root = await makeRoot();
+    await mkdir(join(String(root), '.git'), { recursive: true });
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
+    expect(content).toBe(`${PATTERN}\n`);
+  });
+
+  it('is idempotent — second call with the same pattern does not duplicate', async () => {
+    const root = await makeRoot();
+    await mkdir(join(String(root), '.git/info'), { recursive: true });
+
+    await ensureGitExcludeWildcard(root, PATTERN);
+    await ensureGitExcludeWildcard(root, PATTERN);
+
+    const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
+    const lines = content.split('\n').filter((l) => l.trim() === PATTERN);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('treats whitespace-equivalent lines as already-present', async () => {
+    const root = await makeRoot();
+    await mkdir(join(String(root), '.git/info'), { recursive: true });
+    await writeFile(join(String(root), '.git/info/exclude'), `  ${PATTERN}  \n`, 'utf8');
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
+    expect(content).toBe(`  ${PATTERN}  \n`);
+  });
+
+  it('resolves the worktree pointer file (.git is a file containing gitdir:)', async () => {
+    const root = await makeRoot();
+    const realGitDir = await mkdtemp(join(tmpdir(), 'real-gitdir-'));
+    await mkdir(join(realGitDir, 'info'), { recursive: true });
+    await writeFile(join(realGitDir, 'info/exclude'), '# wt default\n', 'utf8');
+    await writeFile(join(String(root), '.git'), `gitdir: ${realGitDir}\n`, 'utf8');
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const content = await readFile(join(realGitDir, 'info/exclude'), 'utf8');
+    expect(content).toBe(`# wt default\n${PATTERN}\n`);
+  });
+
+  it('preserves a trailing-newline-less file by adding the separator', async () => {
+    const root = await makeRoot();
+    await mkdir(join(String(root), '.git/info'), { recursive: true });
+    await writeFile(join(String(root), '.git/info/exclude'), '# default', 'utf8');
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
+    expect(content).toBe(`# default\n${PATTERN}\n`);
+  });
+});


### PR DESCRIPTION
## Summary

- **Plug onto the repo (commit 2/4).** AI sessions for `refine` / `plan` / `ideate` / `implement` / `readiness` now run from the repo (`cwd = repoPath`) with the harness sandbox mounted via `--add-dir`. Works uniformly for Claude / Copilot / Codex (all three expose `--add-dir`). Net result: the AI auto-discovers the repo's own `CLAUDE.md`, `.claude/{skills,agents,commands}/`, `.mcp.json` (and `.github/` / `.agents/` analogues). Before this PR, those were silently invisible — the comment in the old `implement-session.ts` claiming `--add-dir` exposed them was wrong.
- **`ralphctl-` skill prefix + `.git/info/exclude` wildcard.** Bundled skills renamed `ralphctl-alignment` / `ralphctl-iterative-review` / `ralphctl-abstraction-first`. Detect-skills-authored project skills renamed `ralphctl-<slug>-{setup,verify}`. New `src/integration/io/git-exclude.ts` appends one wildcard line (`<parent>/skills/ralphctl-*`) to `.git/info/exclude` so `git status` never picks them up — no per-entry bookkeeping, handles plain repos + worktree pointers + missing `.git`.
- **Doctor footer no longer drifts.** `SystemStatusContext` exposes `refreshDoctor()`; doctor view consumes the shared report instead of running its own probe. Footer and view now share one source of truth.
- **Log level setting now filters the TUI recent-log.** New `passesLogLevel` helper + a mutable `LogLevelGate`; settings view updates it live on change.
- **Detect-scripts / detect-skills prompts rewritten** — lead with the emit case, consolidate the single omit rule, add worked `<example>` blocks. The four-times-repeated "fabrications are worse than silence" was steering Claude into silence even on repos with explicit CLAUDE.md guidance.
- **Claude headless `session.bodyFile`** mirrors raw assistant body to a tempfile; detect-{scripts,skills} log the path on empty proposals so future "no proposals" cases are debuggable.
- **Chain leaves renamed** `installSkillsLeaf` / `uninstallSkillsLeaf` (was `link` / `unlink`) — vocabulary matches what they do now (copy, not link) and aligns with the `SkillsAdapter` port methods. Blame preserved via `git mv`.

Four commits:
1. `b9c8d02f` fix(tui,ai): refresh doctor + log-level + detect prompts
2. `40fcfcec` refactor(ai): plug onto the repo — cwd=repo, sandbox add-dir, ralphctl- skills
3. `5c0d5b47` refactor(chain): rename link/unlink-skills → install/uninstall-skills
4. `4be117a8` docs: align REQUIREMENTS + KERNEL-DESIGN with install-skills rename

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 1346/1346 pass (was 1335 — added wildcard-exclude, log-level-filter, and git-exclude tests)
- [ ] Manual smoke: launch TUI on a repo with its own \`.claude/skills/dev/\`, run \`detect-scripts\` on a clean React+Vite repo and verify the proposal is non-empty
- [ ] Manual smoke: change \`logging.level\` in settings while a run is producing debug events; recent-log filter updates live
- [ ] Manual smoke: \`r\` in doctor view → footer indicator updates
- [ ] Manual smoke: launch \`implement\` on a repo, confirm \`.claude/skills/ralphctl-*\` lands in the repo and is absent from \`git status\`