### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,7 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-
-- **Claude headless permission mapping.** Read-only flows (`refine`, `plan`, `readiness`,
-  `detect-scripts`, `detect-skills`) previously mapped `READ_ONLY` to `--permission-mode plan`.
-  Recent Claude Code versions require interactive approval for _every_ tool under plan mode —
-  including Read / Grep / Glob — so headless `claude -p` sessions silently fell through with no
-  signals and the model emitted a human-facing "please grant read permission" body instead of
-  the expected harness tags. Operators saw an empty proposal at the confirm prompt with no
-  obvious diagnosis. Every headless session now runs under `--permission-mode bypassPermissions`
-  with a `--disallowedTools` deny list scoped to the configured `SessionPermissions`; Claude's
-  deny rules take precedence over bypass, so writes / shell / network stay blocked while reads
-  flow. No behavioural change for full-auto sessions.
-
-### Added
-
-- **Per-run forensic artifacts for one-shot flows.** `detect-scripts`, `detect-skills`, and
-  `readiness` now persist `<dataRoot>/runs/<flow>/<run-id>/{prompt.md,body.txt}` per AI call.
-  Artifacts survive after the chain exits — user-managed lifecycle (`rm -rf` at will, no auto-GC,
-  symmetric with `<sprintDir>/chain.log` for sprint flows). When the AI returns an empty proposal
-  the confirm leaf splices the raw body inline ("AI response: …") so a permission ask or
-  format slip is visible without leaving the TUI. `readiness` splices the same body into the
-  `ParseError` hint when the tool-specific wire tag is missing. Only the Claude provider
-  implements `bodyFile` today; Copilot / Codex no-op the field per the documented contract.
-
-## [0.7.0] - 2026-05-17
+## [0.7.0] - 2026-05-18
 
 > **Structural rewrite.** Internal architecture, on-disk schema, data root, and several CLI commands
 > all changed. **No automatic migration from 0.6.x** — see [README §Upgrading](./README.md#upgrading-from-06x-to-070).
@@ -54,6 +30,14 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Per-run forensic artifacts for one-shot flows.** `detect-scripts`, `detect-skills`, and
+  `readiness` now persist `<dataRoot>/runs/<flow>/<run-id>/{prompt.md,body.txt}` per AI call.
+  Artifacts survive after the chain exits — user-managed lifecycle (`rm -rf` at will, no auto-GC,
+  symmetric with `<sprintDir>/chain.log` for sprint flows). When the AI returns an empty proposal
+  the confirm leaf splices the raw body inline ("AI response: …") so a permission ask or
+  format slip is visible without leaving the TUI. `readiness` splices the same body into the
+  `ParseError` hint when the tool-specific wire tag is missing. Only the Claude provider
+  implements `bodyFile` today; Copilot / Codex no-op the field per the documented contract.
 - **OpenAI Codex provider** alongside Claude Code and GitHub Copilot — pick via `ralphctl settings`.
 - **Per-flow model selection.** Each chain (`refine`, `plan`, `implement`, `ideate`, `readiness`)
   carries its own model, configurable in `settings.json` or via the settings view.
@@ -99,6 +83,19 @@ to [Semantic Versioning](https://semver.org/).
   (`ProjectRepository`, `SprintRepository`, `SprintExecutionRepository`, `TaskRepository`).
 - v1-only TUI dependencies: `@inkjs/ui`, `colorette`, `gradient-string`, `tabtab`. v0.7.0 ships a
   hand-rolled inline gradient renderer + Ink-native primitives.
+
+### Fixed
+
+- **Claude headless permission mapping.** Read-only flows (`refine`, `plan`, `readiness`,
+  `detect-scripts`, `detect-skills`) previously mapped `READ_ONLY` to `--permission-mode plan`.
+  Recent Claude Code versions require interactive approval for _every_ tool under plan mode —
+  including Read / Grep / Glob — so headless `claude -p` sessions silently fell through with no
+  signals and the model emitted a human-facing "please grant read permission" body instead of
+  the expected harness tags. Operators saw an empty proposal at the confirm prompt with no
+  obvious diagnosis. Every headless session now runs under `--permission-mode bypassPermissions`
+  with a `--disallowedTools` deny list scoped to the configured `SessionPermissions`; Claude's
+  deny rules take precedence over bypass, so writes / shell / network stay blocked while reads
+  flow. No behavioural change for full-auto sessions.
 
 ## [0.6.3] - 2026-05-06
 


### PR DESCRIPTION
## Summary

First public release of the v0.7.0 line. The version was bumped to 0.7.0 during the v2-port commit but never tagged / published; this PR ships the rewrite **plus** today's empty-proposal fixes folded into the same `[0.7.0]` section.

- `package.json` already at `0.7.0` (no bump needed)
- CHANGELOG: folded the two `[Unreleased]` entries (forensic artifacts + Claude permission fix) into the existing `[0.7.0]` section; date bumped 2026-05-17 → 2026-05-18

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean on `src/` + `tests/`
- [x] `pnpm test` — 1347/1350 pass; the 3 failures are pre-existing flaky welcome-view render-timing tests that pass in CI (verified on PR #114)
- [ ] CI green
- [ ] Release workflow extracts the `## [0.7.0] - 2026-05-18` section cleanly into the GitHub Release body