### PR TITLE
implement/refine/plan: per-unit AI session roots + recovery hatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ fenced from business code by the layer rules.
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
 or fallback catches errors, it MUST exempt `AbortError`.
 
-**AI sessions plug onto the repo (plan / implement / ideate).** Cwd is the user's repo (multi-repo flows
+**AI sessions plug onto the repo (implement / ideate).** Cwd is the user's repo (multi-repo flows
 pick `repositories[0]`); the per-flow sandbox under `<sprintDir>/<flow>/<unit-slug>/` is mounted via
 `--add-dir` so `prompt.md`, `done-criteria.md`, and `signals.json` round-trip through harness-controlled
 paths. Cwd is the repo because Claude / Copilot / Codex only auto-discover their context file
@@ -202,12 +202,14 @@ paths. Cwd is the repo because Claude / Copilot / Codex only auto-discover their
 Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-*/` and the skills adapter appends one
 wildcard line to `.git/info/exclude` on first install so they never appear in `git status` or `git add -A`.
 
-**Refine is the exception — its AI session runs in the per-ticket unit root.** Refinement is
-implementation-agnostic by design; rooting the session in the user's repo would auto-load that repo's
-`CLAUDE.md` / agents / `.mcp.json` and bias the AI toward implementation specifics, and would also
-pollute the repo with bundled skills. The session cwd is `<sprintDir>/refinement/<ticket-slug>/`
-instead. The repo path is still consulted at launch time to derive `defaultIssueOrigin` for the
-"update remote" reviewer option, but no AI session is rooted there.
+**Refine and plan are the exceptions — their AI sessions run in the per-sprint unit root.**
+Refine's session is rooted at `<sprintDir>/refinement/<ticket-slug>/`; plan's at
+`<sprintDir>/plan/<run-slug>/`. Rooting either in any one repo would auto-load that repo's `CLAUDE.md` /
+agents / `.mcp.json` and bias the AI toward implementation specifics (refine) or toward repositories[0]
+on a multi-repo project (plan); refine would also pollute the repo with bundled skills. Plan mounts
+**every** project repository as an equal `--add-dir` source — no repo enjoys cwd privilege, so the planner
+treats every repo symmetrically. Refine's repo path is still consulted at launch time to derive
+`defaultIssueOrigin` for the "update remote" reviewer option, but no AI session is rooted there.
 
 **Bundled skills always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already exists, the
 bundled copy is skipped and the project copy is left untouched. The skills adapter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,14 +193,21 @@ fenced from business code by the layer rules.
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
 or fallback catches errors, it MUST exempt `AbortError`.
 
-**AI sessions plug onto the repo.** Cwd is the user's repo (multi-repo flows pick `repositories[0]`);
-the per-flow sandbox under `<sprintDir>/<flow>/<unit-slug>/` is mounted via `--add-dir` so `prompt.md`,
-`done-criteria.md`, and `signals.json` round-trip through harness-controlled paths. Cwd is the repo because
-Claude / Copilot / Codex only auto-discover their context file (`CLAUDE.md` / `.github/copilot-instructions.md`
-/ `AGENTS.md`), skills (`.claude/skills/` / `.github/skills/` / `.agents/skills/`), agents, and `.mcp.json`
-from cwd — not from `--add-dir` roots. Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-*/`
-and the skills adapter appends one wildcard line to `.git/info/exclude` on first install so they never appear
-in `git status` or `git add -A`.
+**AI sessions plug onto the repo (plan / implement / ideate).** Cwd is the user's repo (multi-repo flows
+pick `repositories[0]`); the per-flow sandbox under `<sprintDir>/<flow>/<unit-slug>/` is mounted via
+`--add-dir` so `prompt.md`, `done-criteria.md`, and `signals.json` round-trip through harness-controlled
+paths. Cwd is the repo because Claude / Copilot / Codex only auto-discover their context file
+(`CLAUDE.md` / `.github/copilot-instructions.md` / `AGENTS.md`), skills (`.claude/skills/` /
+`.github/skills/` / `.agents/skills/`), agents, and `.mcp.json` from cwd — not from `--add-dir` roots.
+Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-*/` and the skills adapter appends one
+wildcard line to `.git/info/exclude` on first install so they never appear in `git status` or `git add -A`.
+
+**Refine is the exception — its AI session runs in the per-ticket unit root.** Refinement is
+implementation-agnostic by design; rooting the session in the user's repo would auto-load that repo's
+`CLAUDE.md` / agents / `.mcp.json` and bias the AI toward implementation specifics, and would also
+pollute the repo with bundled skills. The session cwd is `<sprintDir>/refinement/<ticket-slug>/`
+instead. The repo path is still consulted at launch time to derive `defaultIssueOrigin` for the
+"update remote" reviewer option, but no AI session is rooted there.
 
 **Bundled skills always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already exists, the
 bundled copy is skipped and the project copy is left untouched. The skills adapter

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -86,7 +86,11 @@ export interface CreateImplementFlowOpts {
   readonly sprintDir: AbsolutePath;
   /** Configured model for the implement chain — `config.ai.<provider>.models.implement`. */
   readonly model: string;
-  /** How preflight handles a dirty working tree. Default `'cancel'`. */
+  /**
+   * How preflight handles a dirty working tree. Default `'prompt'` — interactive recovery
+   * (Keep / Stash / Reset / Cancel). Non-interactive callers (CI, headless harness) should
+   * explicitly pass `'cancel'` or `'continue'`.
+   */
   readonly dirtyTreePolicy?: DirtyTreePolicy;
 }
 
@@ -325,13 +329,18 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
   }));
 
   // Per-repo dirty-tree preflight. Each affected repo gets its own check so a clean
-  // working tree in one repo doesn't mask a dirty tree in another.
+  // working tree in one repo doesn't mask a dirty tree in another. Default to 'prompt' here
+  // so the interactive recovery menu (Keep / Stash / Reset / Cancel) fires; the business-layer
+  // default stays 'cancel' for non-interactive callers in isolation.
+  const dirtyTreePolicy: DirtyTreePolicy = opts.dirtyTreePolicy ?? 'prompt';
   const preflightLeaves = uniqueRepoCwds.map((cwd, i) =>
     preflightTaskLeaf(
       {
         gitRunner: deps.gitRunner,
+        interactive: deps.interactive,
+        clock: deps.clock,
         logger: deps.logger,
-        ...(opts.dirtyTreePolicy !== undefined ? { dirtyTreePolicy: opts.dirtyTreePolicy } : {}),
+        dirtyTreePolicy,
       },
       cwd,
       `preflight-task-${String(i + 1)}-${String(cwd)}`

--- a/src/application/flows/implement/leaves/preflight-task.ts
+++ b/src/application/flows/implement/leaves/preflight-task.ts
@@ -1,5 +1,7 @@
+import { Result } from '@src/domain/result.ts';
 import {
   preflightTaskUseCase,
+  type DirtyTreeChoice,
   type DirtyTreePolicy,
   type PreflightTaskProps,
 } from '@src/business/task/preflight-task.ts';
@@ -7,22 +9,35 @@ import {
 export type { DirtyTreePolicy };
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
-import { gitStatusPorcelain } from '@src/integration/io/git-operations.ts';
+import { gitResetHard, gitStashPush, gitStatusPorcelain } from '@src/integration/io/git-operations.ts';
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 export interface PreflightTaskLeafDeps {
   readonly gitRunner: GitRunner;
   readonly logger: Logger;
+  readonly interactive: InteractivePrompt;
+  readonly clock: () => IsoTimestamp;
   readonly dirtyTreePolicy?: DirtyTreePolicy;
 }
 
+interface PreflightTaskInput {
+  readonly sprintId: string;
+}
+
+const ELEMENT_NAME = 'preflight-task';
+
 /**
- * Chain leaf — adapts ctx → preflightTaskUseCase → ctx. Wires the gitRunner to a function-shape
- * `gitStatusEntryCount` dep so the use case stays integration-agnostic. Business policy
- * (cancel vs continue on dirty tree) lives in `@src/business/task/preflight-task.ts`.
+ * Chain leaf — adapts ctx → preflightTaskUseCase → ctx. Wires the gitRunner to function-shape
+ * dependencies (`gitStatusEntryCount`, `gitStash`, `gitReset`) and translates the
+ * `InteractivePrompt` port into the function-shape `askDirtyTreeChoice` callback the use case
+ * expects. Business policy (cancel / continue / prompt) lives in
+ * `@src/business/task/preflight-task.ts`.
  */
 export const preflightTaskLeaf = (
   deps: PreflightTaskLeafDeps,
@@ -35,17 +50,57 @@ export const preflightTaskLeaf = (
     return { ok: true, value: status.value.length } as Awaited<ReturnType<PreflightTaskProps['gitStatusEntryCount']>>;
   };
 
-  return leaf<ImplementCtx, void, void>(name, {
+  const gitStash: NonNullable<PreflightTaskProps['gitStash']> = (path, message) =>
+    gitStashPush(deps.gitRunner, path, message);
+  const gitReset: NonNullable<PreflightTaskProps['gitReset']> = (path) => gitResetHard(deps.gitRunner, path);
+
+  const askDirtyTreeChoice: NonNullable<PreflightTaskProps['askDirtyTreeChoice']> = async ({
+    cwd: dirtyCwd,
+    dirtyEntries,
+  }) => {
+    const choice = await deps.interactive.askChoice<DirtyTreeChoice>(
+      `Working tree at ${String(dirtyCwd)} has ${String(dirtyEntries)} uncommitted change(s). How do you want to handle it?`,
+      [
+        {
+          label: 'Keep changes — proceed on the dirty tree',
+          value: 'keep',
+          description: 'AI may build on / overwrite the pending diff',
+        },
+        { label: 'Stash — save changes to a recoverable stash, then proceed', value: 'stash' },
+        {
+          label: 'Reset — discard all uncommitted + untracked changes, then proceed',
+          value: 'reset',
+          description: 'git reset --hard && git clean -fd',
+        },
+        { label: 'Cancel — abort the implement run', value: 'cancel' },
+      ]
+    );
+    if (!choice.ok) {
+      // User cancelled the menu (Ctrl-C / Esc). Surface as AbortError so the chain runner
+      // treats it as explicit user cancellation rather than a configuration bug.
+      return Result.error(
+        new AbortError({ elementName: ELEMENT_NAME, reason: `dirty-tree prompt cancelled — ${choice.error.message}` })
+      );
+    }
+    return Result.ok(choice.value);
+  };
+
+  return leaf<ImplementCtx, PreflightTaskInput, void>(name, {
     useCase: {
-      execute: async () =>
+      execute: async (input) =>
         preflightTaskUseCase({
           cwd,
           gitStatusEntryCount,
+          gitStash,
+          gitReset,
+          askDirtyTreeChoice,
+          clock: deps.clock,
+          sprintId: input.sprintId,
           logger: deps.logger,
           ...(deps.dirtyTreePolicy !== undefined ? { dirtyTreePolicy: deps.dirtyTreePolicy } : {}),
         }),
     },
-    input: () => undefined,
+    input: (ctx) => ({ sprintId: String(ctx.sprintId) }),
     output: (ctx) => ctx,
   });
 };

--- a/src/application/flows/plan/flow.ts
+++ b/src/application/flows/plan/flow.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
 import { loadAndAssertSprintSubChain } from '@src/application/flows/_shared/sprint/load-and-assert-sprint.ts';
@@ -22,12 +23,12 @@ import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/unins
 export interface CreatePlanFlowOpts {
   readonly sprintId: SprintId;
   readonly projectId: ProjectId;
-  /** Working directory for the AI session — typically the repo root for codebase navigation. */
-  readonly cwd: AbsolutePath;
   /**
-   * Extra repo roots to mount alongside `cwd` so the planner can read across every repo on a
-   * multi-repo project without per-file approval prompts. Caller (the launcher) passes
-   * `project.repositories.map((r) => r.path)`; the adapter folds duplicates with `cwd`.
+   * Repo roots mounted as equal `--add-dir` sources so the planner can navigate every repo on
+   * a multi-repo project without per-file approval prompts. Caller (the launcher) passes
+   * `project.repositories.map((r) => r.path)`. No repo enjoys cwd privilege — the session's
+   * cwd is the per-sprint plan unit root, so no repo's `CLAUDE.md` / agents / `.mcp.json`
+   * auto-loads, and the planner treats every repo symmetrically.
    */
   readonly additionalRoots?: readonly AbsolutePath[];
   /** Configured model — `config.ai.<provider>.models.plan`. */
@@ -110,9 +111,21 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
       { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
       {
         flowId: 'plan',
-        // Skills land in the AI session's cwd (the repo) — the provider-native conventions
-        // only auto-discover skills from cwd, not from `--add-dir` roots.
-        cwdPicker: () => opts.cwd,
+        // Skills land in the AI session's cwd — for plan that's the per-sprint plan unit root
+        // (`<sprintDir>/plan/<run-slug>/`), not any project repo. Plan mounts every repo as an
+        // equal `--add-dir` source; rooting the session in any one repo would auto-load that
+        // repo's `CLAUDE.md` / agents / `.mcp.json` and bias the planner toward it.
+        cwdPicker: (ctx) => {
+          if (ctx.currentUnitRoot === undefined) {
+            throw new InvalidStateError({
+              entity: 'chain',
+              currentState: 'pre-plan',
+              attemptedAction: 'install-skills',
+              message: 'install-skills: currentUnitRoot missing — build-plan-unit must run first',
+            });
+          }
+          return ctx.currentUnitRoot;
+        },
       }
     ),
     callPlannerInteractiveLeaf({
@@ -120,14 +133,28 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
       runInTerminal: deps.runInTerminal,
       logger: deps.logger,
       clock: deps.clock,
-      cwd: opts.cwd,
       model: opts.model,
       ...(opts.additionalRoots !== undefined && opts.additionalRoots.length > 0
         ? { additionalRoots: opts.additionalRoots }
         : {}),
       ...(deps.reviewBeforeApprove !== undefined ? { reviewBeforeApprove: deps.reviewBeforeApprove } : {}),
     }),
-    uninstallSkillsLeaf<PlanCtx>({ skillsAdapter: deps.skillsAdapter }, { cwdPicker: () => opts.cwd }),
+    uninstallSkillsLeaf<PlanCtx>(
+      { skillsAdapter: deps.skillsAdapter },
+      {
+        cwdPicker: (ctx) => {
+          if (ctx.currentUnitRoot === undefined) {
+            throw new InvalidStateError({
+              entity: 'chain',
+              currentState: 'pre-plan',
+              attemptedAction: 'uninstall-skills',
+              message: 'uninstall-skills: currentUnitRoot missing — build-plan-unit must run first',
+            });
+          }
+          return ctx.currentUnitRoot;
+        },
+      }
+    ),
     saveTasksLeaf<PlanCtx>({ taskRepo: deps.taskRepo }),
     saveSprintLeaf<PlanCtx>({ sprintRepo: deps.sprintRepo }),
   ]);

--- a/src/application/flows/plan/leaves/call-planner-interactive.ts
+++ b/src/application/flows/plan/leaves/call-planner-interactive.ts
@@ -33,11 +33,10 @@ export interface CallPlannerInteractiveDeps {
   readonly runInTerminal: RunInTerminal;
   readonly logger: Logger;
   readonly clock: () => IsoTimestamp;
-  readonly cwd: AbsolutePath;
   /**
-   * Extra repo roots to mount alongside `cwd`. The plan flow passes every repository on the
-   * project so the AI can navigate across a multi-repo codebase without per-file approval
-   * prompts during interview-style planning. Adapter folds duplicates with `cwd`.
+   * Repo roots mounted as equal `--add-dir` sources alongside the per-sprint plan unit root.
+   * The plan flow passes every repository on the project so the AI can navigate across a
+   * multi-repo codebase without per-file approval prompts during interview-style planning.
    */
   readonly additionalRoots?: readonly AbsolutePath[];
   readonly model: string;
@@ -56,6 +55,7 @@ interface CallPlannerInput {
   readonly sprint: DraftSprint;
   readonly project: Project;
   readonly existingTasks: readonly Task[];
+  readonly cwd: AbsolutePath;
   readonly promptFile: AbsolutePath;
   readonly outputFile: AbsolutePath;
 }
@@ -79,7 +79,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
 
         const session = await deps.runInTerminal(async () =>
           deps.interactiveAi.run({
-            cwd: deps.cwd,
+            cwd: input.cwd,
             promptFile: input.promptFile,
             outputFile: input.outputFile,
             model: deps.model,
@@ -159,10 +159,19 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
           message: 'call-planner-interactive: prompt/output paths missing — render-prompt-to-file must run first',
         });
       }
+      if (ctx.currentUnitRoot === undefined) {
+        throw new InvalidStateError({
+          entity: 'chain',
+          currentState: 'pre-plan',
+          attemptedAction: 'call-planner-interactive',
+          message: 'call-planner-interactive: unit root missing — build-plan-unit must run first',
+        });
+      }
       return {
         sprint: ctx.sprint,
         project: ctx.project,
         existingTasks: ctx.tasks ?? [],
+        cwd: ctx.currentUnitRoot,
         promptFile: ctx.currentPromptFile,
         outputFile: ctx.currentOutputFile,
       };

--- a/src/application/flows/refine/flow.ts
+++ b/src/application/flows/refine/flow.ts
@@ -26,8 +26,6 @@ export interface CreateRefineFlowOpts {
    * time so the trace names every ticket — a crash mid-run shows exactly which ticket failed.
    */
   readonly pendingTickets: readonly PendingTicket[];
-  /** Working directory for the AI session — typically the repo root. */
-  readonly cwd: AbsolutePath;
   /** Configured model for the refine chain. */
   readonly model: string;
   /** Per-sprint refinement directory: `<sprintDir>/refinement/`. The chain materialises per-ticket subfolders under it. */
@@ -118,9 +116,17 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
         {
           name: `install-skills-${String(ticket.id)}`,
           flowId: 'refine',
-          // Skills land in the AI session's cwd (the repo) — the provider-native conventions
-          // only auto-discover skills from cwd, not from `--add-dir` roots.
-          cwdPicker: () => opts.cwd,
+          // Skills land in the AI session's cwd — for refine that's the per-ticket unit root
+          // (`<sprintDir>/refinement/<ticket-slug>/`), not the user's repo. Refinement is
+          // implementation-agnostic, so we keep the AI out of the repo's auto-discovered context.
+          cwdPicker: (ctx) => {
+            if (ctx.currentUnitRoot === undefined) {
+              throw new Error(
+                `install-skills-${String(ticket.id)}: currentUnitRoot missing — build-refine-unit must run first`
+              );
+            }
+            return ctx.currentUnitRoot;
+          },
         }
       ),
       refineTicketInteractiveLeaf(
@@ -128,7 +134,6 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
           interactiveAi: deps.interactiveAi,
           runInTerminal: deps.runInTerminal,
           logger: deps.logger,
-          cwd: opts.cwd,
           model: opts.model,
           ...(deps.reviewBeforeApprove !== undefined ? { reviewBeforeApprove: deps.reviewBeforeApprove } : {}),
           ...(deps.issuePusher !== undefined ? { issuePusher: deps.issuePusher } : {}),
@@ -138,7 +143,17 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
       ),
       uninstallSkillsLeaf<RefineCtx>(
         { skillsAdapter: deps.skillsAdapter },
-        { name: `uninstall-skills-${String(ticket.id)}`, cwdPicker: () => opts.cwd }
+        {
+          name: `uninstall-skills-${String(ticket.id)}`,
+          cwdPicker: (ctx) => {
+            if (ctx.currentUnitRoot === undefined) {
+              throw new Error(
+                `uninstall-skills-${String(ticket.id)}: currentUnitRoot missing — build-refine-unit must run first`
+              );
+            }
+            return ctx.currentUnitRoot;
+          },
+        }
       ),
       saveSprintLeaf<RefineCtx>({ sprintRepo: deps.sprintRepo }, `save-after-${String(ticket.id)}`),
     ])

--- a/src/application/flows/refine/leaves/refine-ticket-interactive.ts
+++ b/src/application/flows/refine/leaves/refine-ticket-interactive.ts
@@ -30,7 +30,6 @@ export interface RefineTicketInteractiveDeps {
   readonly interactiveAi: InteractiveAiProvider;
   readonly runInTerminal: RunInTerminal;
   readonly logger: Logger;
-  readonly cwd: AbsolutePath;
   readonly model: string;
   /**
    * Optional human-in-the-loop approval callback wired by the flow factory. The launcher
@@ -62,6 +61,7 @@ const REFINED_FOOTER = (now: string): string => `\n\n---\n_Refined by ralphctl o
 interface RefineTicketInteractiveInput {
   readonly sprint: Sprint;
   readonly ticket: PendingTicket;
+  readonly cwd: AbsolutePath;
   readonly promptFile: AbsolutePath;
   readonly outputFile: AbsolutePath;
 }
@@ -131,7 +131,7 @@ export const refineTicketInteractiveLeaf = (
       execute: async (input) => {
         const session = await deps.runInTerminal(async () =>
           deps.interactiveAi.run({
-            cwd: deps.cwd,
+            cwd: input.cwd,
             promptFile: input.promptFile,
             outputFile: input.outputFile,
             model: deps.model,
@@ -192,9 +192,18 @@ export const refineTicketInteractiveLeaf = (
           message: `refine-ticket-${String(ticket.id)}: prompt/output paths missing — render-prompt-to-file must run first`,
         });
       }
+      if (ctx.currentUnitRoot === undefined) {
+        throw new InvalidStateError({
+          entity: 'chain',
+          currentState: 'pre-refine',
+          attemptedAction: `refine-ticket-${String(ticket.id)}`,
+          message: `refine-ticket-${String(ticket.id)}: unit root missing — build-refine-unit must run first`,
+        });
+      }
       return {
         sprint: ctx.sprint,
         ticket,
+        cwd: ctx.currentUnitRoot,
         promptFile: ctx.currentPromptFile,
         outputFile: ctx.currentOutputFile,
       };

--- a/src/application/ui/cli/commands/task.ts
+++ b/src/application/ui/cli/commands/task.ts
@@ -3,18 +3,21 @@ import type { Task } from '@src/domain/entity/task.ts';
 import { TaskId } from '@src/domain/value/id/task-id.ts';
 import { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 
 interface SprintOpt {
   readonly sprint: string;
 }
 
 /**
- * Register the `task` command group. Read-side only — task creation is owned by the planning
- * chain (AI generates the task graph from approved tickets); manual `task add` / `task edit`
- * are deferred until there's a concrete UX for tweaking AI-generated plans.
+ * Register the `task` command group. Read-side plus a single recovery hatch (`unblock`) —
+ * task creation is owned by the planning chain (AI generates the task graph from approved
+ * tickets); manual `task add` / `task edit` are deferred until there's a concrete UX for
+ * tweaking AI-generated plans.
  *
  *   ralphctl task list --sprint <id>
  *   ralphctl task show --sprint <id> <task-id>
+ *   ralphctl task unblock --sprint <id> <task-id>
  */
 export const registerTaskCommand = (program: Command): void => {
   const task = program.command('task').description('inspect tasks for a sprint (planning generates them)');
@@ -71,6 +74,44 @@ export const registerTaskCommand = (program: Command): void => {
         return;
       }
       process.stdout.write(`${JSON.stringify(result.value, null, 2)}\n`);
+    });
+
+  task
+    .command('unblock <taskId>')
+    .description('flip a blocked task back to todo so the implement loop picks it up again')
+    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .action(async (rawTaskId: string, opts: SprintOpt) => {
+      const sprintId = SprintId.parse(opts.sprint);
+      if (!sprintId.ok) {
+        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      const taskId = TaskId.parse(rawTaskId);
+      if (!taskId.ok) {
+        process.stderr.write(`error: invalid task id: ${taskId.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      const { deps } = await bootstrapCli();
+      const loaded = await deps.taskRepo.findById(sprintId.value, taskId.value);
+      if (!loaded.ok) {
+        process.stderr.write(`error: ${loaded.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      const result = await unblockTaskUseCase({
+        task: loaded.value,
+        sprintId: sprintId.value,
+        taskRepo: deps.taskRepo,
+        logger: deps.logger,
+      });
+      if (!result.ok) {
+        process.stderr.write(`error: ${result.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      process.stdout.write(`unblocked task '${result.value.name}' (${String(result.value.id)})\n`);
     });
 };
 

--- a/src/application/ui/shared/launch/plan.ts
+++ b/src/application/ui/shared/launch/plan.ts
@@ -8,10 +8,13 @@ import type { LaunchContext } from '@src/application/ui/shared/launch/context.ts
 import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 
 export const launchPlan = (ctx: LaunchContext): LaunchResult => {
-  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, cwd, bridge, sessionId } = ctx;
+  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId } = ctx;
   if (!snapshot.project) return { ok: false, reason: 'No project loaded.' };
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
-  if (!cwd) return { ok: false, reason: 'No repository path resolvable from the project.' };
+  // No `cwd` pre-flight: plan's AI session is rooted at the per-sprint plan unit root
+  // (`<sprintDir>/plan/<run-slug>/`), and every project repository is mounted as an equal
+  // `--add-dir` source. If `repositories` is empty the chain surfaces a clearer error from
+  // inside (e.g. the planner producing a `projectPath` mismatch) than an opaque pre-flight reject.
   const planRoot = AbsolutePath.parse(
     join(String(deps.storage.dataRoot), 'sprints', String(snapshot.sprint.id), 'plan')
   );
@@ -54,9 +57,9 @@ export const launchPlan = (ctx: LaunchContext): LaunchResult => {
     {
       sprintId: snapshot.sprint.id,
       projectId: snapshot.project.id,
-      cwd,
-      // Mount every repo on the project so the planner can navigate across them without per-file
-      // approval prompts. Duplicates with `cwd` are folded out by the adapter.
+      // Mount every repo on the project as an equal `--add-dir` source so the planner can
+      // navigate across them without per-file approval prompts. No repo enjoys cwd privilege —
+      // the session's cwd is the per-sprint plan unit root.
       additionalRoots: snapshot.project.repositories.map((r) => r.path),
       model: extras.modelOverride ?? settings.ai.models.plan,
       planRoot: planRoot.value,

--- a/src/application/ui/shared/launch/refine.ts
+++ b/src/application/ui/shared/launch/refine.ts
@@ -31,9 +31,13 @@ const deriveOriginFromGit = async (
 };
 
 export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> => {
-  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, cwd, bridge, sessionId } = ctx;
+  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId } = ctx;
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
-  if (!cwd) return { ok: false, reason: 'No repository path resolvable from the project.' };
+  // Refine intentionally does not require a repo path — the AI session is rooted at the
+  // per-ticket unit folder (`<sprintDir>/refinement/<ticket-slug>/`), not the repo, because
+  // refinement is implementation-agnostic. The repo path is still consulted below to derive
+  // `defaultIssueOrigin` for the "update remote" reviewer option, but that resolution is
+  // best-effort and tolerates a missing path.
   const pending = snapshot.sprint.tickets.filter((t) => t.status === 'pending');
   const refinementRoot = AbsolutePath.parse(
     join(String(deps.storage.dataRoot), 'sprints', String(snapshot.sprint.id), 'refinement')
@@ -132,7 +136,6 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
     {
       sprintId: snapshot.sprint.id,
       pendingTickets: pending,
-      cwd,
       model: extras.modelOverride ?? settings.ai.models.refine,
       refinementRoot: refinementRoot.value,
     }

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -54,6 +54,7 @@ import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { createTicketRemoveFlow } from '@src/application/flows/ticket-remove/flow.ts';
+import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 
 interface SprintDetailProps extends Readonly<Record<string, unknown>> {
   readonly sprintId: SprintId;
@@ -149,6 +150,9 @@ export const SprintDetailView = (): React.JSX.Element => {
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';
   const inDetail = openIdx !== undefined;
+  const focusedNow = focusList[Math.min(cursorIdx, Math.max(0, focusList.length - 1))];
+  const focusedBlockedTask =
+    focusedNow?.kind === 'task' && focusedNow.task.status === 'blocked' ? focusedNow.task : undefined;
 
   useViewHints(
     inDetail
@@ -158,6 +162,7 @@ export const SprintDetailView = (): React.JSX.Element => {
           { keys: '↵/o', label: 'open' },
           { keys: 'a', label: 'add ticket' },
           { keys: 'd', label: 'remove ticket' },
+          ...(focusedBlockedTask !== undefined ? [{ keys: 'u', label: 'unblock' }] : []),
         ]
   );
 
@@ -186,6 +191,10 @@ export const SprintDetailView = (): React.JSX.Element => {
     if (input === 'd' && ticketsEditable) {
       const focused = focusList[Math.min(cursorIdx, focusList.length - 1)];
       if (focused?.kind === 'ticket') setConfirmRemove(focused.ticket);
+      return;
+    }
+    if (input === 'u' && focusedBlockedTask !== undefined) {
+      void handleUnblock(focusedBlockedTask);
     }
   });
 
@@ -202,6 +211,22 @@ export const SprintDetailView = (): React.JSX.Element => {
       return;
     }
     setFeedback(`✓ removed "${target.title}"`);
+    reload();
+  };
+
+  const handleUnblock = async (target: Task): Promise<void> => {
+    if (sprint === undefined) return;
+    const r = await unblockTaskUseCase({
+      task: target,
+      sprintId: sprint.id,
+      taskRepo: deps.taskRepo,
+      logger: deps.logger,
+    });
+    if (!r.ok) {
+      setFeedback(`✗ ${r.error.message}`);
+      return;
+    }
+    setFeedback(`✓ unblocked "${target.name}"`);
     reload();
   };
 

--- a/src/business/task/preflight-task.ts
+++ b/src/business/task/preflight-task.ts
@@ -1,31 +1,81 @@
 import { Result } from '@src/domain/result.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 
 /**
- * Preflight check before each task: working tree must be clean. Policy is "cancel by default" —
- * uncommitted changes reject the task so the harness doesn't accidentally amend / commit them.
- * `dirtyTreePolicy='continue'` opts out (logs a warning and proceeds).
+ * Preflight check before each task: working tree must be clean. Three policies cover the three
+ * caller shapes:
+ *
+ * - `'cancel'` (default) — reject a dirty tree with `InvalidStateError`. Safe default for
+ *   non-interactive callers (CI, headless harness, tests) so the chain hard-fails instead of
+ *   silently amending or overwriting a pending diff.
+ * - `'continue'` — operator override: log a warning and proceed on whatever's in the tree.
+ *   Used when the operator has manually inspected the tree and wants the AI to build on it.
+ * - `'prompt'` — interactive recovery: invoke `askDirtyTreeChoice` to learn the user's
+ *   preference (keep / stash / reset / cancel). The flow wires the integration-level prompt
+ *   port into `askDirtyTreeChoice` and provides `gitStash` / `gitReset` so the user-chosen
+ *   action can actually be carried out. Selecting "cancel" returns `AbortError`, treated by
+ *   the chain runner as user-initiated cancellation.
  *
  * The `gitStatusEntryCount` dep returns the number of porcelain entries — caller (chain leaf)
  * adapts the underlying git runner.
  */
-export type DirtyTreePolicy = 'cancel' | 'continue';
+export type DirtyTreePolicy = 'cancel' | 'continue' | 'prompt';
+
+/**
+ * The four resolutions a user can pick when preflight finds a dirty tree under
+ * `dirtyTreePolicy='prompt'`. Lifted to the business layer (rather than letting the leaf
+ * map a `Choice<T>` directly) so the business module stays decoupled from the `interactive/`
+ * sibling under `src/business/` (ESLint sibling-isolation rule).
+ */
+export type DirtyTreeChoice = 'keep' | 'stash' | 'reset' | 'cancel';
 
 export interface PreflightTaskProps {
   readonly cwd: AbsolutePath;
   readonly gitStatusEntryCount: (cwd: AbsolutePath) => Promise<Result<number, StorageError>>;
   readonly dirtyTreePolicy?: DirtyTreePolicy;
   readonly logger: Logger;
+  /**
+   * Required when `dirtyTreePolicy === 'prompt'`. Returns the user's pick or an `AbortError`
+   * if the user cancelled the menu itself (e.g. Ctrl-C). Function-shape so the use case
+   * stays decoupled from the integration-level `InteractivePrompt` port (which lives under
+   * a sibling business module).
+   */
+  readonly askDirtyTreeChoice?: (input: {
+    readonly cwd: AbsolutePath;
+    readonly dirtyEntries: number;
+  }) => Promise<Result<DirtyTreeChoice, AbortError>>;
+  /**
+   * Required when `dirtyTreePolicy === 'prompt'` and the user picks 'stash'. Receives the cwd
+   * and a generated stash message; returns `{ stashed }` or a StorageError. Function-shape so
+   * the use case stays integration-agnostic.
+   */
+  readonly gitStash?: (
+    cwd: AbsolutePath,
+    message: string
+  ) => Promise<Result<{ readonly stashed: boolean }, StorageError>>;
+  /**
+   * Required when `dirtyTreePolicy === 'prompt'` and the user picks 'reset'. Wipes uncommitted
+   * + untracked changes. Function-shape so the use case stays integration-agnostic.
+   */
+  readonly gitReset?: (cwd: AbsolutePath) => Promise<Result<void, StorageError>>;
+  /** Required when `dirtyTreePolicy === 'prompt'`. Used to stamp the stash message timestamp. */
+  readonly clock?: () => IsoTimestamp;
+  /** Optional sprint id surfaced in the stash message so the user can locate it later. */
+  readonly sprintId?: string;
 }
 
 export type PreflightTaskOutput = void;
 
+const ELEMENT_NAME = 'preflight-task';
+
 export const preflightTaskUseCase = async (
   props: PreflightTaskProps
-): Promise<Result<PreflightTaskOutput, InvalidStateError | StorageError>> => {
+): Promise<Result<PreflightTaskOutput, AbortError | InvalidStateError | StorageError>> => {
   const log = props.logger.named('task.preflight');
   log.debug('checking working tree', { cwd: props.cwd });
 
@@ -40,12 +90,17 @@ export const preflightTaskUseCase = async (
   }
 
   const policy: DirtyTreePolicy = props.dirtyTreePolicy ?? 'cancel';
+
   if (policy === 'continue') {
     log.warn(`working tree dirty (${String(count.value)} entries) — proceeding (policy=continue)`, {
       cwd: props.cwd,
       dirtyEntries: count.value,
     });
     return Result.ok(undefined);
+  }
+
+  if (policy === 'prompt') {
+    return resolveViaPrompt(props, count.value);
   }
 
   log.warn('refusing to start a task on a dirty tree', { cwd: props.cwd, dirtyEntries: count.value });
@@ -58,4 +113,74 @@ export const preflightTaskUseCase = async (
       hint: 'commit or stash your work, or pass --dirty=continue to override',
     })
   );
+};
+
+const resolveViaPrompt = async (
+  props: PreflightTaskProps,
+  dirtyEntries: number
+): Promise<Result<PreflightTaskOutput, AbortError | InvalidStateError | StorageError>> => {
+  const log = props.logger.named('task.preflight');
+
+  // The flow always wires askDirtyTreeChoice / gitStash / gitReset / clock when it sets
+  // policy='prompt'. A missing dep here means the composition root forgot to plumb something —
+  // a wiring bug, not a runtime condition the user can recover from. Throw an InvalidStateError
+  // so the harness surfaces a clear error rather than silently degrading.
+  if (
+    props.askDirtyTreeChoice === undefined ||
+    props.gitStash === undefined ||
+    props.gitReset === undefined ||
+    props.clock === undefined
+  ) {
+    throw new InvalidStateError({
+      entity: ELEMENT_NAME,
+      currentState: 'prompt-without-deps',
+      attemptedAction: 'configure-prompt-deps',
+      message:
+        "preflight-task: dirtyTreePolicy='prompt' requires askDirtyTreeChoice, gitStash, gitReset, and clock dependencies",
+    });
+  }
+
+  const choice = await props.askDirtyTreeChoice({ cwd: props.cwd, dirtyEntries });
+  if (!choice.ok) {
+    // askDirtyTreeChoice already returns AbortError on user cancellation; propagate verbatim
+    // so the chain treats it as user-initiated cancellation.
+    return Result.error(choice.error);
+  }
+
+  switch (choice.value) {
+    case 'keep':
+      log.info(`working tree dirty (${String(dirtyEntries)} entries) — proceeding (user chose 'keep')`, {
+        cwd: props.cwd,
+        dirtyEntries,
+      });
+      return Result.ok(undefined);
+
+    case 'stash': {
+      const sprintLabel = props.sprintId !== undefined && props.sprintId.length > 0 ? props.sprintId : 'unknown';
+      const message = `ralphctl preflight stash (sprint ${sprintLabel}, ${String(props.clock())})`;
+      const stashed = await props.gitStash(props.cwd, message);
+      if (!stashed.ok) return Result.error(stashed.error);
+      if (!stashed.value.stashed) {
+        // Defensive: we just observed the tree is dirty, so gitStash should have stashed. If it
+        // reports nothing-to-stash anyway (race against an external process), don't block —
+        // the tree is now clean enough to proceed.
+        log.warn('stash reported no changes despite dirty status — proceeding', { cwd: props.cwd });
+        return Result.ok(undefined);
+      }
+      log.info(`stashed working tree — recoverable as: ${message}`, { cwd: props.cwd, stashMessage: message });
+      return Result.ok(undefined);
+    }
+
+    case 'reset': {
+      const reset = await props.gitReset(props.cwd);
+      if (!reset.ok) return Result.error(reset.error);
+      log.info('reset working tree — discarded uncommitted + untracked changes', { cwd: props.cwd });
+      return Result.ok(undefined);
+    }
+
+    case 'cancel':
+      return Result.error(
+        new AbortError({ elementName: ELEMENT_NAME, reason: 'user cancelled on dirty working tree' })
+      );
+  }
 };

--- a/src/business/task/unblock-task.ts
+++ b/src/business/task/unblock-task.ts
@@ -1,0 +1,67 @@
+import { Result } from '@src/domain/result.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import { unblockTask, type Task, type TodoTask } from '@src/domain/entity/task.ts';
+import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+
+/**
+ * Manually unblock a task — recovery hatch for transient pre-task failures (a flaky test
+ * runner, a JVM agent attach hiccup, a one-off mvn/Gradle download wobble) that would
+ * otherwise leave the task stuck in `blocked` and require hand-editing `tasks.json`.
+ *
+ * Policy: domain transition + persist + log. Idempotent — an already-`todo` task passes
+ * through unchanged (mirrors {@link activateSprintUseCase}'s shape).
+ *
+ * Rejects `done` / `in_progress` with `InvalidStateError` (the domain {@link unblockTask}
+ * guard does the work). After this, the task re-enters the implement queue on the next run.
+ */
+export interface UnblockTaskProps {
+  readonly task: Task;
+  readonly sprintId: SprintId;
+  readonly taskRepo: UpdateTask;
+  readonly logger: Logger;
+}
+
+export type UnblockTaskOutput = TodoTask;
+
+export const unblockTaskUseCase = async (
+  props: UnblockTaskProps
+): Promise<Result<UnblockTaskOutput, InvalidStateError | NotFoundError | StorageError>> => {
+  const log = props.logger.named('task.unblock');
+
+  if (props.task.status === 'todo') {
+    log.debug('already todo, skipping', { taskId: props.task.id, sprintId: props.sprintId });
+    return Result.ok(props.task);
+  }
+
+  log.debug('unblocking task', {
+    taskId: props.task.id,
+    sprintId: props.sprintId,
+    from: props.task.status,
+  });
+
+  const transitioned = unblockTask(props.task);
+  if (!transitioned.ok) {
+    log.warn('invalid state transition', {
+      taskId: props.task.id,
+      from: props.task.status,
+      error: transitioned.error.message,
+    });
+    return Result.error(transitioned.error);
+  }
+
+  const persisted = await props.taskRepo.update(props.sprintId, transitioned.value);
+  if (!persisted.ok) {
+    log.error('persist failed', { taskId: transitioned.value.id, error: persisted.error.message });
+    return Result.error(persisted.error);
+  }
+
+  log.info(`unblocked task '${transitioned.value.name}'`, {
+    taskId: transitioned.value.id,
+    sprintId: props.sprintId,
+  });
+  return Result.ok(transitioned.value);
+};

--- a/src/integration/ai/providers/_engine/headless-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/headless-ai-provider.ts
@@ -16,8 +16,8 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
  * tag a flow extracts (`<task-verified>`, `<setup-script>`, `<claude-md>`, …) has a parser in
  * the harness-signal registry, so the signals file is the single uniform read-path.
  *
- * `sessionId` is best-effort per-provider — claude's `--output-format json` envelope, codex's
- * JSONL meta event, copilot's stream meta line. Absence is never an error.
+ * `sessionId` is best-effort per-provider — claude's `--output-format stream-json` init event,
+ * codex's JSONL meta event, copilot's stream meta line. Absence is never an error.
  */
 export interface HeadlessAiProvider {
   generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>>;

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -11,7 +11,7 @@ import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { parseHarnessSignals } from '@src/integration/ai/signals/_engine/parse-signals.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
-import { parseClaudeJsonEnvelope } from '@src/integration/ai/providers/claude/parse-stream.ts';
+import { createClaudeStreamParser, type ClaudeStreamLine } from '@src/integration/ai/providers/claude/parse-stream.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
 import {
@@ -24,13 +24,27 @@ import { writeJsonAtomic, writeTextAtomic } from '@src/integration/io/fs.ts';
 /**
  * Real {@link HeadlessAiProvider} backed by the Claude Code CLI.
  *
- * Output handling — file-based contract: claude is invoked with `-p --output-format json`,
- * which emits ONE JSON envelope to stdout: `{"session_id":"…","result":"<assistant text>",…}`.
- * After `'close'` fires (stdio drained), the captured stdout is JSON.parse'd, the `result`
- * body is fed to {@link parseHarnessSignals}, and the parsed signal array is written to
- * `session.signalsFile`. The body itself is dropped — it never leaves this function. When
- * `session.bodyFile` is set (one-shot flows that extract custom tags outside the harness-signal
- * registry), the body is also written there for the caller to read inline.
+ * Output handling — file-based contract: claude is invoked with
+ * `-p --verbose --output-format stream-json`, which emits one JSON object per line as the
+ * session progresses:
+ *
+ *   {"type":"system","subtype":"init","session_id":"…","model":"…", …}
+ *   {"type":"assistant","message":{…},"session_id":"…"}
+ *   {"type":"result","subtype":"success","result":"<assistant text>","session_id":"…", …}
+ *
+ * `--verbose` is required by the CLI in non-interactive `-p` mode when `--output-format` is
+ * `stream-json`; without it the CLI errors out. Token streaming on stdout is what the
+ * idle-stdout watchdog at `src/integration/ai/providers/_engine/idle-watchdog.ts` relies on
+ * to distinguish a wedged child from a healthy long-running session — plain `json` buffered
+ * everything until end-of-session and SIGTERM'd healthy children mid-task.
+ *
+ * After `'close'` fires (stdio drained), the parser's accumulated envelope (body = the `result`
+ * event's `.result` string; session_id = earliest seen on any line) is read out, the body is
+ * fed to {@link parseHarnessSignals}, and the parsed signal array is written to
+ * `session.signalsFile`. The body itself goes out of scope at function return — never retained
+ * on a domain entity. When `session.bodyFile` is set (one-shot flows that extract custom tags
+ * outside the harness-signal registry), the body is also written there for the caller to read
+ * inline.
  *
  * Rate-limit detection is a lean stderr regex (`/rate.?limit/i`); on match, retry up to
  * `rateLimitRetries` then surface {@link RateLimitError}. `abortSignal` propagates to SIGTERM
@@ -140,7 +154,10 @@ export const buildClaudeArgs = (session: AiSession): Result<readonly string[], I
   }
   // `-p` is the print-mode flag — without it `claude` launches its interactive TUI and the
   // stdin-piped prompt is silently discarded. v1 hit the same gotcha; mirror the fix here.
-  const args: string[] = ['-p', '--output-format', 'json', '--model', session.model];
+  // `--verbose` is required alongside `--output-format stream-json` in non-interactive `-p`
+  // mode; the CLI rejects stream-json without it. stream-json itself is required so the
+  // idle-stdout watchdog has a real liveness signal across multi-minute sessions.
+  const args: string[] = ['-p', '--verbose', '--output-format', 'stream-json', '--model', session.model];
   args.push('--permission-mode', 'bypassPermissions');
   const denied = disallowedToolsFor(session.permissions);
   if (denied.length > 0) {
@@ -233,18 +250,23 @@ interface SpawnAttemptArgs {
 }
 
 /**
- * One spawn attempt: launch `claude`, write prompt, capture stdout in full, then JSON.parse
- * the captured stdout to recover the assistant body. Extracts harness signals from the body
- * and writes them to `session.signalsFile`; optionally mirrors the raw body to
- * `session.bodyFile`. The body is then dropped — it never crosses back to the caller.
+ * One spawn attempt: launch `claude`, write prompt, stream stdout JSONL through the
+ * stream-json parser, accumulate the authoritative assistant body from the `{type:"result"}`
+ * event, then on close extract harness signals and write them to `session.signalsFile`.
+ * Optionally mirrors the body to `session.bodyFile`. The body goes out of scope at function
+ * return — never retained on a domain entity.
  */
 const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> => {
   const { deps, spawnFn, command, args, session } = input;
   const child = spawnFn(command, args, {
     stdio: ['pipe', 'pipe', 'pipe'] as const,
   });
-  let stdoutBuf = '';
+  const parser = createClaudeStreamParser();
   let stderrBuf = '';
+
+  const onLine = (line: ClaudeStreamLine): void => {
+    parser.ingest(line);
+  };
 
   // Wait for the child to fully `'close'` — NOT just `'exit'`. `'exit'` can fire before the
   // final stdout chunk has been delivered to our listener; `'close'` guarantees the streams
@@ -255,9 +277,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   // `session.abortSignal` (Ctrl-C / TUI) threads through the same kill ladder.
   const { code, signal } = await runHeadlessSpawn({
     child,
-    onStdout: (chunk) => {
-      stdoutBuf += chunk;
-    },
+    onStdout: (chunk) => parser.feed(chunk, onLine),
     onStderr: (chunk) => {
       stderrBuf += chunk;
     },
@@ -276,6 +296,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
     },
   });
+  parser.flush(onLine);
 
   if (signal === 'SIGTERM') {
     return {
@@ -289,11 +310,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     };
   }
 
+  const envelope = parser.snapshot();
+
   if (code === 0) {
-    const envelope = parseClaudeJsonEnvelope(stdoutBuf);
-    // Drop the spawn-side stdout buffer NOW. From here on the only string we hold is
-    // `envelope.body`, and that goes out of scope when the function returns.
-    stdoutBuf = '';
     if (envelope.sessionId !== undefined) {
       deps.eventBus.publish({
         type: 'log',
@@ -332,14 +351,13 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 
   // Non-zero exit. Rate-limit detection: stderr regex match — lean heuristic, easy to widen.
   if (RATE_LIMIT_RE.test(stderrBuf)) {
-    // Best-effort: pull session id out of whatever stdout we captured, even on failure.
-    const sessionIdOnFailure = parseClaudeJsonEnvelope(stdoutBuf).sessionId;
+    // Best-effort: surface any session id the stream already carried, even on failure.
     return {
       kind: 'rate-limit',
       error: new RateLimitError({
         subCode: 'spawn-stderr',
         message: `claude-provider: rate-limit detected in stderr (exit ${String(code)})`,
-        ...(sessionIdOnFailure !== undefined ? { sessionId: sessionIdOnFailure } : {}),
+        ...(envelope.sessionId !== undefined ? { sessionId: envelope.sessionId } : {}),
       }),
     };
   }

--- a/src/integration/ai/providers/claude/parse-stream.ts
+++ b/src/integration/ai/providers/claude/parse-stream.ts
@@ -1,61 +1,60 @@
 /**
- * Parser for the JSON envelope `claude -p --output-format json` writes to stdout.
+ * Line-oriented parser for `claude -p --verbose --output-format stream-json` (JSONL).
  *
- * The CLI emits ONE JSON object summarising the run:
+ * The Claude CLI emits one JSON object per line as the session progresses. The shapes we care
+ * about (other fields ignored):
  *
- *   {"type":"result","subtype":"success","result":"<assistant text>","session_id":"…",…}
+ *   {"type":"system","subtype":"init","session_id":"…","model":"claude-…", …}
+ *   {"type":"assistant","message":{ … delta … },"session_id":"…"}
+ *   {"type":"user","message":{ … tool result … },"session_id":"…"}
+ *   {"type":"result","subtype":"success","result":"<assistant text>","session_id":"…", …}
  *
- * The harness pulls `.result` (the rendered assistant turn, harness tags included) and
- * `.session_id` (for replay / cost attribution) and ignores everything else. Mirrors v1's
- * `claude-adapter.parseJsonOutput` (`ralphctl/src/integration/ai/providers/claude-adapter.ts`)
- * — the simplest, most robust thing that works.
+ * The harness pulls the **`result`** event's `.result` string as the authoritative assistant
+ * body (the deltas are useful for live-streaming UX, but `result` is what harness-signal parsing
+ * runs against today) and the **earliest** `session_id` it sees (typically the `system` init
+ * event, which arrives before tokens). `model` is captured from the init event when present.
  *
- * Failure modes are deliberately lenient: if the captured stdout doesn't parse as JSON, or
- * `.result` is missing / non-string, the body falls back to the raw stdout so any inline
- * harness tags still surface to `parseHarnessSignals` rather than being silently dropped.
+ * Failure modes are deliberately lenient (matches the Copilot parser shape): non-JSON lines,
+ * blank lines, banner / ANSI noise — all skipped silently. A truly empty / malformed stream
+ * yields `body=''` and `sessionId=undefined`, so callers' `parseHarnessSignals('')` still runs
+ * (and trivially returns no signals) rather than throwing.
+ *
+ * Replaces the prior single-envelope `--output-format json` parser: stream-json is required so
+ * the idle-stdout watchdog at `src/integration/ai/providers/_engine/idle-watchdog.ts` sees
+ * progress bytes during long sessions. Plain `json` buffers everything until end-of-session and
+ * the watchdog SIGTERMs healthy children mid-task.
  */
 
 export interface ClaudeEnvelope {
-  /** Assistant body — `.result` when parsed cleanly, otherwise raw stdout verbatim. */
+  /** Assistant body — `.result` from the `{type:"result"}` event, or `''` if none arrived. */
   readonly body: string;
-  /** `session_id` from the envelope, when present. */
+  /** Earliest `session_id` seen on any event (init wins under normal operation). */
   readonly sessionId: string | undefined;
-  /** Model name from the envelope, when present. */
+  /** Model name from the `system` init event, when present. */
   readonly model: string | undefined;
 }
 
-/**
- * Parse the full stdout captured from one `claude -p --output-format json` run.
- *
- * The input is the entire stdout string — the caller is responsible for accumulating it and
- * waiting for the child to fully close (`'close'` event) before calling this; doing it any
- * earlier risks parsing a truncated envelope.
- */
-export const parseClaudeJsonEnvelope = (stdout: string): ClaudeEnvelope => {
-  const trimmed = stdout.trim();
-  if (trimmed.length === 0) {
-    return { body: '', sessionId: undefined, model: undefined };
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    // Not JSON — surface the raw output so inline harness tags still parse.
-    return { body: stdout, sessionId: undefined, model: undefined };
-  }
-  if (typeof parsed !== 'object' || parsed === null) {
-    return { body: stdout, sessionId: undefined, model: undefined };
-  }
-  const obj = parsed as Record<string, unknown>;
-  const result = stringField(obj, 'result');
-  const sessionId = stringField(obj, 'session_id', 'sessionId');
-  const model = stringField(obj, 'model');
-  return {
-    body: result ?? stdout,
-    sessionId,
-    model,
-  };
-};
+export interface ClaudeStreamLine {
+  /** Raw line text (no trailing newline). */
+  readonly raw: string;
+  /** Parsed JSON object when the line was a valid JSON record; absent for non-JSON noise. */
+  readonly json?: Record<string, unknown>;
+}
+
+export interface ClaudeStreamParser {
+  /** Feed a chunk of stdout. Calls `onLine` once per complete newline-terminated line. */
+  feed(chunk: string, onLine: (line: ClaudeStreamLine) => void): void;
+  /** Flush a trailing partial line if any (called once on child close). */
+  flush(onLine: (line: ClaudeStreamLine) => void): void;
+  /**
+   * Accumulate state from a parsed line. Called by the adapter for every line `feed`/`flush`
+   * yields, so the running `{ body, sessionId, model }` snapshot stays internal to the parser
+   * and there is one canonical reduction over the stream.
+   */
+  ingest(line: ClaudeStreamLine): void;
+  /** Snapshot the accumulated envelope (body / sessionId / model so far). */
+  snapshot(): ClaudeEnvelope;
+}
 
 const stringField = (obj: Record<string, unknown>, ...names: readonly string[]): string | undefined => {
   for (const name of names) {
@@ -63,4 +62,68 @@ const stringField = (obj: Record<string, unknown>, ...names: readonly string[]):
     if (typeof v === 'string') return v;
   }
   return undefined;
+};
+
+export const createClaudeStreamParser = (): ClaudeStreamParser => {
+  let buffer = '';
+  let body = '';
+  let sessionId: string | undefined;
+  let model: string | undefined;
+
+  const emit = (raw: string, onLine: (line: ClaudeStreamLine) => void): void => {
+    if (raw.length === 0) return;
+    if (raw.startsWith('{') && raw.endsWith('}')) {
+      try {
+        const json = JSON.parse(raw) as Record<string, unknown>;
+        onLine({ raw, json });
+        return;
+      } catch {
+        // fall through — non-JSON or malformed: emit as plain text and let `ingest` skip it.
+      }
+    }
+    onLine({ raw });
+  };
+
+  const ingest = (line: ClaudeStreamLine): void => {
+    const json = line.json;
+    if (json === undefined) return;
+    // Earliest session_id wins. The system/init event normally arrives first and carries it,
+    // but every event after that re-states it; clamping to "first seen" makes the value stable.
+    if (sessionId === undefined) {
+      const seen = stringField(json, 'session_id', 'sessionId');
+      if (seen !== undefined) sessionId = seen;
+    }
+    const type = stringField(json, 'type');
+    if (type === 'system' && model === undefined) {
+      const m = stringField(json, 'model');
+      if (m !== undefined) model = m;
+    }
+    if (type === 'result') {
+      const r = stringField(json, 'result');
+      if (r !== undefined) body = r;
+    }
+  };
+
+  return {
+    feed(chunk, onLine) {
+      buffer += chunk;
+      let nl = buffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        emit(line, onLine);
+        nl = buffer.indexOf('\n');
+      }
+    },
+    flush(onLine) {
+      if (buffer.length > 0) {
+        emit(buffer, onLine);
+        buffer = '';
+      }
+    },
+    ingest,
+    snapshot() {
+      return { body, sessionId, model };
+    },
+  };
 };

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { dirname } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type {
   InteractiveAiProvider,
@@ -65,10 +66,32 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
         );
       }
 
+      // Multi-repo plan mounts every project repository through `additionalRoots`. Codex
+      // accepts repeated `--add-dir <DIR>` exactly like the headless variant; without this the
+      // session is sandboxed to `--cd` alone and the AI can't navigate outside it. We also
+      // auto-mount the dirs that hold the prompt / output files so harness-internal writes land
+      // inside an allowed root without prompting — mirrors Claude's interactive adapter.
+      // Duplicates (e.g. when prompt/output already sit inside cwd) are folded out.
+      const allRoots = [
+        String(input.cwd),
+        ...(input.additionalRoots?.map((r) => String(r)) ?? []),
+        dirname(String(input.outputFile)),
+        dirname(String(input.promptFile)),
+      ];
+      const seen = new Set<string>();
+      const dirFlags = allRoots
+        .filter((p) => {
+          if (seen.has(p)) return false;
+          seen.add(p);
+          return true;
+        })
+        .flatMap((p) => ['--add-dir', shellQuote(p)]);
+
       const inner = [
         'codex',
         '--cd',
         shellQuote(String(input.cwd)),
+        ...dirFlags,
         '--model',
         shellQuote(input.model),
         '-s',

--- a/tests/e2e/cli/task.test.ts
+++ b/tests/e2e/cli/task.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFsTaskRepository } from '@src/integration/persistence/task/repository.ts';
-import { makeDraftSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
+import { markTaskBlocked } from '@src/domain/entity/task.ts';
+import { makeDraftSprint, makeDoneTask, makeTodoTask } from '@tests/fixtures/domain.ts';
 import { createCliHome, runCliCaptured, type CliHome } from '@tests/e2e/cli/_harness.ts';
 
 describe('ralphctl task', () => {
@@ -66,6 +67,64 @@ describe('ralphctl task', () => {
       ]);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('error:');
+    });
+  });
+
+  describe('unblock <taskId>', () => {
+    it('flips a blocked task back to todo and persists', async () => {
+      const sprint = makeDraftSprint();
+      const repo = createFsTaskRepository({ root: cli.paths.dataRoot });
+      const blocked = markTaskBlocked(makeTodoTask({ name: 'wedged' }), 'flaky verify');
+      if (!blocked.ok) throw new Error(`fixture: ${blocked.error.message}`);
+      await repo.saveAll(sprint.id, [blocked.value]);
+
+      const result = await runCliCaptured(cli, [
+        'task',
+        'unblock',
+        String(blocked.value.id),
+        '--sprint',
+        String(sprint.id),
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('unblocked task');
+      expect(result.stdout).toContain('wedged');
+
+      const reloaded = await repo.findById(sprint.id, blocked.value.id);
+      expect(reloaded.ok).toBe(true);
+      if (!reloaded.ok) return;
+      expect(reloaded.value.status).toBe('todo');
+    });
+
+    it('idempotent — already-todo task is a no-op success', async () => {
+      const sprint = makeDraftSprint();
+      const repo = createFsTaskRepository({ root: cli.paths.dataRoot });
+      const todo = makeTodoTask({ name: 'fine' });
+      await repo.saveAll(sprint.id, [todo]);
+
+      const result = await runCliCaptured(cli, ['task', 'unblock', String(todo.id), '--sprint', String(sprint.id)]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('unblocked task');
+    });
+
+    it('exits 1 when the task is done (cannot unblock a done task)', async () => {
+      const sprint = makeDraftSprint();
+      const repo = createFsTaskRepository({ root: cli.paths.dataRoot });
+      const done = makeDoneTask();
+      await repo.saveAll(sprint.id, [done]);
+
+      const result = await runCliCaptured(cli, ['task', 'unblock', String(done.id), '--sprint', String(sprint.id)]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('error:');
+    });
+
+    it('exits 1 on malformed task id', async () => {
+      const sprint = makeDraftSprint();
+      const result = await runCliCaptured(cli, ['task', 'unblock', 'nope', '--sprint', String(sprint.id)]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('invalid task id');
     });
   });
 });

--- a/tests/e2e/flows/plan.test.ts
+++ b/tests/e2e/flows/plan.test.ts
@@ -21,14 +21,7 @@ import type {
   InteractiveAiProviderInput,
 } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
-import {
-  absolutePath,
-  FIXED_LATER,
-  makeDraftSprint,
-  makeExecution,
-  makePendingTicket,
-  makeProject,
-} from '@tests/fixtures/domain.ts';
+import { FIXED_LATER, makeDraftSprint, makeExecution, makePendingTicket, makeProject } from '@tests/fixtures/domain.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { createRunner } from '@src/application/chain/run/runner.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
@@ -37,8 +30,6 @@ import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-term
 import { createPlanFlow } from '@src/application/flows/plan/flow.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
-
-const FAKE_CWD = absolutePath('/tmp/ralph/fake-cwd');
 
 const inMemorySprintRepo = (initial: Sprint): { repo: SprintRepository; current: () => Sprint } => {
   let current = initial;
@@ -201,7 +192,6 @@ describe('createPlanFlow — interactive', () => {
     const flow = createPlanFlow(buildDeps(sprintRepo.repo, project, sprint, taskRepo.repo, fake.session), {
       sprintId: sprint.id,
       projectId: project.id,
-      cwd: FAKE_CWD,
       model: 'claude-opus-4-7',
       planRoot: planRoot(),
     });
@@ -232,7 +222,6 @@ describe('createPlanFlow — interactive', () => {
     const flow = createPlanFlow(buildDeps(sprintRepo.repo, project, sprint, taskRepo.repo, fake.session), {
       sprintId: sprint.id,
       projectId: project.id,
-      cwd: FAKE_CWD,
       model: 'claude-opus-4-7',
       planRoot: planRoot(),
     });
@@ -270,7 +259,6 @@ describe('createPlanFlow — interactive', () => {
     const flow = createPlanFlow(buildDeps(sprintRepo.repo, project, sprint, taskRepo.repo, fake.session), {
       sprintId: sprint.id,
       projectId: project.id,
-      cwd: FAKE_CWD,
       model: 'claude-opus-4-7',
       planRoot: planRoot(),
     });

--- a/tests/e2e/flows/refine.test.ts
+++ b/tests/e2e/flows/refine.test.ts
@@ -19,7 +19,7 @@ import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { parseHttpUrl } from '@src/domain/value/parsers/parse-http-url.ts';
-import { absolutePath, makeDraftSprint, makePendingTicket } from '@tests/fixtures/domain.ts';
+import { makeDraftSprint, makePendingTicket } from '@tests/fixtures/domain.ts';
 import { createRunner } from '@src/application/chain/run/runner.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
@@ -27,8 +27,6 @@ import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-term
 import { createRefineFlow } from '@src/application/flows/refine/flow.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
-
-const FAKE_CWD = absolutePath('/tmp/ralph/fake-cwd');
 
 const inMemoryRepo = (initial?: Sprint): { repo: SprintRepository; saves: Sprint[] } => {
   let current: Sprint | undefined = initial;
@@ -128,7 +126,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }
@@ -186,7 +183,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }
@@ -244,7 +240,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }
@@ -306,7 +301,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }
@@ -382,7 +376,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }
@@ -434,7 +427,6 @@ describe('createRefineFlow — interactive', () => {
       {
         sprintId: sprint.id,
         pendingTickets: tickets,
-        cwd: FAKE_CWD,
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot(),
       }

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -116,17 +116,19 @@ const unwrapArgs = (s: AiSession): readonly string[] => {
 };
 
 describe('createClaudeProvider', () => {
-  it('happy path: parses harness signals from the JSON .result envelope and writes them to signalsFile', async () => {
+  it('happy path: parses harness signals from the stream-json result event and writes them to signalsFile', async () => {
     const cap = createCapturingBus();
     const sess = session();
 
-    const envelope = JSON.stringify({
-      session_id: 'sess-1',
-      model: 'sonnet',
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1', model: 'sonnet' });
+    const resultEvt = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
       result: '<progress>working</progress>\n<task-verified>all good</task-verified>',
+      session_id: 'sess-1',
       num_turns: 4,
     });
-    const { spawn } = makeSpawn([{ stdoutChunks: [`${envelope}\n`], exitCode: 0 }]);
+    const { spawn } = makeSpawn([{ stdoutChunks: [`${init}\n${resultEvt}\n`], exitCode: 0 }]);
 
     const provider = createClaudeProvider({
       rateLimitRetries: 2,
@@ -173,10 +175,16 @@ describe('createClaudeProvider', () => {
     const cap = createCapturingBus();
     const sess = session();
 
-    const okEnvelope = JSON.stringify({ session_id: 'sess-2', result: '<task-complete/>' });
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-2', model: 'sonnet' });
+    const okResult = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: '<task-complete/>',
+      session_id: 'sess-2',
+    });
     const { spawn } = makeSpawn([
       { stderrChunks: ['rate-limit hit\n'], exitCode: 1 },
-      { stdoutChunks: [`${okEnvelope}\n`], exitCode: 0 },
+      { stdoutChunks: [`${init}\n${okResult}\n`], exitCode: 0 },
     ]);
 
     const provider = createClaudeProvider({
@@ -235,6 +243,14 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
     expect(unwrapArgs(session()).includes('-p')).toBe(true);
     expect(unwrapArgs(session({ permissions: FULL_AUTO })).includes('-p')).toBe(true);
     expect(unwrapArgs(session({ permissions: READ_ONLY })).includes('-p')).toBe(true);
+  });
+
+  it('emits --verbose + --output-format stream-json so stdout streams JSONL for the idle watchdog', () => {
+    const args = unwrapArgs(session());
+    expect(args).toContain('--verbose');
+    const fmtIdx = args.indexOf('--output-format');
+    expect(fmtIdx).toBeGreaterThanOrEqual(0);
+    expect(args[fmtIdx + 1]).toBe('stream-json');
   });
 
   it('always emits --permission-mode bypassPermissions (deny rules carry the safety contract)', () => {
@@ -315,7 +331,9 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
 
   it('passes the translated argv through spawn end-to-end', async () => {
     const cap = createCapturingBus();
-    const captured = makeSpawn([{ stdoutChunks: ['{"result":"ok"}\n'], exitCode: 0 }]);
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-e2e', model: 'claude-opus-4-7' });
+    const resultEvt = JSON.stringify({ type: 'result', result: 'ok', session_id: 'sess-e2e' });
+    const captured = makeSpawn([{ stdoutChunks: [`${init}\n${resultEvt}\n`], exitCode: 0 }]);
 
     const provider = createClaudeProvider({
       rateLimitRetries: 0,

--- a/tests/integration/ai/providers/codex/interactive.test.ts
+++ b/tests/integration/ai/providers/codex/interactive.test.ts
@@ -81,6 +81,35 @@ describe('createInteractiveCodexProvider', () => {
     expect(calls[0]!.cwd).toBe(String(CWD));
   });
 
+  it('emits --add-dir for cwd, every additionalRoot, and the prompt / output dirs (deduped)', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn });
+
+    const repoA = absolutePath('/tmp/codex-repo-a');
+    const repoB = absolutePath('/tmp/codex-repo-b');
+
+    const runPromise = provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: CODEX_MODELS[0]!,
+      additionalRoots: [repoA, repoB],
+    });
+    emitExit(0);
+    const result = await runPromise;
+    expect(result.ok).toBe(true);
+
+    const inner = calls[0]!.args[1]!;
+    expect(inner).toContain(`--add-dir '${String(CWD)}'`);
+    expect(inner).toContain(`--add-dir '${String(repoA)}'`);
+    expect(inner).toContain(`--add-dir '${String(repoB)}'`);
+    // dirname(promptFile) === dirname(outputFile) === '/tmp' here — dedupe collapses them
+    // to a single `--add-dir '/tmp'`. Asserting the count keeps the dedupe load-bearing.
+    const addDirOccurrences = inner.match(/--add-dir/g) ?? [];
+    expect(addDirOccurrences).toHaveLength(4);
+  });
+
   it('returns InvalidStateError when the session exits non-zero', async () => {
     const cap = createCapturingBus();
     const { spawn, emitExit } = makeSpawn();

--- a/tests/integration/application/bootstrap/wire.test.ts
+++ b/tests/integration/application/bootstrap/wire.test.ts
@@ -15,13 +15,7 @@ import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { wire } from '@src/application/bootstrap/wire.ts';
 import { createRefineFlow } from '@src/application/flows/refine/flow.ts';
 import type { AppSinks } from '@src/application/bootstrap/runtime-sinks.ts';
-import {
-  absolutePath,
-  makeDraftSprint,
-  makeDraftSprintBundle,
-  makePendingTicket,
-  makeProject,
-} from '@tests/fixtures/domain.ts';
+import { makeDraftSprint, makeDraftSprintBundle, makePendingTicket, makeProject } from '@tests/fixtures/domain.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
@@ -138,7 +132,6 @@ describe('wire', () => {
       {
         sprintId: withTicket.value.id,
         pendingTickets: [ticket],
-        cwd: absolutePath('/tmp/wire-test-cwd'),
         model: 'claude-sonnet-4-6',
         refinementRoot: refinementRoot.value,
       }

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
@@ -14,6 +14,7 @@ import type { TaskRepository } from '@src/domain/repository/task/task-repository
 import type { Task } from '@src/domain/entity/task.ts';
 import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const FIXED_SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
 
@@ -118,6 +119,119 @@ describe('SprintDetailView — phase workspace', () => {
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
     await tick(40);
     expect(result.lastFrame() ?? '').toContain('Open a pull request');
+    result.unmount();
+  });
+
+  it('pressing u on a blocked task flips it to todo and surfaces "✓ unblocked"', async () => {
+    const sprint = makeSprint({
+      status: 'active',
+      tickets: [{ id: 't1' as never, title: 'first', status: 'approved' } as never],
+    });
+    const blockedTask: Task = {
+      id: 'task-blocked' as never,
+      name: 'wedged',
+      status: 'blocked',
+      blockedReason: 'mvn agent attach failed',
+      dependsOn: [],
+      attempts: [],
+      ticketId: 't1' as never,
+      repositoryId: 'r1' as never,
+      order: 1,
+      steps: [],
+      verificationCriteria: [],
+    } as never;
+
+    const updateCalls: Task[] = [];
+    let storedStatus: 'blocked' | 'todo' = 'blocked';
+    const deps = {
+      sprintRepo: {
+        async findById() {
+          return Result.ok(sprint);
+        },
+      } as unknown as SprintRepository,
+      taskRepo: {
+        async findBySprintId() {
+          return Result.ok(
+            storedStatus === 'todo'
+              ? [{ ...(blockedTask as object), status: 'todo' } as unknown as Task]
+              : [blockedTask]
+          );
+        },
+        async update(_sprintId: SprintId, task: Task) {
+          updateCalls.push(task);
+          storedStatus = task.status === 'todo' ? 'todo' : storedStatus;
+          return Result.ok(undefined);
+        },
+      } as unknown as TaskRepository,
+      projectRepo: {} as never,
+      sprintExecutionRepo: {} as never,
+      settingsRepo: {} as never,
+      logger: noopLogger,
+    } as unknown as AppDeps;
+
+    const { result } = renderView(<SprintDetailView />, { deps, initial });
+    await tick(40);
+    // Cursor starts at idx 0 (the ticket). Press 'j' once to land on the (one) task below.
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('u');
+    // Give the async use case + reload a chance to settle.
+    await tick(80);
+    const frame = result.lastFrame() ?? '';
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.status).toBe('todo');
+    expect(frame).toContain('✓ unblocked');
+    expect(frame).toContain('wedged');
+    result.unmount();
+  });
+
+  it('u is a no-op when the focused card is a todo task (no use-case invocation)', async () => {
+    const sprint = makeSprint({
+      status: 'active',
+      tickets: [{ id: 't1' as never, title: 'first', status: 'approved' } as never],
+    });
+    const todoTask: Task = {
+      id: 'task-todo' as never,
+      name: 'fine',
+      status: 'todo',
+      dependsOn: [],
+      attempts: [],
+      ticketId: 't1' as never,
+      repositoryId: 'r1' as never,
+      order: 1,
+      steps: [],
+      verificationCriteria: [],
+    } as never;
+
+    const updateCalls: Task[] = [];
+    const deps = {
+      sprintRepo: {
+        async findById() {
+          return Result.ok(sprint);
+        },
+      } as unknown as SprintRepository,
+      taskRepo: {
+        async findBySprintId() {
+          return Result.ok([todoTask]);
+        },
+        async update(_sprintId: SprintId, task: Task) {
+          updateCalls.push(task);
+          return Result.ok(undefined);
+        },
+      } as unknown as TaskRepository,
+      projectRepo: {} as never,
+      sprintExecutionRepo: {} as never,
+      settingsRepo: {} as never,
+      logger: noopLogger,
+    } as unknown as AppDeps;
+
+    const { result } = renderView(<SprintDetailView />, { deps, initial });
+    await tick(40);
+    result.stdin.write('j');
+    await tick(20);
+    result.stdin.write('u');
+    await tick(40);
+    expect(updateCalls).toHaveLength(0);
     result.unmount();
   });
 });

--- a/tests/unit/application/flows/implement/leaves/preflight-task.test.ts
+++ b/tests/unit/application/flows/implement/leaves/preflight-task.test.ts
@@ -15,9 +15,11 @@ const captureLogEvents = (
 };
 import { absolutePath, isoTimestamp } from '@tests/fixtures/domain.ts';
 import { preflightTaskLeaf } from '@src/application/flows/implement/leaves/preflight-task.ts';
-import type { GitRunner } from '@src/integration/io/git-runner.ts';
+import type { GitRunner, GitRunResult } from '@src/integration/io/git-runner.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { Choice, InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 
 const NOW = isoTimestamp('2026-05-09T10:00:00.000Z');
 const CWD = absolutePath('/tmp/repo');
@@ -34,15 +36,100 @@ const fakeRunner = (status: string, exitCode = 0): GitRunner => ({
   },
 });
 
+interface RoutingRunner {
+  readonly runner: GitRunner;
+  readonly calls: ReadonlyArray<readonly string[]>;
+}
+
+/**
+ * Routes by argv[0] so a single fakeRunner can serve all the git ops the prompt-driven flow
+ * issues: `status` (dirty), `stash` (ok), `reset` / `clean` (ok). Captures every argv list for
+ * assertion.
+ */
+const routingRunner = (statusOut: string): RoutingRunner => {
+  const calls: Array<readonly string[]> = [];
+  const runner: GitRunner = {
+    async run(_cwd, args) {
+      void _cwd;
+      calls.push(args);
+      const verb = args[0];
+      const ok = (stdout: string): Result<GitRunResult, StorageError> => Result.ok({ stdout, stderr: '', exitCode: 0 });
+      switch (verb) {
+        case 'status':
+          return ok(statusOut);
+        case 'stash':
+        case 'reset':
+        case 'clean':
+          return ok('');
+        default:
+          return ok('');
+      }
+    },
+  };
+  return { runner, calls };
+};
+
+const scriptedInteractive = <T>(answer: Result<T, StorageError>): InteractivePrompt => ({
+  async askText() {
+    throw new Error('not used');
+  },
+  async askTextArea() {
+    throw new Error('not used');
+  },
+  async askChoice<U>(_prompt: string, _options: ReadonlyArray<Choice<U>>) {
+    void _prompt;
+    void _options;
+    return answer as unknown as Result<U, StorageError>;
+  },
+  async askMultiChoice() {
+    throw new Error('not used');
+  },
+  async askConfirm() {
+    throw new Error('not used');
+  },
+});
+
+const stubInteractive: InteractivePrompt = {
+  async askText() {
+    throw new Error('not used');
+  },
+  async askTextArea() {
+    throw new Error('not used');
+  },
+  async askChoice() {
+    throw new Error('not used');
+  },
+  async askMultiChoice() {
+    throw new Error('not used');
+  },
+  async askConfirm() {
+    throw new Error('not used');
+  },
+};
+
+const clockNow = () => NOW;
+
 describe('preflightTaskLeaf', () => {
   it('passes through a clean tree', async () => {
-    const leaf = preflightTaskLeaf({ gitRunner: fakeRunner(''), logger: noopLogger }, CWD);
+    const leaf = preflightTaskLeaf(
+      { gitRunner: fakeRunner(''), logger: noopLogger, interactive: stubInteractive, clock: clockNow },
+      CWD
+    );
     const out = await leaf.execute(baseCtx());
     expect(out.ok).toBe(true);
   });
 
-  it('rejects a dirty tree with InvalidStateError when policy=cancel (default)', async () => {
-    const leaf = preflightTaskLeaf({ gitRunner: fakeRunner(' M file\n'), logger: noopLogger }, CWD);
+  it('rejects a dirty tree with InvalidStateError when policy=cancel', async () => {
+    const leaf = preflightTaskLeaf(
+      {
+        gitRunner: fakeRunner(' M file\n'),
+        logger: noopLogger,
+        interactive: stubInteractive,
+        clock: clockNow,
+        dirtyTreePolicy: 'cancel',
+      },
+      CWD
+    );
     const out = await leaf.execute(baseCtx());
     expect(out.ok).toBe(false);
     if (!out.ok) {
@@ -54,7 +141,16 @@ describe('preflightTaskLeaf', () => {
     const eventBus = createInMemoryEventBus();
     const eventLog = captureLogEvents(eventBus);
     const logger = createEventBusLogger({ eventBus, clock: () => NOW });
-    const leaf = preflightTaskLeaf({ gitRunner: fakeRunner(' M file\n'), logger, dirtyTreePolicy: 'continue' }, CWD);
+    const leaf = preflightTaskLeaf(
+      {
+        gitRunner: fakeRunner(' M file\n'),
+        logger,
+        interactive: stubInteractive,
+        clock: clockNow,
+        dirtyTreePolicy: 'continue',
+      },
+      CWD
+    );
     const out = await leaf.execute(baseCtx());
     expect(out.ok).toBe(true);
     expect(eventLog.some((e) => e.level === 'warn' && e.message.includes('working tree dirty'))).toBe(true);
@@ -66,8 +162,95 @@ describe('preflightTaskLeaf', () => {
         return Result.ok({ stdout: '', stderr: 'fatal: not a git repo', exitCode: 128 });
       },
     };
-    const leaf = preflightTaskLeaf({ gitRunner: runner, logger: noopLogger }, CWD);
+    const leaf = preflightTaskLeaf(
+      { gitRunner: runner, logger: noopLogger, interactive: stubInteractive, clock: clockNow },
+      CWD
+    );
     const out = await leaf.execute(baseCtx());
     expect(out.ok).toBe(false);
+  });
+
+  describe("policy='prompt'", () => {
+    it("'keep' choice proceeds without touching the tree", async () => {
+      const routing = routingRunner(' M file\n');
+      const leaf = preflightTaskLeaf(
+        {
+          gitRunner: routing.runner,
+          logger: noopLogger,
+          interactive: scriptedInteractive(Result.ok('keep' as const)),
+          clock: clockNow,
+          dirtyTreePolicy: 'prompt',
+        },
+        CWD
+      );
+      const out = await leaf.execute(baseCtx());
+      expect(out.ok).toBe(true);
+      const verbs = routing.calls.map((args) => args[0]);
+      expect(verbs).toEqual(['status']);
+    });
+
+    it("'stash' choice runs `git stash push -u -m <message>`", async () => {
+      const routing = routingRunner(' M file\n');
+      const leaf = preflightTaskLeaf(
+        {
+          gitRunner: routing.runner,
+          logger: noopLogger,
+          interactive: scriptedInteractive(Result.ok('stash' as const)),
+          clock: clockNow,
+          dirtyTreePolicy: 'prompt',
+        },
+        CWD
+      );
+      const out = await leaf.execute(baseCtx());
+      expect(out.ok).toBe(true);
+      // gitStashPush first checks dirtiness (another `status` call), then `stash push -u -m <msg>`.
+      const verbs = routing.calls.map((args) => args[0]);
+      expect(verbs).toContain('stash');
+      const stashCall = routing.calls.find((args) => args[0] === 'stash');
+      expect(stashCall?.[1]).toBe('push');
+      expect(stashCall?.[2]).toBe('-u');
+      expect(stashCall?.[3]).toBe('-m');
+      expect(stashCall?.[4]).toContain('ralphctl preflight stash');
+    });
+
+    it("'reset' choice runs `git reset --hard HEAD` then `git clean -fd`", async () => {
+      const routing = routingRunner(' M file\n');
+      const leaf = preflightTaskLeaf(
+        {
+          gitRunner: routing.runner,
+          logger: noopLogger,
+          interactive: scriptedInteractive(Result.ok('reset' as const)),
+          clock: clockNow,
+          dirtyTreePolicy: 'prompt',
+        },
+        CWD
+      );
+      const out = await leaf.execute(baseCtx());
+      expect(out.ok).toBe(true);
+      const verbs = routing.calls.map((args) => args[0]);
+      expect(verbs).toEqual(['status', 'reset', 'clean']);
+    });
+
+    it("'cancel' choice returns AbortError", async () => {
+      const routing = routingRunner(' M file\n');
+      const leaf = preflightTaskLeaf(
+        {
+          gitRunner: routing.runner,
+          logger: noopLogger,
+          interactive: scriptedInteractive(Result.ok('cancel' as const)),
+          clock: clockNow,
+          dirtyTreePolicy: 'prompt',
+        },
+        CWD
+      );
+      const out = await leaf.execute(baseCtx());
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        expect(out.error.error.code).toBe('aborted');
+      }
+      const verbs = routing.calls.map((args) => args[0]);
+      // Only the porcelain status check ran — nothing was mutated.
+      expect(verbs).toEqual(['status']);
+    });
   });
 });

--- a/tests/unit/business/task/preflight-task.test.ts
+++ b/tests/unit/business/task/preflight-task.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
-import { absolutePath } from '@tests/fixtures/domain.ts';
+import { absolutePath, isoTimestamp } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
-import { preflightTaskUseCase } from '@src/business/task/preflight-task.ts';
+import { preflightTaskUseCase, type DirtyTreeChoice } from '@src/business/task/preflight-task.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 
 const CWD = absolutePath('/tmp/repo');
+const NOW = isoTimestamp('2026-05-18T10:00:00.000Z');
+const SPRINT_ID = 'sprint-abc';
 
 const okCount = (n: number) => async (_cwd: AbsolutePath) => {
   void _cwd;
@@ -16,6 +19,73 @@ const failCount = async (_cwd: AbsolutePath) => {
   void _cwd;
   return Result.error(new StorageError({ subCode: 'io', message: 'git status exploded' }));
 };
+
+interface AskChoiceCall {
+  readonly cwd: AbsolutePath;
+  readonly dirtyEntries: number;
+}
+
+type AskFn = NonNullable<Parameters<typeof preflightTaskUseCase>[0]['askDirtyTreeChoice']>;
+type AskResult = Awaited<ReturnType<AskFn>>;
+
+const recordingAsk = (
+  result: AskResult
+): {
+  readonly fn: AskFn;
+  readonly calls: AskChoiceCall[];
+} => {
+  const calls: AskChoiceCall[] = [];
+  return {
+    calls,
+    fn: async ({ cwd, dirtyEntries }) => {
+      calls.push({ cwd, dirtyEntries });
+      return result;
+    },
+  };
+};
+
+const okChoice = (choice: DirtyTreeChoice): AskResult => Result.ok(choice);
+const abortChoice = (reason: string): AskResult =>
+  Result.error(new AbortError({ elementName: 'preflight-task', reason }));
+
+interface StashCall {
+  readonly cwd: AbsolutePath;
+  readonly message: string;
+}
+
+const recordingStash = (
+  result: Result<{ stashed: boolean }, StorageError>
+): {
+  readonly fn: (cwd: AbsolutePath, message: string) => Promise<Result<{ stashed: boolean }, StorageError>>;
+  readonly calls: StashCall[];
+} => {
+  const calls: StashCall[] = [];
+  return {
+    calls,
+    fn: async (cwd, message) => {
+      calls.push({ cwd, message });
+      return result;
+    },
+  };
+};
+
+const recordingReset = (
+  result: Result<void, StorageError>
+): {
+  readonly fn: (cwd: AbsolutePath) => Promise<Result<void, StorageError>>;
+  readonly calls: AbsolutePath[];
+} => {
+  const calls: AbsolutePath[] = [];
+  return {
+    calls,
+    fn: async (cwd) => {
+      calls.push(cwd);
+      return result;
+    },
+  };
+};
+
+const clockNow = () => NOW;
 
 describe('preflightTaskUseCase', () => {
   it('returns ok on a clean working tree', async () => {
@@ -69,5 +139,191 @@ describe('preflightTaskUseCase', () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('storage-error');
+  });
+
+  describe("policy='prompt'", () => {
+    it("returns ok when the user chooses 'keep' and runs the prompt with cwd/dirtyEntries", async () => {
+      const ask = recordingAsk(okChoice('keep'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(2),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(true);
+      expect(stash.calls).toHaveLength(0);
+      expect(reset.calls).toHaveLength(0);
+      expect(ask.calls).toEqual([{ cwd: CWD, dirtyEntries: 2 }]);
+    });
+
+    it("stashes when the user chooses 'stash' with a recoverable message including sprintId", async () => {
+      const ask = recordingAsk(okChoice('stash'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(true);
+      expect(stash.calls).toHaveLength(1);
+      expect(stash.calls[0]?.cwd).toBe(CWD);
+      expect(stash.calls[0]?.message).toContain('ralphctl preflight stash');
+      expect(stash.calls[0]?.message).toContain(SPRINT_ID);
+      expect(reset.calls).toHaveLength(0);
+    });
+
+    it("resets when the user chooses 'reset'", async () => {
+      const ask = recordingAsk(okChoice('reset'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(5),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(true);
+      expect(reset.calls).toEqual([CWD]);
+      expect(stash.calls).toHaveLength(0);
+    });
+
+    it("returns AbortError when the user chooses 'cancel'", async () => {
+      const ask = recordingAsk(okChoice('cancel'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('aborted');
+        if (result.error.code === 'aborted') {
+          expect(result.error.elementName).toBe('preflight-task');
+        }
+      }
+      expect(stash.calls).toHaveLength(0);
+      expect(reset.calls).toHaveLength(0);
+    });
+
+    it('propagates StorageError from gitStash failure', async () => {
+      const ask = recordingAsk(okChoice('stash'));
+      const stash = recordingStash(Result.error(new StorageError({ subCode: 'io', message: 'stash exploded' })));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe('storage-error');
+    });
+
+    it('propagates StorageError from gitReset failure', async () => {
+      const ask = recordingAsk(okChoice('reset'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.error(new StorageError({ subCode: 'io', message: 'reset exploded' })));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe('storage-error');
+    });
+
+    it('propagates AbortError from askDirtyTreeChoice (user cancelled the menu)', async () => {
+      const ask = recordingAsk(abortChoice('Ctrl-C'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        sprintId: SPRINT_ID,
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('aborted');
+        if (result.error.code === 'aborted') {
+          expect(result.error.elementName).toBe('preflight-task');
+        }
+      }
+    });
+
+    it("throws InvalidStateError when policy='prompt' is set without the required deps (wiring bug)", async () => {
+      // Programmer error: composition root forgot the askDirtyTreeChoice dep. Throw synchronously
+      // so the harness surfaces a clear configuration error rather than silently degrading.
+      await expect(
+        preflightTaskUseCase({
+          cwd: CWD,
+          gitStatusEntryCount: okCount(1),
+          dirtyTreePolicy: 'prompt',
+          logger: noopLogger,
+        })
+      ).rejects.toThrow(/dirtyTreePolicy='prompt' requires/);
+    });
+
+    it('falls back to "unknown" in the stash message when sprintId is omitted', async () => {
+      const ask = recordingAsk(okChoice('stash'));
+      const stash = recordingStash(Result.ok({ stashed: true }));
+      const reset = recordingReset(Result.ok(undefined));
+      const result = await preflightTaskUseCase({
+        cwd: CWD,
+        gitStatusEntryCount: okCount(1),
+        dirtyTreePolicy: 'prompt',
+        askDirtyTreeChoice: ask.fn,
+        gitStash: stash.fn,
+        gitReset: reset.fn,
+        clock: clockNow,
+        // no sprintId
+        logger: noopLogger,
+      });
+      expect(result.ok).toBe(true);
+      expect(stash.calls[0]?.message).toContain('sprint unknown');
+    });
   });
 });

--- a/tests/unit/business/task/unblock-task.test.ts
+++ b/tests/unit/business/task/unblock-task.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
+import { markTaskBlocked, type BlockedTask, type Task } from '@src/domain/entity/task.ts';
+import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { makeDoneTask, makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+
+const SPRINT_ID = '01900000-0000-7000-8000-0000000000aa' as unknown as SprintId;
+
+const makeBlockedTask = (reason = 'flaky pre-task verify'): BlockedTask => {
+  const r = markTaskBlocked(makeTodoTask(), reason);
+  if (!r.ok) throw new Error(`fixture: ${r.error.message}`);
+  return r.value;
+};
+
+interface RepoDouble extends UpdateTask {
+  readonly saved: Task[];
+}
+
+const repoOk = (): RepoDouble => {
+  const saved: Task[] = [];
+  return {
+    saved,
+    async update(_sprintId, task) {
+      saved.push(task);
+      return Result.ok(undefined);
+    },
+  };
+};
+
+const repoFailing = (): UpdateTask => ({
+  async update() {
+    return Result.error(new StorageError({ subCode: 'io', message: 'disk full', path: 'tasks' }));
+  },
+});
+
+describe('unblockTaskUseCase', () => {
+  it('transitions blocked → todo, strips blockedReason, and persists', async () => {
+    const blocked = makeBlockedTask('mvn agent attach failed');
+    const repo = repoOk();
+
+    const result = await unblockTaskUseCase({
+      task: blocked,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('todo');
+    expect((result.value as unknown as { blockedReason?: string }).blockedReason).toBeUndefined();
+    expect(repo.saved).toHaveLength(1);
+    expect(repo.saved[0]?.status).toBe('todo');
+  });
+
+  it('idempotent — already-todo passes through without re-saving', async () => {
+    const todo = makeTodoTask();
+    const repo = repoOk();
+
+    const result = await unblockTaskUseCase({
+      task: todo,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('todo');
+    expect(repo.saved).toHaveLength(0);
+  });
+
+  it('rejects an in_progress task with InvalidStateError', async () => {
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const repo = repoOk();
+
+    const result = await unblockTaskUseCase({
+      task: inProgress,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-state');
+    expect(repo.saved).toHaveLength(0);
+  });
+
+  it('rejects a done task with InvalidStateError', async () => {
+    const done = makeDoneTask();
+    const repo = repoOk();
+
+    const result = await unblockTaskUseCase({
+      task: done,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-state');
+    expect(repo.saved).toHaveLength(0);
+  });
+
+  it('propagates StorageError when the repository update call fails', async () => {
+    const blocked = makeBlockedTask();
+
+    const result = await unblockTaskUseCase({
+      task: blocked,
+      sprintId: SPRINT_ID,
+      taskRepo: repoFailing(),
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('storage-error');
+  });
+});

--- a/tests/unit/integration/ai/providers/claude/parse-stream.test.ts
+++ b/tests/unit/integration/ai/providers/claude/parse-stream.test.ts
@@ -1,78 +1,137 @@
 import { describe, expect, it } from 'vitest';
-import { parseClaudeJsonEnvelope } from '@src/integration/ai/providers/claude/parse-stream.ts';
+import { createClaudeStreamParser, type ClaudeStreamLine } from '@src/integration/ai/providers/claude/parse-stream.ts';
 
-describe('parseClaudeJsonEnvelope', () => {
-  it('extracts result and session_id from the canonical envelope', () => {
-    const stdout = JSON.stringify({
+/** Drive a parser through one or more chunks; return the accumulated envelope + collected lines. */
+const drive = (chunks: readonly string[]) => {
+  const parser = createClaudeStreamParser();
+  const seen: ClaudeStreamLine[] = [];
+  const onLine = (l: ClaudeStreamLine): void => {
+    seen.push(l);
+    parser.ingest(l);
+  };
+  for (const c of chunks) parser.feed(c, onLine);
+  parser.flush(onLine);
+  return { envelope: parser.snapshot(), lines: seen };
+};
+
+describe('createClaudeStreamParser', () => {
+  it("empty input → body='', sessionId/model undefined", () => {
+    const { envelope, lines } = drive([]);
+    expect(envelope.body).toBe('');
+    expect(envelope.sessionId).toBeUndefined();
+    expect(envelope.model).toBeUndefined();
+    expect(lines).toEqual([]);
+  });
+
+  it('system init event captures sessionId and model', () => {
+    const init = JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'sess-init',
+      model: 'claude-opus-4-7',
+    });
+    const { envelope } = drive([`${init}\n`]);
+    expect(envelope.sessionId).toBe('sess-init');
+    expect(envelope.model).toBe('claude-opus-4-7');
+    // No `result` event yet — body stays empty.
+    expect(envelope.body).toBe('');
+  });
+
+  it("body comes from the result event's .result field, not from assistant deltas", () => {
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1', model: 'm' });
+    const delta1 = JSON.stringify({ type: 'assistant', message: { content: 'partial 1' }, session_id: 'sess-1' });
+    const delta2 = JSON.stringify({ type: 'assistant', message: { content: 'partial 2' }, session_id: 'sess-1' });
+    const finalBody = '<task-verified>all good</task-verified>';
+    const resultEvt = JSON.stringify({
       type: 'result',
       subtype: 'success',
-      result: '<task-verified>all good</task-verified>',
-      session_id: 'sess-abc',
-      model: 'claude-opus-4-7',
-      num_turns: 3,
+      result: finalBody,
+      session_id: 'sess-1',
+      num_turns: 2,
     });
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe('<task-verified>all good</task-verified>');
-    expect(env.sessionId).toBe('sess-abc');
-    expect(env.model).toBe('claude-opus-4-7');
+    const { envelope } = drive([`${init}\n${delta1}\n${delta2}\n${resultEvt}\n`]);
+    expect(envelope.body).toBe(finalBody);
+    expect(envelope.sessionId).toBe('sess-1');
   });
 
-  it('accepts the envelope wrapped in surrounding whitespace / trailing newlines', () => {
-    const stdout = `\n  ${JSON.stringify({ result: 'hi', session_id: 's1' })}\n\n`;
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe('hi');
-    expect(env.sessionId).toBe('s1');
+  it("missing result event (stream cut short) → body='', sessionId still captured from init", () => {
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-cut', model: 'm' });
+    const delta = JSON.stringify({ type: 'assistant', message: { content: 'half a thought' }, session_id: 'sess-cut' });
+    const { envelope } = drive([`${init}\n${delta}\n`]);
+    expect(envelope.body).toBe('');
+    expect(envelope.sessionId).toBe('sess-cut');
   });
 
-  it('preserves multi-line content (newlines / harness tags) inside result', () => {
-    // Real Claude often emits result with embedded newlines (JSON-encoded as \n).
-    const result = '<progress>step 1</progress>\n<task-verified>done</task-verified>';
-    const stdout = JSON.stringify({ result, session_id: 's-multiline' });
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe(result);
-    expect(env.sessionId).toBe('s-multiline');
+  it('skips malformed, non-JSON, and banner lines silently while processing valid events', () => {
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-noisy', model: 'm' });
+    const resultEvt = JSON.stringify({ type: 'result', result: 'hello', session_id: 'sess-noisy' });
+    const chunks = [
+      'Loaded claude config\n', // banner
+      '\n', // blank
+      '{ not json at all\n', // malformed
+      `${init}\n`,
+      'still talking…\n', // plain text noise
+      `${resultEvt}\n`,
+    ];
+    const { envelope } = drive(chunks);
+    expect(envelope.body).toBe('hello');
+    expect(envelope.sessionId).toBe('sess-noisy');
   });
 
-  it('falls back to raw stdout when JSON parsing fails (still surfaces inline harness tags)', () => {
-    const stdout = 'not json at all <task-complete/>';
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe(stdout);
-    expect(env.sessionId).toBeUndefined();
+  it('reassembles a line split across chunks (mid-line chunk boundary)', () => {
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-split', model: 'm' });
+    const resultEvt = JSON.stringify({ type: 'result', result: 'split body', session_id: 'sess-split' });
+    const full = `${init}\n${resultEvt}\n`;
+    // Slice mid-way through the result line.
+    const cut = init.length + 1 + Math.floor(resultEvt.length / 2);
+    const a = full.slice(0, cut);
+    const b = full.slice(cut);
+    const { envelope } = drive([a, b]);
+    expect(envelope.body).toBe('split body');
+    expect(envelope.sessionId).toBe('sess-split');
   });
 
-  it('falls back to raw stdout when .result is missing from the envelope', () => {
-    const stdout = JSON.stringify({ session_id: 's1', model: 'm' });
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe(stdout);
-    expect(env.sessionId).toBe('s1');
-    expect(env.model).toBe('m');
+  it('first sessionId wins — later events do not overwrite the earliest seen', () => {
+    const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-first', model: 'm' });
+    const later = JSON.stringify({ type: 'assistant', message: {}, session_id: 'sess-later' });
+    const resultEvt = JSON.stringify({ type: 'result', result: 'ok', session_id: 'sess-later' });
+    const { envelope } = drive([`${init}\n${later}\n${resultEvt}\n`]);
+    expect(envelope.sessionId).toBe('sess-first');
+    expect(envelope.body).toBe('ok');
   });
 
-  it('ignores non-string .result fields and falls back to raw stdout', () => {
-    const stdout = JSON.stringify({ result: 42, session_id: 's1' });
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe(stdout);
-    expect(env.sessionId).toBe('s1');
+  it('flush emits a trailing partial line without a newline', () => {
+    const resultEvt = JSON.stringify({ type: 'result', result: 'tail', session_id: 's' });
+    // No trailing newline — must still be parsed via flush().
+    const { envelope } = drive([resultEvt]);
+    expect(envelope.body).toBe('tail');
+    expect(envelope.sessionId).toBe('s');
   });
 
-  it('returns empty body / undefined ids for empty stdout', () => {
-    const env = parseClaudeJsonEnvelope('');
-    expect(env.body).toBe('');
-    expect(env.sessionId).toBeUndefined();
-    expect(env.model).toBeUndefined();
-  });
-
-  it('accepts the realistic envelope shape Claude actually produces', () => {
-    // Captured from `claude -p --output-format json` against the real CLI: extra fields,
-    // nested usage object, all on one line.
-    const stdout =
-      '{"type":"result","subtype":"success","is_error":false,"duration_ms":4896,' +
-      '"num_turns":1,"result":"<task-verified>ok</task-verified>",' +
-      '"stop_reason":"end_turn","session_id":"4074df74-053f-4ef7-ae4b-f10c3999cb14",' +
-      '"total_cost_usd":0.08,"usage":{"input_tokens":9,"output_tokens":122},' +
-      '"modelUsage":{"claude-sonnet-4-5":{"inputTokens":9}}}';
-    const env = parseClaudeJsonEnvelope(stdout);
-    expect(env.body).toBe('<task-verified>ok</task-verified>');
-    expect(env.sessionId).toBe('4074df74-053f-4ef7-ae4b-f10c3999cb14');
+  it('accepts the realistic event shape Claude actually produces (extra fields, nested usage)', () => {
+    const init = JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: '4074df74-053f-4ef7-ae4b-f10c3999cb14',
+      model: 'claude-sonnet-4-6',
+      tools: ['Read', 'Write'],
+      cwd: '/repo',
+    });
+    const resultEvt = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      duration_ms: 4896,
+      num_turns: 1,
+      result: '<task-verified>ok</task-verified>',
+      stop_reason: 'end_turn',
+      session_id: '4074df74-053f-4ef7-ae4b-f10c3999cb14',
+      total_cost_usd: 0.08,
+      usage: { input_tokens: 9, output_tokens: 122 },
+    });
+    const { envelope } = drive([`${init}\n${resultEvt}\n`]);
+    expect(envelope.body).toBe('<task-verified>ok</task-verified>');
+    expect(envelope.sessionId).toBe('4074df74-053f-4ef7-ae4b-f10c3999cb14');
+    expect(envelope.model).toBe('claude-sonnet-4-6');
   });
 });


### PR DESCRIPTION
## Summary

Six commits bundled — the first three rewire AI session roots so flows mount the right context; the last three add stability + user-recovery hatches.

### Per-unit AI session roots
- **fix(refine)**: root each ticket's AI session at `<sprintDir>/refinement/<ticket-slug>/` instead of the repo, so refine doesn't auto-load the repo's `CLAUDE.md` / agents / `.mcp.json` and bias the model toward implementation specifics — and stops polluting the repo with bundled skills.
- **fix(plan)**: root the planner at `<sprintDir>/plan/<run-slug>/`, mount **every** project repository as an equal `--add-dir` source so multi-repo planning treats repos symmetrically (no cwd privilege for `repositories[0]`).
- **fix(codex-interactive)**: emit `--add-dir` for `additionalRoots` + prompt/output dirs so Codex actually sees the harness-controlled file contract.

### Recovery hatches & stability
- **feat(task)**: unblock recovery hatch surfaced in the TUI + CLI.
- **fix(claude-provider)**: stream JSONL so the idle-stdout watchdog stops killing healthy sessions during long generator turns.
- **feat(implement)**: interactive dirty-tree preflight prompt — when implement starts on a dirty working tree (e.g. after an interrupted prior run), the user picks Keep / Stash / Reset / Cancel instead of being hard-failed.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1377/1377 green
- [ ] Manual: start implement on a dirty tree → verify all four prompt branches behave
- [ ] Manual: run refine on a multi-repo project → AI session is rooted at `<sprintDir>/refinement/<ticket-slug>/`, no skills pollute the repo
- [ ] Manual: run plan on a multi-repo project → every repo appears as an equal `--add-dir` mount
- [ ] Manual: long claude session → idle watchdog no longer kills it mid-turn