### PR TITLE
Codex headless + readiness parity

### DIFF
--- a/src/application/bootstrap/interactive-provider-factory.ts
+++ b/src/application/bootstrap/interactive-provider-factory.ts
@@ -11,8 +11,8 @@ import { createInteractiveCopilotProvider } from '@src/integration/ai/providers/
  * its own shell-wrapper that translates the {@link InteractiveAiProviderInput} into the
  * provider's TUI invocation:
  *
- *  - claude  → `claude --add-dir <cwd> --model <m> --permission-mode plan "$(cat <prompt>)"`
- *  - codex   → `codex --cd <cwd> --model <m> -s read-only -a never "$(cat <prompt>)"`
+ *  - claude  → `claude --add-dir <cwd> --model <m> --permission-mode acceptEdits "$(cat <prompt>)"`
+ *  - codex   → `codex --cd <cwd> --model <m> -s workspace-write -a on-request "$(cat <prompt>)"`
  *  - copilot → `copilot --add-dir=<cwd> --model=<m> --allow-all-tools -i <prompt>` (equals-only flags)
  *
  * Adding a provider extends this switch plus a sibling `providers/<name>/interactive.ts`.

--- a/src/application/flows/doctor/flow.ts
+++ b/src/application/flows/doctor/flow.ts
@@ -289,6 +289,7 @@ export const createDoctorFlow = (deps: DoctorDeps): Element<DoctorCtx> =>
         // ---- AI providers -----------------------------------------------------
         const settings = await deps.settingsRepo.load();
         const configuredProvider: AiProvider | undefined = settings.ok ? settings.value.ai.provider : undefined;
+        let codexInstalled = false;
         for (const provider of Object.keys(PROVIDER_BINARY) as readonly AiProvider[]) {
           const binary = PROVIDER_BINARY[provider];
           const isConfigured = provider === configuredProvider;
@@ -300,13 +301,14 @@ export const createDoctorFlow = (deps: DoctorDeps): Element<DoctorCtx> =>
             deps.commandExists,
             `install the '${binary}' CLI and ensure it is on your PATH`
           );
+          if (provider === 'openai-codex') codexInstalled = probe.status === 'pass';
           if (probe.status === 'fail') {
             probes.push({ ...probe, status: 'warn' });
           } else {
             probes.push(probe);
           }
         }
-        if (configuredProvider === 'openai-codex' && (await deps.commandExists('codex'))) {
+        if (configuredProvider === 'openai-codex' && codexInstalled) {
           probes.push(
             await probeCliAuth(
               'codex-auth',

--- a/src/application/flows/doctor/flow.ts
+++ b/src/application/flows/doctor/flow.ts
@@ -142,18 +142,19 @@ const probeCliAuth = async (
   binary: string,
   args: readonly string[],
   hint: string,
-  runCommand: RunCommand
+  runCommand: RunCommand,
+  group: ProbeGroup = 'vcs'
 ): Promise<ProbeResult> => {
   const r = await runCommand(binary, args);
   if (r.ok) {
-    return { id, label, status: 'pass', detail: 'authenticated', group: 'vcs' };
+    return { id, label, status: 'pass', detail: 'authenticated', group };
   }
   const detail =
     r.stderr
       .split('\n')
       .find((line) => line.trim().length > 0)
       ?.trim() ?? 'not authenticated';
-  return { id, label, status: 'warn', detail, hint, group: 'vcs' };
+  return { id, label, status: 'warn', detail, hint, group };
 };
 
 /**
@@ -304,6 +305,19 @@ export const createDoctorFlow = (deps: DoctorDeps): Element<DoctorCtx> =>
           } else {
             probes.push(probe);
           }
+        }
+        if (configuredProvider === 'openai-codex' && (await deps.commandExists('codex'))) {
+          probes.push(
+            await probeCliAuth(
+              'codex-auth',
+              'OpenAI Codex CLI authenticated',
+              'codex',
+              ['login', 'status'],
+              'run `codex login` to sign in',
+              deps.runCommand,
+              'ai'
+            )
+          );
         }
 
         // ---- Repositories -----------------------------------------------------

--- a/src/application/flows/readiness/leaves/propose.ts
+++ b/src/application/flows/readiness/leaves/propose.ts
@@ -107,7 +107,7 @@ const proposeReadinessUseCase = async (
  * Return the absolute path of the tool-native context file when the probe surfaced one.
  *  - claude-code → `claudeMd` (preferred) or `agentsMd`.
  *  - copilot     → `copilotInstructions`.
- *  - codex       → no canonical artifact in the v1 catalog yet (placeholder type) → undefined.
+ *  - codex       → `agentsMd`.
  */
 const pickExistingContextPath = (tool: AssistantTool, state: ReadinessState): string | undefined => {
   if (!isPresent(state)) return undefined;
@@ -119,6 +119,9 @@ const pickExistingContextPath = (tool: AssistantTool, state: ReadinessState): st
   }
   if (tool === 'copilot' && a.tool === 'copilot') {
     return a.copilotInstructions !== undefined ? String(a.copilotInstructions.path) : undefined;
+  }
+  if (tool === 'codex' && a.tool === 'codex') {
+    return a.agentsMd !== undefined ? String(a.agentsMd.path) : undefined;
   }
   return undefined;
 };

--- a/src/integration/ai/providers/_engine/ai-session.ts
+++ b/src/integration/ai/providers/_engine/ai-session.ts
@@ -53,8 +53,7 @@ export interface AiSession {
    * up by the caller. Adapters that do not support this field MUST silently ignore it —
    * never surface an error for an unset optional diagnostic path.
    *
-   * Only the Claude adapter currently implements this field. Copilot and Codex support is
-   * deferred; they will silently no-op when `bodyFile` is present.
+   * Implemented by Claude and Codex. Copilot support is deferred and currently a no-op.
    */
   readonly bodyFile?: AbsolutePath;
 }

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -21,7 +21,7 @@ import {
   delayForRetry,
   sleepCancellable,
 } from '@src/integration/ai/providers/_engine/rate-limit-backoff.ts';
-import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { writeJsonAtomic, writeTextAtomic } from '@src/integration/io/fs.ts';
 
 /**
  * {@link HeadlessAiProvider} backed by the OpenAI Codex CLI (`codex` v0.130.0+).
@@ -49,10 +49,10 @@ import { writeJsonAtomic } from '@src/integration/io/fs.ts';
  *
  * Output handling — file-based contract: codex's `-o <tmpfile>` writes the final assistant
  * message to a tempfile; after exit the adapter reads it, runs {@link parseHarnessSignals},
- * and writes the result array to `session.signalsFile`. The body string is dropped — it
- * never leaves this function. Every tag downstream flows care about (`<task-verified>`,
- * `<setup-script>`, `<claude-md>`, …) has a registered parser, so signals.json is the single
- * uniform read-path.
+ * and writes the result array to `session.signalsFile`. When `session.bodyFile` is set, the
+ * adapter also mirrors the raw body there for diagnostic capture (best-effort). Every tag
+ * downstream flows care about (`<task-verified>`, `<setup-script>`, `<claude-md>`, …) has a
+ * registered parser, so signals.json is the single uniform read-path.
  *
  * Session id capture: codex emits JSONL meta events on stdout that carry `session_id` on the
  * leading config / startup record. The adapter line-buffers stdout, picks the first id out,
@@ -384,6 +384,18 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     const signals = parseHarnessSignals(body, IsoTimestamp.now());
     const wrote = await writeJsonAtomic(String(session.signalsFile), signals);
     if (!wrote.ok) return { kind: 'error', error: wrote.error };
+    if (session.bodyFile !== undefined) {
+      const bodyWrote = await writeTextAtomic(String(session.bodyFile), body);
+      if (!bodyWrote.ok) {
+        deps.eventBus.publish({
+          type: 'log',
+          level: 'warn',
+          message: `codex-provider: failed to write body file — diagnostic capture skipped`,
+          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
+          at: IsoTimestamp.now(),
+        });
+      }
+    }
     return {
       kind: 'success',
       output: {

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -28,19 +28,20 @@ import { writeJsonAtomic } from '@src/integration/io/fs.ts';
  *
  * Translation table (intent → Codex CLI argv):
  *
- *   | AiSession field                   | Codex argv                                                 |
- *   | --------------------------------- | ---------------------------------------------------------- |
- *   | (always)                          | leading `exec` (or `exec resume <id>` when resume is set) |
- *   | (always)                          | `--ephemeral --skip-git-repo-check -o <tmpfile> --json`   |
- *   | model: <CodexModel>               | `-m <model>`                                               |
- *   | cwd                               | `-C <cwd>`                                                 |
- *   | additionalRoots: [a, b]           | `--add-dir a --add-dir b`                                  |
- *   | permissions = READ_ONLY           | `-s read-only -a never`                                    |
- *   | permissions = FULL_AUTO           | `-s workspace-write -a never`                              |
- *   | anything else                     | InvalidStateError (only the two locked profiles supported) |
- *   | reasoningEffort (dep-level)       | `-c model_reasoning_effort=<level>`                        |
- *   | (always, trailing)                | `-` (read prompt from stdin)                              |
- *   | prompt                            | piped to stdin                                             |
+ *   | AiSession field                   | Codex argv                                                      |
+ *   | --------------------------------- | --------------------------------------------------------------- |
+ *   | fresh session                     | `exec`                                                          |
+ *   | resume: <SessionId>               | `exec resume <id>`                                              |
+ *   | (always)                          | `--ephemeral --skip-git-repo-check -o <tmpfile> --json`        |
+ *   | model: <CodexModel>               | `-m <model>`                                                    |
+ *   | cwd                               | `-C <cwd>` (fresh only; `exec resume` does not accept it)      |
+ *   | additionalRoots: [a, b]           | `--add-dir a --add-dir b` (fresh only; `exec resume` does not) |
+ *   | permissions = READ_ONLY           | `-s read-only` (fresh only)                                     |
+ *   | permissions = FULL_AUTO           | `-s workspace-write` (fresh only)                               |
+ *   | anything else                     | InvalidStateError (only the two locked profiles supported)      |
+ *   | reasoningEffort (dep-level)       | `-c model_reasoning_effort=<level>`                             |
+ *   | (always, trailing)                | `-` (read prompt from stdin)                                    |
+ *   | prompt                            | piped to stdin                                                  |
  *
  * The trailing `-` is codex's documented sentinel for "the prompt is on stdin." Without it,
  * codex would treat the piped data as side context and wait for a positional prompt arg —
@@ -59,7 +60,10 @@ import { writeJsonAtomic } from '@src/integration/io/fs.ts';
  *
  * Permissions: only the two locked profiles (READ_ONLY / FULL_AUTO) are supported, since
  * those cover every wired chain. Half-permission combos surface `InvalidStateError` —
- * fail loud beats silent surprise.
+ * fail loud beats silent surprise. Codex `exec` on v0.130.0 does not expose a `--search`
+ * flag, so the headless adapter cannot currently translate `canAccessNetwork`; sessions run
+ * without the native live-web-search tool even though the shared permission model keeps the
+ * bit for cross-provider parity.
  *
  * Test seam: `spawn` is overridable so tests script stdout / stderr / exit code without
  * launching the real `codex` binary. `readFile` / `unlink` are also injectable for unit
@@ -154,24 +158,16 @@ export const buildCodexArgs = (
   if (!perms.ok) return Result.error(perms.error);
 
   const args: string[] = ['exec'];
-  if (session.resume !== undefined) {
+  const isResume = session.resume !== undefined;
+  if (isResume) {
     args.push('resume', String(session.resume));
   }
-  args.push(
-    '--ephemeral',
-    '--skip-git-repo-check',
-    '-o',
-    opts.outputFile,
-    '--json',
-    '-m',
-    session.model,
-    '-C',
-    String(session.cwd),
-    '-s',
-    perms.value.sandbox
-  );
-  for (const root of session.additionalRoots ?? []) {
-    args.push('--add-dir', String(root));
+  args.push('--ephemeral', '--skip-git-repo-check', '-o', opts.outputFile, '--json', '-m', session.model);
+  if (!isResume) {
+    args.push('-C', String(session.cwd), '-s', perms.value.sandbox);
+    for (const root of session.additionalRoots ?? []) {
+      args.push('--add-dir', String(root));
+    }
   }
   if (opts.reasoningEffort !== undefined) {
     args.push('-c', `model_reasoning_effort=${opts.reasoningEffort}`);

--- a/src/integration/ai/readiness/_engine/predicates.ts
+++ b/src/integration/ai/readiness/_engine/predicates.ts
@@ -1,6 +1,7 @@
 import type { ReadinessState } from '@src/integration/ai/readiness/_engine/state.ts';
 import type { ClaudeArtifacts } from '@src/integration/ai/readiness/claude/artifacts.ts';
 import type { CopilotArtifacts } from '@src/integration/ai/readiness/copilot/artifacts.ts';
+import type { CodexArtifacts } from '@src/integration/ai/readiness/codex/artifacts.ts';
 
 /** Narrow {@link ReadinessState} to its `present` variant. */
 export const isPresent = (state: ReadinessState): state is Extract<ReadinessState, { kind: 'present' }> =>
@@ -28,3 +29,5 @@ export const hasAnyClaudeArtifact = (a: ClaudeArtifacts): boolean =>
   a.hooks.length > 0;
 
 export const hasAnyCopilotArtifact = (a: CopilotArtifacts): boolean => a.copilotInstructions !== undefined;
+
+export const hasAnyCodexArtifact = (a: CodexArtifacts): boolean => a.agentsMd !== undefined || a.skills.length > 0;

--- a/src/integration/ai/readiness/_engine/probe-fs.ts
+++ b/src/integration/ai/readiness/_engine/probe-fs.ts
@@ -1,0 +1,151 @@
+import { promises as fs, type Stats } from 'node:fs';
+import { basename, join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { Slug } from '@src/domain/value/slug.ts';
+import { toKebabCase } from '@src/domain/value/kebab-case.ts';
+import { ProbeError } from '@src/domain/value/error/probe-error.ts';
+import { isNodeErrnoCode } from '@src/integration/io/fs.ts';
+import type { ArtifactRef, NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+
+/**
+ * Stat a single file and report a typed {@link ArtifactRef} if and only if it exists as a
+ * regular file. Missing paths resolve to `undefined` (a normal absence); permission / I/O
+ * failures surface as {@link ProbeError}. Shared across per-tool readiness probes so they all
+ * classify FS errors identically.
+ *
+ * @public
+ */
+export const probeFile = async (path: string): Promise<Result<ArtifactRef | undefined, ProbeError>> => {
+  try {
+    const stat = await fs.stat(path);
+    if (!stat.isFile()) return Result.ok(undefined);
+    return Result.ok({ path: path as AbsolutePath });
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
+  }
+};
+
+/**
+ * Walk `<dir>/<name>/<childMarker>` collections (e.g. `.claude/skills/<name>/SKILL.md`). Each
+ * immediate sub-directory of `dir` that contains the `childMarker` file becomes a
+ * {@link NamedArtifactRef} whose `name` is the slugified directory name. Sub-directories
+ * without the marker, or with names that don't slugify, are silently skipped.
+ *
+ * @public
+ */
+export const probeNamedDirCollection = async (
+  dir: string,
+  childMarker: string
+): Promise<Result<NamedArtifactRef[], ProbeError>> => {
+  const entries = await listDir(dir);
+  if (!entries.ok) return Result.error(entries.error);
+  const refs: NamedArtifactRef[] = [];
+  for (const entry of entries.value) {
+    const childDir = join(dir, entry);
+    const stat = await statSafely(childDir);
+    if (!stat.ok) return Result.error(stat.error);
+    if (stat.value === undefined || !stat.value.isDirectory()) continue;
+    const markerPath = join(childDir, childMarker);
+    const markerStat = await statSafely(markerPath);
+    if (!markerStat.ok) return Result.error(markerStat.error);
+    if (markerStat.value === undefined || !markerStat.value.isFile()) continue;
+    const slug = Slug.parse(toKebabCase(basename(entry)));
+    if (!slug.ok) continue;
+    refs.push({ name: slug.value, path: markerPath as AbsolutePath });
+  }
+  return Result.ok(refs);
+};
+
+/**
+ * Walk a flat `<dir>/<name>.md` collection (e.g. `.claude/commands/<name>.md`). Each `.md`
+ * file becomes a {@link NamedArtifactRef} keyed on the slugified base name. Non-`.md` entries
+ * and names that don't slugify are silently skipped.
+ *
+ * @public
+ */
+export const probeNamedFileCollection = async (dir: string): Promise<Result<NamedArtifactRef[], ProbeError>> => {
+  const entries = await listDir(dir);
+  if (!entries.ok) return Result.error(entries.error);
+  const refs: NamedArtifactRef[] = [];
+  for (const entry of entries.value) {
+    if (!entry.endsWith('.md')) continue;
+    const full = join(dir, entry);
+    const stat = await statSafely(full);
+    if (!stat.ok) return Result.error(stat.error);
+    if (stat.value === undefined || !stat.value.isFile()) continue;
+    const baseName = entry.slice(0, -'.md'.length);
+    const slug = Slug.parse(toKebabCase(baseName));
+    if (!slug.ok) continue;
+    refs.push({ name: slug.value, path: full as AbsolutePath });
+  }
+  return Result.ok(refs);
+};
+
+/**
+ * List a directory's immediate entries. Missing or non-directory paths resolve to an empty
+ * list (normal absence); permission / I/O failures surface as {@link ProbeError}.
+ *
+ * @public
+ */
+export const listDir = async (dir: string): Promise<Result<string[], ProbeError>> => {
+  try {
+    return Result.ok(await fs.readdir(dir));
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok([]);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied listing ${dir}`, path: dir, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${dir}`, path: dir, cause }));
+  }
+};
+
+/**
+ * Stat a path without throwing on `ENOENT` — the missing case resolves to `undefined` so
+ * callers can branch on existence without try/catch noise. Permission / I/O failures still
+ * surface as {@link ProbeError}.
+ *
+ * @public
+ */
+export const statSafely = async (path: string): Promise<Result<Stats | undefined, ProbeError>> => {
+  try {
+    return Result.ok(await fs.stat(path));
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied stat ${path}`, path, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
+  }
+};
+
+/**
+ * Read a UTF-8 text file. Missing files resolve to `undefined` (a normal absence); permission
+ * / I/O failures surface as {@link ProbeError}. Used by probes that need to spelunk the
+ * contents of a config file (e.g. extracting hook commands from `settings.json`).
+ *
+ * @public
+ */
+export const readFileSafely = async (path: AbsolutePath): Promise<Result<string | undefined, ProbeError>> => {
+  try {
+    return Result.ok(await fs.readFile(path, 'utf8'));
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${path}`, path, cause }));
+  }
+};

--- a/src/integration/ai/readiness/claude/probe.ts
+++ b/src/integration/ai/readiness/claude/probe.ts
@@ -1,13 +1,16 @@
-import { promises as fs, type Stats } from 'node:fs';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
-import { type AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { Slug } from '@src/domain/value/slug.ts';
-import { toKebabCase } from '@src/domain/value/kebab-case.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
-import type { ArtifactRef, HookRef, NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+import type { ArtifactRef, HookRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+import {
+  probeFile,
+  probeNamedDirCollection,
+  probeNamedFileCollection,
+  readFileSafely,
+} from '@src/integration/ai/readiness/_engine/probe-fs.ts';
 import type { ClaudeArtifacts } from '@src/integration/ai/readiness/claude/artifacts.ts';
 import { absentState, type ReadinessState, presentState } from '@src/integration/ai/readiness/_engine/state.ts';
 import { hasAnyClaudeArtifact } from '@src/integration/ai/readiness/_engine/predicates.ts';
@@ -76,91 +79,6 @@ export const claudeProbe: ReadinessProbe<ClaudeArtifacts> = {
   },
 };
 
-const probeFile = async (path: string): Promise<Result<ArtifactRef | undefined, ProbeError>> => {
-  try {
-    const stat = await fs.stat(path);
-    if (!stat.isFile()) return Result.ok(undefined);
-    return Result.ok({ path: path as AbsolutePath });
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
-  }
-};
-
-const probeNamedFileCollection = async (dir: string): Promise<Result<NamedArtifactRef[], ProbeError>> => {
-  const entries = await listDir(dir);
-  if (!entries.ok) return Result.error(entries.error);
-  const refs: NamedArtifactRef[] = [];
-  for (const entry of entries.value) {
-    if (!entry.endsWith('.md')) continue;
-    const full = join(dir, entry);
-    const stat = await statSafely(full);
-    if (!stat.ok) return Result.error(stat.error);
-    if (stat.value === undefined || !stat.value.isFile()) continue;
-    const baseName = entry.slice(0, -'.md'.length);
-    const slug = Slug.parse(toKebabCase(baseName));
-    if (!slug.ok) continue;
-    refs.push({ name: slug.value, path: full as AbsolutePath });
-  }
-  return Result.ok(refs);
-};
-
-const probeNamedDirCollection = async (
-  dir: string,
-  childMarker: string
-): Promise<Result<NamedArtifactRef[], ProbeError>> => {
-  const entries = await listDir(dir);
-  if (!entries.ok) return Result.error(entries.error);
-  const refs: NamedArtifactRef[] = [];
-  for (const entry of entries.value) {
-    const childDir = join(dir, entry);
-    const stat = await statSafely(childDir);
-    if (!stat.ok) return Result.error(stat.error);
-    if (stat.value === undefined || !stat.value.isDirectory()) continue;
-    const markerPath = join(childDir, childMarker);
-    const markerStat = await statSafely(markerPath);
-    if (!markerStat.ok) return Result.error(markerStat.error);
-    if (markerStat.value === undefined || !markerStat.value.isFile()) continue;
-    const slug = Slug.parse(toKebabCase(basename(entry)));
-    if (!slug.ok) continue;
-    refs.push({ name: slug.value, path: markerPath as AbsolutePath });
-  }
-  return Result.ok(refs);
-};
-
-const listDir = async (dir: string): Promise<Result<string[], ProbeError>> => {
-  try {
-    return Result.ok(await fs.readdir(dir));
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok([]);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied listing ${dir}`, path: dir, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${dir}`, path: dir, cause }));
-  }
-};
-
-const statSafely = async (path: string): Promise<Result<Stats | undefined, ProbeError>> => {
-  try {
-    return Result.ok(await fs.stat(path));
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied stat ${path}`, path, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
-  }
-};
-
 const readHooks = async (
   settingsRefs: ReadonlyArray<ArtifactRef | undefined>
 ): Promise<Result<HookRef[], ProbeError>> => {
@@ -181,20 +99,6 @@ const readHooks = async (
     extractHooks(parsed, hooks);
   }
   return Result.ok(hooks);
-};
-
-const readFileSafely = async (path: AbsolutePath): Promise<Result<string | undefined, ProbeError>> => {
-  try {
-    return Result.ok(await fs.readFile(path, 'utf8'));
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${path}`, path, cause }));
-  }
 };
 
 /**
@@ -222,6 +126,3 @@ const extractHooks = (settings: unknown, sink: HookRef[]): void => {
     }
   }
 };
-
-const isNodeErrnoCode = (cause: unknown, code: string): boolean =>
-  typeof cause === 'object' && cause !== null && (cause as { code?: unknown }).code === code;

--- a/src/integration/ai/readiness/codex/artifacts.ts
+++ b/src/integration/ai/readiness/codex/artifacts.ts
@@ -1,8 +1,16 @@
+import type { ArtifactRef, NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+
 /**
- * Codex artifact catalog — placeholder until the on-disk signature is finalized. The probe
- * returns `unknown` for now (see `ai/readiness/<tool>/codex-probe.ts`); when the
- * shape stabilizes, fields go here.
+ * Catalog of Codex-specific artifacts a probe can discover under a Repository.
+ *
+ * Today we treat `AGENTS.md` as the canonical project context file and
+ * `.agents/skills/<name>/SKILL.md` as project-level skills. Both are used by the Codex flows:
+ * readiness writes/updates `AGENTS.md`, and the skills adapter installs into `.agents/skills`.
  */
 export interface CodexArtifacts {
   readonly tool: 'codex';
+  /** Project-level context memory at repo root. */
+  readonly agentsMd?: ArtifactRef;
+  /** `.agents/skills/<name>/SKILL.md`. */
+  readonly skills: readonly NamedArtifactRef[];
 }

--- a/src/integration/ai/readiness/codex/probe.ts
+++ b/src/integration/ai/readiness/codex/probe.ts
@@ -1,21 +1,112 @@
+import { promises as fs, type Stats } from 'node:fs';
+import { basename, join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { Slug } from '@src/domain/value/slug.ts';
+import { toKebabCase } from '@src/domain/value/kebab-case.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
-import type { ProbeError } from '@src/domain/value/error/probe-error.ts';
+import { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
 import type { CodexArtifacts } from '@src/integration/ai/readiness/codex/artifacts.ts';
-import { type ReadinessState, unknownState } from '@src/integration/ai/readiness/_engine/state.ts';
+import type { NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+import { absentState, type ReadinessState, presentState } from '@src/integration/ai/readiness/_engine/state.ts';
+import { hasAnyCodexArtifact } from '@src/integration/ai/readiness/_engine/predicates.ts';
 import type { ReadinessProbe } from '@src/integration/ai/readiness/_engine/probe.ts';
 
 /**
- * Codex probe — placeholder. Codex's on-disk readiness signature is not yet finalized; the
- * probe reports `unknown` until we know what to look for. Adding fields to
- * `CodexArtifacts` and a real filesystem walk here is the migration path.
+ * Filesystem probe for Codex artifacts. Looks under `repository.path` for:
+ *   - `AGENTS.md` (project context memory)
+ *   - `.agents/skills/<name>/SKILL.md` (named project skills)
+ *
+ * Returns `present` iff at least one artifact was discovered. Read errors are surfaced as
+ * {@link ProbeError}; absent paths are normal.
  */
 export const codexProbe: ReadinessProbe<CodexArtifacts> = {
   tool: 'codex',
-  evaluate(repository: Repository, now: IsoTimestamp): Promise<Result<ReadinessState, ProbeError>> {
-    void repository;
-    void now;
-    return Promise.resolve(Result.ok(unknownState));
+  async evaluate(repository: Repository, now: IsoTimestamp): Promise<Result<ReadinessState, ProbeError>> {
+    const root = repository.path;
+
+    const agentsMd = await probeFile(join(root, 'AGENTS.md'));
+    if (!agentsMd.ok) return Result.error(agentsMd.error);
+
+    const skills = await probeNamedDirCollection(join(root, '.agents/skills'), 'SKILL.md');
+    if (!skills.ok) return Result.error(skills.error);
+
+    const artifacts: CodexArtifacts = {
+      tool: 'codex',
+      ...(agentsMd.value !== undefined ? { agentsMd: agentsMd.value } : {}),
+      skills: skills.value,
+    };
+    return Result.ok(hasAnyCodexArtifact(artifacts) ? presentState(now, artifacts) : absentState(now));
   },
 };
+
+const probeFile = async (path: string): Promise<Result<{ readonly path: AbsolutePath } | undefined, ProbeError>> => {
+  try {
+    const stat = await fs.stat(path);
+    if (!stat.isFile()) return Result.ok(undefined);
+    return Result.ok({ path: path as AbsolutePath });
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
+  }
+};
+
+const probeNamedDirCollection = async (
+  dir: string,
+  childMarker: string
+): Promise<Result<NamedArtifactRef[], ProbeError>> => {
+  const entries = await listDir(dir);
+  if (!entries.ok) return Result.error(entries.error);
+  const refs: NamedArtifactRef[] = [];
+  for (const entry of entries.value) {
+    const childDir = join(dir, entry);
+    const stat = await statSafely(childDir);
+    if (!stat.ok) return Result.error(stat.error);
+    if (stat.value === undefined || !stat.value.isDirectory()) continue;
+    const markerPath = join(childDir, childMarker);
+    const markerStat = await statSafely(markerPath);
+    if (!markerStat.ok) return Result.error(markerStat.error);
+    if (markerStat.value === undefined || !markerStat.value.isFile()) continue;
+    const slug = Slug.parse(toKebabCase(basename(entry)));
+    if (!slug.ok) continue;
+    refs.push({ name: slug.value, path: markerPath as AbsolutePath });
+  }
+  return Result.ok(refs);
+};
+
+const listDir = async (dir: string): Promise<Result<string[], ProbeError>> => {
+  try {
+    return Result.ok(await fs.readdir(dir));
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok([]);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied listing ${dir}`, path: dir, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${dir}`, path: dir, cause }));
+  }
+};
+
+const statSafely = async (path: string): Promise<Result<Stats | undefined, ProbeError>> => {
+  try {
+    return Result.ok(await fs.stat(path));
+  } catch (cause) {
+    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
+    if (isNodeErrnoCode(cause, 'EACCES')) {
+      return Result.error(
+        new ProbeError({ subCode: 'fs-permission', message: `permission denied stat ${path}`, path, cause })
+      );
+    }
+    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
+  }
+};
+
+const isNodeErrnoCode = (cause: unknown, code: string): boolean =>
+  typeof cause === 'object' && cause !== null && (cause as { code?: unknown }).code === code;

--- a/src/integration/ai/readiness/codex/probe.ts
+++ b/src/integration/ai/readiness/codex/probe.ts
@@ -1,14 +1,10 @@
-import { promises as fs, type Stats } from 'node:fs';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
-import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { Slug } from '@src/domain/value/slug.ts';
-import { toKebabCase } from '@src/domain/value/kebab-case.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
-import { ProbeError } from '@src/domain/value/error/probe-error.ts';
+import type { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
 import type { CodexArtifacts } from '@src/integration/ai/readiness/codex/artifacts.ts';
-import type { NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+import { probeFile, probeNamedDirCollection } from '@src/integration/ai/readiness/_engine/probe-fs.ts';
 import { absentState, type ReadinessState, presentState } from '@src/integration/ai/readiness/_engine/state.ts';
 import { hasAnyCodexArtifact } from '@src/integration/ai/readiness/_engine/predicates.ts';
 import type { ReadinessProbe } from '@src/integration/ai/readiness/_engine/probe.ts';
@@ -40,73 +36,3 @@ export const codexProbe: ReadinessProbe<CodexArtifacts> = {
     return Result.ok(hasAnyCodexArtifact(artifacts) ? presentState(now, artifacts) : absentState(now));
   },
 };
-
-const probeFile = async (path: string): Promise<Result<{ readonly path: AbsolutePath } | undefined, ProbeError>> => {
-  try {
-    const stat = await fs.stat(path);
-    if (!stat.isFile()) return Result.ok(undefined);
-    return Result.ok({ path: path as AbsolutePath });
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
-  }
-};
-
-const probeNamedDirCollection = async (
-  dir: string,
-  childMarker: string
-): Promise<Result<NamedArtifactRef[], ProbeError>> => {
-  const entries = await listDir(dir);
-  if (!entries.ok) return Result.error(entries.error);
-  const refs: NamedArtifactRef[] = [];
-  for (const entry of entries.value) {
-    const childDir = join(dir, entry);
-    const stat = await statSafely(childDir);
-    if (!stat.ok) return Result.error(stat.error);
-    if (stat.value === undefined || !stat.value.isDirectory()) continue;
-    const markerPath = join(childDir, childMarker);
-    const markerStat = await statSafely(markerPath);
-    if (!markerStat.ok) return Result.error(markerStat.error);
-    if (markerStat.value === undefined || !markerStat.value.isFile()) continue;
-    const slug = Slug.parse(toKebabCase(basename(entry)));
-    if (!slug.ok) continue;
-    refs.push({ name: slug.value, path: markerPath as AbsolutePath });
-  }
-  return Result.ok(refs);
-};
-
-const listDir = async (dir: string): Promise<Result<string[], ProbeError>> => {
-  try {
-    return Result.ok(await fs.readdir(dir));
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok([]);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied listing ${dir}`, path: dir, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${dir}`, path: dir, cause }));
-  }
-};
-
-const statSafely = async (path: string): Promise<Result<Stats | undefined, ProbeError>> => {
-  try {
-    return Result.ok(await fs.stat(path));
-  } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
-    if (isNodeErrnoCode(cause, 'EACCES')) {
-      return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied stat ${path}`, path, cause })
-      );
-    }
-    return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
-  }
-};
-
-const isNodeErrnoCode = (cause: unknown, code: string): boolean =>
-  typeof cause === 'object' && cause !== null && (cause as { code?: unknown }).code === code;

--- a/src/integration/ai/readiness/copilot/probe.ts
+++ b/src/integration/ai/readiness/copilot/probe.ts
@@ -5,6 +5,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
+import { isNodeErrnoCode } from '@src/integration/io/fs.ts';
 import type { CopilotArtifacts } from '@src/integration/ai/readiness/copilot/artifacts.ts';
 import { absentState, type ReadinessState, presentState } from '@src/integration/ai/readiness/_engine/state.ts';
 import { hasAnyCopilotArtifact } from '@src/integration/ai/readiness/_engine/predicates.ts';
@@ -34,6 +35,3 @@ export const copilotProbe: ReadinessProbe<CopilotArtifacts> = {
     }
   },
 };
-
-const isNodeErrnoCode = (cause: unknown, code: string): boolean =>
-  typeof cause === 'object' && cause !== null && (cause as { code?: unknown }).code === code;

--- a/tests/e2e/flows/doctor.test.ts
+++ b/tests/e2e/flows/doctor.test.ts
@@ -216,6 +216,38 @@ describe('doctor use-case', () => {
     expect(probe?.group).toBe('ai');
   });
 
+  it('passes when Codex is configured and `codex login status` succeeds', async () => {
+    const codexDefaults = { ...DEFAULT_SETTINGS, ai: DEFAULT_AI_SETTINGS_BY_PROVIDER['openai-codex'] };
+    const flow = createDoctorFlow({
+      projectRepo: fakeProjectRepo(),
+      sprintRepo: fakeSprintRepo(),
+      settingsRepo: fakeSettingsRepo({
+        async load() {
+          return Result.ok(codexDefaults);
+        },
+      }),
+      commandExists: stubCommandExists(true),
+      runCommand: stubRunCommand((name, args) => {
+        if (name === 'codex' && args[0] === 'login' && args[1] === 'status') {
+          return { ok: true };
+        }
+        return undefined;
+      }),
+      sprintExecutionRepo: fakeSprintExecutionRepo(),
+      nodeVersion: 'v24.0.0',
+    });
+    const result = await flow.execute({
+      input: { dataRoot: absolutePath(dataDir), configRoot: absolutePath(configDir) },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const probe = result.value.ctx.output!.probes.find((p) => p.id === 'codex-auth');
+    expect(probe?.status).toBe('pass');
+    expect(probe?.detail).toBe('authenticated');
+    expect(probe?.group).toBe('ai');
+  });
+
   it('reports the missing-root probe as failed without erroring', async () => {
     const flow = createDoctorFlow({
       projectRepo: fakeProjectRepo(),

--- a/tests/e2e/flows/doctor.test.ts
+++ b/tests/e2e/flows/doctor.test.ts
@@ -10,7 +10,7 @@ import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sp
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import type { RunCommand } from '@src/integration/io/run-command.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
-import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { DEFAULT_AI_SETTINGS_BY_PROVIDER, DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createDoctorFlow } from '@src/application/flows/doctor/flow.ts';
 
@@ -182,6 +182,38 @@ describe('doctor use-case', () => {
     const configuredProbe = result.value.ctx.output!.probes.find((p) => p.id === 'ai-claude-code');
     expect(configuredProbe?.status).toBe('warn');
     expect(configuredProbe?.hint).toContain('install');
+  });
+
+  it('warns when Codex is configured but `codex login status` is unauthenticated', async () => {
+    const codexDefaults = { ...DEFAULT_SETTINGS, ai: DEFAULT_AI_SETTINGS_BY_PROVIDER['openai-codex'] };
+    const flow = createDoctorFlow({
+      projectRepo: fakeProjectRepo(),
+      sprintRepo: fakeSprintRepo(),
+      settingsRepo: fakeSettingsRepo({
+        async load() {
+          return Result.ok(codexDefaults);
+        },
+      }),
+      commandExists: stubCommandExists(true),
+      runCommand: stubRunCommand((name, args) => {
+        if (name === 'codex' && args[0] === 'login' && args[1] === 'status') {
+          return { ok: false, stderr: 'Not logged in' };
+        }
+        return undefined;
+      }),
+      sprintExecutionRepo: fakeSprintExecutionRepo(),
+      nodeVersion: 'v24.0.0',
+    });
+    const result = await flow.execute({
+      input: { dataRoot: absolutePath(dataDir), configRoot: absolutePath(configDir) },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const probe = result.value.ctx.output!.probes.find((p) => p.id === 'codex-auth');
+    expect(probe?.status).toBe('warn');
+    expect(probe?.detail).toContain('Not logged in');
+    expect(probe?.group).toBe('ai');
   });
 
   it('reports the missing-root probe as failed without erroring', async () => {

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -245,6 +245,12 @@ describe('buildCodexArgs — AiSession → CLI argv translation', () => {
     expect(args).not.toContain('-a');
   });
 
+  it('omits -s for resume sessions because `codex exec resume` rejects it', () => {
+    const id = 'sess-abc' as unknown as SessionId;
+    const args = unwrapArgs(session({ resume: id, permissions: FULL_AUTO }));
+    expect(args).not.toContain('-s');
+  });
+
   it('rejects intermediate permission combinations with InvalidStateError', () => {
     const half = { canEditFiles: true, canRunShell: false, canAccessNetwork: true, autoApprove: false };
     const r = buildCodexArgs(session({ permissions: half }), { outputFile: FIXED_OUT });
@@ -261,6 +267,12 @@ describe('buildCodexArgs — AiSession → CLI argv translation', () => {
     expect(args[idx + 1]).toBe(String(CWD));
   });
 
+  it('omits -C for resume sessions because `codex exec resume` rejects it', () => {
+    const id = 'sess-abc' as unknown as SessionId;
+    const args = unwrapArgs(session({ resume: id }));
+    expect(args).not.toContain('-C');
+  });
+
   it('emits one --add-dir per additionalRoots entry, in declared order', () => {
     const a = absolutePath('/tmp/repo-a');
     const b = absolutePath('/tmp/repo-b');
@@ -273,6 +285,13 @@ describe('buildCodexArgs — AiSession → CLI argv translation', () => {
       ['--add-dir', '/tmp/repo-a'],
       ['--add-dir', '/tmp/repo-b'],
     ]);
+  });
+
+  it('omits --add-dir for resume sessions because `codex exec resume` rejects it', () => {
+    const id = 'sess-abc' as unknown as SessionId;
+    const a = absolutePath('/tmp/repo-a');
+    const args = unwrapArgs(session({ resume: id, additionalRoots: [a] }));
+    expect(args).not.toContain('--add-dir');
   });
 
   it('emits -c model_reasoning_effort=<level> when reasoningEffort is set', () => {

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -86,6 +86,14 @@ const tempSignalsFile = () => {
   );
 };
 
+let bodyCounter = 0;
+const tempBodyFile = () => {
+  bodyCounter += 1;
+  return absolutePath(
+    join(tmpdir(), `ralphctl-codex-body-${String(process.pid)}-${String(Date.now())}-${String(bodyCounter)}.txt`)
+  );
+};
+
 const session = (overrides: Partial<AiSession> = {}): AiSession => ({
   prompt: PROMPT,
   cwd: CWD,
@@ -150,6 +158,29 @@ describe('createCodexProvider', () => {
     const signals = await readSignals(String(out.value.signalsFile));
     expect(signals.map((s) => s.type)).toEqual(['progress', 'task-verified']);
     expect(fsStub.unlinks).toEqual([FIXED_OUT]);
+  });
+
+  it('mirrors raw body to session.bodyFile when requested (diagnostic capture)', async () => {
+    const cap = createCapturingBus();
+    const bodyFile = tempBodyFile();
+    const sess = session({ bodyFile });
+    const { spawn } = makeSpawn([{ stdoutChunks: ['{"session_id":"sess-1","type":"config"}\n'], exitCode: 0 }]);
+    const fsStub = stubFs('<task-verified>all good</task-verified>');
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    const mirrored = await fs.readFile(String(bodyFile), 'utf8');
+    expect(mirrored).toBe('<task-verified>all good</task-verified>');
   });
 
   it('rate-limit: retries up to N times and surfaces RateLimitError when exhausted', async () => {

--- a/tests/integration/ai/readiness/codex-probe.test.ts
+++ b/tests/integration/ai/readiness/codex-probe.test.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { codexProbe } from '@src/integration/ai/readiness/codex/probe.ts';
+import { absolutePath, FIXED_NOW, makeRepository } from '@tests/fixtures/domain.ts';
+import type { Repository } from '@src/domain/entity/repository.ts';
+import { isAbsent, isPresent } from '@src/integration/ai/readiness/_engine/predicates.ts';
+
+const repoAt = (path: string): Repository => makeRepository({ path, name: 'tmp', slug: 'tmp' });
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(join(tmpdir(), 'ralphctl-codex-probe-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('codexProbe', () => {
+  it('returns absent for an empty repo', async () => {
+    const r = await codexProbe.evaluate(repoAt(dir), FIXED_NOW);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(isAbsent(r.value)).toBe(true);
+  });
+
+  it('returns present when AGENTS.md exists', async () => {
+    await fs.writeFile(join(dir, 'AGENTS.md'), '# project context\n');
+    const r = await codexProbe.evaluate(repoAt(dir), FIXED_NOW);
+    expect(r.ok).toBe(true);
+    if (!r.ok || !isPresent(r.value) || r.value.artifacts.tool !== 'codex') throw new Error('expected present');
+    expect(r.value.artifacts.agentsMd?.path).toBe(absolutePath(join(dir, 'AGENTS.md')));
+  });
+
+  it('discovers .agents/skills/<name>/SKILL.md folders', async () => {
+    await fs.mkdir(join(dir, '.agents/skills/my-skill'), { recursive: true });
+    await fs.writeFile(join(dir, '.agents/skills/my-skill/SKILL.md'), 'skill body');
+    const r = await codexProbe.evaluate(repoAt(dir), FIXED_NOW);
+    expect(r.ok).toBe(true);
+    if (!r.ok || !isPresent(r.value) || r.value.artifacts.tool !== 'codex') throw new Error('expected present');
+    expect(r.value.artifacts.skills).toHaveLength(1);
+    expect(r.value.artifacts.skills[0]?.name).toBe('my-skill');
+    expect(r.value.artifacts.skills[0]?.path).toBe(absolutePath(join(dir, '.agents/skills/my-skill/SKILL.md')));
+  });
+});

--- a/tests/unit/integration/ai/readiness/predicates.test.ts
+++ b/tests/unit/integration/ai/readiness/predicates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   hasAnyClaudeArtifact,
+  hasAnyCodexArtifact,
   hasAnyCopilotArtifact,
   isAbsent,
   isPresent,
@@ -8,6 +9,7 @@ import {
 } from '@src/integration/ai/readiness/_engine/predicates.ts';
 import type { ClaudeArtifacts } from '@src/integration/ai/readiness/claude/artifacts.ts';
 import type { CopilotArtifacts } from '@src/integration/ai/readiness/copilot/artifacts.ts';
+import type { CodexArtifacts } from '@src/integration/ai/readiness/codex/artifacts.ts';
 import { absentState, presentState, unknownState } from '@src/integration/ai/readiness/_engine/state.ts';
 import { absolutePath, FIXED_NOW } from '@tests/fixtures/domain.ts';
 
@@ -62,5 +64,25 @@ describe('hasAnyCopilotArtifact', () => {
       copilotInstructions: { path: absolutePath('/repo/.github/copilot-instructions.md') },
     };
     expect(hasAnyCopilotArtifact(a)).toBe(true);
+  });
+});
+
+describe('hasAnyCodexArtifact', () => {
+  it('false when agentsMd is missing and skills are empty', () => {
+    const a: CodexArtifacts = { tool: 'codex', skills: [] };
+    expect(hasAnyCodexArtifact(a)).toBe(false);
+  });
+
+  it('true when AGENTS.md exists', () => {
+    const a: CodexArtifacts = { tool: 'codex', agentsMd: { path: absolutePath('/repo/AGENTS.md') }, skills: [] };
+    expect(hasAnyCodexArtifact(a)).toBe(true);
+  });
+
+  it('true when at least one skill exists', () => {
+    const a: CodexArtifacts = {
+      tool: 'codex',
+      skills: [{ name: 'my-skill' as never, path: absolutePath('/repo/.agents/skills/my-skill/SKILL.md') }],
+    };
+    expect(hasAnyCodexArtifact(a)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **Codex headless `exec resume`** — omit `-C`, `-s`, and `--add-dir` (codex rejects them on resume); also map raw model output to `session.bodyFile` for diagnostic capture, matching the Claude adapter.
- **Codex readiness probe** — real filesystem walk for `AGENTS.md` + `.agents/skills/<name>/SKILL.md`. `pickExistingContextPath` now resolves `AGENTS.md` for codex so readiness can preserve it verbatim.
- **Doctor** — new `codex-auth` probe under group `ai` (runs `codex login status` when codex is the configured provider). Redundant `commandExists('codex')` collapsed.
- **Refactor** — extract shared probe-FS helpers (`probeFile`, `probeNamedDirCollection`, `probeNamedFileCollection`, `listDir`, `statSafely`, `readFileSafely`) into `src/integration/ai/readiness/_engine/probe-fs.ts`; claude/codex/copilot probes now fold onto the existing `isNodeErrnoCode` export from `integration/io/fs.ts`.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — 199 files, 1389 tests
- [x] \`pnpm deadcode\` — knip clean
- [ ] Smoke: run \`ralphctl doctor\` with \`ai.provider = openai-codex\` — confirm the new \`codex-auth\` probe surfaces under the AI group with the expected status
- [ ] Smoke: run an implement attempt with codex provider end-to-end — confirm \`exec resume\` succeeds and \`bodyFile\` mirrors the raw model output