### PR TITLE
fix(tui/execute-view): real flow steps + vertical task legend

### DIFF
--- a/src/application/flows/implement/leaves/with-repo-lock.ts
+++ b/src/application/flows/implement/leaves/with-repo-lock.ts
@@ -38,6 +38,11 @@ export interface WithRepoLockOpts {
 
 export const withRepoLock = (opts: WithRepoLockOpts, inner: Element<ImplementCtx>): Element<ImplementCtx> => ({
   name: `with-repo-lock(${inner.name})`,
+  // Expose the wrapped chain through the composite-pattern `children` slot so `flattenLeaves`
+  // walks into it when the TUI builds its planned-leaf list. Without this the wrapper looked
+  // like an opaque single leaf and the Flow-steps panel rendered only "with-repo-lock(…)" —
+  // never the real setup / per-task / teardown sequence inside the lock.
+  children: [inner],
   async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
     const lockPath = repoLockFile(opts.locksRoot, opts.worktreePath);
     if (!lockPath.ok) {

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -152,29 +152,42 @@ const SignalLine = ({ signal }: { readonly signal: HarnessSignal }): React.JSX.E
 };
 
 /**
- * One-line legend rendered above the first task block. Keeps the dashboard readable when the
+ * Vertical legend rendered above the first task block. Keeps the dashboard readable when the
  * 4-letter shorthand was replaced by full words: the operator sees what `change`, `learning`,
- * `decision`, `verified`, `blocked` mean without leaving the view.
+ * `decision`, `verified`, `blocked` mean without leaving the view. One row per signal kind
+ * with the label padded to {@link SIGNAL_LABEL_WIDTH} so the ` = description` column lines up
+ * with the same column under each task's signals block.
  */
+interface LegendEntry {
+  readonly label: string;
+  readonly color: string;
+  readonly description: string;
+}
+
+const LEGEND_ENTRIES: readonly LegendEntry[] = [
+  { label: 'change', color: inkColors.info, description: 'file/code edit' },
+  { label: 'learning', color: inkColors.highlight, description: 'cross-task insight' },
+  { label: 'decision', color: inkColors.highlight, description: 'design choice' },
+  { label: 'verified', color: inkColors.success, description: 'task self-check passed' },
+  { label: 'blocked', color: inkColors.error, description: 'task self-blocked' },
+  { label: 'commit', color: inkColors.info, description: 'proposed commit message' },
+];
+
 const SignalLegend = (): React.JSX.Element => (
   <Box flexDirection="column" paddingX={spacing.indent} marginBottom={spacing.section}>
-    <Text dimColor>
-      <Text bold>legend</Text>
-      {'  '}
-      <Text color={inkColors.info}>change</Text> = file/code edit
-      {'   '}
-      <Text color={inkColors.highlight}>learning</Text> = cross-task insight
-      {'   '}
-      <Text color={inkColors.highlight}>decision</Text> = design choice
+    <Text dimColor bold>
+      legend
     </Text>
-    <Text dimColor>
-      {'        '}
-      <Text color={inkColors.success}>verified</Text> = task self-check passed
-      {'   '}
-      <Text color={inkColors.error}>blocked</Text> = task self-blocked
-      {'   '}
-      <Text color={inkColors.info}>commit</Text> = proposed commit message
-    </Text>
+    <Box flexDirection="column" paddingLeft={2}>
+      {LEGEND_ENTRIES.map((entry) => (
+        <Box key={entry.label}>
+          <Text color={entry.color} bold>
+            {padLabel(entry.label)}
+          </Text>
+          <Text dimColor>= {entry.description}</Text>
+        </Box>
+      ))}
+    </Box>
   </Box>
 );
 

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -256,8 +256,10 @@ export const ExecuteView = (): React.JSX.Element => {
   );
 
   // Top-level flow steps exclude per-task subchain leaves (any name carrying a uuid suffix) —
-  // those render under the Tasks panel.
-  const outerFlowFilter = (name: string): boolean => !isPerTaskLeaf(name);
+  // those render under the Tasks panel. The `with-repo-lock(…)` wrapper is plumbing the
+  // operator never needs to see in the plan; it only lands in the trace on a lock-acquire
+  // failure, in which case the failure surfaces through the Recent-log panel anyway.
+  const outerFlowFilter = (name: string): boolean => !isPerTaskLeaf(name) && !name.startsWith('with-repo-lock(');
 
   const flowStepsPanel = (
     <StepTrace


### PR DESCRIPTION
## Summary
- `withRepoLock` now exposes `children: [inner]` so `flattenLeaves` walks the wrapped chain — the Flow-steps panel renders the real outer sequence (`activate-sprint`, `setup-script-runner`, `resolve-branch`, `preflight-tasks`, `save-tasks`, `transition-sprint-to-review-when-any-done`, `flush-progress-sink`, plus per-repo preflight rows) instead of a single opaque `with-repo-lock(implement-locked)` row.
- The wrapper name is filtered out of the merged plan view defensively (only ever lands in the trace on a lock-acquire failure, which surfaces via Recent log anyway).
- Re-stack the Tasks legend vertically — one row per signal kind, aligned to the same `padLabel(16)` column as the per-task signals beneath.

Phases 1 + 2 of a five-phase iterative polish of the Implement execute view (phases 3-5 remaining: hierarchical flow+task column, header/terminal-state cleanup, token/alignment sweep).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (198 files, 1377 tests green)
- [ ] Manual: run an Implement flow and confirm Flow-steps panel shows the real outer sequence and the legend reads top-to-bottom