### PR TITLE
fix(tui): cap TasksPanel renders + isolate spinner re-renders (OOM)

### DIFF
--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -287,6 +287,12 @@ pushes a dedicated `*-detail-view.tsx`).
 - Behave like a workflow view: `SectionStamp`, phase state, `ResultCard` for outcome.
 - No bespoke input handlers — everything goes through the injected `PromptPort`.
 
+### 7.5 Render caps for list data
+
+Every list rendered from chain trace, event-bus, or harness-signal data MUST `.slice(-max)` before `.map()` to JSX, with an elision row above the rendered tail when truncated. Exception: lists with a hard domain bound (legend entries, settings options, fixed phase order) may render in full — comment the bound at the call site.
+
+Spinner state lives in the leaf `<Spinner />` component (`src/application/ui/tui/components/spinner.tsx`). Don't call `useSpinnerFrame` from a component that renders a subtree larger than itself — the 90 ms re-render propagates. Use `<Spinner active … />` instead.
+
 ## 8. Copy & tone
 
 ### 8.1 Spinner labels

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,9 @@ signals without explicit threading.
 **Ink TUI** at `src/application/ui/tui/`. Bare `ralphctl` mounts via `runtime/mount.tsx` — alt-screen
 takeover (vim/htop-style), restored on every exit path (`exit`, `SIGINT`, `SIGTERM`, `SIGHUP`,
 `uncaughtException`). Non-TTY / `CI=1` / `RALPHCTL_NO_TUI=1` skip the mount. Tokens are the single source of
-visual truth at `src/application/ui/tui/theme/tokens.ts` — no inline hex / glyph / spacing. See DESIGN-SYSTEM.md.
+visual truth at `src/application/ui/tui/theme/tokens.ts` — no inline hex / glyph / spacing. List renders
+sliced before `.map()`; spinner state lives in the leaf `<Spinner />` so 90 ms timer re-renders don't
+propagate. See DESIGN-SYSTEM.md.
 
 **CLI** at `src/application/ui/cli/`. Interactive flows (`refine` / `plan` / `ideate` / `implement` /
 `readiness` / `create-sprint`) stay TUI-only by design. The CLI exposes `doctor`, `completion`,

--- a/src/application/ui/tui/components/spinner.tsx
+++ b/src/application/ui/tui/components/spinner.tsx
@@ -1,6 +1,14 @@
 /**
- * Braille spinner. Reads the shared frame counter so multiple spinners on the same screen tick
- * in sync.
+ * Braille spinner — leaf component that owns its own frame state. The 90 ms `setInterval` lives
+ * inside this leaf, so re-renders are isolated to the spinner node and don't reconcile parent
+ * subtrees. Critical for views like ExecuteView / TasksPanel that render unbounded child lists:
+ * driving the spinner from a parent would tick every list child ~11× per second and OOM Ink's
+ * reconciler on long Implement runs.
+ *
+ * Two render shapes:
+ *  - With `label`: glyph + space + label (legacy callers — status bar, loading panels).
+ *  - Without `label`: glyph only (used inline inside an existing `<Text>` parent that supplies
+ *    surrounding copy and color).
  */
 
 import React from 'react';
@@ -11,13 +19,30 @@ import { inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 export interface SpinnerProps {
   readonly label?: string;
   readonly color?: string;
+  /**
+   * When false the timer is paused — the glyph stays on its current frame. Keeps the
+   * `useSpinnerFrame` interval from firing when the spinner is decorative-only (e.g. a task
+   * row that's no longer the running task). Defaults to true.
+   */
+  readonly active?: boolean;
+  /** Render with `dimColor` instead of the explicit `color`. */
+  readonly dim?: boolean;
 }
 
-export const Spinner = ({ label, color = inkColors.info }: SpinnerProps): React.JSX.Element => {
-  const frame = useSpinnerFrame();
+export const Spinner = ({ label, color = inkColors.info, active = true, dim }: SpinnerProps): React.JSX.Element => {
+  const frame = useSpinnerFrame(active);
+  const glyph = spinnerGlyph(frame);
+  if (dim === true) {
+    return (
+      <Text dimColor>
+        {glyph}
+        {label !== undefined && label.length > 0 ? ` ${label}` : ''}
+      </Text>
+    );
+  }
   return (
     <Text color={color}>
-      {spinnerGlyph(frame)}
+      {glyph}
       {label !== undefined && label.length > 0 ? ` ${label}` : ''}
     </Text>
   );

--- a/src/application/ui/tui/components/step-trace.tsx
+++ b/src/application/ui/tui/components/step-trace.tsx
@@ -19,7 +19,7 @@ import { Box, Text } from 'ink';
 import type { Trace, TraceEntry } from '@src/application/chain/trace.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { fmtDuration } from '@src/application/ui/tui/theme/duration.ts';
-import { useSpinnerFrame, spinnerGlyph } from '@src/application/ui/tui/runtime/use-spinner-frame.ts';
+import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
 
 export interface StepTraceProps {
   readonly trace: Trace;
@@ -44,20 +44,31 @@ interface MergedRow {
   readonly errorMessage?: string;
 }
 
-const glyphFor = (status: RowStatus, frame: number): readonly [string, string] => {
+/**
+ * Per-row glyph instruction. Either a static glyph (rendered inline by the caller's `<Text>`) or
+ * a `spinner` sentinel — in which case the caller renders a `<Spinner />` leaf, which owns its
+ * own 90 ms re-render scope. Returning the sentinel (instead of calling `spinnerGlyph(frame)`
+ * here) is what allows StepTrace to drop the `useSpinnerFrame` call at the top of the component:
+ * the spinner re-render no longer ticks the whole row list, only the spinner node itself.
+ */
+type GlyphInstruction =
+  | { readonly kind: 'static'; readonly glyph: string; readonly color: string }
+  | { readonly kind: 'spinner'; readonly color: string };
+
+const glyphFor = (status: RowStatus): GlyphInstruction => {
   switch (status) {
     case 'completed':
-      return [glyphs.phaseDone, inkColors.success];
+      return { kind: 'static', glyph: glyphs.phaseDone, color: inkColors.success };
     case 'failed':
-      return [glyphs.cross, inkColors.error];
+      return { kind: 'static', glyph: glyphs.cross, color: inkColors.error };
     case 'aborted':
-      return [glyphs.warningGlyph, inkColors.warning];
+      return { kind: 'static', glyph: glyphs.warningGlyph, color: inkColors.warning };
     case 'skipped':
-      return [glyphs.phaseDisabled, inkColors.muted];
+      return { kind: 'static', glyph: glyphs.phaseDisabled, color: inkColors.muted };
     case 'running':
-      return [spinnerGlyph(frame), inkColors.info];
+      return { kind: 'spinner', color: inkColors.info };
     case 'pending':
-      return [glyphs.phasePending, inkColors.muted];
+      return { kind: 'static', glyph: glyphs.phasePending, color: inkColors.muted };
   }
 };
 
@@ -124,7 +135,6 @@ export const StepTrace = ({
   inFlightLabel,
   plan,
 }: StepTraceProps): React.JSX.Element => {
-  const frame = useSpinnerFrame(running);
   // Memoize the plan/trace merge — `mergePlanWithTrace` walks the entire trace to build a
   // lookup Map on every call. For long running sessions (5k+ trace entries) re-allocating that
   // every render adds avoidable GC pressure even though the cost is fast in absolute terms.
@@ -154,14 +164,18 @@ export const StepTrace = ({
   return (
     <Box flexDirection="column">
       {rows.map((row, i) => {
-        const [g, color] = glyphFor(row.status, frame);
+        const instruction = glyphFor(row.status);
         const trailing = trailingLabelFor(row.status);
         const dimRow = row.status === 'pending';
         return (
           <Box key={`${row.name}-${String(i)}`} paddingX={spacing.indent}>
-            <Text color={color} bold>
-              {g}
-            </Text>
+            {instruction.kind === 'spinner' ? (
+              <Spinner active={running} color={instruction.color} />
+            ) : (
+              <Text color={instruction.color} bold>
+                {instruction.glyph}
+              </Text>
+            )}
             <Text dimColor={dimRow}> {row.name}</Text>
             {row.durationMs !== undefined && (
               <Text dimColor>
@@ -170,7 +184,7 @@ export const StepTrace = ({
               </Text>
             )}
             {trailing !== undefined && (
-              <Text color={color}>
+              <Text color={instruction.color}>
                 {'  '}
                 {glyphs.emDash} {trailing}
               </Text>
@@ -189,9 +203,7 @@ export const StepTrace = ({
           to avoid double-rendering. */}
       {plan === undefined && running && inFlightLabel !== undefined && (
         <Box paddingX={spacing.indent}>
-          <Text color={inkColors.info} bold>
-            {spinnerGlyph(frame)}
-          </Text>
+          <Spinner active={running} color={inkColors.info} />
           <Text dimColor> {inFlightLabel}</Text>
         </Box>
       )}

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -29,7 +29,7 @@ import type {
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { fmtDuration, fmtIsoTime } from '@src/application/ui/tui/theme/duration.ts';
-import { useSpinnerFrame, spinnerGlyph } from '@src/application/ui/tui/runtime/use-spinner-frame.ts';
+import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
 
 export interface TasksPanelProps {
   readonly bucketed: BucketedExecution;
@@ -40,6 +40,14 @@ export interface TasksPanelProps {
   readonly maxSignalsPerTask?: number;
   /** Max orphan signals to render. */
   readonly maxOrphanSignals?: number;
+  /**
+   * Max sub-step rows per task to render; older ones drop off the top behind a single elision
+   * row. Bounds Ink reconciliation cost on long gen-eval loops (every retry adds ~12 leaves),
+   * preventing the OOM mode where unbounded child lists thrash the V8 heap every spinner tick.
+   */
+  readonly maxSubStepsPerTask?: number;
+  /** Max evaluation rows per task to render; same elision treatment as sub-steps. */
+  readonly maxEvaluationsPerTask?: number;
 }
 
 const STATUS_PRESENTATION: Readonly<Record<TaskBucketStatus, { readonly color: string; readonly glyph: string }>> = {
@@ -226,18 +234,9 @@ const EvaluationLine = ({ evaluation }: { readonly evaluation: EvaluationSignal 
   );
 };
 
-const SubStepLine = ({
-  sub,
-  running,
-  spinner,
-}: {
-  readonly sub: TaskSubStep;
-  readonly running: boolean;
-  readonly spinner: string;
-}): React.JSX.Element => {
+const SubStepLine = ({ sub, running }: { readonly sub: TaskSubStep; readonly running: boolean }): React.JSX.Element => {
   const presentation = SUB_STEP_PRESENTATION[sub.status];
   const glyph = running && sub.status === 'completed' ? presentation.glyph : presentation.glyph;
-  void spinner;
   return (
     <Box>
       <Text color={presentation.color} bold>
@@ -263,22 +262,33 @@ const TaskBlock = ({
   running,
   display,
   maxSignals,
+  maxSubSteps,
+  maxEvaluations,
 }: {
   readonly task: TaskBucket;
   readonly running: boolean;
   readonly display: string;
   readonly maxSignals: number;
+  readonly maxSubSteps: number;
+  readonly maxEvaluations: number;
 }): React.JSX.Element => {
   const presentation = STATUS_PRESENTATION[task.status];
-  const frame = useSpinnerFrame(running && task.status === 'running');
-  const glyph = task.status === 'running' ? spinnerGlyph(frame) : presentation.glyph;
+  const isSpinning = task.status === 'running';
   const signalRows = task.signals.slice(-maxSignals);
+  const subStepRows = task.subSteps.slice(-maxSubSteps);
+  const subStepElided = task.subSteps.length - subStepRows.length;
+  const evalRows = task.evaluations.slice(-maxEvaluations);
+  const evalElided = task.evaluations.length - evalRows.length;
   return (
     <Box flexDirection="column" marginBottom={spacing.section}>
       <Box>
-        <Text color={presentation.color} bold>
-          {glyph}
-        </Text>
+        {isSpinning ? (
+          <Spinner active={running} color={presentation.color} />
+        ) : (
+          <Text color={presentation.color} bold>
+            {presentation.glyph}
+          </Text>
+        )}
         <Text bold> {display}</Text>
         {task.durationMs !== undefined && (
           <Text dimColor>
@@ -303,16 +313,18 @@ const TaskBlock = ({
           <Text color={inkColors.error}>{task.errorMessage}</Text>
         </Box>
       )}
-      {task.subSteps.length > 0 && (
+      {subStepRows.length > 0 && (
         <Box flexDirection="column" paddingLeft={2}>
-          {task.subSteps.map((s, i) => (
-            <SubStepLine key={`${task.id}-sub-${String(i)}`} sub={s} running={running} spinner={spinnerGlyph(frame)} />
+          {subStepElided > 0 && <Text dimColor>{`… ${String(subStepElided)} earlier sub-steps`}</Text>}
+          {subStepRows.map((s, i) => (
+            <SubStepLine key={`${task.id}-sub-${String(i)}`} sub={s} running={running} />
           ))}
         </Box>
       )}
-      {task.evaluations.length > 0 && (
+      {evalRows.length > 0 && (
         <Box flexDirection="column" paddingLeft={2} marginTop={1}>
-          {task.evaluations.map((e, i) => (
+          {evalElided > 0 && <Text dimColor>{`… ${String(evalElided)} earlier evaluations`}</Text>}
+          {evalRows.map((e, i) => (
             <EvaluationLine key={`${task.id}-eval-${String(i)}`} evaluation={e} />
           ))}
         </Box>
@@ -360,6 +372,8 @@ export const TasksPanel = ({
   nameById,
   maxSignalsPerTask = 8,
   maxOrphanSignals = 6,
+  maxSubStepsPerTask = 12,
+  maxEvaluationsPerTask = 6,
 }: TasksPanelProps): React.JSX.Element => {
   if (bucketed.tasks.length === 0 && bucketed.orphanSignals.length === 0) {
     return (
@@ -375,7 +389,15 @@ export const TasksPanel = ({
       {bucketed.tasks.map((task) => {
         const display = nameById?.get(task.id) ?? `${task.id.slice(0, 8)}…`;
         return (
-          <TaskBlock key={task.id} task={task} running={running} display={display} maxSignals={maxSignalsPerTask} />
+          <TaskBlock
+            key={task.id}
+            task={task}
+            running={running}
+            display={display}
+            maxSignals={maxSignalsPerTask}
+            maxSubSteps={maxSubStepsPerTask}
+            maxEvaluations={maxEvaluationsPerTask}
+          />
         );
       })}
     </Box>

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -41,7 +41,6 @@ import type { AppEvent } from '@src/business/observability/events.ts';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
-import { useSpinnerFrame, spinnerGlyph } from '@src/application/ui/tui/runtime/use-spinner-frame.ts';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
 
 interface ExecuteProps extends Readonly<Record<string, unknown>> {
@@ -95,7 +94,6 @@ export const ExecuteView = (): React.JSX.Element => {
     filter: (e): e is AppEvent => 'chainId' in e && (e as { chainId: string }).chainId === sessionId,
     limit: 2000,
   });
-  const frame = useSpinnerFrame(session?.descriptor.status === 'running');
   const term = useTerminalSize();
 
   const isRunning = session?.descriptor.status === 'running';
@@ -222,7 +220,7 @@ export const ExecuteView = (): React.JSX.Element => {
           )}
           {isRunning && (
             <Box marginLeft={2}>
-              <Text color={inkColors.info}>{spinnerGlyph(frame)} live</Text>
+              <Spinner active={isRunning} color={inkColors.info} label="live" />
             </Box>
           )}
         </Box>

--- a/tests/integration/application/ui/tui/components/tasks-panel-budget.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-budget.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Render-budget fence for TasksPanel. Catches the OOM class — "some descendant component
+ * renders an unbounded child array driven by the 90 ms spinner heartbeat" — without naming
+ * the offending array. If a future author deletes the `.slice()` from any nested list
+ * (sub-steps, evaluations, signals, orphan signals), the worst-case fixture explodes past the
+ * line / character ceilings and the test fails loudly with "frame too large".
+ *
+ * The fixture is intentionally adversarial:
+ *   20 tasks × 500 sub-steps × 30 evaluations × 200 signals + 100 orphan signals.
+ *
+ * Without the existing per-task caps the rendered frame would be on the order of tens of
+ * thousands of lines and millions of characters; with the caps it stays well under both
+ * ceilings (current caps yield ~520 lines for this shape).
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
+import type {
+  BucketedExecution,
+  TaskBucket,
+  TaskSubStep,
+} from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import type { ChangeSignal, EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+const ts = (n: number): IsoTimestamp => new Date(Date.UTC(2026, 0, 1, 0, 0, 0, n)).toISOString() as IsoTimestamp;
+
+const subStep = (i: number): TaskSubStep => ({
+  leafName: `leaf-${String(i).padStart(4, '0')}`,
+  status: 'completed',
+  durationMs: 1,
+});
+
+const evaluation = (i: number): EvaluationSignal => ({
+  type: 'evaluation',
+  status: 'passed',
+  dimensions: [],
+  overallScore: 5,
+  timestamp: ts(i),
+});
+
+const changeSignal = (taskIdx: number, sigIdx: number): ChangeSignal => ({
+  type: 'change',
+  text: `task-${String(taskIdx)} change ${String(sigIdx)}`,
+  timestamp: ts(sigIdx),
+});
+
+const buildWorstCaseFixture = (): BucketedExecution => {
+  const tasks: TaskBucket[] = Array.from({ length: 20 }, (_outerUnused, taskIdx) => ({
+    id: `01933fbb-0000-7000-8000-${String(taskIdx).padStart(12, '0')}`,
+    status: 'running',
+    subSteps: Array.from({ length: 500 }, (_subUnused, i) => subStep(i)),
+    evaluations: Array.from({ length: 30 }, (_evalUnused, i) => evaluation(i)),
+    signals: Array.from({ length: 200 }, (_sigUnused, i) => changeSignal(taskIdx, i)),
+    genEvalRound: 0,
+  }));
+  const orphanSignals: HarnessSignal[] = Array.from({ length: 100 }, (_orphanUnused, i) => changeSignal(-1, i));
+  return { tasks, orphanSignals };
+};
+
+describe('TasksPanel render budget', () => {
+  it('keeps the worst-case frame under hard line / character ceilings', () => {
+    const bucketed = buildWorstCaseFixture();
+    const r = render(<TasksPanel bucketed={bucketed} running={true} />);
+    const frame = r.lastFrame() ?? '';
+
+    // Line ceiling — current per-task caps (12 sub-steps + 6 evaluations + 8 signals + chrome)
+    // yield roughly 25 lines × 20 tasks + legend / orphans ≈ 520 lines. 800 leaves margin
+    // without being toothless; if any descendant list silently uncaps, this trips first.
+    const lineCount = frame.split('\n').length;
+    expect(lineCount).toBeLessThanOrEqual(800);
+
+    // Character ceiling — bounds the worst-case Ink reconciliation cost. Calibrated by
+    // measuring the actual fixture (~37k chars in practice) and rounding generously up.
+    expect(frame.length).toBeLessThanOrEqual(80_000);
+
+    // Truncation must actually happen — the elision row proves the descendant `.slice()`
+    // calls fired. Without this assertion a regression that produced a tiny frame for some
+    // unrelated reason (e.g. broken rendering) would silently pass the ceilings.
+    expect(frame).toContain('… 488 earlier sub-steps');
+
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/components/tasks-panel.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * TasksPanel render caps — regression for the OOM mode where long gen-eval loops appended
+ * hundreds of sub-steps and dozens of evaluations per task. Without per-list slicing every
+ * spinner heartbeat re-reconciled an unbounded child array; V8 walked off the heap after ~1h.
+ *
+ * These tests pin the caps + the elision row wording so a future "just render everything"
+ * regression fails loudly.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
+import type { BucketedExecution, TaskSubStep } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import type { EvaluationSignal } from '@src/domain/signal.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+const ts = (n: number): IsoTimestamp => new Date(Date.UTC(2026, 0, 1, 0, 0, n)).toISOString() as IsoTimestamp;
+
+const subStep = (i: number): TaskSubStep => ({
+  leafName: `leaf-${String(i).padStart(3, '0')}`,
+  status: 'completed',
+  durationMs: 1,
+});
+
+const evaluation = (i: number): EvaluationSignal => ({
+  type: 'evaluation',
+  status: 'passed',
+  dimensions: [],
+  overallScore: 5,
+  timestamp: ts(i),
+});
+
+describe('TasksPanel render caps', () => {
+  it('renders only the last maxSubStepsPerTask sub-steps with an elision row above', () => {
+    const subSteps: TaskSubStep[] = Array.from({ length: 200 }, (_, i) => subStep(i));
+    const bucketed: BucketedExecution = {
+      tasks: [
+        {
+          id: 'task-1',
+          status: 'running',
+          subSteps,
+          evaluations: [],
+          signals: [],
+          genEvalRound: 0,
+        },
+      ],
+      orphanSignals: [],
+    };
+
+    const r = render(<TasksPanel bucketed={bucketed} running={true} />);
+    const frame = r.lastFrame() ?? '';
+
+    // Default cap is 12 → 200 - 12 = 188 elided.
+    expect(frame).toContain('… 188 earlier sub-steps');
+
+    // The last 12 leaf names (188..199) are rendered.
+    for (let i = 188; i < 200; i++) {
+      expect(frame).toContain(`leaf-${String(i).padStart(3, '0')}`);
+    }
+    // Anything older than the cap must NOT appear (spot-check a few).
+    expect(frame).not.toContain('leaf-187');
+    expect(frame).not.toContain('leaf-000');
+
+    r.unmount();
+  });
+
+  it('renders only the last maxEvaluationsPerTask evaluations with an elision row above', () => {
+    const evaluations: EvaluationSignal[] = Array.from({ length: 50 }, (_, i) => evaluation(i));
+    const bucketed: BucketedExecution = {
+      tasks: [
+        {
+          id: 'task-1',
+          status: 'running',
+          subSteps: [],
+          evaluations,
+          signals: [],
+          genEvalRound: 0,
+        },
+      ],
+      orphanSignals: [],
+    };
+
+    const r = render(<TasksPanel bucketed={bucketed} running={true} />);
+    const frame = r.lastFrame() ?? '';
+
+    // Default cap is 6 → 50 - 6 = 44 elided.
+    expect(frame).toContain('… 44 earlier evaluations');
+
+    // Each rendered evaluation shows its score as "<score>/5.0" — exactly 6 should appear.
+    // ("passed" alone occurs in the SignalLegend's "task self-check passed" copy too.)
+    const evalScoreCount = frame.split('5.0/5.0').length - 1;
+    expect(evalScoreCount).toBe(6);
+
+    r.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix:** Cap rendered `subSteps` (12) and `evaluations` (6) tails per task in `TasksPanel`; drop a dead `spinner` prop on `SubStepLine` that defeated React prop-equality every 90 ms.
- **Prevention:** Move the 90 ms spinner state into the leaf `<Spinner />` component so its re-renders no longer propagate through `ExecuteView` / `TaskBlock` / `StepTrace` subtrees.
- **Regression net:** Add a render-budget test that asserts `<TasksPanel>` produces a bounded frame under worst-case input (20 tasks × 500 subSteps × 30 evaluations × 200 signals).
- **Doc rule:** Codify "slice before `.map`, spinner state stays in the leaf" in `CLAUDE.md` and `DESIGN-SYSTEM.md` § 7.5.

## Why

After ~1h of an Implement run the harness OOMed at the 4 GB heap limit with `Ineffective mark-compacts near heap limit`. The V8 stack pointed at Ink's reconciler inside `Environment::CheckImmediate` (`ArrayMap` → `SetConstructor` → `SetPrototypeAdd`) — the signature of an unbounded children array iterated with `.map()` under a 90 ms re-render driver.

Same class as commit `0b6eece4` (which capped `StepTrace`). The new render surface — `TasksPanel`'s per-task `subSteps` / `evaluations` blocks — shipped without a consumer-side slice. A long Implement run with rate-limit retries can accumulate hundreds of substeps per task, and the spinner pulse propagated re-renders into the whole tree.

## What's in this PR

1. `tasks-panel.tsx` — `.slice(-N)` + elision row for subSteps and evaluations; drop dead `spinner` prop.
2. `spinner.tsx` — extended leaf with `active` / `color` / `dim` props; takes over the 90 ms timer from its parents.
3. `step-trace.tsx`, `tasks-panel.tsx` (TaskBlock), `execute-view.tsx` — migrate from `useSpinnerFrame` + `spinnerGlyph` to `<Spinner />` at the leaves.
4. `tests/.../tasks-panel.test.tsx` — assert the elision row and that only the tail renders.
5. `tests/.../tasks-panel-budget.test.tsx` — render-budget regression: line-count and frame-length ceilings catch any future unbounded list render.
6. `CLAUDE.md`, `.claude/docs/DESIGN-SYSTEM.md` — short structural rules.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 201 files / 1392 tests pass
- [ ] Manual: run a long Implement sprint and watch RSS plateau instead of climb

## Out of scope

- `multi-select-prompt.tsx` options-list windowing (low risk; user-initiated, currently small option sets).
- `file-log-sink.ts` in-memory queue cap (bounded in practice by Node's event-loop serialization).

These were flagged during the second-pass audit but don't warrant inclusion in this PR.