### PR TITLE
feat(observability): heap watchdog + memory-pressure TUI banner

### DIFF
--- a/src/application/ui/tui/App.tsx
+++ b/src/application/ui/tui/App.tsx
@@ -31,6 +31,7 @@ import { renderView } from '@src/application/ui/tui/views/view-registry.tsx';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
+import { MemoryPressureBanner } from '@src/application/ui/tui/components/memory-pressure-banner.tsx';
 
 export interface AppProps {
   readonly deps: AppDeps;
@@ -116,6 +117,7 @@ const Layout = ({ children }: { readonly children: React.ReactNode }): React.JSX
   // prompt-host → footer, with header / prompt / footer pinned via `flexShrink={0}`.
   return (
     <Box flexDirection="column" height={rows}>
+      <MemoryPressureBanner />
       {children}
     </Box>
   );

--- a/src/application/ui/tui/components/memory-pressure-banner.tsx
+++ b/src/application/ui/tui/components/memory-pressure-banner.tsx
@@ -1,0 +1,51 @@
+/**
+ * MemoryPressureBanner — process-wide heap-pressure indicator. Subscribes to the EventBus's
+ * `'memory-pressure'` events (emitted by the heap watchdog on every band transition) and
+ * surfaces a single-line strip above the routed view so the operator gets a 30-second warning
+ * before V8 SIGKILLs the harness.
+ *
+ * Renders nothing while the heap is healthy. On `'warning'` shows a warning-tone strip;
+ * on `'critical'` shows an error-tone strip and notes that in-memory buffers were auto-cleared
+ * (the watchdog's `onCritical` hatch is what does the clearing — this component only reflects
+ * the state). On `'recovered'` we collapse back to nothing so the chrome stays calm once the
+ * heap drains.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import type { MemoryPressureEvent } from '@src/business/observability/events.ts';
+
+const formatMb = (bytes: number): string => `${(bytes / 1_048_576).toFixed(0)} MB`;
+const formatPercent = (ratio: number): string => `${Math.round(ratio * 100)}%`;
+
+export const MemoryPressureBanner = (): React.JSX.Element | null => {
+  const deps = useDeps();
+  const [latest, setLatest] = useState<MemoryPressureEvent | undefined>(undefined);
+
+  useEffect(() => {
+    const unsub = deps.eventBus.subscribe((event) => {
+      if (event.type === 'memory-pressure') setLatest(event);
+    });
+    return unsub;
+  }, [deps.eventBus]);
+
+  if (latest === undefined || latest.severity === 'recovered') return null;
+
+  const tone = latest.severity === 'critical' ? inkColors.error : inkColors.warning;
+  const headline =
+    latest.severity === 'critical'
+      ? `memory critical — ${formatPercent(latest.ratio)} of heap; auto-cleared in-memory buffers`
+      : `memory pressure — ${formatPercent(latest.ratio)} of heap used; consider aborting and restarting`;
+  const detail = `(${formatMb(latest.heapUsed)} / ${formatMb(latest.heapLimit)})`;
+
+  return (
+    <Box paddingX={spacing.indent} flexDirection="row">
+      <Text bold color={tone}>
+        {glyphs.warningGlyph} {headline}
+      </Text>
+      <Text dimColor> {detail}</Text>
+    </Box>
+  );
+};

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -30,6 +30,7 @@ import { App } from '@src/application/ui/tui/App.tsx';
 import { resolveInitialState } from '@src/application/ui/tui/launch-routing.ts';
 import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
 import { createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
+import { startHeapWatchdog } from '@src/integration/observability/heap-watchdog.ts';
 
 interface Bootstrapped {
   readonly app: Parameters<typeof App>[0];
@@ -79,6 +80,17 @@ const bootstrap = async (): Promise<Bootstrapped> => {
     if (event.type === 'log' && passesLogLevel(event.level, logLevelGate.get())) logBus.emit(event);
   });
 
+  // Heap watchdog gives the operator a 30-second warning before V8 SIGKILLs the harness on a
+  // long-running session. On 'critical' it dumps the TUI's in-memory buffers (which retain the
+  // bulk of process memory after the per-list render caps) so the GC has something to free.
+  const heapWatchdog = startHeapWatchdog({
+    eventBus: deps.eventBus,
+    onCritical: () => {
+      harnessBus.clear();
+      logBus.clear();
+    },
+  });
+
   const sessions = createSessionManager();
   const queue = createPromptQueue();
 
@@ -125,6 +137,7 @@ const bootstrap = async (): Promise<Bootstrapped> => {
     drain: (): void => {
       queue.drain(new Error('TUI shutting down'));
       unsubLogForward();
+      heapWatchdog.stop();
     },
   };
 };

--- a/src/business/observability/events.ts
+++ b/src/business/observability/events.ts
@@ -97,6 +97,26 @@ export interface LogEvent {
   readonly at: IsoTimestamp;
 }
 
+/**
+ * Process-wide heap-pressure signal. Emitted by the heap watchdog on every
+ * threshold TRANSITION (not on every poll) so subscribers can render a banner
+ * that mirrors the current band without de-duping a stream of identical samples.
+ *
+ * `'recovered'` is fired once when the ratio drops back below the warning band,
+ * giving the banner an explicit clear signal.
+ */
+export interface MemoryPressureEvent {
+  readonly type: 'memory-pressure';
+  readonly severity: 'warning' | 'critical' | 'recovered';
+  /** heapUsed / heap_size_limit ratio at sample time, 0–1. */
+  readonly ratio: number;
+  /** Bytes used. */
+  readonly heapUsed: number;
+  /** V8's `heap_size_limit`. */
+  readonly heapLimit: number;
+  readonly at: IsoTimestamp;
+}
+
 export type AppEvent =
   | ChainStartedEvent
   | ChainStepStartedEvent
@@ -108,4 +128,5 @@ export type AppEvent =
   | TaskAttemptStartedEvent
   | TaskAttemptEvaluatedEvent
   | FeedbackRoundAppliedEvent
-  | LogEvent;
+  | LogEvent
+  | MemoryPressureEvent;

--- a/src/integration/observability/heap-watchdog.ts
+++ b/src/integration/observability/heap-watchdog.ts
@@ -1,0 +1,130 @@
+import * as v8 from 'node:v8';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { MemoryPressureEvent } from '@src/business/observability/events.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Heap-pressure watchdog. Samples V8's heap statistics on an interval and emits
+ * a {@link MemoryPressureEvent} on every band transition so a TUI banner can
+ * surface impending OOM long before the kernel sends SIGKILL.
+ *
+ * Bands (default thresholds):
+ *   - `ok`        — ratio < 0.80
+ *   - `warning`   — 0.80 ≤ ratio < 0.95 (operator still has time to abort)
+ *   - `critical`  — ratio ≥ 0.95 (kernel SIGKILL is seconds away on a 4 GB heap)
+ *
+ * Events are emitted only on transitions, never on every poll, so subscribers
+ * can treat the latest event as the current band without de-duping. Going down
+ * past the warning floor emits one `'recovered'` event so the banner clears.
+ *
+ * `onCritical` is the operator-side eviction hatch: the TUI uses it to drop
+ * harness/log/chain in-memory buffers, freeing retained memory before the
+ * kernel kills us. Fired exactly once per critical-band entry; re-arms on the
+ * way down. Idempotent — if the user-supplied callback is missing or throws
+ * the watchdog keeps polling.
+ */
+
+export interface HeapReading {
+  readonly heapUsed: number;
+  readonly heapLimit: number;
+}
+
+export interface HeapWatchdogDeps {
+  readonly eventBus: EventBus;
+  readonly clock?: () => IsoTimestamp;
+  /** Polling interval ms. Default 10_000. Floored at 1000ms. */
+  readonly intervalMs?: number;
+  /** Ratio for the 'warning' threshold. Default 0.80. */
+  readonly warningRatio?: number;
+  /** Ratio for the 'critical' threshold. Default 0.95. */
+  readonly criticalRatio?: number;
+  /**
+   * Optional eviction hatch: invoked once when severity transitions to 'critical'.
+   * The TUI launcher passes a callback that clears the harness/log/chainEvents
+   * buffers to free retained memory. Idempotent — the watchdog calls it at most
+   * once per critical-entry (re-arms after going back below critical).
+   */
+  readonly onCritical?: () => void;
+  /** Inject for tests. Real impl uses `v8.getHeapStatistics()`. */
+  readonly readHeap?: () => HeapReading;
+}
+
+export interface HeapWatchdog {
+  /** Stop polling. Idempotent. */
+  stop(): void;
+}
+
+const MIN_INTERVAL_MS = 1000;
+const DEFAULT_INTERVAL_MS = 10_000;
+const DEFAULT_WARNING_RATIO = 0.8;
+const DEFAULT_CRITICAL_RATIO = 0.95;
+
+type Band = 'ok' | 'warning' | 'critical';
+
+const defaultReadHeap = (): HeapReading => {
+  const stats = v8.getHeapStatistics();
+  return { heapUsed: stats.used_heap_size, heapLimit: stats.heap_size_limit };
+};
+
+const classify = (ratio: number, warning: number, critical: number): Band => {
+  if (ratio >= critical) return 'critical';
+  if (ratio >= warning) return 'warning';
+  return 'ok';
+};
+
+export const startHeapWatchdog = (deps: HeapWatchdogDeps): HeapWatchdog => {
+  const intervalMs = Math.max(MIN_INTERVAL_MS, deps.intervalMs ?? DEFAULT_INTERVAL_MS);
+  const warning = deps.warningRatio ?? DEFAULT_WARNING_RATIO;
+  const critical = deps.criticalRatio ?? DEFAULT_CRITICAL_RATIO;
+  const clock = deps.clock ?? IsoTimestamp.now;
+  const readHeap = deps.readHeap ?? defaultReadHeap;
+
+  let stopped = false;
+  let previousBand: Band = 'ok';
+
+  const emit = (severity: MemoryPressureEvent['severity'], reading: HeapReading, ratio: number): void => {
+    deps.eventBus.publish({
+      type: 'memory-pressure',
+      severity,
+      ratio,
+      heapUsed: reading.heapUsed,
+      heapLimit: reading.heapLimit,
+      at: clock(),
+    });
+  };
+
+  const sample = (): void => {
+    if (stopped) return;
+    const reading = readHeap();
+    const ratio = reading.heapLimit > 0 ? reading.heapUsed / reading.heapLimit : 0;
+    const band = classify(ratio, warning, critical);
+    if (band === previousBand) return;
+
+    if (band === 'warning') emit('warning', reading, ratio);
+    else if (band === 'critical') {
+      emit('critical', reading, ratio);
+      try {
+        deps.onCritical?.();
+      } catch (err) {
+        console.warn('[heap-watchdog] onCritical threw:', err);
+      }
+    } else {
+      // band === 'ok' — came down from warning or critical.
+      emit('recovered', reading, ratio);
+    }
+    previousBand = band;
+  };
+
+  const handle = setInterval(sample, intervalMs);
+  // Don't keep the event loop alive just for memory polling — if every other
+  // handle is gone the process should exit cleanly.
+  handle.unref?.();
+
+  return {
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(handle);
+    },
+  };
+};

--- a/tests/unit/integration/observability/heap-watchdog.test.ts
+++ b/tests/unit/integration/observability/heap-watchdog.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemoryPressureEvent } from '@src/business/observability/events.ts';
+import { startHeapWatchdog, type HeapReading } from '@src/integration/observability/heap-watchdog.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { isoTimestamp } from '@tests/fixtures/domain.ts';
+
+const HEAP_LIMIT = 4_000_000_000; // 4 GB
+const NOW = isoTimestamp('2026-05-20T10:00:00.000Z');
+
+const readingForRatio = (ratio: number): HeapReading => ({
+  heapUsed: Math.round(HEAP_LIMIT * ratio),
+  heapLimit: HEAP_LIMIT,
+});
+
+/**
+ * Test harness: build a watchdog with an injected ratio queue. Each call to
+ * advanceOnce() steps fake timers by intervalMs so setInterval fires exactly once.
+ */
+const createHarness = (opts: { readonly onCritical?: () => void } = {}) => {
+  const ratios: number[] = [];
+  const bus = createInMemoryEventBus();
+  const events: MemoryPressureEvent[] = [];
+  bus.subscribe((event) => {
+    if (event.type === 'memory-pressure') events.push(event);
+  });
+
+  const readHeap = (): HeapReading => {
+    const next = ratios.shift();
+    if (next === undefined) throw new Error('test: no more ratios queued');
+    return readingForRatio(next);
+  };
+
+  const watchdog = startHeapWatchdog({
+    eventBus: bus,
+    clock: () => NOW,
+    intervalMs: 1000,
+    warningRatio: 0.8,
+    criticalRatio: 0.95,
+    readHeap,
+    ...(opts.onCritical !== undefined ? { onCritical: opts.onCritical } : {}),
+  });
+
+  return {
+    watchdog,
+    events,
+    queueRatios: (...rs: number[]): void => {
+      ratios.push(...rs);
+    },
+    advanceOnce: (): void => {
+      vi.advanceTimersByTime(1000);
+    },
+  };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('startHeapWatchdog', () => {
+  it('emits no event while the ratio stays below the warning threshold', () => {
+    const h = createHarness();
+    h.queueRatios(0.1, 0.5, 0.79);
+    h.advanceOnce();
+    h.advanceOnce();
+    h.advanceOnce();
+
+    expect(h.events).toEqual([]);
+    h.watchdog.stop();
+  });
+
+  it("emits exactly one 'warning' event on first crossing of the warning ratio", () => {
+    const h = createHarness();
+    h.queueRatios(0.5, 0.85, 0.86, 0.9);
+    h.advanceOnce(); // 0.5 → ok, no event
+    h.advanceOnce(); // 0.85 → warning, event
+    h.advanceOnce(); // 0.86 → still warning, no event
+    h.advanceOnce(); // 0.9 → still warning, no event
+
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0]?.severity).toBe('warning');
+    expect(h.events[0]?.ratio).toBeCloseTo(0.85, 5);
+    h.watchdog.stop();
+  });
+
+  it("emits exactly one 'critical' event on first crossing of the critical ratio", () => {
+    const h = createHarness();
+    h.queueRatios(0.5, 0.96, 0.97);
+    h.advanceOnce(); // 0.5 → ok
+    h.advanceOnce(); // 0.96 → critical, event (skipping warning band)
+    h.advanceOnce(); // 0.97 → still critical, no event
+
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0]?.severity).toBe('critical');
+    h.watchdog.stop();
+  });
+
+  it('fires onCritical exactly once when severity enters critical', () => {
+    const onCritical = vi.fn();
+    const h = createHarness({ onCritical });
+    h.queueRatios(0.5, 0.85, 0.96, 0.97, 0.98);
+    h.advanceOnce(); // ok
+    h.advanceOnce(); // warning
+    h.advanceOnce(); // critical → fires onCritical
+    h.advanceOnce(); // critical (no transition)
+    h.advanceOnce(); // critical (no transition)
+
+    expect(onCritical).toHaveBeenCalledTimes(1);
+    h.watchdog.stop();
+  });
+
+  it("emits one 'recovered' event when the ratio drops back below the warning floor", () => {
+    const h = createHarness();
+    h.queueRatios(0.5, 0.85, 0.5, 0.4);
+    h.advanceOnce(); // ok
+    h.advanceOnce(); // warning
+    h.advanceOnce(); // recovered
+    h.advanceOnce(); // ok, no event
+
+    expect(h.events.map((e) => e.severity)).toEqual(['warning', 'recovered']);
+    h.watchdog.stop();
+  });
+
+  it('re-arms across ok → warning → critical → warning → critical (no duplicate band events)', () => {
+    const onCritical = vi.fn();
+    const h = createHarness({ onCritical });
+    h.queueRatios(0.5, 0.85, 0.96, 0.85, 0.96);
+    h.advanceOnce(); // ok
+    h.advanceOnce(); // warning
+    h.advanceOnce(); // critical (onCritical 1)
+    h.advanceOnce(); // warning (transition down)
+    h.advanceOnce(); // critical (onCritical 2)
+
+    expect(h.events.map((e) => e.severity)).toEqual(['warning', 'critical', 'warning', 'critical']);
+    expect(onCritical).toHaveBeenCalledTimes(2);
+    h.watchdog.stop();
+  });
+
+  it('stop() halts further sampling and emissions', () => {
+    const h = createHarness();
+    h.queueRatios(0.5, 0.85);
+    h.advanceOnce(); // ok
+    h.watchdog.stop();
+    h.queueRatios(0.96, 0.97); // would-be critical, but watchdog is stopped
+    h.advanceOnce();
+    h.advanceOnce();
+
+    expect(h.events).toEqual([]);
+  });
+
+  it('stop() is idempotent', () => {
+    const h = createHarness();
+    h.queueRatios(0.5);
+    h.advanceOnce();
+    h.watchdog.stop();
+    expect(() => h.watchdog.stop()).not.toThrow();
+  });
+
+  it('floors the polling interval at 1000ms even when a shorter interval is requested', () => {
+    const bus = createInMemoryEventBus();
+    const events: MemoryPressureEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.type === 'memory-pressure') events.push(event);
+    });
+    const ratios = [0.5, 0.85];
+    const watchdog = startHeapWatchdog({
+      eventBus: bus,
+      clock: () => NOW,
+      intervalMs: 1, // requested 1ms — floor should bump this to 1000
+      warningRatio: 0.8,
+      criticalRatio: 0.95,
+      readHeap: () => readingForRatio(ratios.shift() ?? 0),
+    });
+
+    vi.advanceTimersByTime(999);
+    expect(events).toEqual([]); // not yet fired
+
+    vi.advanceTimersByTime(1); // now at 1000ms — first tick
+    vi.advanceTimersByTime(1000); // second tick → warning
+    expect(events.map((e) => e.severity)).toEqual(['warning']);
+    watchdog.stop();
+  });
+
+  it('populates heapUsed, heapLimit, and at on each emitted event', () => {
+    const h = createHarness();
+    h.queueRatios(0.5, 0.85);
+    h.advanceOnce();
+    h.advanceOnce();
+
+    expect(h.events[0]).toMatchObject({
+      type: 'memory-pressure',
+      severity: 'warning',
+      heapUsed: Math.round(HEAP_LIMIT * 0.85),
+      heapLimit: HEAP_LIMIT,
+      at: NOW,
+    });
+    h.watchdog.stop();
+  });
+
+  it('swallows a throwing onCritical and continues polling', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onCritical = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const h = createHarness({ onCritical });
+    h.queueRatios(0.5, 0.96, 0.5);
+    h.advanceOnce(); // ok
+    h.advanceOnce(); // critical → onCritical throws but watchdog continues
+    h.advanceOnce(); // recovered
+
+    expect(h.events.map((e) => e.severity)).toEqual(['critical', 'recovered']);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    h.watchdog.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Generic memory-pressure watchdog that surfaces heap pressure in the TUI before a SIGKILL. Gives the operator a 30-second heads-up instead of a crash without warning.

- **Watchdog** (`src/integration/observability/heap-watchdog.ts`) polls `v8.getHeapStatistics()` every 10 s (configurable, floored at 1000 ms). Emits one `MemoryPressureEvent` per *transition* between `ok` (< 80%) / `warning` (≥ 80%) / `critical` (≥ 95%) bands — no per-poll spam.
- **Eviction hatch:** on entering the critical band, an `onCritical` callback fires exactly once to clear the harness + log bus buffers in `launch.ts`. Re-arms when the ratio drops back below critical.
- **Banner** (`src/application/ui/tui/components/memory-pressure-banner.tsx`) subscribes to the event bus, renders nothing on `'recovered'`, warning-tone strip in the warning band, error-tone strip when critical. Mounted above the routed view in `App.tsx`.
- **AppEvent variant** `MemoryPressureEvent` added to `business/observability/events.ts` — carries severity, ratio, heapUsed, heapLimit, and ISO timestamp.
- **Lifecycle:** started from `launch.ts` after `wire()`; `.stop()` called from the existing `drain()` alongside `unsubLogForward()`. The setInterval handle is `.unref()`-ed so heap polling can't keep the event loop alive on its own.

## Why

PR #122 closes the actual OOM root cause in `TasksPanel`. This PR is the *next layer of defense*: a generic watchdog that catches any future regression by surfacing pressure before it crashes. Same approach as the existing rate-limit / idle-stdout watchdogs — a process-level safety net independent of the specific code path that allocated memory.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 202 files / 1403 tests pass
- [x] Watchdog unit tests cover: no-emit below warning, exactly-one-emit per band entry, `onCritical` fires once per critical entry and re-arms, `'recovered'` emits once on drop-below-warning, `stop()` halts and is idempotent, interval floor, throwing `onCritical` doesn't stall the watchdog
- [ ] Manual: drive a long run and confirm the banner appears at 80% / 95% thresholds

## Out of scope

- Trace ring buffer shrink (`MAX_TRACE_ENTRIES`)
- `file-log-sink` queue cap
- `--max-old-space-size` bump in the bin
- Session-manager auto-eviction policy

These are separate items from the durability shortlist; bundle later when convenient.

## Stack

Built on top of `main`. Independent of PR #122 — merge order doesn't matter (no overlapping files).