### PR TITLE
ci: bump GitHub Actions to Node 24-capable majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: pnpm
@@ -104,7 +104,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ steps.version.outputs.version }}
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout`, `actions/setup-node`, and `pnpm/action-setup` from v4 to v6 across `ci.yml` and `release.yml`
- Bumps `softprops/action-gh-release` from v2 to v3 in `release.yml`
- Drops reliance on the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` shim — the new majors ship Node 24-capable runtimes natively

Closes #118

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] Release workflow remains valid (verified at next tag push)