### PR TITLE
feat(cli): add `runs list` and `runs prune` for forensic artifacts

### DIFF
--- a/src/application/ui/cli/cli.ts
+++ b/src/application/ui/cli/cli.ts
@@ -10,6 +10,7 @@ import { registerProjectCommand } from '@src/application/ui/cli/commands/project
 import { registerSprintCommand } from '@src/application/ui/cli/commands/sprint.ts';
 import { registerTicketCommand } from '@src/application/ui/cli/commands/ticket.ts';
 import { registerTaskCommand } from '@src/application/ui/cli/commands/task.ts';
+import { registerRunsCommand } from '@src/application/ui/cli/commands/runs.ts';
 import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
 
 /**
@@ -42,6 +43,7 @@ export const runCli = async (argv: readonly string[]): Promise<void> => {
   registerSprintCommand(program);
   registerTicketCommand(program);
   registerTaskCommand(program);
+  registerRunsCommand(program);
 
   await program.parseAsync([...argv]);
 };

--- a/src/application/ui/cli/commands/runs.ts
+++ b/src/application/ui/cli/commands/runs.ts
@@ -50,7 +50,7 @@ export const registerRunsCommand = (program: Command): void => {
     .command('prune')
     .description('delete per-run forensic artifacts (filters required unless invoked interactively)')
     .option('--older-than <duration>', 'delete runs older than this (h / d / w suffix, e.g. 7d)')
-    .option('--keep-last <n>', 'retain the N most-recent runs per flow', parseKeepLastOption)
+    .option('--keep-last <n>', 'retain the N most-recent runs per flow')
     .option('-f, --flow <name>', 'restrict pruning to a single flow')
     .option('--dry-run', 'list candidates without deleting (wins over --yes)')
     .option('-y, --yes', 'skip the interactive y/N confirmation')
@@ -122,7 +122,6 @@ const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
 
   let keepLast: number | undefined;
   if (opts.keepLast !== undefined) {
-    // Commander has already run parseKeepLastOption — opts.keepLast is the validated string form.
     const parsed = Number(opts.keepLast);
     if (!Number.isInteger(parsed) || parsed < 0) {
       process.stderr.write(`error: --keep-last must be a non-negative integer\n`);
@@ -162,33 +161,7 @@ const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
     return;
   }
 
-  // Per-flow candidate selection. When both criteria are set, a dir qualifies only when it is
-  // older than the duration AND not among the N most-recent for its flow. When only one is set,
-  // only that criterion gates the dir. Non-conforming dir names (no embedded timestamp) cannot
-  // satisfy `--older-than`; they're warned about and skipped from the age branch but still
-  // considered for `--keep-last` ordering (they sort to the tail in groupByFlow).
-  const candidates: RunEntry[] = [];
-  const unknownStampWarnings: string[] = [];
-  const nowMs = Date.now();
-  for (const [, runsForFlow] of grouped) {
-    const keep = new Set<string>();
-    if (keepLast !== undefined) {
-      for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
-    }
-    for (const run of runsForFlow) {
-      let ageQualifies = true;
-      if (olderThanMs !== undefined) {
-        if (run.timestamp === null) {
-          unknownStampWarnings.push(run.path);
-          ageQualifies = false;
-        } else {
-          ageQualifies = nowMs - run.timestamp.getTime() >= olderThanMs;
-        }
-      }
-      const keepQualifies = keepLast === undefined ? true : !keep.has(run.path);
-      if (ageQualifies && keepQualifies) candidates.push(run);
-    }
-  }
+  const { candidates, unknownStampWarnings } = selectCandidates(grouped, { olderThanMs, keepLast });
 
   for (const warning of unknownStampWarnings) {
     process.stdout.write(`warning: skipping run with non-conforming dir name (no timestamp): ${warning}\n`);
@@ -294,22 +267,10 @@ const runInteractivePrune = async (): Promise<void> => {
     }
 
     const scoped = flowFilter !== undefined ? listed.value.filter((r) => r.flow === flowFilter) : listed.value;
-    const candidates: RunEntry[] = [];
     const grouped = groupByFlow(scoped);
-    const nowMs = Date.now();
-    for (const [, runsForFlow] of grouped) {
-      const keep = new Set<string>();
-      if (keepLast !== undefined) {
-        for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
-      }
-      for (const run of runsForFlow) {
-        if (olderThanMs !== undefined) {
-          if (run.timestamp === null) continue;
-          if (nowMs - run.timestamp.getTime() >= olderThanMs) candidates.push(run);
-        } else if (keepLast !== undefined && !keep.has(run.path)) {
-          candidates.push(run);
-        }
-      }
+    const { candidates, unknownStampWarnings } = selectCandidates(grouped, { olderThanMs, keepLast });
+    for (const warning of unknownStampWarnings) {
+      process.stdout.write(`warning: skipping run with non-conforming dir name (no timestamp): ${warning}\n`);
     }
     if (candidates.length === 0) {
       process.stdout.write('nothing to prune\n');
@@ -323,11 +284,49 @@ const runInteractivePrune = async (): Promise<void> => {
       process.stdout.write('aborted\n');
       return;
     }
-    rl.close();
     await performPrune(candidates);
   } finally {
     rl.close();
   }
+};
+
+/**
+ * Per-flow candidate selection. When both criteria are set, a dir qualifies only when it is
+ * older than the duration AND not among the N most-recent for its flow. When only one is set,
+ * only that criterion gates the dir. Non-conforming dir names (no embedded timestamp) cannot
+ * satisfy `--older-than`; they're surfaced via `unknownStampWarnings` so the caller can warn
+ * once, and skipped from the age branch but still considered for `--keep-last` ordering
+ * (they sort to the tail in groupByFlow).
+ */
+const selectCandidates = (
+  grouped: ReadonlyMap<string, readonly RunEntry[]>,
+  filters: { readonly olderThanMs: number | undefined; readonly keepLast: number | undefined }
+): { readonly candidates: readonly RunEntry[]; readonly unknownStampWarnings: readonly string[] } => {
+  const { olderThanMs, keepLast } = filters;
+  const candidates: RunEntry[] = [];
+  const unknownStampWarnings: string[] = [];
+  const nowMs = Date.now();
+  for (const [, runsForFlow] of grouped) {
+    let keep: Set<string> | undefined;
+    if (keepLast !== undefined) {
+      keep = new Set<string>();
+      for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
+    }
+    for (const run of runsForFlow) {
+      let ageQualifies = true;
+      if (olderThanMs !== undefined) {
+        if (run.timestamp === null) {
+          unknownStampWarnings.push(run.path);
+          ageQualifies = false;
+        } else {
+          ageQualifies = nowMs - run.timestamp.getTime() >= olderThanMs;
+        }
+      }
+      const keepQualifies = keep === undefined ? true : !keep.has(run.path);
+      if (ageQualifies && keepQualifies) candidates.push(run);
+    }
+  }
+  return { candidates, unknownStampWarnings };
 };
 
 const printCandidateSummary = (candidates: readonly RunEntry[]): void => {
@@ -372,13 +371,6 @@ const performPrune = async (candidates: readonly RunEntry[]): Promise<void> => {
     );
     process.exit(1);
   }
-};
-
-const parseKeepLastOption = (raw: string): string => {
-  // Commander invokes this when the operator passes --keep-last. We defer hard validation to the
-  // action handler so the error message is consistent with the duration-parser branch and we can
-  // emit a single error line ahead of any filesystem work.
-  return raw;
 };
 
 const question = (rl: ReturnType<typeof createInterface>, prompt: string): Promise<string> =>

--- a/src/application/ui/cli/commands/runs.ts
+++ b/src/application/ui/cli/commands/runs.ts
@@ -1,0 +1,402 @@
+import { promises as fs } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { Command } from 'commander';
+import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import {
+  formatBytes,
+  formatRelativeAge,
+  groupByFlow,
+  listRuns,
+  parseDuration,
+  type RunEntry,
+} from '@src/integration/ai/runs/_engine/run-enumeration.ts';
+
+interface ListOpts {
+  readonly flow?: string;
+}
+
+interface PruneOpts {
+  readonly olderThan?: string;
+  readonly keepLast?: string;
+  readonly flow?: string;
+  readonly dryRun?: boolean;
+  readonly yes?: boolean;
+}
+
+/**
+ * Register the `runs` command group — inspection + tidy-up for per-run forensic artifacts
+ * under `<dataRoot>/runs/<flow>/<run-id>/`.
+ *
+ *   ralphctl runs list   [--flow <name>]
+ *   ralphctl runs prune  [--older-than <dur>] [--keep-last <n>] [--flow <name>]
+ *                        [--dry-run] [--yes|-y]
+ *
+ * Lifecycle of the runs tree is user-managed (`rm -rf` at will, no auto-GC). This surface
+ * gives operators a safer alternative to `rm -rf` — with filters, a confirm prompt, dry-run,
+ * and per-failure tolerance so a single permission-denied entry doesn't strand the rest.
+ */
+export const registerRunsCommand = (program: Command): void => {
+  const runs = program.command('runs').description('inspect and prune per-run forensic artifacts');
+
+  runs
+    .command('list')
+    .description('list per-run forensic artifacts grouped by flow')
+    .option('-f, --flow <name>', 'restrict the listing to a single flow')
+    .action(async (opts: ListOpts) => {
+      await runListCommand(opts);
+    });
+
+  runs
+    .command('prune')
+    .description('delete per-run forensic artifacts (filters required unless invoked interactively)')
+    .option('--older-than <duration>', 'delete runs older than this (h / d / w suffix, e.g. 7d)')
+    .option('--keep-last <n>', 'retain the N most-recent runs per flow', parseKeepLastOption)
+    .option('-f, --flow <name>', 'restrict pruning to a single flow')
+    .option('--dry-run', 'list candidates without deleting (wins over --yes)')
+    .option('-y, --yes', 'skip the interactive y/N confirmation')
+    .action(async (opts: PruneOpts) => {
+      await runPruneCommand(opts);
+    });
+};
+
+const runListCommand = async (opts: ListOpts): Promise<void> => {
+  const { storage } = await bootstrapCli();
+  const result = await listRuns(storage.runsRoot);
+  if (!result.ok) {
+    process.stderr.write(`error: ${result.error.message}\n`);
+    process.exit(1);
+    return;
+  }
+  const entries = opts.flow !== undefined ? result.value.filter((r) => r.flow === opts.flow) : result.value;
+  if (entries.length === 0) {
+    if (opts.flow !== undefined) {
+      process.stdout.write(`no runs for flow '${opts.flow}' under ${String(storage.runsRoot)}\n`);
+    } else {
+      process.stdout.write(`no runs yet under ${String(storage.runsRoot)}\n`);
+    }
+    return;
+  }
+  const groups = groupByFlow(entries);
+  const now = new Date();
+  let grandTotalBytes = 0;
+  let grandTotalRuns = 0;
+  for (const [flow, runs] of groups) {
+    const flowBytes = runs.reduce((acc, r) => acc + r.sizeBytes, 0);
+    grandTotalBytes += flowBytes;
+    grandTotalRuns += runs.length;
+    process.stdout.write(
+      `${flow}  (${String(runs.length)} run${runs.length === 1 ? '' : 's'}, ${formatBytes(flowBytes)})\n`
+    );
+    for (const run of runs) {
+      process.stdout.write(`  ${run.runId}  ${formatRelativeAge(run.timestamp, now)}  ${formatBytes(run.sizeBytes)}\n`);
+    }
+  }
+  process.stdout.write(
+    `total: ${String(grandTotalRuns)} run${grandTotalRuns === 1 ? '' : 's'}, ${formatBytes(grandTotalBytes)}\n`
+  );
+};
+
+const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
+  // No-args interactive path: every flag is unset → run the interactive picker (only on a TTY).
+  const noFlags =
+    opts.olderThan === undefined &&
+    opts.keepLast === undefined &&
+    opts.flow === undefined &&
+    opts.dryRun !== true &&
+    opts.yes !== true;
+  if (noFlags) {
+    await runInteractivePrune();
+    return;
+  }
+
+  let olderThanMs: number | undefined;
+  if (opts.olderThan !== undefined) {
+    const parsed = parseDuration(opts.olderThan);
+    if (!parsed.ok) {
+      process.stderr.write(`error: ${parsed.error.message}\n`);
+      process.exit(1);
+      return;
+    }
+    olderThanMs = parsed.value;
+  }
+
+  let keepLast: number | undefined;
+  if (opts.keepLast !== undefined) {
+    // Commander has already run parseKeepLastOption — opts.keepLast is the validated string form.
+    const parsed = Number(opts.keepLast);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      process.stderr.write(`error: --keep-last must be a non-negative integer\n`);
+      process.exit(1);
+      return;
+    }
+    keepLast = parsed;
+  }
+
+  const { storage } = await bootstrapCli();
+  const result = await listRuns(storage.runsRoot);
+  if (!result.ok) {
+    process.stderr.write(`error: ${result.error.message}\n`);
+    process.exit(1);
+    return;
+  }
+
+  const allEntries = result.value;
+
+  if (opts.flow !== undefined) {
+    const flowExists = allEntries.some((r) => r.flow === opts.flow);
+    if (!flowExists) {
+      process.stderr.write(`error: no such flow '${opts.flow}' under ${String(storage.runsRoot)}\n`);
+      process.exit(1);
+      return;
+    }
+  }
+
+  const scoped = opts.flow !== undefined ? allEntries.filter((r) => r.flow === opts.flow) : allEntries;
+  const grouped = groupByFlow(scoped);
+
+  if (olderThanMs === undefined && keepLast === undefined) {
+    process.stderr.write(
+      'error: --older-than or --keep-last is required (or invoke `ralphctl runs prune` with no flags for the interactive picker)\n'
+    );
+    process.exit(1);
+    return;
+  }
+
+  // Per-flow candidate selection. When both criteria are set, a dir qualifies only when it is
+  // older than the duration AND not among the N most-recent for its flow. When only one is set,
+  // only that criterion gates the dir. Non-conforming dir names (no embedded timestamp) cannot
+  // satisfy `--older-than`; they're warned about and skipped from the age branch but still
+  // considered for `--keep-last` ordering (they sort to the tail in groupByFlow).
+  const candidates: RunEntry[] = [];
+  const unknownStampWarnings: string[] = [];
+  const nowMs = Date.now();
+  for (const [, runsForFlow] of grouped) {
+    const keep = new Set<string>();
+    if (keepLast !== undefined) {
+      for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
+    }
+    for (const run of runsForFlow) {
+      let ageQualifies = true;
+      if (olderThanMs !== undefined) {
+        if (run.timestamp === null) {
+          unknownStampWarnings.push(run.path);
+          ageQualifies = false;
+        } else {
+          ageQualifies = nowMs - run.timestamp.getTime() >= olderThanMs;
+        }
+      }
+      const keepQualifies = keepLast === undefined ? true : !keep.has(run.path);
+      if (ageQualifies && keepQualifies) candidates.push(run);
+    }
+  }
+
+  for (const warning of unknownStampWarnings) {
+    process.stdout.write(`warning: skipping run with non-conforming dir name (no timestamp): ${warning}\n`);
+  }
+
+  if (candidates.length === 0) {
+    process.stdout.write('nothing to prune\n');
+    return;
+  }
+
+  printCandidateSummary(candidates);
+
+  if (opts.dryRun === true) {
+    return;
+  }
+
+  if (opts.yes !== true) {
+    if (process.stdin.isTTY !== true) {
+      process.stderr.write(
+        'error: refusing to delete without confirmation on a non-TTY stdin — re-run with --yes to bypass, or --dry-run to list candidates only\n'
+      );
+      process.exit(1);
+      return;
+    }
+    const confirmed = await confirmYesNo(
+      `delete ${String(candidates.length)} run${candidates.length === 1 ? '' : 's'}? [y/N] `
+    );
+    if (!confirmed) {
+      process.stdout.write('aborted\n');
+      return;
+    }
+  }
+
+  await performPrune(candidates);
+};
+
+const runInteractivePrune = async (): Promise<void> => {
+  if (process.stdin.isTTY !== true) {
+    process.stderr.write(
+      'error: interactive prune requires a TTY — supply --older-than or --keep-last (plus --yes / --dry-run) on non-interactive stdin\n'
+    );
+    process.exit(1);
+    return;
+  }
+  const { storage } = await bootstrapCli();
+  const listed = await listRuns(storage.runsRoot);
+  if (!listed.ok) {
+    process.stderr.write(`error: ${listed.error.message}\n`);
+    process.exit(1);
+    return;
+  }
+  if (listed.value.length === 0) {
+    process.stdout.write(`no runs to prune under ${String(storage.runsRoot)}\n`);
+    return;
+  }
+  const groups = groupByFlow(listed.value);
+  const flows = Array.from(groups.keys());
+  process.stdout.write('current runs:\n');
+  for (const [flow, runs] of groups) {
+    const flowBytes = runs.reduce((acc, r) => acc + r.sizeBytes, 0);
+    process.stdout.write(
+      `  ${flow}  (${String(runs.length)} run${runs.length === 1 ? '' : 's'}, ${formatBytes(flowBytes)})\n`
+    );
+  }
+  process.stdout.write('\n');
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const criterion = (await question(rl, 'prune by [1] age threshold or [2] keep-last N? ')).trim();
+    let olderThanMs: number | undefined;
+    let keepLast: number | undefined;
+    if (criterion === '1') {
+      const duration = (await question(rl, 'duration (e.g. 7d, 24h, 2w): ')).trim();
+      const parsed = parseDuration(duration);
+      if (!parsed.ok) {
+        process.stderr.write(`error: ${parsed.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      olderThanMs = parsed.value;
+    } else if (criterion === '2') {
+      const n = (await question(rl, 'keep last N runs per flow: ')).trim();
+      const parsed = Number(n);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        process.stderr.write('error: keep-last must be a non-negative integer\n');
+        process.exit(1);
+        return;
+      }
+      keepLast = parsed;
+    } else {
+      process.stderr.write(`error: unrecognised choice '${criterion}' — expected 1 or 2\n`);
+      process.exit(1);
+      return;
+    }
+    const flowAnswer = (
+      await question(rl, `restrict to a flow? [enter for all, or one of: ${flows.join(', ')}] `)
+    ).trim();
+    const flowFilter = flowAnswer.length === 0 ? undefined : flowAnswer;
+    if (flowFilter !== undefined && !flows.includes(flowFilter)) {
+      process.stderr.write(`error: no such flow '${flowFilter}'\n`);
+      process.exit(1);
+      return;
+    }
+
+    const scoped = flowFilter !== undefined ? listed.value.filter((r) => r.flow === flowFilter) : listed.value;
+    const candidates: RunEntry[] = [];
+    const grouped = groupByFlow(scoped);
+    const nowMs = Date.now();
+    for (const [, runsForFlow] of grouped) {
+      const keep = new Set<string>();
+      if (keepLast !== undefined) {
+        for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
+      }
+      for (const run of runsForFlow) {
+        if (olderThanMs !== undefined) {
+          if (run.timestamp === null) continue;
+          if (nowMs - run.timestamp.getTime() >= olderThanMs) candidates.push(run);
+        } else if (keepLast !== undefined && !keep.has(run.path)) {
+          candidates.push(run);
+        }
+      }
+    }
+    if (candidates.length === 0) {
+      process.stdout.write('nothing to prune\n');
+      return;
+    }
+    printCandidateSummary(candidates);
+    const ok = (
+      await question(rl, `delete ${String(candidates.length)} run${candidates.length === 1 ? '' : 's'}? [y/N] `)
+    ).trim();
+    if (!isYes(ok)) {
+      process.stdout.write('aborted\n');
+      return;
+    }
+    rl.close();
+    await performPrune(candidates);
+  } finally {
+    rl.close();
+  }
+};
+
+const printCandidateSummary = (candidates: readonly RunEntry[]): void => {
+  const grouped = groupByFlow(candidates);
+  process.stdout.write('candidates:\n');
+  let totalBytes = 0;
+  for (const [flow, runs] of grouped) {
+    const flowBytes = runs.reduce((acc, r) => acc + r.sizeBytes, 0);
+    totalBytes += flowBytes;
+    process.stdout.write(
+      `  ${flow}: ${String(runs.length)} run${runs.length === 1 ? '' : 's'}, ${formatBytes(flowBytes)}\n`
+    );
+  }
+  process.stdout.write(
+    `  total: ${String(candidates.length)} run${candidates.length === 1 ? '' : 's'}, ${formatBytes(totalBytes)}\n`
+  );
+};
+
+const performPrune = async (candidates: readonly RunEntry[]): Promise<void> => {
+  const failures: Array<{ readonly path: string; readonly reason: string }> = [];
+  let freedBytes = 0;
+  let freedCount = 0;
+  for (const candidate of candidates) {
+    try {
+      await fs.rm(String(candidate.path), { recursive: true, force: false });
+      freedBytes += candidate.sizeBytes;
+      freedCount += 1;
+    } catch (cause) {
+      const reason = cause instanceof Error ? cause.message : String(cause);
+      failures.push({ path: String(candidate.path), reason });
+    }
+  }
+  process.stdout.write(
+    `pruned ${String(freedCount)} run${freedCount === 1 ? '' : 's'}, freed ${formatBytes(freedBytes)}\n`
+  );
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      process.stderr.write(`  failed: ${failure.path} — ${failure.reason}\n`);
+    }
+    process.stderr.write(
+      `error: ${String(failures.length)} run${failures.length === 1 ? '' : 's'} could not be deleted\n`
+    );
+    process.exit(1);
+  }
+};
+
+const parseKeepLastOption = (raw: string): string => {
+  // Commander invokes this when the operator passes --keep-last. We defer hard validation to the
+  // action handler so the error message is consistent with the duration-parser branch and we can
+  // emit a single error line ahead of any filesystem work.
+  return raw;
+};
+
+const question = (rl: ReturnType<typeof createInterface>, prompt: string): Promise<string> =>
+  new Promise((resolve) => {
+    rl.question(prompt, (answer) => resolve(answer));
+  });
+
+const confirmYesNo = async (prompt: string): Promise<boolean> => {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await question(rl, prompt);
+    return isYes(answer.trim());
+  } finally {
+    rl.close();
+  }
+};
+
+const isYes = (answer: string): boolean => {
+  const lower = answer.toLowerCase();
+  return lower === 'y' || lower === 'yes';
+};

--- a/src/integration/ai/runs/_engine/run-enumeration.ts
+++ b/src/integration/ai/runs/_engine/run-enumeration.ts
@@ -1,0 +1,265 @@
+import { promises as fs, type Dirent } from 'node:fs';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+
+/**
+ * Enumeration + parsing helpers for per-run forensic artifact directories under
+ * `<dataRoot>/runs/<flow>/<run-id>/`. Used by the `ralphctl runs list` / `ralphctl runs prune`
+ * CLI surface to inspect and tidy what the one-shot AI flows (detect-scripts / detect-skills /
+ * readiness) leave on disk.
+ *
+ * All filesystem helpers swallow `ENOENT` on the supplied `runsRoot` and return `[]` so a
+ * fresh install where the directory doesn't exist yet looks identical to an empty one — the
+ * CLI prints an empty-state message in both cases. Parse helpers return `Result<…>` so
+ * downstream callers can render a single clear error line and exit non-zero without scanning
+ * the filesystem.
+ */
+
+export interface RunEntry {
+  /** Subdirectory immediately under `runsRoot` — e.g. `detect-scripts`, `readiness`. */
+  readonly flow: string;
+  /** Directory name under `runsRoot/<flow>/` — the value produced by `buildRunDirName`. */
+  readonly runId: string;
+  /** Parsed `Date` from the embedded ISO stamp, or `null` when the dir name is non-conforming. */
+  readonly timestamp: Date | null;
+  /** Total bytes under the run dir (file sizes summed; directory inodes ignored). */
+  readonly sizeBytes: number;
+  /** Absolute path to the run dir itself, suitable for downstream rm. */
+  readonly path: AbsolutePath;
+}
+
+/**
+ * Convert a `buildRunDirName` output back to a `Date`. The dir-name convention is
+ * `YYYY-MM-DDTHH-MM-SS-mmmZ-<6-char-suffix>` (colons + dot replaced with `-`). We rebuild
+ * the canonical ISO shape and `new Date(...)` it. Returns `null` (not an error) for names
+ * that don't match the pattern — those are valid manual additions an operator may have made,
+ * and the caller surfaces them as a warning rather than failing the scan.
+ */
+export const parseRunTimestamp = (runDirName: string): Date | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z-/.exec(runDirName);
+  if (match === null) return null;
+  const [, yyyy, mm, dd, hh, mi, ss, ms] = match;
+  const iso = `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}.${ms}Z`;
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * Parse a duration like `7d`, `24h`, `2w`. Suffixes are deliberately restricted to `h` / `d` /
+ * `w` — minute granularity isn't useful when forensic dirs live for hours-to-weeks, and `m`
+ * being ambiguous (minutes vs months) is a common foot-gun. The function returns a
+ * `ValidationError` for negative, zero, NaN, unsupported suffix, or unparsable input so the
+ * CLI can print a single clear error line before any filesystem access.
+ */
+export const parseDuration = (input: string): Result<number, ValidationError> => {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return Result.error(
+      new ValidationError({
+        field: 'duration',
+        value: input,
+        message: 'duration must not be empty',
+        hint: 'use a value like 24h, 7d, or 2w',
+      })
+    );
+  }
+  const match = /^(-?\d+(?:\.\d+)?)([a-zA-Z]+)$/.exec(trimmed);
+  if (match === null) {
+    return Result.error(
+      new ValidationError({
+        field: 'duration',
+        value: input,
+        message: `unparsable duration: ${input}`,
+        hint: 'use a value like 24h, 7d, or 2w',
+      })
+    );
+  }
+  const [, numStr, suffix] = match;
+  const num = Number(numStr);
+  if (!Number.isFinite(num) || num <= 0) {
+    return Result.error(
+      new ValidationError({
+        field: 'duration',
+        value: input,
+        message: `duration must be a positive number: ${input}`,
+        hint: 'use a value like 24h, 7d, or 2w',
+      })
+    );
+  }
+  let unitMs: number;
+  switch (suffix) {
+    case 'h':
+      unitMs = 60 * 60 * 1000;
+      break;
+    case 'd':
+      unitMs = 24 * 60 * 60 * 1000;
+      break;
+    case 'w':
+      unitMs = 7 * 24 * 60 * 60 * 1000;
+      break;
+    default:
+      return Result.error(
+        new ValidationError({
+          field: 'duration',
+          value: input,
+          message: `unsupported duration suffix '${suffix}'`,
+          hint: 'supported suffixes are h (hours), d (days), w (weeks)',
+        })
+      );
+  }
+  return Result.ok(num * unitMs);
+};
+
+/** Format a byte count using binary units. Used in list rows and prune summaries. */
+export const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const formatted = value >= 100 ? value.toFixed(0) : value >= 10 ? value.toFixed(1) : value.toFixed(2);
+  return `${formatted} ${units[unitIndex]}`;
+};
+
+/**
+ * Format an age relative to now in coarse buckets — seconds / minutes / hours / days / weeks.
+ * `now` is injectable so tests get deterministic output.
+ */
+export const formatRelativeAge = (timestamp: Date | null, now: Date = new Date()): string => {
+  if (timestamp === null) return 'unknown age';
+  const deltaMs = now.getTime() - timestamp.getTime();
+  if (deltaMs < 0) return 'in the future';
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w ago`;
+};
+
+/**
+ * Enumerate every run dir under `runsRoot`. Returns one `RunEntry` per `<runsRoot>/<flow>/<run-id>/`
+ * directory. ENOENT on `runsRoot` returns `[]`. Per-flow / per-run ENOENT (race with a concurrent
+ * delete) is also tolerated — the affected entry is skipped. Other I/O errors propagate as
+ * `Result.error`.
+ *
+ * Symbolic links are not followed: directory entries are filtered by `Dirent.isDirectory()` only,
+ * and size accumulation uses `lstat`. Together this confines the scan to `runsRoot`.
+ */
+export const listRuns = async (runsRoot: AbsolutePath): Promise<Result<readonly RunEntry[], ValidationError>> => {
+  const root = String(runsRoot);
+  let flowDirs: Dirent[];
+  try {
+    flowDirs = await fs.readdir(root, { withFileTypes: true });
+  } catch (cause) {
+    if (isErrnoException(cause) && cause.code === 'ENOENT') return Result.ok([]);
+    return Result.error(
+      new ValidationError({
+        field: 'runs-root',
+        value: root,
+        message: `unable to read runs root: ${isErrnoException(cause) ? (cause.code ?? 'unknown') : 'unknown'}`,
+      })
+    );
+  }
+
+  const entries: RunEntry[] = [];
+  for (const flowDir of flowDirs) {
+    if (!flowDir.isDirectory()) continue;
+    const flowPath = join(root, flowDir.name);
+    let runDirs: Dirent[];
+    try {
+      runDirs = await fs.readdir(flowPath, { withFileTypes: true });
+    } catch (cause) {
+      if (isErrnoException(cause) && cause.code === 'ENOENT') continue;
+      return Result.error(
+        new ValidationError({
+          field: 'runs-root',
+          value: flowPath,
+          message: `unable to read flow dir: ${isErrnoException(cause) ? (cause.code ?? 'unknown') : 'unknown'}`,
+        })
+      );
+    }
+    for (const runDir of runDirs) {
+      if (!runDir.isDirectory()) continue;
+      const runPath = join(flowPath, runDir.name);
+      const parsedPath = AbsolutePath.parse(runPath);
+      if (!parsedPath.ok) continue;
+      const sizeBytes = await computeDirSize(runPath);
+      entries.push({
+        flow: flowDir.name,
+        runId: runDir.name,
+        timestamp: parseRunTimestamp(runDir.name),
+        sizeBytes,
+        path: parsedPath.value,
+      });
+    }
+  }
+  return Result.ok(entries);
+};
+
+/**
+ * Group entries by flow and sort within each group newest-first (parsed timestamp; entries
+ * with `timestamp === null` sort last and keep stable lexicographic order between themselves
+ * so an operator's `ls` output and the CLI agree).
+ */
+export const groupByFlow = (entries: readonly RunEntry[]): Map<string, readonly RunEntry[]> => {
+  const groups = new Map<string, RunEntry[]>();
+  for (const entry of entries) {
+    const bucket = groups.get(entry.flow);
+    if (bucket === undefined) groups.set(entry.flow, [entry]);
+    else bucket.push(entry);
+  }
+  for (const [flow, bucket] of groups) {
+    bucket.sort(compareNewestFirst);
+    groups.set(flow, bucket);
+  }
+  return new Map(Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b)));
+};
+
+/**
+ * Sum file sizes recursively under `dir`. Symlinks are not followed (we use `lstat`); per-entry
+ * errors are swallowed and treated as zero so an unreadable file doesn't break the whole scan.
+ */
+const computeDirSize = async (dir: string): Promise<number> => {
+  let total = 0;
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += await computeDirSize(entryPath);
+      continue;
+    }
+    try {
+      const stat = await fs.lstat(entryPath);
+      if (stat.isFile()) total += stat.size;
+    } catch {
+      // best-effort; missing file in the middle of a scan is fine
+    }
+  }
+  return total;
+};
+
+const compareNewestFirst = (a: RunEntry, b: RunEntry): number => {
+  if (a.timestamp === null && b.timestamp === null) return a.runId.localeCompare(b.runId);
+  if (a.timestamp === null) return 1;
+  if (b.timestamp === null) return -1;
+  return b.timestamp.getTime() - a.timestamp.getTime();
+};
+
+const isErrnoException = (cause: unknown): cause is NodeJS.ErrnoException =>
+  typeof cause === 'object' && cause !== null && 'code' in cause;

--- a/tests/e2e/cli/runs.test.ts
+++ b/tests/e2e/cli/runs.test.ts
@@ -1,0 +1,157 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createCliHome, runCliCaptured, type CliHome } from '@tests/e2e/cli/_harness.ts';
+
+describe('ralphctl runs', () => {
+  let cli: CliHome;
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+  });
+
+  afterEach(async () => cli.cleanup());
+
+  /**
+   * Build a run dir under `<runsRoot>/<flow>/<runId>/` and seed it with a `prompt.md`. `ageMs`
+   * controls the embedded ISO stamp so test cases can deterministically vet `--older-than`
+   * windows; `bodyBytes` controls the byte total `formatBytes` reports.
+   */
+  const seedRun = async (flow: string, ageMs: number, bodyBytes = 100): Promise<string> => {
+    const ts = new Date(Date.now() - ageMs);
+    const suffix = Math.random().toString(36).slice(2, 8).padEnd(6, '0');
+    const runId = `${ts.toISOString().replace(/[:.]/g, '-')}-${suffix}`;
+    const dir = join(String(cli.paths.runsRoot), flow, runId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(join(dir, 'prompt.md'), 'x'.repeat(bodyBytes), 'utf8');
+    return runId;
+  };
+
+  const HOUR = 60 * 60 * 1000;
+
+  describe('list', () => {
+    it('reports the empty state on a fresh install and names the resolved path', async () => {
+      const result = await runCliCaptured(cli, ['runs', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('no runs yet');
+      expect(result.stdout).toContain(String(cli.paths.runsRoot));
+    });
+
+    it('groups populated runs per flow and prints a grand total', async () => {
+      await seedRun('detect-scripts', 1 * HOUR, 100);
+      await seedRun('detect-scripts', 5 * HOUR, 100);
+      await seedRun('readiness', 2 * HOUR, 50);
+
+      const result = await runCliCaptured(cli, ['runs', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('detect-scripts');
+      expect(result.stdout).toContain('readiness');
+      expect(result.stdout).toContain('total:');
+      expect(result.stdout).toContain('3 runs');
+    });
+
+    it('honours --flow by restricting rows and totals to one flow', async () => {
+      await seedRun('detect-scripts', HOUR);
+      await seedRun('readiness', HOUR);
+
+      const result = await runCliCaptured(cli, ['runs', 'list', '--flow', 'readiness']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('readiness');
+      expect(result.stdout).not.toContain('detect-scripts');
+    });
+  });
+
+  describe('prune', () => {
+    it('--dry-run --older-than lists candidates and deletes nothing, exit 0', async () => {
+      const oldRun = await seedRun('detect-scripts', 5 * HOUR);
+      const recent = await seedRun('detect-scripts', 30 * 60 * 1000);
+
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--dry-run', '--older-than', '1h']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('candidates:');
+      expect(result.stdout).toContain('detect-scripts');
+      const oldStillThere = await fs
+        .stat(join(String(cli.paths.runsRoot), 'detect-scripts', oldRun))
+        .then(() => true)
+        .catch(() => false);
+      const recentStillThere = await fs
+        .stat(join(String(cli.paths.runsRoot), 'detect-scripts', recent))
+        .then(() => true)
+        .catch(() => false);
+      expect(oldStillThere).toBe(true);
+      expect(recentStillThere).toBe(true);
+    });
+
+    it('--yes --older-than deletes matching runs and reports freed bytes', async () => {
+      const oldRun = await seedRun('detect-scripts', 5 * HOUR, 200);
+      const recent = await seedRun('detect-scripts', 30 * 60 * 1000, 200);
+
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--yes', '--older-than', '1h']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('pruned');
+      expect(result.stdout).toMatch(/freed \d+/);
+      const oldStillThere = await fs
+        .stat(join(String(cli.paths.runsRoot), 'detect-scripts', oldRun))
+        .then(() => true)
+        .catch(() => false);
+      const recentStillThere = await fs
+        .stat(join(String(cli.paths.runsRoot), 'detect-scripts', recent))
+        .then(() => true)
+        .catch(() => false);
+      expect(oldStillThere).toBe(false);
+      expect(recentStillThere).toBe(true);
+    });
+
+    it('--yes --keep-last 1 retains exactly the newest run per flow', async () => {
+      const oldA = await seedRun('detect-scripts', 5 * HOUR);
+      const midA = await seedRun('detect-scripts', 3 * HOUR);
+      const newA = await seedRun('detect-scripts', HOUR);
+
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--yes', '--keep-last', '1']);
+      expect(result.exitCode).toBe(0);
+      const surviving = await fs.readdir(join(String(cli.paths.runsRoot), 'detect-scripts'));
+      expect(surviving).toEqual([newA]);
+      expect(surviving).not.toContain(oldA);
+      expect(surviving).not.toContain(midA);
+    });
+
+    it('--flow <missing> exits non-zero with a "no such flow" message', async () => {
+      await seedRun('detect-scripts', 5 * HOUR);
+      const result = await runCliCaptured(cli, [
+        'runs',
+        'prune',
+        '--flow',
+        'not-a-real-flow',
+        '--yes',
+        '--older-than',
+        '1h',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("no such flow 'not-a-real-flow'");
+    });
+
+    it('refuses to delete on non-TTY without --yes and prints actionable guidance', async () => {
+      await seedRun('detect-scripts', 5 * HOUR);
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--older-than', '1h']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--yes');
+      expect(result.stderr).toContain('--dry-run');
+      const survivors = await fs.readdir(join(String(cli.paths.runsRoot), 'detect-scripts'));
+      expect(survivors).toHaveLength(1);
+    });
+
+    it('rejects malformed --older-than before scanning the filesystem', async () => {
+      await seedRun('detect-scripts', 5 * HOUR);
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--yes', '--older-than', '5m']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/unsupported duration suffix 'm'/);
+    });
+
+    it('prints "nothing to prune" and exits 0 when the candidate set is empty', async () => {
+      await seedRun('detect-scripts', 30 * 60 * 1000);
+      const result = await runCliCaptured(cli, ['runs', 'prune', '--yes', '--older-than', '1h']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('nothing to prune');
+    });
+  });
+});

--- a/tests/unit/integration/ai/runs/run-enumeration.test.ts
+++ b/tests/unit/integration/ai/runs/run-enumeration.test.ts
@@ -1,0 +1,214 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  formatBytes,
+  formatRelativeAge,
+  groupByFlow,
+  listRuns,
+  parseDuration,
+  parseRunTimestamp,
+  type RunEntry,
+} from '@src/integration/ai/runs/_engine/run-enumeration.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+
+describe('parseDuration', () => {
+  it('accepts hours / days / weeks', () => {
+    const h = parseDuration('24h');
+    const d = parseDuration('7d');
+    const w = parseDuration('2w');
+    expect(h.ok && h.value).toBe(24 * 60 * 60 * 1000);
+    expect(d.ok && d.value).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(w.ok && w.value).toBe(2 * 7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('rejects unsupported suffixes with a clear error message', () => {
+    const minutes = parseDuration('5m');
+    expect(minutes.ok).toBe(false);
+    if (!minutes.ok) expect(minutes.error.message).toContain("unsupported duration suffix 'm'");
+    const years = parseDuration('1y');
+    expect(years.ok).toBe(false);
+    if (!years.ok) expect(years.error.message).toContain("unsupported duration suffix 'y'");
+  });
+
+  it('rejects zero and negative values', () => {
+    const zero = parseDuration('0d');
+    expect(zero.ok).toBe(false);
+    const neg = parseDuration('-3h');
+    expect(neg.ok).toBe(false);
+  });
+
+  it('rejects unparsable input', () => {
+    const garbage = parseDuration('abc');
+    expect(garbage.ok).toBe(false);
+    const empty = parseDuration('');
+    expect(empty.ok).toBe(false);
+    const noSuffix = parseDuration('7');
+    expect(noSuffix.ok).toBe(false);
+  });
+});
+
+describe('parseRunTimestamp', () => {
+  it('returns a Date for a buildRunDirName-style name', () => {
+    const parsed = parseRunTimestamp('2026-05-19T19-56-56-781Z-abc123');
+    expect(parsed).not.toBeNull();
+    expect(parsed?.toISOString()).toBe('2026-05-19T19:56:56.781Z');
+  });
+
+  it('returns null for a non-conforming name', () => {
+    expect(parseRunTimestamp('legacy-folder')).toBeNull();
+    expect(parseRunTimestamp('2026-05-19_run')).toBeNull();
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders sub-KiB values in bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('rolls over to KiB / MiB / GiB', () => {
+    expect(formatBytes(2048)).toMatch(/KiB$/);
+    expect(formatBytes(5 * 1024 * 1024)).toMatch(/MiB$/);
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toMatch(/GiB$/);
+  });
+});
+
+describe('formatRelativeAge', () => {
+  it('describes coarse buckets', () => {
+    const now = new Date('2026-05-19T12:00:00.000Z');
+    expect(formatRelativeAge(new Date('2026-05-19T11:59:30.000Z'), now)).toBe('30s ago');
+    expect(formatRelativeAge(new Date('2026-05-19T11:30:00.000Z'), now)).toBe('30m ago');
+    expect(formatRelativeAge(new Date('2026-05-19T06:00:00.000Z'), now)).toBe('6h ago');
+    expect(formatRelativeAge(new Date('2026-05-15T12:00:00.000Z'), now)).toBe('4d ago');
+    expect(formatRelativeAge(new Date('2026-05-01T12:00:00.000Z'), now)).toBe('2w ago');
+  });
+
+  it('reports unknown age for null timestamps', () => {
+    expect(formatRelativeAge(null)).toBe('unknown age');
+  });
+});
+
+describe('listRuns', () => {
+  let tmp: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    tmp = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await tmp.cleanup();
+  });
+
+  const seed = async (flow: string, runId: string, bodyBytes = 32): Promise<void> => {
+    const runDir = join(String(tmp.root), flow, runId);
+    await fs.mkdir(runDir, { recursive: true });
+    await fs.writeFile(join(runDir, 'prompt.md'), 'x'.repeat(bodyBytes), 'utf8');
+  };
+
+  it('returns [] when the runs root does not exist (ENOENT swallowed)', async () => {
+    const missing = AbsolutePath.parse(join(String(tmp.root), 'no-such-dir'));
+    expect(missing.ok).toBe(true);
+    if (!missing.ok) throw new Error('test setup: bad path');
+    const result = await listRuns(missing.value);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
+  });
+
+  it('enumerates every run dir grouped by flow and accumulates sizes', async () => {
+    await seed('detect-scripts', '2026-05-19T10-00-00-000Z-aaaaaa', 100);
+    await seed('detect-scripts', '2026-05-19T11-00-00-000Z-bbbbbb', 200);
+    await seed('readiness', '2026-05-19T12-00-00-000Z-cccccc', 64);
+
+    const result = await listRuns(tmp.root);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value).toHaveLength(3);
+    const ds = result.value.filter((r) => r.flow === 'detect-scripts');
+    expect(ds).toHaveLength(2);
+    expect(ds.reduce((acc, r) => acc + r.sizeBytes, 0)).toBe(300);
+  });
+});
+
+describe('candidate-set selection (intersect of --older-than and --keep-last, per-flow scoping)', () => {
+  // The CLI builds the candidate set inline; here we mirror that logic against `groupByFlow`
+  // to lock in the contract: when both criteria are set, intersect; when only one, that one
+  // gates; per-flow scoping cuts the entry list before grouping. This is the unit-level
+  // safety net behind the e2e prune cases.
+  const mkRun = (flow: string, isoOffsetMs: number, suffix: string): RunEntry => {
+    const ts = new Date(Date.UTC(2026, 4, 19, 12, 0, 0) - isoOffsetMs);
+    const runId = `${ts.toISOString().replace(/[:.]/g, '-')}-${suffix}`;
+    return {
+      flow,
+      runId,
+      timestamp: ts,
+      sizeBytes: 100,
+      path: `/tmp/${flow}/${runId}` as AbsolutePath,
+    };
+  };
+
+  const candidates = (
+    runs: readonly RunEntry[],
+    nowMs: number,
+    olderThanMs: number | undefined,
+    keepLast: number | undefined
+  ): readonly RunEntry[] => {
+    const grouped = groupByFlow(runs);
+    const out: RunEntry[] = [];
+    for (const [, runsForFlow] of grouped) {
+      const keep = new Set<string>();
+      if (keepLast !== undefined) for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
+      for (const run of runsForFlow) {
+        const ageQualifies =
+          olderThanMs === undefined ? true : run.timestamp !== null && nowMs - run.timestamp.getTime() >= olderThanMs;
+        const keepQualifies = keepLast === undefined ? true : !keep.has(run.path);
+        if (ageQualifies && keepQualifies) out.push(run);
+      }
+    }
+    return out;
+  };
+
+  const nowMs = Date.UTC(2026, 4, 19, 12, 0, 0);
+  const HOUR = 60 * 60 * 1000;
+
+  it('--older-than alone selects every run past the threshold', () => {
+    const [r0, r2h, r5h] = [mkRun('a', 0, '0'), mkRun('a', 2 * HOUR, '2h'), mkRun('a', 5 * HOUR, '5h')] as const;
+    const out = candidates([r0, r2h, r5h], nowMs, 3 * HOUR, undefined);
+    expect(out.map((r) => r.runId)).toEqual([r5h.runId]);
+  });
+
+  it('--keep-last alone retains the N most-recent per flow', () => {
+    const r0 = mkRun('a', 0, '0');
+    const r1h = mkRun('a', HOUR, '1h');
+    const r2h = mkRun('a', 2 * HOUR, '2h');
+    const rB = mkRun('b', HOUR, '1h-b');
+    const out = candidates([r0, r1h, r2h, rB], nowMs, undefined, 1);
+    // Flow a keeps the newest (offset 0); the 1h + 2h candidates remain. Flow b keeps its only run.
+    const ids = out.map((r) => r.runId).sort();
+    expect(ids).toEqual([r1h.runId, r2h.runId].sort());
+  });
+
+  it('intersection: --older-than AND not-in-keep-last', () => {
+    const r0 = mkRun('a', 0, '0');
+    const r2h = mkRun('a', 2 * HOUR, '2h');
+    const r5h = mkRun('a', 5 * HOUR, '5h');
+    // older-than 3h ⇒ only the 5h-old run qualifies; keep-last 2 keeps {0, 2h};
+    // the 5h-old run is not kept, so intersection ⇒ [5h].
+    const out = candidates([r0, r2h, r5h], nowMs, 3 * HOUR, 2);
+    expect(out.map((r) => r.runId)).toEqual([r5h.runId]);
+
+    // older-than 3h ⇒ 5h qualifies; keep-last 1 keeps {0}; intersection ⇒ [5h]. The 2h-old run is
+    // NOT old enough so it stays even though it's outside keep-last.
+    const out2 = candidates([r0, r2h, r5h], nowMs, 3 * HOUR, 1);
+    expect(out2.map((r) => r.runId)).toEqual([r5h.runId]);
+  });
+
+  it('per-flow scoping limits the candidate set to the requested flow', () => {
+    const runs = [mkRun('a', 5 * HOUR, '5h-a'), mkRun('b', 5 * HOUR, '5h-b')];
+    const scoped = runs.filter((r) => r.flow === 'a');
+    const out = candidates(scoped, nowMs, 3 * HOUR, undefined);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.flow).toBe('a');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the `runs` CLI command group for inspecting and tidying per-run forensic artifacts under `<dataRoot>/runs/<flow>/<run-id>/` — the one-shot AI flows (detect-scripts / detect-skills / readiness) leave directories there with no auto-GC, so operators previously had only `rm -rf`.
- `ralphctl runs list [--flow <name>]` groups runs per flow with relative age + byte totals; `ralphctl runs prune` accepts `--older-than <dur>` / `--keep-last <n>` / `--flow <name>` / `--dry-run` / `--yes`, plus a TTY-only interactive picker when invoked with no flags. Both criteria intersect when both are set.
- Shared `selectCandidates(...)` helper is used by the interactive and flag-driven paths so both warn identically on dir names with no embedded timestamp; size scan uses `lstat` (no symlink follow); ENOENT on the runs root or a per-flow dir returns an empty result rather than failing.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test` — all green (1464 tests)
- [x] Unit coverage for `parseDuration`, `parseRunTimestamp`, `formatBytes`, `formatRelativeAge`, `listRuns`, and the candidate-set selection contract — `tests/unit/integration/ai/runs/run-enumeration.test.ts`
- [x] E2E coverage of `runs list` empty state, populated grouping, `--flow` filter; `runs prune` with `--dry-run`, `--yes --older-than`, `--keep-last 1`, missing flow, non-TTY refusal, malformed duration, empty candidate set — `tests/e2e/cli/runs.test.ts`
- [ ] Manual smoke: `pnpm dev runs list` on a seeded `<dataRoot>/runs/` and `pnpm dev runs prune --older-than 1h --dry-run` to eyeball the formatting

Closes #113
Refs #124