### PR TITLE
2026-05-23-01

### DIFF
--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -357,7 +357,7 @@ export const wire = (opts: WireOptions): AppDeps => {
     eventBus,
     logger,
     pullRequestCreator: createPullRequestCreator({ gitRunner: createGitRunner(), spawn }),
-    issueFetcher: createIssueFetcher({ spawn }),
+    issueFetcher: createIssueFetcher({ spawn, logger }),
     issuePusher: createIssuePusher({ spawn }),
     versionChecker: createNpmVersionChecker({
       stateRoot: opts.storage.stateRoot,

--- a/src/application/ui/tui/launch-routing.ts
+++ b/src/application/ui/tui/launch-routing.ts
@@ -5,9 +5,13 @@
  *
  *   - No settings file yet           → welcome flow
  *   - Settings present, no projects  → create-project wizard
- *   - Settings + projects exist      → home, with the persisted last-selection pre-seeded
- *                                       (falls back to the first project). The user can
- *                                       press `P` to open the picker if they want to switch.
+ *   - Settings + projects exist      → home. The persisted last-selection wins if it still
+ *                                       resolves; otherwise the only project (when there's
+ *                                       exactly one) is pre-seeded so single-project users
+ *                                       skip the picker. With multiple projects and no
+ *                                       persisted choice, no selection is seeded — Home
+ *                                       renders the "pick a project to work on" card and
+ *                                       nothing gets written to disk until the user picks.
  *
  * Pulled out so launch.ts stays a thin orchestrator and the routing logic gets a focused
  * unit test instead of a full Ink boot.
@@ -54,8 +58,11 @@ export const resolveInitialState = ({
 }: InitialStateInputs): InitialState => {
   if (!settingsExist) return { initialView: { id: 'welcome' } };
   if (projects.length === 0) return { initialView: { id: 'create-project' } };
-  const preselected =
-    (lastProjectId !== undefined ? projects.find((p) => p.id === lastProjectId) : undefined) ?? projects[0];
+  // Restore the persisted project when it still resolves. Otherwise pre-seed only the
+  // single-project case (no real choice to make). Picking projects[0] arbitrarily would get
+  // persisted on first render and masquerade as a user choice on every subsequent launch.
+  const restored = lastProjectId !== undefined ? projects.find((p) => p.id === lastProjectId) : undefined;
+  const preselected = restored ?? (projects.length === 1 ? projects[0] : undefined);
   if (preselected === undefined) return { initialView: { id: 'home' } };
   // Only thread sprintId through when the pinned project still matches — re-pinning a project
   // elsewhere invalidates the previous sprint pick.

--- a/src/application/ui/tui/runtime/selection-context.tsx
+++ b/src/application/ui/tui/runtime/selection-context.tsx
@@ -110,6 +110,11 @@ export const SelectionProvider = ({
   // Keep the callback in a ref so re-renders don't churn the persistence effect's deps.
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  // Mirror projectId in a ref so `setProject` can decide whether the sprint cursor needs
+  // clearing without taking `projectId` as a dep (which would re-create the setter every render
+  // and force every memoised consumer to re-evaluate).
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
 
   // Persist whenever the canonical selection changes. The initial render also fires this, so
   // closing the picker without changes is a no-op write — fine for our flat-file store.
@@ -123,11 +128,17 @@ export const SelectionProvider = ({
   }, [projectId, projectLabel, sprintId, sprintLabel]);
 
   const setProject = useCallback((id: ProjectId | undefined, label?: string) => {
+    const changed = id !== projectIdRef.current;
     setProjectId(id);
     setProjectLabel(id === undefined ? undefined : label);
-    // Picking a different project clears the sprint cursor — sprint ids are scoped to a project.
-    setSprintId(undefined);
-    setSprintLabel(undefined);
+    // Only clear the sprint cursor when the project actually changes. Re-opening the same
+    // project (e.g. browsing its detail view, which calls setProject on mount) must not drop
+    // a sprint the user picked earlier — they'd lose their place every time they navigated
+    // back through the projects list.
+    if (changed) {
+      setSprintId(undefined);
+      setSprintLabel(undefined);
+    }
   }, []);
 
   const setSprint = useCallback((id: SprintId | undefined, label?: string) => {

--- a/src/domain/entity/ticket.ts
+++ b/src/domain/entity/ticket.ts
@@ -1,5 +1,6 @@
 import { Result } from '@src/domain/result.ts';
 import type { Entity } from '@src/domain/entity/_base/entity.ts';
+import { parseExternalRefFromUrl } from '@src/domain/value/external-ref.ts';
 import type { HttpUrl } from '@src/domain/value/http-url.ts';
 import { TicketId } from '@src/domain/value/id/ticket-id.ts';
 import { parseHttpUrl } from '@src/domain/value/parsers/parse-http-url.ts';
@@ -64,9 +65,11 @@ export const createTicket = (input: TicketCreateInput): Result<PendingTicket, Va
 
   // Trim the external ref at intake so persisted tickets never carry whitespace-only refs;
   // downstream renderers (commit trailer, PR body) treat those as absent anyway, so the
-  // persisted shape should match.
+  // persisted shape should match. When the caller didn't supply one, derive `#NN` from a
+  // recognised issue URL on `link` so commits + PR bodies auto-close the source issue.
   const trimmedRef = input.externalRef?.trim();
-  const externalRef = trimmedRef !== undefined && trimmedRef.length > 0 ? trimmedRef : undefined;
+  const suppliedRef = trimmedRef !== undefined && trimmedRef.length > 0 ? trimmedRef : undefined;
+  const externalRef = suppliedRef ?? (link !== undefined ? parseExternalRefFromUrl(link) : undefined);
 
   return Result.ok({
     id: input.id ?? TicketId.generate(),
@@ -83,6 +86,11 @@ export const createTicket = (input: TicketCreateInput): Result<PendingTicket, Va
  * Set or clear the ticket's `link` field. Used by the refine flow's "create origin" path
  * after the issue is created on the remote tracker — we attach the new URL to the now-approved
  * ticket so subsequent refines / implement runs see it.
+ *
+ * When a new link is set AND the ticket has no `externalRef` yet, derive `#NN` from the URL
+ * so commit trailers + PR bodies auto-close the source issue. An existing externalRef is
+ * preserved verbatim — operators who chose a specific format (`PROJ-7`, `owner/repo#42`) keep
+ * it. Clearing the link (`url === undefined`) never touches externalRef.
  */
 export function setTicketLink(ticket: ApprovedTicket, url: string | undefined): Result<ApprovedTicket, ValidationError>;
 export function setTicketLink(ticket: PendingTicket, url: string | undefined): Result<PendingTicket, ValidationError>;
@@ -94,7 +102,12 @@ export function setTicketLink(ticket: Ticket, url: string | undefined): Result<T
   }
   const parsed = parseHttpUrl('ticket.link', url);
   if (!parsed.ok) return Result.error(parsed.error);
-  return Result.ok({ ...ticket, link: parsed.value });
+  const derivedRef = ticket.externalRef === undefined ? parseExternalRefFromUrl(parsed.value) : undefined;
+  return Result.ok({
+    ...ticket,
+    link: parsed.value,
+    ...(derivedRef !== undefined ? { externalRef: derivedRef } : {}),
+  });
 }
 
 /**

--- a/src/domain/value/external-ref.ts
+++ b/src/domain/value/external-ref.ts
@@ -1,4 +1,54 @@
 /**
+ * Best-effort derivation of an `externalRef` short form (`#<number>`) from a
+ * GitHub or GitLab issue URL. Returns `undefined` for shapes we don't
+ * recognise — including pull-request / merge-request URLs, which are not
+ * issues and shouldn't auto-close anything when referenced in a commit.
+ *
+ * Used by ticket creation paths (interactive add-loop, one-shot CLI add,
+ * refine-create) so a ticket sourced from an issue URL automatically carries
+ * the ref that the commit trailer + PR-body renderers consume — closing
+ * `Ticket.externalRef === undefined` blind spots that left commits without a
+ * `Closes #N` line.
+ *
+ * Format choice: short `#NN` (not `owner/repo#NN`). Same-repo close is the
+ * dominant case for sprint work; users who need cross-repo refs can set
+ * `externalRef` explicitly.
+ *
+ * Examples:
+ *   `https://github.com/foo/bar/issues/42`            → `'#42'`
+ *   `https://gitlab.com/grp/sub/proj/-/issues/7`      → `'#7'`
+ *   `https://github.com/foo/bar/pull/42`              → `undefined`
+ *   `https://example.com/anything`                    → `undefined`
+ */
+export const parseExternalRefFromUrl = (url: string): string | undefined => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return undefined;
+  const segments = parsed.pathname.split('/').filter((s) => s.length > 0);
+
+  // GitHub: /<owner>/<repo>/issues/<number>
+  if (parsed.hostname.includes('github')) {
+    if (segments.length >= 4 && segments[2] === 'issues') {
+      const num = Number(segments[3]);
+      if (Number.isInteger(num) && num > 0) return `#${String(num)}`;
+    }
+    return undefined;
+  }
+
+  // GitLab (incl. self-hosted): /<group...>/<project>/-/issues/<number>
+  const dashIdx = segments.indexOf('-');
+  if (dashIdx >= 2 && segments[dashIdx + 1] === 'issues') {
+    const num = Number(segments[dashIdx + 2]);
+    if (Number.isInteger(num) && num > 0) return `#${String(num)}`;
+  }
+  return undefined;
+};
+
+/**
  * Normalize a list of external tracker references (`Ticket.externalRef` /
  * `Task.externalRefs`): trim each entry, drop empties, dedupe first-seen-wins,
  * preserve input order.

--- a/src/integration/scm/issue-fetcher.ts
+++ b/src/integration/scm/issue-fetcher.ts
@@ -1,5 +1,6 @@
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
 import type { ExternalIssue, ExternalIssueComment, IssueFetcher } from '@src/business/scm/issue-fetcher.ts';
 import { runCli } from '@src/integration/io/run-cli.ts';
 import type { Spawn } from '@src/integration/io/spawn.ts';
@@ -46,6 +47,13 @@ interface GlabIssueResponse {
   readonly description?: string;
   readonly state?: string;
   readonly web_url?: string;
+}
+
+interface GlabNote {
+  readonly body?: string;
+  readonly author?: { readonly username?: string };
+  readonly system?: boolean;
+  readonly created_at?: string;
 }
 
 /**
@@ -196,10 +204,58 @@ const fetchGitHub = async (
   });
 };
 
+/**
+ * Best-effort fetch of issue notes via `glab issue note list`. Never throws —
+ * every failure mode (spawn error, non-zero exit, malformed JSON) collapses to
+ * `{ comments: [], failure: <description> }` so `fetchGitLab` can still return
+ * the issue body and let the caller log a warning.
+ *
+ * System notes (label changes, assignments, …) are filtered out — they are
+ * noise for refinement. Remaining notes are sorted oldest-first by
+ * `created_at` (defensive — `glab` order is not contractually stable) and the
+ * tail is sliced to {@link MAX_COMMENTS} so the GitLab adapter matches the
+ * "last 20" behaviour of {@link fetchGitHub}.
+ */
+const fetchGitLabNotes = async (
+  spawn: Spawn,
+  parsed: ParsedUrl
+): Promise<{ readonly comments: ExternalIssueComment[]; readonly failure?: string }> => {
+  const result = await runCli(
+    spawn,
+    'glab',
+    ['issue', 'note', 'list', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--output', 'json'],
+    { timeoutMs: CLI_TIMEOUT_MS }
+  );
+  if (!result.ok) return { comments: [], failure: result.error.message };
+  if (result.value.exitCode !== 0) {
+    return {
+      comments: [],
+      failure: `glab issue note list exited ${String(result.value.exitCode)}: ${result.value.stderr.trim() || 'unknown error'}`,
+    };
+  }
+  let notes: readonly GlabNote[];
+  try {
+    notes = JSON.parse(result.value.stdout) as readonly GlabNote[];
+  } catch (cause) {
+    return {
+      comments: [],
+      failure: `failed to parse glab issue note list response: ${cause instanceof Error ? cause.message : String(cause)}`,
+    };
+  }
+  const filtered = notes.filter((n) => n.system !== true);
+  const sorted = [...filtered].sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+  const comments = sorted.slice(-MAX_COMMENTS).map<ExternalIssueComment>((n) => ({
+    author: n.author?.username ?? 'unknown',
+    body: n.body ?? '',
+  }));
+  return { comments };
+};
+
 const fetchGitLab = async (
   spawn: Spawn,
   parsed: ParsedUrl,
-  url: string
+  url: string,
+  logger: Logger | undefined
 ): Promise<Result<ExternalIssue | null, StorageError>> => {
   const result = await runCli(
     spawn,
@@ -229,17 +285,22 @@ const fetchGitLab = async (
       })
     );
   }
+  const notes = await fetchGitLabNotes(spawn, parsed);
+  if (notes.failure !== undefined) {
+    logger?.warn(`glab issue note list failed for ${url}: ${notes.failure} — proceeding without comments`);
+  }
   return Result.ok({
     url: parsedJson.web_url ?? url,
     title: parsedJson.title ?? '',
     body: parsedJson.description ?? '',
     state: (parsedJson.state ?? 'open').toLowerCase() === 'closed' ? 'closed' : 'open',
-    comments: [], // glab doesn't include notes in the default --output json
+    comments: notes.comments,
   });
 };
 
 export interface IssueFetcherDeps {
   readonly spawn: Spawn;
+  readonly logger?: Logger;
 }
 
 export const createIssueFetcher =
@@ -248,7 +309,7 @@ export const createIssueFetcher =
     const parsed = parseIssueUrl(url);
     if (parsed === null) return Result.ok(null);
     if (parsed.host === 'github') return fetchGitHub(deps.spawn, parsed, url);
-    return fetchGitLab(deps.spawn, parsed, url);
+    return fetchGitLab(deps.spawn, parsed, url, deps.logger);
   };
 
 // `formatIssueContext` lives in `core/external/issue-fetcher.ts` (pure formatter, layer-neutral).

--- a/tests/integration/scm/issue-fetcher.test.ts
+++ b/tests/integration/scm/issue-fetcher.test.ts
@@ -1,8 +1,26 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { Logger } from '@src/business/observability/logger.ts';
 import { createIssueFetcher, parseGitRemoteUrl, parseIssueUrl } from '@src/integration/scm/issue-fetcher.ts';
 import type { Spawn } from '@src/integration/io/spawn.ts';
+
+const createRecordingLogger = (): {
+  readonly logger: Logger;
+  readonly warns: string[];
+} => {
+  const warns: string[] = [];
+  const logger: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: (message) => {
+      warns.push(message);
+    },
+    error: vi.fn(),
+    named: () => logger,
+  };
+  return { logger, warns };
+};
 
 const scriptedSpawn = (
   responses: ReadonlyArray<{
@@ -182,6 +200,12 @@ describe('createIssueFetcher', () => {
         }),
         exitCode: 0,
       },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: '[]',
+        exitCode: 0,
+      },
     ]);
     const fetcher = createIssueFetcher({ spawn });
     const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
@@ -190,6 +214,207 @@ describe('createIssueFetcher', () => {
     expect(out.value.title).toBe('GLab issue');
     expect(out.value.body).toBe('desc body');
     expect(out.value.state).toBe('closed');
+    expect(out.value.comments).toEqual([]);
+  });
+
+  it('GitLab notes — filters system notes, maps username + body', async () => {
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify({
+          title: 'T',
+          description: 'D',
+          state: 'opened',
+          web_url: 'https://gitlab.com/foo/bar/-/issues/5',
+        }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify([
+          { body: 'first reply', author: { username: 'alice' }, system: false, created_at: '2026-01-01T00:00:00Z' },
+          {
+            body: 'assigned to bob',
+            author: { username: 'gitlab-bot' },
+            system: true,
+            created_at: '2026-01-02T00:00:00Z',
+          },
+          { body: 'second reply', author: { username: 'bob' }, system: false, created_at: '2026-01-03T00:00:00Z' },
+        ]),
+        exitCode: 0,
+      },
+    ]);
+    const fetcher = createIssueFetcher({ spawn });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.comments).toEqual([
+      { author: 'alice', body: 'first reply' },
+      { author: 'bob', body: 'second reply' },
+    ]);
+  });
+
+  it('GitLab notes — all-system fixture yields comments: []', async () => {
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify({ title: 'T', description: 'D', state: 'opened' }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify([
+          { body: 'closed', author: { username: 'bot' }, system: true, created_at: '2026-01-01T00:00:00Z' },
+          { body: 'reopened', author: { username: 'bot' }, system: true, created_at: '2026-01-02T00:00:00Z' },
+        ]),
+        exitCode: 0,
+      },
+    ]);
+    const fetcher = createIssueFetcher({ spawn });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.comments).toEqual([]);
+  });
+
+  it('GitLab notes — caps at last 20 oldest-first, even when input is newest-first', async () => {
+    const total = 25;
+    // Emit newest-first so we exercise the defensive sort.
+    const raw = Array.from({ length: total }, (_, i) => {
+      const idx = total - 1 - i;
+      return {
+        body: `note ${String(idx)}`,
+        author: { username: `u${String(idx)}` },
+        system: false,
+        created_at: `2026-01-${String(idx + 1).padStart(2, '0')}T00:00:00Z`,
+      };
+    });
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify({ title: 'T', description: 'D', state: 'opened' }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify(raw),
+        exitCode: 0,
+      },
+    ]);
+    const fetcher = createIssueFetcher({ spawn });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.comments).toHaveLength(20);
+    // Oldest of the kept window: index 5 (0..4 dropped); newest: index 24.
+    expect(out.value.comments[0]).toEqual({ author: 'u5', body: 'note 5' });
+    expect(out.value.comments[19]).toEqual({ author: 'u24', body: 'note 24' });
+  });
+
+  it('GitLab note-list non-zero exit — issue still returned, comments: [], one warn, no throw', async () => {
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify({
+          title: 'T',
+          description: 'D',
+          state: 'opened',
+          web_url: 'https://gitlab.com/foo/bar/-/issues/5',
+        }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: '',
+        stderr: 'permission denied',
+        exitCode: 1,
+      },
+    ]);
+    const { logger, warns } = createRecordingLogger();
+    const fetcher = createIssueFetcher({ spawn, logger });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.title).toBe('T');
+    expect(out.value.body).toBe('D');
+    expect(out.value.state).toBe('open');
+    expect(out.value.url).toBe('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.value.comments).toEqual([]);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('glab issue note list failed');
+    expect(warns[0]).toContain('permission denied');
+  });
+
+  it('GitLab note-list JSON parse error — issue still returned, comments: [], one warn', async () => {
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: JSON.stringify({
+          title: 'T',
+          description: 'D',
+          state: 'opened',
+          web_url: 'https://gitlab.com/foo/bar/-/issues/5',
+        }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        stdout: 'not json',
+        exitCode: 0,
+      },
+    ]);
+    const { logger, warns } = createRecordingLogger();
+    const fetcher = createIssueFetcher({ spawn, logger });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.title).toBe('T');
+    expect(out.value.body).toBe('D');
+    expect(out.value.comments).toEqual([]);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('failed to parse');
+  });
+
+  it('GitLab note-list spawn error — issue still returned, comments: [], one warn', async () => {
+    let call = 0;
+    const spawn: Spawn = (command, args) => {
+      call += 1;
+      if (call === 1) {
+        // First spawn is `glab issue view` — succeed normally.
+        return makeChild(
+          JSON.stringify({
+            title: 'T',
+            description: 'D',
+            state: 'opened',
+            web_url: 'https://gitlab.com/foo/bar/-/issues/5',
+          }),
+          '',
+          0
+        );
+      }
+      // Second spawn (`glab issue note list ...`) blows up before producing a child.
+      throw new Error(`spawn EACCES ${command} ${args.join(' ')}`);
+    };
+    const { logger, warns } = createRecordingLogger();
+    const fetcher = createIssueFetcher({ spawn, logger });
+    const out = await fetcher('https://gitlab.com/foo/bar/-/issues/5');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.title).toBe('T');
+    expect(out.value.body).toBe('D');
+    expect(out.value.comments).toEqual([]);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('glab issue note list failed');
   });
 
   it('unrecognised host → Result.ok(null) without spawning', async () => {

--- a/tests/unit/application/ui/tui/launch-routing.test.ts
+++ b/tests/unit/application/ui/tui/launch-routing.test.ts
@@ -36,12 +36,15 @@ describe('resolveInitialState', () => {
     });
   });
 
-  it('routes to home with the first project pre-seeded when several exist and nothing was used last', () => {
+  it('routes to home with no selection when several projects exist and nothing was used last', () => {
+    // Picking projects[0] arbitrarily would get persisted on first render and look like a real
+    // user choice on every subsequent launch. Home renders its "pick a project to work on" card
+    // instead; nothing is written until the user picks.
     const a = makeProject({ id: ProjectId.generate(), slug: 'one', displayName: 'One' });
     const b = makeProject({ id: ProjectId.generate(), slug: 'two', displayName: 'Two' });
     const result = resolveInitialState({ settingsExist: true, projects: [a, b] });
     expect(result.initialView).toEqual({ id: 'home' });
-    expect(result.initialSelection).toEqual({ projectId: a.id, projectLabel: 'One' });
+    expect(result.initialSelection).toBeUndefined();
   });
 
   it('honours the persisted last-selection when present', () => {
@@ -56,7 +59,8 @@ describe('resolveInitialState', () => {
     expect(result.initialSelection).toEqual({ projectId: b.id, projectLabel: 'Two' });
   });
 
-  it('falls back to the first project when the persisted last-selection no longer exists', () => {
+  it('falls back to the only project when the persisted last-selection no longer exists', () => {
+    // Single-project case: pre-seeding is unambiguous — there's no choice to make.
     const a = makeProject({ slug: 'one', displayName: 'One' });
     const result = resolveInitialState({
       settingsExist: true,
@@ -65,5 +69,17 @@ describe('resolveInitialState', () => {
       lastProjectId: 'does-not-exist' as unknown as typeof a.id,
     });
     expect(result.initialSelection).toEqual({ projectId: a.id, projectLabel: 'One' });
+  });
+
+  it('drops the selection when the persisted last-selection no longer exists and several projects are present', () => {
+    const a = makeProject({ id: ProjectId.generate(), slug: 'one', displayName: 'One' });
+    const b = makeProject({ id: ProjectId.generate(), slug: 'two', displayName: 'Two' });
+    const result = resolveInitialState({
+      settingsExist: true,
+      projects: [a, b],
+      lastProjectId: 'does-not-exist' as unknown as typeof a.id,
+    });
+    expect(result.initialView).toEqual({ id: 'home' });
+    expect(result.initialSelection).toBeUndefined();
   });
 });

--- a/tests/unit/application/ui/tui/runtime/selection-context.test.tsx
+++ b/tests/unit/application/ui/tui/runtime/selection-context.test.tsx
@@ -63,6 +63,79 @@ const makeTrigger = (
   };
 };
 
+describe('SelectionProvider.setProject', () => {
+  it('keeps the sprint cursor when called with the same project id', async () => {
+    // Regression: project-detail-view calls setProject on mount to stamp the display name.
+    // If the user picked sprint X under project A, then navigates Home → Projects → opens A
+    // to look at it, the sprint pick must survive. Clearing only matters when actually
+    // switching projects (sprint ids are scoped to a project).
+    const seeds: SelectionSeed[] = [];
+    const onChange = vi.fn<(s: SelectionSeed) => void>((s) => {
+      seeds.push(s);
+    });
+    const triggered = { current: false };
+    const Trigger = makeTrigger(
+      triggered,
+      () => {
+        /* baseline captured implicitly via seeds[] */
+      },
+      (api) => api.setProject(PID_A, 'Project A')
+    );
+
+    const r = render(
+      <SelectionProvider
+        seed={{ projectId: PID_A, projectLabel: 'Project A', sprintId: SID_X, sprintLabel: 'Sprint X' }}
+        onChange={onChange}
+      >
+        <Trigger />
+      </SelectionProvider>
+    );
+
+    await new Promise((res) => setTimeout(res, 30));
+
+    // Final persisted state must still carry the sprint.
+    expect(seeds[seeds.length - 1]).toEqual({
+      projectId: PID_A,
+      projectLabel: 'Project A',
+      sprintId: SID_X,
+      sprintLabel: 'Sprint X',
+    });
+    r.unmount();
+  });
+
+  it('clears the sprint cursor when called with a different project id', async () => {
+    const seeds: SelectionSeed[] = [];
+    const onChange = vi.fn<(s: SelectionSeed) => void>((s) => {
+      seeds.push(s);
+    });
+    const triggered = { current: false };
+    const Trigger = makeTrigger(
+      triggered,
+      () => {
+        /* baseline */
+      },
+      (api) => api.setProject(PID_B, 'Project B')
+    );
+
+    const r = render(
+      <SelectionProvider
+        seed={{ projectId: PID_A, projectLabel: 'Project A', sprintId: SID_X, sprintLabel: 'Sprint X' }}
+        onChange={onChange}
+      >
+        <Trigger />
+      </SelectionProvider>
+    );
+
+    await new Promise((res) => setTimeout(res, 30));
+
+    expect(seeds[seeds.length - 1]).toEqual({
+      projectId: PID_B,
+      projectLabel: 'Project B',
+    });
+    r.unmount();
+  });
+});
+
 describe('SelectionProvider.setProjectAndSprint', () => {
   it('fires onChange exactly once for the atomic write and sets both ids in one shot', async () => {
     const onChange = vi.fn<(s: SelectionSeed) => void>();

--- a/tests/unit/business/scm/issue-fetcher.test.ts
+++ b/tests/unit/business/scm/issue-fetcher.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatIssueContext, type ExternalIssue } from '@src/business/scm/issue-fetcher.ts';
+
+describe('formatIssueContext', () => {
+  it('renders GitLab issue comments under the Source Issue Data section', () => {
+    const issue: ExternalIssue = {
+      url: 'https://gitlab.com/foo/bar/-/issues/5',
+      title: 'GLab issue',
+      body: 'desc body',
+      state: 'open',
+      comments: [
+        { author: 'alice', body: 'first reply' },
+        { author: 'bob', body: 'second reply' },
+      ],
+    };
+
+    const out = formatIssueContext(issue);
+
+    expect(out).toContain('## Source Issue Data');
+    expect(out).toContain('**Comments (2):**');
+    expect(out).toContain('**@alice**:');
+    expect(out).toContain('first reply');
+    expect(out).toContain('**@bob**:');
+    expect(out).toContain('second reply');
+  });
+});

--- a/tests/unit/domain/entity/ticket.test.ts
+++ b/tests/unit/domain/entity/ticket.test.ts
@@ -3,6 +3,7 @@ import {
   approveTicketRequirements,
   createTicket,
   setTicketDescription,
+  setTicketLink,
   setTicketRequirements,
   setTicketTitle,
 } from '@src/domain/entity/ticket.ts';
@@ -46,6 +47,65 @@ describe('createTicket', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.value.externalRef).toBeUndefined();
+  });
+
+  it('derives externalRef from a GitHub issue URL when none is supplied', () => {
+    const r = createTicket({ title: 'x', link: 'https://github.com/foo/bar/issues/42' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalRef).toBe('#42');
+  });
+
+  it('derives externalRef from a GitLab issue URL when none is supplied', () => {
+    const r = createTicket({ title: 'x', link: 'https://gitlab.com/grp/sub/proj/-/issues/7' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalRef).toBe('#7');
+  });
+
+  it('keeps an explicitly supplied externalRef over the URL-derived one', () => {
+    const r = createTicket({
+      title: 'x',
+      link: 'https://github.com/foo/bar/issues/42',
+      externalRef: 'PROJ-7',
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalRef).toBe('PROJ-7');
+  });
+
+  it('does not derive externalRef from a non-issue URL (e.g. pull request)', () => {
+    const r = createTicket({ title: 'x', link: 'https://github.com/foo/bar/pull/42' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalRef).toBeUndefined();
+  });
+});
+
+describe('setTicketLink', () => {
+  it('backfills externalRef when attaching a recognised issue URL to a ticket that had none', () => {
+    const r = setTicketLink(makePendingTicket(), 'https://github.com/foo/bar/issues/42');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.link).toBe('https://github.com/foo/bar/issues/42');
+    expect(r.value.externalRef).toBe('#42');
+  });
+
+  it('preserves an existing externalRef when the link changes', () => {
+    const seeded = makePendingTicket({ externalRef: 'PROJ-7' });
+    const r = setTicketLink(seeded, 'https://github.com/foo/bar/issues/99');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalRef).toBe('PROJ-7');
+  });
+
+  it('clearing the link leaves externalRef untouched', () => {
+    const seeded = makePendingTicket({ externalRef: '#42' });
+    const r = setTicketLink(seeded, undefined);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.link).toBeUndefined();
+    expect(r.value.externalRef).toBe('#42');
   });
 });
 

--- a/tests/unit/domain/value/external-ref.test.ts
+++ b/tests/unit/domain/value/external-ref.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeRefs } from '@src/domain/value/external-ref.ts';
+import { normalizeRefs, parseExternalRefFromUrl } from '@src/domain/value/external-ref.ts';
+
+describe('parseExternalRefFromUrl', () => {
+  it('returns #<n> for a GitHub issue URL', () => {
+    expect(parseExternalRefFromUrl('https://github.com/foo/bar/issues/42')).toBe('#42');
+  });
+
+  it('returns #<n> for a GitLab issue URL with a single-segment group', () => {
+    expect(parseExternalRefFromUrl('https://gitlab.com/grp/proj/-/issues/7')).toBe('#7');
+  });
+
+  it('returns #<n> for a GitLab issue URL with a multi-segment group', () => {
+    expect(parseExternalRefFromUrl('https://gitlab.com/grp/sub/proj/-/issues/99')).toBe('#99');
+  });
+
+  it('returns #<n> for a self-hosted GitLab issue URL', () => {
+    expect(parseExternalRefFromUrl('https://gitlab.example.com/team/svc/-/issues/3')).toBe('#3');
+  });
+
+  it('returns undefined for a GitHub pull-request URL', () => {
+    expect(parseExternalRefFromUrl('https://github.com/foo/bar/pull/42')).toBeUndefined();
+  });
+
+  it('returns undefined for a GitLab merge-request URL', () => {
+    expect(parseExternalRefFromUrl('https://gitlab.com/grp/proj/-/merge_requests/3')).toBeUndefined();
+  });
+
+  it('returns undefined for an unrecognised host', () => {
+    expect(parseExternalRefFromUrl('https://example.com/foo/bar/issues/1')).toBeUndefined();
+  });
+
+  it('returns undefined for non-http(s) protocols', () => {
+    expect(parseExternalRefFromUrl('ftp://github.com/foo/bar/issues/1')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed input', () => {
+    expect(parseExternalRefFromUrl('not a url')).toBeUndefined();
+  });
+
+  it('returns undefined when the issue number is missing or zero', () => {
+    expect(parseExternalRefFromUrl('https://github.com/foo/bar/issues/0')).toBeUndefined();
+    expect(parseExternalRefFromUrl('https://github.com/foo/bar/issues/abc')).toBeUndefined();
+    expect(parseExternalRefFromUrl('https://github.com/foo/bar/issues')).toBeUndefined();
+  });
+});
 
 describe('normalizeRefs', () => {
   it('returns an empty array for undefined input', () => {


### PR DESCRIPTION
Sprint `019e5649-c4f0-729e-b5e8-e4b97675c3a9` — three independent fixes.

## Changes

- **feat(scm): fetch GitLab issue notes** — `IssueFetcher` GitLab branch now shells `glab issue note list` (filters system notes, sorts asc, caps at 20). Note-list failures soft-fail with a `logger.warn`. Refine prompt's `## Source Issue Data` now matches GitHub parity.
- **fix(ticket): derive externalRef from issue URL** — new `parseExternalRefFromUrl` (GitHub `/issues/N` + GitLab `/-/issues/N` → `#N`). `createTicket` / `setTicketLink` auto-fill so the implement commit leaf appends `Closes #N` trailers. Explicit refs and clears are preserved verbatim.
- **fix(tui): stop preselecting projects[0] and dropping sprint cursor** — Home no longer pre-seeds a project unless there's exactly one. `setProject(sameId)` preserves the sprint cursor across project-detail mount.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green locally
- [ ] CI green