### PR TITLE
Enhancements: per-spawn session-id file, ticket-suffix commits, sprintDir-local create-pr

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -359,11 +359,11 @@ of the stack — the leaf or use-case wrapping them catches and converts to `Res
 │           │       ├── generator/
 │           │       │   ├── prompt.md           ← rendered generator prompt (written before spawn)
 │           │       │   ├── signals.json
-│           │       │   └── sessionId
+│           │       │   └── session-id.txt
 │           │       └── evaluator/
 │           │           ├── prompt.md           ← rendered evaluator prompt (written before spawn)
 │           │           ├── signals.json
-│           │           └── sessionId
+│           │           └── session-id.txt
 │           └── review/<unit-slug>/        ← apply-feedback sandbox
 └── state/
     └── locks/

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -140,15 +140,15 @@ Status flow: `draft → active → review → done`.
 
 - [ ] **Distinct chain** — `review` flow lives in `application/flows/review/`; not embedded inside `implement`.
 - [ ] **Free-form feedback** — multi-line editor prompt; empty submission terminates the loop.
-- [x] **AI session resumes via session id** — the harness reads back the per-task `sessionId` file from
-      `<sprintDir>/implement/<unit>/rounds/<N>/generator/sessionId` and resumes the relevant task's session.
+- [x] **AI session resumes via session id** — the harness reads back the per-task `session-id.txt` file from
+      `<sprintDir>/implement/<unit>/rounds/<N>/generator/session-id.txt` and resumes the relevant task's session.
 - [ ] **EventBus emits `FeedbackRoundApplied`** per round.
 
 ## AI provider integration
 
 - [ ] **Three providers** — `claude-code`, `github-copilot`, `openai-codex`, each with its own adapter under
       `integration/ai/providers/<tool>/`. Sibling-isolated; cross-tool sharing through `providers/_engine/`.
-- [x] **File-based contract** — providers write `signals.json` and `sessionId` files per spawn (both under
+- [x] **File-based contract** — providers write `signals.json` and `session-id.txt` files per spawn (both under
       `rounds/<N>/<role>/`); the harness reads them post-spawn. No stdout parsing for signals or session IDs.
 - [ ] **Idle-stdout watchdog** — wedged children get reaped.
 - [ ] **Exponential backoff** — rate-limit retries use `rate-limit-backoff.ts` (`integration/ai/providers/_engine/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ bundled copy is skipped and the project copy is left untouched. The skills adapt
 (`src/integration/ai/skills/adapter-factory.ts`) tracks only what it installed; uninstall removes only
 those entries.
 
-**File-based AI provider contract** — providers write `signals.json` and a `sessionId` file per spawn
+**File-based AI provider contract** — providers write `signals.json` and a `session-id.txt` file per spawn
 (both persisted to `<sprintDir>/implement/<unit-slug>/rounds/<N>/<role>/`); the harness reads them
 post-spawn. No stdout parsing for signals or session IDs. Replaces a long-standing brittleness vector
 when CLI vendors tweak JSON shape.

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -79,6 +79,12 @@ export type ChainLogSinkLaunchDeps = Omit<FileLogSinkDeps, 'appendFile'>;
  * `settingsRepo` directly so writes round-trip through validation.
  */
 export interface AppDeps {
+  /**
+   * Resolved storage paths — exposed so flows / TUI views can derive per-sprint paths
+   * (`<dataRoot>/sprints/<sprintId>/`) without re-resolving from env or `os.homedir()`.
+   * The composition root computes this once; callers down the tree consume the same record.
+   */
+  readonly storage: StoragePaths;
   readonly projectRepo: ProjectRepository;
   readonly sprintRepo: SprintRepository;
   readonly sprintExecutionRepo: SprintExecutionRepository;
@@ -332,6 +338,7 @@ export const wire = (opts: WireOptions): AppDeps => {
     },
   });
   return {
+    storage: opts.storage,
     projectRepo: createFsProjectRepository({ root: opts.storage.dataRoot }),
     sprintRepo: createFsSprintRepository({ root: opts.storage.dataRoot }),
     sprintExecutionRepo: createFsSprintExecutionRepository({ root: opts.storage.dataRoot }),

--- a/src/application/flows/create-pr/ctx.ts
+++ b/src/application/flows/create-pr/ctx.ts
@@ -6,6 +6,13 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 export interface CreatePrInput {
   readonly sprintId: SprintId;
   readonly cwd: AbsolutePath;
+  /**
+   * Per-sprint persisted-state folder (`<dataRoot>/sprints/<sprintId>/`). The AI sub-chain's
+   * unit builder writes `prompt.md`, `signals.json`, `session-id.txt`, and `pr-content.md`
+   * under `<sprintDir>/create-pr/<run-slug>/` — same convention implement / refine / plan use,
+   * so the user's repo working tree stays untouched.
+   */
+  readonly sprintDir: AbsolutePath;
   readonly base: string;
   readonly draft: boolean;
   /** Pre-loaded tasks to feed the body deriver. Empty omits the `## Tasks` section. */

--- a/src/application/flows/create-pr/flow.ts
+++ b/src/application/flows/create-pr/flow.ts
@@ -67,17 +67,11 @@ export const createCreatePrFlow = (deps: CreatePrDeps, opts: CreateCreatePrFlowO
       createLoadCreatePrContextLeaf(deps),
       buildUnitLeaf<CreatePrCtx>({
         name: 'build-create-pr-unit',
-        // Per-sprint unit root: `<sprintExecutionDir>/create-pr/<run-slug>/`. The flow does
-        // not have access to the sprint dir directly; we derive it from the branch + sprintId
-        // via a stable slug — one unit per branch so re-runs land in the same place.
+        // Per-sprint unit root: `<sprintDir>/create-pr/<run-slug>/` — same layout the implement
+        // / refine / plan flows use, so the user's repo working tree never collects scratch
+        // artifacts from a `ralphctl create-pr` run.
         parent: (ctx) => {
-          // The "sprint dir" convention is `<dataRoot>/sprints/<sprintId>/`. We don't have
-          // that path on deps here; the load-context leaf doesn't carry it either. Place
-          // the unit under the cwd's `.ralphctl-create-pr/<sprintId>/` so the leaf has a
-          // deterministic writable path without coupling to the storage layout — the unit
-          // dir is a per-run scratchpad, not a long-lived audit artefact.
-          const sprintId = String(ctx.input.sprintId);
-          const parentDir = AbsolutePath.parse(join(String(ctx.input.cwd), '.ralphctl-create-pr', sprintId));
+          const parentDir = AbsolutePath.parse(join(String(ctx.input.sprintDir), 'create-pr'));
           if (!parentDir.ok) throw parentDir.error;
           return parentDir.value;
         },

--- a/src/application/flows/implement/ctx.ts
+++ b/src/application/flows/implement/ctx.ts
@@ -95,7 +95,7 @@ export interface ImplementCtx {
    * on every spawn. Cleared by `start-attempt-<id>` when a new task begins so the next task
    * starts a fresh "developer."
    *
-   * Read from `<workspaceRoot>/rounds/<N>/generator/sessionId` per the file-based provider
+   * Read from `<workspaceRoot>/rounds/<N>/generator/session-id.txt` per the file-based provider
    * contract — the Claude adapter writes the file via `persistSessionIdFile` after every spawn.
    * Undefined on the first round of a task or when the prior spawn failed before reporting an id.
    */

--- a/src/application/flows/implement/leaves/commit-task.ts
+++ b/src/application/flows/implement/leaves/commit-task.ts
@@ -11,7 +11,7 @@ import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { gitCommitWithMessage } from '@src/integration/io/git-operations.ts';
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
-import { renderTicketRefsSection } from '@src/integration/ai/prompts/_engine/renderers/task.ts';
+import { renderTicketRefsSubjectSuffix } from '@src/integration/ai/prompts/_engine/renderers/task.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 export type CommitMessageFactory = (input: { readonly task: Task }) => string;
@@ -26,8 +26,10 @@ export interface CommitTaskLeafDeps {
 // Audit-[03] + audit-[09]: commit messages are AI signal bodies — no caps, no truncation.
 // `git commit -m <msg>` passes via argv with ARG_MAX headroom in the hundreds of KB; git
 // itself has no length limit. Subject + body land verbatim from the validated
-// `commit-message` signal, with the deterministic `Closes …` trailer appended when the task
-// carries external refs.
+// `commit-message` signal; when the task carries external refs the harness appends them
+// as a ` (#123, !456)` suffix on the subject line (conventional-commit shape). Auto-close
+// on merge is the PR body's job (see `renderIssueRefs` in create-pr) so no body trailer
+// is emitted here.
 
 const firstParagraph = (text: string): string => {
   const trimmed = text.trim();
@@ -44,10 +46,16 @@ const assembleCommitMessage = (subject: string, body: string | undefined): strin
 const defaultMessageFactory: CommitMessageFactory = ({ task }): string =>
   assembleCommitMessage(task.name, firstParagraph(task.description ?? ''));
 
-const appendTrailerToMessage = (message: string, refs: readonly string[] | undefined): string => {
-  const trailer = renderTicketRefsSection(refs);
-  if (trailer.length === 0) return message;
-  return `${message}\n\n${trailer}`;
+const appendSubjectSuffix = (message: string, refs: readonly string[] | undefined): string => {
+  const suffix = renderTicketRefsSubjectSuffix(refs);
+  if (suffix.length === 0) return message;
+  const newlineIdx = message.indexOf('\n');
+  const subject = newlineIdx === -1 ? message : message.slice(0, newlineIdx);
+  const rest = newlineIdx === -1 ? '' : message.slice(newlineIdx);
+  // Idempotency: a hand-authored subject that already ends with the verbatim suffix is left
+  // untouched so re-runs / regenerated messages don't grow `(#123) (#123)`.
+  if (subject.endsWith(suffix)) return message;
+  return `${subject}${suffix}${rest}`;
 };
 
 export interface CommitTaskLeafOpts {
@@ -113,14 +121,16 @@ export const commitTaskLeaf = (
       //      Subject + optional body are joined with the conventional blank-line separator.
       //   2. Caller-supplied `opts.messageFactory` (legacy injection point).
       //   3. Default `task(<short-id>): <name>` factory.
-      // After resolution we always append the deterministic `Closes …` trailer when the task
+      // After resolution we append a ` (#123, !456)` suffix to the subject line when the task
       // carries external refs — the AI no longer sees the refs, so this is the only writer.
+      // The PR body's `Closes #X` lines (rendered by create-pr's `renderIssueRefs`) handle
+      // auto-close on merge; no body trailer is added here.
       const proposed = ctx.proposedCommitMessage;
       const baseMessage =
         proposed !== undefined
           ? assembleCommitMessage(proposed.subject, proposed.body)
           : (opts.messageFactory ?? defaultMessageFactory)({ task });
-      const message = appendTrailerToMessage(baseMessage, task.externalRefs);
+      const message = appendSubjectSuffix(baseMessage, task.externalRefs);
       return { task, sprintId: ctx.sprintId, message };
     },
     output: (ctx, out) => ({

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -124,7 +124,7 @@ interface EvaluatorOutput {
   readonly turnRecord?: PlateauTurnRecord;
   /**
    * `session_id` captured by the Claude adapter for THIS turn — read from
-   * `rounds/<N>/evaluator/sessionId` after the spawn returns. Stamped onto ctx by the output
+   * `rounds/<N>/evaluator/session-id.txt` after the spawn returns. Stamped onto ctx by the output
    * projection so the next round's evaluator can resume the same thread.
    */
   readonly capturedSessionId?: SessionId;

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -121,7 +121,7 @@ interface GeneratorOutput {
   readonly roundNum: number;
   /**
    * `session_id` captured by the Claude adapter for THIS turn — read from
-   * `rounds/<N>/generator/sessionId` after the spawn returns. Stamped onto ctx by the output
+   * `rounds/<N>/generator/session-id.txt` after the spawn returns. Stamped onto ctx by the output
    * projection so the next round's generator can resume the same thread. `undefined` when the
    * adapter never reported an id (failed spawn, non-Claude provider, …).
    */

--- a/src/application/flows/implement/leaves/round-artifacts.ts
+++ b/src/application/flows/implement/leaves/round-artifacts.ts
@@ -56,8 +56,8 @@ export const roundSignalsPath = (workspaceRoot: AbsolutePath, round: number, rol
   join(String(workspaceRoot), 'rounds', String(round), role, 'signals.json');
 
 /**
- * Read the captured Claude `session_id` from `rounds/<N>/<role>/sessionId` — the sibling text
- * file the Claude adapter writes via `persistSessionIdFile` after every spawn. Returns
+ * Read the captured Claude `session_id` from `rounds/<N>/<role>/session-id.txt` — the sibling
+ * text file the Claude adapter writes via `persistSessionIdFile` after every spawn. Returns
  * `undefined` when the file is missing (the adapter skips the write on a spawn that never
  * reported an id — process crash, malformed stream-json, …) or empty.
  *
@@ -71,7 +71,7 @@ export const readRoundSessionId = async (
   round: number,
   role: 'generator' | 'evaluator'
 ): Promise<SessionId | undefined> => {
-  const path = join(String(workspaceRoot), 'rounds', String(round), role, 'sessionId');
+  const path = join(String(workspaceRoot), 'rounds', String(round), role, 'session-id.txt');
   let content: string;
   try {
     content = await fs.readFile(path, 'utf8');

--- a/src/application/ui/cli/commands/create-pr.ts
+++ b/src/application/ui/cli/commands/create-pr.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import type { Command } from 'commander';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -45,10 +46,14 @@ export const registerCreatePrCommand = (program: Command): void => {
       if (!cwd.ok) {
         process.stderr.write(`error: --cwd: ${cwd.error.message}\n`);
         process.exit(1);
-        return;
       }
 
-      const { deps } = await bootstrapCli();
+      const { deps, storage } = await bootstrapCli();
+      const sprintDir = AbsolutePath.parse(join(String(storage.dataRoot), 'sprints', opts.sprint));
+      if (!sprintDir.ok) {
+        process.stderr.write(`error: sprint dir: ${sprintDir.error.message}\n`);
+        process.exit(1);
+      }
       const flow = createCreatePrFlow(
         {
           sprintRepo: deps.sprintRepo,
@@ -72,6 +77,7 @@ export const registerCreatePrCommand = (program: Command): void => {
         input: {
           sprintId: opts.sprint as SprintId,
           cwd: cwd.value,
+          sprintDir: sprintDir.value,
           base: opts.base,
           draft: opts.draft,
           ...(opts.title !== undefined ? { title: opts.title } : {}),
@@ -82,7 +88,6 @@ export const registerCreatePrCommand = (program: Command): void => {
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.error.message}\n`);
         process.exit(1);
-        return;
       }
       process.stdout.write(`opened PR ${result.value.ctx.output!.url}\n`);
     });

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -57,7 +57,9 @@ export interface TasksPanelProps {
    *
    * The cursor traverses the flat sequence of visible signal rows (orphans first, then each
    * task in order). When focused on a `commit-message` row, Enter / Space toggles expansion to
-   * reveal the body + trailing `Closes #…` trailer. Expansion state lives in panel-local
+   * reveal the body. The subject row shows the AI-proposed subject; the harness-appended
+   * ` (#123, !456)` ref suffix lands at `git commit -F` time and is not threaded back onto the
+   * signal. Expansion state lives in panel-local
    * `useState` so it persists across re-renders within the session but resets if the panel
    * unmounts (e.g. on `D` detach back to home).
    */
@@ -284,9 +286,9 @@ const SignalLine = ({
  * under the signal label column.
  *
  * Source of truth for the multi-line body is `signal.body` when present. The harness-appended
- * deterministic trailers (`Closes #…`) are added by the commit-task leaf when calling
- * `git commit -F` but are not threaded back onto the signal — the TUI shows the AI's proposed
- * message, not the post-trailer resolved form.
+ * ` (#123, !456)` subject suffix is added by the commit-task leaf when calling `git commit -F`
+ * but is not threaded back onto the signal — the TUI shows the AI's proposed message, not the
+ * post-suffix resolved form.
  *
  * Width handling: every body line uses the same `wrap="truncate-end"` discipline as the
  * subject row, so a 200-col commit body still ellides cleanly at narrow widths instead of

--- a/src/application/ui/tui/views/create-pr-view.tsx
+++ b/src/application/ui/tui/views/create-pr-view.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
+import { join } from 'node:path';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
@@ -21,7 +22,7 @@ import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
-import { type AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 
 const DEFAULT_BASE = 'main';
 const DEFAULT_DRAFT = false;
@@ -88,6 +89,11 @@ export const CreatePrView = (): React.JSX.Element => {
         setRun({ kind: 'error', message: 'No sprint selected.' });
         return;
       }
+      const sprintDir = AbsolutePath.parse(join(String(deps.storage.dataRoot), 'sprints', String(selection.sprintId)));
+      if (!sprintDir.ok) {
+        setRun({ kind: 'error', message: `sprint dir: ${sprintDir.error.message}` });
+        return;
+      }
       setRun({ kind: 'running' });
       const flow = createCreatePrFlow(
         {
@@ -109,7 +115,13 @@ export const CreatePrView = (): React.JSX.Element => {
         { useAi }
       );
       const result = await flow.execute({
-        input: { sprintId: selection.sprintId, cwd, base: DEFAULT_BASE, draft: DEFAULT_DRAFT },
+        input: {
+          sprintId: selection.sprintId,
+          cwd,
+          sprintDir: sprintDir.value,
+          base: DEFAULT_BASE,
+          draft: DEFAULT_DRAFT,
+        },
       });
       if (!result.ok) {
         setRun({ kind: 'error', message: result.error.error.message });

--- a/src/domain/signal.ts
+++ b/src/domain/signal.ts
@@ -245,9 +245,9 @@ export interface ContextCompactedSignal {
  *  - `body` is optional and may span multiple paragraphs. Convention: wrap at 72 chars,
  *    explain the why, not the what.
  *
- * Deterministic trailers (`Closes #…`) are appended by the commit-task leaf at `git commit -F`
- * time — they are not threaded back onto the signal. UI surfaces show the AI-authored subject +
- * body; reviewers see the trailered version in `git log`.
+ * A ` (#123, !456)` subject suffix is appended by the commit-task leaf at `git commit -F` time
+ * when the task carries external refs — it is not threaded back onto the signal. UI surfaces
+ * show the AI-authored subject + body; reviewers see the suffixed subject in `git log`.
  *
  * When the signal is absent the harness falls back to its auto-generated default
  * (`task(<short-id>): <task-name>`).

--- a/src/domain/value/external-ref.ts
+++ b/src/domain/value/external-ref.ts
@@ -6,9 +6,9 @@
  *
  * Used by ticket creation paths (interactive add-loop, one-shot CLI add,
  * refine-create) so a ticket sourced from an issue URL automatically carries
- * the ref that the commit trailer + PR-body renderers consume — closing
+ * the ref the commit subject-suffix + PR-body renderers consume — closing
  * `Ticket.externalRef === undefined` blind spots that left commits without a
- * `Closes #N` line.
+ * ref annotation and PRs without a `Closes #N` line.
  *
  * Format choice: short `#NN` (not `owner/repo#NN`). Same-repo close is the
  * dominant case for sprint work; users who need cross-repo refs can set

--- a/src/integration/ai/contract/_engine/signals/commit-message/schema.ts
+++ b/src/integration/ai/contract/_engine/signals/commit-message/schema.ts
@@ -6,8 +6,8 @@ import type { Compatible } from '@src/integration/persistence/shared/codec-inter
 /**
  * Zod schema for the `commit-message` AI signal — generator-proposed message the
  * `commit-task` leaf threads into `git commit -F`. The harness still owns the actual commit;
- * the signal is advisory. Deterministic trailers (`Closes #…`) are appended by the harness at
- * commit time and not surfaced back onto the signal.
+ * the signal is advisory. The harness appends a ` (#123, !456)` subject suffix at commit time
+ * when the task carries external refs; this suffix is not surfaced back onto the signal.
  */
 /** @public */
 export const commitMessageSignalSchema = z.object({

--- a/src/integration/ai/contract/_engine/validate-signals-file.ts
+++ b/src/integration/ai/contract/_engine/validate-signals-file.ts
@@ -47,7 +47,7 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
           currentState: 'post-spawn',
           attemptedAction: 'validate-signals',
           message: `signals-missing: ${path}`,
-          hint: 'The AI exited without writing signals.json. Inspect the per-spawn directory for stdout / sessionId and re-run.',
+          hint: 'The AI exited without writing signals.json. Inspect the per-spawn directory for stdout / session-id.txt and re-run.',
         })
       );
     }

--- a/src/integration/ai/prompts/_engine/renderers/task.ts
+++ b/src/integration/ai/prompts/_engine/renderers/task.ts
@@ -148,23 +148,26 @@ export const renderExtraDimensionsSection = (extras: readonly string[] | undefin
 };
 
 /**
- * Render the closing-keyword trailer block appended to per-task commit messages. GitHub and
- * GitLab both parse `Closes <ref>` (case-insensitive) and auto-close the referenced issue
- * when the PR / MR merges, so one line per ref is what both platforms expect. Used today by
- * `commit-task.ts`; the implement prompt no longer carries the trailer placeholder.
+ * Render the subject-line suffix appended to per-task commit messages — the conventional
+ * `feat(scope): subject (#123)` shape that GitHub renders as a clickable issue ref in `git
+ * log` and on the PR timeline. Used today by `commit-task.ts`; the implement prompt no longer
+ * carries any ref placeholder. PR-body-level auto-close on merge is handled separately by
+ * `renderIssueRefs` in the create-pr prompt definition, which still injects `Closes #X` into
+ * the PR body — keeping the suffix here purely subject-shaped means double-close lines never
+ * land in `git log`.
  *
- * Format:
- *   `Closes #123`                       (single ref)
- *   `Closes #123\nCloses #456`          (multiple refs — one keyword per line)
+ * Format (leading space, parens, comma-space between refs):
+ *   ` (#123)`              (single ref)
+ *   ` (#123, !456)`        (multiple refs — comma-separated inside one paren)
  *
  * Empty / undefined → empty string. Refs are trimmed, deduped first-seen-wins, and emitted in
  * input order via {@link normalizeRefs}. The harness writes the ref tokens verbatim —
  * `#`/`!`/`PROJ-` decoration is the source ticket's choice, not ours to normalise.
  */
-export const renderTicketRefsSection = (refs: readonly string[] | undefined): string => {
+export const renderTicketRefsSubjectSuffix = (refs: readonly string[] | undefined): string => {
   const normalized = normalizeRefs(refs);
   if (normalized.length === 0) return '';
-  return normalized.map((r) => `Closes ${r}`).join('\n');
+  return ` (${normalized.join(', ')})`;
 };
 
 /**

--- a/src/integration/ai/providers/_engine/persist-session-id.ts
+++ b/src/integration/ai/providers/_engine/persist-session-id.ts
@@ -8,14 +8,14 @@ import type { StorageError } from '@src/domain/value/error/storage-error.ts';
  * Persist a captured session id next to `signals.json` so `--resume` / forensic re-attach works
  * without log parsing.
  *
- * The CLAUDE.md contract states "providers write `signals.json` + `sessionId` files per spawn"
- * — historically only `signals.json` landed on disk; session ids escaped into `chain.log`. This
- * helper closes that gap: every adapter calls it after writing `signals.json`, passing the same
- * directory's signals path and the id its provider captured.
+ * The CLAUDE.md contract states "providers write `signals.json` + `session-id.txt` files per
+ * spawn" — historically only `signals.json` landed on disk; session ids escaped into `chain.log`.
+ * This helper closes that gap: every adapter calls it after writing `signals.json`, passing the
+ * same directory's signals path and the id its provider captured.
  *
  * File layout:
  *   - `signals.json` is written by the adapter at `session.signalsFile`.
- *   - This helper writes `sessionId` as a sibling in the same directory.
+ *   - This helper writes `session-id.txt` as a sibling in the same directory.
  *
  * Contents:
  *   - Plain UTF-8, exactly one line containing the session id, trailing newline. Matches the
@@ -37,6 +37,6 @@ export const persistSessionIdFile = async (
   sessionId: string | undefined
 ): Promise<Result<void, StorageError> | undefined> => {
   if (sessionId === undefined) return undefined;
-  const path = join(dirname(String(signalsFile)), 'sessionId');
+  const path = join(dirname(String(signalsFile)), 'session-id.txt');
   return writeTextAtomic(path, `${sessionId}\n`);
 };

--- a/tests/e2e/flows/create-pr.test.ts
+++ b/tests/e2e/flows/create-pr.test.ts
@@ -175,7 +175,13 @@ describe('create-pr flow — happy path', () => {
       { useAi: false }
     );
     const result = await flow.execute({
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     });
 
     expect(result.ok).toBe(true);
@@ -218,7 +224,13 @@ describe('create-pr flow — happy path', () => {
       { useAi: false }
     );
     const result = await flow.execute({
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     });
 
     expect(result.ok).toBe(true);
@@ -254,6 +266,7 @@ describe('create-pr flow — happy path', () => {
       input: {
         sprintId: sprint.id,
         cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
         base: 'main',
         draft: true,
         title: 'My PR Title',
@@ -288,7 +301,13 @@ describe('create-pr flow — failures', () => {
       { useAi: false }
     );
     const result = await flow.execute({
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     });
 
     expect(result.ok).toBe(false);
@@ -315,7 +334,13 @@ describe('create-pr flow — failures', () => {
       { useAi: false }
     );
     const result = await flow.execute({
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     });
 
     expect(result.ok).toBe(false);
@@ -344,7 +369,13 @@ describe('create-pr flow — failures', () => {
       { useAi: false }
     );
     const result = await flow.execute({
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     });
 
     expect(result.ok).toBe(false);
@@ -421,15 +452,16 @@ describe('create-pr flow — useAi=true happy path', () => {
         { useAi: true }
       );
       const result = await flow.execute({
-        input: { sprintId: sprint.id, cwd: tmp.root, base: 'main', draft: false },
+        input: { sprintId: sprint.id, cwd: tmp.root, sprintDir: tmp.root, base: 'main', draft: false },
       });
 
       expect(result.ok).toBe(true);
       // AI title + body landed on the PR, not the template-derived default.
       expect(pr.calls[0]?.title).toBe(aiTitle);
       expect(pr.calls[0]?.body).toBe(aiBody);
-      // The sidecar file was rendered alongside signals.json.
-      const sidecarPath = `${String(tmp.root)}/.ralphctl-create-pr/${String(sprint.id)}/feature-ai/pr-content.md`;
+      // The sidecar file landed under `<sprintDir>/create-pr/<branch-slug>/` — same convention
+      // implement / refine / plan use, so the user's repo working tree stays untouched.
+      const sidecarPath = `${String(tmp.root)}/create-pr/feature-ai/pr-content.md`;
       const sidecarBody = await fsp.readFile(sidecarPath, 'utf8');
       expect(sidecarBody).toContain(`# ${aiTitle}`);
       expect(sidecarBody).toContain(aiBody);
@@ -482,7 +514,7 @@ describe('create-pr flow — useAi=true happy path', () => {
         { useAi: true }
       );
       const result = await flow.execute({
-        input: { sprintId: sprint.id, cwd: tmp.root, base: 'main', draft: false },
+        input: { sprintId: sprint.id, cwd: tmp.root, sprintDir: tmp.root, base: 'main', draft: false },
       });
 
       expect(result.ok).toBe(true);

--- a/tests/fixtures/fake-ai-provider.ts
+++ b/tests/fixtures/fake-ai-provider.ts
@@ -34,9 +34,9 @@ import { writeJsonAtomic, writeTextAtomic } from '@src/integration/io/fs.ts';
  * ## Session ids
  *
  * `sessionIds[templateName]` is threaded onto `ProviderOutput.sessionId` AND written to
- * `<dirname-of-signalsFile>/sessionId` as a sibling text file — mirroring the production Claude
- * adapter's `persistSessionIdFile` contract so leaves that read the file (`readRoundSessionId`)
- * see the captured id without manual test setup. `sessionIds[templateName]` may be a string
+ * `<dirname-of-signalsFile>/session-id.txt` as a sibling text file — mirroring the production
+ * Claude adapter's `persistSessionIdFile` contract so leaves that read the file
+ * (`readRoundSessionId`) see the captured id without manual test setup. `sessionIds[templateName]` may be a string
  * (same id every call) or a function `(session) => string | undefined` (per-call ids, e.g. for
  * round-1-vs-round-2 resume tests where each round produces its own id).
  *
@@ -138,10 +138,10 @@ export const createFakeAiProvider = (script: FakeAiProviderScript): FakeAiProvid
       const sessionIdEntry = script.sessionIds?.[templateName];
       const sessionId = typeof sessionIdEntry === 'function' ? sessionIdEntry(session) : sessionIdEntry;
       // Mirror Claude's `persistSessionIdFile` contract: when a sessionId is captured, write a
-      // sibling `sessionId` text file next to signals.json so leaves reading via
+      // sibling `session-id.txt` text file next to signals.json so leaves reading via
       // `readRoundSessionId` see the same file shape production produces.
       if (sessionId !== undefined && sessionId.length > 0) {
-        const sidPath = join(dirname(String(session.signalsFile)), 'sessionId');
+        const sidPath = join(dirname(String(session.signalsFile)), 'session-id.txt');
         await writeTextAtomic(sidPath, `${sessionId}\n`);
       }
       return Result.ok({

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -225,7 +225,7 @@ describe('createClaudeProvider', () => {
     await expect(fs.access(String(out.value.signalsFile))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('persists sessionId as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
+  it('persists session-id.txt as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-persist', model: 'sonnet' });
@@ -237,13 +237,13 @@ describe('createClaudeProvider', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) return;
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     const sidContent = await fs.readFile(sidPath, 'utf8');
     expect(sidContent).toBe('sess-persist\n');
     expect(out.value.sessionId).toBe('sess-persist');
   });
 
-  it('skips the sessionId file when the stream never emitted a session_id (no empty marker)', async () => {
+  it('skips the session-id.txt file when the stream never emitted a session_id (no empty marker)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     // result event WITHOUT session_id — Claude can omit it on early-exit / malformed init.
@@ -256,11 +256,11 @@ describe('createClaudeProvider', () => {
     if (!out.ok) return;
     expect(out.value.sessionId).toBeUndefined();
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('does not write sessionId on non-zero exit (spawn failure path)', async () => {
+  it('does not write session-id.txt on non-zero exit (spawn failure path)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const init = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-doomed', model: 'sonnet' });
@@ -270,7 +270,7 @@ describe('createClaudeProvider', () => {
     const out = await provider.generate(sess);
     expect(out.ok).toBe(false);
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
     // signals.json is also never written on the failure path.
     await expect(fs.access(String(sess.signalsFile))).rejects.toMatchObject({ code: 'ENOENT' });

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -214,7 +214,7 @@ describe('createCodexProvider', () => {
     expect(mirrored).toBe('<task-verified>all good</task-verified>');
   });
 
-  it('persists sessionId as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
+  it('persists session-id.txt as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const { spawn } = makeSpawn([{ stdoutChunks: ['{"session_id":"sess-persist","type":"config"}\n'], exitCode: 0 }]);
@@ -233,16 +233,16 @@ describe('createCodexProvider', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) return;
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     const sidContent = await fs.readFile(sidPath, 'utf8');
     expect(sidContent).toBe('sess-persist\n');
     expect(out.value.sessionId).toBe('sess-persist');
   });
 
-  it('skips the sessionId file when stdout never carried a session_id (no empty marker)', async () => {
+  it('skips the session-id.txt file when stdout never carried a session_id (no empty marker)', async () => {
     const cap = createCapturingBus();
     const sess = session();
-    // stdout JSONL with no session_id field — adapter must not write an empty sessionId file.
+    // stdout JSONL with no session_id field — adapter must not write an empty session-id.txt file.
     const { spawn } = makeSpawn([{ stdoutChunks: ['{"type":"config"}\n'], exitCode: 0 }]);
     const fsStub = stubFs('<task-complete/>');
 
@@ -260,11 +260,11 @@ describe('createCodexProvider', () => {
     if (!out.ok) return;
     expect(out.value.sessionId).toBeUndefined();
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('does not write sessionId on non-zero exit (spawn failure path)', async () => {
+  it('does not write session-id.txt on non-zero exit (spawn failure path)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const { spawn } = makeSpawn([
@@ -288,7 +288,7 @@ describe('createCodexProvider', () => {
     const out = await provider.generate(sess);
     expect(out.ok).toBe(false);
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fs.access(String(sess.signalsFile))).rejects.toMatchObject({ code: 'ENOENT' });
   });

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -139,7 +139,7 @@ describe('createCopilotProvider', () => {
     expect(sessionEntry?.meta?.['sessionId']).toBe('sess-1');
   });
 
-  it('persists sessionId as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
+  it('persists session-id.txt as a sibling file when captured (UTF-8, one line + trailing newline)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const { spawn } = makeSpawn([
@@ -154,13 +154,13 @@ describe('createCopilotProvider', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) return;
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     const sidContent = await fs.readFile(sidPath, 'utf8');
     expect(sidContent).toBe('sess-persist\n');
     expect(out.value.sessionId).toBe('sess-persist');
   });
 
-  it('skips the sessionId file when no meta line carried a session_id (no empty marker)', async () => {
+  it('skips the session-id.txt file when no meta line carried a session_id (no empty marker)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     // Only plain-text body lines — no JSON meta line, so no session_id is ever extracted.
@@ -172,11 +172,11 @@ describe('createCopilotProvider', () => {
     if (!out.ok) return;
     expect(out.value.sessionId).toBeUndefined();
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('does not write sessionId on non-zero exit (spawn failure path)', async () => {
+  it('does not write session-id.txt on non-zero exit (spawn failure path)', async () => {
     const cap = createCapturingBus();
     const sess = session();
     const { spawn } = makeSpawn([
@@ -191,7 +191,7 @@ describe('createCopilotProvider', () => {
     const out = await provider.generate(sess);
     expect(out.ok).toBe(false);
 
-    const sidPath = join(dirname(String(sess.signalsFile)), 'sessionId');
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
     await expect(fs.access(sidPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fs.access(String(sess.signalsFile))).rejects.toMatchObject({ code: 'ENOENT' });
   });

--- a/tests/integration/application/flows/implement/leaves/round-artifacts.test.ts
+++ b/tests/integration/application/flows/implement/leaves/round-artifacts.test.ts
@@ -77,19 +77,19 @@ describe('round-artifacts', () => {
     it('reads the captured session id when the sibling file exists', async () => {
       const dir = join(String(root.root), 'rounds', '3', 'generator');
       await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(join(dir, 'sessionId'), 'gen-session-xyz\n', 'utf8');
+      await fs.writeFile(join(dir, 'session-id.txt'), 'gen-session-xyz\n', 'utf8');
       expect(await readRoundSessionId(root.root, 3, 'generator')).toBe('gen-session-xyz');
     });
 
-    it('returns undefined when the sessionId file is absent (provider never reported one)', async () => {
+    it('returns undefined when the session-id.txt file is absent (provider never reported one)', async () => {
       expect(await readRoundSessionId(root.root, 99, 'generator')).toBeUndefined();
       expect(await readRoundSessionId(root.root, 99, 'evaluator')).toBeUndefined();
     });
 
-    it('returns undefined for an empty sessionId file rather than a zero-length id', async () => {
+    it('returns undefined for an empty session-id.txt file rather than a zero-length id', async () => {
       const dir = join(String(root.root), 'rounds', '7', 'evaluator');
       await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(join(dir, 'sessionId'), '\n', 'utf8');
+      await fs.writeFile(join(dir, 'session-id.txt'), '\n', 'utf8');
       expect(await readRoundSessionId(root.root, 7, 'evaluator')).toBeUndefined();
     });
   });

--- a/tests/integration/application/ui/tui/components/tasks-panel-commit-expand.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-commit-expand.test.tsx
@@ -4,8 +4,8 @@
  * A `commit-message` signal carries `subject` + optional `body`. The TUI default is collapsed:
  * subject only. When the cursor focuses a commit row and the user presses Enter or Space, the
  * body expands under the signal label column. Multiple rows can be expanded; expansion state
- * persists across re-renders. Deterministic `Closes #…` trailers are appended by the harness
- * at `git commit -F` time and are not surfaced back onto the signal.
+ * persists across re-renders. The harness-appended ` (#123, !456)` subject suffix is added
+ * at `git commit -F` time and is not surfaced back onto the signal.
  */
 
 import { render } from 'ink-testing-library';

--- a/tests/unit/application/flows/create-pr/leaves/create-pr-leaf.test.ts
+++ b/tests/unit/application/flows/create-pr/leaves/create-pr-leaf.test.ts
@@ -109,7 +109,13 @@ describe('createCreatePrLeaf — title/body precedence', () => {
     const { creator, calls } = captureCreator();
     const leaf = createCreatePrLeaf(buildDeps(sprint, exec, creator));
     const ctx: CreatePrCtx = {
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
     };
     const result = await leaf.execute(ctx);
     expect(result.ok).toBe(true);
@@ -121,7 +127,13 @@ describe('createCreatePrLeaf — title/body precedence', () => {
     const { creator, calls } = captureCreator();
     const leaf = createCreatePrLeaf(buildDeps(sprint, exec, creator));
     const ctx: CreatePrCtx = {
-      input: { sprintId: sprint.id, cwd: absolutePath('/tmp/repo'), base: 'main', draft: false },
+      input: {
+        sprintId: sprint.id,
+        cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
+        base: 'main',
+        draft: false,
+      },
       aiContent: { title: 'AI title', body: 'AI body' },
     };
     const result = await leaf.execute(ctx);
@@ -137,6 +149,7 @@ describe('createCreatePrLeaf — title/body precedence', () => {
       input: {
         sprintId: sprint.id,
         cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
         base: 'main',
         draft: false,
         title: 'Explicit title',
@@ -157,6 +170,7 @@ describe('createCreatePrLeaf — title/body precedence', () => {
       input: {
         sprintId: sprint.id,
         cwd: absolutePath('/tmp/repo'),
+        sprintDir: absolutePath('/tmp/sprint-dir'),
         base: 'main',
         draft: false,
         title: 'Explicit title',

--- a/tests/unit/application/flows/create-pr/leaves/generate-pr-content-leaf.test.ts
+++ b/tests/unit/application/flows/create-pr/leaves/generate-pr-content-leaf.test.ts
@@ -44,6 +44,7 @@ const buildCtx = (unitRoot: AbsolutePath, promptFile: AbsolutePath): CreatePrCtx
     input: {
       sprintId: sprint.id,
       cwd: absolutePath('/tmp/repo'),
+      sprintDir: absolutePath('/tmp/sprint-dir'),
       base: 'main',
       draft: false,
     },

--- a/tests/unit/application/flows/create-pr/leaves/push-branch-leaf.test.ts
+++ b/tests/unit/application/flows/create-pr/leaves/push-branch-leaf.test.ts
@@ -100,7 +100,13 @@ const stubCreatePrDeps = (overrides: {
 const sprint = makeReviewSprint();
 const execution = setExecutionBranch(createSprintExecution({ sprintId: sprint.id }), BRANCH);
 const baseCtx = {
-  input: { sprintId: sprint.id, cwd: CWD, base: 'main', draft: false },
+  input: {
+    sprintId: sprint.id,
+    cwd: CWD,
+    sprintDir: absolutePath('/tmp/sprint-dir'),
+    base: 'main',
+    draft: false,
+  },
 };
 
 describe('push-branch-leaf', () => {

--- a/tests/unit/application/flows/implement/leaves/commit-task.test.ts
+++ b/tests/unit/application/flows/implement/leaves/commit-task.test.ts
@@ -290,7 +290,7 @@ describe('commitTaskLeaf', () => {
     expect(observedMessage!.endsWith('...')).toBe(false);
   });
 
-  it('appends a deterministic `Closes <ref>` trailer when the task carries externalRefs', async () => {
+  it('appends a ` (<ref>)` suffix to the subject line when the task carries externalRefs', async () => {
     const repo = fakeRepo();
     const baseTask = makeInProgressTaskWithRunningAttempt();
     const task: Task = { ...baseTask, externalRefs: ['#123'] };
@@ -319,11 +319,13 @@ describe('commitTaskLeaf', () => {
     };
     await leaf.execute(ctx);
     expect(observedMessage).toBeDefined();
-    expect(observedMessage!.endsWith('\n\nCloses #123')).toBe(true);
-    expect(observedMessage!.startsWith('feat(auth): rotate refresh tokens\n\n')).toBe(true);
+    // Suffix on the subject line, body unchanged.
+    expect(observedMessage!).toBe('feat(auth): rotate refresh tokens (#123)\n\nWHY this matters');
+    // No body trailer — auto-close lives in the PR body.
+    expect(observedMessage!).not.toContain('Closes');
   });
 
-  it('renders one `Closes <ref>` line per ref for multi-ref tasks', async () => {
+  it('renders multiple refs comma-separated inside one paren for multi-ref tasks', async () => {
     const repo = fakeRepo();
     const baseTask = makeInProgressTaskWithRunningAttempt();
     const task: Task = { ...baseTask, externalRefs: ['#123', '!456'] };
@@ -346,13 +348,15 @@ describe('commitTaskLeaf', () => {
       { cwd: CWD },
       task.id
     );
-    // No proposed message → default factory + trailer append.
+    // No proposed message → default factory + suffix append.
     await leaf.execute(baseCtx(task));
     expect(observedMessage).toBeDefined();
-    expect(observedMessage!.endsWith('\n\nCloses #123\nCloses !456')).toBe(true);
+    // The subject from the default factory + the refs suffix lands on a single line.
+    const firstLine = observedMessage!.split('\n')[0] ?? '';
+    expect(firstLine.endsWith(' (#123, !456)')).toBe(true);
   });
 
-  it('does not append a trailer when the task has no externalRefs', async () => {
+  it('does not append a suffix when the task has no externalRefs', async () => {
     const repo = fakeRepo();
     const task = makeInProgressTaskWithRunningAttempt();
     const sha = '3'.repeat(40);
@@ -376,17 +380,18 @@ describe('commitTaskLeaf', () => {
     );
     const ctx: ImplementCtx = {
       ...baseCtx(task),
-      proposedCommitMessage: { subject: 'chore: nothing fancy', body: 'no trailer please' },
+      proposedCommitMessage: { subject: 'chore: nothing fancy', body: 'no suffix please' },
     };
     await leaf.execute(ctx);
     expect(observedMessage).toBeDefined();
     expect(observedMessage).not.toContain('Closes');
-    expect(observedMessage).toBe('chore: nothing fancy\n\nno trailer please');
+    expect(observedMessage).toBe('chore: nothing fancy\n\nno suffix please');
   });
 
-  it('appends trailer verbatim alongside a long body — no truncation', async () => {
-    // Realistic shape: a long AI-written body plus the harness-appended Closes trailer.
-    // Audit-[03]: nothing gets clipped at write time. Both body and trailer land intact.
+  it('appends suffix verbatim alongside a long body — no truncation, body untouched', async () => {
+    // Realistic shape: a long AI-written body plus the harness-appended subject suffix.
+    // Audit-[03]: nothing gets clipped at write time. The body lands intact; only the
+    // subject grows by the parenthesized refs.
     const repo = fakeRepo();
     const baseTask = makeInProgressTaskWithRunningAttempt();
     const task: Task = { ...baseTask, externalRefs: ['#9999'] };
@@ -417,14 +422,15 @@ describe('commitTaskLeaf', () => {
     };
     await leaf.execute(ctx);
     expect(observedMessage).toBeDefined();
-    expect(observedMessage!).toBe(`${subject}\n\n${body}\n\nCloses #9999`);
+    expect(observedMessage!).toBe(`${subject} (#9999)\n\n${body}`);
     expect(observedMessage!.endsWith('...')).toBe(false);
   });
 
-  it('appends the deterministic Closes trailer when the task carries externalRefs', async () => {
-    // The AI's parse-time `commit-message` signal cannot carry the deterministic `Closes …`
-    // trailer (the AI never sees the task's externalRefs). The commit-task leaf appends it
-    // before invoking `git commit -m` so reviewers see the trailered message in `git log`.
+  it('threads the subject suffix only — body trailer never appears', async () => {
+    // The AI's parse-time `commit-message` signal cannot carry the deterministic refs
+    // (the AI never sees the task's externalRefs). The commit-task leaf appends them as
+    // a subject suffix; PR-body-level `Closes #X` is the create-pr flow's job, so no body
+    // trailer is added here.
     const repo = fakeRepo();
     const baseTask = makeInProgressTaskWithRunningAttempt();
     const task: Task = { ...baseTask, externalRefs: ['#128'] };
@@ -457,8 +463,41 @@ describe('commitTaskLeaf', () => {
     };
     await leaf.execute(ctx);
     expect(observedMessage).toBeDefined();
-    expect(observedMessage).toContain('Closes #128');
-    // The trailer lives on its own line — never inside the subject.
-    expect(observedMessage?.endsWith('\n\nCloses #128')).toBe(true);
+    // Subject ends with the ref, body untouched, no `Closes` line anywhere.
+    expect(observedMessage).toBe('feat(tui): show full commit message (#128)\n\nWhy this matters.');
+    expect(observedMessage).not.toContain('Closes');
+  });
+
+  it('is idempotent: a subject already ending in the verbatim suffix is left untouched', async () => {
+    const repo = fakeRepo();
+    const baseTask = makeInProgressTaskWithRunningAttempt();
+    const task: Task = { ...baseTask, externalRefs: ['#7'] };
+    const sha = '6'.repeat(40);
+    let observedMessage: string | undefined;
+    const runner: GitRunner = {
+      async run(_, args) {
+        if (args[0] === 'commit') {
+          observedMessage = args[2];
+          return ok();
+        }
+        if (args[0] === 'add') return ok();
+        if (args[0] === 'status') return ok(' M file\n');
+        if (args[0] === 'rev-parse') return ok(`${sha}\n`);
+        throw new Error('unhandled');
+      },
+    };
+    const leaf = commitTaskLeaf(
+      { gitRunner: runner, taskRepo: repo, clock: () => NOW, logger: noopLogger },
+      { cwd: CWD },
+      task.id
+    );
+    const ctx: ImplementCtx = {
+      ...baseCtx(task),
+      // Generator hand-authored the ref already — leaf must not double up.
+      proposedCommitMessage: { subject: 'fix(ui): rename button (#7)', body: 'Body line.' },
+    };
+    await leaf.execute(ctx);
+    expect(observedMessage).toBe('fix(ui): rename button (#7)\n\nBody line.');
+    expect(observedMessage).not.toMatch(/\(#7\) \(#7\)/);
   });
 });

--- a/tests/unit/integration/ai/prompts/_engine/renderers/task.test.ts
+++ b/tests/unit/integration/ai/prompts/_engine/renderers/task.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Task } from '@src/domain/entity/task.ts';
 import {
   renderContractMd,
-  renderTicketRefsSection,
+  renderTicketRefsSubjectSuffix,
   renderVerificationCriteriaSection,
 } from '@src/integration/ai/prompts/_engine/renderers/task.ts';
 import { makeTodoTask } from '@tests/fixtures/domain.ts';
@@ -72,32 +72,32 @@ describe('renderContractMd', () => {
   });
 });
 
-describe('renderTicketRefsSection', () => {
-  it('renders a single `Closes <ref>` line for a single-element refs array', () => {
-    expect(renderTicketRefsSection(['#123'])).toBe('Closes #123');
+describe('renderTicketRefsSubjectSuffix', () => {
+  it('renders ` (<ref>)` with a leading space for a single-element refs array', () => {
+    expect(renderTicketRefsSubjectSuffix(['#123'])).toBe(' (#123)');
   });
 
-  it('renders one `Closes <ref>` line per ref, newline-joined', () => {
-    expect(renderTicketRefsSection(['#123', '!456'])).toBe('Closes #123\nCloses !456');
+  it('renders multiple refs comma-separated inside one paren', () => {
+    expect(renderTicketRefsSubjectSuffix(['#123', '!456'])).toBe(' (#123, !456)');
   });
 
   it('returns the empty string for undefined', () => {
-    expect(renderTicketRefsSection(undefined)).toBe('');
+    expect(renderTicketRefsSubjectSuffix(undefined)).toBe('');
   });
 
   it('returns the empty string for an empty array', () => {
-    expect(renderTicketRefsSection([])).toBe('');
+    expect(renderTicketRefsSubjectSuffix([])).toBe('');
   });
 
   it('dedupes repeated refs (set-style) while preserving first-seen order', () => {
-    expect(renderTicketRefsSection(['#123', '#123', '!456', '#123'])).toBe('Closes #123\nCloses !456');
+    expect(renderTicketRefsSubjectSuffix(['#123', '#123', '!456', '#123'])).toBe(' (#123, !456)');
   });
 
   it('drops whitespace-only entries and trims survivors', () => {
-    expect(renderTicketRefsSection(['  #123  ', '', '  ', '\t#999'])).toBe('Closes #123\nCloses #999');
+    expect(renderTicketRefsSubjectSuffix(['  #123  ', '', '  ', '\t#999'])).toBe(' (#123, #999)');
   });
 
   it('returns empty when every entry is whitespace-only', () => {
-    expect(renderTicketRefsSection(['  ', '\t', ''])).toBe('');
+    expect(renderTicketRefsSubjectSuffix(['  ', '\t', ''])).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- **refactor(provider):** rename per-spawn session-id file from `sessionId` to `session-id.txt` for clarity in the file-based provider contract.
- **feat(commit):** carry the ticket reference as a subject suffix and drop the `Closes` trailer — keeps commit subjects self-describing while staying scannable.
- **fix(create-pr):** land the per-flow unit directory under `<sprintDir>/create-pr/<unit-slug>/` instead of leaking into the user's repo cwd.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (one flaky retry in `selection-context.test.tsx`; full suite green on re-run)