### PR TITLE
docs: 0.8.0 public polish + release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-24
+
 ### Notes
 
 The 0.7.x line shipped a lot of structural change in a short window — an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,86 +7,49 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Changed
+### Notes
 
-- **One signal pipeline (audit-[09] contract) for every AI-spawning leaf.** The three legacy
-  flows (`review/review-round`, `detect-scripts/propose`, `detect-skills/propose`) migrated to
-  the Zod-validated `<leaf>.contract.ts` shape that `implement`, `refine`, `plan`, `ideate`,
-  and `readiness` already used. The AI writes one `signals.json` envelope to `outputDir` via
-  its Write tool; the harness validates post-spawn via `validateSignalsFile`, fans signals to
-  the sink + event bus, and renders sidecars from the validated array. The old XML-tag parser
-  tree (`src/integration/ai/signals/` — 15 per-kind parsers, parser registry, `consumeSignals`
-  / `readSignalsFile` / `withSignalsTempPath` helpers, `sink.ts`) is deleted in production.
-  Parsers are relocated to `tests/helpers/legacy-signal-parsers/` where `fake-ai-provider.ts`
-  still uses them to translate scripted XML-tag response bodies into `signals.json` fixtures
-  for tests. `HarnessSignalSink` moves to `src/business/observability/harness-signal-sink.ts`.
-  ESLint fences `src/integration/ai/signals/**` so the deleted path cannot reappear.
+The 0.7.x line shipped a lot of structural change in a short window — an
+on-disk rewrite, a settings-schema refactor, a domain rename, and a
+signal-pipeline migration, across four releases in six days. That was a lot to
+keep up with, and we're sorry for the churn. Thank you for sticking with
+ralphctl through it.
 
-- **Permission model split into capabilities and topology.** `SessionPermissions` now has
-  `canModifyRepoFiles` (renamed from `canEditFiles`) which gates `Edit` / `MultiEdit` /
-  `NotebookEdit` only; the `Write` tool is **always** allowed because the audit-[09] contract
-  requires it for `signals.json`. Path scope is the primary defense and lives on `AiSession`
-  (`cwd` + `additionalRoots` + `outputDir`). A new `providers/_engine/resolve-roots.ts`
-  helper auto-mounts `outputDir` as a writable root in every provider, so leaves never need
-  to thread it manually. Codex collapses to `-s workspace-write` for every profile because
-  its `read-only` sandbox blocks every write including `signals.json` — topology now carries
-  the safety envelope on Codex. Pre-refactor, READ_ONLY profiles silently failed to write
-  `signals.json` against every provider since Wave 6 of the audit landed.
+**Upgrading:** install the latest version, re-run `ralphctl settings
+apply-preset <name>` (or reconfigure manually), re-register your projects if
+needed, and go. We don't try to support multiple versions in parallel —
+latest is what's supported. If your old `~/.ralphctl/` data doesn't load
+cleanly, back it up (`mv ~/.ralphctl ~/.ralphctl.bak`) and start fresh; the
+backup keeps your ticket bodies and plan output around for reference.
+Contributions and bug reports very welcome — see
+[CONTRIBUTING.md](./CONTRIBUTING.md).
 
-- **Domain rename: `checkScript` → `verifyScript` everywhere.** Aligns the field name with the user-facing
-  verb the harness emits in prompts (`<verify-script>`). Touches `Repository.{checkScript,checkTimeout}` →
-  `{verifyScript,verifyTimeout}`, the `CheckRun` / `CheckRunOutcome` / `CheckRunPhase` types →
-  `VerifyRun` / `VerifyRunOutcome` / `VerifyRunPhase`, the `Attempt.checkRuns` field → `verifyRuns`, the
-  `pre-task-check.ts` / `post-task-check.ts` leaves → `pre-task-verify.ts` / `post-task-verify.ts`, the
-  `run-check-script.ts` use case → `run-verify-script.ts`, the prompt section `## Check Script` →
-  `## Verify Script` (placeholder `{{CHECK_SCRIPT_SECTION}}` → `{{VERIFY_SCRIPT_SECTION}}`), and every TUI
-  label / log message in that domain. Persisted `project.json` and per-task `tasks.json` records written
-  before the rename continue to load via lazy migration in the Zod schema: legacy `checkScript` /
-  `checkTimeout` / `checkRuns` fields are read once, migrated to the new field names in the in-memory
-  entity, and dropped on the next save. No manual migration step.
+### Breaking
 
-### Removed
-
-- **`src/integration/ai/signals/` (24 files) deleted.** Production code is fully off the
-  legacy XML-tag parser pipeline after the three remaining flows migrated. Per-kind parsers
-  - parser registry + `consumeSignals` / `readSignalsFile` / `withSignalsTempPath` /
-    `sink.ts` are gone. The 15 per-kind parsers moved to `tests/helpers/legacy-signal-parsers/`
-    (test infrastructure only; `fake-ai-provider.ts` still uses them). Dead-only tests
-    (`consume-signals.test.ts`, `temp-signals-file.test.ts`, `read-signals-file.test.ts`)
-    deleted. ESLint fence on `src/integration/ai/signals/**` prevents accidental re-creation.
-
-- **`CI=true` auto-retry for pnpm no-TTY aborts on `setup-script`.** A successful retry could mask drift
-  from the real baseline the post-task verify gate later runs without `CI=true` (Maven Surefire skips
-  `@DisabledIfEnvironmentVariable("CI")` tests, Spring Boot env-gated tests skip, pnpm switches to
-  non-interactive / frozen-lockfile semantics). The marker detection and the actionable project-side hint
-  (pin pnpm < 11, resync in a terminal, or set `confirm-modules-purge=false`) are preserved.
+- (none in this section — see _Changed_ for field renames and schema reshapes that load older
+  files via best-effort migration on read.)
 
 ### Added
 
-- **Coverage thresholds in `vitest.config.ts`.** v8 provider with regression floors set ~5%
-  below the 2026-05-23 baseline (statements 80 · branches 70 · functions 90 · lines 85);
-  CI catches real drops without flapping on natural drift.
+- **Per-flow AI settings + four-preset bootstrap (`mixed`, `claude-only`, `copilot-only`, `codex-only`).**
+  Apply via `ralphctl settings apply-preset <name>` from the CLI or the TUI settings view. A preset stamps
+  the entire `ai` section in one shot; subsequent per-key edits via
+  `ralphctl settings set ai.<flow>.<field> <value>` stick.
 
-- **Sequence + data-flow diagrams under `.claude/docs/diagrams/`.** State machines and
-  nested-subgraph flowcharts replaced with one-Mermaid-block-per-file sequence diagrams that
-  narrate "what happens, in order." New `04-ai-session-data-flow.md` documents the audit-[09]
-  file-based contract end to end.
+- **Fail-fast PATH probe on every AI-spawning flow.** The launcher probes for the configured CLI
+  (`claude` / `gh` / `codex`) at launch and exits with a clear error naming the binary, the flow, and
+  the offending `settings.ai.<flow>.provider` key when the binary is absent. First-run auto-seeds a preset
+  based on what's installed.
 
-- **`HarnessSignalEvent` AppEvent variant.** A new `harness-signal` event on the `AppEvent` union carries
-  `signalKind` (`'change' | 'learning' | 'note'`), optional `taskId`, and `text`. Published by the signal
-  adapter whenever the AI emits a `<change>`, `<learning>`, or `<note>` tag during an in-flight task, so
-  `<sprintDir>/chain.log` retains a machine-readable record of the per-task narrative that `progress.md`
-  can reconstruct on every snapshot regenerate.
+- **Readiness fan-out across every referenced provider.** One native context file per provider
+  (claude-code → `CLAUDE.md`, github-copilot → `.github/copilot-instructions.md`, openai-codex →
+  `AGENTS.md`). Single-provider configurations produce exactly one file; mixed configurations produce one
+  per distinct provider.
 
-- **Per-task `#### Changes` / `#### Learnings` / `#### Notes` sub-sections in `progress.md`.** The
-  `state-projection.ts` miner reads `harness-signal` entries from `chain.log`, groups them by `taskId`,
-  and exposes them as `TaskProjection.{changes, learnings, notes}`. `render-progress-markdown.ts`
-  renders these under each `### Task N — <name>` section.
-
-- **Machine-readable JSON block at the bottom of `progress.md`.** A `<!-- machine:begin -->` / `<!-- machine:end -->`
-  fenced JSON payload (`sprintId`, `status`, task array with `id`, `name`, `status`, `attempts`,
-  `blockReason?`, `lastVerdict?`, `commitSha?`) closes every generated `progress.md` for tooling that
-  needs to parse sprint state without loading the full entity layer.
+- **`ralphctl snapshot [--sprint <id>]` CLI command.** Writes a single-frame text digest of the active
+  sprint's current state to stdout (no Ink mount) — header, status, tasks table, active-task block,
+  recent-signals tail. Resolves sprint from `--sprint`, then from the pinned selection; exits 1 with a hint
+  when neither is set.
 
 - **`ralphctl sprint regenerate-progress <id>` CLI subcommand.** Rebuilds `progress.md` from disk state
   (`chain.log` + `decisions.log` + `sprint.json` / `tasks.json` / `execution.json`) without running
@@ -107,23 +70,38 @@ to [Semantic Versioning](https://semver.org/).
 - **Banner full ↔ compact toggle on `b`.** A global `b` hotkey flips the banner between full and compact for
   the session. Implement view defaults to compact so long runs preserve vertical real estate.
 
-- **Signal legend replaced by inline kinds bar + help overlay entry.** The static 6-row `SignalLegend` is gone;
-  a one-row `InlineKindsBar` labels only the signal kinds that have actually appeared in the run. A Signals
-  reference section in the help overlay (`?`) auto-populates from the same colour-map. `NO_COLOR` glyph backups
-  (`change → +`, `learning → ~`, `decision → ◇`, `verified → ★`, `blocked → △`, `commit → ■`, `note → •`)
-  ensure signal-kind discrimination survives monochrome terminals.
+- **Sprint-level `decisions.log` + prompt-driven decision capture.** A new `_partials/decisions.md` prompt
+  section instructs the AI to emit `<decision>` tags for non-obvious architectural choices. A
+  `decisions-log-sink` appends one line per decision to `<sprintDir>/decisions.log` (atomic serial drain);
+  `projectSprintState` merges decisions-log entries into the `## Decisions` section of `progress.md`.
 
-- **SprintState projection as single TUI/progress.md surface.** A pure `projectSprintState` function projects
-  Sprint + SprintExecution + Task[] + chain.log entries into a normalised view model used by both the progress
-  renderer and TUI panels. Encodes effective-status synthesis (active-but-all-blocked → `'blocked'`), stale-task
-  detection (24 h threshold), dependency-cycle detection with orphan synthesis, run-boundary grouping, and median
-  attempt-duration for ETA.
+- **Per-task `#### Changes` / `#### Learnings` / `#### Notes` sub-sections in `progress.md`.** The
+  `state-projection.ts` miner reads `harness-signal` entries from `chain.log`, groups them by `taskId`,
+  and exposes them as `TaskProjection.{changes, learnings, notes}`. `render-progress-markdown.ts`
+  renders these under each `### Task N — <name>` section.
+
+- **`HarnessSignalEvent` AppEvent variant.** A new `harness-signal` event on the `AppEvent` union carries
+  `signalKind` (`'change' | 'learning' | 'note'`), optional `taskId`, and `text`. Published by the signal
+  adapter whenever the AI emits a `<change>`, `<learning>`, or `<note>` tag during an in-flight task, so
+  `<sprintDir>/chain.log` retains a machine-readable record of the per-task narrative that `progress.md`
+  can reconstruct on every snapshot regenerate.
+
+- **Machine-readable JSON block at the bottom of `progress.md`.** A `<!-- machine:begin -->` / `<!-- machine:end -->`
+  fenced JSON payload (`sprintId`, `status`, task array with `id`, `name`, `status`, `attempts`,
+  `blockReason?`, `lastVerdict?`, `commitSha?`) closes every generated `progress.md` for tooling that
+  needs to parse sprint state without loading the full entity layer.
 
 - **`progress.md` snapshot renderer replaces streaming sink.** `renderProgressMarkdown` turns the SprintState
   projection into a Markdown bootstrap document targeting a fresh AI session — sections for status, branch/PR,
   tickets, tasks, blockers, stale tasks, dependency cycles, decisions, and recent runs. Empty sections are
   omitted. Snapshot regenerates at three trigger points: sprint start, post-settle, post-review transition.
   Legacy streaming `progress-file-sink` and `flush-progress-sink` leaf removed.
+
+- **SprintState projection as single TUI/progress.md surface.** A pure `projectSprintState` function projects
+  Sprint + SprintExecution + Task[] + chain.log entries into a normalised view model used by both the progress
+  renderer and TUI panels. Encodes effective-status synthesis (active-but-all-blocked → `'blocked'`), stale-task
+  detection (24 h threshold), dependency-cycle detection with orphan synthesis, run-boundary grouping, and median
+  attempt-duration for ETA.
 
 - **Global `g` overlay reads `progress.md` from disk.** Pressing `g` (when a sprint is loaded) opens a
   read-only, scrollable Ink overlay mirroring `<sprintDir>/progress.md`. Esc or `g` again dismisses. The file
@@ -191,16 +169,6 @@ spawn-error | skipped`). The runner appends every attempt without upsert. Spawn-
   `wl-copy` / `xclip` / `clip.exe`. A 2-second banner confirms success or reports the error; the hotkey is
   best-effort and never throws into the TUI.
 
-- **`ralphctl snapshot [--sprint <id>]` CLI command.** Writes a single-frame text digest of the active
-  sprint's current state to stdout (no Ink mount) — header, status, tasks table, active-task block,
-  recent-signals tail. Resolves sprint from `--sprint`, then from the pinned selection; exits 1 with a hint
-  when neither is set.
-
-- **Sprint-level `decisions.log` + prompt-driven decision capture.** A new `_partials/decisions.md` prompt
-  section instructs the AI to emit `<decision>` tags for non-obvious architectural choices. A
-  `decisions-log-sink` appends one line per decision to `<sprintDir>/decisions.log` (atomic serial drain);
-  `projectSprintState` merges decisions-log entries into the `## Decisions` section of `progress.md`.
-
 - **Collapsed-by-default task cards with `j`/`k` expansion.** Non-active task cards collapse to a single-line
   summary (`<icon> <name> · <status> · <attempts>× · <sha?>`). The active task auto-expands. `j`/`k`/arrows
   navigate; Enter/Space expand a focused card; Esc collapses a manually-expanded card (active card exempt).
@@ -228,6 +196,12 @@ generate tasks`; on the first round before any signal fires, the active-task spi
   critique-prose shift (trigram Jaccard < 0.5), and proposed-commit-subject change (softened to a non-exiting
   warning). `settings.harness.plateauThreshold` (2–5, default 2) is configurable.
 
+- **Signal legend replaced by inline kinds bar + help overlay entry.** The static 6-row `SignalLegend` is gone;
+  a one-row `InlineKindsBar` labels only the signal kinds that have actually appeared in the run. A Signals
+  reference section in the help overlay (`?`) auto-populates from the same colour-map. `NO_COLOR` glyph backups
+  (`change → +`, `learning → ~`, `decision → ◇`, `verified → ★`, `blocked → △`, `commit → ■`, `note → •`)
+  ensure signal-kind discrimination survives monochrome terminals.
+
 - **Context-compacted signal type + TUI marker.** `ContextCompactedSignal` is a first-class lifecycle event
   for the provider's auto-compaction boundary, rendered as a dedented separator line in the signal stream using
   the muted colour token.
@@ -241,6 +215,11 @@ generate tasks`; on the first round before any signal fires, the active-task spi
   Enter/Space, revealing the full commit message (subject, body paragraphs, harness-appended `Closes #…`
   trailer). A disclosure glyph (`▸` / `▾`) replaces one leading space; degenerate subject-only rows suppress
   the caret.
+
+- **Cross-project sprint picker (`S`) and project picker (`P`).** Two new global hotkeys open modal
+  overlay pickers that work from any view. The sprint picker's `t` key toggles scope between the current
+  project and all projects. `setProjectAndSprint` on the `SelectionApi` updates project and sprint
+  atomically — no partial state visible mid-transition.
 
 - **Named responsive breakpoints + `useBreakpoint` hook.** `theme/tokens.ts` now exports a full web-style
   breakpoint vocabulary for terminal widths: `sm` (80), `md` (100), `lg` (140), `xl` (180), `xxl` (220).
@@ -258,15 +237,50 @@ generate tasks`; on the first round before any signal fires, the active-task spi
   `label` when present and mid-truncates to fit the rail column budget, preventing path-jammed element
   names from appearing in the rail.
 
-- **Cross-project sprint picker (`S`) and project picker (`P`).** Two new global hotkeys open modal
-  overlay pickers that work from any view. The sprint picker's `t` key toggles scope between the current
-  project and all projects. `setProjectAndSprint` on the `SelectionApi` updates project and sprint
-  atomically — no partial state visible mid-transition.
-
 - **Copilot `session.cwd` forwarded to spawned child process.** Provider adapters now pass
   `AiSession.cwd` as the child process working directory so context-file autoload
   (`CLAUDE.md` / `.github/copilot-instructions.md` / `AGENTS.md`), agents, and `.mcp.json` resolve
   correctly from the repo root rather than ralphctl's own cwd.
+
+### Changed
+
+- **Domain rename: `checkScript` → `verifyScript` everywhere.** Aligns the field name with the user-facing
+  verb the harness emits in prompts (`<verify-script>`). Touches `Repository.{checkScript,checkTimeout}` →
+  `{verifyScript,verifyTimeout}`, the `CheckRun` / `CheckRunOutcome` / `CheckRunPhase` types →
+  `VerifyRun` / `VerifyRunOutcome` / `VerifyRunPhase`, the `Attempt.checkRuns` field → `verifyRuns`, the
+  `pre-task-check.ts` / `post-task-check.ts` leaves → `pre-task-verify.ts` / `post-task-verify.ts`, the
+  `run-check-script.ts` use case → `run-verify-script.ts`, the prompt section `## Check Script` →
+  `## Verify Script` (placeholder `{{CHECK_SCRIPT_SECTION}}` → `{{VERIFY_SCRIPT_SECTION}}`), and every TUI
+  label / log message in that domain. The Zod schema accepts the legacy keys on read; reach for a fresh
+  start (`mv ~/.ralphctl ~/.ralphctl.bak`) if anything looks off.
+
+- **One signal pipeline (file-based contract) for every AI-spawning leaf.** The three legacy
+  flows (`review/review-round`, `detect-scripts/propose`, `detect-skills/propose`) migrated to
+  the Zod-validated `<leaf>.contract.ts` shape that `implement`, `refine`, `plan`, `ideate`,
+  and `readiness` already used. The AI writes one `signals.json` envelope to `outputDir` via
+  its Write tool; the harness validates post-spawn via `validateSignalsFile`, fans signals to
+  the sink + event bus, and renders sidecars from the validated array. Replaces a long-standing
+  brittleness vector when CLI vendors tweak JSON shape.
+
+- **Permission model split into capabilities and topology.** `SessionPermissions` now has
+  `canModifyRepoFiles` (renamed from `canEditFiles`) which gates `Edit` / `MultiEdit` /
+  `NotebookEdit` only; the `Write` tool is **always** allowed because the file-based contract
+  requires it for `signals.json`. Path scope is the primary defense and lives on `AiSession`
+  (`cwd` + `additionalRoots` + `outputDir`). A new `providers/_engine/resolve-roots.ts`
+  helper auto-mounts `outputDir` as a writable root in every provider, so leaves never need
+  to thread it manually. Codex collapses to `-s workspace-write` for every profile because
+  its `read-only` sandbox blocks every write including `signals.json` — topology now carries
+  the safety envelope on Codex.
+
+- **Removed `CI=true` auto-retry for pnpm no-TTY aborts on `setup-script`.** A successful retry could mask
+  drift from the real baseline the post-task verify gate later runs without `CI=true` (Maven Surefire skips
+  `@DisabledIfEnvironmentVariable("CI")` tests, Spring Boot env-gated tests skip, pnpm switches to
+  non-interactive / frozen-lockfile semantics). The marker detection and the actionable project-side hint
+  (pin pnpm < 11, resync in a terminal, or set `confirm-modules-purge=false`) are preserved.
+
+- **Shell scripts use narrow pnpm flag.** Setup and check scripts no longer set `CI=true` when
+  invoking pnpm — the narrower `--reporter=default` flag is used instead, avoiding accidental CI
+  detection in downstream tooling.
 
 ### Fixed
 
@@ -305,11 +319,25 @@ generate tasks`; on the first round before any signal fires, the active-task spi
   objects are forwarded to the log instead of dropped; the body-text parser now matches a wider range
   of Copilot CLI output shapes for more robust signal extraction.
 
-- **Shell scripts use narrow pnpm flag.** Setup and check scripts no longer set `CI=true` when
-  invoking pnpm — the narrower `--reporter=default` flag is used instead, avoiding accidental CI
-  detection in downstream tooling.
+### Internal
 
-### Changed
+- **`src/integration/ai/signals/` (24 files) deleted.** Production code is fully off the
+  legacy XML-tag parser pipeline after the three remaining flows migrated. Per-kind parsers
+  - parser registry + `consumeSignals` / `readSignalsFile` / `withSignalsTempPath` /
+    `sink.ts` are gone. The 15 per-kind parsers moved to `tests/helpers/legacy-signal-parsers/`
+    (test infrastructure only; `fake-ai-provider.ts` still uses them). Dead-only tests
+    (`consume-signals.test.ts`, `temp-signals-file.test.ts`, `read-signals-file.test.ts`)
+    deleted. `HarnessSignalSink` moves to `src/business/observability/harness-signal-sink.ts`.
+    ESLint fence on `src/integration/ai/signals/**` prevents accidental re-creation.
+
+- **Coverage thresholds in `vitest.config.ts`.** v8 provider with regression floors set ~5%
+  below the 2026-05-23 baseline (statements 80 · branches 70 · functions 90 · lines 85);
+  CI catches real drops without flapping on natural drift.
+
+- **Sequence + data-flow diagrams under `.claude/docs/diagrams/`.** State machines and
+  nested-subgraph flowcharts replaced with one-Mermaid-block-per-file sequence diagrams that
+  narrate "what happens, in order." New `04-ai-session-data-flow.md` documents the file-based
+  contract end to end.
 
 - **`decisions-log-sink` caps decision body at 500 chars.** Defence-in-depth — the parser already rejects
   bodies over 500 chars, but the sink now slices independently so a non-parser source cannot produce a
@@ -322,8 +350,6 @@ generate tasks`; on the first round before any signal fires, the active-task spi
 - **Setup-script runner migrated off deprecated `SETUP_TAIL_BYTES`.** Both `SetupRun` and `CheckRun` now
   import `SCRIPT_TAIL_BYTES` from the shared constant; the deprecated `SETUP_TAIL_BYTES` alias is kept for
   backward compat until removed.
-
-### Internal
 
 - **`commit-task` leaf re-emits `CommitMessageSignal` with `fullMessage`** after `appendTrailerToMessage` so
   TUI and audit-log consumers see the exact text that landed in git history, not the AI's pre-trailer proposal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,9 @@ pnpm lint:fix            # Auto-fix lint issues
 pnpm format              # Format all files with Prettier
 ```
 
+> Pre-commit hooks (lint + format on staged files) are installed automatically
+> on `pnpm install` via Husky. No manual setup needed.
+
 ## Making changes
 
 1. **Fork and branch.** Create a feature branch from `main`:
@@ -116,16 +119,18 @@ See [ARCHITECTURE.md](./.claude/docs/ARCHITECTURE.md) for the full technical ref
 
 ## Releasing
 
-Releases are automated via GitHub Actions. To publish a new version:
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml),
+which triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+`. To cut a release:
 
-1. Bump the version in `package.json`
-2. Update `CHANGELOG.md` with the new version section
-3. Commit: `git commit -am "chore: bump version to X.Y.Z"`
+1. Bump `package.json#version` to `X.Y.Z`
+2. Move `## [Unreleased]` to `## [X.Y.Z] - <date>` in `CHANGELOG.md`
+3. Commit: `git commit -am "chore: release X.Y.Z"`
 4. Tag: `git tag vX.Y.Z`
 5. Push: `git push origin main --tags`
 
-The release pipeline will run CI checks, publish to npm, and create a GitHub Release with the changelog section for that
-version.
+The workflow runs the full CI gate (typecheck / lint / test), publishes to
+npm with `--provenance`, and drafts a GitHub Release from the matching
+CHANGELOG section.
 
 ## Questions?
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,14 +13,14 @@ Only the latest version is supported — no backporting, no parallel branches.
 The sections below give per-version context for what changed and why, in case
 you're crossing a big jump and want to know what to expect.
 
-## 0.7.x → upcoming (Unreleased)
+## 0.7.x → 0.8.0
 
-The Unreleased work flattens AI settings to per-flow rows, renames `checkScript`
-→ `verifyScript`, and consolidates the signal pipeline onto the file-based
+0.8.0 flattens AI settings to per-flow rows, renames `checkScript` →
+`verifyScript`, and consolidates the signal pipeline onto the file-based
 contract. The harness will try to read your old settings and data, but if
 anything looks off after upgrading, the safe path is to back up `~/.ralphctl/`
 and start fresh — sprints are short-lived and projects are quick to re-register.
-See [CHANGELOG](./CHANGELOG.md#unreleased) for the full list.
+See [CHANGELOG](./CHANGELOG.md#080---2026-05-24) for the full list.
 
 ## 0.6.x → 0.7.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,77 @@
+# Migration Guide
+
+The universal upgrade recipe for ralphctl is always:
+
+```bash
+npm install -g ralphctl@latest
+ralphctl settings apply-preset <name>    # if your settings need a reset
+mv ~/.ralphctl ~/.ralphctl.bak           # only if your old data doesn't load cleanly
+ralphctl                                  # re-register projects as the TUI prompts
+```
+
+Only the latest version is supported — no backporting, no parallel branches.
+The sections below give per-version context for what changed and why, in case
+you're crossing a big jump and want to know what to expect.
+
+## 0.7.x → upcoming (Unreleased)
+
+The Unreleased work flattens AI settings to per-flow rows, renames `checkScript`
+→ `verifyScript`, and consolidates the signal pipeline onto the file-based
+contract. The harness will try to read your old settings and data, but if
+anything looks off after upgrading, the safe path is to back up `~/.ralphctl/`
+and start fresh — sprints are short-lived and projects are quick to re-register.
+See [CHANGELOG](./CHANGELOG.md#unreleased) for the full list.
+
+## 0.6.x → 0.7.0
+
+> **0.7.0 is a structural rewrite.** Internal architecture, on-disk schema, and several CLI
+> commands all changed. **There is no automatic migration from 0.6.x** — sprints, projects,
+> and settings written by 0.6.x will not be read by 0.7.0, even though the data directory
+> path is the same.
+>
+> If you launch 0.7.0 with v0.6.x data still in `~/.ralphctl/`, the harness detects the
+> legacy layout, **refuses to start**, and prints the exact backup command you need to run.
+> No data is touched. The steps below are what the safeguard will tell you.
+
+### Before upgrading
+
+1. **Back up your 0.6.x data**:
+
+   ```bash
+   mv ~/.ralphctl ~/.ralphctl.0.6-backup
+   ```
+
+2. Install the latest ralphctl:
+
+   ```bash
+   npm install -g ralphctl@latest
+   ```
+
+3. Launch the TUI and re-register your projects:
+
+   ```bash
+   ralphctl
+   ```
+
+4. (Optional) Re-create sprints by hand from the backup — `~/.ralphctl.0.6-backup/data/sprints/<id>/`
+   still holds the original ticket bodies, plan output, and progress notes for reference.
+
+### What changed
+
+- **On-disk schema is incompatible.** Each sprint now spans three files — `sprint.json` (planning),
+  `execution.json` (branch / PR / setup audit), `tasks.json` (the task list) — instead of the single
+  0.6.x `sprint.json`. Override the data root with `RALPHCTL_HOME=<absolute-path>` if you need a
+  separate location.
+- **`settings.json` schema changed.** Per-flow model selection replaces the single global `model`;
+  each chain picks its own. 0.6.x settings files are rejected on read — re-run `ralphctl settings`
+  to reconfigure.
+- **CLI surface intentionally smaller.** These commands were removed in favour of the TUI:
+  `sprint feedback / edit`, `ticket approve / edit`, `project repo add / remove`, all
+  `task add / edit / edit-status / remove`, and `sessions list / attach / detach / kill`. Switch
+  to the interactive TUI or to `ralphctl sprint show <id>` / the relevant flow command.
+- **OpenAI Codex provider added** (preview) alongside Claude Code and GitHub Copilot — pick via
+  `ralphctl settings`.
+
+See [CHANGELOG.md](./CHANGELOG.md#070---2026-05-18) for the full list, including non-breaking
+improvements (cross-project sprint lock, idle-stdout watchdog, resume-aborted runs, persistent
+`<sprintDir>/chain.log`, exponential rate-limit backoff).

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ with [GitHub Copilot](https://docs.github.com/en/copilot/github-copilot-in-the-c
 > _"I'm helping!"_ — Ralph Wiggum
 
 > [!NOTE]
-> **Active development** — new features and polish ship regularly. Setup is quick, so upgrading is low-friction.
-> See [CHANGELOG](./CHANGELOG.md).
+> **Active development.** New features and polish ship regularly. The 0.7.x
+> line landed a burst of structural changes — thanks for sticking with us
+> through it. Upgrades are simple: install the latest version, redo your
+> config, proceed. See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
 
 ---
 
@@ -90,8 +92,16 @@ ralphctl export-context --sprint <id> --project <id> --output <path>
 
 # Settings
 ralphctl settings show
-ralphctl settings set ai.provider claude-code
-ralphctl settings set ai.models.implement <model-id>
+ralphctl settings apply-preset claude-only     # or mixed / copilot-only / codex-only
+ralphctl settings set ai.implement.provider claude-code
+ralphctl settings set ai.implement.model      <model-id>
+ralphctl settings set ai.implement.effort     high
+
+# Rebuild a sprint's progress.md from disk
+ralphctl sprint regenerate-progress <sprint-id>
+
+# Single-frame text digest of the active sprint
+ralphctl snapshot [--sprint <id>]
 ```
 
 </details>
@@ -150,6 +160,9 @@ forensic artifacts). Codex cannot fine-grained-deny edits on existing repo files
 path scope (cwd + `--add-dir`) is the only safety envelope. If you hit a rough edge on a preview provider,
 please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
+One-shot configuration for any provider: `ralphctl settings apply-preset <name>` where `<name>` is
+`mixed`, `claude-only`, `copilot-only`, or `codex-only`.
+
 ---
 
 ## Features
@@ -173,24 +186,34 @@ please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
 ## Configuration
 
-Configure via the TUI `Settings` view or one-shot CLI commands:
+Configure via the TUI `Settings` view or one-shot CLI commands.
+
+**Quickest path — apply a preset:**
 
 ```bash
-ralphctl settings set ai.provider claude-code         # Use Claude Code (stable)
-ralphctl settings set ai.provider github-copilot      # Use GitHub Copilot (preview)
-ralphctl settings set ai.provider openai-codex        # Use OpenAI Codex (preview)
+ralphctl settings apply-preset mixed          # best-fit provider per flow
+ralphctl settings apply-preset claude-only    # every flow on Claude Code
+ralphctl settings apply-preset copilot-only   # every flow on GitHub Copilot
+ralphctl settings apply-preset codex-only     # every flow on OpenAI Codex
 ```
 
-The selected provider's CLI must be in your `PATH` and authenticated. The TUI prompts you on first launch if no provider
-is configured.
+A preset stamps the entire `ai` section in one shot. None is marked default; on a fresh install the welcome
+view silently auto-seeds a preset based on which provider CLIs it detects on `PATH`.
 
-**Per-flow model selection.** Each chain (`refine`, `plan`, `implement`, `ideate`, `readiness`) carries its own model
-from the configured provider's catalog:
+**Per-flow settings.** Each chain (`refine`, `plan`, `implement`, `ideate`, `readiness`) carries its own
+`{provider, model, effort?}` row. Edit individual keys with:
 
 ```bash
-ralphctl settings set ai.models.implement <model-id>
-ralphctl settings set ai.models.plan      <model-id>
+ralphctl settings set ai.implement.provider claude-code
+ralphctl settings set ai.implement.model    <model-id>
+ralphctl settings set ai.implement.effort   high
+
+ralphctl settings set ai.plan.provider      github-copilot
+ralphctl settings set ai.plan.model         <model-id>
 ```
+
+The selected provider's CLI must be in your `PATH` and authenticated. Every AI-spawning flow probes its
+row's CLI at launch and exits with a clear error if the binary is missing.
 
 **Tune the generator-evaluator loop** (under `harness`):
 
@@ -224,57 +247,28 @@ export RALPHCTL_HOME="/path/to/custom/dir"
 
 ---
 
-## Upgrading from 0.6.x to 0.7.0
+## Upgrading
 
-> [!IMPORTANT]
-> **0.7.0 is a structural rewrite.** Internal architecture, on-disk schema, and several CLI
-> commands all changed. **There is no automatic migration from 0.6.x** — sprints, projects,
-> and settings written by 0.6.x will not be read by 0.7.0, even though the data directory
-> path is the same.
->
-> If you launch 0.7.0 with v0.6.x data still in `~/.ralphctl/`, the harness detects the
-> legacy layout, **refuses to start**, and prints the exact backup command you need to run.
-> No data is touched. The steps below are what the safeguard will tell you.
+Install the latest version, redo your config, proceed. Only the latest
+release is supported — there's no backporting, and upgrading is the answer
+to most "is this fixed?" questions.
 
-### Before upgrading
+```bash
+npm install -g ralphctl@latest
+ralphctl settings apply-preset <name>    # if your settings need a reset
+ralphctl                                  # TUI prompts you to re-register projects if needed
+```
 
-1. **Back up your 0.6.x data**:
+If your `~/.ralphctl/` data from an older release doesn't load cleanly, back
+it up and start fresh:
 
-   ```bash
-   mv ~/.ralphctl ~/.ralphctl.0.6-backup
-   ```
+```bash
+mv ~/.ralphctl ~/.ralphctl.bak
+```
 
-2. Install ralphctl (the latest published version is `0.7.x` — pin only if you need a specific patch):
-
-   ```bash
-   npm install -g ralphctl
-   ```
-
-3. Launch the TUI and re-register your projects:
-
-   ```bash
-   ralphctl
-   ```
-
-4. (Optional) Re-create sprints by hand from the backup — `~/.ralphctl.0.6-backup/data/sprints/<id>/` still holds the
-   original ticket bodies, plan output, and progress notes for reference.
-
-### What changed
-
-- **On-disk schema is incompatible.** Each sprint now spans three files — `sprint.json` (planning), `execution.json` (
-  branch / PR / setup audit), `tasks.json` (the task list) — instead of the single 0.6.x `sprint.json`. Override the
-  data root with `RALPHCTL_HOME=<absolute-path>` if you need a separate location.
-- **`settings.json` schema changed.** Per-flow model selection replaces the single global `model`; each chain picks its
-  own. 0.6.x settings files are rejected on read — re-run `ralphctl settings` to reconfigure.
-- **CLI surface intentionally smaller.** These commands were removed in favour of the TUI: `sprint feedback / edit`,
-  `ticket approve / edit`, `project repo add / remove`, all `task add / edit / edit-status / remove`, and
-  `sessions list / attach / detach / kill`. Switch to the interactive TUI or to `ralphctl sprint show <id>` / the
-  relevant flow command.
-- **OpenAI Codex provider added** (preview) alongside Claude Code and GitHub Copilot — pick via `ralphctl settings`.
-
-See [CHANGELOG.md](./CHANGELOG.md#070---2026-05-17) for the full list, including non-breaking improvements (
-cross-project sprint lock, idle-stdout watchdog, resume-aborted runs, persistent `<sprintDir>/chain.log`, exponential
-rate-limit backoff).
+The backup keeps your ticket bodies, plan output, and progress notes around
+for reference. See [MIGRATION.md](./MIGRATION.md) if you're crossing a major
+boundary (e.g. 0.6.x → 0.7.x) and want the longer story.
 
 ---
 
@@ -286,13 +280,15 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 
 ### Getting Started
 
-| Command                               | Description                       |
-| ------------------------------------- | --------------------------------- |
-| `ralphctl`                            | Interactive TUI (primary surface) |
-| `ralphctl doctor`                     | Check environment health          |
-| `ralphctl settings show`              | Print current settings            |
-| `ralphctl settings set <key> <value>` | Set a single settings key         |
-| `ralphctl completion <shell>`         | Print shell tab-completion script |
+| Command                                 | Description                                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------------- |
+| `ralphctl`                              | Interactive TUI (primary surface)                                                       |
+| `ralphctl doctor`                       | Check environment health                                                                |
+| `ralphctl settings show`                | Print current settings                                                                  |
+| `ralphctl settings set <key> <value>`   | Set a single settings key                                                               |
+| `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section (`mixed` / `claude-only` / `copilot-only` / `codex-only`) |
+| `ralphctl completion <shell>`           | Print shell tab-completion script                                                       |
+| `ralphctl snapshot [--sprint <id>]`     | Single-frame text digest of sprint state                                                |
 
 ### Project & Sprint Inspection
 
@@ -312,11 +308,12 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 
 ### Sprint Lifecycle
 
-| Command                         | Description                     |
-| ------------------------------- | ------------------------------- |
-| `ralphctl sprint activate <id>` | Flip a draft sprint to `active` |
-| `ralphctl sprint close <id>`    | Transition `review` → `done`    |
-| `ralphctl sprint remove <id>`   | Delete a sprint permanently     |
+| Command                                    | Description                           |
+| ------------------------------------------ | ------------------------------------- |
+| `ralphctl sprint activate <id>`            | Flip a draft sprint to `active`       |
+| `ralphctl sprint close <id>`               | Transition `review` → `done`          |
+| `ralphctl sprint remove <id>`              | Delete a sprint permanently           |
+| `ralphctl sprint regenerate-progress <id>` | Rebuild `progress.md` from disk state |
 
 ### Export & PR
 
@@ -334,12 +331,13 @@ Run `ralphctl <command> --help` for flag-level detail.
 
 ## Documentation
 
-| Resource                                       | Description                                |
-| ---------------------------------------------- | ------------------------------------------ |
-| [Architecture](./.claude/docs/ARCHITECTURE.md) | Data models, file storage, error reference |
-| [Requirements](./.claude/docs/REQUIREMENTS.md) | Acceptance criteria and feature checklist  |
-| [Contributing](./CONTRIBUTING.md)              | Dev setup, code style, PR process          |
-| [Changelog](./CHANGELOG.md)                    | Version history                            |
+| Resource                                       | Description                                       |
+| ---------------------------------------------- | ------------------------------------------------- |
+| [Architecture](./.claude/docs/ARCHITECTURE.md) | Data models, file storage, error reference        |
+| [Requirements](./.claude/docs/REQUIREMENTS.md) | Acceptance criteria and feature checklist         |
+| [Contributing](./CONTRIBUTING.md)              | Dev setup, code style, PR process                 |
+| [Migration](./MIGRATION.md)                    | Per-version upgrade context for big version jumps |
+| [Changelog](./CHANGELOG.md)                    | Version history                                   |
 
 **Blog posts:** [Building ralphctl](https://lukasgrigis.dev/blog/building-ralphctl) (
 backstory) | [From task CLI to agent harness](https://lukasgrigis.dev/blog/ralphctl-agent-harness/) (evaluator

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,11 +25,22 @@ through [GitHub's private vulnerability reporting](https://github.com/lukas-grig
 RalphCTL is a local CLI tool. The main security considerations are:
 
 - **File system access** — ralphctl reads/writes to `~/.ralphctl/` and project directories
-- **Process spawning** — ralphctl spawns `claude` CLI processes with user-provided prompts
-- **No network access** — ralphctl itself makes no network requests (Claude CLI handles its own connections)
+- **Process spawning** — ralphctl spawns AI provider CLIs (`claude`, `gh`, `codex`) with user-provided prompts
+- **No network access** — ralphctl itself makes no network requests; the spawned AI CLIs handle their own connections
+
+### Permission model
+
+The harness uses two orthogonal axes to constrain what a spawned AI session can touch:
+
+- **Capabilities** (`SessionPermissions`) gate per-tool actions: `canModifyRepoFiles`, `canRunShell`, `canAccessNetwork`, `autoApprove`.
+- **Topology** (`cwd` + `additionalRoots` + `outputDir` on the `AiSession`) defines which paths the AI can read or write at all.
+
+Topology is the primary defense. The `Write` tool is always allowed under every profile because the file-based provider contract requires the AI to land `signals.json` in `outputDir` — to deny writes to a tree, don't mount it. See [CLAUDE.md § Security & Safety](./CLAUDE.md#security--safety) for the per-provider mapping (Claude Code / GitHub Copilot / OpenAI Codex).
 
 ## Supported versions
 
-| Version | Supported |
-| ------- | --------- |
-| 0.0.x   | Yes       |
+Only the **latest published version** of ralphctl is supported. There is no
+backporting of fixes to older minors — if you're on an older release, the
+first step toward any fix is to upgrade. Reports against unsupported
+versions will be acknowledged but resolved by asking you to reproduce on
+latest.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ralphctl",
   "version": "0.7.3",
-  "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code & GitHub Copilot across repositories",
+  "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Apology + thanks at the top of `## [0.8.0] - 2026-05-24` in CHANGELOG; restructured the body so user-impact leads and developer internals come last
- README softened (stays "Active development"), stale `ai.provider` / `ai.models.*` examples refreshed to per-flow `ai.<flow>.{provider,model,effort}`, 0.6→0.7 upgrade content moved out into new `MIGRATION.md`
- New `## Upgrading` README section + `MIGRATION.md` lead with the universal "install latest, redo config, proceed" recipe — no stability promises, no lazy-migration as a feature
- SECURITY.md supported-versions table replaced with latest-only prose; capabilities-vs-topology paragraph added to Scope
- CONTRIBUTING.md gains a pre-commit-hooks note and a tighter Releasing section linking the actual workflow file
- package.json description now mentions OpenAI Codex alongside Claude Code and GitHub Copilot
- Version bumped 0.7.3 → 0.8.0; `## [0.8.0] - 2026-05-24` opened in CHANGELOG with a fresh empty `## [Unreleased]` above per Keep-a-Changelog convention

## Test plan
- [x] \`pnpm typecheck && pnpm lint && pnpm test\` — 297 files / 2196 tests, green at tip
- [ ] PR CI green
- [ ] After merge: tag \`v0.8.0\` to trigger the npm publish workflow