### PR TITLE
Ingest Anthropic harness principles + audit ralphctl AI setup

### DIFF
--- a/.claude/agent-memory/docs-keeper/MEMORY.md
+++ b/.claude/agent-memory/docs-keeper/MEMORY.md
@@ -4,3 +4,4 @@
 - [reference_step_trace_locations.md](reference_step_trace_locations.md) — Where step traces live in the docs (three locations per chain)
 - [reference_agent_files_also_drift.md](reference_agent_files_also_drift.md) — .claude/agents/\*.md + .claude/docs/README.md also list kernel primitives; grep them when primitives change
 - [project_high_drift_areas.md](project_high_drift_areas.md) — Top 10 doc sections that go stale fastest; check these first after any feature drop
+- [reference_harness_principles_doc.md](reference_harness_principles_doc.md) — HARNESS-PRINCIPLES.md: 18 rows, applied/partial/gap; update when chain/flow/\_engine changes close a gap

--- a/.claude/agent-memory/docs-keeper/reference_harness_principles_doc.md
+++ b/.claude/agent-memory/docs-keeper/reference_harness_principles_doc.md
@@ -1,0 +1,18 @@
+---
+name: reference_harness_principles_doc
+description: HARNESS-PRINCIPLES.md is the canonical home for harness research principles; 18 rows with applied/partial/gap status; must be updated when chain/flow/_engine changes close a gap or weaken an applied row.
+metadata:
+  type: reference
+---
+
+`.claude/docs/HARNESS-PRINCIPLES.md` — landed in the `worktree-agent-ad1b25382f7b772d4` commits (695b488e..fbda7474).
+
+18 principles, each with **Rule** / **Source** / **ralphctl status** / **Where it lives**. Current status distribution:
+
+- `applied`: 13 principles (1–13)
+- `partial`: 2 principles (14 — minimal scaffolding, 16 — context reset)
+- `gap`: 3 principles (15 — evaluator tuning, 17 — cost-benefit framing, 18 — model-bump audit cadence)
+
+**How to apply:** When any structural change lands in `src/application/chain/`, `src/application/flows/`, or `src/integration/ai/providers/_engine/`, audit step 10 in the docs-keeper audit workflow checks whether a row's status changed. Update the status tag, "Where it lives" anchor, and remove "Next step" when a gap closes.
+
+Related: [[reference_agent_files_also_drift]] — agents also reference the principles doc now via their hooks.

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -81,6 +81,16 @@ Error: Project 'frontend' not found.
 - Sensible limits (page size, timeout)
 - Auto-detect from environment when possible
 
+### 6. Flow surface cost-benefit
+
+Flow surfaces encode cost-benefit decisions. When designing a new flow's TUI/CLI entry point, weigh `ideate`
+(single AI session, no evaluator loop, lower cost) vs full `implement` (generator → evaluator → settle,
+higher confidence, substantially higher cost). `Read .claude/docs/HARNESS-PRINCIPLES.md § Cost-benefit
+framing` before adding scaffolding to a new flow — the principle is explicit that the evaluator adds 20×
+cost and its value is tied to task difficulty relative to current model capability. Design the lighter path
+as the default for low-stakes or exploratory work; reserve the full harness for tasks where the evaluator
+demonstrably pays for itself.
+
 ## ralphctl Design Language
 
 ### Command Structure

--- a/.claude/agents/docs-keeper.md
+++ b/.claude/agents/docs-keeper.md
@@ -20,14 +20,14 @@ runtime.
 
 ralphctl maintains six spec documents that the team and other agents treat as ground truth:
 
-| Doc                                    | Purpose                                                                          |
-| -------------------------------------- | -------------------------------------------------------------------------------- |
-| `CLAUDE.md`                            | Top-of-mind constraints, common mistakes, workflow surface (auto-imported)       |
-| `.claude/docs/ARCHITECTURE.md`         | Four-module layout, ports, data models, storage, errors, exit codes              |
-| `.claude/docs/KERNEL-DESIGN.md`        | Chain framework reference (`element` / `leaf` / `sequential` / `loop` / `guard`) |
-| `.claude/docs/REQUIREMENTS.md`         | Testable acceptance criteria — the architectural fence                           |
-| `.claude/docs/DESIGN-SYSTEM.md`        | TUI tokens, components, copy rules, anti-patterns                                |
-| `.claude/docs/MANUAL-TEST-PLAYBOOK.md` | Manual smoke-test scenarios before cutting a release                             |
+| Doc                                    | Purpose                                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------------------ |
+| `CLAUDE.md`                            | Top-of-mind constraints, common mistakes, workflow surface (auto-imported)           |
+| `.claude/docs/ARCHITECTURE.md`         | Four-module layout, ports, data models, storage, errors, exit codes                  |
+| `.claude/docs/KERNEL-DESIGN.md`        | Chain framework reference (`element` / `leaf` / `sequential` / `loop` / `guard`)     |
+| `.claude/docs/REQUIREMENTS.md`         | Testable acceptance criteria — the architectural fence                               |
+| `.claude/docs/DESIGN-SYSTEM.md`        | TUI tokens, components, copy rules, anti-patterns                                    |
+| `.claude/docs/MANUAL-TEST-PLAYBOOK.md` | Manual smoke-test scenarios before cutting a release                                 |
 | `.claude/docs/HARNESS-PRINCIPLES.md`   | Distilled harness research; rules + ralphctl status tags (`applied`/`partial`/`gap`) |
 
 When code ships and these docs aren't updated alongside, the project starts lying to its future self and to

--- a/.claude/agents/docs-keeper.md
+++ b/.claude/agents/docs-keeper.md
@@ -28,6 +28,7 @@ ralphctl maintains six spec documents that the team and other agents treat as gr
 | `.claude/docs/REQUIREMENTS.md`         | Testable acceptance criteria — the architectural fence                           |
 | `.claude/docs/DESIGN-SYSTEM.md`        | TUI tokens, components, copy rules, anti-patterns                                |
 | `.claude/docs/MANUAL-TEST-PLAYBOOK.md` | Manual smoke-test scenarios before cutting a release                             |
+| `.claude/docs/HARNESS-PRINCIPLES.md`   | Distilled harness research; rules + ralphctl status tags (`applied`/`partial`/`gap`) |
 
 When code ships and these docs aren't updated alongside, the project starts lying to its future self and to
 every agent that reads them. Your job is to keep doc and code in lockstep — proactively after a meaningful
@@ -119,6 +120,10 @@ Workflows & State` (sub-section "CLI Command Surface").
 8. **TUI views and global keys.** `ls src/application/ui/tui/views/` and `cat
 src/application/ui/tui/runtime/use-global-keys.ts` vs `DESIGN-SYSTEM.md` and `REQUIREMENTS.md § TUI`.
 9. **Env vars.** `grep -rn 'process\.env\.' src/` vs the table in `CLAUDE.md § Performance & Limits`.
+10. **Harness principles.** After any structural change to `src/application/chain/`, `src/application/flows/`,
+    or `src/integration/ai/providers/_engine/` — check whether any `applied` row in
+    `.claude/docs/HARNESS-PRINCIPLES.md` was weakened or any `partial`/`gap` row was closed. Update the
+    status tag and "Where it lives" anchor as part of the same doc pass.
 
 Report findings as a delta list, then propose / apply edits. For ambiguous cases, ask the user before
 editing.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -124,6 +124,21 @@ ESLint blocks the shortcut.
 - `zod` for serialization-boundary validation; `Result` from `@src/domain/result.ts` for Result types.
 - `vitest` for testing.
 
+## Before structural harness code
+
+Before writing code that adds a chain primitive, wraps the evaluator, introduces a new sub-agent, or
+changes `src/integration/ai/providers/_engine/` — `Read .claude/docs/HARNESS-PRINCIPLES.md`. The
+principles doc names which harness components are `applied` (intentional), `partial` (incomplete), or
+`gap` (missing). Two specific rationale traces are worth calling out:
+
+- **No `retry` / no `onError` primitives** — this is not an oversight. Retry-on-429 is an adapter concern
+  (`IterationConfig.rateLimitRetries` in the headless provider wrapper); branching belongs inside a use case
+  or a `guard`. Both constraints come directly from the harness research (§ 14 Minimal scaffolding) — adding
+  either primitive would duplicate adapter logic in the chain layer and hide the retry model from callers.
+- **Evaluator over-praises by default (§ 15)** — if you are wrapping or extending the evaluator, the
+  principles doc records that this component requires ongoing prompt tuning; code changes alone do not fix
+  the grading-leniency failure mode.
+
 ## Chain framework
 
 When orchestrating a workflow, do NOT write a bespoke imperative loop. Use the chain primitives in

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -65,6 +65,15 @@ Tackle uncertainty early:
 - Don't hide complexity in "simple" tasks
 - Better to over-scope than under-scope
 
+### 5. Harness Principles Check
+
+Before proposing a plan that adds a new chain primitive, a new flow, removes an existing harness component,
+or restructures the evaluator — `Read .claude/docs/HARNESS-PRINCIPLES.md` and weigh the change against the
+relevant sections. Structural changes to `src/application/chain/`, `src/application/flows/<flow>/`,
+`src/application/registry.ts`, or `src/integration/ai/providers/_engine/` all touch territory the
+principles doc covers. The status tags (`applied` / `partial` / `gap`) tell you where ralphctl's coverage
+is thin and where a proposed removal risks regressing a load-bearing piece.
+
 ## Grounding (use Bash before guessing)
 
 You have read-only Bash. Ground every plan in actual repo state — never invent context you could have

--- a/.claude/agents/prompt-template-engineer.md
+++ b/.claude/agents/prompt-template-engineer.md
@@ -120,6 +120,7 @@ templates this role owns. Read the relevant sections before editing the affected
 
 **Evaluator over-praises by default (§ 15).** `evaluate/template.md` is the sole prompt-side control for
 grading leniency. When editing this template:
+
 - Name concrete evaluator failure modes explicitly (identifying issues then talking itself into approving;
   superficial testing; crediting incomplete work).
 - Weight subjective criteria (design quality, originality, craft) heavier than technical defaults when the
@@ -134,6 +135,7 @@ grading leniency. When editing this template:
 each govern sessions that may run immediately after a prior session or after a cold start. The model's
 behaviour differs depending on whether it assumes fresh-slate or continuity — and the template phrasing
 steers that assumption. When editing these templates:
+
 - Make fresh-slate vs continuity explicit ("no prior context is assumed — read `progress.md` to orient"
   vs "this session continues from the prior refinement pass").
 - Do not assume the AI retains memory across sessions unless the template explicitly passes prior context

--- a/.claude/agents/prompt-template-engineer.md
+++ b/.claude/agents/prompt-template-engineer.md
@@ -113,6 +113,35 @@ These come from `CLAUDE.md § Implementation Style` (prompt sub-section) and are
    pluralise placeholder names without checking the call site — the substitution layer is case-sensitive
    and exact.
 
+## Owned principle fences
+
+Two harness principles from `.claude/docs/HARNESS-PRINCIPLES.md` have their only prompt-side fence in
+templates this role owns. Read the relevant sections before editing the affected templates:
+
+**Evaluator over-praises by default (§ 15).** `evaluate/template.md` is the sole prompt-side control for
+grading leniency. When editing this template:
+- Name concrete evaluator failure modes explicitly (identifying issues then talking itself into approving;
+  superficial testing; crediting incomplete work).
+- Weight subjective criteria (design quality, originality, craft) heavier than technical defaults when the
+  task spec includes them — technical gates alone allow aesthetic failures to pass.
+- Add or maintain few-shot calibration examples that bias the evaluator toward harsh grading. A lenient
+  evaluator is worse than no evaluator; it adds cost while providing false confidence.
+
+`Read .claude/docs/HARNESS-PRINCIPLES.md § Evaluator over-praises by default` before editing
+`evaluate/template.md`.
+
+**Context reset vs compaction (§ 16).** `refine/template.md`, `plan/template.md`, and `ideate/template.md`
+each govern sessions that may run immediately after a prior session or after a cold start. The model's
+behaviour differs depending on whether it assumes fresh-slate or continuity — and the template phrasing
+steers that assumption. When editing these templates:
+- Make fresh-slate vs continuity explicit ("no prior context is assumed — read `progress.md` to orient"
+  vs "this session continues from the prior refinement pass").
+- Do not assume the AI retains memory across sessions unless the template explicitly passes prior context
+  as a filled placeholder.
+
+`Read .claude/docs/HARNESS-PRINCIPLES.md § Context reset vs compaction` before editing
+`refine/template.md`, `plan/template.md`, or `ideate/template.md`.
+
 ## Signal vocabulary discipline
 
 Every AI-spawning leaf carries a per-leaf `AiOutputContract` at

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -204,6 +204,11 @@ ralphctl uses a **four-module Clean Architecture** under `src/`. Watch for these
   it MUST exempt `AbortError`. User-initiated cancellation cannot be silently absorbed.
 - **`@public` JSDoc tag** — symbols intentionally kept after dead-code cleanup must be tagged `@public`
   (whitelisted via `knip.json`). `pnpm deadcode` exits 0 on a clean tree.
+- **Harness principles check** — for any diff touching `src/application/chain/`, `src/application/flows/<flow>/`,
+  or `src/integration/ai/providers/_engine/`, `Read .claude/docs/HARNESS-PRINCIPLES.md` before reporting.
+  Flag any `partial` or `gap` row the diff regresses (e.g. removing the idle watchdog without evidence it
+  is no longer load-bearing) and any `applied` row the diff weakens. The status tags are the source of truth
+  for which harness components are considered intentional vs. candidates for removal.
 
 ## What I Don't Do
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -183,6 +183,19 @@ Focus coverage on:
 - **Flow step-order fence tests** — `tests/integration/flows/<flow>/<flow>.test.ts` asserts
   `trace.map(s => s.elementName)` for happy + failure paths. These lock orchestration order; update them
   when intentionally changing a flow's element list.
+- **Harness-pattern critical paths** — these behaviours encode the harness research in
+  `.claude/docs/HARNESS-PRINCIPLES.md`; silent drift breaks the entire pattern. Tests must defend:
+  - Plateau detection — `plateauThreshold` predicate exits the loop when consecutive evaluator rounds flag
+    the same failed-dimension set without improvement (§ 6).
+  - Idle watchdog kill and downstream recovery — the chain does not hang when the watchdog fires (§ 7).
+  - Rate-limit retry with `--resume <sid>` session continuity — the retry loop passes the prior session-id,
+    not a fresh spawn (§ 8).
+  - `task-blocked` transition when `maxAttempts` exhausts — tasks never silently drop; they surface as
+    `blocked` (§ 5).
+  - Evaluator critique injection across rounds — the evaluator's prior critique reaches the generator on
+    the next attempt (§ 1, § 15).
+
+  `Read .claude/docs/HARNESS-PRINCIPLES.md` before redesigning a test that touches any of these paths.
 
 Don't obsess over:
 

--- a/.claude/docs/HARNESS-PRINCIPLES.md
+++ b/.claude/docs/HARNESS-PRINCIPLES.md
@@ -1,0 +1,363 @@
+# Harness Principles
+
+Distilled from the two Anthropic harness articles and the Martin Fowler structured-prompt series. Each
+principle below carries a **ralphctl status** (`applied` / `partial` / `gap`) and a **code anchor** — the
+exact path where the principle is exercised today. `partial` and `gap` rows each name a concrete next step.
+
+**When to read this doc:**
+
+1. Before any structural change to `src/application/chain/`, `src/application/flows/<flow>/`,
+   `src/application/registry.ts`, or `src/integration/ai/providers/_engine/`.
+2. Before adding a new chain primitive, a new flow, or a new sub-agent.
+3. On every new model release (Opus bump, Sonnet bump) — walk the `partial` and `gap` rows and ask whether
+   any `applied` row has become over-built relative to the new capability baseline.
+
+---
+
+### 1. Multi-agent split (planner / generator / evaluator)
+
+**Rule.** Separate the agent that writes the spec from the agent that generates code from the agent that
+grades it. Mixing roles degrades all three.
+
+**Source.** Anthropic — Harness Design: *"Multi-agent GAN structure — planner / generator / evaluator.
+Evaluators tuned to skepticism; tuning standalone evaluator > making generator self-critical."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Planner: `src/application/flows/plan/` (AI expands ticket list into `tasks.json`)
+- Generator: `src/application/flows/implement/leaves/generator.ts`
+- Evaluator: `src/application/flows/implement/leaves/evaluator.ts`
+
+---
+
+### 2. File-based agent communication
+
+**Rule.** Agents write files; other agents read and respond. No stdout parsing for structured output — that
+breaks whenever a CLI vendor changes their JSON shape.
+
+**Source.** Anthropic — Harness Design: *"File-based agent communication. Agents write files; other agents
+read and respond. Keeps work faithful to spec without over-specification."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- `signals.json` contract: `src/integration/ai/providers/_engine/run-headless-spawn.ts`
+- Session-id file: `src/integration/ai/providers/_engine/persist-session-id.ts`
+- Per-spawn layout: `<sprintDir>/<flow>/<unit>/rounds/<N>/{generator,evaluator}/signals.json`
+
+---
+
+### 3. Progress file as session handoff
+
+**Rule.** Each new context window must be able to orient itself from a file — not from memory, not from
+stdout history. The progress artefact is the handoff between "shifts."
+
+**Source.** Anthropic — Effective Harnesses: *"Agents work like software engineers collaborating across
+shifts — each new engineer arrives with no memory of what happened on the previous shift."* Progress file
+= the shift handoff note.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Append-only sprint journal: `src/application/flows/implement/leaves/progress-journal.ts`
+- Separator on new run: `src/application/flows/_shared/progress/append-journal-separator.ts`
+- Prompts that consume it: `progress.md` body inlined via `{{PROGRESS_JOURNAL}}` in
+  `src/integration/ai/prompts/plan/template.md` and `src/integration/ai/prompts/evaluate/template.md`
+
+---
+
+### 4. Git as state backbone, descriptive commits
+
+**Rule.** Every task attempt ends in a commit. The AI agent reads `git log` at session start; commit
+messages are its memory of what changed and why.
+
+**Source.** Anthropic — Effective Harnesses: *"Git as state backbone. Descriptive commit messages enable
+revert + recovery. Model reads git logs at session start."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Commit leaf: `src/application/flows/implement/leaves/` (commit-message signal drives per-task commits)
+- Conventional commits enforced: project `commitlint` config; `CLAUDE.md § Git Practices`
+
+---
+
+### 5. Hard cap on attempts → blocked transition
+
+**Rule.** When the generator-evaluator loop exhausts its attempt budget, the task must transition to
+`blocked` — not `done`, not silently dropped. Silent failure hides bugs; `blocked` surfaces them.
+
+**Source.** Anthropic — Harness Design: *"Hard thresholds — any failed criterion triggers rework. Sprint
+contracts define testable success up-front."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- `maxAttempts` setting: `src/application/chain/run/iteration-config.ts`
+- Blocked transition: `src/application/flows/implement/leaves/` (settle-attempt leaf)
+- Task status enum includes `blocked`: `src/domain/entity/task.ts`
+
+---
+
+### 6. Plateau detection (no productive iteration)
+
+**Rule.** When consecutive evaluator rounds flag the same failed-dimension set without improvement, exit the
+loop with a plateau warning rather than exhausting the full attempt budget on non-productive work.
+
+**Source.** Anthropic — Harness Design: *"Early signs [of evaluator failure]: identifying issues then talking
+self into approving anyway; superficial testing."* Plateau detection is the harness-side guard against this.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- `plateauThreshold` (2–5, default 2): `src/application/chain/run/iteration-config.ts`
+- Exemptions (score improvement, commit progress, critique-Jaccard shift prevent counting): same file
+- Loop predicate in the implement flow: `src/application/flows/implement/`
+
+---
+
+### 7. Idle watchdog (kill wedged children)
+
+**Rule.** A headless AI process whose stdout has been silent past a configurable threshold must be killed.
+A stuck child cannot be allowed to strand the harness indefinitely.
+
+**Source.** Anthropic — Effective Harnesses (implicit): robust harnesses detect and recover from wedged
+sessions rather than waiting for user intervention.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- `src/integration/ai/providers/_engine/idle-watchdog.ts`
+
+---
+
+### 8. Rate-limit retry with session resume
+
+**Rule.** On a 429, retry with exponential backoff and pass `--resume <session-id>` so the AI continues
+from where it stopped — not from scratch. Restarting wastes the prior context window.
+
+**Source.** Anthropic — Effective Harnesses: resume via git state and session continuity. Harness Design:
+*"Context resets > compaction for models with context anxiety."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Retry loop: `src/integration/ai/providers/_engine/rate-limit-backoff.ts`
+- Session-id capture and `--resume` pass-through: `src/integration/ai/providers/_engine/run-headless-spawn.ts`
+- Cap: `settings.harness.rateLimitRetries` (0–10)
+
+---
+
+### 9. Sprint contracts (testable success up-front)
+
+**Rule.** Before the AI touches a task, a verify script runs and records a baseline. After the AI commits,
+the same script runs again with an attribution algorithm — the harness rejects work that regresses passing
+tests, but does not block the AI for pre-existing failures.
+
+**Source.** Anthropic — Harness Design: *"Sprint contracts define testable success up-front. Grade against
+concrete criteria with hard thresholds — any failed criterion triggers rework."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Pre-task verify + post-task verify: `src/application/flows/implement/leaves/`
+- Attribution algorithm (`clean` / `regressed` / `baseline-broken` / `fixed-baseline`): implement leaves
+- Scripts collected during readiness: `src/application/flows/detect-scripts/`
+
+---
+
+### 10. Native context file per provider
+
+**Rule.** Each AI CLI discovers its context file from cwd (`CLAUDE.md`, `.github/copilot-instructions.md`,
+`AGENTS.md`). The harness writes one file per distinct provider — no symlinks, no pointer schemes.
+
+**Source.** Anthropic — Effective Harnesses: *"Cwd is the repo because Claude / Copilot / Codex only
+auto-discover their context file from cwd — not from `--add-dir` roots."*
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Fan-out: `src/application/flows/readiness/` fans out across every uniquely referenced provider
+- One file per provider: `CLAUDE.md` / `.github/copilot-instructions.md` / `AGENTS.md`
+- No symlinks by convention: `CLAUDE.md § Security & Safety`
+
+---
+
+### 11. Iterative review (cheap check often)
+
+**Rule.** Run the cheapest check after each meaningful change, not at the end of the whole diff. The harness
+check gate is the deployed form of this loop; the same posture belongs inside each phase's work.
+
+**Source.** Martin Fowler — Structured Prompt Driven: iterative review concept.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Cross-phase skill: `.claude/skills/ralphctl-iterative-review/SKILL.md` (main repo)
+
+---
+
+### 12. Alignment before output
+
+**Rule.** Name the entities, boundaries, and seams the change touches before generating code, tasks, or
+acceptance criteria. "Big blob" output is a failure to align first.
+
+**Source.** Martin Fowler — Structured Prompt Driven: alignment concept.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Cross-phase skill: `.claude/skills/ralphctl-alignment/SKILL.md` (main repo)
+
+---
+
+### 13. Abstraction-first
+
+**Rule.** Design the shape of the change (entities, boundaries, seams) before generating code, tasks, or
+acceptance criteria.
+
+**Source.** Martin Fowler — Structured Prompt Driven: abstraction-first concept.
+
+**ralphctl status.** `applied`
+
+**Where it lives.**
+- Cross-phase skill: `.claude/skills/ralphctl-abstraction-first/SKILL.md` (main repo)
+
+---
+
+### 14. Minimal scaffolding; remove one component at a time as models improve
+
+**Rule.** Every harness component encodes an assumption about what the model cannot do unaided. Stress-test
+that assumption on every model release. Remove non-load-bearing pieces one at a time, with measurement.
+
+**Source.** Anthropic — Harness Design: *"Find the simplest solution possible, and only increase complexity
+when needed. Every component encodes assumptions about model limitations. Stress-test assumptions; they can
+go stale quickly as models improve. Remove one component at a time when simplifying. Re-examine entire
+harness when new model releases; strip non-load-bearing pieces."*
+
+**ralphctl status.** `partial`
+
+**Where it lives.**
+- Cross-phase skill in progress: `.claude/skills/ralphctl-minimal-scaffolding/SKILL.md` (this PR)
+- No audit cadence yet — nothing enforces a per-model-release walk of this doc.
+
+**Next step.** The `ralphctl-minimal-scaffolding` skill captures the principle; what's missing is a ritual.
+Add a checklist block to this doc's "model-bump audit" section (below) and gate it on a team process (e.g.
+open a ticket when a new model version ships).
+
+---
+
+### 15. Evaluator over-praises by default; needs heavy tuning
+
+**Rule.** An LLM evaluator out-of-the-box is a poor QA agent — it will identify issues and then talk itself
+into approving anyway. The evaluate prompt must name concrete failure modes, weight subjective criteria
+heavier than technical defaults, and use few-shot calibration toward harsh grading.
+
+**Source.** Anthropic — Harness Design: *"LLMs are poor QA agents out-of-box. Early signs: identifying
+issues then talking self into approving anyway; superficial testing. Fix: read logs, identify judgment
+divergence from desired outcomes, update prompts iteratively. Requires significant prompt tuning to avoid
+over-praising."*
+
+**ralphctl status.** `gap`
+
+**Where it lives.**
+- Evaluator template: `src/integration/ai/prompts/evaluate/template.md`
+- Today's template grades against `{{TASK_ACCEPTANCE_CRITERIA}}` and the verify-script outcome but does not
+  name evaluator failure modes or push toward harsh grading.
+
+**Next step.** The `prompt-template-engineer` agent owns this. Edit `evaluate/template.md` to:
+  - Name concrete failure modes (superficial testing, talking self into approval, over-praising incomplete
+    work).
+  - Weight subjective criteria (design quality, originality, craft) heavier than technical defaults when
+    the task spec includes them.
+  - Add few-shot calibration examples that bias the evaluator toward harsh grading.
+
+---
+
+### 16. Context reset vs compaction for long sessions
+
+**Rule.** Decide explicitly — before a session starts — whether the AI should assume a fresh context window
+or continue from a prior one. Ambiguity here causes the AI to behave as though it has context it doesn't, or
+to compact unnecessarily.
+
+**Source.** Anthropic — Harness Design: *"Resets > compaction for models with context anxiety. Opus 4.5 had
+strong context anxiety; Opus 4.6 largely eliminated it. Automatic compaction can handle context growth in
+continuous sessions with capable models."*
+
+**ralphctl status.** `partial`
+
+**Where it lives.**
+- Session scoping: `src/application/session/session.ts` (`AsyncLocalStorage` per runner call)
+- Interactive flows (refine / plan / ideate) hand off a full session to the AI CLI; the AI decides how to
+  handle its own context.
+- No explicit convention in the prompt templates for when to assume fresh-slate vs continuity.
+
+**Next step.** The `prompt-template-engineer` agent owns this. Add a phrasing convention to the relevant
+templates (`refine/template.md`, `plan/template.md`, `ideate/template.md`) that either signals fresh-slate
+("no prior context is assumed") or continuity ("read `progress.md` to orient before proceeding"). The
+convention should be documented in `prompt-template-engineer.md` as an owned fence.
+
+---
+
+### 17. Cost-benefit framing (evaluator value tied to task difficulty / model capability)
+
+**Rule.** The evaluator adds cost and latency. Its value depends on task difficulty relative to model
+capability — and that relationship shifts as models improve. Design flow surfaces so the lighter `ideate`
+path is the default for low-stakes work; full `implement` (with evaluator) is reserved for tasks where
+the evaluator pays for itself.
+
+**Source.** Anthropic — Harness Design: *"Solo agent (20 min, $9) vs full harness (6 hr, $200) — 20x
+expense for substantially better output. Evaluator value depends on task difficulty relative to model
+capability. Boundary shifts as models improve."* Also: *"The space of interesting harness combinations
+doesn't shrink as models improve. Instead, it moves."*
+
+**ralphctl status.** `gap`
+
+**Where it lives.**
+- `ideate`: `src/application/flows/ideate/` — single AI session, no evaluator loop
+- `implement`: `src/application/flows/implement/` — full generator-evaluator-settle loop
+- No guidance in the TUI help text or the designer agent steers the flow-surface choice toward cost-benefit
+  thinking.
+
+**Next step.** The `designer` agent owns the flow surface. When designing a new flow's TUI/CLI entry point,
+reference this section to weigh `ideate` (single session, low ceremony, lower cost) vs full `implement`
+(evaluator loop, higher confidence, higher cost). Add this framing to the designer agent's Design Principles
+and to flow help text for new flows.
+
+---
+
+### 18. Every harness component encodes assumptions about model limits; re-audit on model bumps
+
+**Rule.** When a new model version ships, walk every `partial` and `gap` row in this doc and re-evaluate
+every `applied` row's load-bearing status. Components that were necessary for Opus 4.5 may be overhead for
+Opus 4.7.
+
+**Source.** Anthropic — Harness Design: *"Re-examine entire harness when new model releases; strip
+non-load-bearing pieces."*
+
+**ralphctl status.** `gap`
+
+**Where it lives.**
+- No audit cadence exists. This doc is the intended home for the checklist; the `ralphctl-minimal-scaffolding`
+  skill captures the per-change discipline.
+
+**Next step.** On every significant model release (Opus bump, Sonnet bump), open a ticket: "Model-bump
+harness audit." The ritual: read this doc top-to-bottom; for each `applied` row, ask "is this still
+load-bearing against the new model?" For `partial` / `gap` rows, ask "has the model closed the gap
+unaided?" Findings feed into targeted removals or promos from `gap` → `applied`.
+
+---
+
+## How to use this doc
+
+**Before structural changes.** Read before adding a chain primitive, a new flow, a new sub-agent, or any
+change to `src/integration/ai/providers/_engine/`. The relevant principle section names the risk; the status
+tag says how covered ralphctl is today.
+
+**Before model-bump work.** Read the full principle list. Walk `partial` and `gap` rows first — a model
+upgrade may close gaps for free. Then walk `applied` rows and ask whether any have become over-built.
+
+**When a `gap` closes.** Update the row's status from `gap` → `applied` (or `partial` → `applied`),
+update the "Where it lives" anchor, and remove the "Next step" line. Cross-reference the commit that closed
+it.

--- a/.claude/docs/HARNESS-PRINCIPLES.md
+++ b/.claude/docs/HARNESS-PRINCIPLES.md
@@ -19,12 +19,13 @@ exact path where the principle is exercised today. `partial` and `gap` rows each
 **Rule.** Separate the agent that writes the spec from the agent that generates code from the agent that
 grades it. Mixing roles degrades all three.
 
-**Source.** Anthropic — Harness Design: *"Multi-agent GAN structure — planner / generator / evaluator.
-Evaluators tuned to skepticism; tuning standalone evaluator > making generator self-critical."*
+**Source.** Anthropic — Harness Design: _"Multi-agent GAN structure — planner / generator / evaluator.
+Evaluators tuned to skepticism; tuning standalone evaluator > making generator self-critical."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Planner: `src/application/flows/plan/` (AI expands ticket list into `tasks.json`)
 - Generator: `src/application/flows/implement/leaves/generator.ts`
 - Evaluator: `src/application/flows/implement/leaves/evaluator.ts`
@@ -36,12 +37,13 @@ Evaluators tuned to skepticism; tuning standalone evaluator > making generator s
 **Rule.** Agents write files; other agents read and respond. No stdout parsing for structured output — that
 breaks whenever a CLI vendor changes their JSON shape.
 
-**Source.** Anthropic — Harness Design: *"File-based agent communication. Agents write files; other agents
-read and respond. Keeps work faithful to spec without over-specification."*
+**Source.** Anthropic — Harness Design: _"File-based agent communication. Agents write files; other agents
+read and respond. Keeps work faithful to spec without over-specification."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - `signals.json` contract: `src/integration/ai/providers/_engine/run-headless-spawn.ts`
 - Session-id file: `src/integration/ai/providers/_engine/persist-session-id.ts`
 - Per-spawn layout: `<sprintDir>/<flow>/<unit>/rounds/<N>/{generator,evaluator}/signals.json`
@@ -53,13 +55,14 @@ read and respond. Keeps work faithful to spec without over-specification."*
 **Rule.** Each new context window must be able to orient itself from a file — not from memory, not from
 stdout history. The progress artefact is the handoff between "shifts."
 
-**Source.** Anthropic — Effective Harnesses: *"Agents work like software engineers collaborating across
-shifts — each new engineer arrives with no memory of what happened on the previous shift."* Progress file
+**Source.** Anthropic — Effective Harnesses: _"Agents work like software engineers collaborating across
+shifts — each new engineer arrives with no memory of what happened on the previous shift."_ Progress file
 = the shift handoff note.
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Append-only sprint journal: `src/application/flows/implement/leaves/progress-journal.ts`
 - Separator on new run: `src/application/flows/_shared/progress/append-journal-separator.ts`
 - Prompts that consume it: `progress.md` body inlined via `{{PROGRESS_JOURNAL}}` in
@@ -72,12 +75,13 @@ shifts — each new engineer arrives with no memory of what happened on the prev
 **Rule.** Every task attempt ends in a commit. The AI agent reads `git log` at session start; commit
 messages are its memory of what changed and why.
 
-**Source.** Anthropic — Effective Harnesses: *"Git as state backbone. Descriptive commit messages enable
-revert + recovery. Model reads git logs at session start."*
+**Source.** Anthropic — Effective Harnesses: _"Git as state backbone. Descriptive commit messages enable
+revert + recovery. Model reads git logs at session start."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Commit leaf: `src/application/flows/implement/leaves/` (commit-message signal drives per-task commits)
 - Conventional commits enforced: project `commitlint` config; `CLAUDE.md § Git Practices`
 
@@ -88,12 +92,13 @@ revert + recovery. Model reads git logs at session start."*
 **Rule.** When the generator-evaluator loop exhausts its attempt budget, the task must transition to
 `blocked` — not `done`, not silently dropped. Silent failure hides bugs; `blocked` surfaces them.
 
-**Source.** Anthropic — Harness Design: *"Hard thresholds — any failed criterion triggers rework. Sprint
-contracts define testable success up-front."*
+**Source.** Anthropic — Harness Design: _"Hard thresholds — any failed criterion triggers rework. Sprint
+contracts define testable success up-front."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - `maxAttempts` setting: `src/application/chain/run/iteration-config.ts`
 - Blocked transition: `src/application/flows/implement/leaves/` (settle-attempt leaf)
 - Task status enum includes `blocked`: `src/domain/entity/task.ts`
@@ -105,12 +110,13 @@ contracts define testable success up-front."*
 **Rule.** When consecutive evaluator rounds flag the same failed-dimension set without improvement, exit the
 loop with a plateau warning rather than exhausting the full attempt budget on non-productive work.
 
-**Source.** Anthropic — Harness Design: *"Early signs [of evaluator failure]: identifying issues then talking
-self into approving anyway; superficial testing."* Plateau detection is the harness-side guard against this.
+**Source.** Anthropic — Harness Design: _"Early signs [of evaluator failure]: identifying issues then talking
+self into approving anyway; superficial testing."_ Plateau detection is the harness-side guard against this.
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - `plateauThreshold` (2–5, default 2): `src/application/chain/run/iteration-config.ts`
 - Exemptions (score improvement, commit progress, critique-Jaccard shift prevent counting): same file
 - Loop predicate in the implement flow: `src/application/flows/implement/`
@@ -128,6 +134,7 @@ sessions rather than waiting for user intervention.
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - `src/integration/ai/providers/_engine/idle-watchdog.ts`
 
 ---
@@ -138,11 +145,12 @@ sessions rather than waiting for user intervention.
 from where it stopped — not from scratch. Restarting wastes the prior context window.
 
 **Source.** Anthropic — Effective Harnesses: resume via git state and session continuity. Harness Design:
-*"Context resets > compaction for models with context anxiety."*
+_"Context resets > compaction for models with context anxiety."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Retry loop: `src/integration/ai/providers/_engine/rate-limit-backoff.ts`
 - Session-id capture and `--resume` pass-through: `src/integration/ai/providers/_engine/run-headless-spawn.ts`
 - Cap: `settings.harness.rateLimitRetries` (0–10)
@@ -155,12 +163,13 @@ from where it stopped — not from scratch. Restarting wastes the prior context 
 the same script runs again with an attribution algorithm — the harness rejects work that regresses passing
 tests, but does not block the AI for pre-existing failures.
 
-**Source.** Anthropic — Harness Design: *"Sprint contracts define testable success up-front. Grade against
-concrete criteria with hard thresholds — any failed criterion triggers rework."*
+**Source.** Anthropic — Harness Design: _"Sprint contracts define testable success up-front. Grade against
+concrete criteria with hard thresholds — any failed criterion triggers rework."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Pre-task verify + post-task verify: `src/application/flows/implement/leaves/`
 - Attribution algorithm (`clean` / `regressed` / `baseline-broken` / `fixed-baseline`): implement leaves
 - Scripts collected during readiness: `src/application/flows/detect-scripts/`
@@ -172,12 +181,13 @@ concrete criteria with hard thresholds — any failed criterion triggers rework.
 **Rule.** Each AI CLI discovers its context file from cwd (`CLAUDE.md`, `.github/copilot-instructions.md`,
 `AGENTS.md`). The harness writes one file per distinct provider — no symlinks, no pointer schemes.
 
-**Source.** Anthropic — Effective Harnesses: *"Cwd is the repo because Claude / Copilot / Codex only
-auto-discover their context file from cwd — not from `--add-dir` roots."*
+**Source.** Anthropic — Effective Harnesses: _"Cwd is the repo because Claude / Copilot / Codex only
+auto-discover their context file from cwd — not from `--add-dir` roots."_
 
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Fan-out: `src/application/flows/readiness/` fans out across every uniquely referenced provider
 - One file per provider: `CLAUDE.md` / `.github/copilot-instructions.md` / `AGENTS.md`
 - No symlinks by convention: `CLAUDE.md § Security & Safety`
@@ -194,6 +204,7 @@ check gate is the deployed form of this loop; the same posture belongs inside ea
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Cross-phase skill: `.claude/skills/ralphctl-iterative-review/SKILL.md` (main repo)
 
 ---
@@ -208,6 +219,7 @@ acceptance criteria. "Big blob" output is a failure to align first.
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Cross-phase skill: `.claude/skills/ralphctl-alignment/SKILL.md` (main repo)
 
 ---
@@ -222,6 +234,7 @@ acceptance criteria.
 **ralphctl status.** `applied`
 
 **Where it lives.**
+
 - Cross-phase skill: `.claude/skills/ralphctl-abstraction-first/SKILL.md` (main repo)
 
 ---
@@ -231,14 +244,15 @@ acceptance criteria.
 **Rule.** Every harness component encodes an assumption about what the model cannot do unaided. Stress-test
 that assumption on every model release. Remove non-load-bearing pieces one at a time, with measurement.
 
-**Source.** Anthropic — Harness Design: *"Find the simplest solution possible, and only increase complexity
+**Source.** Anthropic — Harness Design: _"Find the simplest solution possible, and only increase complexity
 when needed. Every component encodes assumptions about model limitations. Stress-test assumptions; they can
 go stale quickly as models improve. Remove one component at a time when simplifying. Re-examine entire
-harness when new model releases; strip non-load-bearing pieces."*
+harness when new model releases; strip non-load-bearing pieces."_
 
 **ralphctl status.** `partial`
 
 **Where it lives.**
+
 - Cross-phase skill in progress: `.claude/skills/ralphctl-minimal-scaffolding/SKILL.md` (this PR)
 - No audit cadence yet — nothing enforces a per-model-release walk of this doc.
 
@@ -254,24 +268,26 @@ open a ticket when a new model version ships).
 into approving anyway. The evaluate prompt must name concrete failure modes, weight subjective criteria
 heavier than technical defaults, and use few-shot calibration toward harsh grading.
 
-**Source.** Anthropic — Harness Design: *"LLMs are poor QA agents out-of-box. Early signs: identifying
+**Source.** Anthropic — Harness Design: _"LLMs are poor QA agents out-of-box. Early signs: identifying
 issues then talking self into approving anyway; superficial testing. Fix: read logs, identify judgment
 divergence from desired outcomes, update prompts iteratively. Requires significant prompt tuning to avoid
-over-praising."*
+over-praising."_
 
 **ralphctl status.** `gap`
 
 **Where it lives.**
+
 - Evaluator template: `src/integration/ai/prompts/evaluate/template.md`
 - Today's template grades against `{{TASK_ACCEPTANCE_CRITERIA}}` and the verify-script outcome but does not
   name evaluator failure modes or push toward harsh grading.
 
 **Next step.** The `prompt-template-engineer` agent owns this. Edit `evaluate/template.md` to:
-  - Name concrete failure modes (superficial testing, talking self into approval, over-praising incomplete
-    work).
-  - Weight subjective criteria (design quality, originality, craft) heavier than technical defaults when
-    the task spec includes them.
-  - Add few-shot calibration examples that bias the evaluator toward harsh grading.
+
+- Name concrete failure modes (superficial testing, talking self into approval, over-praising incomplete
+  work).
+- Weight subjective criteria (design quality, originality, craft) heavier than technical defaults when
+  the task spec includes them.
+- Add few-shot calibration examples that bias the evaluator toward harsh grading.
 
 ---
 
@@ -281,13 +297,14 @@ over-praising."*
 or continue from a prior one. Ambiguity here causes the AI to behave as though it has context it doesn't, or
 to compact unnecessarily.
 
-**Source.** Anthropic — Harness Design: *"Resets > compaction for models with context anxiety. Opus 4.5 had
+**Source.** Anthropic — Harness Design: _"Resets > compaction for models with context anxiety. Opus 4.5 had
 strong context anxiety; Opus 4.6 largely eliminated it. Automatic compaction can handle context growth in
-continuous sessions with capable models."*
+continuous sessions with capable models."_
 
 **ralphctl status.** `partial`
 
 **Where it lives.**
+
 - Session scoping: `src/application/session/session.ts` (`AsyncLocalStorage` per runner call)
 - Interactive flows (refine / plan / ideate) hand off a full session to the AI CLI; the AI decides how to
   handle its own context.
@@ -307,14 +324,15 @@ capability — and that relationship shifts as models improve. Design flow surfa
 path is the default for low-stakes work; full `implement` (with evaluator) is reserved for tasks where
 the evaluator pays for itself.
 
-**Source.** Anthropic — Harness Design: *"Solo agent (20 min, $9) vs full harness (6 hr, $200) — 20x
+**Source.** Anthropic — Harness Design: _"Solo agent (20 min, $9) vs full harness (6 hr, $200) — 20x
 expense for substantially better output. Evaluator value depends on task difficulty relative to model
-capability. Boundary shifts as models improve."* Also: *"The space of interesting harness combinations
-doesn't shrink as models improve. Instead, it moves."*
+capability. Boundary shifts as models improve."_ Also: _"The space of interesting harness combinations
+doesn't shrink as models improve. Instead, it moves."_
 
 **ralphctl status.** `gap`
 
 **Where it lives.**
+
 - `ideate`: `src/application/flows/ideate/` — single AI session, no evaluator loop
 - `implement`: `src/application/flows/implement/` — full generator-evaluator-settle loop
 - No guidance in the TUI help text or the designer agent steers the flow-surface choice toward cost-benefit
@@ -333,12 +351,13 @@ and to flow help text for new flows.
 every `applied` row's load-bearing status. Components that were necessary for Opus 4.5 may be overhead for
 Opus 4.7.
 
-**Source.** Anthropic — Harness Design: *"Re-examine entire harness when new model releases; strip
-non-load-bearing pieces."*
+**Source.** Anthropic — Harness Design: _"Re-examine entire harness when new model releases; strip
+non-load-bearing pieces."_
 
 **ralphctl status.** `gap`
 
 **Where it lives.**
+
 - No audit cadence exists. This doc is the intended home for the checklist; the `ralphctl-minimal-scaffolding`
   skill captures the per-change discipline.
 

--- a/.claude/skills/harness-principles/SKILL.md
+++ b/.claude/skills/harness-principles/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: harness-principles
+description: "Auto-triggers on structural harness decisions: new chain primitive, new flow, remove evaluator, wrap evaluator, redesign harness, scaffolding, load-bearing, model upgrade, harness audit, refactor flow, sub-agent. Also triggers on file mentions of `src/application/chain/`, `src/application/flows/`, `src/integration/ai/providers/_engine/`. Instructs the agent to read the principles doc before proceeding."
+when_to_use: 'When the user prompt contains any of: "chain primitive", "new flow", "remove evaluator", "wrap evaluator", "redesign harness", "scaffolding", "load-bearing", "model upgrade", "harness audit", "refactor flow", "sub-agent". Also when the prompt references `src/application/chain/`, `src/application/flows/`, or `src/integration/ai/providers/_engine/`. Not needed for pure business logic, UI, or persistence work that does not touch the chain or provider engine.'
+---
+
+# Harness Principles — Auto-trigger
+
+This skill exists because the harness research evolves with model capability. What was load-bearing in
+Opus 4.5 may be overhead in Opus 4.7. Without an explicit read-first gate, structural changes happen
+without awareness of the research behind the current design.
+
+**Before proceeding with any structural harness change:**
+
+1. `Read .claude/docs/HARNESS-PRINCIPLES.md` in full.
+2. Identify the relevant principle section(s) by name (e.g. "§ 14 Minimal scaffolding", "§ 7 Idle watchdog").
+3. Note the current `ralphctl status` for each relevant principle (`applied` / `partial` / `gap`).
+4. Proceed with the change, keeping the principle's intent visible in the diff.
+
+If you are **removing** a harness component, confirm which principle the component implements and verify the
+removal does not regress an `applied` row. If the removal moves a row from `applied` to `gap`, update
+`HARNESS-PRINCIPLES.md` as part of the same commit.
+
+If you are **adding** a new chain primitive — there are five and only five: `element` (interface), `leaf`,
+`sequential`, `loop`, `guard`. Push back if a proposal adds a sixth. The principle behind this constraint
+is § 14 (Minimal scaffolding) and the rationale is in `CLAUDE.md § Architecture`.

--- a/.claude/skills/harness-principles/SKILL.md
+++ b/.claude/skills/harness-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-principles
-description: "Auto-triggers on structural harness decisions: new chain primitive, new flow, remove evaluator, wrap evaluator, redesign harness, scaffolding, load-bearing, model upgrade, harness audit, refactor flow, sub-agent. Also triggers on file mentions of `src/application/chain/`, `src/application/flows/`, `src/integration/ai/providers/_engine/`. Instructs the agent to read the principles doc before proceeding."
+description: 'Auto-triggers on structural harness decisions: new chain primitive, new flow, remove evaluator, wrap evaluator, redesign harness, scaffolding, load-bearing, model upgrade, harness audit, refactor flow, sub-agent. Also triggers on file mentions of `src/application/chain/`, `src/application/flows/`, `src/integration/ai/providers/_engine/`. Instructs the agent to read the principles doc before proceeding.'
 when_to_use: 'When the user prompt contains any of: "chain primitive", "new flow", "remove evaluator", "wrap evaluator", "redesign harness", "scaffolding", "load-bearing", "model upgrade", "harness audit", "refactor flow", "sub-agent". Also when the prompt references `src/application/chain/`, `src/application/flows/`, or `src/integration/ai/providers/_engine/`. Not needed for pure business logic, UI, or persistence work that does not touch the chain or provider engine.'
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Both `commander.version()` and the npm-update poll consume the same constant —
 - `.claude/docs/REQUIREMENTS.md` — acceptance-criteria checklist
 - `.claude/docs/DESIGN-SYSTEM.md` — TUI tokens, components, copy rules
 - `.claude/docs/MANUAL-TEST-PLAYBOOK.md` — manual smoke-test script
+- `.claude/docs/HARNESS-PRINCIPLES.md` — distilled harness research from Anthropic + Fowler, with per-principle ralphctl status tags
 - `.claude/docs/diagrams/` — Mermaid diagrams: module layout, chain framework, flow lifecycle, sprint / task state machines
 
 ## Build & Run
@@ -348,4 +349,8 @@ before each spawn; `settle-attempt-leaf` writes `rounds/<N>/outcome.md` after se
 `package.json#version`; `CHANGELOG.md` needs a `## [X.Y.Z]` section (the literal-prefix extractor surfaces
 it). NPM publish uses `--provenance`. Pre-releases are tags containing `-`.
 
-**References** — [Anthropic — Effective Harnesses](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents), [Anthropic — Harness Design](https://www.anthropic.com/engineering/harness-design-long-running-apps), [Martin Fowler — Harness Engineering](https://martinfowler.com/articles/harness-engineering.html).
+**References** — Principles distilled in `.claude/docs/HARNESS-PRINCIPLES.md`; consult before structural
+changes to the chain framework, flow registry, or provider engine. Sources: [Anthropic — Effective
+Harnesses](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents), [Anthropic
+— Harness Design](https://www.anthropic.com/engineering/harness-design-long-running-apps), [Martin Fowler
+— Harness Engineering](https://martinfowler.com/articles/harness-engineering.html).

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -22,11 +22,11 @@ export type { FlowId };
 
 /** Skill ids referenced below — must each exist as `src/ai/skills/bundled/<id>/SKILL.md`. */
 export const FLOW_SKILLS: Record<FlowId, readonly string[]> = {
-  refine: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
-  plan: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
-  implement: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
-  readiness: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
-  ideate: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first'],
+  refine: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
+  plan: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
+  implement: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
+  readiness: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
+  ideate: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
 };
 
 /** Type-safe lookup. Returns the configured skill ids or an empty list. */

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -22,11 +22,36 @@ export type { FlowId };
 
 /** Skill ids referenced below — must each exist as `src/ai/skills/bundled/<id>/SKILL.md`. */
 export const FLOW_SKILLS: Record<FlowId, readonly string[]> = {
-  refine: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
-  plan: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
-  implement: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
-  readiness: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
-  ideate: ['ralphctl-alignment', 'ralphctl-iterative-review', 'ralphctl-abstraction-first', 'ralphctl-minimal-scaffolding'],
+  refine: [
+    'ralphctl-alignment',
+    'ralphctl-iterative-review',
+    'ralphctl-abstraction-first',
+    'ralphctl-minimal-scaffolding',
+  ],
+  plan: [
+    'ralphctl-alignment',
+    'ralphctl-iterative-review',
+    'ralphctl-abstraction-first',
+    'ralphctl-minimal-scaffolding',
+  ],
+  implement: [
+    'ralphctl-alignment',
+    'ralphctl-iterative-review',
+    'ralphctl-abstraction-first',
+    'ralphctl-minimal-scaffolding',
+  ],
+  readiness: [
+    'ralphctl-alignment',
+    'ralphctl-iterative-review',
+    'ralphctl-abstraction-first',
+    'ralphctl-minimal-scaffolding',
+  ],
+  ideate: [
+    'ralphctl-alignment',
+    'ralphctl-iterative-review',
+    'ralphctl-abstraction-first',
+    'ralphctl-minimal-scaffolding',
+  ],
 };
 
 /** Type-safe lookup. Returns the configured skill ids or an empty list. */

--- a/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
@@ -10,7 +10,7 @@ description: Cross-phase skill — question every harness component on every mod
 > Remove one component at a time when simplifying. Re-examine entire harness when new model releases; strip
 > non-load-bearing pieces."
 >
-> — Anthropic, *Harness Design for Long-Running Apps*
+> — Anthropic, _Harness Design for Long-Running Apps_
 
 Harness complexity drifts upward. Each component that solves a real problem at the time of its addition
 becomes a permanent fixture — even after the model capability that made it necessary has improved past the

--- a/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: ralphctl-minimal-scaffolding
+description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline.
+---
+
+# Minimal Scaffolding
+
+> "Find the simplest solution possible, and only increase complexity when needed. Every component encodes
+> assumptions about model limitations. Stress-test assumptions; they can go stale quickly as models improve.
+> Remove one component at a time when simplifying. Re-examine entire harness when new model releases; strip
+> non-load-bearing pieces."
+>
+> — Anthropic, *Harness Design for Long-Running Apps*
+
+Harness complexity drifts upward. Each component that solves a real problem at the time of its addition
+becomes a permanent fixture — even after the model capability that made it necessary has improved past the
+threshold. Without an active counter-pressure, the harness grows into a weight that slows iteration and
+obscures the actual design signal. Minimal scaffolding is not a one-time decision at design time; it is a
+discipline applied on every model release and on every proposed addition.
+
+## When this applies
+
+- **Refine** — before proposing that the refine phase needs a new guard, new evaluator, or new validation
+  step, ask whether the model would produce the right output without it given a well-scoped prompt.
+- **Plan** — before adding a new planning sub-agent or splitting a flow into more phases, ask whether the
+  additional structure would improve output quality measurably, or whether it is defensive scaffolding
+  against a past model's limitations.
+- **Execute** — before wiring a new chain primitive, a new leaf, or a new wrapper around the evaluator, ask
+  which assumption about current model capability the addition encodes, and whether that assumption is still
+  valid.
+
+## What to do
+
+1. **Start with the simplest viable shape.** Draft the simplest version that could work given today's model
+   capability. Only add components when the simple version demonstrably fails.
+2. **Question every component on every model bump.** When a new model version ships, re-read
+   `HARNESS-PRINCIPLES.md` § 14 and § 18 in the project's `.claude/docs/` directory. For each `applied` row,
+   ask: "Would removing this component degrade output quality on the new model?" If the answer is uncertain,
+   run the test.
+3. **Remove one component at a time, measure.** Never refactor two components simultaneously — you cannot
+   isolate the regression. Remove one; run the project's check gate; observe output quality; decide.
+4. **Default toward subtraction over addition.** When in doubt, omit. Adding a component later when its
+   need is proven is cheaper than carrying a component whose need was assumed.
+
+## Anti-patterns
+
+- **Stacking primitives "just in case".** Adding a `guard` around the evaluator, a `loop` around the guard,
+  and a retry decorator around the loop — each layer may have been justified at the time, but the stack
+  encodes four separate assumptions, each of which needs re-validation on every model bump.
+- **Treating scaffolding as load-bearing without measurement.** "We've always had the idle watchdog" is not
+  a reason to keep it — it is a reason to measure whether it still fires in practice. If it never fires on
+  the current model, it may be removable.
+- **Mass refactors that change more than one component at a time.** Removing the plateau detector and the
+  idle watchdog in the same PR makes it impossible to attribute a quality change to either. One component
+  at a time.
+- **Never re-auditing existing scaffolding when models get better.** Capability improvements accrue quietly.
+  A component that was essential for an older model may be transparently handled by a newer one. Without an
+  explicit re-audit cadence, the harness ossifies around old assumptions.


### PR DESCRIPTION
## Summary

- Adds `.claude/docs/HARNESS-PRINCIPLES.md` distilling the two Anthropic harness articles + Fowler's harness engineering into 18 principles, each tagged `applied` / `partial` / `gap` against ralphctl's current state. Audit findings live inline with the rule that triggered them, so one read shows principle + how we stand against it.
- Adds two skills: `harness-principles` (auto-triggers on chain / flow / `_engine` keyword matches, pulls the doc in before structural changes) and `ralphctl-minimal-scaffolding` (completes the Fowler quartet alongside alignment / abstraction-first / iterative-review; bundled and wired into all 5 flows in `FLOW_SKILLS`).
- Hooks all 7 specialist agents into the principles doc with role-shaped bullets — `planner` / `reviewer` / `implementer` for structural decisions, `tester` for harness-pattern critical paths, `designer` for flow-surface cost-benefit, `docs-keeper` extends its audit workflow, and `prompt-template-engineer` takes ownership of the two prompt-side fences the audit surfaced (evaluator over-praising tuning, context reset vs compaction phrasing).
- CLAUDE.md's References footer bumps from a passive link list to an active "consult before structural changes" directive pointing at the new doc.

Three `gap` rows the audit identified are tracked in the principles doc with concrete next steps (no code change yet): evaluator over-praising tuning, cost-benefit framing for flow choice, model-bump audit cadence. The new `harness-principles` skill is what forces those rows to be walked on every Opus / Sonnet release.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 297 files / 2196 tests pass (skills registry test validates the new bundled folder)
- [x] `pnpm format:check` — clean
- [x] `pnpm deadcode` — clean
- [ ] Skill triggering smoke test: open a fresh Claude Code session with prompt *"I'm thinking about adding a retry primitive to the chain framework"*; the `harness-principles` and `ralphctl-minimal-scaffolding` skills should both fire.
- [ ] Agent hook smoke test: invoke the `reviewer` agent on a fake diff touching `src/application/chain/build/loop.ts`; confirm it Reads `HARNESS-PRINCIPLES.md` before reporting.
- [ ] Cold-read pass on `HARNESS-PRINCIPLES.md`: every section actionable, every `partial` / `gap` row names a concrete next step, every code anchor verified.