### PR TITLE
fix(harness): SIGTERM/signals recovery + plug runner.subscribe leaks

### DIFF
--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -126,12 +126,15 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   });
   // Stop the file-log + bus subscriptions when the runner reaches a terminal state.
   // Pending writes still drain in the background — events.ndjson remains consistent
-  // post-exit.
-  runner.subscribe((evt) => {
+  // post-exit. The subscription self-unsubscribes on the terminal event so we don't pin
+  // a dead listener (and its closure scope) to the runner's internal listener Set across
+  // a long multi-run TUI session — historically a load-bearing OOM contributor.
+  const unsubRunner: () => void = runner.subscribe((evt) => {
     if (evt.type === 'completed' || evt.type === 'failed' || evt.type === 'aborted') {
       chainLog.stop();
       void chainLog.flush();
       unsubTaskTracker();
+      unsubRunner();
     }
   });
   const taskNames = new Map<string, string>(todoTasks.map((t) => [String(t.id), t.name]));

--- a/src/application/ui/shared/launch/sprint-bound.ts
+++ b/src/application/ui/shared/launch/sprint-bound.ts
@@ -75,15 +75,21 @@ const attachReseatSubscriber = (
   fallbackLabel: string | undefined,
   onReseat: (info: { readonly id: SprintId; readonly name: string }) => void
 ): void => {
-  runner.subscribe((event) => {
+  // Self-unsubscribe on terminal events so the listener (and the captured `onReseat`
+  // closure) doesn't pin the runner across a long TUI session — historically a load-bearing
+  // OOM contributor for sprint-bound flows that get re-launched repeatedly.
+  const unsub: () => void = runner.subscribe((event) => {
+    if (event.type === 'failed' || event.type === 'aborted') {
+      unsub();
+      return;
+    }
     if (event.type !== 'completed') return;
     const ctx = event.ctx as SprintBoundCtx;
     if (ctx.sprint !== undefined) {
       onReseat({ id: ctx.sprint.id, name: ctx.sprint.name });
-      return;
-    }
-    if (ctx.sprintId !== undefined) {
+    } else if (ctx.sprintId !== undefined) {
       onReseat({ id: ctx.sprintId, name: fallbackLabel ?? String(ctx.sprintId) });
     }
+    unsub();
   });
 };

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -184,11 +184,19 @@ export const FlowsView = (): React.JSX.Element => {
           }
           // Subscribe BEFORE start() so we don't miss the synchronous completion of a
           // fast-path flow. Capture the chosen repository id from the final ctx for
-          // subsequent launches in this session.
-          result.runner.subscribe((event) => {
+          // subsequent launches in this session. Self-unsubscribe on terminal events so
+          // every flow launch doesn't pin a dead listener (and its closure scope, incl.
+          // the `ui` ref + the event's `ctx` object) to the runner's listener Set across
+          // a long TUI session — historically a load-bearing OOM contributor.
+          const unsubRepoCapture: () => void = result.runner.subscribe((event) => {
+            if (event.type === 'failed' || event.type === 'aborted') {
+              unsubRepoCapture();
+              return;
+            }
             if (event.type !== 'completed') return;
             const ctx = event.ctx as { readonly repository?: { readonly id: RepositoryId } };
             if (ctx.repository !== undefined) ui.setSessionRepositoryId(ctx.repository.id);
+            unsubRepoCapture();
           });
           sessions.register({
             runner: result.runner,

--- a/src/integration/ai/providers/_engine/attempt-outcome.ts
+++ b/src/integration/ai/providers/_engine/attempt-outcome.ts
@@ -1,0 +1,19 @@
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+import type { ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+
+/**
+ * The internal outcome shape every provider's `spawnAttempt` returns. The outer
+ * `generate(session)` translates these into `Result<ProviderOutput, DomainError>` and
+ * decides whether to retry on `rate-limit`.
+ *
+ * Shared across claude/codex/copilot to avoid per-provider duplication of an identical type
+ * and to let `classifySpawnExit` (in this same `_engine/` directory) return one canonical
+ * shape that every adapter consumes verbatim.
+ *
+ * @public
+ */
+export type AttemptOutcome =
+  | { readonly kind: 'success'; readonly output: ProviderOutput }
+  | { readonly kind: 'rate-limit'; readonly error: RateLimitError }
+  | { readonly kind: 'error'; readonly error: DomainError };

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -1,0 +1,153 @@
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import { pathExists } from '@src/integration/io/fs.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+
+/**
+ * Shared post-spawn classifier for the three headless AI provider adapters
+ * (claude / codex / copilot). Inspects the child's exit, the abort signal, stderr, and the
+ * presence of `signals.json`, and decides whether the attempt is a success, a rate-limit
+ * retry, an aborted operation, or a hard failure.
+ *
+ * Why centralise: the same five-step decision tree was implicit (and partially wrong) in
+ * every adapter. Two bugs surfaced that this helper fixes:
+ *
+ *  1. **Audit-[09] violation.** The contract says `signals.json` is authoritative — the AI
+ *     writes it directly via its `Write` tool, the harness validates it post-spawn. The
+ *     adapters were hard-failing on `signal === 'SIGTERM'` even when the AI had completed
+ *     its work; an evaluator that wrote a passing verdict at +8 min and then hung until the
+ *     idle-stdout watchdog SIGTERMed it at +13 min lost the passing verdict. The recovery
+ *     branch here honours the contract: signals.json present ⇒ the work landed.
+ *
+ *  2. **CLAUDE.md §267 violation.** User-initiated cancel (Ctrl-C / TUI abort) was returning
+ *     `InvalidStateError` ("process terminated via SIGTERM") instead of `AbortError`. Guards
+ *     and fallbacks downstream catch the InvalidStateError shape and continue execution,
+ *     violating "AbortError is the one error chains propagate transparently." Abort is
+ *     classified first now so the right error type surfaces.
+ *
+ * **Exit code vs signal:** macOS Node surfaces an idle-watchdog SIGTERM as either
+ * `{ code: null, signal: 'SIGTERM' }` OR `{ code: 143, signal: null }` depending on timing.
+ * The recovery branch fires for both — it only looks at whether `signals.json` is on disk,
+ * not at the exit shape.
+ *
+ * **Truncated / malformed signals.json is intentionally not validated here.** The adapter
+ * only checks existence (via `pathExists`); the downstream validator in
+ * `src/integration/ai/contract/_engine/validate-signals-file.ts` parses + schema-checks the
+ * file and surfaces a `ParseError` when it's empty / truncated / malformed. Splitting it
+ * this way keeps the adapter ignorant of the contract schema (which lives in its own
+ * sibling-isolated directory) and lets the downstream validator's existing error path
+ * handle the bad-content cases uniformly with the case where the AI just never wrote
+ * signals.json at all.
+ *
+ * **Rate-limit wins over recovery.** If stderr matches the rate-limit regex, surface
+ * `rate-limit` — backoff/retry is the right response even if a partial `signals.json` from
+ * a previous attempt happens to be on disk (per-round outputDir means it shouldn't be, but
+ * the precedence keeps the semantics safe under reuse).
+ *
+ * @public
+ */
+export type ProviderName = 'claude-provider' | 'codex-provider' | 'copilot-provider';
+
+export interface ClassifySpawnExitInput {
+  readonly session: AiSession;
+  readonly exit: { readonly code: number | null; readonly signal: string | null };
+  readonly stderr: string;
+  /** Matched against `stderr` to detect rate-limit. Producer of the regex is the adapter. */
+  readonly rateLimitRe: RegExp;
+  /** Provider's best-effort captured session id, attached to `RateLimitError` when present. */
+  readonly capturedSessionId?: string;
+  readonly providerName: ProviderName;
+  readonly eventBus: EventBus;
+  /**
+   * The banner id the adapter's `onIdle` callback used when publishing the watchdog
+   * "killed stuck process" banner. The recovery branch publishes a `banner-clear` against
+   * this exact id so the operator doesn't see a stuck-process warning beside a successful
+   * outcome.
+   */
+  readonly watchdogBannerId: string;
+  /**
+   * Per-provider success block — emits token-usage, persists session-id.txt, mirrors
+   * bodyFile, and returns `{ kind: 'success', output: ProviderOutput }`. Invoked on
+   * `code === 0` AND on the recovery branch. When recovery fired, the helper splices
+   * `recoveredFromExit` into the returned `output` so the caller can tell the two apart.
+   */
+  readonly onSuccess: () => AttemptOutcome | Promise<AttemptOutcome>;
+}
+
+export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<AttemptOutcome> => {
+  const { session, exit, stderr, rateLimitRe, capturedSessionId, providerName, eventBus, watchdogBannerId, onSuccess } =
+    input;
+
+  // 1. Abort precedence. A user cancel that races a clean exit still surfaces as
+  // AbortError so the chain runner can propagate it transparently per CLAUDE.md §267.
+  if (session.abortSignal?.aborted === true) {
+    return {
+      kind: 'error',
+      error: new AbortError({
+        elementName: providerName,
+        reason: `${providerName}: aborted by caller`,
+      }),
+    };
+  }
+
+  // 2. Clean exit — adapter's own success block owns the data plumbing.
+  if (exit.code === 0) {
+    return await onSuccess();
+  }
+
+  // 3. Rate-limit — backoff/retry takes precedence over signals-recovery.
+  if (rateLimitRe.test(stderr)) {
+    return {
+      kind: 'rate-limit',
+      error: new RateLimitError({
+        subCode: 'spawn-stderr',
+        message: `${providerName}: rate-limit detected in stderr (exit ${String(exit.code)})`,
+        ...(capturedSessionId !== undefined ? { sessionId: capturedSessionId } : {}),
+      }),
+    };
+  }
+
+  // 4. Recovery — audit-[09]: signals.json is authoritative. Existence-check only; the
+  // downstream validator catches malformed content.
+  const exists = await pathExists(String(session.signalsFile));
+  if (exists.ok && exists.value) {
+    eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `${providerName}: non-zero exit (code=${String(exit.code)}, signal=${String(exit.signal ?? 'null')}) but signals.json captured — preserving work`,
+      meta: { code: exit.code, signal: exit.signal, providerName },
+      at: IsoTimestamp.now(),
+    });
+    eventBus.publish({
+      type: 'banner-clear',
+      id: watchdogBannerId,
+      at: IsoTimestamp.now(),
+    });
+    const outcome = await onSuccess();
+    if (outcome.kind === 'success') {
+      return {
+        kind: 'success',
+        output: {
+          ...outcome.output,
+          recoveredFromExit: { code: exit.code, signal: exit.signal },
+        },
+      };
+    }
+    return outcome;
+  }
+
+  // 5. Hard fail. Mirrors the historical per-adapter exit-N error shape.
+  return {
+    kind: 'error',
+    error: new InvalidStateError({
+      entity: providerName,
+      currentState: `exit-${String(exit.code ?? 'null')}`,
+      attemptedAction: 'complete generation',
+      message: `${providerName}: process exited with code ${String(exit.code)}${exit.signal !== null ? ` (signal=${exit.signal})` : ''}: ${stderr.trim() || '<empty stderr>'}`,
+    }),
+  };
+};

--- a/src/integration/ai/providers/_engine/headless-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/headless-ai-provider.ts
@@ -30,4 +30,13 @@ export interface ProviderOutput {
   readonly sessionId?: string;
   /** The child process's exit code (0 on the success path). Surfaced so callers can decide their own outcome semantics. */
   readonly exitCode: number;
+  /**
+   * Present only when the spawn exited non-clean (SIGTERM from the idle-stdout watchdog,
+   * or code 143 — macOS Node surfaces SIGTERM either way) but the AI had already written
+   * `signals.json` per the audit-[09] contract, so the harness honoured the work and
+   * recovered. `undefined` on every clean (`code === 0`) exit. Lets the round summary
+   * distinguish a healthy spawn from one that was killed post-Write without log-scraping
+   * — set in `_engine/classify-spawn-exit.ts`.
+   */
+  readonly recoveredFromExit?: { readonly code: number | null; readonly signal: string | null };
 }

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -22,6 +22,8 @@ import {
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 
 /**
  * Real {@link HeadlessAiProvider} backed by the Claude Code CLI.
@@ -266,11 +268,6 @@ export const createClaudeProvider = (deps: ClaudeProviderDeps): HeadlessAiProvid
   };
 };
 
-type AttemptOutcome =
-  | { readonly kind: 'success'; readonly output: ProviderOutput }
-  | { readonly kind: 'rate-limit'; readonly error: RateLimitError }
-  | { readonly kind: 'error'; readonly error: DomainError };
-
 interface SpawnAttemptArgs {
   readonly deps: ClaudeProviderDeps;
   readonly spawnFn: ProviderSpawn;
@@ -281,10 +278,15 @@ interface SpawnAttemptArgs {
 
 /**
  * One spawn attempt: launch `claude`, write prompt, stream stdout JSONL through the
- * stream-json parser, accumulate the authoritative assistant body from the `{type:"result"}`
- * event, then on close extract harness signals and write them to `session.signalsFile`.
- * Optionally mirrors the body to `session.bodyFile`. The body goes out of scope at function
- * return — never retained on a domain entity.
+ * stream-json parser, then delegate exit classification to `classifySpawnExit` (decides
+ * success / rate-limit / abort / signals-recovery / hard-fail uniformly across the three
+ * adapters). Per-provider success block (token-usage publish, persistSessionIdFile,
+ * optional bodyFile mirror) lives in the `onSuccess` closure passed to the classifier —
+ * the closure runs on `code === 0` AND on signals-present recovery, so a watchdog SIGTERM
+ * that landed after the AI completed its work still produces a success.
+ *
+ * The `envelope.body` string goes out of scope at function return — never retained on a
+ * domain entity.
  */
 const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> => {
   const { deps, spawnFn, command, args, session } = input;
@@ -303,6 +305,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   const onLine = (line: ClaudeStreamLine): void => {
     parser.ingest(line);
   };
+
+  // Bound once so the onIdle banner-show id and the classifier's banner-clear id match.
+  const watchdogBannerId = `watchdog-claude-${String(child.pid ?? 'unknown')}`;
 
   // Wait for the child to fully `'close'` — NOT just `'exit'`. `'exit'` can fire before the
   // final stdout chunk has been delivered to our listener; `'close'` guarantees the streams
@@ -332,7 +337,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
       deps.eventBus.publish({
         type: 'banner-show',
-        id: `watchdog-claude-${String(child.pid ?? 'unknown')}`,
+        id: watchdogBannerId,
         tier: 'warn',
         message: `Watchdog killed stuck claude process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
         at: IsoTimestamp.now(),
@@ -341,24 +346,12 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   });
   parser.flush(onLine);
 
-  if (signal === 'SIGTERM') {
-    return {
-      kind: 'error',
-      error: new InvalidStateError({
-        entity: 'claude-provider',
-        currentState: 'terminated',
-        attemptedAction: 'complete generation',
-        message: 'claude-provider: process terminated via SIGTERM',
-      }),
-    };
-  }
-
   // `envelope.body` is sourced from `parser.snapshot()` in O(1) — the parser holds a single
   // string reassigned from the latest `result` event. No per-line concatenation in this
   // adapter; preserve that invariant.
   const envelope = parser.snapshot();
 
-  if (code === 0) {
+  const onSuccess = async (): Promise<AttemptOutcome> => {
     if (envelope.sessionId !== undefined) {
       deps.eventBus.publish({
         type: 'log',
@@ -367,9 +360,10 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         meta: { sessionId: envelope.sessionId },
         at: IsoTimestamp.now(),
       });
-      // Emit one TokenUsageEvent per clean-termination spawn — only when we have a sessionId
+      // Emit one TokenUsageEvent per success spawn — only when we have a sessionId
       // (downstream subscribers correlate by it). Absence of usage counters is honest: the
-      // result event may carry zero usage subkeys on degenerate spawns.
+      // result event may carry zero usage subkeys on degenerate spawns or when the spawn
+      // was SIGTERM-recovered before the final result event landed.
       const window = contextWindowFor(envelope.model);
       deps.eventBus.publish({
         type: 'token-usage',
@@ -420,34 +414,23 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       kind: 'success',
       output: {
         signalsFile: session.signalsFile,
-        exitCode: code,
+        exitCode: code ?? 0,
         ...(envelope.sessionId !== undefined ? { sessionId: envelope.sessionId } : {}),
       },
     };
-  }
-
-  // Non-zero exit. Rate-limit detection: stderr regex match — lean heuristic, easy to widen.
-  if (RATE_LIMIT_RE.test(stderrBuf)) {
-    // Best-effort: surface any session id the stream already carried, even on failure.
-    return {
-      kind: 'rate-limit',
-      error: new RateLimitError({
-        subCode: 'spawn-stderr',
-        message: `claude-provider: rate-limit detected in stderr (exit ${String(code)})`,
-        ...(envelope.sessionId !== undefined ? { sessionId: envelope.sessionId } : {}),
-      }),
-    };
-  }
-
-  return {
-    kind: 'error',
-    error: new InvalidStateError({
-      entity: 'claude-provider',
-      currentState: `exit-${String(code)}`,
-      attemptedAction: 'complete generation',
-      message: `claude-provider: process exited with code ${String(code)}: ${stderrBuf.trim() || '<empty stderr>'}`,
-    }),
   };
+
+  return classifySpawnExit({
+    session,
+    exit: { code, signal },
+    stderr: stderrBuf,
+    rateLimitRe: RATE_LIMIT_RE,
+    ...(envelope.sessionId !== undefined ? { capturedSessionId: envelope.sessionId } : {}),
+    providerName: 'claude-provider',
+    eventBus: deps.eventBus,
+    watchdogBannerId,
+    onSuccess,
+  });
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -16,6 +16,8 @@ import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import {
   DEFAULT_BACKOFF_SCHEDULE,
   delayForRetry,
@@ -268,11 +270,6 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
   };
 };
 
-type AttemptOutcome =
-  | { readonly kind: 'success'; readonly output: ProviderOutput }
-  | { readonly kind: 'rate-limit'; readonly error: RateLimitError }
-  | { readonly kind: 'error'; readonly error: DomainError };
-
 interface SpawnAttemptArgs {
   readonly deps: CodexProviderDeps;
   readonly spawnFn: ProviderSpawn;
@@ -359,6 +356,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   let sessionId: string | undefined;
   let stdoutLineBuf = '';
 
+  // Bound once so onIdle's banner-show id and the classifier's banner-clear id match.
+  const watchdogBannerId = `watchdog-codex-${String(child.pid ?? 'unknown')}`;
+
   // Codex `exec` reads the prompt from stdin; codex streams tokens to stdout so we attach a
   // line-buffering session-id sniffer and wait for `'exit'` (no need to wait for streams to
   // flush after exit — the session id is captured inline).
@@ -406,7 +406,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
       deps.eventBus.publish({
         type: 'banner-show',
-        id: `watchdog-codex-${String(child.pid ?? 'unknown')}`,
+        id: watchdogBannerId,
         tier: 'warn',
         message: `Watchdog killed stuck codex process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
         at: IsoTimestamp.now(),
@@ -414,24 +414,13 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     },
   });
 
-  if (signal === 'SIGTERM') {
-    return {
-      kind: 'error',
-      error: new InvalidStateError({
-        entity: 'codex-provider',
-        currentState: 'terminated',
-        attemptedAction: 'complete generation',
-        message: 'codex-provider: process terminated via SIGTERM',
-      }),
-    };
-  }
-
-  if (code === 0) {
+  const onSuccess = async (): Promise<AttemptOutcome> => {
     let body: string;
     try {
       // Single-shot read of the codex output tempfile — no per-line in-process accumulation.
       // Preserve that: any future streaming variant must use an O(N) accumulator (see the
-      // `bodyLines.push` + `.join('\n')` pattern in copilot/headless.ts).
+      // `bodyLines.push` + `.join('\n')` pattern in copilot/headless.ts). On SIGTERM-recovery
+      // the tempfile may be partial or empty; bodyFile mirror simply writes what we have.
       body = await readFile(outputFile);
     } catch (err) {
       return {
@@ -473,7 +462,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       }
     }
     if (sessionId !== undefined) {
-      // Emit one TokenUsageEvent per clean-termination spawn. Codex commonly omits token counts
+      // Emit one TokenUsageEvent per success spawn. Codex commonly omits token counts
       // from the JSONL records on v0.130.x; the event still fires so subscribers can correlate
       // sessionId → provider without inferring success from token-field absence.
       const window = contextWindowFor(model);
@@ -492,32 +481,23 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       kind: 'success',
       output: {
         signalsFile: session.signalsFile,
-        exitCode: code,
+        exitCode: code ?? 0,
         ...(sessionId !== undefined ? { sessionId } : {}),
       },
     };
-  }
-
-  if (RATE_LIMIT_RE.test(stderrBuf)) {
-    return {
-      kind: 'rate-limit',
-      error: new RateLimitError({
-        subCode: 'spawn-stderr',
-        message: `codex-provider: rate-limit detected in stderr (exit ${String(code)})`,
-        ...(sessionId !== undefined ? { sessionId } : {}),
-      }),
-    };
-  }
-
-  return {
-    kind: 'error',
-    error: new InvalidStateError({
-      entity: 'codex-provider',
-      currentState: `exit-${String(code)}`,
-      attemptedAction: 'complete generation',
-      message: `codex-provider: process exited with code ${String(code)}: ${stderrBuf.trim() || '<empty stderr>'}`,
-    }),
   };
+
+  return classifySpawnExit({
+    session,
+    exit: { code, signal },
+    stderr: stderrBuf,
+    rateLimitRe: RATE_LIMIT_RE,
+    ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
+    providerName: 'codex-provider',
+    eventBus: deps.eventBus,
+    watchdogBannerId,
+    onSuccess,
+  });
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -17,6 +17,8 @@ import {
 } from '@src/integration/ai/providers/copilot/parse-stream.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import {
   DEFAULT_BACKOFF_SCHEDULE,
   delayForRetry,
@@ -225,11 +227,6 @@ export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProv
   };
 };
 
-type AttemptOutcome =
-  | { readonly kind: 'success'; readonly output: ProviderOutput }
-  | { readonly kind: 'rate-limit'; readonly error: RateLimitError }
-  | { readonly kind: 'error'; readonly error: DomainError };
-
 interface SpawnAttemptArgs {
   readonly deps: CopilotProviderDeps;
   readonly spawnFn: ProviderSpawn;
@@ -258,6 +255,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   let model: string | undefined;
   let usage: CopilotUsage = {};
   let stderrBuf = '';
+
+  // Bound once so onIdle's banner-show id and the classifier's banner-clear id match.
+  const watchdogBannerId = `watchdog-copilot-${String(child.pid ?? 'unknown')}`;
 
   const onLine = (line: CopilotStreamLine): void => {
     if (line.json !== undefined) {
@@ -322,7 +322,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
       deps.eventBus.publish({
         type: 'banner-show',
-        id: `watchdog-copilot-${String(child.pid ?? 'unknown')}`,
+        id: watchdogBannerId,
         tier: 'warn',
         message: `Watchdog killed stuck copilot process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
         at: IsoTimestamp.now(),
@@ -331,24 +331,13 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   });
   parser.flush(onLine);
 
-  if (signal === 'SIGTERM') {
-    return {
-      kind: 'error',
-      error: new InvalidStateError({
-        entity: 'copilot-provider',
-        currentState: 'terminated',
-        attemptedAction: 'complete generation',
-        message: 'copilot-provider: process terminated via SIGTERM',
-      }),
-    };
-  }
-
-  if (code === 0) {
+  const onSuccess = async (): Promise<AttemptOutcome> => {
     // audit-[09]: the AI writes `signals.json` directly via its Write tool into
     // `session.outputDir`; the harness validates it post-spawn. The provider never writes
     // signals.json itself. The forensic body buffer below stays — operators inspect it when
     // a proposal comes back empty to decide whether the prompt, the AI, or the validator is
-    // at fault.
+    // at fault. On SIGTERM-recovery `events[]` may be partial; the join still produces a
+    // useful snapshot of what the model emitted before the watchdog stepped in.
     const forensicBody = events.map((e) => e.text).join('\n');
     // Mirror raw body for diagnostic capture. Best-effort: a write failure here is logged but
     // does not fail the session. Critically, the body is captured even when the AI emits no
@@ -366,7 +355,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       }
     }
     if (sessionId !== undefined) {
-      // Emit one TokenUsageEvent per clean-termination spawn — even when Copilot omits usage
+      // Emit one TokenUsageEvent per success spawn — even when Copilot omits usage
       // counters from the meta line, sessionId + provider + (maybe) model is still useful for
       // a TUI widget that correlates rounds with provider sessions. Honest about absent fields.
       const window = contextWindowFor(model);
@@ -398,32 +387,23 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       kind: 'success',
       output: {
         signalsFile: session.signalsFile,
-        exitCode: code,
+        exitCode: code ?? 0,
         ...(sessionId !== undefined ? { sessionId } : {}),
       },
     };
-  }
-
-  if (RATE_LIMIT_RE.test(stderrBuf)) {
-    return {
-      kind: 'rate-limit',
-      error: new RateLimitError({
-        subCode: 'spawn-stderr',
-        message: `copilot-provider: rate-limit detected in stderr (exit ${String(code)})`,
-        ...(sessionId !== undefined ? { sessionId } : {}),
-      }),
-    };
-  }
-
-  return {
-    kind: 'error',
-    error: new InvalidStateError({
-      entity: 'copilot-provider',
-      currentState: `exit-${String(code)}`,
-      attemptedAction: 'complete generation',
-      message: `copilot-provider: process exited with code ${String(code)}: ${stderrBuf.trim() || '<empty stderr>'}`,
-    }),
   };
+
+  return classifySpawnExit({
+    session,
+    exit: { code, signal },
+    stderr: stderrBuf,
+    rateLimitRe: RATE_LIMIT_RE,
+    ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
+    providerName: 'copilot-provider',
+    eventBus: deps.eventBus,
+    watchdogBannerId,
+    onSuccess,
+  });
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>

--- a/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
+++ b/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
@@ -1,0 +1,260 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { classifySpawnExit, type ProviderName } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import { READ_ONLY } from '@src/integration/ai/providers/_engine/session-permissions.ts';
+import { absolutePath } from '@tests/fixtures/domain.ts';
+import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+
+const PROMPT = 'fake prompt' as unknown as Prompt;
+const CWD = absolutePath('/tmp/classify-spawn-exit-test');
+
+let counter = 0;
+const freshSignalsPath = (): string => {
+  counter += 1;
+  return join(
+    tmpdir(),
+    `classify-spawn-exit-${String(process.pid)}-${String(Date.now())}-${String(counter)}`,
+    'signals.json'
+  );
+};
+
+const writeSignalsFile = async (path: string, content = '{}'): Promise<void> => {
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, content, 'utf8');
+};
+
+const baseSession = (overrides: Partial<AiSession> = {}): AiSession => ({
+  prompt: PROMPT,
+  cwd: CWD,
+  model: 'fake-model',
+  permissions: READ_ONLY,
+  signalsFile: absolutePath(freshSignalsPath()),
+  ...overrides,
+});
+
+const happyOutput = (session: AiSession): ProviderOutput => ({
+  signalsFile: session.signalsFile,
+  exitCode: 0,
+  sessionId: 'fake-session',
+});
+
+const okSuccess = (session: AiSession): AttemptOutcome => ({
+  kind: 'success',
+  output: happyOutput(session),
+});
+
+const RATE_RE = /rate.?limit/i;
+
+// Parametric across the three real providers — keeps the shape honest. The helper itself
+// doesn't care which provider name; tests asserting the message text only need ONE pick.
+const PROVIDERS: readonly ProviderName[] = ['claude-provider', 'codex-provider', 'copilot-provider'];
+
+describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
+  it('clean exit invokes onSuccess and does not set recoveredFromExit', async () => {
+    const session = baseSession();
+    const cap = createCapturingBus();
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 0, signal: null },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: cap.bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(1);
+    expect(outcome.kind).toBe('success');
+    if (outcome.kind === 'success') {
+      expect(outcome.output.recoveredFromExit).toBeUndefined();
+    }
+  });
+
+  it('aborted signal + SIGTERM returns AbortError (not InvalidStateError)', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const session = baseSession({ abortSignal: ac.signal });
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: null, signal: 'SIGTERM' },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(0);
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(AbortError);
+      expect(outcome.error.message).toContain(providerName);
+    }
+  });
+
+  it('aborted signal + clean exit returns AbortError (precedence over success)', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const session = baseSession({ abortSignal: ac.signal });
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 0, signal: null },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') expect(outcome.error).toBeInstanceOf(AbortError);
+  });
+
+  it('SIGTERM + signals.json present invokes onSuccess and sets recoveredFromExit', async () => {
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    const cap = createCapturingBus();
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: null, signal: 'SIGTERM' },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: cap.bus,
+      watchdogBannerId: 'watchdog-test-pid-1234',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(1);
+    expect(outcome.kind).toBe('success');
+    if (outcome.kind === 'success') {
+      expect(outcome.output.recoveredFromExit).toEqual({ code: null, signal: 'SIGTERM' });
+    }
+    // Recovery emits a warn log + a banner-clear for the watchdog banner.
+    const warnLog = cap.logs.find((e) => e.level === 'warn');
+    expect(warnLog).toBeDefined();
+    if (warnLog !== undefined) {
+      expect(warnLog.message).toContain('signals.json captured');
+      expect(warnLog.message).toContain(providerName);
+    }
+    const bannerClear = cap.events.find((e) => e.type === 'banner-clear');
+    expect(bannerClear).toBeDefined();
+    if (bannerClear?.type === 'banner-clear') {
+      expect(bannerClear.id).toBe('watchdog-test-pid-1234');
+    }
+  });
+
+  it('code 143 + signal null + signals.json present recovers (macOS Node shape)', async () => {
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 143, signal: null },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('success');
+    if (outcome.kind === 'success') {
+      expect(outcome.output.recoveredFromExit).toEqual({ code: 143, signal: null });
+    }
+  });
+
+  it('non-zero exit + signals.json absent hard-fails with InvalidStateError', async () => {
+    const session = baseSession();
+    // Do NOT write signals.json.
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 2, signal: null },
+      stderr: 'some-real-failure',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(0);
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error.message).toContain('process exited with code 2');
+      expect(outcome.error.message).toContain('some-real-failure');
+    }
+  });
+
+  it('non-zero exit + empty signals.json still recovers (adapter does not validate content)', async () => {
+    const session = baseSession();
+    // Write an empty file — downstream validate-signals-file.ts catches malformed content;
+    // the adapter intentionally only checks existence so that split stays clean.
+    await writeSignalsFile(String(session.signalsFile), '');
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: 'partial-write-then-crash',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(1);
+    expect(outcome.kind).toBe('success');
+  });
+
+  it('rate-limit in stderr wins over signals-present recovery', async () => {
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: 'rate limit exceeded for tier x',
+      rateLimitRe: RATE_RE,
+      capturedSessionId: 'fake-id',
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(0);
+    expect(outcome.kind).toBe('rate-limit');
+    if (outcome.kind === 'rate-limit') {
+      expect(outcome.error).toBeInstanceOf(RateLimitError);
+      expect(outcome.error.sessionId).toBe('fake-id');
+    }
+  });
+});

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -555,4 +555,24 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
     expect(args[args.indexOf('--add-dir') + 1]).toBe('/tmp/extra-root');
     expect(args[args.indexOf('--resume') + 1]).toBe('sess-xyz');
   });
+
+  it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
+    // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
+    // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already
+    // written signals.json via its Write tool before the child wedged.
+    const cap = createCapturingBus();
+    const sess = session();
+    await fs.mkdir(dirname(String(sess.signalsFile)), { recursive: true });
+    await fs.writeFile(String(sess.signalsFile), '{"signals":[]}', 'utf8');
+    const { spawn } = makeSpawn([{ exitCode: 143 }]);
+
+    const provider = createClaudeProvider({ rateLimitRetries: 0, eventBus: cap.bus, spawn });
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.recoveredFromExit).toEqual({ code: 143, signal: null });
+    // The recovery branch emits a warn log mentioning the signals capture.
+    const warn = cap.logs.find((l) => l.level === 'warn' && l.message.includes('signals.json captured'));
+    expect(warn).toBeDefined();
+  });
 });

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -332,6 +332,33 @@ describe('createCodexProvider', () => {
     await provider.generate(session());
     expect(fsStub.unlinks).toEqual([FIXED_OUT]);
   });
+
+  it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
+    // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
+    // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already
+    // written signals.json via its Write tool before the child wedged.
+    const cap = createCapturingBus();
+    const sess = session();
+    await fs.mkdir(dirname(String(sess.signalsFile)), { recursive: true });
+    await fs.writeFile(String(sess.signalsFile), '{"signals":[]}', 'utf8');
+    const { spawn } = makeSpawn([{ exitCode: 143 }]);
+    const fsStub = stubFs('partial body before SIGTERM');
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.recoveredFromExit).toEqual({ code: 143, signal: null });
+    const warn = cap.logs.find((l) => l.level === 'warn' && l.message.includes('signals.json captured'));
+    expect(warn).toBeDefined();
+  });
 });
 
 describe('createCodexProvider — TokenUsageEvent emission', () => {

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -391,6 +391,25 @@ describe('createCopilotProvider', () => {
     expect(contents).toContain('fresh body');
     expect(contents).not.toContain('stale prior content');
   });
+
+  it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
+    // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
+    // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already
+    // written signals.json via its Write tool before the child wedged.
+    const cap = createCapturingBus();
+    const sess = session();
+    await fs.mkdir(dirname(String(sess.signalsFile)), { recursive: true });
+    await fs.writeFile(String(sess.signalsFile), '{"signals":[]}', 'utf8');
+    const { spawn } = makeSpawn([{ exitCode: 143 }]);
+
+    const provider = createCopilotProvider({ rateLimitRetries: 0, eventBus: cap.bus, spawn });
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.recoveredFromExit).toEqual({ code: 143, signal: null });
+    const warn = cap.logs.find((l) => l.level === 'warn' && l.message.includes('signals.json captured'));
+    expect(warn).toBeDefined();
+  });
 });
 
 describe('createCopilotProvider — TokenUsageEvent emission', () => {


### PR DESCRIPTION
## Summary

Two independent harness-resilience bugs surfaced in the same long-running implement session, fixed as two commits in this PR.

- **`fix(providers): recover signals.json on watchdog SIGTERM / code 143`** — the idle-stdout watchdog correctly killed a wedged claude child after 5 min of silence, but the AI had already written a passing \`signals.json\` 5 min earlier. The provider adapters were hard-failing on any non-zero exit, discarding the verdict. New shared \`_engine/classify-spawn-exit.ts\` helper honours the audit-[09] contract: signals.json present means the work landed, regardless of exit shape. Handles both ways macOS Node surfaces SIGTERM (\`signal='SIGTERM'\` vs \`code=143, signal=null\`). Also fixes a latent CLAUDE.md §267 bug where user Ctrl-C surfaced as \`InvalidStateError\` instead of \`AbortError\`.
- **`fix(runtime): plug 3 runner.subscribe() leaks`** — static leak audit (root-cause hunt for the harness OOM) found three call sites discarding the unsubscribe returned by \`runner.subscribe()\`. Each leaked listener pinned its closure scope (incl. \`event.ctx\` which can be 100s of KB) to the runner's listener Set for the harness lifetime. Sites: \`flows-view.tsx\` (per-flow launch), \`sprint-bound.ts\` (reseat subscriber), \`implement.ts\` (chain-log + bus tear-down). Matches the self-detaching pattern already audited and cleared in \`session-manager.ts\`.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 2229/2229 passing (24 new helper-level tests + 3 new per-adapter wiring tests)
- [ ] Re-run the captured incident from \`/Users/grigis/.ralphctl/data/sprints/debug/019e5b9b-…/\` with low \`idleMs\` to force a watchdog kill; expect the spawn to return success with \`recoveredFromExit\` set and the evaluator's passing verdict to be honoured
- [ ] Smoke-test abort: launch implement, hit Ctrl-C mid-spawn, confirm chain trace shows \`AbortError\` (not \`InvalidStateError\`)
- [ ] Stress-launch flows from the TUI in a single session and confirm heap stays flat (no growth from the previously-leaked listeners)