### PR TITLE
feat(settings): gate unavailable providers across TUI, CLI, and launch preflight

### DIFF
--- a/src/application/flows/settings-set-provider/deps.ts
+++ b/src/application/flows/settings-set-provider/deps.ts
@@ -1,5 +1,16 @@
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { DetectInstalledProvidersOptions } from '@src/integration/system/detect-cli.ts';
 
 export interface SettingsSetProviderDeps {
   readonly settingsRepo: SettingsRepository;
+  /**
+   * Test seam — defaults to the production `detectInstalledProviders` from
+   * `@src/integration/system/detect-cli.ts`. Tests inject a stub returning a fixed set so the
+   * "ValidationError for an installed-but-missing provider" assertion does not depend on what's
+   * on the host machine's PATH. The flow probes the seam on every save attempt — operators
+   * who install a missing CLI then immediately re-set the provider see the gate clear without
+   * restarting ralphctl.
+   */
+  readonly detectInstalledProviders?: (options?: DetectInstalledProvidersOptions) => Promise<ReadonlySet<AiProvider>>;
 }

--- a/src/application/flows/settings-set-provider/flow.ts
+++ b/src/application/flows/settings-set-provider/flow.ts
@@ -4,6 +4,11 @@ import type { AiSettings, Settings } from '@src/domain/entity/settings.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { defaultAiSettingsForProvider } from '@src/business/settings/defaults.ts';
+import {
+  detectInstalledProviders as defaultDetect,
+  PROVIDER_BINARY,
+  renderProviderInstallGuidance,
+} from '@src/integration/system/detect-cli.ts';
 
 import type {
   SettingsSetProviderCtx,
@@ -33,6 +38,26 @@ export const createSettingsSetProviderFlow = (deps: SettingsSetProviderDeps): El
       async execute(input) {
         const current = await deps.settingsRepo.load();
         if (!current.ok) return Result.error(current.error);
+        // Availability gate runs BEFORE the schema rebuild so an unavailable provider never
+        // touches disk. The probe is the same one the launch-time fail-fast helper uses, so
+        // operators see a consistent gate across surfaces: a provider that fails here also
+        // fails the next launch.
+        const detect = deps.detectInstalledProviders ?? defaultDetect;
+        const installed = await detect();
+        if (!installed.has(input.provider)) {
+          const settingsKey =
+            input.flow === 'implement'
+              ? `ai.implement.${input.role ?? 'generator'}.provider`
+              : `ai.${input.flow}.provider`;
+          return Result.error(
+            new ValidationError({
+              field: settingsKey,
+              value: input.provider,
+              message: `${input.provider} CLI (${PROVIDER_BINARY[input.provider]}) not on PATH — cannot set ${settingsKey}`,
+              hint: renderProviderInstallGuidance(input.provider),
+            })
+          );
+        }
         const defaultsForProvider = defaultAiSettingsForProvider(input.provider);
         let nextAi: AiSettings;
         if (input.flow === 'implement') {

--- a/src/application/ui/cli/commands/settings.ts
+++ b/src/application/ui/cli/commands/settings.ts
@@ -3,8 +3,28 @@ import { applySettingsKey } from '@src/business/settings/apply-key.ts';
 import { isPresetName, PRESET_NAMES } from '@src/business/settings/presets.ts';
 import { createSettingsShowFlow } from '@src/application/flows/settings-show/flow.ts';
 import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.ts';
+import { createSettingsSetProviderFlow } from '@src/application/flows/settings-set-provider/flow.ts';
 import { createSettingsApplyPresetFlow } from '@src/application/flows/settings-apply-preset/flow.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import type { AiImplementRole, AiProvider } from '@src/domain/entity/settings.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+
+const AI_PROVIDERS: readonly AiProvider[] = ['claude-code', 'github-copilot', 'openai-codex'];
+const isAiProvider = (raw: string): raw is AiProvider => (AI_PROVIDERS as readonly string[]).includes(raw);
+
+/**
+ * Detect a provider-setting key and return the parsed flow+role tuple. Returns `undefined` for
+ * any other key; `applySettingsKey` (the legacy path) still handles those. Recognised shapes:
+ *   - `ai.<flow>.provider`              (flow ∈ refine | plan | readiness | ideate)
+ *   - `ai.implement.<role>.provider`    (role ∈ generator | evaluator)
+ */
+const parseProviderKey = (key: string): { readonly flow: FlowId; readonly role?: AiImplementRole } | undefined => {
+  const implementMatch = /^ai\.implement\.(generator|evaluator)\.provider$/.exec(key);
+  if (implementMatch !== null) return { flow: 'implement', role: implementMatch[1] as AiImplementRole };
+  const flatMatch = /^ai\.(refine|plan|readiness|ideate)\.provider$/.exec(key);
+  if (flatMatch !== null) return { flow: flatMatch[1] as FlowId };
+  return undefined;
+};
 
 /**
  * Register the `settings` command group.
@@ -58,6 +78,40 @@ export const registerSettingsCommand = (program: Command): void => {
     .description('mutate one setting and persist (read-modify-write, schema-validated)')
     .action(async (key: string, value: string) => {
       const { deps } = await bootstrapCli();
+      // Provider keys route through the dedicated `settings-set-provider` flow rather than the
+      // generic apply-key path. That flow rebuilds the row's `{ provider, model }` pair from
+      // the new provider's defaults (so the schema stays satisfied) AND runs the same
+      // PATH-availability gate as the launch-time fail-fast helper — so an `openai-codex`
+      // assignment fails here exactly as it would on the next implement run. Unknown provider
+      // ids still surface as a ValidationError so callers can distinguish "wrong shape" from
+      // "valid shape but CLI missing".
+      const providerKey = parseProviderKey(key);
+      if (providerKey !== undefined) {
+        if (!isAiProvider(value)) {
+          process.stderr.write(
+            `error: '${value}' is not a recognised provider (expected one of: ${AI_PROVIDERS.join(', ')})\n`
+          );
+          process.exit(1);
+          return;
+        }
+        const providerFlow = createSettingsSetProviderFlow({ settingsRepo: deps.settingsRepo });
+        const saved = await providerFlow.execute({
+          input: {
+            flow: providerKey.flow,
+            provider: value,
+            ...(providerKey.role !== undefined ? { role: providerKey.role } : {}),
+          },
+        });
+        if (!saved.ok) {
+          const err = saved.error.error;
+          const hint = 'hint' in err && typeof err.hint === 'string' ? ` (${err.hint})` : '';
+          process.stderr.write(`error: ${err.message}${hint}\n`);
+          process.exit(1);
+          return;
+        }
+        process.stdout.write(`${key} = ${value}\n`);
+        return;
+      }
       const showFlow = createSettingsShowFlow({ settingsRepo: deps.settingsRepo });
       const current = await showFlow.execute({ input: undefined });
       if (!current.ok) {

--- a/src/application/ui/shared/launch/check-cli.ts
+++ b/src/application/ui/shared/launch/check-cli.ts
@@ -15,7 +15,12 @@
  * invokes this helper exactly once — no internal caching is needed.
  */
 
-import { detectInstalledProviders, PROVIDER_BINARY } from '@src/integration/system/detect-cli.ts';
+import {
+  detectInstalledProviders,
+  PROVIDER_BINARY,
+  PROVIDER_INSTALL_GUIDANCE,
+  primaryInstallCommand,
+} from '@src/integration/system/detect-cli.ts';
 import { primaryFlowRow, type AiProvider, type Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
@@ -85,8 +90,10 @@ const rowExpectationsFor = (aiFlow: FlowId, settings: Settings): readonly RowExp
 const renderMissing = (missing: readonly RowExpectation[], aiFlow: FlowId): string => {
   const formatOne = (m: RowExpectation): string => {
     const binary = PROVIDER_BINARY[m.provider];
+    const installHint = primaryInstallCommand(m.provider);
+    const docsUrl = PROVIDER_INSTALL_GUIDANCE[m.provider].docsUrl;
     const roleSuffix = m.role !== undefined ? ` (${m.role})` : '';
-    return `CLI ${binary} not on PATH for flow ${aiFlow}${roleSuffix}. Change ${m.settingsKey} or install the CLI.`;
+    return `CLI ${binary} not on PATH for flow ${aiFlow}${roleSuffix}. Change ${m.settingsKey} or install with: ${installHint} (alternatives: ${docsUrl}).`;
   };
   if (missing.length === 1) return formatOne(missing[0]!);
   return missing.map(formatOne).join(' ');

--- a/src/application/ui/tui/prompts/select-prompt.tsx
+++ b/src/application/ui/tui/prompts/select-prompt.tsx
@@ -23,10 +23,54 @@ export interface SelectPromptProps {
   readonly options: ReadonlyArray<Choice<unknown>>;
   readonly onSubmit: (value: unknown) => void;
   readonly onCancel: () => void;
+  /**
+   * Optional dim line rendered between the option list and the navigation legend. Used by the
+   * Settings provider picker to surface install guidance ("install codex CLI with …") so the
+   * user can act on the gate without leaving the prompt.
+   */
+  readonly footer?: string;
 }
 
-export const SelectPrompt = ({ message, options, onSubmit, onCancel }: SelectPromptProps): React.JSX.Element => {
-  const [cursor, setCursor] = useState(0);
+const isEnabled = (opt: Choice<unknown> | undefined): boolean => opt !== undefined && opt.disabled !== true;
+
+/**
+ * Walk from `from` (exclusive) in `direction` (-1 or +1) and return the first enabled index.
+ * Returns `from` unchanged when no enabled option exists in that direction so the cursor never
+ * jumps onto a disabled row.
+ */
+const nextEnabledIndex = (options: ReadonlyArray<Choice<unknown>>, from: number, direction: -1 | 1): number => {
+  for (let i = from + direction; i >= 0 && i < options.length; i += direction) {
+    if (isEnabled(options[i])) return i;
+  }
+  return from;
+};
+
+const firstEnabledIndex = (options: ReadonlyArray<Choice<unknown>>): number => {
+  for (let i = 0; i < options.length; i += 1) {
+    if (isEnabled(options[i])) return i;
+  }
+  return 0;
+};
+
+const lastEnabledIndex = (options: ReadonlyArray<Choice<unknown>>): number => {
+  for (let i = options.length - 1; i >= 0; i -= 1) {
+    if (isEnabled(options[i])) return i;
+  }
+  return Math.max(0, options.length - 1);
+};
+
+export const SelectPrompt = ({
+  message,
+  options,
+  onSubmit,
+  onCancel,
+  footer,
+}: SelectPromptProps): React.JSX.Element => {
+  // Seed the cursor on the first enabled option so the initial frame doesn't land on a
+  // disabled row (e.g. when every provider's CLI is missing the picker still must show
+  // something selectable — the caller is expected to provide at least one enabled option, but
+  // we tolerate an all-disabled list by leaving the cursor at 0 with submission blocked).
+  const [cursor, setCursor] = useState(() => firstEnabledIndex(options));
 
   useInput((input, key) => {
     if (key.escape) {
@@ -35,13 +79,17 @@ export const SelectPrompt = ({ message, options, onSubmit, onCancel }: SelectPro
     }
     if (key.return || input === ' ') {
       const opt = options[cursor];
-      if (opt !== undefined) onSubmit(opt.value);
+      // Block submission of a disabled option — the renderer also surfaces the disabled
+      // affordance visually, but we belt-and-brace here so a stale cursor cannot bypass the
+      // gate.
+      if (opt !== undefined && opt.disabled !== true) onSubmit(opt.value);
       return;
     }
-    if (key.upArrow || input === 'k') setCursor((c) => clamp(c - 1, 0, options.length - 1));
-    else if (key.downArrow || input === 'j') setCursor((c) => clamp(c + 1, 0, options.length - 1));
-    else if (input === 'g') setCursor(0);
-    else if (input === 'G') setCursor(options.length - 1);
+    if (key.upArrow || input === 'k') setCursor((c) => clamp(nextEnabledIndex(options, c, -1), 0, options.length - 1));
+    else if (key.downArrow || input === 'j')
+      setCursor((c) => clamp(nextEnabledIndex(options, c, 1), 0, options.length - 1));
+    else if (input === 'g') setCursor(firstEnabledIndex(options));
+    else if (input === 'G') setCursor(lastEnabledIndex(options));
   });
 
   const half = Math.floor(VISIBLE_ROWS / 2);
@@ -55,10 +103,17 @@ export const SelectPrompt = ({ message, options, onSubmit, onCancel }: SelectPro
         {options.slice(start, end).map((opt, localIdx) => {
           const i = start + localIdx;
           const focused = i === cursor;
+          const disabled = opt.disabled === true;
+          // Disabled rows render dim with no cursor glyph even on the (rare) focused frame so
+          // the visual affordance matches the keyboard behaviour — they aren't reachable.
           return (
             <Box key={`opt-${String(i)}`}>
-              <Text color={focused ? inkColors.primary : inkColors.muted}>{focused ? glyphs.actionCursor : ' '} </Text>
-              <Text bold={focused}>{opt.label}</Text>
+              <Text color={focused && !disabled ? inkColors.primary : inkColors.muted}>
+                {focused && !disabled ? glyphs.actionCursor : ' '}{' '}
+              </Text>
+              <Text bold={focused && !disabled} dimColor={disabled}>
+                {opt.label}
+              </Text>
               {opt.description !== undefined && (
                 <Text dimColor>
                   {' '}
@@ -74,6 +129,7 @@ export const SelectPrompt = ({ message, options, onSubmit, onCancel }: SelectPro
           {String(cursor + 1)} of {String(options.length)}
         </Text>
       )}
+      {footer !== undefined && <Text dimColor>{footer}</Text>}
       <Text dimColor>↑/↓ navigate · ↵ submit · esc cancel</Text>
     </Box>
   );

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -44,6 +44,7 @@ import type { LogLevel } from '@src/domain/value/log-level.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+import { detectInstalledProviders, primaryInstallCommand } from '@src/integration/system/detect-cli.ts';
 
 const AI_PROVIDERS: readonly AiProvider[] = ['claude-code', 'github-copilot', 'openai-codex'];
 
@@ -205,6 +206,14 @@ export const SettingsView = (): React.JSX.Element => {
   const logLevel = useLogLevel();
   const [settings, setSettings] = useState<Settings | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | undefined>(undefined);
+  /**
+   * Set of providers whose CLI binary resolved on PATH at mount time. Probed once per Settings
+   * session — the per-row Settings editor never re-probes; the user has to leave and re-enter
+   * Settings to refresh the gate (matches the apply-preset / launch-time probe sites). Stays
+   * `undefined` while the probe is in flight; the provider picker treats `undefined` as "all
+   * enabled" so the picker is usable in the rare frame between mount and probe-completion.
+   */
+  const [installedProviders, setInstalledProviders] = useState<ReadonlySet<AiProvider> | undefined>(undefined);
   const [cursor, setCursor] = useState(0);
   const [editingField, setEditingField] = useState<EditableField | undefined>(undefined);
   /** Holds a model field when the user picked "+ custom" — the editor swaps to a TextPrompt. */
@@ -234,6 +243,16 @@ export const SettingsView = (): React.JSX.Element => {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectInstalledProviders().then((installed) => {
+      if (!cancelled) setInstalledProviders(installed);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const fields = useMemo<readonly EditableField[]>(
     () => (settings === undefined ? [] : buildEditableFields(settings)),
@@ -351,6 +370,46 @@ export const SettingsView = (): React.JSX.Element => {
     await refresh();
   };
 
+  /**
+   * `true` when `field` is a per-flow / per-role provider picker. Provider fields surface the
+   * availability gate (dimmed unavailable rows, install-guidance footer); every other select
+   * stays plain.
+   */
+  const isProviderField = (field: EditableField): boolean =>
+    field.kind === 'select' && (field.key.endsWith('.provider') || field.key === 'ai.provider');
+
+  /**
+   * Build the option list for a provider picker. Unavailable providers render `'(not installed)'`
+   * suffixed and are marked `disabled` so SelectPrompt skips them on keyboard navigation and
+   * refuses submission. When the availability probe has not completed yet, every option stays
+   * enabled — the gate still fires server-side via the settings-set-provider flow.
+   */
+  const buildProviderOptions = (
+    options: readonly string[]
+  ): {
+    readonly choices: ReadonlyArray<{ readonly label: string; readonly value: string; readonly disabled?: boolean }>;
+    readonly footer?: string;
+  } => {
+    const installed = installedProviders;
+    const choices = options.map((value) => {
+      const provider = value as AiProvider;
+      const available = installed === undefined || installed.has(provider);
+      const label = available ? value : `${value} (not installed)`;
+      return available ? { label, value } : { label, value, disabled: true };
+    });
+    const anyEnabled = choices.some((o) => o.disabled !== true);
+    const missing = options.filter((v) => installed !== undefined && !installed.has(v as AiProvider));
+    const footerParts: string[] = [];
+    if (!anyEnabled) {
+      footerParts.push('No AI provider CLI is installed.');
+    }
+    for (const m of missing) {
+      footerParts.push(`install ${m}: ${primaryInstallCommand(m as AiProvider)}`);
+    }
+    if (footerParts.length === 0) return { choices };
+    return { choices, footer: footerParts.join(' · ') };
+  };
+
   const renderEditor = (field: EditableField): React.JSX.Element => {
     if (field.kind === 'model' && customModelField !== undefined) {
       return (
@@ -363,6 +422,18 @@ export const SettingsView = (): React.JSX.Element => {
       );
     }
     if (field.kind === 'select' || field.kind === 'model') {
+      if (field.kind === 'select' && isProviderField(field)) {
+        const { choices, footer } = buildProviderOptions(field.options);
+        return (
+          <SelectPrompt
+            message={`${field.label} (current: ${field.current})`}
+            options={choices}
+            {...(footer !== undefined ? { footer } : {})}
+            onSubmit={(value) => void submit(String(value), field)}
+            onCancel={closeEditor}
+          />
+        );
+      }
       return (
         <SelectPrompt
           message={`${field.label} (current: ${field.current})`}

--- a/src/business/interactive/prompt.ts
+++ b/src/business/interactive/prompt.ts
@@ -11,6 +11,12 @@ export interface Choice<T> {
   readonly value: T;
   /** Optional one-line clarifier rendered next to the label. Reserved for richer renderers. */
   readonly description?: string;
+  /**
+   * When `true` the renderer must skip the entry on keyboard navigation, dim the label, and
+   * reject submission. Used by gating surfaces (e.g. the Settings provider picker dimming
+   * providers whose CLI is missing). Defaults to `false` / undefined.
+   */
+  readonly disabled?: boolean;
 }
 
 /** Input bag for {@link InteractivePrompt.askConfirm}. Object form keeps room for future fields. */

--- a/src/integration/system/detect-cli.ts
+++ b/src/integration/system/detect-cli.ts
@@ -16,6 +16,133 @@ export const PROVIDER_BINARY: Readonly<Record<AiProvider, string>> = {
 };
 
 /**
+ * The three desktop OS families ralphctl supports. `darwin` / `linux` / `win32` mirror Node's
+ * `process.platform` values; any other value the runtime might report (`aix`, `freebsd`, …)
+ * is mapped onto `linux` by {@link resolveInstallPlatform}, since the POSIX install paths apply.
+ */
+export type InstallPlatform = 'darwin' | 'linux' | 'win32';
+
+/**
+ * Per-provider install guidance derived from each vendor's official setup docs. Each OS lists
+ * commands in recommended order — the first entry is the one ralphctl points operators at
+ * inline; the rest surface as "alternatives" in the richer render. `docsUrl` is the canonical
+ * setup page operators can open when none of the listed commands fit their environment.
+ *
+ * Sources (verified against vendor docs at the time of writing):
+ *   - claude-code:    https://docs.claude.com/en/docs/claude-code/setup
+ *   - github-copilot: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli
+ *                     plus https://cli.github.com (for the underlying `gh` install)
+ *   - openai-codex:   https://github.com/openai/codex
+ *
+ * Single source of truth — adding a new provider means one entry here plus the existing entry
+ * in `PROVIDER_BINARY`.
+ */
+export interface ProviderInstallGuidance {
+  readonly docsUrl: string;
+  readonly commandsByPlatform: Readonly<Record<InstallPlatform, readonly string[]>>;
+}
+
+export const PROVIDER_INSTALL_GUIDANCE: Readonly<Record<AiProvider, ProviderInstallGuidance>> = {
+  'claude-code': {
+    docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup',
+    commandsByPlatform: {
+      darwin: [
+        'brew install --cask claude-code',
+        'curl -fsSL https://claude.ai/install.sh | bash',
+        'npm install -g @anthropic-ai/claude-code',
+      ],
+      linux: ['curl -fsSL https://claude.ai/install.sh | bash', 'npm install -g @anthropic-ai/claude-code'],
+      win32: [
+        'winget install Anthropic.ClaudeCode',
+        'irm https://claude.ai/install.ps1 | iex',
+        'npm install -g @anthropic-ai/claude-code',
+      ],
+    },
+  },
+  'github-copilot': {
+    docsUrl: 'https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+    commandsByPlatform: {
+      darwin: ['brew install gh && gh extension install github/gh-copilot', 'gh extension install github/gh-copilot'],
+      linux: [
+        'install gh from https://github.com/cli/cli/blob/trunk/docs/install_linux.md, then: gh extension install github/gh-copilot',
+        'gh extension install github/gh-copilot',
+      ],
+      win32: [
+        'winget install --id GitHub.cli && gh extension install github/gh-copilot',
+        'gh extension install github/gh-copilot',
+      ],
+    },
+  },
+  'openai-codex': {
+    docsUrl: 'https://github.com/openai/codex',
+    commandsByPlatform: {
+      darwin: [
+        'brew install --cask codex',
+        'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+        'npm install -g @openai/codex',
+      ],
+      linux: ['curl -fsSL https://chatgpt.com/codex/install.sh | sh', 'npm install -g @openai/codex'],
+      win32: [
+        'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+        'npm install -g @openai/codex',
+      ],
+    },
+  },
+};
+
+/**
+ * Collapse Node's `process.platform` onto the three OS families we publish guidance for.
+ * Unknown values (e.g. `aix`, `freebsd`) fall back to `linux` — its POSIX install commands
+ * are the closest match.
+ */
+export const resolveInstallPlatform = (platform: NodeJS.Platform = process.platform): InstallPlatform => {
+  if (platform === 'darwin' || platform === 'win32') return platform;
+  return 'linux';
+};
+
+/**
+ * One-line install command tailored to the operator's OS — the first entry in the OS-specific
+ * list (brew on macOS, winget on Windows, the curl installer on Linux). Used in inline,
+ * space-constrained surfaces (TUI footer, single-line launch banner, ValidationError summary).
+ */
+export const primaryInstallCommand = (provider: AiProvider, platform: NodeJS.Platform = process.platform): string => {
+  const os = resolveInstallPlatform(platform);
+  const list = PROVIDER_INSTALL_GUIDANCE[provider].commandsByPlatform[os];
+  const first = list[0];
+  if (first === undefined) {
+    throw new Error(`No install command registered for ${provider} on ${os}`);
+  }
+  return first;
+};
+
+/**
+ * Render the multi-line "install X" guidance ralphctl shows when an availability gate fires.
+ * Lists every OS-appropriate install option (brew, winget, native installer, npm) plus a link
+ * to the vendor's setup docs so operators can verify against the canonical source. Used in
+ * richer contexts (validation-error hint, doctor-style banners) where a single one-liner is
+ * not enough.
+ *
+ * Format:
+ *
+ *   <provider> CLI (<binary>) not on PATH
+ *   Install options (<os>):
+ *     • <cmd 1>
+ *     • <cmd 2>
+ *   Docs: <docs url>
+ */
+export const renderProviderInstallGuidance = (
+  provider: AiProvider,
+  platform: NodeJS.Platform = process.platform
+): string => {
+  const os = resolveInstallPlatform(platform);
+  const guidance = PROVIDER_INSTALL_GUIDANCE[provider];
+  const commands = guidance.commandsByPlatform[os];
+  const header = `${provider} CLI (${PROVIDER_BINARY[provider]}) not on PATH`;
+  const bullets = commands.map((c) => `  • ${c}`).join('\n');
+  return `${header}\nInstall options (${os}):\n${bullets}\nDocs: ${guidance.docsUrl}`;
+};
+
+/**
  * Test seam — async predicate that returns `true` when the binary resolves on the current
  * `PATH`. The production implementation shells out to `command -v <binary>`; tests inject a
  * stub that returns based on a mocked set.

--- a/tests/e2e/cli/settings.test.ts
+++ b/tests/e2e/cli/settings.test.ts
@@ -1,4 +1,23 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DetectCliModule from '@src/integration/system/detect-cli.ts';
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+
+// Hoisted state holder — each test mutates this before running so the mocked
+// `detectInstalledProviders` returns a deterministic set regardless of the host's PATH. The
+// CLI's `settings set ai.<flow>.provider` path runs the same gate the launch-time fail-fast
+// helper uses; mocking here lets us assert blocked-vs-allowed without depending on what's
+// installed on whoever is running the suite.
+const detectRef = vi.hoisted(() => ({ installed: new Set<AiProvider>() }));
+
+vi.mock('@src/integration/system/detect-cli.ts', async () => {
+  const actual = await vi.importActual<typeof DetectCliModule>('@src/integration/system/detect-cli.ts');
+  return {
+    ...actual,
+    detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> =>
+      new Set(detectRef.installed) as ReadonlySet<AiProvider>,
+  };
+});
+
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { createCliHome, runCliCaptured, type CliHome } from '@tests/e2e/cli/_harness.ts';
 
@@ -7,6 +26,9 @@ describe('ralphctl settings', () => {
 
   beforeEach(async () => {
     cli = await createCliHome();
+    // Default to "every provider installed" — individual tests narrow this for gate
+    // assertions. Re-seeding here avoids cross-test contamination.
+    detectRef.installed = new Set(['claude-code', 'github-copilot', 'openai-codex']);
   });
 
   afterEach(async () => cli.cleanup());
@@ -92,6 +114,52 @@ describe('ralphctl settings', () => {
       const result = await runCliCaptured(cli, ['settings', 'set', 'ai.refine.provider', 'not-a-real-provider']);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('not a recognised provider');
+    });
+
+    it('persists a per-flow provider via the gated settings-set-provider flow when the CLI is installed', async () => {
+      detectRef.installed = new Set(['claude-code', 'github-copilot', 'openai-codex']);
+      const setResult = await runCliCaptured(cli, ['settings', 'set', 'ai.refine.provider', 'github-copilot']);
+      expect(setResult.exitCode).toBe(0);
+      expect(setResult.stdout).toContain('ai.refine.provider = github-copilot');
+
+      const showResult = await runCliCaptured(cli, ['settings', 'show']);
+      const parsed = JSON.parse(showResult.stdout) as {
+        readonly ai: { readonly refine: { readonly provider: string; readonly model: string } };
+      };
+      expect(parsed.ai.refine.provider).toBe('github-copilot');
+      // Model rebuilt from the target provider's defaults — the discriminated-union schema
+      // would otherwise reject the save with claude-only models still in the row.
+      expect(parsed.ai.refine.model).toContain('gpt');
+    });
+
+    it('blocks ai.<flow>.provider when the requested provider CLI is not installed', async () => {
+      detectRef.installed = new Set(['claude-code']);
+      const result = await runCliCaptured(cli, ['settings', 'set', 'ai.refine.provider', 'openai-codex']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('openai-codex');
+      expect(result.stderr).toContain('ai.refine.provider');
+      expect(result.stderr).toContain('npm install -g @openai/codex');
+
+      // Persistence must NOT have happened — the disk still shows the default refine row.
+      const showResult = await runCliCaptured(cli, ['settings', 'show']);
+      const parsed = JSON.parse(showResult.stdout) as {
+        readonly ai: { readonly refine: { readonly provider: string } };
+      };
+      expect(parsed.ai.refine.provider).toBe(DEFAULT_SETTINGS.ai.refine.provider);
+    });
+
+    it('blocks ai.implement.<role>.provider when the requested provider CLI is not installed', async () => {
+      detectRef.installed = new Set(['claude-code']);
+      const result = await runCliCaptured(cli, [
+        'settings',
+        'set',
+        'ai.implement.evaluator.provider',
+        'github-copilot',
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('github-copilot');
+      expect(result.stderr).toContain('ai.implement.evaluator.provider');
+      expect(result.stderr).toContain('gh extension install github/gh-copilot');
     });
   });
 });

--- a/tests/e2e/flows/settings.test.ts
+++ b/tests/e2e/flows/settings.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 import type { Settings } from '@src/domain/entity/settings.ts';
 import { DEFAULT_SETTINGS, defaultAiSettingsForProvider } from '@src/business/settings/defaults.ts';
 import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
@@ -63,7 +64,12 @@ describe('settings use-cases — read/write through the JSON adapter', () => {
     };
     await createSettingsSetFlow({ settingsRepo: repo }).execute({ input: { next: initial } });
 
-    const switched = await createSettingsSetProviderFlow({ settingsRepo: repo }).execute({
+    const switched = await createSettingsSetProviderFlow({
+      settingsRepo: repo,
+      // Stub the PATH probe so the test passes regardless of what's installed on the host —
+      // the gate is exercised by the dedicated "rejects unavailable provider" test below.
+      detectInstalledProviders: async () => new Set(['claude-code', 'github-copilot', 'openai-codex'] as const),
+    }).execute({
       input: { flow: 'implement', provider: 'github-copilot', role: 'generator' },
     });
     expect(switched.ok).toBe(true);
@@ -123,6 +129,57 @@ describe('settings use-cases — read/write through the JSON adapter', () => {
     }
     expect(reread.value.ctx.output!.ai.implement.generator.provider).toBe('openai-codex');
     expect(reread.value.ctx.output!.ai.implement.evaluator.provider).toBe('openai-codex');
+  });
+
+  it('settings-set-provider rejects an unavailable provider with a ValidationError naming the settings key and install command', async () => {
+    const repo = createJsonSettingsRepository({ configRoot });
+    // Persist a known starting state so we can confirm the disk record is untouched after
+    // the gate fires.
+    await createSettingsSetFlow({ settingsRepo: repo }).execute({ input: { next: DEFAULT_SETTINGS } });
+
+    const blocked = await createSettingsSetProviderFlow({
+      settingsRepo: repo,
+      // Codex is the requested provider; the stub deliberately excludes it.
+      detectInstalledProviders: async () => new Set(['claude-code', 'github-copilot'] as const),
+    }).execute({
+      input: { flow: 'refine', provider: 'openai-codex' },
+    });
+    expect(blocked.ok).toBe(false);
+    if (blocked.ok) return;
+    const err = blocked.error.error;
+    expect(err).toBeInstanceOf(ValidationError);
+    if (!(err instanceof ValidationError)) return;
+    expect(err.field).toBe('ai.refine.provider');
+    expect(err.value).toBe('openai-codex');
+    expect(err.message).toContain('openai-codex');
+    expect(err.message).toContain('codex');
+    expect(err.message).toContain('ai.refine.provider');
+    expect(err.hint).toContain('npm install -g @openai/codex');
+
+    // Disk state matches the pre-attempt record — the gate fires BEFORE persistence.
+    const reread = await createSettingsShowFlow({ settingsRepo: repo }).execute({ input: undefined });
+    if (!reread.ok) throw new Error('expected ok');
+    expect(reread.value.ctx.output!.ai.refine.provider).toBe(DEFAULT_SETTINGS.ai.refine.provider);
+  });
+
+  it('settings-set-provider names the implement role in the ValidationError settings key', async () => {
+    const repo = createJsonSettingsRepository({ configRoot });
+    await createSettingsSetFlow({ settingsRepo: repo }).execute({ input: { next: DEFAULT_SETTINGS } });
+
+    const blocked = await createSettingsSetProviderFlow({
+      settingsRepo: repo,
+      detectInstalledProviders: async () => new Set(['claude-code'] as const),
+    }).execute({
+      input: { flow: 'implement', provider: 'github-copilot', role: 'evaluator' },
+    });
+    expect(blocked.ok).toBe(false);
+    if (blocked.ok) return;
+    const err = blocked.error.error;
+    expect(err).toBeInstanceOf(ValidationError);
+    if (!(err instanceof ValidationError)) return;
+    expect(err.field).toBe('ai.implement.evaluator.provider');
+    expect(err.message).toContain('ai.implement.evaluator.provider');
+    expect(err.hint).toContain('gh extension install github/gh-copilot');
   });
 
   it('settings-set rejects an invalid record without writing to disk', async () => {

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -3,14 +3,31 @@
  * status bar surfaces ↑/↓ + ↵/e hints.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Result } from '@src/domain/result.ts';
+import type * as DetectCliModule from '@src/integration/system/detect-cli.ts';
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+
+// Hoisted state holder — each test mutates this before rendering so the mocked
+// `detectInstalledProviders` returns the desired set. The mock targets the integration
+// module rather than the SettingsView itself so the view's import is exercised end-to-end.
+const detectRef = vi.hoisted(() => ({ installed: new Set<AiProvider>() }));
+
+vi.mock('@src/integration/system/detect-cli.ts', async () => {
+  const actual = await vi.importActual<typeof DetectCliModule>('@src/integration/system/detect-cli.ts');
+  return {
+    ...actual,
+    detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> =>
+      new Set(detectRef.installed) as ReadonlySet<AiProvider>,
+  };
+});
+
 import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Settings } from '@src/domain/entity/settings.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeSettingsRepo: SettingsRepository = {
@@ -128,5 +145,70 @@ describe('SettingsView', () => {
     // Generator received the new model; evaluator is byte-for-byte the pre-edit value.
     expect(reread.value.ai.implement.generator.model).toBe('claude-haiku-4-5-20251001');
     expect(reread.value.ai.implement.evaluator).toEqual(initial.ai.implement.evaluator);
+  });
+
+  describe('provider availability gate', () => {
+    // Field order (built in buildEditableFields): four preset buttons, global effort, then six
+    // provider/model/effort triples per flow + the implement pair. Refine is the first flow
+    // after the four presets + global effort, so its provider field sits at index 5 (zero-indexed):
+    // [preset×4, ai.effort, ai.refine.provider]. Five 'j' presses move from cursor 0 (the first
+    // preset) to cursor 5 (ai.refine.provider), where the picker opens.
+    const navigateToRefineProvider = async (stdin: { write: (s: string) => void }): Promise<void> => {
+      for (let i = 0; i < 5; i += 1) {
+        stdin.write('j');
+        await tick(20);
+      }
+      stdin.write(ENTER);
+      await tick(40);
+    };
+
+    it("labels unavailable providers as '(not installed)' in the provider picker", async () => {
+      detectRef.installed = new Set(['claude-code']);
+      const stub = stubRepoWith(DEFAULT_SETTINGS);
+      const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
+      const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
+      await tick(80);
+      await navigateToRefineProvider(result.stdin);
+      const frame = result.lastFrame() ?? '';
+      expect(frame).toContain('github-copilot (not installed)');
+      expect(frame).toContain('openai-codex (not installed)');
+      // claude-code stays plain (no '(not installed)' suffix); detect a substring that the
+      // unavailable row cannot accidentally match.
+      expect(frame).toMatch(/claude-code(?! \(not installed\))/);
+    });
+
+    it('surfaces the install command in the picker footer when a provider is unavailable', async () => {
+      detectRef.installed = new Set(['claude-code']);
+      const stub = stubRepoWith(DEFAULT_SETTINGS);
+      const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
+      const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
+      await tick(80);
+      await navigateToRefineProvider(result.stdin);
+      // Strip the rendered frame's word-wrap whitespace before asserting — ink may break the
+      // footer across multiple lines depending on terminal width, but the install command must
+      // still be present as a contiguous token sequence.
+      const frame = (result.lastFrame() ?? '').replace(/\s+/g, ' ');
+      // Footer renders the OS-preferred command (brew on macOS, winget on Windows, the curl
+      // installer / gh-install hint on Linux). Assert on the OS-invariant prefix and the
+      // command fragment that every option references.
+      expect(frame).toMatch(/install github-copilot: \S/);
+      expect(frame).toContain('gh-copilot');
+      expect(frame).toMatch(/install openai-codex: \S/);
+      expect(frame).toContain('codex');
+    });
+
+    it("surfaces 'No AI provider CLI is installed.' when every provider is missing", async () => {
+      detectRef.installed = new Set();
+      const stub = stubRepoWith(DEFAULT_SETTINGS);
+      const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
+      const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
+      await tick(80);
+      await navigateToRefineProvider(result.stdin);
+      const frame = result.lastFrame() ?? '';
+      expect(frame).toContain('No AI provider CLI is installed.');
+      expect(frame).toContain('claude-code (not installed)');
+      expect(frame).toContain('github-copilot (not installed)');
+      expect(frame).toContain('openai-codex (not installed)');
+    });
   });
 });

--- a/tests/unit/application/ui/shared/launch/check-cli.test.ts
+++ b/tests/unit/application/ui/shared/launch/check-cli.test.ts
@@ -117,4 +117,38 @@ describe('checkCli', () => {
     expect(result.reason).toContain('ai.implement.evaluator.provider');
     expect(result.reason).not.toContain('ai.implement.generator.provider');
   });
+
+  it('includes an install command and a docs URL in the failure reason', async () => {
+    // Operators reading the launch-time banner shouldn't have to guess how to install the
+    // missing CLI — the message names a one-shot command for the operator's OS plus a link
+    // to the vendor's setup docs.
+    const settings = withFlowProvider('refine', 'openai-codex');
+    const result = await checkCli('refine', settings, { detect: detectFor([]) });
+    expect(result).toBeDefined();
+    if (result === undefined || result.ok) return;
+    expect(result.reason).toMatch(/install with: \S/);
+    expect(result.reason).toContain('https://github.com/openai/codex');
+  });
+
+  it('install-guidance coverage spans every provider', async () => {
+    // Probe each provider in isolation so changes to the install guidance table cause the
+    // test to fail loudly rather than slipping past one-by-one assertions. Asserts on the
+    // vendor's setup docs URL (OS-invariant) rather than a per-OS command.
+    const cases = [
+      { provider: 'claude-code' as const, docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup' },
+      {
+        provider: 'github-copilot' as const,
+        docsUrl: 'https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+      },
+      { provider: 'openai-codex' as const, docsUrl: 'https://github.com/openai/codex' },
+    ];
+    for (const { provider, docsUrl } of cases) {
+      const settings = withFlowProvider('refine', provider);
+      const result = await checkCli('refine', settings, { detect: detectFor([]) });
+      expect(result).toBeDefined();
+      if (result === undefined || result.ok) continue;
+      expect(result.reason).toMatch(/install with: \S/);
+      expect(result.reason).toContain(docsUrl);
+    }
+  });
 });

--- a/tests/unit/integration/system/detect-cli.test.ts
+++ b/tests/unit/integration/system/detect-cli.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { detectInstalledProviders, PROVIDER_BINARY, type WhichFn } from '@src/integration/system/detect-cli.ts';
+import {
+  detectInstalledProviders,
+  PROVIDER_BINARY,
+  PROVIDER_INSTALL_GUIDANCE,
+  primaryInstallCommand,
+  renderProviderInstallGuidance,
+  resolveInstallPlatform,
+  type WhichFn,
+} from '@src/integration/system/detect-cli.ts';
 
 const whichFor =
   (present: ReadonlySet<string>): WhichFn =>
@@ -40,5 +48,84 @@ describe('detectInstalledProviders', () => {
     };
     await detectInstalledProviders({ which });
     expect(calls.sort()).toEqual(['claude', 'codex', 'gh']);
+  });
+});
+
+describe('PROVIDER_INSTALL_GUIDANCE', () => {
+  it('publishes a docs URL and per-OS command list for every provider', () => {
+    for (const provider of ['claude-code', 'github-copilot', 'openai-codex'] as const) {
+      const g = PROVIDER_INSTALL_GUIDANCE[provider];
+      expect(g.docsUrl).toMatch(/^https:\/\//);
+      expect(g.commandsByPlatform.darwin.length).toBeGreaterThan(0);
+      expect(g.commandsByPlatform.linux.length).toBeGreaterThan(0);
+      expect(g.commandsByPlatform.win32.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('recommends brew first on macOS where the vendor publishes a cask', () => {
+    expect(PROVIDER_INSTALL_GUIDANCE['claude-code'].commandsByPlatform.darwin[0]).toContain('brew install');
+    expect(PROVIDER_INSTALL_GUIDANCE['openai-codex'].commandsByPlatform.darwin[0]).toContain('brew install');
+    expect(PROVIDER_INSTALL_GUIDANCE['github-copilot'].commandsByPlatform.darwin[0]).toContain('brew install gh');
+  });
+
+  it('recommends winget first on Windows where the vendor publishes a winget package', () => {
+    expect(PROVIDER_INSTALL_GUIDANCE['claude-code'].commandsByPlatform.win32[0]).toContain('winget install');
+    expect(PROVIDER_INSTALL_GUIDANCE['github-copilot'].commandsByPlatform.win32[0]).toContain('winget install');
+  });
+});
+
+describe('resolveInstallPlatform', () => {
+  it('passes darwin and win32 through, collapses everything else to linux', () => {
+    expect(resolveInstallPlatform('darwin')).toBe('darwin');
+    expect(resolveInstallPlatform('win32')).toBe('win32');
+    expect(resolveInstallPlatform('linux')).toBe('linux');
+    expect(resolveInstallPlatform('freebsd')).toBe('linux');
+    expect(resolveInstallPlatform('aix')).toBe('linux');
+  });
+});
+
+describe('primaryInstallCommand', () => {
+  it('returns the OS-preferred command (first entry in the per-OS list)', () => {
+    expect(primaryInstallCommand('claude-code', 'darwin')).toBe('brew install --cask claude-code');
+    expect(primaryInstallCommand('claude-code', 'linux')).toBe('curl -fsSL https://claude.ai/install.sh | bash');
+    expect(primaryInstallCommand('claude-code', 'win32')).toBe('winget install Anthropic.ClaudeCode');
+    expect(primaryInstallCommand('openai-codex', 'darwin')).toBe('brew install --cask codex');
+    expect(primaryInstallCommand('openai-codex', 'linux')).toBe('curl -fsSL https://chatgpt.com/codex/install.sh | sh');
+    expect(primaryInstallCommand('github-copilot', 'darwin')).toBe(
+      'brew install gh && gh extension install github/gh-copilot'
+    );
+  });
+});
+
+describe('renderProviderInstallGuidance', () => {
+  it('lists every OS-relevant option as a bullet and ends with the docs URL', () => {
+    expect(renderProviderInstallGuidance('claude-code', 'darwin')).toBe(
+      [
+        'claude-code CLI (claude) not on PATH',
+        'Install options (darwin):',
+        '  • brew install --cask claude-code',
+        '  • curl -fsSL https://claude.ai/install.sh | bash',
+        '  • npm install -g @anthropic-ai/claude-code',
+        'Docs: https://docs.claude.com/en/docs/claude-code/setup',
+      ].join('\n')
+    );
+    expect(renderProviderInstallGuidance('openai-codex', 'linux')).toBe(
+      [
+        'openai-codex CLI (codex) not on PATH',
+        'Install options (linux):',
+        '  • curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+        '  • npm install -g @openai/codex',
+        'Docs: https://github.com/openai/codex',
+      ].join('\n')
+    );
+    expect(renderProviderInstallGuidance('github-copilot', 'win32')).toBe(
+      [
+        'github-copilot CLI (gh) not on PATH',
+        'Install options (win32):',
+        '  • winget install --id GitHub.cli && gh extension install github/gh-copilot',
+        '  • gh extension install github/gh-copilot',
+        'Docs: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+      ].join('\n')
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Settings TUI provider picker labels missing providers as `(not installed)`, skips them during keyboard navigation, refuses submission, and surfaces the install command in the picker footer.
- `settings-set-provider` flow probes PATH on every save and rejects an installed-but-missing provider with a `ValidationError` whose `field` is the exact dotted-path key (e.g. `ai.refine.provider`) and whose `hint` is the install command. Disk state stays untouched on rejection.
- CLI `settings set ai.<flow>.provider` / `ai.implement.<role>.provider` routes through the gated flow; unknown provider ids still produce a "not a recognised provider" error so invalid-input and CLI-missing remain distinguishable.
- Launch-time `check-cli` message embeds the offending settings key and install command alongside the missing binary so operators can act from the banner.
- `PROVIDER_INSTALL_HINT` + `renderProviderInstallGuidance` in `detect-cli` are the single source for install copy; the four surfaces share verbatim wording.

## Why
In v0.7.0 a user could silently save `ai.refine.provider = openai-codex` without having `codex` on PATH; the failure only surfaced at the next launch with a thin message. Gating at the persistence boundary turns the misconfiguration into an actionable error at the point of action, with the install command in-line.

Closes #137.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test` green (CI)
- [x] Unit + e2e coverage: detect-cli, settings flow (e2e), settings CLI (e2e), settings-view, check-cli
- [ ] Manual smoke: try saving an absent provider via TUI picker and via `ralphctl settings set` — confirm install hint surfaces