### PR TITLE
feat(tui): sprint detail polish + per-launch AI customize picker

### DIFF
--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -362,7 +362,46 @@ pushes a dedicated `*-detail-view.tsx`).
 - Behave like a workflow view: `SectionStamp`, phase state, `ResultCard` for outcome.
 - No bespoke input handlers — everything goes through the injected `PromptPort`.
 
-### 7.5 Render caps for list data
+### 7.5 Settings view — section tabs
+
+`SettingsView` is the only configuration surface dense enough to need an in-view nav primitive.
+It uses a **segmented section strip** (text tabs, no chrome) along the top: `← / →` cycle
+sections; `↑ / ↓` navigate fields inside the active section; `↵ / e` opens the editor for the
+focused field. Only one section's fields render at a time.
+
+**Why tabs over collapsible cards or a two-pane split.** A flat scroll listed ~30 editable rows
+in one column; the cursor path from the first preset button to the last harness budget was a
+keypress-counting exercise. Three candidate fixes:
+
+- **Collapsible cards** (one expanded at a time) — saves vertical space but keeps every label
+  on screen and still requires the user to land on the right header before the editable rows
+  appear. The collapsed strip is busier than a tab row.
+- **Two-pane layout** (left section list, right active section body) — clean at wide widths but
+  forces a `←/→` pane-switch idiom that fights every other list view in the app (where `←/→`
+  pages or does nothing) and degrades to a single-column stack below ~140 cols anyway.
+- **Section tabs** — one horizontal strip, one body card below it. Discoverable (every section
+  label is always on screen), bounded (the per-section row count is the per-section keypress
+  budget), and the `←/→` idiom matches the canonical "prev/next page" vocabulary in
+  [§6.3](#63-view-local-keys--published-via-useviewhints).
+
+Per-section row counts (all ≤ ~8): `Presets 4`, `Global 1`, `Refine 3`, `Plan 3`, `Implement 6`
+(generator triple + evaluator triple), `Readiness 3`, `Ideate 3`, `Harness 4`, `Other 2`,
+`Storage 0` (read-only). Implement is the largest and is the right stress-test for the cap.
+
+**Responsive fallback.** The section strip uses `flexWrap="wrap"`, so on terminals narrower
+than the strip's natural width (~76 cols at the default 10 labels) the strip wraps onto a
+second row. The body card below the strip is a stock `<Card>` — it follows the same
+single-column layout at every breakpoint, since the per-section field lists are short enough
+that wrapping was never the bottleneck. No special handling at `sm` is needed beyond the strip
+wrap; the active-section glyph (`▸`) keeps the focused label identifiable even when wrapped.
+
+**Model field is catalog-only.** The per-flow model row mounts a `SelectPrompt` populated from
+the active provider's catalog. There is no "+ custom" / free-text affordance; pinning to an
+off-catalog model is done by editing the settings file directly (or via `ralphctl settings set
+ai.<flow>.model <id>`). The read side still shows whatever is persisted — an off-catalog model
+remains visible on screen until the user picks a catalog entry to overwrite it.
+
+### 7.6 Render caps for list data
 
 Every list rendered from chain trace, event-bus, or harness-signal data MUST `.slice(-max)` before `.map()` to JSX, with an elision row above the rendered tail when truncated. Exception: lists with a hard domain bound (legend entries, settings options, fixed phase order) may render in full — comment the bound at the call site.
 

--- a/src/application/ui/shared/launch/check-cli.ts
+++ b/src/application/ui/shared/launch/check-cli.ts
@@ -23,7 +23,7 @@ import {
 } from '@src/integration/system/detect-cli.ts';
 import { primaryFlowRow, type AiProvider, type Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
-import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
+import type { LaunchExtras, LaunchResult } from '@src/application/ui/shared/launcher.ts';
 
 /**
  * Map a launcher flow id to the AI {@link FlowId} that owns its session — same mapping as
@@ -51,31 +51,55 @@ const aiFlowIdForCheck = (flowId: string): FlowId | undefined => {
 export interface CheckCliOptions {
   /** Test seam — defaults to the production `detectInstalledProviders`. */
   readonly detect?: () => Promise<ReadonlySet<AiProvider>>;
+  /**
+   * Per-launch single-row override (from the TUI customize picker). When the missing
+   * provider matches `override.provider`, the failure message names the source as a per-run
+   * override rather than a saved settings key — the operator should not be told to "change
+   * ai.<flow>.provider" when they actually picked it transiently from the picker.
+   */
+  readonly override?: LaunchExtras['override'];
+  /**
+   * Per-launch implement-role overrides (from the TUI customize picker or the bare-`ralphctl`
+   * CLI flags). Same intent as {@link override}: when the missing provider for an implement
+   * role matches its override, the failure message identifies the source as a per-run
+   * override.
+   */
+  readonly implementRoleOverrides?: LaunchExtras['implementRoleOverrides'];
 }
 
 /**
  * One row's expectation under the launch-time probe. `role` is set for implement's two-row
  * fan-out (so the failure message can name the offending role); single-row flows leave it
- * undefined and the message names just the flow.
+ * undefined and the message names just the flow. `fromOverride` is `true` when the row's
+ * provider was supplied by a per-launch override (TUI picker / CLI flag) — the failure
+ * message then identifies the source as a per-run override rather than the settings key the
+ * operator never actually edited.
  */
 interface RowExpectation {
   readonly provider: AiProvider;
   readonly settingsKey: string;
   readonly role?: 'generator' | 'evaluator';
+  readonly fromOverride: boolean;
 }
 
-const rowExpectationsFor = (aiFlow: FlowId, settings: Settings): readonly RowExpectation[] => {
+const rowExpectationsFor = (
+  aiFlow: FlowId,
+  settings: Settings,
+  options: CheckCliOptions
+): readonly RowExpectation[] => {
   if (aiFlow === 'implement') {
     return [
       {
         provider: settings.ai.implement.generator.provider,
         settingsKey: 'ai.implement.generator.provider',
         role: 'generator',
+        fromOverride: options.implementRoleOverrides?.generator?.provider !== undefined,
       },
       {
         provider: settings.ai.implement.evaluator.provider,
         settingsKey: 'ai.implement.evaluator.provider',
         role: 'evaluator',
+        fromOverride: options.implementRoleOverrides?.evaluator?.provider !== undefined,
       },
     ];
   }
@@ -83,6 +107,7 @@ const rowExpectationsFor = (aiFlow: FlowId, settings: Settings): readonly RowExp
     {
       provider: primaryFlowRow(settings.ai, aiFlow).provider,
       settingsKey: `ai.${aiFlow}.provider`,
+      fromOverride: options.override?.provider !== undefined,
     },
   ];
 };
@@ -93,7 +118,12 @@ const renderMissing = (missing: readonly RowExpectation[], aiFlow: FlowId): stri
     const installHint = primaryInstallCommand(m.provider);
     const docsUrl = PROVIDER_INSTALL_GUIDANCE[m.provider].docsUrl;
     const roleSuffix = m.role !== undefined ? ` (${m.role})` : '';
-    return `CLI ${binary} not on PATH for flow ${aiFlow}${roleSuffix}. Change ${m.settingsKey} or install with: ${installHint} (alternatives: ${docsUrl}).`;
+    // Per-run overrides come from the customize picker / CLI flag — the operator picked
+    // this provider transiently and the saved settings key is unchanged. Naming "per-run
+    // override" instead of the settings key prevents the operator from chasing the wrong
+    // edit surface to undo the failure.
+    const source = m.fromOverride ? `per-run override (${m.settingsKey} unchanged)` : m.settingsKey;
+    return `CLI ${binary} not on PATH for flow ${aiFlow}${roleSuffix}. Change ${source} or install with: ${installHint} (alternatives: ${docsUrl}).`;
   };
   if (missing.length === 1) return formatOne(missing[0]!);
   return missing.map(formatOne).join(' ');
@@ -106,7 +136,7 @@ export const checkCli = async (
 ): Promise<LaunchResult | undefined> => {
   const aiFlow = aiFlowIdForCheck(flowId);
   if (aiFlow === undefined) return undefined;
-  const expectations = rowExpectationsFor(aiFlow, settings);
+  const expectations = rowExpectationsFor(aiFlow, settings, options);
   const detect = options.detect ?? (() => detectInstalledProviders());
   const installed = await detect();
   // Dedupe by provider+role — when implement's two roles target the same provider, a single

--- a/src/application/ui/shared/launch/detect-scripts.ts
+++ b/src/application/ui/shared/launch/detect-scripts.ts
@@ -22,7 +22,9 @@ export const launchDetectScripts = (ctx: LaunchContext): LaunchResult => {
     {
       projectId: snapshot.project.id,
       // Reuse the readiness row — both flows are read-only inventory round-trips.
-      model: extras.modelOverride ?? settings.ai.readiness.model,
+      // Override flows in through ctx.settings (launcher applied it to ai.readiness when the
+      // picker emitted a non-empty override), so per-field fallback is automatic.
+      model: settings.ai.readiness.model,
       ...(effort !== undefined ? { effort } : {}),
       ...(extras.repositoryId !== undefined ? { repositoryId: extras.repositoryId } : {}),
     }

--- a/src/application/ui/shared/launch/detect-skills.ts
+++ b/src/application/ui/shared/launch/detect-skills.ts
@@ -23,8 +23,10 @@ export const launchDetectSkills = (ctx: LaunchContext): LaunchResult => {
     },
     {
       projectId: snapshot.project.id,
-      // Reuse the readiness row — same read-only inventory shape.
-      model: extras.modelOverride ?? settings.ai.readiness.model,
+      // Reuse the readiness row — same read-only inventory shape. Override flows in through
+      // ctx.settings (launcher applied it to ai.readiness when the picker emitted a non-empty
+      // override), so per-field fallback is automatic.
+      model: settings.ai.readiness.model,
       ...(effort !== undefined ? { effort } : {}),
       ...(extras.repositoryId !== undefined ? { repositoryId: extras.repositoryId } : {}),
     }

--- a/src/application/ui/shared/launch/ideate.ts
+++ b/src/application/ui/shared/launch/ideate.ts
@@ -9,20 +9,8 @@ import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 export const launchIdeate = async (ctx: LaunchContext): Promise<LaunchResult> => {
-  const {
-    deps,
-    snapshot,
-    extras,
-    settings,
-    interactiveAi,
-    skillsAdapter,
-    skillSource,
-    cwd,
-    bridge,
-    sessionId,
-    effort,
-  } = ctx;
-  const missing = await checkCli('ideate', settings);
+  const { deps, snapshot, settings, interactiveAi, skillsAdapter, skillSource, cwd, bridge, sessionId, effort } = ctx;
+  const missing = await checkCli('ideate', settings, { override: ctx.extras.override });
   if (missing !== undefined) return missing;
   if (!snapshot.project) return { ok: false, reason: 'No project loaded.' };
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
@@ -57,7 +45,7 @@ export const launchIdeate = async (ctx: LaunchContext): Promise<LaunchResult> =>
       ideaText: bodyAns.value,
       cwd,
       providerId: settings.ai.ideate.provider,
-      model: extras.modelOverride ?? settings.ai.ideate.model,
+      model: settings.ai.ideate.model,
       ...(effort !== undefined ? { effort } : {}),
       ideateRoot: ideateRoot.value,
     }

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -24,11 +24,23 @@ import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 /**
  * Apply role-level overrides from {@link LaunchExtras.implementRoleOverrides} on top of the
- * persisted `settings.ai.implement` pair. Each role accepts `{ provider, model }` together —
- * the CLI parser rejects half-supplied pairs before we reach this point, so the merge is
- * straightforward: when a role override is present, swap its row entirely; otherwise leave
- * the persisted row alone.
+ * persisted `settings.ai.implement` pair. Each role accepts `{ provider?, model?, effort? }`
+ * with every field independently optional — supplying only `provider` keeps the persisted
+ * model / effort for that role. The TUI customize picker assembles coherent overrides (a
+ * provider switch always rides with a fresh model from the new provider's catalog); the CLI
+ * parser still rejects half-supplied provider/model pairs upstream. The discriminated-union
+ * cast remains sound under both call sites.
  */
+const mergeImplementRole = (
+  base: AiFlowSettings,
+  override: NonNullable<NonNullable<LaunchContext['extras']['implementRoleOverrides']>['generator']>
+): AiFlowSettings => {
+  const provider = override.provider ?? base.provider;
+  const model = override.model ?? base.model;
+  const effort = override.effort ?? base.effort;
+  return { provider, model, ...(effort !== undefined ? { effort } : {}) } as AiFlowSettings;
+};
+
 const applyImplementRoleOverrides = (
   base: AiImplementSettings,
   overrides: NonNullable<LaunchContext['extras']['implementRoleOverrides']> | undefined
@@ -39,10 +51,10 @@ const applyImplementRoleOverrides = (
     evaluator: base.evaluator,
   };
   if (overrides.generator !== undefined) {
-    next.generator = { provider: overrides.generator.provider, model: overrides.generator.model } as AiFlowSettings;
+    next.generator = mergeImplementRole(base.generator, overrides.generator);
   }
   if (overrides.evaluator !== undefined) {
-    next.evaluator = { provider: overrides.evaluator.provider, model: overrides.evaluator.model } as AiFlowSettings;
+    next.evaluator = mergeImplementRole(base.evaluator, overrides.evaluator);
   }
   return next;
 };
@@ -58,7 +70,9 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     ...settings,
     ai: { ...settings.ai, implement: implementPair },
   };
-  const missing = await checkCli('implement', effectiveSettings);
+  const missing = await checkCli('implement', effectiveSettings, {
+    implementRoleOverrides: extras.implementRoleOverrides,
+  });
   if (missing !== undefined) return missing;
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
   if (!snapshot.project) return { ok: false, reason: 'No project loaded for the selected sprint.' };
@@ -171,11 +185,8 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
       repositories,
       progressFile: progressPath.value,
       sprintDir: sprintDirPath.value,
-      // `extras.modelOverride` is a legacy single-model knob from the flows-view picker;
-      // applied to the generator role since that's the one that drove the prior single-model
-      // implement path. Evaluator model stays bound to its settings row.
       generatorProviderId: implementPair.generator.provider,
-      generatorModel: extras.modelOverride ?? implementPair.generator.model,
+      generatorModel: implementPair.generator.model,
       ...(generatorEffort !== undefined ? { generatorEffort } : {}),
       evaluatorProviderId: implementPair.evaluator.provider,
       evaluatorModel: implementPair.evaluator.model,
@@ -229,12 +240,10 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   for (const leaf of flattened) {
     if (leaf.label !== undefined && leaf.label.length > 0) planLabelByName.set(leaf.name, leaf.label);
   }
-  // The generator model honours the legacy single-model `extras.modelOverride` (flows-view's
-  // pre-launch picker) — same precedence the per-task subchain uses upstream. The evaluator
-  // model is always bound to its settings row. Both fields are projected onto the session
-  // descriptor so the execute view's rail/banner can render `<gen> → <eval> (eval)` (or
-  // collapse to one name when they match) without re-reading settings.
-  const generatorModel = extras.modelOverride ?? implementPair.generator.model;
+  // Both role models are drawn from the post-merge implementPair so per-launch role overrides
+  // (TUI customize picker or CLI flags) flow through to the rail/banner without a second
+  // settings read.
+  const generatorModel = implementPair.generator.model;
   const evaluatorModel = implementPair.evaluator.model;
   return {
     ok: true,

--- a/src/application/ui/shared/launch/plan.ts
+++ b/src/application/ui/shared/launch/plan.ts
@@ -9,9 +9,8 @@ import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 export const launchPlan = async (ctx: LaunchContext): Promise<LaunchResult> => {
-  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId, effort } =
-    ctx;
-  const missing = await checkCli('plan', settings);
+  const { deps, snapshot, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId, effort } = ctx;
+  const missing = await checkCli('plan', settings, { override: ctx.extras.override });
   if (missing !== undefined) return missing;
   if (!snapshot.project) return { ok: false, reason: 'No project loaded.' };
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
@@ -66,7 +65,7 @@ export const launchPlan = async (ctx: LaunchContext): Promise<LaunchResult> => {
       // the session's cwd is the per-sprint plan unit root.
       additionalRoots: snapshot.project.repositories.map((r) => r.path),
       providerId: settings.ai.plan.provider,
-      model: extras.modelOverride ?? settings.ai.plan.model,
+      model: settings.ai.plan.model,
       ...(effort !== undefined ? { effort } : {}),
       planRoot: planRoot.value,
     }

--- a/src/application/ui/shared/launch/readiness.ts
+++ b/src/application/ui/shared/launch/readiness.ts
@@ -32,7 +32,7 @@ const flowIdForProvider = (settings: LaunchContext['settings'], provider: AiProv
 
 export const launchReadiness = async (ctx: LaunchContext): Promise<LaunchResult> => {
   const { deps, snapshot, settings, cwd, bridge, sessionId } = ctx;
-  const missing = await checkCli('readiness', settings);
+  const missing = await checkCli('readiness', settings, { override: ctx.extras.override });
   if (missing !== undefined) return missing;
   if (!snapshot.project) return { ok: false, reason: 'No project loaded.' };
   if (!cwd) return { ok: false, reason: 'No repository path resolvable from the project.' };

--- a/src/application/ui/shared/launch/refine.ts
+++ b/src/application/ui/shared/launch/refine.ts
@@ -32,9 +32,8 @@ const deriveOriginFromGit = async (
 };
 
 export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> => {
-  const { deps, snapshot, extras, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId, effort } =
-    ctx;
-  const missing = await checkCli('refine', settings);
+  const { deps, snapshot, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId, effort } = ctx;
+  const missing = await checkCli('refine', settings, { override: ctx.extras.override });
   if (missing !== undefined) return missing;
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
   // Refine intentionally does not require a repo path — the AI session is rooted at the
@@ -142,7 +141,7 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
       sprintId: snapshot.sprint.id,
       pendingTickets: pending,
       providerId: settings.ai.refine.provider,
-      model: extras.modelOverride ?? settings.ai.refine.model,
+      model: settings.ai.refine.model,
       ...(effort !== undefined ? { effort } : {}),
       refinementRoot: refinementRoot.value,
     }

--- a/src/application/ui/shared/launch/review.ts
+++ b/src/application/ui/shared/launch/review.ts
@@ -32,7 +32,7 @@ const renderRepositoriesBlock = (affected: readonly Repository[]): string =>
   affected.map((r) => `- \`${String(r.path)}\` (${r.name})`).join('\n');
 
 export const launchReview = (ctx: LaunchContext): LaunchResult => {
-  const { deps, snapshot, extras, settings, provider, bridge, sessionId } = ctx;
+  const { deps, snapshot, settings, provider, bridge, sessionId } = ctx;
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
   if (!snapshot.project) return { ok: false, reason: 'No project loaded for the selected sprint.' };
   if (snapshot.project.repositories.length === 0) {
@@ -85,8 +85,10 @@ export const launchReview = (ctx: LaunchContext): LaunchResult => {
       locksRoot: deps.storage.locksRoot,
       appendFile: deps.app.appendFile,
       // Review uses the implement generator model — same code-mutation profile, same
-      // accuracy expectations. No per-flow `review` row in settings today.
-      model: extras.modelOverride ?? settings.ai.implement.generator.model,
+      // accuracy expectations. No per-flow `review` row in settings today. Override flows in
+      // through ctx.settings (launcher applied it to ai.implement.generator when the picker
+      // emitted a non-empty override), so per-field fallback is automatic.
+      model: settings.ai.implement.generator.model,
     },
     {
       sprintId: snapshot.sprint.id,

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -19,14 +19,11 @@ import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts
 import { createInteractiveAiProvider } from '@src/application/bootstrap/interactive-provider-factory.ts';
 import { createSkillsAdapter } from '@src/integration/ai/skills/adapter-factory.ts';
 import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
-import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
-import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
-import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { composeSkillSources, createProjectSkillSource } from '@src/integration/ai/skills/project/source.ts';
-import { primaryFlowRow, type AiProvider, type Settings } from '@src/domain/entity/settings.ts';
+import { primaryFlowRow, type AiFlowSettings, type AiProvider, type Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import { resolveEffort } from '@src/business/settings/resolve-effort.ts';
 import type { RunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
@@ -98,9 +95,10 @@ export type LaunchResult =
 /**
  * Optional per-launch overrides supplied by the caller. `repositoryId` skips the in-flow pick
  * prompt (used when launching from a focused repo row on the project-detail view or when the
- * TUI's session-scoped repo pin has been set). `modelOverride` replaces the settings-default
- * model for one launch — flows-view's pre-launch picker writes here when the user picks a
- * different model than the configured default.
+ * TUI's session-scoped repo pin has been set). `override` swaps the settings-default
+ * provider / model / effort for one launch — flows-view's pre-launch customize picker writes
+ * here when the user picks different values than the configured defaults. Each field is
+ * independently optional: an unset field falls back to the matching `settings.ai[flow]` slot.
  *
  * `settingsSnapshot` lets the caller pass a freshly-loaded {@link Settings} record (e.g. the
  * TUI re-reads via `settingsRepo.load()` at click-time so provider/model changes in the
@@ -109,21 +107,40 @@ export type LaunchResult =
  */
 export interface LaunchExtras {
   readonly repositoryId?: RepositoryId;
-  /** Per-launch model override; falls back to `settings.ai[flow].model` when undefined. */
-  readonly modelOverride?: string;
+  /**
+   * Per-launch single-row override (refine / plan / readiness / ideate plus the implement-
+   * generator-driven flows review / detect-scripts / detect-skills). Each field is independent
+   * — supplying only `provider` keeps the persisted model / effort for fields not named. The
+   * implement flow itself does NOT consume this; it reads {@link implementRoleOverrides}
+   * instead because its two roles each carry their own row.
+   */
+  readonly override?: {
+    readonly provider?: AiProvider;
+    readonly model?: string;
+    readonly effort?: string;
+  };
   /** Freshly-loaded settings snapshot; overrides the stale `app.settings` boot snapshot. */
   readonly settingsSnapshot?: Settings;
   /**
-   * Per-launch implement-role overrides — supplied by the bare-`ralphctl` CLI flags
+   * Per-launch implement-role overrides — supplied either by the bare-`ralphctl` CLI flags
    * (`--implement-generator-provider`, `--implement-generator-model`,
-   * `--implement-evaluator-provider`, `--implement-evaluator-model`) and threaded through the
-   * TUI runtime. Each role accepts `{ provider, model }` together; the CLI parser rejects
-   * half-supplied pairs upstream so the launcher only sees fully-formed overrides. Roles are
-   * independent — overriding only generator leaves evaluator on its persisted settings row.
+   * `--implement-evaluator-provider`, `--implement-evaluator-model`) or by the TUI's
+   * pre-launch customize picker. Each role accepts `{ provider?, model?, effort? }` with
+   * every field independently optional — a role override that only carries `provider` keeps
+   * the persisted model / effort for that role. Roles are independent — overriding only
+   * generator leaves evaluator on its persisted settings row.
    */
   readonly implementRoleOverrides?: {
-    readonly generator?: { readonly provider: AiProvider; readonly model: string };
-    readonly evaluator?: { readonly provider: AiProvider; readonly model: string };
+    readonly generator?: {
+      readonly provider?: AiProvider;
+      readonly model?: string;
+      readonly effort?: string;
+    };
+    readonly evaluator?: {
+      readonly provider?: AiProvider;
+      readonly model?: string;
+      readonly effort?: string;
+    };
   };
 }
 
@@ -169,36 +186,6 @@ export const sessionHintsFromLaunchResult = (
 });
 
 /**
- * Models the user can choose from for one flow's configured provider — passed to the model
- * picker in the flow menu. Lookup is keyed by `settings.ai[flow].provider`, so switching the
- * provider on that flow in Settings instantly changes the picker's option list.
- */
-export const modelsForFlowProvider = (flowId: string, settings: AppDeps['settings']): readonly string[] => {
-  const aiFlow = aiFlowIdFor(flowId);
-  if (aiFlow === undefined) return [];
-  switch (primaryFlowRow(settings.ai, aiFlow).provider) {
-    case 'claude-code':
-      return CLAUDE_MODELS;
-    case 'github-copilot':
-      return COPILOT_MODELS;
-    case 'openai-codex':
-      return CODEX_MODELS;
-  }
-};
-
-/**
- * Default AI model for one flow, derived from settings — exposed for UI affordances that want
- * to show "you're about to launch with model X" before actually calling {@link launchFlow}.
- * Returns `undefined` for flows that don't run an AI session (doctor, settings, create-pr,
- * export, ticket-add / remove, add-tickets, create-sprint).
- */
-export const modelForFlow = (flowId: string, settings: AppDeps['settings']): string | undefined => {
-  const aiFlow = aiFlowIdFor(flowId);
-  if (aiFlow === undefined) return undefined;
-  return primaryFlowRow(settings.ai, aiFlow).model;
-};
-
-/**
  * Map a launcher flow id to the {@link FlowId} that owns the AI session, or `undefined` for
  * flows that don't open one. `detect-scripts` and `detect-skills` are read-only inventory
  * round-trips that reuse the `readiness` row's provider / model / effort — they don't have
@@ -225,6 +212,61 @@ const aiFlowIdFor = (flowId: string): FlowId | undefined => {
   }
 };
 
+/**
+ * Per-field merge of `override` onto an `AiFlowSettings` row. Each field of the override is
+ * independent — supplying only `provider` keeps the row's persisted model / effort. The
+ * resulting row is cast to {@link AiFlowSettings} because TypeScript can't narrow the
+ * discriminated union from a dynamic provider key; the picker only ever assembles coherent
+ * overrides (a provider switch always rides with a fresh model from the new provider's
+ * catalog) so the cast remains sound.
+ */
+const mergeRow = (base: AiFlowSettings, override: NonNullable<LaunchExtras['override']>): AiFlowSettings => {
+  const provider = override.provider ?? base.provider;
+  const model = override.model ?? base.model;
+  const effort = override.effort ?? base.effort;
+  return { provider, model, ...(effort !== undefined ? { effort } : {}) } as AiFlowSettings;
+};
+
+/**
+ * Apply `extras.override` to the {@link Settings} record so the launcher's adapter rebuild
+ * (provider, interactiveAi, skillsAdapter) and the per-flow launcher's row read both see the
+ * same overridden values. Implement is excluded — its two roles are addressed through
+ * `extras.implementRoleOverrides` exclusively; `extras.override` on an implement launch is a
+ * caller bug we silently ignore here so the merge stays single-row.
+ *
+ * For review (and any other flow that aliases another flow's row via {@link aiFlowIdFor}),
+ * the override applies to the aliased row. Review uses `ai.implement.generator`; an override
+ * at review-launch time rewrites generator only — evaluator is untouched.
+ *
+ * @public
+ */
+export const applyOverrideToSettings = (
+  settings: Settings,
+  flowId: string,
+  override: LaunchExtras['override']
+): Settings => {
+  if (override === undefined) return settings;
+  const aiFlow = aiFlowIdFor(flowId);
+  if (aiFlow === undefined) return settings;
+  // Implement uses implementRoleOverrides exclusively — the customize picker for implement
+  // emits per-role overrides, not the single-row shape.
+  if (flowId === 'implement') return settings;
+  if (aiFlow === 'implement') {
+    // review / detect-scripts / detect-skills aliases that read implement.generator. The
+    // launcher's primary-row helper resolves implement → generator, so we override the
+    // generator slot only.
+    const merged = mergeRow(settings.ai.implement.generator, override);
+    return {
+      ...settings,
+      ai: { ...settings.ai, implement: { ...settings.ai.implement, generator: merged } },
+    };
+  }
+  return {
+    ...settings,
+    ai: { ...settings.ai, [aiFlow]: mergeRow(settings.ai[aiFlow], override) },
+  };
+};
+
 const cwdFromSnapshot = (snapshot: AppStateSnapshot): AbsolutePath | undefined => {
   if (!snapshot.project) return undefined;
   const repo = snapshot.project.repositories[0];
@@ -243,11 +285,17 @@ export const launchFlow = async (
   // current choice. Callers that already reloaded (e.g. flows-view, for its model picker) just
   // pass their fresh snapshot via `extras.settingsSnapshot`; callers that didn't (project-
   // detail-view) implicitly opt into a one-roundtrip reload here so they don't have to remember.
-  let settings = extras.settingsSnapshot ?? deps.app.settings;
+  let baseSettings = extras.settingsSnapshot ?? deps.app.settings;
   if (extras.settingsSnapshot === undefined) {
     const reloaded = await deps.app.settingsRepo.load();
-    if (reloaded.ok) settings = reloaded.value;
+    if (reloaded.ok) baseSettings = reloaded.value;
   }
+  // Apply the picker's per-launch override BEFORE constructing adapters / resolving effort so
+  // a provider override re-keys the adapter rebuild below. Implement is handled inside its
+  // launcher because its two roles need independent merges; for every other AI flow the
+  // override applies to the single row identified by aiFlowIdFor (review and detect-* aliases
+  // included).
+  const settings = applyOverrideToSettings(baseSettings, flowId, extras.override);
 
   // Rebuild the provider-bound adapters from the fresh settings every launch, keyed on the
   // dispatched flow's id. `app.provider`, `app.interactiveAi`, and `app.skillsAdapter` are

--- a/src/application/ui/tui/components/baseline-health-card.tsx
+++ b/src/application/ui/tui/components/baseline-health-card.tsx
@@ -31,25 +31,24 @@
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { SetupRun, SprintExecution } from '@src/domain/entity/sprint-execution.ts';
-import type { Attribution, VerifyRun } from '@src/domain/entity/attempt.ts';
+import type { VerifyRun } from '@src/domain/entity/attempt.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { CONTEXT_WIDTH, glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
+import {
+  type AttributionCounts,
+  type BaselineTier,
+  countAttributions,
+  latestVerifyRun,
+  synthesiseBaselineHealth,
+} from '@src/application/ui/tui/components/baseline-health.ts';
 
 /**
  * Visual tier driven by status — maps to the existing semantic-state tokens.
  * `ok` / `warning` / `error` mirror the Card tone vocabulary; `pending` covers not-yet-run.
  */
 type Tier = 'ok' | 'warning' | 'error' | 'pending';
-
-/** @public */
-export interface AttributionCounts {
-  readonly clean: number;
-  readonly regressed: number;
-  readonly fixedBaseline: number;
-  readonly baselineBroken: number;
-}
 
 /** @public */
 export interface BaselineHealthCardProps {
@@ -168,24 +167,6 @@ const setupRowData = (execution: SprintExecution | undefined, now: number): RowD
 // ---------------------------------------------------------------------------
 
 /**
- * Walk every attempt across every task and return the most recent {@link VerifyRun} for the
- * given phase. Ordered by `ranAt`. Returns `undefined` when no row exists.
- */
-const latestVerifyRun = (tasks: readonly Task[], phase: 'pre' | 'post'): VerifyRun | undefined => {
-  let latest: VerifyRun | undefined;
-  for (const task of tasks) {
-    for (const attempt of task.attempts) {
-      if (attempt.verifyRuns === undefined) continue;
-      for (const row of attempt.verifyRuns) {
-        if (row.phase !== phase) continue;
-        if (latest === undefined || row.ranAt > latest.ranAt) latest = row;
-      }
-    }
-  }
-  return latest;
-};
-
-/**
  * Map a VerifyRun (or absence of one) to a RowData entry.
  * `shortLabel` is the display name for the row — callers pass "Pre verify" / "Post verify"
  * (≤12 chars) to guarantee the label never wraps inside the 28-col card.
@@ -216,24 +197,6 @@ const verifyRowData = (run: VerifyRun | undefined, now: number, shortLabel: stri
 // Attribution derivation
 // ---------------------------------------------------------------------------
 
-/** @public */
-export const countAttributions = (tasks: readonly Task[]): AttributionCounts => {
-  let clean = 0;
-  let regressed = 0;
-  let fixedBaseline = 0;
-  let baselineBroken = 0;
-  for (const task of tasks) {
-    for (const attempt of task.attempts) {
-      const a: Attribution | undefined = attempt.attribution;
-      if (a === 'clean') clean++;
-      else if (a === 'regressed') regressed++;
-      else if (a === 'fixed-baseline') fixedBaseline++;
-      else if (a === 'baseline-broken') baselineBroken++;
-    }
-  }
-  return { clean, regressed, fixedBaseline, baselineBroken };
-};
-
 const attributionRowData = (counts: AttributionCounts): RowData => {
   // "Attrib" keeps the label ≤12 chars and avoids wrap in the 28-col card.
   const label = 'Attrib';
@@ -256,36 +219,35 @@ const attributionRowData = (counts: AttributionCounts): RowData => {
 // Card-level tone
 // ---------------------------------------------------------------------------
 
+/** Card-tone palette. Mirrors the {@link Card} tone vocabulary. */
+type CardTone = 'success' | 'warning' | 'error' | 'rule';
+
 /**
- * Synthesise the overall card tone from the four indicator rows:
- *  - any `error` → `error`
- *  - any `warning` → `warning`
- *  - all `ok` (at least one ran) → `success`
- *  - everything `pending` → `rule` (quiet)
+ * Map the shared baseline tier onto a Card tone. This is the load-bearing call that keeps
+ * the card's border / title color in sync with the {@link BaselineHealthChip} — both surfaces
+ * read the same tier from {@link synthesiseBaselineHealth}.
  */
-const cardTone = (rows: readonly RowData[]): 'success' | 'warning' | 'error' | 'rule' => {
-  if (rows.some((r) => r.tier === 'error')) return 'error';
-  if (rows.some((r) => r.tier === 'warning')) return 'warning';
-  if (rows.some((r) => r.tier === 'ok')) return 'success';
+const toneFromTier = (tier: BaselineTier): CardTone => {
+  if (tier === 'red') return 'error';
+  if (tier === 'amber') return 'warning';
+  if (tier === 'green') return 'success';
   return 'rule';
 };
 
 /**
- * Build the title suffix from the dominant error in the rows.
- * Returns `undefined` when there is no suffix to add.
+ * Title-suffix logic uses the same predicate tier as the tone, then refines with the rows
+ * for fine-grained labels:
  *
- * - `error`   → `"<label> failed"` (e.g. `"setup failed"`)
- * - all `ok`  → `"clean"` (only when EVERY row has run and passed — not mixed)
- * - otherwise → no suffix; plain `"Baseline"` title
+ *  - tier `red`   → first failing row's label, e.g. `"setup failed"` / `"post verify failed"`.
+ *  - tier `green` → `"clean"` only when EVERY row is ok (not mixed ok + pending).
+ *  - otherwise    → no suffix; plain `"Baseline"` title.
  */
-const titleSuffix = (rows: readonly RowData[], tone: ReturnType<typeof cardTone>): string | undefined => {
-  if (tone === 'error') {
-    // Surface the first failing row's label as context.
+const titleSuffix = (rows: readonly RowData[], tier: BaselineTier): string | undefined => {
+  if (tier === 'red') {
     const errRow = rows.find((r) => r.tier === 'error');
     return errRow !== undefined ? `${errRow.label.toLowerCase()} failed` : 'failed';
   }
-  // "clean" only when every single row is ok — not a mixed ok+pending state.
-  if (rows.every((r) => r.tier === 'ok')) return 'clean';
+  if (tier === 'green' && rows.every((r) => r.tier === 'ok')) return 'clean';
   return undefined;
 };
 
@@ -398,8 +360,14 @@ export const BaselineHealthCard = ({ execution, tasks, now, width }: BaselineHea
   const attribData = attributionRowData(counts);
 
   const rows: readonly RowData[] = [setupData, preData, postData, attribData];
-  const tone = cardTone(rows);
-  const suffix = titleSuffix(rows, tone);
+  // Tier (and therefore tone) come from the shared predicate so chip + card never disagree.
+  const health = synthesiseBaselineHealth({
+    ...(execution !== undefined ? { execution } : {}),
+    tasks: taskList,
+    now: tNow,
+  });
+  const tone = toneFromTier(health.tier);
+  const suffix = titleSuffix(rows, health.tier);
   const title = suffix !== undefined ? `Baseline · ${suffix}` : 'Baseline';
 
   const isAllPending =

--- a/src/application/ui/tui/components/baseline-health-chip.tsx
+++ b/src/application/ui/tui/components/baseline-health-chip.tsx
@@ -2,115 +2,33 @@
  * Baseline-Health Chip — single-line companion to the right-context {@link BaselineHealthCard}.
  *
  * Renders above the active-task header so the verify-gate state is visible without scrolling.
- * Three states (colour is the load-bearing signal; glyphs / words are the fallback for
+ * Four states (colour is the load-bearing signal; glyphs / words are the fallback for
  * monochrome / colour-blind operators):
  *
- *  - `green` — every verify run seen so far has passed; no regressions.
- *  - `amber` — pre-verify showed a stale baseline (last run > N minutes ago) OR the latest
- *               attempt landed on a broken baseline (`attribution: 'baseline-broken'`).
- *  - `red`   — any regression or red post-verify; the AI broke a previously-green baseline.
+ *  - `green`   — at least one signal has run and nothing is red / amber.
+ *  - `amber`   — broken-baseline attempts OR the latest verify ran long enough ago to be stale.
+ *  - `red`     — any regression, any red setup row, or the LATEST pre/post verify row is red.
+ *  - `unknown` — initial state; no setup, no verify runs yet.
  *
- * State source mirrors the card — derives from the same `SprintExecution.setupRanAt` +
- * `Task.attempts[].verifyRuns` data, kept in this one place so card + chip never disagree.
+ * Tier source is {@link synthesiseBaselineHealth} — the same predicate the card consumes, so
+ * chip and card cannot disagree.
  */
 
 import React from 'react';
 import { Box, Text } from 'ink';
 import type { SprintExecution } from '@src/domain/entity/sprint-execution.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import type { VerifyRun } from '@src/domain/entity/attempt.ts';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
-import { countAttributions } from '@src/application/ui/tui/components/baseline-health-card.tsx';
+import { type BaselineTier, synthesiseBaselineHealth } from '@src/application/ui/tui/components/baseline-health.ts';
 
-/** Stale threshold for the "baseline state may be out of date" warning, in ms. */
-const STALE_MS = 30 * 60 * 1000;
-
-type Tier = 'green' | 'amber' | 'red' | 'unknown';
-
-const latestVerifyTimestamp = (tasks: readonly Task[]): number | undefined => {
-  let latestMs: number | undefined;
-  for (const task of tasks) {
-    for (const attempt of task.attempts) {
-      if (attempt.verifyRuns === undefined) continue;
-      for (const row of attempt.verifyRuns) {
-        const ms = new Date(row.ranAt).getTime();
-        if (latestMs === undefined || ms > latestMs) latestMs = ms;
-      }
-    }
-  }
-  return latestMs;
-};
-
-const anyRedVerify = (tasks: readonly Task[]): boolean => {
-  for (const task of tasks) {
-    for (const attempt of task.attempts) {
-      if (attempt.verifyRuns === undefined) continue;
-      for (const row of attempt.verifyRuns) {
-        if (row.outcome === 'failed') return true;
-      }
-    }
-  }
-  return false;
-};
-
-const anySetupRed = (execution: SprintExecution | undefined): boolean => {
-  if (execution === undefined) return false;
-  // Reduce-by-repo: a later success overwrites an earlier failure.
-  const byRepo = new Map<string, VerifyRun['outcome'] | 'success' | 'failed' | 'spawn-error' | 'skipped'>();
-  for (const row of execution.setupRanAt) byRepo.set(String(row.repositoryId), row.outcome);
-  for (const v of byRepo.values()) {
-    if (v === 'failed' || v === 'spawn-error') return true;
-  }
-  return false;
-};
-
-const synthesise = (
-  execution: SprintExecution | undefined,
-  tasks: readonly Task[],
-  now: number
-): { tier: Tier; label: string } => {
-  const counts = countAttributions(tasks);
-  const anyVerifies = latestVerifyTimestamp(tasks) !== undefined;
-  const setupHasRun = execution !== undefined && execution.setupRanAt.length > 0;
-
-  // Hard red: a regression — the AI broke a previously-green baseline. Always wins.
-  if (counts.regressed > 0) {
-    return { tier: 'red', label: `red (${String(counts.regressed)} regression${counts.regressed === 1 ? '' : 's'})` };
-  }
-  // Red setup is also a hard red — the working tree can't run, so any green verify is bogus.
-  if (anySetupRed(execution)) {
-    return { tier: 'red', label: 'red' };
-  }
-
-  // Amber: broken-baseline attempts mean the red VerifyRuns we'd otherwise blame are explained
-  // by a pre-existing failure. Surface as amber (warning) rather than red so the operator knows
-  // it's a known-state, not "the harness is on fire". Check this BEFORE `anyRedVerify` so the
-  // baseline-broken context wins over the raw red-verify signal it contains.
-  if (counts.baselineBroken > 0) {
-    return { tier: 'amber', label: `broken-base (${String(counts.baselineBroken)})` };
-  }
-  if (anyRedVerify(tasks)) {
-    return { tier: 'red', label: 'red' };
-  }
-
-  // Stale: the most recent verify run was a long time ago — the baseline state may have drifted.
-  const latest = latestVerifyTimestamp(tasks);
-  if (latest !== undefined && now - latest > STALE_MS) {
-    return { tier: 'amber', label: 'stale' };
-  }
-
-  if (!setupHasRun && !anyVerifies) return { tier: 'unknown', label: 'awaiting first run' };
-  return { tier: 'green', label: 'green' };
-};
-
-const tierColor = (tier: Tier): string => {
+const tierColor = (tier: BaselineTier): string => {
   if (tier === 'green') return inkColors.success;
   if (tier === 'amber') return inkColors.warning;
   if (tier === 'red') return inkColors.error;
   return inkColors.muted;
 };
 
-const tierGlyph = (tier: Tier): string => {
+const tierGlyph = (tier: BaselineTier): string => {
   if (tier === 'green') return glyphs.check;
   if (tier === 'amber') return glyphs.warningGlyph;
   if (tier === 'red') return glyphs.cross;
@@ -126,7 +44,11 @@ export interface BaselineHealthChipProps {
 
 /** @public */
 export const BaselineHealthChip = ({ execution, tasks, now }: BaselineHealthChipProps): React.JSX.Element => {
-  const summary = synthesise(execution, tasks ?? [], now ?? Date.now());
+  const summary = synthesiseBaselineHealth({
+    ...(execution !== undefined ? { execution } : {}),
+    ...(tasks !== undefined ? { tasks } : {}),
+    now: now ?? Date.now(),
+  });
   return (
     <Box>
       <Text dimColor>baseline </Text>

--- a/src/application/ui/tui/components/baseline-health.ts
+++ b/src/application/ui/tui/components/baseline-health.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared baseline-health predicate — the single source of truth for the verify-gate tier
+ * that drives both {@link BaselineHealthChip} (one-line) and {@link BaselineHealthCard}
+ * (four-row expanded). Co-locating the synthesis here is what keeps the two surfaces from
+ * disagreeing after a red → green transition.
+ *
+ * Latest-wins semantics: only the most recent pre-verify row and the most recent post-verify
+ * row contribute to the tier; historical reds on earlier attempts are ignored. Attribution
+ * counts (regressed / baseline-broken) and the setup-script audit still drive hard-red /
+ * amber states because those signals already capture the relevant history.
+ *
+ *  - `red`     — any regression, any red setup row, or the LATEST pre/post verify row is red
+ *  - `amber`   — broken-baseline attempts OR every verify row is older than {@link STALE_MS}
+ *  - `green`   — at least one signal has run and nothing is red / amber
+ *  - `unknown` — no setup-script row, no verify-run row anywhere
+ */
+
+import type { SprintExecution } from '@src/domain/entity/sprint-execution.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { Attribution, VerifyRun } from '@src/domain/entity/attempt.ts';
+
+/** Stale threshold for "baseline state may be out of date", in ms. */
+const STALE_MS = 30 * 60 * 1000;
+
+/** @public */
+export type BaselineTier = 'green' | 'amber' | 'red' | 'unknown';
+
+/** @public */
+export interface BaselineHealth {
+  readonly tier: BaselineTier;
+  readonly label: string;
+}
+
+/** @public */
+export interface AttributionCounts {
+  readonly clean: number;
+  readonly regressed: number;
+  readonly fixedBaseline: number;
+  readonly baselineBroken: number;
+}
+
+/** @public */
+export const countAttributions = (tasks: readonly Task[]): AttributionCounts => {
+  let clean = 0;
+  let regressed = 0;
+  let fixedBaseline = 0;
+  let baselineBroken = 0;
+  for (const task of tasks) {
+    for (const attempt of task.attempts) {
+      const a: Attribution | undefined = attempt.attribution;
+      if (a === 'clean') clean++;
+      else if (a === 'regressed') regressed++;
+      else if (a === 'fixed-baseline') fixedBaseline++;
+      else if (a === 'baseline-broken') baselineBroken++;
+    }
+  }
+  return { clean, regressed, fixedBaseline, baselineBroken };
+};
+
+/**
+ * Walk every attempt across every task and return the most recent {@link VerifyRun} for the
+ * given phase. Ordered by `ranAt`. Returns `undefined` when no row exists.
+ * @public
+ */
+export const latestVerifyRun = (tasks: readonly Task[], phase: 'pre' | 'post'): VerifyRun | undefined => {
+  let latest: VerifyRun | undefined;
+  for (const task of tasks) {
+    for (const attempt of task.attempts) {
+      if (attempt.verifyRuns === undefined) continue;
+      for (const row of attempt.verifyRuns) {
+        if (row.phase !== phase) continue;
+        if (latest === undefined || row.ranAt > latest.ranAt) latest = row;
+      }
+    }
+  }
+  return latest;
+};
+
+const anySetupRed = (execution: SprintExecution | undefined): boolean => {
+  if (execution === undefined) return false;
+  // Reduce-by-repo: a later success overwrites an earlier failure.
+  const byRepo = new Map<string, string>();
+  for (const row of execution.setupRanAt) byRepo.set(String(row.repositoryId), row.outcome);
+  for (const v of byRepo.values()) {
+    if (v === 'failed' || v === 'spawn-error') return true;
+  }
+  return false;
+};
+
+/** @public */
+export interface SynthesiseBaselineHealthInput {
+  readonly execution?: SprintExecution;
+  readonly tasks?: readonly Task[];
+  /** Wall-clock `Date.now()` value used for the stale-threshold comparison. */
+  readonly now: number;
+}
+
+/** @public */
+export const synthesiseBaselineHealth = ({ execution, tasks, now }: SynthesiseBaselineHealthInput): BaselineHealth => {
+  const taskList = tasks ?? [];
+  const counts = countAttributions(taskList);
+  const setupHasRun = execution !== undefined && execution.setupRanAt.length > 0;
+  const latestPre = latestVerifyRun(taskList, 'pre');
+  const latestPost = latestVerifyRun(taskList, 'post');
+  const anyVerifies = latestPre !== undefined || latestPost !== undefined;
+
+  // Hard red: a regression — the AI broke a previously-green baseline. Always wins.
+  if (counts.regressed > 0) {
+    return {
+      tier: 'red',
+      label: `red (${String(counts.regressed)} regression${counts.regressed === 1 ? '' : 's'})`,
+    };
+  }
+  // Red setup is also a hard red — the working tree can't run, so any green verify is bogus.
+  if (anySetupRed(execution)) {
+    return { tier: 'red', label: 'red' };
+  }
+
+  // Amber: broken-baseline attempts mean the red verify rows we'd otherwise blame are
+  // explained by a pre-existing failure. Check this BEFORE the latest-row red probe so the
+  // baseline-broken context wins over the raw red signal it contains.
+  if (counts.baselineBroken > 0) {
+    return { tier: 'amber', label: `broken-base (${String(counts.baselineBroken)})` };
+  }
+
+  // Latest-wins: only the LATEST pre + LATEST post row contribute. Historical reds on
+  // earlier attempts are ignored — a red → green transition flips the tier to green.
+  if (latestPre?.outcome === 'failed' || latestPost?.outcome === 'failed') {
+    return { tier: 'red', label: 'red' };
+  }
+
+  // Stale: the most recent verify run was a long time ago — the baseline may have drifted.
+  let latestMs: number | undefined;
+  if (latestPre !== undefined) latestMs = new Date(latestPre.ranAt).getTime();
+  if (latestPost !== undefined) {
+    const t = new Date(latestPost.ranAt).getTime();
+    if (latestMs === undefined || t > latestMs) latestMs = t;
+  }
+  if (latestMs !== undefined && now - latestMs > STALE_MS) {
+    return { tier: 'amber', label: 'stale' };
+  }
+
+  if (!setupHasRun && !anyVerifies) return { tier: 'unknown', label: 'awaiting first run' };
+  return { tier: 'green', label: 'green' };
+};

--- a/src/application/ui/tui/components/list-card.tsx
+++ b/src/application/ui/tui/components/list-card.tsx
@@ -1,0 +1,53 @@
+/**
+ * ListCard — the shared frame for a card in a vertical list (tickets, tasks). Thin wrapper
+ * around {@link Card} that centralises the visual contract — border tone, dim policy, internal
+ * padding, marginBottom gutter, and the title row layout (cursor + index + title on the left,
+ * status chip on the right). Both TicketCard and TaskCard render through this primitive so they
+ * cannot drift on any of those dimensions.
+ *
+ * Tone semantics:
+ *   focused   → tone='info'  (highlighted border, no dim)
+ *   unfocused → tone='rule'  (recessive divider tone, dimmed border)
+ *
+ * The `expanded` prop is part of the public contract — call-sites pass it so the API is explicit
+ * about open/closed state — but the layout itself does not vary by open/closed today; consumers
+ * decide what to render inside `children` for the two states.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Card } from '@src/application/ui/tui/components/card.tsx';
+import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+
+export interface ListCardProps {
+  readonly focused: boolean;
+  readonly expanded: boolean;
+  readonly rightSlot?: React.ReactNode;
+  readonly indexLabel: string;
+  readonly title: string;
+  readonly children?: React.ReactNode;
+}
+
+export const ListCard = ({ focused, rightSlot, indexLabel, title, children }: ListCardProps): React.JSX.Element => (
+  // The outer wrapper uses `flexDirection="column"` so the inner Card stretches to the parent
+  // column's full width on the cross-axis. A default row wrapper would let the bordered Card
+  // shrink to its content width, producing visually mismatched border edges between ticket
+  // and task cards stacked in the same section.
+  <Box flexDirection="column" marginBottom={spacing.section}>
+    <Card tone={focused ? 'info' : 'rule'}>
+      <Box flexDirection="column" paddingX={spacing.indent}>
+        <Box justifyContent="space-between">
+          <Box>
+            <Text {...(focused ? { color: inkColors.primary } : { dimColor: true })}>
+              {focused ? `${glyphs.actionCursor} ` : `  `}
+              {indexLabel}
+            </Text>
+            <Text bold> {title}</Text>
+          </Box>
+          {rightSlot !== undefined && <Box>{rightSlot}</Box>}
+        </Box>
+        {children}
+      </Box>
+    </Card>
+  </Box>
+);

--- a/src/application/ui/tui/components/list-card.tsx
+++ b/src/application/ui/tui/components/list-card.tsx
@@ -9,9 +9,7 @@
  *   focused   → tone='info'  (highlighted border, no dim)
  *   unfocused → tone='rule'  (recessive divider tone, dimmed border)
  *
- * The `expanded` prop is part of the public contract — call-sites pass it so the API is explicit
- * about open/closed state — but the layout itself does not vary by open/closed today; consumers
- * decide what to render inside `children` for the two states.
+ * Open/closed state is the caller's concern — pass the expanded / collapsed body via `children`.
  */
 
 import React from 'react';
@@ -21,7 +19,6 @@ import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens
 
 export interface ListCardProps {
   readonly focused: boolean;
-  readonly expanded: boolean;
   readonly rightSlot?: React.ReactNode;
   readonly indexLabel: string;
   readonly title: string;

--- a/src/application/ui/tui/components/status-bar.tsx
+++ b/src/application/ui/tui/components/status-bar.tsx
@@ -11,7 +11,11 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
-import { useActiveHints, type ViewHint } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
+import {
+  useActiveHints,
+  useSuppressedGlobalKeys,
+  type ViewHint,
+} from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useSessions } from '@src/application/ui/tui/runtime/sessions-context.tsx';
 import { useSystemStatus } from '@src/application/ui/tui/runtime/system-status-context.tsx';
 import { KeyboardHints } from '@src/application/ui/tui/components/keyboard-hints.tsx';
@@ -37,7 +41,13 @@ const STETHOSCOPE = '🩺';
 export const StatusBar = (): React.JSX.Element => {
   const sessions = useSessions();
   const localHints = useActiveHints();
+  const suppressedKeys = useSuppressedGlobalKeys();
   const system = useSystemStatus();
+  // Per-view suppressions hide specific global hints so the footer never advertises a key combo
+  // whose default meaning is contradicted by the currently-mounted view (e.g. a Review-step
+  // description that fits the viewport mutes the ↑/↓ scroll hint because arrows are inert).
+  const visibleGlobalHints =
+    suppressedKeys.size === 0 ? GLOBAL_HINTS : GLOBAL_HINTS.filter((h) => !suppressedKeys.has(h.keys));
 
   const running = sessions.filter((s) => s.descriptor.status === 'running').length;
   const sessionSummary =
@@ -64,7 +74,7 @@ export const StatusBar = (): React.JSX.Element => {
         </Box>
       </Box>
       <Box paddingX={spacing.indent}>
-        <KeyboardHints hints={[...localHints, ...GLOBAL_HINTS]} />
+        <KeyboardHints hints={[...localHints, ...visibleGlobalHints]} />
       </Box>
     </Box>
   );

--- a/src/application/ui/tui/runtime/use-view-hints.tsx
+++ b/src/application/ui/tui/runtime/use-view-hints.tsx
@@ -16,8 +16,18 @@ export interface ViewHint {
 
 interface HintsRegistryApi {
   readonly hints: readonly ViewHint[];
+  /**
+   * Set of global hint `keys` strings that should be hidden from the status bar while at least
+   * one view requests it. The status bar filters `GLOBAL_HINTS` against this set, leaving the
+   * local hint list untouched. Used by views whose locally-active surface contradicts a global
+   * hint (e.g. the Review-step scroll widget hides the global `↑/↓ scroll` hint when the
+   * description fits and arrows are inert).
+   */
+  readonly suppressedGlobalKeys: ReadonlySet<string>;
   set(id: number, hints: readonly ViewHint[]): void;
   remove(id: number): void;
+  setSuppressed(id: number, keys: readonly string[]): void;
+  removeSuppressed(id: number): void;
 }
 
 const HintsContext = createContext<HintsRegistryApi | undefined>(undefined);
@@ -37,9 +47,20 @@ const hintsEqual = (a: readonly ViewHint[], b: readonly ViewHint[]): boolean => 
   return true;
 };
 
+const keysEqual = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 export const HintsProvider = ({ children }: { readonly children: React.ReactNode }): React.JSX.Element => {
   // Map id → hints; merge in registration order on read.
   const [registry, setRegistry] = useState<ReadonlyMap<number, readonly ViewHint[]>>(new Map());
+  // Map id → suppressed global hint keys. Merged into a single set on read.
+  const [suppressions, setSuppressions] = useState<ReadonlyMap<number, readonly string[]>>(new Map());
 
   const set = useCallback((id: number, hints: readonly ViewHint[]): void => {
     setRegistry((prev) => {
@@ -60,9 +81,47 @@ export const HintsProvider = ({ children }: { readonly children: React.ReactNode
     });
   }, []);
 
-  const merged = useMemo<readonly ViewHint[]>(() => [...registry.values()].flat(), [registry]);
+  const setSuppressed = useCallback((id: number, keys: readonly string[]): void => {
+    setSuppressions((prev) => {
+      const cur = prev.get(id);
+      if (cur !== undefined && keysEqual(cur, keys)) return prev;
+      if (cur === undefined && keys.length === 0) return prev;
+      const next = new Map(prev);
+      if (keys.length === 0) {
+        next.delete(id);
+      } else {
+        next.set(id, keys);
+      }
+      return next;
+    });
+  }, []);
 
-  const api = useMemo<HintsRegistryApi>(() => ({ hints: merged, set, remove }), [merged, set, remove]);
+  const removeSuppressed = useCallback((id: number): void => {
+    setSuppressions((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const merged = useMemo<readonly ViewHint[]>(() => [...registry.values()].flat(), [registry]);
+  const mergedSuppressed = useMemo<ReadonlySet<string>>(
+    () => new Set([...suppressions.values()].flat()),
+    [suppressions]
+  );
+
+  const api = useMemo<HintsRegistryApi>(
+    () => ({
+      hints: merged,
+      suppressedGlobalKeys: mergedSuppressed,
+      set,
+      remove,
+      setSuppressed,
+      removeSuppressed,
+    }),
+    [merged, mergedSuppressed, set, remove, setSuppressed, removeSuppressed]
+  );
 
   return <HintsContext.Provider value={api}>{children}</HintsContext.Provider>;
 };
@@ -108,4 +167,39 @@ export const useViewHints = (hints: readonly ViewHint[]): void => {
 export const useActiveHints = (): readonly ViewHint[] => {
   const ctx = useContext(HintsContext);
   return ctx?.hints ?? [];
+};
+
+/**
+ * Suppress one or more global hints by their `keys` string while this component is mounted (or
+ * while `keys` is non-empty). Passing an empty array clears the suppression. Used when a view
+ * temporarily owns a key combo whose default meaning the global hint advertises — the global
+ * hint disappears so the footer never lies about what `↑/↓` does on this screen.
+ *
+ * Other views are unaffected; suppressions are scoped per component instance, removed on
+ * unmount, and merged into a single set the StatusBar filters GLOBAL_HINTS against.
+ */
+export const useSuppressGlobalHints = (keys: readonly string[]): void => {
+  const ctx = useContext(HintsContext);
+  const [id] = useState<number>(() => nextHintId++);
+
+  const ctxRef = useRef<HintsRegistryApi | undefined>(ctx);
+  ctxRef.current = ctx;
+
+  useEffect(() => {
+    return (): void => {
+      ctxRef.current?.removeSuppressed(id);
+    };
+  }, [id]);
+
+  // Push the latest set into the registry every render. `setSuppressed` short-circuits when
+  // contents match, so a fresh-array ref on a steady caller is a no-op at the registry level.
+  useEffect(() => {
+    ctxRef.current?.setSuppressed(id, keys);
+  }, [id, keys]);
+};
+
+/** Read the suppressed global hint set. Used by StatusBar to filter GLOBAL_HINTS. */
+export const useSuppressedGlobalKeys = (): ReadonlySet<string> => {
+  const ctx = useContext(HintsContext);
+  return ctx?.suppressedGlobalKeys ?? new Set<string>();
 };

--- a/src/application/ui/tui/views/add-ticket-view.tsx
+++ b/src/application/ui/tui/views/add-ticket-view.tsx
@@ -10,8 +10,8 @@
  * an error step.
  */
 
-import React, { useEffect, useState } from 'react';
-import { Box, Text } from 'ink';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { FieldList } from '@src/application/ui/tui/components/field-list.tsx';
@@ -22,6 +22,8 @@ import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.ts
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useSuppressGlobalHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
+import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 import { spacing, inkColors, glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { createTicketAddFlow } from '@src/application/flows/ticket-add/flow.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -322,7 +324,7 @@ const StepView = ({ step, onChange, onCancel, onSubmit }: StepViewProps): React.
               <FieldList
                 fields={[
                   { label: 'Title', value: <Text bold>{step.title}</Text> },
-                  { label: 'Description', value: <Text>{descTrim}</Text> },
+                  { label: 'Description', value: <ReviewScrollableDescription text={descTrim} /> },
                   {
                     label: 'Link',
                     value:
@@ -361,6 +363,77 @@ const StepView = ({ step, onChange, onCancel, onSubmit }: StepViewProps): React.
         </Box>
       );
   }
+};
+
+/**
+ * Reserve rows for the chrome around the scrollable description body — banner + breadcrumb +
+ * section stamp at the top, plus the Title row, the Link row, the spacing gutter, the
+ * ConfirmPrompt (message + pills + hint), and the status bar at the bottom. The exact rows
+ * vary with banner mode and terminal width; this constant is the worst-case estimate that
+ * keeps the Link row and the confirm pills visible on a default 24-row terminal. Floor on the
+ * viewport ensures a tiny terminal still shows something useful.
+ */
+const REVIEW_CHROME_ROWS = 14;
+const REVIEW_MIN_VIEWPORT = 4;
+
+/**
+ * Bounded scrolling viewport for the Review-step description body. When the description fits,
+ * renders a single `<Text>` so the static output matches the pre-fix rendering. When it
+ * overflows, slices a window plus a position indicator and binds ↑/↓ + PgUp/PgDn (no wrap, no
+ * line yank, no g/G). The ConfirmPrompt's y/n/↵/esc are unaffected — arrows are exclusively
+ * ours, and ConfirmPrompt itself only listens for ←/→/h/l/y/n/↵/esc.
+ *
+ * When the body fits the viewport, the global `↑/↓ scroll` footer hint is suppressed so the
+ * status bar never lies about what arrows do on this screen; when the body overflows, the
+ * hint remains because arrows now legitimately scroll the description.
+ */
+interface ReviewScrollableDescriptionProps {
+  readonly text: string;
+}
+
+const ReviewScrollableDescription = ({ text }: ReviewScrollableDescriptionProps): React.JSX.Element => {
+  const term = useTerminalSize();
+  const lines = useMemo<readonly string[]>(() => text.split('\n'), [text]);
+  const viewport = Math.max(REVIEW_MIN_VIEWPORT, term.rows - REVIEW_CHROME_ROWS);
+  const overflows = lines.length > viewport;
+  const maxOffset = Math.max(0, lines.length - viewport);
+  const [offset, setOffset] = useState(0);
+
+  // Clamp on resize / line-count change so a window-shrink can't strand the offset past the
+  // new bottom.
+  useEffect(() => {
+    setOffset((o) => Math.max(0, Math.min(o, maxOffset)));
+  }, [maxOffset]);
+
+  // Suppress the global ↑/↓ scroll hint while the description fits — arrows are inert and the
+  // footer should not advertise them.
+  useSuppressGlobalHints(overflows ? [] : ['↑/↓']);
+
+  useInput((_input, key) => {
+    if (!overflows) return;
+    const clamp = (n: number): number => Math.max(0, Math.min(n, maxOffset));
+    if (key.upArrow) setOffset((o) => clamp(o - 1));
+    else if (key.downArrow) setOffset((o) => clamp(o + 1));
+    else if (key.pageUp) setOffset((o) => clamp(o - viewport));
+    else if (key.pageDown) setOffset((o) => clamp(o + viewport));
+  });
+
+  if (!overflows) {
+    return <Text>{text}</Text>;
+  }
+
+  const visible = lines.slice(offset, offset + viewport);
+  const lastVisible = Math.min(offset + viewport, lines.length);
+  return (
+    <Box flexDirection="column">
+      {visible.map((line, i) => (
+        <Text key={`desc-${String(offset + i)}`}>{line.length === 0 ? ' ' : line}</Text>
+      ))}
+      <Text dimColor>
+        lines {String(offset + 1)}–{String(lastVisible)} of {String(lines.length)}
+      </Text>
+    </Box>
+  );
 };
 
 /**

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -1,0 +1,250 @@
+/**
+ * Pre-launch customize picker used by `flows-view.tsx`. For an AI-driven flow the user gets
+ * three choices on the entry prompt — `Start (use defaults)`, `Customize for this run…`, or
+ * `Cancel`. Customize walks the user through provider → model → effort, with `Keep default`
+ * as the first option on each step; implement walks generator (three steps) then evaluator
+ * (three steps). The picker only ever reads {@link Settings}; it never calls `save()`, so
+ * the on-disk file is byte-identical before and after any picker session.
+ *
+ * Extracted from the view into a standalone module so tests can drive it with a scripted
+ * {@link InteractivePrompt} fake without mounting Ink. The view's `onSelect` calls
+ * {@link runCustomizePicker} and threads the returned {@link CustomizePickerResult} into the
+ * launcher's {@link LaunchExtras}.
+ */
+
+import type { Choice, InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import {
+  primaryFlowRow,
+  type AiFlowSettings,
+  type AiImplementRole,
+  type AiProvider,
+  type Settings,
+} from '@src/domain/entity/settings.ts';
+import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
+import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
+import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+import { PROVIDER_EFFORT_LEVELS } from '@src/domain/value/settings-models/effort.ts';
+import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+import type { LaunchExtras } from '@src/application/ui/shared/launcher.ts';
+
+/**
+ * Catalog lookup for the customize picker — imported from the same domain modules
+ * `settings-view.tsx` reads so the two surfaces can never drift on a model bump.
+ */
+export const modelCatalogFor = (provider: AiProvider): readonly string[] => {
+  switch (provider) {
+    case 'claude-code':
+      return CLAUDE_MODELS;
+    case 'github-copilot':
+      return COPILOT_MODELS;
+    case 'openai-codex':
+      return CODEX_MODELS;
+  }
+};
+
+const AI_PROVIDERS: readonly AiProvider[] = ['claude-code', 'github-copilot', 'openai-codex'];
+
+/** Sentinel value returned for the `Keep default` option — never collides with a real id. */
+const KEEP = '__keep__';
+
+/**
+ * Outcome of one picker session. `kind` discriminates:
+ *   - `cancel`: user pressed Esc / picked Cancel at any step — launcher should NOT launch
+ *   - `defaults`: user picked Start — launcher should launch with no override
+ *   - `single`: customize completed for a single-row flow; `override` is the per-field diff
+ *   - `implement`: customize completed for implement; `implementRoleOverrides` carries both
+ *     roles (each independently optional)
+ *
+ * The picker never returns `single` for implement and never returns `implement` for any
+ * other flow.
+ */
+export type CustomizePickerResult =
+  | { readonly kind: 'cancel' }
+  | { readonly kind: 'defaults' }
+  | { readonly kind: 'single'; readonly override: NonNullable<LaunchExtras['override']> }
+  | {
+      readonly kind: 'implement';
+      readonly implementRoleOverrides: NonNullable<LaunchExtras['implementRoleOverrides']>;
+    };
+
+/**
+ * Map a TUI flow id to the AI {@link FlowId} that owns its session — same mapping the launcher
+ * and check-cli use. Returns `undefined` for non-AI flows; the picker is skipped for those.
+ */
+const aiFlowIdForPicker = (flowId: string): FlowId | undefined => {
+  switch (flowId) {
+    case 'refine':
+    case 'plan':
+    case 'implement':
+    case 'readiness':
+    case 'ideate':
+      return flowId;
+    case 'detect-scripts':
+    case 'detect-skills':
+      return 'readiness';
+    case 'review':
+      return 'implement';
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Resolve the single row the picker should present as the default for a non-implement-launch
+ * flow. For review the launcher uses `ai.implement.generator`; the picker shows that row.
+ */
+const defaultRowFor = (flowId: string, settings: Settings): AiFlowSettings | undefined => {
+  const aiFlow = aiFlowIdForPicker(flowId);
+  if (aiFlow === undefined) return undefined;
+  return primaryFlowRow(settings.ai, aiFlow);
+};
+
+const labelKeepDefault = (value: string | undefined): string => `Keep default (${value ?? 'unset'})`;
+
+const formatRow = (row: AiFlowSettings, globalEffort: Settings['ai']['effort']): string => {
+  const resolved = resolveEffortForRow(row, globalEffort);
+  return `${row.provider} / ${row.model} / ${resolved ?? 'auto'}`;
+};
+
+/**
+ * Walk one row through the three sequential prompts — provider → model → effort. Returns the
+ * per-field override (only fields the user changed) or `undefined` when the user cancels at
+ * any step. Empty when the user picked `Keep default` on every step.
+ */
+const customizeRow = async (
+  interactive: InteractivePrompt,
+  header: string,
+  defaultRow: AiFlowSettings,
+  globalEffort: Settings['ai']['effort']
+): Promise<NonNullable<LaunchExtras['override']> | undefined> => {
+  // Step 1 — provider. Keep default first, then every provider option (including the
+  // default's own provider; picking it explicitly is treated as "no change").
+  const providerOptions: ReadonlyArray<Choice<string>> = [
+    { label: labelKeepDefault(defaultRow.provider), value: KEEP },
+    ...AI_PROVIDERS.map((p) => ({ label: p, value: p })),
+  ];
+  const providerAns = await interactive.askChoice<string>(`${header}\nProvider:`, providerOptions);
+  if (!providerAns.ok) return undefined;
+  const providerChanged = providerAns.value !== KEEP && providerAns.value !== defaultRow.provider;
+  const effectiveProvider: AiProvider = providerChanged ? (providerAns.value as AiProvider) : defaultRow.provider;
+
+  // Step 2 — model. When the provider switched, the saved default model belongs to a
+  // different provider's catalog; omit `Keep default` so the user can't accidentally pick an
+  // incompatible model. Otherwise show `Keep default` first.
+  const modelCatalog = modelCatalogFor(effectiveProvider);
+  const modelOptions: ReadonlyArray<Choice<string>> = providerChanged
+    ? modelCatalog.map((m) => ({ label: m, value: m }))
+    : [
+        { label: labelKeepDefault(defaultRow.model), value: KEEP },
+        ...modelCatalog.map((m) => ({ label: m, value: m })),
+      ];
+  const modelAns = await interactive.askChoice<string>(`${header}\nModel:`, modelOptions);
+  if (!modelAns.ok) return undefined;
+
+  // Step 3 — effort. When the provider switched, the saved row's effort may not exist in the
+  // new provider's vocabulary; `Keep default` then means "let the launcher resolve" (the row
+  // carries no per-flow effort, so resolveEffort floors the global value to the new provider).
+  const effortCatalog = PROVIDER_EFFORT_LEVELS[effectiveProvider];
+  const effortDefaultLabel = providerChanged
+    ? 'Keep default'
+    : labelKeepDefault(resolveEffortForRow(defaultRow, globalEffort) ?? 'auto');
+  const effortOptions: ReadonlyArray<Choice<string>> = [
+    { label: effortDefaultLabel, value: KEEP },
+    ...effortCatalog.map((e) => ({ label: e, value: e })),
+  ];
+  const effortAns = await interactive.askChoice<string>(`${header}\nEffort:`, effortOptions);
+  if (!effortAns.ok) return undefined;
+
+  const override: { provider?: AiProvider; model?: string; effort?: string } = {};
+  if (providerChanged) override.provider = providerAns.value as AiProvider;
+  if (modelAns.value !== KEEP && modelAns.value !== defaultRow.model) override.model = modelAns.value;
+  if (effortAns.value !== KEEP) override.effort = effortAns.value;
+  // When the provider switched but model / effort were not chosen, we still need a model
+  // (the launcher can't merge a model from the old provider's catalog). When provider
+  // changed and model was unset above (because it matched defaultRow.model on a single
+  // catalog overlap), force the picked value through.
+  if (providerChanged && override.model === undefined) override.model = modelAns.value;
+  return override;
+};
+
+export interface RunCustomizePickerArgs {
+  readonly interactive: InteractivePrompt;
+  readonly flowId: string;
+  readonly flowTitle: string;
+  readonly settings: Settings;
+}
+
+/**
+ * Drive the pre-launch picker for one click of an AI-driven flow row. Returns `kind: 'cancel'`
+ * for the cancel path (launcher should not launch); `kind: 'defaults'` when the user picked
+ * Start (launcher should launch with no override); `kind: 'single'` / `kind: 'implement'`
+ * with the override payload when the user completed Customize.
+ *
+ * Non-AI flows (create-sprint, ticket-*, etc.) never reach this function — the picker is only
+ * called when {@link aiFlowIdForPicker} resolves to a flow id.
+ */
+export const runCustomizePicker = async ({
+  interactive,
+  flowId,
+  flowTitle,
+  settings,
+}: RunCustomizePickerArgs): Promise<CustomizePickerResult> => {
+  const aiFlow = aiFlowIdForPicker(flowId);
+  if (aiFlow === undefined) return { kind: 'defaults' };
+
+  // Header context — shown at the top of every prompt frame so the user always knows what
+  // the current defaults are. For implement we render both gen and eval; for everything else
+  // we render the single resolved row.
+  const header =
+    flowId === 'implement'
+      ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort)}`
+      : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort)}`;
+
+  const action = await interactive.askChoice<'start' | 'customize' | 'cancel'>(
+    `${header}\n\nWhat would you like to do?`,
+    [
+      { label: 'Start (use defaults)', value: 'start' },
+      { label: 'Customize for this run…', value: 'customize' },
+      { label: 'Cancel', value: 'cancel' },
+    ]
+  );
+  if (!action.ok || action.value === 'cancel') return { kind: 'cancel' };
+  if (action.value === 'start') return { kind: 'defaults' };
+
+  if (flowId === 'implement') {
+    // Walk generator first, then evaluator. Cancel at any step (including mid-evaluator)
+    // closes the picker without launching and discards any generator override already set —
+    // the launcher must not apply a half-completed customize session.
+    const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
+    const collected: {
+      generator?: NonNullable<LaunchExtras['override']>;
+      evaluator?: NonNullable<LaunchExtras['override']>;
+    } = {};
+    for (const role of roles) {
+      const row = role === 'generator' ? settings.ai.implement.generator : settings.ai.implement.evaluator;
+      const roleHeader = `${header}\n\nRole: ${role}`;
+      const result = await customizeRow(interactive, roleHeader, row, settings.ai.effort);
+      if (result === undefined) return { kind: 'cancel' };
+      if (Object.keys(result).length > 0) collected[role] = result;
+    }
+    if (collected.generator === undefined && collected.evaluator === undefined) {
+      // Both roles kept all defaults — same outcome as picking Start.
+      return { kind: 'defaults' };
+    }
+    return {
+      kind: 'implement',
+      implementRoleOverrides: {
+        ...(collected.generator !== undefined ? { generator: collected.generator } : {}),
+        ...(collected.evaluator !== undefined ? { evaluator: collected.evaluator } : {}),
+      },
+    };
+  }
+
+  const defaultRow = defaultRowFor(flowId, settings);
+  if (defaultRow === undefined) return { kind: 'defaults' };
+  const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort);
+  if (override === undefined) return { kind: 'cancel' };
+  if (Object.keys(override).length === 0) return { kind: 'defaults' };
+  return { kind: 'single', override };
+};

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -28,12 +28,8 @@ import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.t
 import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
-import {
-  launchFlow,
-  modelForFlow,
-  modelsForFlowProvider,
-  sessionHintsFromLaunchResult,
-} from '@src/application/ui/shared/launcher.ts';
+import { launchFlow, sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customize-picker.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
 import { getImplementRoleOverrides } from '@src/application/ui/tui/runtime/implement-role-overrides.ts';
@@ -137,52 +133,41 @@ export const FlowsView = (): React.JSX.Element => {
           const freshSettings = await deps.settingsRepo.load();
           const settings = freshSettings.ok ? freshSettings.value : deps.settings;
 
-          // Pre-launch model picker — for AI-driven flows, offer the configured default first
-          // (Enter starts immediately), with a "Pick a different model…" option that opens a
-          // nested SelectPrompt. Non-AI flows skip this step entirely. The override is single-
-          // use; the next launch falls back to the settings default again. Settings is the
-          // place for permanent changes.
-          const defaultModel = modelForFlow(entry.manifest.id, settings);
-          let modelOverride: string | undefined;
-          if (defaultModel !== undefined) {
-            const action = await interactive.askChoice<'start' | 'pick' | 'cancel'>(
-              `Run ${entry.manifest.title} with model '${defaultModel}'?`,
-              [
-                { label: `Start (use ${defaultModel})`, value: 'start' },
-                { label: 'Pick a different model…', value: 'pick' },
-                { label: 'Cancel', value: 'cancel' },
-              ]
-            );
-            if (!action.ok || action.value === 'cancel') return;
-            if (action.value === 'pick') {
-              const models = modelsForFlowProvider(entry.manifest.id, settings);
-              const picked = await interactive.askChoice<string>(
-                'Choose model for this run (does not change settings):',
-                models.map((m) => ({ label: m, value: m, ...(m === defaultModel ? { description: '(default)' } : {}) }))
-              );
-              if (!picked.ok) return;
-              modelOverride = picked.value;
-            }
-          }
+          // Pre-launch customize picker — for AI-driven flows the user gets Start /
+          // Customize / Cancel. Customize walks provider → model → effort for each row
+          // (implement walks generator then evaluator). Settings are never mutated; per-launch
+          // overrides are passed through {@link LaunchExtras}. Non-AI flows return
+          // `kind: 'defaults'` without prompting.
+          const picker = await runCustomizePicker({
+            interactive,
+            flowId: entry.manifest.id,
+            flowTitle: entry.manifest.title,
+            settings,
+          });
+          if (picker.kind === 'cancel') return;
 
           // Thread the session-pinned repository id as a pre-selection so flows that pick a
           // repo (detect-scripts / detect-skills / readiness) skip the prompt after the first
           // pick of the session. First launch leaves extras empty → the user picks → the
           // runner emits `completed` with the chosen `ctx.repository` and we record it below.
-          // Pull the CLI-derived implement-role overrides (parsed from
+          // Implement role overrides come from the picker when the user customized; otherwise
+          // they fall back to the CLI-derived module holder (parsed from
           // `--implement-{generator,evaluator}-{provider,model}` on the bare `ralphctl`
-          // invocation) only when launching the implement flow — every other flow ignores
-          // them. Reading through the module-level holder keeps the override path
-          // out of the UI-state context while still threading the parsed shape into the
-          // launcher's `LaunchExtras`.
-          const implementRoleOverrides = entry.manifest.id === 'implement' ? getImplementRoleOverrides() : undefined;
+          // invocation).
+          const implementRoleOverrides =
+            picker.kind === 'implement'
+              ? picker.implementRoleOverrides
+              : entry.manifest.id === 'implement'
+                ? getImplementRoleOverrides()
+                : undefined;
+          const override = picker.kind === 'single' ? picker.override : undefined;
           const result = await launchFlow(
             { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
             entry.manifest.id,
             snapshot,
             {
               ...(ui.sessionRepositoryId !== undefined ? { repositoryId: ui.sessionRepositoryId } : {}),
-              ...(modelOverride !== undefined ? { modelOverride } : {}),
+              ...(override !== undefined ? { override } : {}),
               ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
               settingsSnapshot: settings,
             }

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -1,19 +1,26 @@
 /**
- * Settings view — read + write surface. Navigation is field-by-field: ↑/↓ moves the cursor
- * through editable fields, Enter mounts the prompt appropriate to the field's type
- * (`SelectPrompt` for enums, `TextPrompt` for numbers/strings). Most routes funnel through
- * `applySettingsKey` (validation) → `settingsSet` use-case (persistence) so the TUI and the
- * `ralphctl settings set` CLI share a single mutation grammar.
+ * Settings view — read + write surface, organised into a tabbed section strip so the cursor
+ * path within any one section stays bounded (≤ ~8 rows). `←/→` switch sections; `↑/↓` navigate
+ * fields inside the active section; `↵/e` mounts the prompt appropriate to the field's type
+ * (`SelectPrompt` for enums + model catalogs, `TextPrompt` for numbers / free-text strings).
+ * Most routes funnel through `applySettingsKey` (validation) → `settingsSet` use-case
+ * (persistence) so the TUI and the `ralphctl settings set` CLI share a single mutation
+ * grammar.
  *
- * AI configuration is per-flow. Each row shows three editable fields — provider (enum), model
- * (provider catalog + a `+ custom` affordance for off-catalog ids), and effort
- * (provider-native levels, or `Default` to clear). A global `effort` row supplies a default
- * when a per-flow row leaves its `effort` unset. Switching a row's provider routes through
- * `settings-set-provider` (which rebuilds that row's `{ provider, model }` from the new
- * provider's defaults so the persistence schema stays satisfied).
+ * AI configuration is per-flow. Each flow renders as a dedicated section with three editable
+ * rows — provider (enum), model (provider catalog only), and effort (provider-native levels,
+ * or `Default` to clear). The Implement section carries six rows (generator + evaluator
+ * triples) which still falls inside the per-section cap. A global `effort` row supplies a
+ * default when a per-flow row leaves its `effort` unset. Switching a row's provider routes
+ * through `settings-set-provider` (which rebuilds that row's `{ provider, model }` from the
+ * new provider's defaults so the persistence schema stays satisfied).
  *
- * Storage paths remain read-only — they reflect the resolved runtime root rather than a
- * mutable setting.
+ * Off-catalog persisted model values stay visible on read — the model row renders whatever
+ * `s.ai.<flow>.model` is. Only the editor surface is catalog-only: picking a catalog entry
+ * overwrites the off-catalog string; until the user does so, the persisted value remains.
+ *
+ * Storage paths sit in their own read-only section so they don't compete with editable rows;
+ * they reflect the resolved runtime root rather than a mutable setting.
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
@@ -39,7 +46,7 @@ import { applySettingsKey } from '@src/business/settings/apply-key.ts';
 import { PRESET_NAMES, type PresetName } from '@src/business/settings/presets.ts';
 import type { PresetWarning } from '@src/application/flows/settings-apply-preset/ctx.ts';
 import type { AiFlowSettings, AiProvider, Settings } from '@src/domain/entity/settings.ts';
-import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { LogLevel } from '@src/domain/value/log-level.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
@@ -59,21 +66,9 @@ type EditableField =
   | { readonly kind: 'text'; readonly key: string; readonly label: string; readonly current: string }
   | {
       /**
-       * Model picker — a select prompt with a "+ custom" affordance that, when chosen, swaps
-       * to a TextPrompt for a free-form model id. Used only by the per-flow model rows.
-       */
-      readonly kind: 'model';
-      readonly key: string;
-      readonly label: string;
-      readonly options: readonly string[];
-      readonly current: string;
-    }
-  | {
-      /**
        * Preset button — activating it opens a confirmation prompt and (on yes) stamps the
        * preset onto the settings record via the apply-preset flow. The preset action group
-       * renders as four equal buttons above the global effort row; no preset is marked as
-       * "recommended" or "default".
+       * renders as four equal buttons; no preset is marked as "recommended" or "default".
        */
       readonly kind: 'preset';
       readonly key: string;
@@ -81,6 +76,32 @@ type EditableField =
       readonly preset: PresetName;
       readonly current: string;
     };
+
+/**
+ * Top-level section identifier — drives the segmented strip and the per-section field list.
+ * Sections are picked so no one section exceeds the ~8-row cursor cap; Implement (six rows —
+ * generator + evaluator triples) is the largest.
+ */
+type SectionId =
+  | 'presets'
+  | 'global'
+  | 'refine'
+  | 'plan'
+  | 'implement'
+  | 'readiness'
+  | 'ideate'
+  | 'harness'
+  | 'other'
+  | 'storage';
+
+interface SettingsSection {
+  readonly id: SectionId;
+  readonly label: string;
+  readonly title: string;
+  readonly fields: readonly EditableField[];
+  /** `true` when the section carries no editable fields (just read-only display). */
+  readonly readonly: boolean;
+}
 
 const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
   mixed: 'Apply: Mixed',
@@ -92,7 +113,6 @@ const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
 const LOG_LEVELS = ['silent', 'debug', 'info', 'warn', 'error'] as const;
 
 const DEFAULT_TOKEN = 'Default' as const;
-const CUSTOM_TOKEN = '+ custom' as const;
 
 const PROVIDER_EFFORT_LEVELS: Readonly<Record<AiProvider, readonly string[]>> = {
   'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
@@ -113,64 +133,65 @@ const modelOptionsFor = (provider: AiProvider): readonly string[] => {
   }
 };
 
-const buildEditableFields = (s: Settings): readonly EditableField[] => {
-  const fields: EditableField[] = [];
+const capitalize = (s: string): string => (s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1));
 
-  for (const preset of PRESET_NAMES) {
-    fields.push({
-      kind: 'preset',
-      key: `presets.${preset}`,
-      label: PRESET_LABEL[preset],
-      preset,
-      current: '↵ apply',
-    });
-  }
-
-  fields.push({
+const buildFlowFields = (keyPrefix: string, label: string, row: AiFlowSettings): readonly EditableField[] => [
+  {
     kind: 'select',
-    key: 'ai.effort',
-    label: 'Global effort',
-    options: [DEFAULT_TOKEN, ...GLOBAL_EFFORT_LEVELS],
-    current: s.ai.effort ?? DEFAULT_TOKEN,
+    key: `${keyPrefix}.provider`,
+    label: `${label} provider`,
+    options: AI_PROVIDERS,
+    current: row.provider,
+  },
+  {
+    kind: 'select',
+    key: `${keyPrefix}.model`,
+    label: `${label} model`,
+    options: modelOptionsFor(row.provider),
+    current: row.model,
+  },
+  {
+    kind: 'select',
+    key: `${keyPrefix}.effort`,
+    label: `${label} effort`,
+    options: [DEFAULT_TOKEN, ...PROVIDER_EFFORT_LEVELS[row.provider]],
+    current: row.effort ?? DEFAULT_TOKEN,
+  },
+];
+
+const buildSections = (s: Settings): readonly SettingsSection[] => {
+  const presetFields: readonly EditableField[] = PRESET_NAMES.map((preset) => ({
+    kind: 'preset' as const,
+    key: `presets.${preset}`,
+    label: PRESET_LABEL[preset],
+    preset,
+    current: '↵ apply',
+  }));
+
+  const globalFields: readonly EditableField[] = [
+    {
+      kind: 'select',
+      key: 'ai.effort',
+      label: 'Global effort',
+      options: [DEFAULT_TOKEN, ...GLOBAL_EFFORT_LEVELS],
+      current: s.ai.effort ?? DEFAULT_TOKEN,
+    },
+  ];
+
+  const implementFields: readonly EditableField[] = [
+    ...buildFlowFields('ai.implement.generator', 'Generator', s.ai.implement.generator),
+    ...buildFlowFields('ai.implement.evaluator', 'Evaluator', s.ai.implement.evaluator),
+  ];
+
+  const flowSection = (flow: Exclude<FlowId, 'implement'>): SettingsSection => ({
+    id: flow,
+    label: capitalize(flow),
+    title: `AI — ${capitalize(flow)}`,
+    fields: buildFlowFields(`ai.${flow}`, capitalize(flow), s.ai[flow]),
+    readonly: false,
   });
 
-  const pushRowFields = (keyPrefix: string, label: string, row: AiFlowSettings): void => {
-    fields.push({
-      kind: 'select',
-      key: `${keyPrefix}.provider`,
-      label: `${label} provider`,
-      options: AI_PROVIDERS,
-      current: row.provider,
-    });
-    fields.push({
-      kind: 'model',
-      key: `${keyPrefix}.model`,
-      label: `${label} model`,
-      options: [...modelOptionsFor(row.provider), CUSTOM_TOKEN],
-      current: row.model,
-    });
-    fields.push({
-      kind: 'select',
-      key: `${keyPrefix}.effort`,
-      label: `${label} effort`,
-      options: [DEFAULT_TOKEN, ...PROVIDER_EFFORT_LEVELS[row.provider]],
-      current: row.effort ?? DEFAULT_TOKEN,
-    });
-  };
-
-  for (const flow of FLOW_IDS) {
-    if (flow === 'implement') {
-      // Implement splits into a generator / evaluator pair — render one set of fields per
-      // role so the user can configure each independently. Keys mirror the dotted-path
-      // grammar consumed by `applySettingsKey`.
-      pushRowFields('ai.implement.generator', 'Implement (generator)', s.ai.implement.generator);
-      pushRowFields('ai.implement.evaluator', 'Implement (evaluator)', s.ai.implement.evaluator);
-      continue;
-    }
-    pushRowFields(`ai.${flow}`, capitalize(flow), s.ai[flow]);
-  }
-
-  fields.push(
+  const harnessFields: readonly EditableField[] = [
     { kind: 'text', key: 'harness.maxTurns', label: 'Max turns', current: String(s.harness.maxTurns) },
     { kind: 'text', key: 'harness.maxAttempts', label: 'Max attempts', current: String(s.harness.maxAttempts) },
     {
@@ -185,19 +206,39 @@ const buildEditableFields = (s: Settings): readonly EditableField[] => {
       label: 'Plateau threshold',
       current: String(s.harness.plateauThreshold),
     },
+  ];
+
+  const otherFields: readonly EditableField[] = [
     { kind: 'select', key: 'logging.level', label: 'Log level', options: LOG_LEVELS, current: s.logging.level },
     {
       kind: 'text',
       key: 'concurrency.maxParallelTasks',
       label: 'Concurrency',
       current: String(s.concurrency.maxParallelTasks),
-    }
-  );
+    },
+  ];
 
-  return fields;
+  return [
+    { id: 'presets', label: 'Presets', title: 'Presets', fields: presetFields, readonly: false },
+    { id: 'global', label: 'Global', title: 'AI — global', fields: globalFields, readonly: false },
+    flowSection('refine'),
+    flowSection('plan'),
+    { id: 'implement', label: 'Implement', title: 'AI — Implement', fields: implementFields, readonly: false },
+    flowSection('readiness'),
+    flowSection('ideate'),
+    { id: 'harness', label: 'Harness', title: 'Harness budgets', fields: harnessFields, readonly: false },
+    { id: 'other', label: 'Other', title: 'Other', fields: otherFields, readonly: false },
+    { id: 'storage', label: 'Storage', title: 'Storage paths', fields: [], readonly: true },
+  ];
 };
 
-const capitalize = (s: string): string => (s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1));
+const HARNESS_HINTS: Readonly<Record<string, string>> = {
+  'harness.maxTurns': 'Cap on gen/eval iterations inside ONE task attempt — generator → evaluator → repeat.',
+  'harness.maxAttempts':
+    'How many times a single task may be re-attempted across separate Implement runs before it blocks.',
+  'harness.rateLimitRetries': 'Auto-retries with exponential backoff when the AI provider returns a rate-limit error.',
+  'harness.plateauThreshold': 'Consecutive evaluator turns on the same failed dimensions before the loop exits (2-5).',
+};
 
 export const SettingsView = (): React.JSX.Element => {
   const deps = useDeps();
@@ -214,10 +255,9 @@ export const SettingsView = (): React.JSX.Element => {
    * enabled" so the picker is usable in the rare frame between mount and probe-completion.
    */
   const [installedProviders, setInstalledProviders] = useState<ReadonlySet<AiProvider> | undefined>(undefined);
+  const [sectionIdx, setSectionIdx] = useState(0);
   const [cursor, setCursor] = useState(0);
   const [editingField, setEditingField] = useState<EditableField | undefined>(undefined);
-  /** Holds a model field when the user picked "+ custom" — the editor swaps to a TextPrompt. */
-  const [customModelField, setCustomModelField] = useState<EditableField | undefined>(undefined);
   /** Pending preset confirmation — populated when the user activates a preset button. */
   const [pendingPreset, setPendingPreset] = useState<PresetName | undefined>(undefined);
   const [feedback, setFeedback] = useState<{ readonly tone: 'ok' | 'error'; readonly text: string } | undefined>(
@@ -229,6 +269,7 @@ export const SettingsView = (): React.JSX.Element => {
    */
   const [presetWarnings, setPresetWarnings] = useState<readonly PresetWarning[]>([]);
   useViewHints([
+    { keys: '←/→', label: 'section' },
     { keys: '↑/↓', label: 'navigate' },
     { keys: '↵/e', label: 'edit' },
   ]);
@@ -254,29 +295,51 @@ export const SettingsView = (): React.JSX.Element => {
     };
   }, []);
 
-  const fields = useMemo<readonly EditableField[]>(
-    () => (settings === undefined ? [] : buildEditableFields(settings)),
+  const sections = useMemo<readonly SettingsSection[]>(
+    () => (settings === undefined ? [] : buildSections(settings)),
     [settings]
   );
 
-  // Clamp cursor when the field set changes (e.g. provider switch resets model + effort).
+  const activeSection = sections[sectionIdx];
+  const activeFields = activeSection?.fields ?? [];
+
+  // Clamp cursor when the active section's field set changes (e.g. a provider switch resets
+  // the model + effort options on the same section).
   useEffect(() => {
-    if (cursor >= fields.length && fields.length > 0) setCursor(fields.length - 1);
-  }, [fields, cursor]);
+    if (cursor >= activeFields.length && activeFields.length > 0) setCursor(activeFields.length - 1);
+  }, [activeFields, cursor]);
+
+  // Clamp the section pointer if the section list ever shrinks below the current index.
+  useEffect(() => {
+    if (sectionIdx >= sections.length && sections.length > 0) setSectionIdx(sections.length - 1);
+  }, [sections, sectionIdx]);
 
   useInput((input, key) => {
     if (ui.helpOpen || editingField !== undefined || pendingPreset !== undefined || ui.promptActive) return;
-    if (fields.length === 0) return;
+    if (sections.length === 0) return;
+    if (key.leftArrow || input === '[') {
+      setSectionIdx((i) => (i - 1 + sections.length) % sections.length);
+      setCursor(0);
+      setFeedback(undefined);
+      return;
+    }
+    if (key.rightArrow || input === ']') {
+      setSectionIdx((i) => (i + 1) % sections.length);
+      setCursor(0);
+      setFeedback(undefined);
+      return;
+    }
+    if (activeFields.length === 0) return;
     if (key.upArrow || input === 'k') {
       setCursor((c) => Math.max(0, c - 1));
       return;
     }
     if (key.downArrow || input === 'j') {
-      setCursor((c) => Math.min(fields.length - 1, c + 1));
+      setCursor((c) => Math.min(activeFields.length - 1, c + 1));
       return;
     }
     if (key.return || input === 'e') {
-      const field = fields[cursor];
+      const field = activeFields[cursor];
       if (field === undefined) return;
       setFeedback(undefined);
       if (field.kind === 'preset') {
@@ -294,16 +357,12 @@ export const SettingsView = (): React.JSX.Element => {
   // got clobbered by the PromptHost when its queue was empty.
   const claimPrompt = ui.claimPrompt;
   useEffect(
-    () =>
-      editingField !== undefined || customModelField !== undefined || pendingPreset !== undefined
-        ? claimPrompt()
-        : undefined,
-    [editingField, customModelField, pendingPreset, claimPrompt]
+    () => (editingField !== undefined || pendingPreset !== undefined ? claimPrompt() : undefined),
+    [editingField, pendingPreset, claimPrompt]
   );
 
   const closeEditor = (): void => {
     setEditingField(undefined);
-    setCustomModelField(undefined);
   };
 
   const applyPreset = async (preset: PresetName): Promise<void> => {
@@ -412,18 +471,8 @@ export const SettingsView = (): React.JSX.Element => {
   };
 
   const renderEditor = (field: EditableField): React.JSX.Element => {
-    if (field.kind === 'model' && customModelField !== undefined) {
-      return (
-        <TextPrompt
-          message={`${field.label} (custom id, current: ${field.current})`}
-          initial={field.current}
-          onSubmit={(value) => void submit(value, field)}
-          onCancel={closeEditor}
-        />
-      );
-    }
-    if (field.kind === 'select' || field.kind === 'model') {
-      if (field.kind === 'select' && isProviderField(field)) {
+    if (field.kind === 'select') {
+      if (isProviderField(field)) {
         const { choices, footer } = buildProviderOptions(field.options);
         return (
           <SelectPrompt
@@ -439,13 +488,7 @@ export const SettingsView = (): React.JSX.Element => {
         <SelectPrompt
           message={`${field.label} (current: ${field.current})`}
           options={field.options.map((value) => ({ label: value, value }))}
-          onSubmit={(value) => {
-            if (field.kind === 'model' && String(value) === CUSTOM_TOKEN) {
-              setCustomModelField(field);
-              return;
-            }
-            void submit(String(value), field);
-          }}
+          onSubmit={(value) => void submit(String(value), field)}
           onCancel={closeEditor}
         />
       );
@@ -462,8 +505,8 @@ export const SettingsView = (): React.JSX.Element => {
 
   const valueFor = (key: string): React.ReactNode => {
     if (settings === undefined) return null;
-    const focused = fields[cursor]?.key === key;
-    const field = fields.find((f) => f.key === key);
+    const focused = activeFields[cursor]?.key === key;
+    const field = activeFields.find((f) => f.key === key);
     const value = field?.current ?? '';
     return (
       <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
@@ -473,8 +516,139 @@ export const SettingsView = (): React.JSX.Element => {
     );
   };
 
+  const renderSectionStrip = (): React.JSX.Element => (
+    <Box flexWrap="wrap">
+      {sections.map((sec, i) => {
+        const isActive = i === sectionIdx;
+        return (
+          <Box key={sec.id} marginRight={spacing.indent}>
+            <Text {...(isActive ? { color: inkColors.primary } : { dimColor: true })} bold={isActive}>
+              {isActive ? `${glyphs.actionCursor} ${sec.label}` : `  ${sec.label}`}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+
+  const renderSectionBody = (section: SettingsSection): React.JSX.Element => {
+    if (section.id === 'storage') {
+      return (
+        <Card title={section.title} tone="rule">
+          <FieldList
+            fields={[
+              { label: 'App root', value: <Text dimColor>{storage.appRoot}</Text> },
+              { label: 'Data root', value: <Text dimColor>{storage.dataRoot}</Text> },
+              { label: 'Config root', value: <Text dimColor>{storage.configRoot}</Text> },
+            ]}
+          />
+        </Card>
+      );
+    }
+    if (section.id === 'presets') {
+      return (
+        <Card title={section.title} tone="primary">
+          <FieldList
+            fields={PRESET_NAMES.map((preset) => ({
+              label: PRESET_LABEL[preset],
+              value: valueFor(`presets.${preset}`),
+            }))}
+          />
+          {presetWarnings.length > 0 && (
+            <Box flexDirection="column" paddingX={spacing.indent} marginTop={spacing.section}>
+              {presetWarnings.map((w) => (
+                <Text key={w.provider} dimColor>
+                  ⚠ {w.provider} CLI not found on PATH; affects flows: {w.flows.join(', ')}
+                </Text>
+              ))}
+            </Box>
+          )}
+        </Card>
+      );
+    }
+    if (section.id === 'implement') {
+      // Implement is the only flow whose runtime carries two AI sessions per task — the
+      // generator that proposes a commit and the evaluator that judges it. Render the parent
+      // section title once; the two roles render as indented sub-rows underneath so the
+      // operator sees at a glance that they're two halves of the same flow rather than two
+      // independent flows. Edits on either role flow through the same dotted-path keys
+      // (`ai.implement.<role>.<field>`), so changing one role's provider/model/effort cannot
+      // perturb the other.
+      return (
+        <Card title={section.title} tone="primary">
+          {(['generator', 'evaluator'] as const).map((role, idx) => (
+            <Box
+              key={role}
+              flexDirection="column"
+              paddingLeft={spacing.indent}
+              marginTop={idx === 0 ? 0 : spacing.section}
+            >
+              <Text dimColor bold>
+                {role}
+              </Text>
+              <FieldList
+                fields={[
+                  { label: 'Provider', value: valueFor(`ai.implement.${role}.provider`) },
+                  { label: 'Model', value: valueFor(`ai.implement.${role}.model`) },
+                  { label: 'Effort', value: valueFor(`ai.implement.${role}.effort`) },
+                ]}
+              />
+            </Box>
+          ))}
+        </Card>
+      );
+    }
+    if (section.id === 'harness') {
+      return (
+        <Card title={section.title} tone="primary">
+          <FieldList
+            fields={section.fields.map((f) => {
+              const hint = HARNESS_HINTS[f.key];
+              return {
+                label: f.label,
+                value: valueFor(f.key),
+                ...(hint !== undefined ? { hint } : {}),
+              };
+            })}
+          />
+        </Card>
+      );
+    }
+    if (section.id === 'global') {
+      return (
+        <Card title={section.title} tone="primary">
+          <FieldList fields={[{ label: 'Effort (default)', value: valueFor('ai.effort') }]} />
+        </Card>
+      );
+    }
+    if (section.id === 'other') {
+      return (
+        <Card title={section.title} tone="primary">
+          <FieldList
+            fields={[
+              { label: 'Log level', value: valueFor('logging.level') },
+              { label: 'Concurrency', value: valueFor('concurrency.maxParallelTasks') },
+            ]}
+          />
+        </Card>
+      );
+    }
+    // Per-flow section (refine / plan / readiness / ideate) — three editable rows.
+    return (
+      <Card title={section.title} tone="primary">
+        <FieldList
+          fields={[
+            { label: 'Provider', value: valueFor(`ai.${section.id}.provider`) },
+            { label: 'Model', value: valueFor(`ai.${section.id}.model`) },
+            { label: 'Effort', value: valueFor(`ai.${section.id}.effort`) },
+          ]}
+        />
+      </Card>
+    );
+  };
+
   return (
-    <ViewShell title="Settings" subtitle="↑/↓ navigate · ↵ edit · esc cancel">
+    <ViewShell title="Settings" subtitle="←/→ section · ↑/↓ navigate · ↵ edit · esc cancel">
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : pendingPreset !== undefined ? (
@@ -494,129 +668,14 @@ export const SettingsView = (): React.JSX.Element => {
         <Box paddingX={spacing.indent}>
           <Text color="red">Failed to load settings: {loadError}</Text>
         </Box>
-      ) : settings === undefined ? (
+      ) : settings === undefined || activeSection === undefined ? (
         <Box paddingX={spacing.indent}>
           <Text dimColor>Loading…</Text>
         </Box>
       ) : (
         <Box flexDirection="column">
-          <Card title="Presets" tone="primary">
-            <FieldList
-              fields={PRESET_NAMES.map((preset) => ({
-                label: PRESET_LABEL[preset],
-                value: valueFor(`presets.${preset}`),
-              }))}
-            />
-            {presetWarnings.length > 0 && (
-              <Box flexDirection="column" paddingX={spacing.indent} marginTop={spacing.section}>
-                {presetWarnings.map((w) => (
-                  <Text key={w.provider} dimColor>
-                    ⚠ {w.provider} CLI not found on PATH; affects flows: {w.flows.join(', ')}
-                  </Text>
-                ))}
-              </Box>
-            )}
-          </Card>
-          <Box marginTop={spacing.section}>
-            <Card title="AI — global" tone="primary">
-              <FieldList fields={[{ label: 'Effort (default)', value: valueFor('ai.effort') }]} />
-            </Card>
-          </Box>
-          {FLOW_IDS.map((flow) =>
-            flow === 'implement' ? (
-              // Implement is the only flow whose runtime carries two AI sessions per task — the
-              // generator that proposes a commit and the evaluator that judges it. Render the
-              // parent flow name as a non-editable card title; the two roles render as indented
-              // sub-rows underneath so the operator sees at a glance that they're two halves of
-              // the same flow rather than two independent flows. Edits on either role flow
-              // through the same dotted-path keys (`ai.implement.<role>.<field>`), so changing
-              // one role's provider/model/effort cannot perturb the other.
-              <Box key={flow} marginTop={spacing.section}>
-                <Card title="AI — Implement" tone="primary">
-                  {(['generator', 'evaluator'] as const).map((role, idx) => (
-                    <Box
-                      key={role}
-                      flexDirection="column"
-                      paddingLeft={spacing.indent}
-                      marginTop={idx === 0 ? 0 : spacing.section}
-                    >
-                      <Text dimColor bold>
-                        {role}
-                      </Text>
-                      <FieldList
-                        fields={[
-                          { label: 'Provider', value: valueFor(`ai.implement.${role}.provider`) },
-                          { label: 'Model', value: valueFor(`ai.implement.${role}.model`) },
-                          { label: 'Effort', value: valueFor(`ai.implement.${role}.effort`) },
-                        ]}
-                      />
-                    </Box>
-                  ))}
-                </Card>
-              </Box>
-            ) : (
-              <Box key={flow} marginTop={spacing.section}>
-                <Card title={`AI — ${capitalize(flow)}`} tone="primary">
-                  <FieldList
-                    fields={[
-                      { label: 'Provider', value: valueFor(`ai.${flow}.provider`) },
-                      { label: 'Model', value: valueFor(`ai.${flow}.model`) },
-                      { label: 'Effort', value: valueFor(`ai.${flow}.effort`) },
-                    ]}
-                  />
-                </Card>
-              </Box>
-            )
-          )}
-          <Box marginTop={spacing.section}>
-            <Card title="Harness budgets" tone="primary">
-              <FieldList
-                fields={[
-                  {
-                    label: 'Max turns',
-                    value: valueFor('harness.maxTurns'),
-                    hint: 'Cap on gen/eval iterations inside ONE task attempt — generator → evaluator → repeat.',
-                  },
-                  {
-                    label: 'Max attempts',
-                    value: valueFor('harness.maxAttempts'),
-                    hint: 'How many times a single task may be re-attempted across separate Implement runs before it blocks.',
-                  },
-                  {
-                    label: 'Rate-limit retries',
-                    value: valueFor('harness.rateLimitRetries'),
-                    hint: 'Auto-retries with exponential backoff when the AI provider returns a rate-limit error.',
-                  },
-                  {
-                    label: 'Plateau threshold',
-                    value: valueFor('harness.plateauThreshold'),
-                    hint: 'Consecutive evaluator turns on the same failed dimensions before the loop exits (2-5).',
-                  },
-                ]}
-              />
-            </Card>
-          </Box>
-          <Box marginTop={spacing.section}>
-            <Card title="Other" tone="primary">
-              <FieldList
-                fields={[
-                  { label: 'Log level', value: valueFor('logging.level') },
-                  { label: 'Concurrency', value: valueFor('concurrency.maxParallelTasks') },
-                ]}
-              />
-            </Card>
-          </Box>
-          <Box marginTop={spacing.section}>
-            <Card title="Storage paths" tone="rule">
-              <FieldList
-                fields={[
-                  { label: 'App root', value: <Text dimColor>{storage.appRoot}</Text> },
-                  { label: 'Data root', value: <Text dimColor>{storage.dataRoot}</Text> },
-                  { label: 'Config root', value: <Text dimColor>{storage.configRoot}</Text> },
-                ]}
-              />
-            </Card>
-          </Box>
+          {renderSectionStrip()}
+          <Box marginTop={spacing.section}>{renderSectionBody(activeSection)}</Box>
           {feedback !== undefined && (
             <Box paddingX={spacing.indent} marginTop={spacing.section}>
               <Text color={feedback.tone === 'ok' ? inkColors.primary : 'red'}>

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -51,6 +51,7 @@ import type { LogLevel } from '@src/domain/value/log-level.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+import { PROVIDER_EFFORT_LEVELS } from '@src/domain/value/settings-models/effort.ts';
 import { detectInstalledProviders, primaryInstallCommand } from '@src/integration/system/detect-cli.ts';
 
 const AI_PROVIDERS: readonly AiProvider[] = ['claude-code', 'github-copilot', 'openai-codex'];
@@ -113,12 +114,6 @@ const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
 const LOG_LEVELS = ['silent', 'debug', 'info', 'warn', 'error'] as const;
 
 const DEFAULT_TOKEN = 'Default' as const;
-
-const PROVIDER_EFFORT_LEVELS: Readonly<Record<AiProvider, readonly string[]>> = {
-  'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
-  'github-copilot': ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
-  'openai-codex': ['minimal', 'low', 'medium', 'high'],
-};
 
 const GLOBAL_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -40,6 +40,7 @@ import { useEditField, type OpenEditPromptInput } from '@src/application/ui/tui/
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
+import { ListCard } from '@src/application/ui/tui/components/list-card.tsx';
 import { FieldList } from '@src/application/ui/tui/components/field-list.tsx';
 import {
   StatusChip,
@@ -60,6 +61,7 @@ import type { Attempt } from '@src/domain/entity/attempt.ts';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { fmtDuration, fmtIsoAbsolute } from '@src/application/ui/tui/theme/duration.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
@@ -792,35 +794,28 @@ const TicketCard = ({
   readonly expanded: boolean;
   readonly index: number;
 }): React.JSX.Element => (
-  <Box marginBottom={1}>
-    <Card
-      tone={focused ? 'info' : 'rule'}
-      right={<StatusChip label={ticket.status} kind={ticketStatusKind(ticket.status)} />}
-    >
-      <Box flexDirection="column" paddingX={spacing.indent}>
-        <Box>
-          <Text {...(focused ? { color: inkColors.primary } : { dimColor: true })}>
-            {focused ? `${glyphs.actionCursor} ` : `  `}#{String(index + 1)}
-          </Text>
-          <Text bold> {ticket.title}</Text>
-        </Box>
-        <Box>
-          <Text dimColor>
-            {glyphs.bullet} {String(taskCount)} task{taskCount === 1 ? '' : 's'}
-          </Text>
-          {ticket.link !== undefined && (
-            <Text dimColor>
-              {' '}
-              {glyphs.bullet} {String(ticket.link)}
-            </Text>
-          )}
-          {ticket.status === 'approved' && <Text dimColor> {glyphs.bullet} requirements ✓</Text>}
-        </Box>
-        {!expanded && ticket.description !== undefined && <Description text={ticket.description} maxLines={2} />}
-        {expanded && <TicketDetailBody ticket={ticket} tasks={tasks} />}
-      </Box>
-    </Card>
-  </Box>
+  <ListCard
+    focused={focused}
+    expanded={expanded}
+    rightSlot={<StatusChip label={ticket.status} kind={ticketStatusKind(ticket.status)} />}
+    indexLabel={`#${String(index + 1)}`}
+    title={ticket.title}
+  >
+    <Box>
+      <Text dimColor>
+        {glyphs.bullet} {String(taskCount)} task{taskCount === 1 ? '' : 's'}
+      </Text>
+      {ticket.link !== undefined && (
+        <Text dimColor>
+          {' '}
+          {glyphs.bullet} {String(ticket.link)}
+        </Text>
+      )}
+      {ticket.status === 'approved' && <Text dimColor> {glyphs.bullet} requirements ✓</Text>}
+    </Box>
+    {!expanded && ticket.description !== undefined && <Description text={ticket.description} maxLines={2} />}
+    {expanded && <TicketDetailBody ticket={ticket} tasks={tasks} />}
+  </ListCard>
 );
 
 // ─── Tasks section ────────────────────────────────────────────────────────────────────────────
@@ -902,63 +897,116 @@ const TaskCard = ({
 }): React.JSX.Element => {
   const lastAttempt: Attempt | undefined = task.attempts[task.attempts.length - 1];
   const lastAttemptElapsed = lastAttempt !== undefined ? attemptElapsedMs(lastAttempt) : undefined;
+  const { atLeast } = useBreakpoint();
+  // At ≥md (≥100 cols) the metadata row stays on a single line and ellides on overflow so the
+  // task card height stays a predictable two lines. Below md, the row is allowed to wrap so
+  // narrow terminals don't lose information at the tail.
+  const singleLineMetadata = atLeast('md');
+  const metadataParts: readonly React.ReactNode[] = buildTaskMetadataParts({
+    ticketTitle,
+    dependsOnCount: task.dependsOn.length,
+    repoName,
+    attempts: task.attempts.length,
+    maxAttempts: task.maxAttempts,
+    lastAttemptElapsed,
+  });
   return (
-    <Box marginBottom={1}>
-      <Card
-        tone={focused ? 'info' : 'rule'}
-        right={<StatusChip label={task.status} kind={taskStatusKind(task.status)} />}
-      >
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          <Box>
-            <Text {...(focused ? { color: inkColors.primary } : { dimColor: true })}>
-              {focused ? `${glyphs.actionCursor} ` : `  `}#{String(index)}
-            </Text>
-            <Text bold> {task.name}</Text>
-          </Box>
-          <Box flexWrap="wrap">
-            {ticketTitle !== undefined && (
-              <Text dimColor>
-                {glyphs.bullet} ticket: <Text bold>{ticketTitle}</Text>
-              </Text>
-            )}
-            {task.dependsOn.length > 0 && (
-              <Text dimColor>
-                {' '}
-                {glyphs.bullet} {String(task.dependsOn.length)} dep{task.dependsOn.length === 1 ? '' : 's'}
-              </Text>
-            )}
-            {repoName !== undefined && (
-              <Text dimColor>
-                {' '}
-                {glyphs.bullet} repo: <Text>{repoName}</Text>
-              </Text>
-            )}
-            <Text dimColor>
-              {' '}
-              {glyphs.bullet} attempts: {String(task.attempts.length)}
-              {task.maxAttempts !== undefined ? `/${String(task.maxAttempts)}` : ''}
-            </Text>
-            {lastAttemptElapsed !== undefined && (
-              <Text dimColor>
-                {' '}
-                {glyphs.bullet} last: {fmtDuration(lastAttemptElapsed)}
-              </Text>
-            )}
-          </Box>
-          {!expanded && task.description !== undefined && <Description text={task.description} maxLines={2} />}
-          {!expanded && task.status === 'blocked' && (
-            <Box paddingLeft={2}>
-              <Text color={inkColors.error}>
-                {glyphs.cross} blocked: {task.blockedReason}
-              </Text>
-            </Box>
-          )}
-          {expanded && <TaskDetailBody task={task} sprint={sprint} tasks={tasks} project={project} />}
+    <ListCard
+      focused={focused}
+      expanded={expanded}
+      rightSlot={<StatusChip label={task.status} kind={taskStatusKind(task.status)} />}
+      indexLabel={`#${String(index)}`}
+      title={task.name}
+    >
+      {singleLineMetadata ? (
+        <Box>
+          <Text wrap="truncate-end" dimColor>
+            {joinMetadataInline(metadataParts)}
+          </Text>
         </Box>
-      </Card>
-    </Box>
+      ) : (
+        <Box flexWrap="wrap">
+          {metadataParts.map((node, i) => (
+            <Text key={`meta-${String(i)}`} dimColor>
+              {i > 0 ? ' ' : ''}
+              {node}
+            </Text>
+          ))}
+        </Box>
+      )}
+      {!expanded && task.description !== undefined && <Description text={task.description} maxLines={2} />}
+      {!expanded && task.status === 'blocked' && (
+        <Box paddingLeft={2}>
+          <Text color={inkColors.error}>
+            {glyphs.cross} blocked: {task.blockedReason}
+          </Text>
+        </Box>
+      )}
+      {expanded && <TaskDetailBody task={task} sprint={sprint} tasks={tasks} project={project} />}
+    </ListCard>
   );
 };
+
+interface TaskMetadataInput {
+  readonly ticketTitle: string | undefined;
+  readonly dependsOnCount: number;
+  readonly repoName: string | undefined;
+  readonly attempts: number;
+  readonly maxAttempts: number | undefined;
+  readonly lastAttemptElapsed: number | undefined;
+}
+
+/**
+ * Build the per-field React nodes for the task metadata row. Each entry already carries its
+ * leading bullet glyph (`·`); the caller decides whether to join them on one line (with an
+ * intervening space) or render them as wrapped flex items.
+ */
+const buildTaskMetadataParts = (input: TaskMetadataInput): readonly React.ReactNode[] => {
+  const parts: React.ReactNode[] = [];
+  if (input.ticketTitle !== undefined) {
+    parts.push(
+      <React.Fragment key="ticket">
+        {glyphs.bullet} ticket: <Text bold>{input.ticketTitle}</Text>
+      </React.Fragment>
+    );
+  }
+  if (input.dependsOnCount > 0) {
+    parts.push(
+      <React.Fragment key="deps">
+        {glyphs.bullet} {String(input.dependsOnCount)} dep{input.dependsOnCount === 1 ? '' : 's'}
+      </React.Fragment>
+    );
+  }
+  if (input.repoName !== undefined) {
+    parts.push(
+      <React.Fragment key="repo">
+        {glyphs.bullet} repo: <Text>{input.repoName}</Text>
+      </React.Fragment>
+    );
+  }
+  parts.push(
+    <React.Fragment key="attempts">
+      {glyphs.bullet} attempts: {String(input.attempts)}
+      {input.maxAttempts !== undefined ? `/${String(input.maxAttempts)}` : ''}
+    </React.Fragment>
+  );
+  if (input.lastAttemptElapsed !== undefined) {
+    parts.push(
+      <React.Fragment key="last">
+        {glyphs.bullet} last: {fmtDuration(input.lastAttemptElapsed)}
+      </React.Fragment>
+    );
+  }
+  return parts;
+};
+
+const joinMetadataInline = (parts: readonly React.ReactNode[]): React.ReactNode =>
+  parts.map((node, i) => (
+    <React.Fragment key={`inline-${String(i)}`}>
+      {i > 0 ? ' ' : ''}
+      {node}
+    </React.Fragment>
+  ));
 
 const repositoryName = (project: Project | undefined, id: RepositoryId): string | undefined => {
   if (project === undefined) return undefined;

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -9,17 +9,19 @@
  *  - Tasks section — one bordered card per task, showing ticket reference, deps, repo, attempts.
  *
  * Inline expand-in-place: every ticket / task card stays in the list. Pressing ↵/o on the
- * focused card expands it inline (full description, requirements, referenced tasks for
- * tickets; steps, verification criteria, dependencies, attempt history for tasks) inside the
- * same border. Same key (or `esc`) collapses it. Cursor still moves between cards via ↑/↓ /
- * j/k across both sections without auto-collapsing.
+ * focused card toggles its expansion inline (full description, requirements, referenced tasks
+ * for tickets; steps, verification criteria, dependencies, attempt history for tasks) inside
+ * the same border. Each card's expansion is tracked independently by stable id, so opening a
+ * second card leaves the first one open. Cursor still moves between cards via ↑/↓ / j/k
+ * across both sections without changing which cards are expanded. Pressing `esc` / `q` while
+ * any card is expanded collapses every expansion in one action.
  *
  * Local keys:
  *   a       add ticket (draft only)
  *   d       remove the focused ticket (draft only) after a confirm
  *   ↑/↓     move the focus cursor across BOTH tickets and tasks
  *   ↵/o     expand / collapse the focused card inline
- *   esc     collapse the expanded card (back to list)
+ *   esc/q   collapse every expanded card (back to list)
  *   n       open Flows, scoped to this sprint
  */
 
@@ -188,13 +190,13 @@ export const SprintDetailView = (): React.JSX.Element => {
   const focusList = useMemo(() => (sprint !== undefined ? buildFocusList(sprint, tasks) : []), [sprint, tasks]);
 
   const [cursorIdx, setCursorIdx] = useState(0);
-  const [openIdx, setOpenIdx] = useState<number | undefined>(undefined);
+  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(() => new Set());
   const [confirmRemove, setConfirmRemove] = useState<Ticket | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';
-  const inDetail = openIdx !== undefined;
+  const inDetail = openIds.size > 0;
   const focusedNow = focusList[Math.min(cursorIdx, Math.max(0, focusList.length - 1))];
   // "Stuck" covers both `blocked` (maxAttempts exhausted / verify failed) and `in_progress`
   // with a settled last attempt (crash recovery after Ctrl-C / watchdog kill). Both map to the
@@ -329,9 +331,9 @@ export const SprintDetailView = (): React.JSX.Element => {
 
   useInput((input, key) => {
     if (ui.helpOpen || ui.promptActive || confirmRemove !== undefined || sprint === undefined) return;
-    // Esc collapses an inline-expanded card; falls through to global pop otherwise.
+    // Esc/q collapses every expanded card in one action; falls through to global pop otherwise.
     if ((key.escape || input === 'q') && inDetail) {
-      setOpenIdx(undefined);
+      setOpenIds(new Set());
       return;
     }
     if (input === 'a' && ticketsEditable) {
@@ -360,8 +362,15 @@ export const SprintDetailView = (): React.JSX.Element => {
       return;
     }
     if ((key.return || input === 'o') && focusList.length > 0) {
-      const target = Math.min(cursorIdx, focusList.length - 1);
-      setOpenIdx((prev) => (prev === target ? undefined : target));
+      const target = focusList[Math.min(cursorIdx, focusList.length - 1)];
+      if (target === undefined) return;
+      const targetId = target.kind === 'ticket' ? String(target.ticket.id) : String(target.task.id);
+      setOpenIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(targetId)) next.delete(targetId);
+        else next.add(targetId);
+        return next;
+      });
       return;
     }
     if (input === 'd' && ticketsEditable) {
@@ -444,7 +453,7 @@ export const SprintDetailView = (): React.JSX.Element => {
           project={project}
           focusList={focusList}
           cursorIdx={Math.min(cursorIdx, Math.max(0, focusList.length - 1))}
-          openIdx={openIdx}
+          openIds={openIds}
           ticketsEditable={ticketsEditable}
           feedback={feedback ?? edit.feedback}
           isCurrent={selection.sprintId === state.value.sprint.id}
@@ -459,7 +468,7 @@ interface BodyProps {
   readonly project: Project | undefined;
   readonly focusList: readonly FocusItem[];
   readonly cursorIdx: number;
-  readonly openIdx: number | undefined;
+  readonly openIds: ReadonlySet<string>;
   readonly ticketsEditable: boolean;
   readonly feedback: string | undefined;
   readonly isCurrent: boolean;
@@ -470,14 +479,13 @@ const Body = ({
   project,
   focusList,
   cursorIdx,
-  openIdx,
+  openIds,
   ticketsEditable,
   feedback,
   isCurrent,
 }: BodyProps): React.JSX.Element => {
   const { sprint, tasks } = bundle;
   const action = phaseAction(sprint, tasks);
-  const expandedFocusItem = openIdx !== undefined ? focusList[openIdx] : undefined;
   return (
     <Box flexDirection="column">
       <SprintHeader sprint={sprint} tasks={tasks} isCurrent={isCurrent} />
@@ -511,7 +519,7 @@ const Body = ({
         cursorIdx={cursorIdx}
         ticketsEditable={ticketsEditable}
         feedback={feedback}
-        expandedFocusItem={expandedFocusItem}
+        openIds={openIds}
       />
       <TasksSection
         sprint={sprint}
@@ -519,7 +527,7 @@ const Body = ({
         focusList={focusList}
         cursorIdx={cursorIdx}
         project={project}
-        expandedFocusItem={expandedFocusItem}
+        openIds={openIds}
       />
 
       <Box paddingX={spacing.indent} marginTop={spacing.section}>
@@ -711,7 +719,7 @@ interface TicketsSectionProps {
   readonly cursorIdx: number;
   readonly ticketsEditable: boolean;
   readonly feedback: string | undefined;
-  readonly expandedFocusItem: FocusItem | undefined;
+  readonly openIds: ReadonlySet<string>;
 }
 
 const TicketsSection = ({
@@ -721,7 +729,7 @@ const TicketsSection = ({
   cursorIdx,
   ticketsEditable,
   feedback,
-  expandedFocusItem,
+  openIds,
 }: TicketsSectionProps): React.JSX.Element => (
   <Box marginTop={spacing.section} flexDirection="column">
     <Text bold>{glyphs.badge} Tickets</Text>
@@ -738,7 +746,7 @@ const TicketsSection = ({
       <Box flexDirection="column" marginTop={1}>
         {sprint.tickets.map((ticket, idx) => {
           const focused = focusList[cursorIdx]?.kind === 'ticket' && focusList[cursorIdx]?.ticket.id === ticket.id;
-          const expanded = expandedFocusItem?.kind === 'ticket' && expandedFocusItem.ticket.id === ticket.id;
+          const expanded = openIds.has(String(ticket.id));
           const taskCount = tasks.filter((t) => t.ticketId === ticket.id).length;
           return (
             <TicketCard
@@ -823,7 +831,7 @@ interface TasksSectionProps {
   readonly focusList: readonly FocusItem[];
   readonly cursorIdx: number;
   readonly project: Project | undefined;
-  readonly expandedFocusItem: FocusItem | undefined;
+  readonly openIds: ReadonlySet<string>;
 }
 
 const TasksSection = ({
@@ -832,7 +840,7 @@ const TasksSection = ({
   focusList,
   cursorIdx,
   project,
-  expandedFocusItem,
+  openIds,
 }: TasksSectionProps): React.JSX.Element => (
   <Box marginTop={spacing.section} flexDirection="column">
     <Text bold>{glyphs.badge} Tasks</Text>
@@ -845,7 +853,7 @@ const TasksSection = ({
         {tasks.map((task, idx) => {
           const focusItem = focusList[cursorIdx];
           const focused = focusItem?.kind === 'task' && focusItem.task.id === task.id;
-          const expanded = expandedFocusItem?.kind === 'task' && expandedFocusItem.task.id === task.id;
+          const expanded = openIds.has(String(task.id));
           const ticket = sprint.tickets.find((t) => t.id === task.ticketId);
           const repoName = repositoryName(project, task.repositoryId);
           return (

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -796,7 +796,6 @@ const TicketCard = ({
 }): React.JSX.Element => (
   <ListCard
     focused={focused}
-    expanded={expanded}
     rightSlot={<StatusChip label={ticket.status} kind={ticketStatusKind(ticket.status)} />}
     indexLabel={`#${String(index + 1)}`}
     title={ticket.title}
@@ -913,7 +912,6 @@ const TaskCard = ({
   return (
     <ListCard
       focused={focused}
-      expanded={expanded}
       rightSlot={<StatusChip label={task.status} kind={taskStatusKind(task.status)} />}
       indexLabel={`#${String(index)}`}
       title={task.name}

--- a/src/domain/value/settings-models/effort.ts
+++ b/src/domain/value/settings-models/effort.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-provider effort vocabularies — the editable values each provider's CLI accepts on its
+ * effort / reasoning-depth flag. Shared between the Settings view and the per-launch customize
+ * picker so the two surfaces always offer the same option list without diverging copies.
+ *
+ * Domain-owned: the schema in `domain/entity/settings.ts` validates persisted rows against
+ * the same enums (Claude / Copilot / Codex variants); keeping the levels here lets every UI
+ * surface read from the same array rather than re-declaring the literal list.
+ *
+ * @public
+ */
+
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+
+export const PROVIDER_EFFORT_LEVELS: Readonly<Record<AiProvider, readonly string[]>> = {
+  'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
+  'github-copilot': ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+  'openai-codex': ['minimal', 'low', 'medium', 'high'],
+};

--- a/tests/integration/application/ui/tui/components/baseline-health-harmony.test.tsx
+++ b/tests/integration/application/ui/tui/components/baseline-health-harmony.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Harmony tests — render BaselineHealthChip and BaselineHealthCard against the SAME inputs and
+ * assert they never disagree. The bug these tests guard against: the chip used to flag "any
+ * historical red verify" while the card already showed only the latest run per phase, so a
+ * red → green transition left the chip stuck on red and the card green. The shared predicate
+ * eliminates that drift.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { BaselineHealthCard } from '@src/application/ui/tui/components/baseline-health-card.tsx';
+import { BaselineHealthChip } from '@src/application/ui/tui/components/baseline-health-chip.tsx';
+import type { SprintExecution, SetupRun } from '@src/domain/entity/sprint-execution.ts';
+import type { Attempt, VerifyRun, Attribution } from '@src/domain/entity/attempt.ts';
+import type { Task, InProgressTask } from '@src/domain/entity/task.ts';
+import {
+  FIXED_NOW,
+  FIXED_REPOSITORY_ID,
+  isoTimestamp,
+  makeInProgressTaskWithRunningAttempt,
+} from '@tests/fixtures/domain.ts';
+
+const sprintId = 'sprint-1' as never;
+
+const setupRow = (outcome: SetupRun['outcome'] = 'success'): SetupRun => ({
+  repositoryId: FIXED_REPOSITORY_ID,
+  ranAt: FIXED_NOW,
+  command: 'pnpm install',
+  exitCode: outcome === 'success' ? 0 : -1,
+  durationMs: 0,
+  outcome,
+});
+
+const executionWith = (setupRanAt: readonly SetupRun[]): SprintExecution => ({
+  id: sprintId,
+  sprintId,
+  branch: null,
+  pullRequestUrl: null,
+  setupRanAt,
+});
+
+const verifyRun = (phase: 'pre' | 'post', outcome: VerifyRun['outcome'], minutesAgo: number): VerifyRun => ({
+  phase,
+  ranAt: isoTimestamp(new Date(new Date(FIXED_NOW).getTime() - minutesAgo * 60_000).toISOString()),
+  command: 'pnpm test',
+  exitCode: outcome === 'success' ? 0 : 1,
+  durationMs: 0,
+  outcome,
+});
+
+/**
+ * Build a multi-attempt task: attempt N=1 carries `attempt1VerifyRuns` and settles as `failed`;
+ * attempt N=2 is the running attempt carrying `attempt2VerifyRuns`. Lets a single task show
+ * "earlier attempt was red, latest attempt is green" — the exact bug fixture.
+ */
+const taskWithTwoAttempts = (
+  attempt1VerifyRuns: readonly VerifyRun[],
+  attempt2VerifyRuns: readonly VerifyRun[],
+  options: { readonly attribution?: Attribution; readonly baselineBroken?: boolean } = {}
+): Task => {
+  const base = makeInProgressTaskWithRunningAttempt() as InProgressTask;
+  const runningAttempt = base.attempts.at(-1) as Attempt;
+  const firstAttempt: Attempt = {
+    ...runningAttempt,
+    n: 1,
+    status: 'failed',
+    finishedAt: runningAttempt.startedAt,
+    verifyRuns: attempt1VerifyRuns,
+  };
+  const secondAttempt: Attempt = {
+    ...runningAttempt,
+    n: 2,
+    verifyRuns: attempt2VerifyRuns,
+    ...(options.attribution !== undefined ? { attribution: options.attribution } : {}),
+    ...(options.baselineBroken !== undefined ? { baselineBroken: options.baselineBroken } : {}),
+  };
+  return {
+    ...base,
+    attempts: [firstAttempt, secondAttempt],
+  };
+};
+
+const taskWithAttempt = (
+  verifyRuns: readonly VerifyRun[],
+  options: { readonly attribution?: Attribution; readonly baselineBroken?: boolean } = {}
+): Task => {
+  const base = makeInProgressTaskWithRunningAttempt() as InProgressTask;
+  const lastAttempt = base.attempts.at(-1) as Attempt;
+  const next: Attempt = {
+    ...lastAttempt,
+    verifyRuns,
+    ...(options.attribution !== undefined ? { attribution: options.attribution } : {}),
+    ...(options.baselineBroken !== undefined ? { baselineBroken: options.baselineBroken } : {}),
+  };
+  return {
+    ...base,
+    attempts: [...base.attempts.slice(0, -1), next],
+  };
+};
+
+const now = new Date(FIXED_NOW).getTime();
+
+const renderBoth = (
+  task: Task,
+  execution: SprintExecution = executionWith([setupRow()])
+): { chip: string; card: string } => {
+  const chip = render(<BaselineHealthChip execution={execution} tasks={[task]} now={now} />).lastFrame() ?? '';
+  const card = render(<BaselineHealthCard execution={execution} tasks={[task]} now={now} />).lastFrame() ?? '';
+  return { chip, card };
+};
+
+describe('BaselineHealthChip / BaselineHealthCard harmony', () => {
+  it('red → green transition: attempt-1 pre-verify failed, attempt-2 pre-verify success ⇒ both green', () => {
+    // The repro fixture from the bug report. Attempt 1 hit a red pre-verify (and was aborted);
+    // attempt 2's pre-verify came back green. The card had always shown only the latest run
+    // per phase, so it read green. The chip's old `anyRedVerify` walked every attempt's
+    // verifyRuns and stayed stuck on red. After the shared latest-wins predicate they agree.
+    const task = taskWithTwoAttempts(
+      [verifyRun('pre', 'failed', 30)],
+      [verifyRun('pre', 'success', 2), verifyRun('post', 'success', 1)],
+      { attribution: 'clean' }
+    );
+    const { chip, card } = renderBoth(task);
+    expect(chip).toContain('green');
+    // Card title reflects an ok state (clean compact variant) when every row is ok.
+    expect(card).toContain('clean');
+  });
+
+  it('latest post-verify red while latest pre-verify green ⇒ both red', () => {
+    const task = taskWithAttempt([verifyRun('pre', 'success', 2), verifyRun('post', 'failed', 1)]);
+    const { chip, card } = renderBoth(task);
+    expect(chip).toContain('red');
+    // The card surfaces the failing post-verify row.
+    expect(card).toContain('Post verify');
+    expect(card).toContain('failed');
+  });
+
+  it('alternating red/green pre-verify across attempts ⇒ both reflect the latest only', () => {
+    // Attempt 1: pre red. Attempt 2: pre green. With latest-wins the historical red is
+    // ignored on both surfaces. Without latest-wins the chip would still show red.
+    const task = taskWithTwoAttempts([verifyRun('pre', 'failed', 30)], [verifyRun('pre', 'success', 2)], {
+      attribution: 'clean',
+    });
+    const { chip, card } = renderBoth(task);
+    expect(chip).toContain('green');
+    // Card should not declare the run failed in its title.
+    expect(card).not.toContain('failed');
+  });
+
+  it('empty verifyRuns on latest attempt ⇒ both surfaces show the same fallback', () => {
+    // No verify rows on either attempt. With a green setup row both surfaces should land in
+    // the "nothing red, has run" state — chip reads green, card title omits any red suffix.
+    const task = taskWithTwoAttempts([], []);
+    const { chip, card } = renderBoth(task);
+    expect(chip).toContain('green');
+    expect(card).not.toContain('failed');
+  });
+
+  it('agreement preserved on hard-red regression', () => {
+    const task = taskWithAttempt([verifyRun('pre', 'success', 2), verifyRun('post', 'failed', 1)], {
+      attribution: 'regressed',
+    });
+    const { chip, card } = renderBoth(task);
+    expect(chip).toContain('red');
+    expect(chip).toContain('regression');
+    // Card shows the failed post-verify row.
+    expect(card).toContain('failed');
+  });
+});

--- a/tests/integration/application/ui/tui/views/add-ticket-view.review-scroll.test.tsx
+++ b/tests/integration/application/ui/tui/views/add-ticket-view.review-scroll.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Review-step description scroll tests for the add-ticket wizard. The Review step renders a
+ * three-row FieldList (Title / Description / Link) plus a ConfirmPrompt; long descriptions
+ * used to push the Link row and the confirm pills off the bottom of the terminal. The
+ * description body now lives in a bounded viewport that scrolls under ↑/↓ + PgUp/PgDn so the
+ * Link row and the pills stay in view.
+ *
+ * Covered:
+ *   - long description: ↓ shifts the visible window by one line; position indicator updates
+ *   - short description: no indicator, no scroll widget — static rendering matches today's
+ *     output for that content (a single `<Text>` value alongside the Description label)
+ *   - PgDn then PgUp: window shifts by a page, then returns
+ *   - resize: changing stdout rows triggers a clamp so the offset stays within the new bounds
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { AddTicketView } from '@src/application/ui/tui/views/add-ticket-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import type { ExternalIssue, IssueFetcher } from '@src/business/scm/issue-fetcher.ts';
+import { makeDraftSprint } from '@tests/fixtures/domain.ts';
+import { DOWN, ENTER, UP } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
+import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+
+const tick = (ms = 30): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const buildDescription = (lineCount: number): string => {
+  const lines: string[] = [];
+  for (let i = 0; i < lineCount; i++) {
+    if (i === 0) lines.push('FIRST-LINE-SENTINEL');
+    else if (i === lineCount - 1) lines.push('LAST-LINE-SENTINEL');
+    else lines.push(`filler-line-${String(i).padStart(2, '0')}`);
+  }
+  return lines.join('\n');
+};
+
+const makeDepsWithFetchedDescription = (description: string): { deps: AppDeps; sprint: Sprint } => {
+  const sprint = makeDraftSprint();
+  const save = vi.fn(async (s: Sprint) => {
+    void s;
+    return Result.ok(undefined);
+  });
+  const sprintRepo: SprintRepository = {
+    async findById() {
+      return Result.ok(sprint);
+    },
+    save,
+  } as unknown as SprintRepository;
+  const fetched: ExternalIssue = {
+    url: 'https://github.com/acme/repo/issues/42',
+    title: 'Long ticket',
+    body: description,
+    state: 'open',
+    comments: [],
+  };
+  const issueFetcher: IssueFetcher = async () => Result.ok(fetched);
+  const deps: AppDeps = { sprintRepo, issueFetcher } as unknown as AppDeps;
+  return { deps, sprint };
+};
+
+/**
+ * Walk the wizard via the URL-prefill path (link → fetch → title prefilled → description
+ * prefilled → confirm). Returns once the Review step is on screen. The harness's auto-cleanup
+ * unmounts on test end so callers do not need to dispose explicitly.
+ */
+const walkToReview = async (
+  deps: AppDeps,
+  sprintId: Sprint['id']
+): Promise<ReturnType<typeof renderView>['result']> => {
+  const { result } = renderView(<AddTicketView />, {
+    deps,
+    initial: { id: 'add-ticket', props: { sprintId } },
+  });
+
+  await waitFor(() => expect(result.lastFrame()).toContain('Issue link'));
+  result.stdin.write('https://github.com/acme/repo/issues/42');
+  await waitFor(() => expect(result.lastFrame()).toContain('issues/42'));
+  result.stdin.write(ENTER);
+
+  // Title step: prompt header is "▸ Title".
+  await waitFor(() => expect(result.lastFrame()).toMatch(/▸\s*Title/));
+  result.stdin.write(ENTER);
+
+  // Description step: prompt header is "▸ Description". Distinct from the FieldList
+  // "Description:" label that appears later on the Review card (no cursor glyph).
+  await waitFor(() => expect(result.lastFrame()).toMatch(/▸\s*Description/));
+  result.stdin.write(ENTER);
+
+  // Review card + ConfirmPrompt.
+  await waitFor(() => expect(result.lastFrame()).toContain('Add this ticket?'));
+  return result;
+};
+
+describe('AddTicketView — Review step scrollable description', () => {
+  it('long description: ↓ shifts the visible window by one line and the position indicator updates', async () => {
+    const description = buildDescription(20);
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    // On the default 24-row test terminal the 20-line description overflows the viewport.
+    // The FIRST-LINE sentinel is visible at the head of the window; LAST-LINE is not yet on
+    // screen; a `lines 1–N of 20` indicator hangs below the slice.
+    const initial = result.lastFrame() ?? '';
+    expect(initial).toContain('FIRST-LINE-SENTINEL');
+    expect(initial).not.toContain('LAST-LINE-SENTINEL');
+    expect(initial).toMatch(/lines 1[–-]\d+ of 20/);
+
+    // ↓ shifts the window by one line — FIRST-LINE leaves; the indicator advances to start at 2.
+    result.stdin.write(DOWN);
+    await waitFor(() => expect(result.lastFrame()).toMatch(/lines 2[–-]\d+ of 20/));
+    const shifted = result.lastFrame() ?? '';
+    expect(shifted).not.toContain('FIRST-LINE-SENTINEL');
+    // Link row and the confirm pills remain visible regardless of scroll position.
+    expect(shifted).toContain('https://github.com/acme/repo/issues/42');
+    expect(shifted).toContain('Add this ticket?');
+  });
+
+  it('short description: no position indicator, no scroll widget — static rendering matches', async () => {
+    const description = 'A short two-line description.\nNothing more to scroll.';
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    const frame = result.lastFrame() ?? '';
+    // Full body fits in one viewport — no `lines N–M of T` indicator anywhere on the frame.
+    expect(frame).not.toMatch(/lines \d+[–-]\d+ of \d+/);
+    // The description renders inline next to the Description label, identical to the pre-fix
+    // single-`<Text>` value. Both lines visible end-to-end.
+    expect(frame).toContain('A short two-line description.');
+    expect(frame).toContain('Nothing more to scroll.');
+    // Footer ↑/↓ scroll hint is suppressed on this view because arrows are inert here. The
+    // footer hint row is the last line that ends with `quit`.
+    const footerLine =
+      frame
+        .split('\n')
+        .reverse()
+        .find((l) => l.includes('quit')) ?? '';
+    expect(footerLine).not.toContain('↑/↓');
+  });
+
+  it('PgDn then PgUp: window shifts by a page then returns', async () => {
+    const description = buildDescription(30);
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    // Start at the top.
+    await waitFor(() => expect(result.lastFrame()).toMatch(/lines 1[–-]\d+ of 30/));
+
+    // PgDn → window shifts by one viewport-height. The exact viewport size depends on the
+    // chrome heuristic, so we only assert the start index strictly increases past 1.
+    result.stdin.write('\x1b[6~'); // VT220 PgDn — ink maps this to key.pageDown
+    await waitFor(() => {
+      const m = /lines (\d+)[–-]\d+ of 30/.exec(result.lastFrame() ?? '');
+      expect(m).not.toBeNull();
+      const start = Number(m?.[1] ?? '1');
+      expect(start).toBeGreaterThan(1);
+    });
+
+    // PgUp returns toward the top.
+    result.stdin.write('\x1b[5~'); // VT220 PgUp — ink maps this to key.pageUp
+    await waitFor(() => expect(result.lastFrame()).toMatch(/lines 1[–-]\d+ of 30/));
+
+    // PgUp at the top clamps — one more press is a no-op.
+    result.stdin.write('\x1b[5~');
+    await tick(30);
+    expect(result.lastFrame()).toMatch(/lines 1[–-]\d+ of 30/);
+  });
+
+  it('↑ at the top clamps and Link / confirm rows stay visible', async () => {
+    const description = buildDescription(20);
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    // ↑ at offset 0 — clamp keeps us at line 1.
+    result.stdin.write(UP);
+    await tick(30);
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toMatch(/lines 1[–-]\d+ of 20/);
+    // Link row + confirm pills still on screen.
+    expect(frame).toContain('https://github.com/acme/repo/issues/42');
+    expect(frame).toContain('Add this ticket?');
+  });
+
+  it('resize: shrinking the terminal clamps the offset within the new bounds', async () => {
+    const description = buildDescription(30);
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    // ink-testing-library's stdout does not expose `rows` natively; the production terminal-
+    // size hook falls back to 24 when rows is undefined. We monkey-patch `rows` onto the
+    // emitter and dispatch 'resize' to drive the production listener. The viewport on the
+    // pre-resize 24-row default is ~10 rows (CHROME=14, MIN=4); after rows=40 the viewport
+    // grows to ~26 — equivalent to a wider terminal that needs less scroll headroom.
+    const stdout = result.stdout as unknown as { rows?: number; emit(event: string): boolean };
+
+    // Scroll near the bottom of the 30-line body on the default 24-row viewport.
+    for (let i = 0; i < 6; i++) {
+      result.stdin.write('\x1b[6~'); // PgDn
+      await tick(20);
+    }
+    await waitFor(() => expect(result.lastFrame()).toContain('LAST-LINE-SENTINEL'));
+    const beforeMatch = /lines (\d+)[–-]\d+ of 30/.exec(result.lastFrame() ?? '');
+    expect(beforeMatch).not.toBeNull();
+    const beforeStart = Number(beforeMatch?.[1] ?? '0');
+    expect(beforeStart).toBeGreaterThan(1);
+
+    // Grow the terminal: rows 24 → 40 ⇒ viewport ≈ 10 → 26 ⇒ maxOffset shrinks. Any offset
+    // that exceeded the new maxOffset must clamp down. The clamp effect runs on the
+    // maxOffset dependency; emitting 'resize' triggers the useTerminalSize listener which
+    // updates the rows state, which re-derives the viewport, which trips the effect.
+    stdout.rows = 40;
+    stdout.emit('resize');
+    await tick(60);
+
+    const after = result.lastFrame() ?? '';
+    const afterMatch = /lines (\d+)[–-](\d+) of 30/.exec(after);
+    expect(afterMatch).not.toBeNull();
+    const afterStart = Number(afterMatch?.[1] ?? '0');
+    const afterEnd = Number(afterMatch?.[2] ?? '0');
+    // Offset stays valid: start ≥ 1, end ≤ 30. After clamp the offset is ≤ the new maxOffset
+    // (= 30 - viewport), so the bottom of the body remains pinned to the bottom of the
+    // viewport — LAST-LINE-SENTINEL still visible.
+    expect(afterStart).toBeGreaterThanOrEqual(1);
+    expect(afterEnd).toBeLessThanOrEqual(30);
+    expect(after).toContain('LAST-LINE-SENTINEL');
+  });
+});

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -1,0 +1,557 @@
+/**
+ * Pre-launch customize picker — unit-level tests for `runCustomizePicker`.
+ *
+ * The picker is driven by a scripted {@link InteractivePrompt} fake instead of an Ink mount
+ * so each assertion sees the exact `LaunchExtras` payload the launcher would receive without
+ * the indirection of stdin keystrokes. The behaviour under test is:
+ *  - Start (use defaults) → kind 'defaults'; launcher launches with no override.
+ *  - Customize for this run… → walks provider / model / effort; the resulting `override` only
+ *    carries fields the user changed (per-field fallback to settings).
+ *  - Cancel (at any step) → kind 'cancel'; launcher does not launch.
+ *  - Implement walks generator → evaluator; canceling mid-evaluator discards the generator
+ *    override (no partial state leaks into LaunchExtras).
+ *
+ * A separate integration assertion uses the real on-disk `createJsonSettingsRepository` to
+ * verify that no picker path mutates `settings.json` — the file's sha256 is byte-identical
+ * before and after every picker session.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { Choice, InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
+import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
+import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
+import {
+  modelCatalogFor,
+  runCustomizePicker,
+  type CustomizePickerResult,
+} from '@src/application/ui/tui/views/flows-customize-picker.ts';
+import { applyOverrideToSettings } from '@src/application/ui/shared/launcher.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
+
+/**
+ * Script-driven {@link InteractivePrompt}. Each `askChoice` consumes the next script entry; a
+ * `pick` entry resolves to the named option's value, a `cancel` entry resolves to an
+ * `AbortError` via the Result error channel (mirroring the production InkPromptAdapter on
+ * Esc). Order is FIFO. The captured list of prompts each test made is returned alongside the
+ * picker result for stronger assertions on the prompt sequence the picker actually showed.
+ */
+interface ScriptEntryPick {
+  readonly action: 'pick';
+  /** Either an option label or a value — first label match wins; falls back to value match. */
+  readonly choice: string;
+}
+interface ScriptEntryCancel {
+  readonly action: 'cancel';
+}
+type ScriptEntry = ScriptEntryPick | ScriptEntryCancel;
+
+interface CapturedPrompt {
+  readonly message: string;
+  readonly options: readonly string[];
+}
+
+const buildScriptedPrompt = (
+  script: readonly ScriptEntry[]
+): { readonly interactive: InteractivePrompt; readonly captured: CapturedPrompt[] } => {
+  const captured: CapturedPrompt[] = [];
+  let cursor = 0;
+  const interactive: InteractivePrompt = {
+    async askText() {
+      throw new Error('askText not supported by scripted prompt');
+    },
+    async askTextArea() {
+      throw new Error('askTextArea not supported by scripted prompt');
+    },
+    async askConfirm() {
+      throw new Error('askConfirm not supported by scripted prompt');
+    },
+    async askMultiChoice() {
+      throw new Error('askMultiChoice not supported by scripted prompt');
+    },
+    async askChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
+      captured.push({ message, options: options.map((o) => o.label) });
+      const entry = script[cursor];
+      cursor += 1;
+      if (entry === undefined) {
+        throw new Error(`scripted prompt exhausted at message: ${message}`);
+      }
+      if (entry.action === 'cancel') {
+        return Result.error(new AbortError({ elementName: 'test', reason: 'scripted cancel' })) as unknown as Result<
+          T,
+          DomainError
+        >;
+      }
+      const found =
+        options.find((o) => o.label === entry.choice) ?? options.find((o) => String(o.value) === entry.choice);
+      if (found === undefined) {
+        throw new Error(
+          `scripted prompt: option '${entry.choice}' not found in ${options.map((o) => o.label).join(' / ')}`
+        );
+      }
+      return Result.ok(found.value) as unknown as Result<T, DomainError>;
+    },
+  };
+  return { interactive, captured };
+};
+
+const driveSettings = (overrides: Partial<Settings['ai']> = {}): Settings => ({
+  ...DEFAULT_SETTINGS,
+  ai: { ...DEFAULT_SETTINGS.ai, ...overrides },
+});
+
+const SIMPLE_FLOWS = ['refine', 'plan', 'readiness', 'ideate'] as const;
+
+describe('runCustomizePicker — single-row flows (refine / plan / readiness / ideate)', () => {
+  for (const flowId of SIMPLE_FLOWS) {
+    describe(`flow=${flowId}`, () => {
+      it('keep-all-defaults → kind defaults; LaunchExtras carries no override', async () => {
+        // Start path takes precedence; the picker never walks provider/model/effort prompts.
+        const { interactive, captured } = buildScriptedPrompt([{ action: 'pick', choice: 'Start (use defaults)' }]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        expect(result.kind).toBe('defaults');
+        // Only the entry prompt rendered; no row-walk happened.
+        expect(captured).toHaveLength(1);
+        expect(captured[0]?.options).toContain('Start (use defaults)');
+        expect(captured[0]?.options).toContain('Customize for this run…');
+      });
+
+      it('keep-all on every customize step → kind defaults (empty override collapses to Start)', async () => {
+        // Customize walks provider → model → effort; Keep-default on every step means the
+        // user changed nothing. Collapse to `defaults` so launchers never see an empty
+        // `override: {}` payload that would otherwise look identical to "no override".
+        const { interactive } = buildScriptedPrompt([
+          { action: 'pick', choice: 'Customize for this run…' },
+          // provider step: Keep default — exact label matches the row's default provider id
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].model})` },
+          // The default row carries no per-flow effort and DEFAULT_SETTINGS has no global
+          // effort either, so resolveEffortForRow returns undefined and Keep default's label
+          // renders 'unset'.
+          { action: 'pick', choice: 'Keep default (auto)' },
+        ]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        expect(result.kind).toBe('defaults');
+      });
+
+      it('change provider only → override = { provider }; launcher uses override.provider + settings model + settings effort', async () => {
+        // Switching provider auto-fills the new provider's first catalog model so the
+        // launcher always sees a coherent provider/model pair. The test asserts only
+        // `override.provider` survives because the user explicitly picked the catalog's
+        // first entry — equivalent to the picker's auto-default.
+        const newProvider: AiProvider = 'openai-codex';
+        const newFirstModel = modelCatalogFor(newProvider)[0]!;
+        const { interactive } = buildScriptedPrompt([
+          { action: 'pick', choice: 'Customize for this run…' },
+          { action: 'pick', choice: newProvider },
+          { action: 'pick', choice: newFirstModel },
+          { action: 'pick', choice: 'Keep default' },
+        ]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        if (result.kind !== 'single') throw new Error(`expected kind 'single', got ${result.kind}`);
+        // Provider switch forces a fresh model from the new provider's catalog so the
+        // implementPair / single-flow row stays valid; effort kept at default → not present.
+        expect(result.override.provider).toBe(newProvider);
+        expect(result.override.model).toBe(newFirstModel);
+        expect(result.override.effort).toBeUndefined();
+      });
+
+      it('change model only → override = { model }; provider + effort fall back to settings', async () => {
+        // Provider stays the same so the model step still offers Keep default; picking a
+        // catalog entry that differs from the default leaves only `model` on the override.
+        const otherModel = CLAUDE_MODELS.find((m) => m !== DEFAULT_SETTINGS.ai[flowId].model)!;
+        const { interactive } = buildScriptedPrompt([
+          { action: 'pick', choice: 'Customize for this run…' },
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
+          { action: 'pick', choice: otherModel },
+          { action: 'pick', choice: 'Keep default (auto)' },
+        ]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        if (result.kind !== 'single') throw new Error(`expected kind 'single', got ${result.kind}`);
+        expect(result.override.provider).toBeUndefined();
+        expect(result.override.model).toBe(otherModel);
+        expect(result.override.effort).toBeUndefined();
+      });
+
+      it('change effort only → override = { effort }; provider + model fall back to settings', async () => {
+        const { interactive } = buildScriptedPrompt([
+          { action: 'pick', choice: 'Customize for this run…' },
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].model})` },
+          // Claude's vocabulary; settings default has no per-flow effort so any pick differs.
+          { action: 'pick', choice: 'high' },
+        ]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        if (result.kind !== 'single') throw new Error(`expected kind 'single', got ${result.kind}`);
+        expect(result.override.provider).toBeUndefined();
+        expect(result.override.model).toBeUndefined();
+        expect(result.override.effort).toBe('high');
+      });
+
+      it('cancel at the entry prompt → kind cancel; no further prompts were shown', async () => {
+        const { interactive, captured } = buildScriptedPrompt([{ action: 'cancel' }]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        expect(result.kind).toBe('cancel');
+        expect(captured).toHaveLength(1);
+      });
+
+      it('cancel at the model step → kind cancel; no override is returned', async () => {
+        // Walked into Customize and through provider; Esc on the model step throws away the
+        // session — the launcher must not see a half-completed override carrying just the
+        // provider half.
+        const { interactive } = buildScriptedPrompt([
+          { action: 'pick', choice: 'Customize for this run…' },
+          { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
+          { action: 'cancel' },
+        ]);
+        const result = await runCustomizePicker({
+          interactive,
+          flowId,
+          flowTitle: flowId,
+          settings: DEFAULT_SETTINGS,
+        });
+        expect(result.kind).toBe('cancel');
+      });
+    });
+  }
+});
+
+describe('runCustomizePicker — implement (generator → evaluator)', () => {
+  it('keep-all-defaults → kind defaults; no role overrides emitted', async () => {
+    const { interactive } = buildScriptedPrompt([{ action: 'pick', choice: 'Start (use defaults)' }]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.kind).toBe('defaults');
+  });
+
+  it('change generator only → implementRoleOverrides.generator set; evaluator absent', async () => {
+    // Walk Customize through generator's three steps (change model), then evaluator's three
+    // steps (Keep default on all). The launcher reads role overrides per-field, so an
+    // unchanged evaluator role is simply absent.
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const newGenModel = CLAUDE_MODELS.find((m) => m !== gen.model)!;
+    const { interactive } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      // generator
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: newGenModel },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      // evaluator (all keep-default)
+      { action: 'pick', choice: `Keep default (${eva.provider})` },
+      { action: 'pick', choice: `Keep default (${eva.model})` },
+      { action: 'pick', choice: 'Keep default (auto)' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+    });
+    if (result.kind !== 'implement') throw new Error(`expected kind 'implement', got ${result.kind}`);
+    expect(result.implementRoleOverrides.generator).toEqual({ model: newGenModel });
+    expect(result.implementRoleOverrides.evaluator).toBeUndefined();
+  });
+
+  it('change evaluator only → implementRoleOverrides.evaluator set; generator absent', async () => {
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const newEvaModel = CODEX_MODELS.find((m) => m !== eva.model)!;
+    const { interactive } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      // generator (all keep-default)
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: `Keep default (${gen.model})` },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      // evaluator (change model)
+      { action: 'pick', choice: `Keep default (${eva.provider})` },
+      { action: 'pick', choice: newEvaModel },
+      { action: 'pick', choice: 'Keep default (auto)' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+    });
+    if (result.kind !== 'implement') throw new Error(`expected kind 'implement', got ${result.kind}`);
+    expect(result.implementRoleOverrides.generator).toBeUndefined();
+    expect(result.implementRoleOverrides.evaluator).toEqual({ model: newEvaModel });
+  });
+
+  it('change both roles → both implementRoleOverrides set', async () => {
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const newGenModel = CLAUDE_MODELS.find((m) => m !== gen.model)!;
+    const newEvaModel = CODEX_MODELS.find((m) => m !== eva.model)!;
+    const { interactive } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      // generator
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: newGenModel },
+      { action: 'pick', choice: 'high' },
+      // evaluator
+      { action: 'pick', choice: `Keep default (${eva.provider})` },
+      { action: 'pick', choice: newEvaModel },
+      { action: 'pick', choice: 'medium' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+    });
+    if (result.kind !== 'implement') throw new Error(`expected kind 'implement', got ${result.kind}`);
+    expect(result.implementRoleOverrides.generator).toEqual({ model: newGenModel, effort: 'high' });
+    expect(result.implementRoleOverrides.evaluator).toEqual({ model: newEvaModel, effort: 'medium' });
+  });
+
+  it('cancel mid-evaluator → kind cancel; generator override is discarded (no partial state)', async () => {
+    // The user changed the generator's model successfully but cancels on the evaluator's
+    // first step. The picker must NOT leak the generator change into LaunchExtras — the
+    // whole session is voided so settings.json stays the single source of truth.
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const newGenModel = CLAUDE_MODELS.find((m) => m !== gen.model)!;
+    const { interactive } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      // generator (change model)
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: newGenModel },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      // evaluator — provider step starts; Esc here aborts the entire session.
+      { action: 'cancel' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.kind).toBe('cancel');
+    // Sanity: no `evaluator` would be present on a cancel result.
+    expect((result as { implementRoleOverrides?: unknown }).implementRoleOverrides).toBeUndefined();
+    // Header is rendered with both defaults shown — sanity that the prompt reached evaluator.
+    expect(eva.provider).toBeDefined();
+  });
+});
+
+describe('runCustomizePicker — catalog source parity with settings', () => {
+  // The picker MUST import the same catalogs the Settings view does. Asserting against
+  // CLAUDE_MODELS directly (and not a hand-rolled copy) catches divergence at the import
+  // boundary: if the picker ever forks its own list, this test fails on the next model bump.
+  it('renders every CLAUDE_MODELS entry on the model step when the provider is claude-code', async () => {
+    let modelStepOptions: readonly string[] | undefined;
+    const interactive: InteractivePrompt = {
+      async askText() {
+        throw new Error('not used');
+      },
+      async askTextArea() {
+        throw new Error('not used');
+      },
+      async askConfirm() {
+        throw new Error('not used');
+      },
+      async askMultiChoice() {
+        throw new Error('not used');
+      },
+      async askChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
+        // Step 1: entry prompt → pick Customize.
+        if (message.includes('What would you like to do?')) {
+          const c = options.find((o) => o.label === 'Customize for this run…');
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        // Step 2: provider → Keep default.
+        if (message.includes('Provider:')) {
+          const c = options.find((o) => o.label.startsWith('Keep default'));
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        // Step 3: model → capture options for the snapshot assertion + cancel.
+        if (message.includes('Model:')) {
+          modelStepOptions = options.map((o) => o.label);
+          return Result.error(new AbortError({ elementName: 'test', reason: 'snapshot' })) as unknown as Result<
+            T,
+            DomainError
+          >;
+        }
+        throw new Error(`unexpected prompt: ${message}`);
+      },
+    };
+    await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+    });
+    // The first label is `Keep default (<saved model>)`; the rest must match the
+    // CLAUDE_MODELS catalog in order so a model bump or rename is caught immediately.
+    expect(modelStepOptions).toBeDefined();
+    const catalogLabels = modelStepOptions!.slice(1);
+    expect(catalogLabels).toEqual([...CLAUDE_MODELS]);
+  });
+});
+
+describe('runCustomizePicker — settings.json is byte-identical after the picker', () => {
+  // Hash the on-disk file before and after a picker session; the picker must never call
+  // settingsRepo.save() under any path (Start / Customize-with-changes / Cancel). Uses the
+  // production JsonSettingsRepository for a true round-trip, not a stub.
+  const hashFile = (path: string): string => createHash('sha256').update(readFileSync(path)).digest('hex');
+
+  const runScenario = async (script: readonly ScriptEntry[]): Promise<CustomizePickerResult> => {
+    const dir = mkdtempSync(join(tmpdir(), 'flows-customize-disk-'));
+    const file = join(dir, 'settings.json');
+    // Write a settings file the JsonSettingsRepository can load round-trip-clean.
+    writeFileSync(file, JSON.stringify(DEFAULT_SETTINGS, null, 2));
+    const configRoot = AbsolutePath.parse(dir);
+    if (!configRoot.ok) throw new Error(`tmp path invalid: ${dir}`);
+    const repo = createJsonSettingsRepository({ configRoot: configRoot.value });
+    const loaded = await repo.load();
+    if (!loaded.ok) throw new Error(`load failed: ${loaded.error.message}`);
+    const before = hashFile(file);
+    const { interactive } = buildScriptedPrompt(script);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: loaded.value,
+    });
+    const after = hashFile(file);
+    expect(after).toBe(before);
+    return result;
+  };
+
+  it('Start path leaves the file byte-identical', async () => {
+    const result = await runScenario([{ action: 'pick', choice: 'Start (use defaults)' }]);
+    expect(result.kind).toBe('defaults');
+  });
+
+  it('Customize-with-changes leaves the file byte-identical', async () => {
+    const newModel = CLAUDE_MODELS.find((m) => m !== DEFAULT_SETTINGS.ai.refine.model)!;
+    const result = await runScenario([
+      { action: 'pick', choice: 'Customize for this run…' },
+      { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai.refine.provider})` },
+      { action: 'pick', choice: newModel },
+      { action: 'pick', choice: 'high' },
+    ]);
+    expect(result.kind).toBe('single');
+  });
+
+  it('Cancel at the entry prompt leaves the file byte-identical', async () => {
+    const result = await runScenario([{ action: 'cancel' }]);
+    expect(result.kind).toBe('cancel');
+  });
+});
+
+describe('applyOverrideToSettings — launcher per-field fallback', () => {
+  // The launcher applies the picker's override to the settings row BEFORE constructing
+  // adapters; the per-flow launchers then read from the resulting effective settings. These
+  // tests assert the merge semantics directly so the picker's "only changed fields" payload
+  // and the launcher's "fall back per field" rule meet end-to-end.
+  it('keeps every persisted field when override is undefined', () => {
+    const effective = applyOverrideToSettings(DEFAULT_SETTINGS, 'refine', undefined);
+    expect(effective).toBe(DEFAULT_SETTINGS);
+  });
+
+  it('refine: override.provider only — model + effort fall back to settings.ai.refine', () => {
+    const base = driveSettings({ refine: { provider: 'claude-code', model: 'claude-opus-4-7', effort: 'high' } });
+    const effective = applyOverrideToSettings(base, 'refine', { provider: 'openai-codex' });
+    expect(effective.ai.refine.provider).toBe('openai-codex');
+    expect(effective.ai.refine.model).toBe('claude-opus-4-7');
+    expect(effective.ai.refine.effort).toBe('high');
+  });
+
+  it('refine: override.model only — provider + effort fall back to settings.ai.refine', () => {
+    const base = driveSettings({ refine: { provider: 'claude-code', model: 'claude-opus-4-7', effort: 'medium' } });
+    const effective = applyOverrideToSettings(base, 'refine', { model: 'claude-sonnet-4-6' });
+    expect(effective.ai.refine.provider).toBe('claude-code');
+    expect(effective.ai.refine.model).toBe('claude-sonnet-4-6');
+    expect(effective.ai.refine.effort).toBe('medium');
+  });
+
+  it('refine: override.effort only — provider + model fall back to settings.ai.refine', () => {
+    const base = driveSettings({ refine: { provider: 'claude-code', model: 'claude-sonnet-4-6' } });
+    const effective = applyOverrideToSettings(base, 'refine', { effort: 'high' });
+    expect(effective.ai.refine.provider).toBe('claude-code');
+    expect(effective.ai.refine.model).toBe('claude-sonnet-4-6');
+    expect(effective.ai.refine.effort).toBe('high');
+  });
+
+  it('plan / readiness / ideate behave the same as refine', () => {
+    for (const flow of ['plan', 'readiness', 'ideate'] as const) {
+      const effective = applyOverrideToSettings(DEFAULT_SETTINGS, flow, { model: 'claude-haiku-4-5' });
+      expect(effective.ai[flow].model).toBe('claude-haiku-4-5');
+      expect(effective.ai[flow].provider).toBe(DEFAULT_SETTINGS.ai[flow].provider);
+    }
+  });
+
+  it('review / detect-scripts / detect-skills route override through their aliased row', () => {
+    // review aliases ai.implement.generator; detect-* aliases ai.readiness.
+    const reviewEffective = applyOverrideToSettings(DEFAULT_SETTINGS, 'review', { model: 'claude-haiku-4-5' });
+    expect(reviewEffective.ai.implement.generator.model).toBe('claude-haiku-4-5');
+    // Evaluator must not be perturbed — review only touches the generator-side single row.
+    expect(reviewEffective.ai.implement.evaluator).toEqual(DEFAULT_SETTINGS.ai.implement.evaluator);
+
+    for (const flow of ['detect-scripts', 'detect-skills'] as const) {
+      const effective = applyOverrideToSettings(DEFAULT_SETTINGS, flow, { model: 'claude-haiku-4-5' });
+      expect(effective.ai.readiness.model).toBe('claude-haiku-4-5');
+      expect(effective.ai.readiness.provider).toBe(DEFAULT_SETTINGS.ai.readiness.provider);
+    }
+  });
+
+  it('implement flow itself ignores extras.override (uses implementRoleOverrides exclusively)', () => {
+    // The customize picker never emits `override` for implement — it emits role overrides.
+    // If a caller accidentally passes `override`, the launcher must NOT touch ai.implement
+    // because the merge would be ambiguous (which role gets the override?). This test pins
+    // the safety hatch.
+    const effective = applyOverrideToSettings(DEFAULT_SETTINGS, 'implement', { provider: 'openai-codex' });
+    expect(effective).toBe(DEFAULT_SETTINGS);
+  });
+
+  it('non-AI flows pass through unchanged regardless of override', () => {
+    const effective = applyOverrideToSettings(DEFAULT_SETTINGS, 'create-sprint', { provider: 'openai-codex' });
+    expect(effective).toBe(DEFAULT_SETTINGS);
+  });
+});

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Smoke tests for SettingsView. Renders the editable fields after the settings load, and the
- * status bar surfaces ↑/↓ + ↵/e hints.
+ * Smoke tests for SettingsView. The view is split into sections; only the active section's
+ * fields render at a time, so the ↑/↓ cursor path is bounded by the section's row count.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -27,7 +27,7 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Settings } from '@src/domain/entity/settings.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, RIGHT, tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeSettingsRepo: SettingsRepository = {
@@ -68,42 +68,81 @@ const stubRepoWith = (settings: Settings): { readonly repo: SettingsRepository; 
   };
 };
 
+/**
+ * Section ordering must match `buildSections` in settings-view.tsx. Tests use this to step
+ * `→` the right number of times to land on a known section.
+ */
+const SECTIONS = [
+  'presets',
+  'global',
+  'refine',
+  'plan',
+  'implement',
+  'readiness',
+  'ideate',
+  'harness',
+  'other',
+  'storage',
+] as const;
+
+/** Step the section cursor from the initial `presets` to the named section. */
+const goToSection = async (stdin: { write: (s: string) => void }, target: (typeof SECTIONS)[number]): Promise<void> => {
+  const steps = SECTIONS.indexOf(target);
+  for (let i = 0; i < steps; i += 1) {
+    stdin.write(RIGHT);
+    await tick(20);
+  }
+};
+
 describe('SettingsView', () => {
-  it('renders every editable field after the load completes', async () => {
+  it('renders the section strip and the active section after the load completes', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
     await tick(40);
     const frame = result.lastFrame() ?? '';
-    expect(frame).toContain('Provider');
-    expect(frame).toContain('Refine');
-    expect(frame).toContain('Plan');
-    expect(frame).toContain('Implement');
-    expect(frame).toContain('Max turns');
-    expect(frame).toContain('Concurrency');
-    expect(frame).toContain('Log level');
+    // Every section label is in the strip.
+    for (const label of [
+      'Presets',
+      'Global',
+      'Refine',
+      'Plan',
+      'Implement',
+      'Readiness',
+      'Ideate',
+      'Harness',
+      'Other',
+      'Storage',
+    ]) {
+      expect(frame).toContain(label);
+    }
+    // The active (initial) section is Presets; its card title renders below the strip.
+    expect(frame).toContain('Apply: Mixed');
     result.unmount();
   });
 
-  it('shows the storage paths card', async () => {
+  it('shows the storage paths card when the storage section is active', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
     await tick(40);
+    await goToSection(result.stdin, 'storage');
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Storage paths');
     expect(frame).toContain('App root');
     result.unmount();
   });
 
-  it('exposes ↑/↓ navigate and ↵/e edit hints', async () => {
+  it('exposes ←/→ section, ↑/↓ navigate, ↵/e edit hints', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
     await tick(40);
     const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('section');
     expect(frame).toContain('navigate');
     expect(frame).toContain('edit');
     result.unmount();
   });
 
-  it('renders Implement as a parent label with indented generator and evaluator sub-rows', async () => {
+  it('renders Implement as a parent card with indented generator and evaluator sub-rows', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
     await tick(40);
+    await goToSection(result.stdin, 'implement');
     const frame = result.lastFrame() ?? '';
     // The parent card carries the non-editable Implement label exactly once; the two role
     // sub-rows render their own dim sub-labels underneath.
@@ -136,28 +175,122 @@ describe('SettingsView', () => {
     const { applySettingsKey } = await import('@src/business/settings/apply-key.ts');
     const loaded = await role1Repo.load();
     if (!loaded.ok) throw new Error('expected ok load');
-    const updated = applySettingsKey(loaded.value, 'ai.implement.generator.model', 'claude-haiku-4-5-20251001');
+    const updated = applySettingsKey(loaded.value, 'ai.implement.generator.model', 'claude-haiku-4-5');
     if (!updated.ok) throw new Error(`expected updated ok: ${updated.error.message}`);
     await role1Repo.save(updated.value);
 
     const reread = await role1Repo.load();
     if (!reread.ok) throw new Error('expected reread ok');
     // Generator received the new model; evaluator is byte-for-byte the pre-edit value.
-    expect(reread.value.ai.implement.generator.model).toBe('claude-haiku-4-5-20251001');
+    expect(reread.value.ai.implement.generator.model).toBe('claude-haiku-4-5');
     expect(reread.value.ai.implement.evaluator).toEqual(initial.ai.implement.evaluator);
   });
 
-  describe('provider availability gate', () => {
-    // Field order (built in buildEditableFields): four preset buttons, global effort, then six
-    // provider/model/effort triples per flow + the implement pair. Refine is the first flow
-    // after the four presets + global effort, so its provider field sits at index 5 (zero-indexed):
-    // [preset×4, ai.effort, ai.refine.provider]. Five 'j' presses move from cursor 0 (the first
-    // preset) to cursor 5 (ai.refine.provider), where the picker opens.
-    const navigateToRefineProvider = async (stdin: { write: (s: string) => void }): Promise<void> => {
-      for (let i = 0; i < 5; i += 1) {
-        stdin.write('j');
-        await tick(20);
+  describe('per-section bounded cursor', () => {
+    // Within one section, ↑/↓ stops at the section's first / last editable field. Holding ↓
+    // past the last row leaves the cursor pinned, and the cursor never escapes into another
+    // section's fields. The Implement section is the largest (six rows — generator triple +
+    // evaluator triple) and is the right stress-test for the ≤ ~8-row cap.
+    it('caps ↓ at the Implement section last row no matter how many presses arrive', async () => {
+      const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
+      await tick(40);
+      await goToSection(result.stdin, 'implement');
+      // The Implement section has six fields (generator.{provider,model,effort} +
+      // evaluator.{provider,model,effort}). Ten ↓ presses pin the cursor at the last row.
+      for (let i = 0; i < 10; i += 1) {
+        result.stdin.write('j');
+        await tick(15);
       }
+      const frame = result.lastFrame() ?? '';
+      // The cursor glyph ▸ marks the focused row's value. Only one row carries it.
+      const cursorMatches = frame.match(/▸/g) ?? [];
+      // One ▸ in the section strip (the active section label) + one ▸ on the focused field.
+      expect(cursorMatches.length).toBeLessThanOrEqual(2);
+      // The focused row must be the evaluator's effort (the last of the six). Search the
+      // rendered text for the cursor adjacent to the Default / current effort token; the
+      // value is `Default` for a freshly-loaded settings record.
+      // Approximate the assertion with a substring match: the last evaluator row's value cell
+      // is preceded by `Effort:` in the field list.
+      // We can't easily verify alignment but we can confirm the cursor did not escape into
+      // the next section — Readiness fields (e.g. `AI — Readiness`) must NOT be on screen.
+      expect(frame).not.toContain('AI — Readiness');
+      expect(frame).not.toContain('AI — Plan');
+      result.unmount();
+    });
+
+    it('caps ↑ at the first row inside a section', async () => {
+      const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
+      await tick(40);
+      await goToSection(result.stdin, 'harness');
+      // Park the cursor on the last row first, then hammer ↑.
+      for (let i = 0; i < 5; i += 1) {
+        result.stdin.write('j');
+        await tick(15);
+      }
+      for (let i = 0; i < 10; i += 1) {
+        result.stdin.write('k');
+        await tick(15);
+      }
+      const frame = result.lastFrame() ?? '';
+      // Only Harness fields are visible — the previous section (Ideate) must not bleed in.
+      expect(frame).toContain('Max turns');
+      expect(frame).not.toContain('AI — Ideate');
+      result.unmount();
+    });
+  });
+
+  describe('model field is catalog-only', () => {
+    it('does not mount a TextPrompt on a model row (no free-text input affordance)', async () => {
+      const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
+      await tick(40);
+      await goToSection(result.stdin, 'refine');
+      // Refine section field order: 0 provider, 1 model, 2 effort. One ↓ lands on the model
+      // row; ↵ opens the picker.
+      result.stdin.write('j');
+      await tick(20);
+      result.stdin.write(ENTER);
+      await tick(40);
+      const frame = result.lastFrame() ?? '';
+      // SelectPrompt always renders the navigation legend below its option list.
+      expect(frame).toContain('↑/↓ navigate · ↵ submit · esc cancel');
+      // TextPrompt's hint row carries the `←/→ cursor · home/end edge` suffix; its absence
+      // confirms the active editor is the SelectPrompt, not a free-text input.
+      expect(frame).not.toContain('←/→ cursor · home/end edge');
+      // Every Claude catalog model must be selectable; no "+ custom" affordance lingers.
+      expect(frame).toContain('claude-sonnet-4-6');
+      expect(frame).not.toContain('+ custom');
+      result.unmount();
+    });
+  });
+
+  it('renders a persisted off-catalog model value on load (regression)', async () => {
+    // A settings file pinned to a model the harness catalog does not list (an older release
+    // or an experimental id) must still show that value on screen — the catalog gate applies
+    // to the editor surface, not the read-side render.
+    const offCatalogModel = 'claude-experimental-pinned-2099';
+    const initial: Settings = {
+      ...DEFAULT_SETTINGS,
+      ai: {
+        ...DEFAULT_SETTINGS.ai,
+        refine: { provider: 'claude-code', model: offCatalogModel },
+      },
+    };
+    const stub = stubRepoWith(initial);
+    const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
+    const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
+    await tick(40);
+    await goToSection(result.stdin, 'refine');
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain(offCatalogModel);
+    result.unmount();
+  });
+
+  describe('provider availability gate', () => {
+    // Section ordering puts Refine third (presets → global → refine), so two RIGHT presses
+    // step from the initial Presets section to Refine; ENTER on the first row (provider)
+    // opens the picker.
+    const openRefineProviderPicker = async (stdin: { write: (s: string) => void }): Promise<void> => {
+      await goToSection(stdin, 'refine');
       stdin.write(ENTER);
       await tick(40);
     };
@@ -168,7 +301,7 @@ describe('SettingsView', () => {
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
       await tick(80);
-      await navigateToRefineProvider(result.stdin);
+      await openRefineProviderPicker(result.stdin);
       const frame = result.lastFrame() ?? '';
       expect(frame).toContain('github-copilot (not installed)');
       expect(frame).toContain('openai-codex (not installed)');
@@ -183,7 +316,7 @@ describe('SettingsView', () => {
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
       await tick(80);
-      await navigateToRefineProvider(result.stdin);
+      await openRefineProviderPicker(result.stdin);
       // Strip the rendered frame's word-wrap whitespace before asserting — ink may break the
       // footer across multiple lines depending on terminal width, but the install command must
       // still be present as a contiguous token sequence.
@@ -203,7 +336,7 @@ describe('SettingsView', () => {
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
       await tick(80);
-      await navigateToRefineProvider(result.stdin);
+      await openRefineProviderPicker(result.stdin);
       const frame = result.lastFrame() ?? '';
       expect(frame).toContain('No AI provider CLI is installed.');
       expect(frame).toContain('claude-code (not installed)');

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Sprint-detail view — ticket / task card harmony.
+ *
+ * Both card types render through the shared `ListCard` primitive, so they must agree on the
+ * structural visual contract: identical left + right border columns and identical border
+ * frame shape (same top / bottom border line). These tests guard against future regressions
+ * where someone reintroduces a bespoke wrapper around `Card` for one of the lists and the
+ * two visually drift apart.
+ *
+ * A separate group exercises the responsive task-metadata row: single-line + ellipsis at
+ * terminal widths ≥ 100 cols, wrapping below that threshold.
+ *
+ * `useTerminalSize` is mocked so the responsive predicate (`useBreakpoint`) sees the width
+ * we want regardless of the test stdout's hardcoded 100 cols. The actual layout box is
+ * still bounded by stdout columns — that's fine: width-based truncation in Ink fires at the
+ * actual layout width, so the `…` clip marker shows up for content that overflows the
+ * stdout box. ink-testing-library's stdout strips chalk colour, so border tone identity
+ * is asserted structurally (same border characters at the same columns) rather than by
+ * ANSI sequence comparison.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const sizeRef = vi.hoisted(() => ({ columns: 120, rows: 40 }));
+
+vi.mock('@src/application/ui/tui/runtime/use-terminal-size.ts', () => ({
+  useTerminalSize: (): { columns: number; rows: number } => ({ columns: sizeRef.columns, rows: sizeRef.rows }),
+}));
+
+import { Result } from '@src/domain/result.ts';
+import { SprintDetailView } from '@src/application/ui/tui/views/sprint-detail-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+
+const FIXED_SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
+
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_ESCAPE_PATTERN, '');
+
+const makeSprint = (tickets: readonly unknown[]): Sprint =>
+  ({
+    id: FIXED_SPRINT_ID,
+    slug: 'demo-sprint',
+    name: 'Demo Sprint',
+    projectId: 'proj-fixture' as never,
+    // `done` keeps the "Next phase" affordance as plain text rather than a card so the only
+    // bordered frames in the rendered tree are the sprint header, the tickets, and the tasks.
+    status: 'done',
+    tickets,
+  }) as unknown as Sprint;
+
+const stubDeps = (sprint: Sprint, tasks: readonly Task[]): AppDeps =>
+  ({
+    sprintRepo: {
+      async findById() {
+        return Result.ok(sprint);
+      },
+    } as unknown as SprintRepository,
+    taskRepo: {
+      async findBySprintId() {
+        return Result.ok([...tasks]);
+      },
+    } as unknown as TaskRepository,
+    projectRepo: {} as never,
+    sprintExecutionRepo: {} as never,
+    settingsRepo: {} as never,
+    logger: noopLogger,
+  }) as unknown as AppDeps;
+
+const initial = { id: 'sprint-detail', props: { sprintId: FIXED_SPRINT_ID } };
+
+interface CardFrame {
+  readonly topLine: string;
+  readonly leftCol: number;
+  readonly rightCol: number;
+}
+
+/**
+ * Find the bordered card surrounding the header line containing `marker`. The top border is
+ * the line directly above the marker, and the left / right border columns are the indices of
+ * the `╭` / `╮` glyphs on that top line.
+ */
+const findCard = (lines: readonly string[], marker: string): CardFrame | undefined => {
+  const idx = lines.findIndex((l) => l.includes(marker));
+  if (idx <= 0) return undefined;
+  const topLine = lines[idx - 1] ?? '';
+  const leftCol = topLine.indexOf('╭');
+  const rightCol = topLine.lastIndexOf('╮');
+  if (leftCol < 0 || rightCol < 0) return undefined;
+  return { topLine, leftCol, rightCol };
+};
+
+describe('SprintDetailView — ticket / task card harmony', () => {
+  beforeEach(() => {
+    sizeRef.columns = 120;
+    sizeRef.rows = 40;
+  });
+  afterEach(() => {
+    sizeRef.columns = 120;
+    sizeRef.rows = 40;
+  });
+
+  it('ticket card and task card share identical border alignment and unfocused tone at width 120', async () => {
+    sizeRef.columns = 120;
+    const sprint = makeSprint([
+      { id: 'ticket-a' as never, title: 'alpha-card-marker', status: 'approved' } as never,
+      { id: 'ticket-b' as never, title: 'bravo-card-marker', status: 'approved' } as never,
+    ]);
+    const tasks: readonly Task[] = [
+      {
+        id: 'task-alpha' as never,
+        name: 'alpha-task-marker',
+        status: 'todo',
+        dependsOn: [],
+        attempts: [],
+        ticketId: 'ticket-a' as never,
+        repositoryId: 'r1' as never,
+        order: 1,
+        steps: [],
+        verificationCriteria: [],
+      } as never,
+    ];
+    const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
+    await tick(60);
+
+    const frame = stripAnsi(result.lastFrame() ?? '');
+    const lines = frame.split('\n');
+
+    // Default cursor sits on ticket #0 (alpha). That makes alpha focused and bravo +
+    // alpha-task unfocused. Compare bravo vs alpha-task — both unfocused cards must agree
+    // on every aspect of their frame.
+    const ticketCard = findCard(lines, 'bravo-card-marker');
+    const taskCard = findCard(lines, 'alpha-task-marker');
+
+    expect(ticketCard).toBeDefined();
+    expect(taskCard).toBeDefined();
+    if (ticketCard === undefined || taskCard === undefined) return;
+
+    // Column alignment: both cards live in the same outer column stack, so their borders
+    // must land in the same columns. A regression where one card path picked up extra
+    // padding / margin would surface here as a left- or right-col mismatch.
+    expect(ticketCard.leftCol).toBe(taskCard.leftCol);
+    expect(ticketCard.rightCol).toBe(taskCard.rightCol);
+
+    // Tone identity at the structural level: both unfocused cards must produce a
+    // character-identical top border (same border glyphs, same width, same horizontal
+    // extent). If a future change splits the two paths (e.g. a different border style,
+    // padding, or dim policy on one of them) the top borders would diverge — even with
+    // chalk colour stripped from the test stdout, the border characters and their
+    // positions remain visible signal.
+    expect(ticketCard.topLine).toBe(taskCard.topLine);
+  });
+});
+
+describe('SprintDetailView — task metadata row wrap policy', () => {
+  beforeEach(() => {
+    sizeRef.columns = 120;
+    sizeRef.rows = 40;
+  });
+  afterEach(() => {
+    sizeRef.columns = 120;
+    sizeRef.rows = 40;
+  });
+
+  const buildMetadataHeavyTask = (id: string): Task =>
+    ({
+      id: id as never,
+      name: 'meta-task',
+      status: 'todo',
+      dependsOn: ['dep-a' as never, 'dep-b' as never, 'dep-c' as never],
+      attempts: [],
+      maxAttempts: 5,
+      ticketId: 'ticket-a' as never,
+      repositoryId: 'r1' as never,
+      order: 1,
+      steps: [],
+      verificationCriteria: [],
+    }) as never;
+
+  it('keeps the task metadata row on a single line with an ellipsis at width 120', async () => {
+    sizeRef.columns = 120;
+    // The ticket title is intentionally long so the metadata row overflows even the
+    // generous stdout box. We expect Ink to ellide the tail with `…` rather than wrap.
+    const longTicketTitle = 'an-intentionally-long-ticket-title-that-pushes-the-metadata-row-past-the-line-budget';
+    const sprint = makeSprint([{ id: 'ticket-a' as never, title: longTicketTitle, status: 'approved' } as never]);
+    const tasks: readonly Task[] = [buildMetadataHeavyTask('task-meta-wide')];
+    const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
+    await tick(60);
+
+    const frame = stripAnsi(result.lastFrame() ?? '');
+    const lines = frame.split('\n');
+
+    // The metadata line is the one carrying `· ticket:` plus the depends-on count. Wrapping
+    // would split those across multiple lines; truncation keeps them on one line whose tail
+    // ends in the ellipsis glyph.
+    const metaLines = lines.filter((l) => l.includes('· ticket:'));
+    expect(metaLines.length).toBe(1);
+    expect(metaLines[0]).toContain('…');
+    // The depends-on count should NOT appear on its own row (it would have wrapped).
+    const standaloneDepsLine = lines.find((l) => l.includes('3 deps') && !l.includes('· ticket:'));
+    expect(standaloneDepsLine).toBeUndefined();
+  });
+
+  it('allows the task metadata row to wrap onto multiple lines below 100 cols', async () => {
+    sizeRef.columns = 80;
+    // Same long ticket title as the truncate test so the metadata row is wider than the
+    // stdout content area. With the wrap-policy branch active (mocked columns < md), the
+    // overflow tail must land on a second line instead of being elided away.
+    const longTicketTitle = 'an-intentionally-long-ticket-title-that-pushes-the-metadata-row-past-the-line-budget';
+    const sprint = makeSprint([{ id: 'ticket-a' as never, title: longTicketTitle, status: 'approved' } as never]);
+    const tasks: readonly Task[] = [buildMetadataHeavyTask('task-meta-narrow')];
+    const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
+    await tick(60);
+
+    const frame = stripAnsi(result.lastFrame() ?? '');
+    const lines = frame.split('\n');
+
+    // With wrap behaviour, fields scatter across multiple metadata rows; the wrapping path
+    // never emits the truncation ellipsis, since flexbox absorbs the overflow instead.
+    const metadataRows = lines.filter(
+      (l) => l.includes('ticket:') || l.includes('repo:') || l.includes('attempts:') || /\b3 deps\b/.test(l)
+    );
+    expect(metadataRows.length).toBeGreaterThan(1);
+    const metaLineWithEllipsis = metadataRows.find((l) => l.includes('…'));
+    expect(metaLineWithEllipsis).toBeUndefined();
+  });
+});

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Sprint-detail view — per-card expand/collapse keyed by stable id.
+ *
+ * Each ticket / task card tracks its expansion independently. These tests guard the
+ * properties that the prior single-slot openIdx could not honour:
+ *
+ *  - opening a second card leaves the first one expanded;
+ *  - closing one expanded card leaves the other still expanded;
+ *  - pressing esc with at least one card open collapses every expansion in a single action;
+ *  - moving the focus cursor with j/k does not change which cards are expanded;
+ *  - removing a card above the expanded ones does not migrate expansion onto a different
+ *    card (identity stability: expansion is bound to the item's id, not its list index).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { SprintDetailView } from '@src/application/ui/tui/views/sprint-detail-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick, ESC } from '@tests/integration/application/ui/tui/_keys.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeApprovedTicket, makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+type Renderable = { readonly lastFrame: () => string | undefined };
+
+const waitForFrame = async (rendered: Renderable, predicate: (frame: string) => boolean): Promise<void> => {
+  for (let i = 0; i < 50; i++) {
+    const frame = rendered.lastFrame() ?? '';
+    if (predicate(frame)) return;
+    await tick(40);
+  }
+};
+
+const FIXED_SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
+
+const makeTicket = (id: string, title: string, description: string): unknown => ({
+  id,
+  title,
+  status: 'approved',
+  description,
+  requirements: `requirements for ${title}`,
+});
+
+const makeSprintWithTickets = (tickets: readonly unknown[]): Sprint =>
+  ({
+    id: FIXED_SPRINT_ID,
+    slug: 'demo-sprint',
+    name: 'Demo Sprint',
+    projectId: 'proj-fixture' as never,
+    status: 'planned',
+    tickets,
+  }) as unknown as Sprint;
+
+const stubReadOnlyDeps = (sprint: Sprint, tasks: readonly Task[]): AppDeps =>
+  ({
+    sprintRepo: {
+      async findById() {
+        return Result.ok(sprint);
+      },
+    } as unknown as SprintRepository,
+    taskRepo: {
+      async findBySprintId() {
+        return Result.ok([...tasks]);
+      },
+    } as unknown as TaskRepository,
+    projectRepo: {} as never,
+    sprintExecutionRepo: {} as never,
+    settingsRepo: {} as never,
+    logger: noopLogger,
+  }) as unknown as AppDeps;
+
+const initial = { id: 'sprint-detail', props: { sprintId: FIXED_SPRINT_ID } };
+
+describe('SprintDetailView — per-card expand/collapse', () => {
+  it('opens two cards independently — both remain expanded', async () => {
+    const sprint = makeSprintWithTickets([
+      makeTicket('ticket-a', 'alpha card', 'alpha-only-marker-line-in-description'),
+      makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
+    ]);
+    const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
+    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+
+    // Expand the first ticket (cursor starts at idx 0).
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    // Move to the second ticket and expand it without collapsing the first.
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+
+    const frame = result.lastFrame() ?? '';
+    // Both expanded views render their per-ticket Requirements heading; if either card
+    // collapsed back to its preview, the heading for that ticket would not appear.
+    expect(frame).toContain('requirements for alpha card');
+    expect(frame).toContain('requirements for bravo card');
+  });
+
+  it('closing one expanded card leaves the other expanded', async () => {
+    const sprint = makeSprintWithTickets([
+      makeTicket('ticket-a', 'alpha card', 'alpha-only-marker-line-in-description'),
+      makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
+    ]);
+    const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
+    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+
+    // Open card 0.
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    // Move to card 1 and open it.
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+    // Move back to card 0 and toggle it closed.
+    result.stdin.write('k');
+    await tick(40);
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => !f.includes('requirements for alpha card'));
+
+    const frame = result.lastFrame() ?? '';
+    // Card 0's requirements heading should be gone; card 1's must remain.
+    expect(frame).not.toContain('requirements for alpha card');
+    expect(frame).toContain('requirements for bravo card');
+  });
+
+  it('pressing esc with multiple cards expanded collapses every card in a single action', async () => {
+    const sprint = makeSprintWithTickets([
+      makeTicket('ticket-a', 'alpha card', 'alpha-only-marker-line-in-description'),
+      makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
+    ]);
+    const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
+    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+
+    // Expand both cards.
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+
+    // Confirm pre-condition: both cards expanded.
+    let frame = result.lastFrame() ?? '';
+    expect(frame).toContain('requirements for alpha card');
+    expect(frame).toContain('requirements for bravo card');
+
+    // One Esc must clear the entire openIds set.
+    result.stdin.write(ESC);
+    await waitForFrame(result, (f) => !f.includes('requirements for alpha card'));
+
+    frame = result.lastFrame() ?? '';
+    expect(frame).not.toContain('requirements for alpha card');
+    expect(frame).not.toContain('requirements for bravo card');
+  });
+
+  it('moving the cursor with j/k does not change which cards are expanded', async () => {
+    const sprint = makeSprintWithTickets([
+      makeTicket('ticket-a', 'alpha card', 'alpha-only-marker-line-in-description'),
+      makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
+      makeTicket('ticket-c', 'charlie card', 'charlie-only-marker-line-in-description'),
+    ]);
+    const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
+    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+
+    // Expand only the first card.
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+
+    // Navigate cursor up and down across all three cards.
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('k');
+    await tick(40);
+    result.stdin.write('k');
+    await tick(40);
+
+    const frame = result.lastFrame() ?? '';
+    // The alpha card must remain expanded throughout cursor movement; the others must not
+    // have auto-expanded just because the cursor passed over them.
+    expect(frame).toContain('requirements for alpha card');
+    expect(frame).not.toContain('requirements for bravo card');
+    expect(frame).not.toContain('requirements for charlie card');
+  });
+
+  it('removing a ticket above expanded cards does not migrate expansion to a different row', async () => {
+    // Build a draft sprint with three real approved tickets so the `d` removal flow can
+    // travel through the genuine `removeTicket` use-case. The expansion is keyed by id, so
+    // dropping the middle ticket must leave the OTHER two cards visibly expanded — a list-
+    // index-based implementation would mis-track expansion onto whichever rows now sit at
+    // the previously-recorded indices.
+    const alpha = makeApprovedTicket({
+      title: 'alpha card',
+      requirements: 'requirements for alpha card',
+    });
+    const bravo = makeApprovedTicket({
+      title: 'bravo card',
+      requirements: 'requirements for bravo card',
+    });
+    const charlie = makeApprovedTicket({
+      title: 'charlie card',
+      requirements: 'requirements for charlie card',
+    });
+    let storedSprint: Sprint = makeDraftSprint({ tickets: [alpha, bravo, charlie] }) as unknown as Sprint;
+
+    const deps = {
+      sprintRepo: {
+        async findById() {
+          return Result.ok(storedSprint);
+        },
+        async save(s: Sprint) {
+          storedSprint = s;
+          return Result.ok(s);
+        },
+      } as unknown as SprintRepository,
+      taskRepo: {
+        async findBySprintId() {
+          return Result.ok([] as readonly Task[]);
+        },
+      } as unknown as TaskRepository,
+      projectRepo: {} as never,
+      sprintExecutionRepo: {} as never,
+      settingsRepo: {} as never,
+      logger: noopLogger,
+    } as unknown as AppDeps;
+
+    const initialWithRealId = { id: 'sprint-detail', props: { sprintId: storedSprint.id } };
+    const { result } = renderView(<SprintDetailView />, { deps, initial: initialWithRealId });
+    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+
+    // Open card 0 (alpha).
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    // Move down twice to card 2 (charlie) and open it.
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('j');
+    await tick(40);
+    result.stdin.write('o');
+    await waitForFrame(result, (f) => f.includes('requirements for charlie card'));
+
+    // Pre-condition: alpha and charlie expanded; bravo collapsed.
+    let frame = result.lastFrame() ?? '';
+    expect(frame).toContain('requirements for alpha card');
+    expect(frame).not.toContain('requirements for bravo card');
+    expect(frame).toContain('requirements for charlie card');
+
+    // Move cursor up one to bravo (the middle ticket) and remove it via d → y. The confirm
+    // prompt mounts, then on `y` the ticket-remove flow fires + reload pulls a fresh sprint
+    // without bravo. Expansion state on alpha + charlie must survive the reload — the reload
+    // briefly flips the view to a Loading spinner while the new bundle resolves, so we poll
+    // until the cards are back before asserting.
+    result.stdin.write('k');
+    await tick(40);
+    result.stdin.write('d');
+    await waitForFrame(result, (f) => f.includes('Remove ticket'));
+    result.stdin.write('y');
+    await waitForFrame(
+      result,
+      (f) =>
+        f.includes('alpha card') && f.includes('charlie card') && !f.includes('bravo card') && !f.includes('Loading')
+    );
+
+    frame = result.lastFrame() ?? '';
+    // The two surviving cards (alpha + charlie) keep their expansion; bravo is gone from the
+    // list entirely, so its requirements line must no longer appear anywhere.
+    expect(frame).toContain('requirements for alpha card');
+    expect(frame).toContain('requirements for charlie card');
+    expect(frame).not.toContain('requirements for bravo card');
+  });
+});

--- a/tests/unit/application/ui/shared/launch/check-cli.test.ts
+++ b/tests/unit/application/ui/shared/launch/check-cli.test.ts
@@ -130,6 +130,62 @@ describe('checkCli', () => {
     expect(result.reason).toContain('https://github.com/openai/codex');
   });
 
+  describe('per-run override source identification', () => {
+    it("names 'per-run override' instead of the settings key when the missing provider came from a single-row override", async () => {
+      // The launcher applies override to settings before calling checkCli, so the effective
+      // settings row already reflects the override. The override flag tells check-cli that
+      // the row's provider was supplied transiently — so the failure message should NOT
+      // tell the operator to change the saved settings key (it hasn't changed).
+      const effective = withFlowProvider('refine', 'openai-codex');
+      const result = await checkCli('refine', effective, {
+        detect: detectFor([]),
+        override: { provider: 'openai-codex' },
+      });
+      expect(result).toBeDefined();
+      if (result === undefined || result.ok) return;
+      expect(result.reason).toContain('codex');
+      expect(result.reason).toContain('per-run override');
+      expect(result.reason).toContain('ai.refine.provider unchanged');
+    });
+
+    it('keeps the original settings-key message form when the missing provider came from saved settings', async () => {
+      const settings = withFlowProvider('refine', 'openai-codex');
+      const result = await checkCli('refine', settings, { detect: detectFor([]) });
+      expect(result).toBeDefined();
+      if (result === undefined || result.ok) return;
+      // No override supplied; the reason names the saved settings key plainly.
+      expect(result.reason).toContain('Change ai.refine.provider');
+      expect(result.reason).not.toContain('per-run override');
+    });
+
+    it('implement: identifies generator-only override source when only the generator provider was swapped per-run', async () => {
+      // Effective implement pair: generator on the missing codex (per-run override),
+      // evaluator on the missing codex (saved). Both rows surface missing — but only the
+      // generator row identifies the source as a per-run override.
+      const effective: Settings = {
+        ...DEFAULT_SETTINGS,
+        ai: {
+          ...DEFAULT_SETTINGS.ai,
+          implement: {
+            generator: { provider: 'openai-codex', model: 'gpt-5.5' },
+            evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+          },
+        },
+      };
+      const result = await checkCli('implement', effective, {
+        detect: detectFor([]),
+        implementRoleOverrides: { generator: { provider: 'openai-codex' } },
+      });
+      expect(result).toBeDefined();
+      if (result === undefined || result.ok) return;
+      expect(result.reason).toContain('generator');
+      expect(result.reason).toContain('per-run override');
+      expect(result.reason).toContain('ai.implement.generator.provider unchanged');
+      // Evaluator (saved) keeps the original settings-key form.
+      expect(result.reason).toContain('Change ai.implement.evaluator.provider');
+    });
+  });
+
   it('install-guidance coverage spans every provider', async () => {
     // Probe each provider in isolation so changes to the install guidance table cause the
     // test to fail loudly rather than slipping past one-by-one assertions. Asserts on the


### PR DESCRIPTION
## Summary

Six TUI improvements landed as one branch (one commit per ticket, each verified independently):

- **#152** — Share a single `synthesiseBaselineHealth` predicate between `BaselineHealthChip` and `BaselineHealthCard` so they can no longer disagree after a red→green recovery. Latest pre-verify + latest post-verify per attempt drive both surfaces.
- **#149** — Sprint-detail per-card expand/collapse keyed by stable item id (`Set<string>` replaces the single-slot `openIdx`). Esc/q does a bulk collapse; navigation never mutates expansion; identity-stable across list mutations.
- **#148** — Extract `ListCard` so `TicketCard` and `TaskCard` share border tone, dim policy, padding, and gutter. Task metadata row is single-line with `…` truncation at ≥100 cols (wraps below).
- **#150** — Add-ticket Review step description is viewport-bounded scrollable (`↑/↓`, `PgUp/PgDn`) with position indicator. Link row + confirm pills stay visible; footer hint reflects scrollable state.
- **#151 (part 1)** — Section-tabbed settings view bounds default cursor traversal to ≤ ~8 stops per section; `+ custom` model affordance removed (catalog-only on write, persisted off-catalog values still display).
- **#151 (part 2)** — Per-launch provider / model / effort customize picker for every AI-driven flow. Implement walks generator then evaluator. `LaunchExtras.override` replaces the legacy `modelOverride` string. Picker never mutates `settings.json` (byte-identical pre/post-picker test).

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` — 311 files, 2433 tests pass
- [ ] Sanity-check sprint detail view: open two cards, collapse one, bulk-Esc the other
- [ ] Sanity-check add-ticket Review on a long description: scroll, page, confirm
- [ ] Sanity-check settings view: section tabs, model picker has no custom-text option
- [ ] Sanity-check flows-view: pick `Customize for this run…` on implement, override generator only, verify evaluator still uses settings