### PR TITLE
fix(tui): plug React Hook desync in execute-view + wire react-hooks lint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,9 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import globals from 'globals';
-import type { Linter } from 'eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import sonarjs from 'eslint-plugin-sonarjs';
+import type { ESLint, Linter } from 'eslint';
 
 /**
  * Layer rules.
@@ -348,6 +350,32 @@ export default [
         ecmaVersion: 'latest',
         sourceType: 'module',
       },
+    },
+  },
+
+  // ── memory-leak + correctness hygiene plugins ─────────────────────────────────
+  // `react-hooks/rules-of-hooks` is the plugin that surfaced the conditional-Hook bug
+  // in execute-view.tsx (suspected root of the recurring 8h OOM). `exhaustive-deps`
+  // catches stale closures that retain references across re-renders. The sonarjs
+  // subset is a cheap collection-correctness net for the same class of slow leaks.
+  //
+  // react-hooks's exported Plugin type doesn't align with `Linter.Config['plugins']`
+  // under `exactOptionalPropertyTypes`, so we cast once at the boundary — the rules
+  // themselves are still type-checked through ESLint's runtime config validator.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: {
+      'react-hooks': reactHooks as unknown as ESLint.Plugin,
+      sonarjs: sonarjs as unknown as ESLint.Plugin,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'sonarjs/no-unused-collection': 'warn',
+      'sonarjs/no-ignored-return': 'warn',
+      'sonarjs/no-element-overwrite': 'warn',
+      'sonarjs/no-identical-conditions': 'warn',
+      'sonarjs/no-collection-size-mischeck': 'warn',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "@types/react": "^19.2.14",
     "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.4.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "ink-testing-library": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-sonarjs:
+        specifier: ^4.0.3
+        version: 4.0.3(eslint@10.4.0(jiti@2.7.0))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -82,12 +88,62 @@ packages:
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -95,8 +151,25 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -485,6 +558,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1048,9 +1124,23 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1058,9 +1148,16 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1139,6 +1236,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  electron-to-chromium@1.5.361:
+    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1162,6 +1262,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -1169,6 +1273,17 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-sonarjs@4.0.3:
+    resolution: {integrity: sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1271,6 +1386,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1289,6 +1411,12 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1379,6 +1507,14 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1387,6 +1523,15 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsx-ast-utils-x@0.1.0:
+    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1424,9 +1569,15 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1469,6 +1620,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1582,6 +1737,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1607,6 +1770,14 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
@@ -1805,6 +1976,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -1931,6 +2108,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -1943,6 +2123,12 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -1953,18 +2139,118 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -2193,6 +2479,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -2628,16 +2919,32 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.10.32: {}
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  builtin-modules@3.3.0: {}
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
@@ -2696,6 +3003,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  electron-to-chromium@1.5.361: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2763,9 +3072,38 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@7.1.1(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.3
+      eslint: 10.4.0(jiti@2.7.0)
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-sonarjs@4.0.3(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      builtin-modules: 3.3.0
+      bytes: 3.1.2
+      eslint: 10.4.0(jiti@2.7.0)
+      functional-red-black-tree: 1.0.1
+      globals: 17.6.0
+      jsx-ast-utils-x: 0.1.0
+      lodash.merge: 4.6.2
+      minimatch: 10.2.5
+      scslre: 0.3.0
+      semver: 7.8.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   eslint-scope@9.1.2:
     dependencies:
@@ -2884,6 +3222,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  functional-red-black-tree@1.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
+
   get-east-asian-width@1.6.0: {}
 
   get-tsconfig@4.14.0:
@@ -2897,6 +3239,12 @@ snapshots:
   globals@17.6.0: {}
 
   has-flag@4.0.0: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   html-escaper@2.0.2: {}
 
@@ -2981,11 +3329,19 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
+
+  jsx-ast-utils-x@0.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -3043,6 +3399,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.merge@4.6.2: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -3050,6 +3408,10 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -3093,6 +3455,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
+
+  node-releases@2.0.46: {}
 
   object-assign@4.1.1: {}
 
@@ -3224,6 +3588,15 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3272,6 +3645,14 @@ snapshots:
       fsevents: 2.3.3
 
   scheduler@0.27.0: {}
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+
+  semver@6.3.1: {}
 
   semver@7.8.1: {}
 
@@ -3450,6 +3831,12 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -3528,10 +3915,16 @@ snapshots:
 
   ws@8.21.0: {}
 
+  yallist@3.1.1: {}
+
   yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 
   yoga-layout@3.2.1: {}
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/src/application/ui/tui/components/baseline-health-card.tsx
+++ b/src/application/ui/tui/components/baseline-health-card.tsx
@@ -381,7 +381,11 @@ const CompactCleanRow = ({ rows }: { readonly rows: readonly RowData[] }): React
 /** @public */
 export const BaselineHealthCard = ({ execution, tasks, now, width }: BaselineHealthCardProps): React.JSX.Element => {
   const tNow = now ?? Date.now();
-  const taskList = tasks ?? [];
+  // Wrap the `tasks ?? []` fallback in its own useMemo so the identity is stable across
+  // renders that don't change `tasks`. Without this, the inline `??` allocates a fresh empty
+  // array each render, which would cascade into re-running every downstream `useMemo` that
+  // takes `taskList` as a dep — defeating the memo'd setup/verify-row computations.
+  const taskList = useMemo(() => tasks ?? [], [tasks]);
   const cardWidth = width ?? CONTEXT_WIDTH;
 
   const setupData = useMemo(() => setupRowData(execution, tNow), [execution, tNow]);

--- a/src/application/ui/tui/components/scroll-region.tsx
+++ b/src/application/ui/tui/components/scroll-region.tsx
@@ -59,7 +59,10 @@ export const ScrollRegion = ({ children, disabled = false }: ScrollRegionProps):
     }
     const max = maxOffset();
     if (offset > max) setOffset(max);
-  });
+    // `offset` is the only externally-visible state this effect reads; including it in the dep
+    // list keeps the clamp correct AND tames the previous "no-deps" form which the React-Hooks
+    // linter flagged as an infinite-update risk (every render → setOffset → render).
+  }, [offset]);
 
   useInput(
     (input, key) => {

--- a/src/application/ui/tui/components/step-trace.tsx
+++ b/src/application/ui/tui/components/step-trace.tsx
@@ -200,12 +200,17 @@ export const StepTrace = ({
   // every render adds avoidable GC pressure even though the cost is fast in absolute terms.
   //
   // The runner mutates `trace` in place via push (+ ring eviction at the cap), so the array
-  // reference is stable across pushes. Including `trace.length` AND the last-entry identity in
-  // the dep list keeps the memo correct: length flips while the buffer fills; once we hit the
-  // ring cap, length sticks but the last entry's object identity still changes per push.
+  // reference is stable across pushes — react-hooks/exhaustive-deps believes a single `trace`
+  // dep is sufficient (and so flags `trace.length` + `traceLastEntry` as "unnecessary"). It is
+  // NOT: with `trace` ref-stable, listing only `trace` would freeze the memo on the initial
+  // value and never recompute as items are pushed. The length + last-entry identity covers
+  // both regimes (length flips while the buffer fills; once we hit the ring cap, length sticks
+  // but the last entry's object identity still changes per push). Disable the rule locally
+  // with this explanation rather than restructuring around it.
   const traceLastEntry = trace[trace.length - 1];
   const merged = useMemo(
     () => (plan !== undefined ? mergePlanWithTrace(plan, trace, running, labelByName) : traceToRows(trace)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- in-place ring-buffer mutation; see comment above
     [plan, labelByName, trace, trace.length, traceLastEntry, running]
   );
   const filtered = useMemo(

--- a/src/application/ui/tui/prompts/prompt-host.tsx
+++ b/src/application/ui/tui/prompts/prompt-host.tsx
@@ -38,7 +38,12 @@ export const PromptHost = ({ queue }: PromptHostProps): React.JSX.Element | null
   // Claim the global-key mute only while a queued prompt is mounted. The previous code set
   // `promptActive=false` whenever the queue was empty, which clobbered view-level claims
   // (wizards setting it to true) on every commit cycle.
-  useEffect(() => (head !== undefined ? ui.claimPrompt() : undefined), [head, ui.claimPrompt]);
+  //
+  // Stash `claimPrompt` in a local so the effect depends on the stable callback — depending on
+  // `ui` itself would re-fire whenever any unrelated UI state (helpOpen, claims counter, …)
+  // toggled, which would release + re-claim the mute on every keystroke.
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (head !== undefined ? claimPrompt() : undefined), [head, claimPrompt]);
 
   if (!head) return null;
 

--- a/src/application/ui/tui/runtime/use-async-load.ts
+++ b/src/application/ui/tui/runtime/use-async-load.ts
@@ -13,7 +13,7 @@
  * running until natural completion, then gets discarded).
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export type AsyncLoadState<T, E> =
   | { readonly kind: 'idle' }
@@ -36,11 +36,21 @@ export const useAsyncLoad = <T, E = unknown>(
   const [state, setState] = useState<AsyncLoadState<T, E>>({ kind: 'idle' });
   const [version, setVersion] = useState(0);
 
+  // Capture `loader` and `errorMap` in refs so the effect reads the latest closure WITHOUT
+  // re-firing on every render (callers commonly pass fresh arrows). The dep list stays
+  // `[version, ...deps]` — the caller-supplied `deps` are the trigger axis; loader/errorMap
+  // identity is not. Mirrors the filterRef pattern in use-event-bus.ts.
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+  const errorMapRef = useRef(errorMap);
+  errorMapRef.current = errorMap;
+
   useEffect(() => {
     const controller = new AbortController();
     let cancelled = false;
     setState({ kind: 'loading' });
-    loader(controller.signal)
+    loaderRef
+      .current(controller.signal)
       .then((value) => {
         if (cancelled) return;
         setState({ kind: 'ok', value });
@@ -50,12 +60,13 @@ export const useAsyncLoad = <T, E = unknown>(
         // Treat AbortError as a silent cancel rather than an error state — the view is about
         // to unmount or re-fetch; surfacing "aborted" to the user would be confusing.
         if (err instanceof Error && err.name === 'AbortError') return;
-        setState({ kind: 'error', error: errorMap(err) });
+        setState({ kind: 'error', error: errorMapRef.current(err) });
       });
     return () => {
       cancelled = true;
       controller.abort();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- spread of caller-supplied deps is the entire API; loader + errorMap captured via refs above
   }, [version, ...deps]);
 
   return {

--- a/src/application/ui/tui/runtime/use-edit-field.ts
+++ b/src/application/ui/tui/runtime/use-edit-field.ts
@@ -66,6 +66,9 @@ const enqueueText = (queue: PromptQueue, title: string, kind: EditFieldKind, ini
 export const useEditField = (): UseEditFieldState => {
   const queue = usePromptQueue();
   const ui = useUiState();
+  // Pin the stable callback so the useCallback dep list can reference it without re-firing on
+  // every unrelated UI-state change (helpOpen, claims counter, …).
+  const claimPrompt = ui.claimPrompt;
   const [feedback, setFeedbackState] = useState<string | undefined>(undefined);
 
   // Mounted-ref guard: `openEditPrompt` is async and the host view can unmount between the
@@ -91,7 +94,7 @@ export const useEditField = (): UseEditFieldState => {
       // the operator is typing. The prompt-host already does this for queued prompts but the
       // release is tied to the host's render cycle; we mirror the claim here for symmetry with
       // confirm-prompt consumers and so feedback runs the same code path on cancel.
-      const release = ui.claimPrompt();
+      const release = claimPrompt();
       try {
         const raw = await enqueueText(queue, input.title, input.kind, input.currentValue ?? '');
         const normalised = input.validate ? input.validate(raw) : Result.ok(raw);
@@ -115,7 +118,7 @@ export const useEditField = (): UseEditFieldState => {
         release();
       }
     },
-    [queue, ui.claimPrompt, setFeedback]
+    [queue, claimPrompt, setFeedback]
   );
 
   const reset = useCallback((): void => {

--- a/src/application/ui/tui/views/add-repository-view.tsx
+++ b/src/application/ui/tui/views/add-repository-view.tsx
@@ -68,12 +68,13 @@ export const AddRepositoryView = (): React.JSX.Element => {
   // Claim prompt focus only while a real prompt is rendered. In 'saving' / 'error' states no
   // component is listening for Esc, so we must release the claim so the parent router's global
   // Esc handler fires and the "Press esc to go back" hint becomes truthful.
+  const claimPrompt = ui.claimPrompt;
   useEffect(() => {
     if (step.kind === 'path' || step.kind === 'name' || step.kind === 'confirm') {
-      return ui.claimPrompt();
+      return claimPrompt();
     }
     return undefined;
-  }, [ui.claimPrompt, step.kind]);
+  }, [claimPrompt, step.kind]);
 
   const cancel = (): void => router.pop();
 

--- a/src/application/ui/tui/views/add-ticket-view.tsx
+++ b/src/application/ui/tui/views/add-ticket-view.tsx
@@ -94,7 +94,8 @@ export const AddTicketView = (): React.JSX.Element => {
   const { sprintId } = useViewProps<AddTicketProps>();
   const [step, setStep] = useState<Step>({ kind: 'link' });
 
-  useEffect(() => ui.claimPrompt(), [ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => claimPrompt(), [claimPrompt]);
 
   const cancel = (): void => router.pop();
 

--- a/src/application/ui/tui/views/create-project-view.tsx
+++ b/src/application/ui/tui/views/create-project-view.tsx
@@ -120,7 +120,8 @@ export const CreateProjectView = (): React.JSX.Element => {
 
   // The wizard owns input focus end-to-end; suspend global keybindings so `n`/`s`/etc don't
   // hijack characters the user is typing into the prompt.
-  useEffect(() => ui.claimPrompt(), [ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => claimPrompt(), [claimPrompt]);
 
   const cancel = (): void => router.pop();
 

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -272,31 +272,13 @@ export const ExecuteView = (): React.JSX.Element => {
     return { ...rawBucketed, tasks };
   }, [rawBucketed, taskRounds]);
 
-  if (!session) {
-    return (
-      <ViewShell title="Implement" subtitle="(unknown session)">
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>The session id was not found in the registry. It may have been removed.</Text>
-        </Box>
-      </ViewShell>
-    );
-  }
-
-  const { descriptor } = session;
-  const elapsed = fmtElapsed(descriptor.startedAt, descriptor.finishedAt ?? now);
+  // Derived values gated on session presence. Computed BEFORE the early return so they can
+  // feed the hooks below — every Hook must run on every render in the same order, including
+  // renders where `session` is absent. The values below collapse to undefined when no session
+  // is registered, and each downstream hook short-circuits to a safe default in that case.
+  const descriptor = session?.descriptor;
   const tasksDone = bucketed?.tasks.filter((t) => t.status === 'completed').length ?? 0;
   const tasksTotal = bucketed?.tasks.length ?? 0;
-  const threeColumn = term.columns >= THREE_COL_BREAKPOINT;
-  const twoColumn = !threeColumn && term.columns >= TWO_COL_BREAKPOINT;
-  // Intermediate breakpoint (100–139 cols): a compact two-column layout with the rail
-  // collapsed to status glyphs (no labels). Below 100 cols we drop the rail entirely.
-  const compactTwoColumn = !threeColumn && !twoColumn && term.columns >= NARROW_FLOW_STEPS_BREAKPOINT;
-  const singleColumn = !threeColumn && !twoColumn && !compactTwoColumn;
-
-  const baseFlowStepsRows = isRunning ? Math.max(8, term.rows - 22) : 16;
-  const flowStepsRows = singleColumn ? NARROW_FLOW_STEPS_ROWS : baseFlowStepsRows;
-  const tasksMaxSignals = isRunning ? 6 : 12;
-  const logRows = isRunning ? 6 : 10;
 
   // Current task = the first non-completed one — which is `running` mid-task and `pending` in
   // the brief transition window between tasks. Completed/failed/aborted/skipped tasks are
@@ -306,9 +288,8 @@ export const ExecuteView = (): React.JSX.Element => {
   const currentTask = currentTaskIdx >= 0 ? bucketed?.tasks[currentTaskIdx] : undefined;
   const currentTaskName =
     currentTask !== undefined
-      ? (descriptor.taskNames?.get(currentTask.id) ?? `${currentTask.id.slice(0, 8)}${glyphs.clipEllipsis}`)
+      ? (descriptor?.taskNames?.get(currentTask.id) ?? `${currentTask.id.slice(0, 8)}${glyphs.clipEllipsis}`)
       : undefined;
-  const currentSubStep = currentTask?.subSteps[currentTask.subSteps.length - 1]?.leafName;
 
   // Register the active-task summary provider so the global `y` (yank) hotkey can copy a
   // markdown snapshot of whatever task the operator is currently watching. The provider closes
@@ -316,18 +297,23 @@ export const ExecuteView = (): React.JSX.Element => {
   // change, so the closure always reflects the current frame. Cleanup clears the registration
   // on unmount or when the deps change — important because the global handler reads the
   // provider through a ref and a stale closure would leak yesterday's task name into copies.
+  //
+  // Stash `ui.setActiveTaskSummaryProvider` in a local so the dep is the stable callback —
+  // depending on `ui` itself would re-fire the effect every time any unrelated UI state
+  // (helpOpen, claims, …) toggled.
+  const setActiveTaskSummaryProvider = ui.setActiveTaskSummaryProvider;
   useEffect(() => {
     if (currentTask === undefined || currentTaskName === undefined) {
-      ui.setActiveTaskSummaryProvider(undefined);
+      setActiveTaskSummaryProvider(undefined);
       return undefined;
     }
     const task = currentTask;
     const displayName = currentTaskName;
-    ui.setActiveTaskSummaryProvider(() => renderActiveTaskSummary({ task, displayName }));
+    setActiveTaskSummaryProvider(() => renderActiveTaskSummary({ task, displayName }));
     return () => {
-      ui.setActiveTaskSummaryProvider(undefined);
+      setActiveTaskSummaryProvider(undefined);
     };
-  }, [currentTask, currentTaskName, ui]);
+  }, [currentTask, currentTaskName, setActiveTaskSummaryProvider]);
 
   // Elapsed time on the latest attempt of the active task — drives the cancel-scope overlay's
   // "estimated wasted output" hint. Sourced from the most recent `task-attempt-started` event
@@ -386,6 +372,54 @@ export const ExecuteView = (): React.JSX.Element => {
   const onDismissCancelScope = React.useCallback(() => {
     setCancelScopeOpen(false);
   }, []);
+
+  // Synchronous criteria map — built from the in-memory Task[] state already polled above.
+  // Audit [05]: `Task.verificationCriteria` is the canonical source; the panel never reads
+  // `done-criteria.md` (file no longer exists). Each criterion renders to a single line that
+  // surfaces the id + check kind + (auto) command + assertion so operators can audit auto
+  // checks at a glance. Empty arrays are passed through so the panel can render a "no
+  // criteria declared" affordance instead of guessing.
+  const taskCriteriaById = useMemo<ReadonlyMap<string, readonly string[]> | undefined>(() => {
+    if (taskState === undefined) return undefined;
+    const m = new Map<string, readonly string[]>();
+    for (const t of taskState) {
+      const bullets = t.verificationCriteria.map((c) =>
+        c.check === 'auto' && c.command !== undefined
+          ? `[${c.id}] auto \`${c.command}\` — ${c.assertion}`
+          : `[${c.id}] manual — ${c.assertion}`
+      );
+      m.set(String(t.id), bullets);
+    }
+    return m;
+  }, [taskState]);
+
+  // Early-return for "no session in registry" must come AFTER every hook above so the Hook
+  // call order is identical across renders. Hooks below this line do not exist — every Hook
+  // the view needs has already run.
+  if (!session || descriptor === undefined) {
+    return (
+      <ViewShell title="Implement" subtitle="(unknown session)">
+        <Box paddingX={spacing.indent}>
+          <Text dimColor>The session id was not found in the registry. It may have been removed.</Text>
+        </Box>
+      </ViewShell>
+    );
+  }
+
+  const elapsed = fmtElapsed(descriptor.startedAt, descriptor.finishedAt ?? now);
+  const threeColumn = term.columns >= THREE_COL_BREAKPOINT;
+  const twoColumn = !threeColumn && term.columns >= TWO_COL_BREAKPOINT;
+  // Intermediate breakpoint (100–139 cols): a compact two-column layout with the rail
+  // collapsed to status glyphs (no labels). Below 100 cols we drop the rail entirely.
+  const compactTwoColumn = !threeColumn && !twoColumn && term.columns >= NARROW_FLOW_STEPS_BREAKPOINT;
+  const singleColumn = !threeColumn && !twoColumn && !compactTwoColumn;
+
+  const baseFlowStepsRows = isRunning ? Math.max(8, term.rows - 22) : 16;
+  const flowStepsRows = singleColumn ? NARROW_FLOW_STEPS_ROWS : baseFlowStepsRows;
+  const tasksMaxSignals = isRunning ? 6 : 12;
+  const logRows = isRunning ? 6 : 10;
+
+  const currentSubStep = currentTask?.subSteps[currentTask.subSteps.length - 1]?.leafName;
 
   // Active-attempt model display. For implement runs the launcher projects both gen/eval
   // models onto the descriptor; when they differ render `<gen> → <eval> (eval)` so the
@@ -508,26 +542,6 @@ export const ExecuteView = (): React.JSX.Element => {
   // expand a commit-message row). Disabled while any modal owns the keyboard so the cursor
   // can't fight the help overlay (`?`), the progress overlay (`g`), or a prompt.
   const tasksInputActive = !ui.helpOpen && !ui.progressOpen && !ui.promptActive;
-
-  // Synchronous criteria map — built from the in-memory Task[] state already polled above.
-  // Audit [05]: `Task.verificationCriteria` is the canonical source; the panel never reads
-  // `done-criteria.md` (file no longer exists). Each criterion renders to a single line that
-  // surfaces the id + check kind + (auto) command + assertion so operators can audit auto
-  // checks at a glance. Empty arrays are passed through so the panel can render a "no
-  // criteria declared" affordance instead of guessing.
-  const taskCriteriaById = useMemo<ReadonlyMap<string, readonly string[]> | undefined>(() => {
-    if (taskState === undefined) return undefined;
-    const m = new Map<string, readonly string[]>();
-    for (const t of taskState) {
-      const bullets = t.verificationCriteria.map((c) =>
-        c.check === 'auto' && c.command !== undefined
-          ? `[${c.id}] auto \`${c.command}\` — ${c.assertion}`
-          : `[${c.id}] manual — ${c.assertion}`
-      );
-      m.set(String(t.id), bullets);
-    }
-    return m;
-  }, [taskState]);
 
   const tasksPanel =
     bucketed !== undefined ? (

--- a/src/application/ui/tui/views/home-view.tsx
+++ b/src/application/ui/tui/views/home-view.tsx
@@ -69,7 +69,9 @@ export const HomeView = (): React.JSX.Element => {
   const snapshot = state.kind === 'ok' ? state.value : undefined;
   const hasProject = snapshot?.project !== undefined;
   const currentSprint = snapshot?.sprint;
-  const recentSprints = snapshot?.recentSprints ?? [];
+  // Stabilise the empty-array fallback so downstream `useMemo`s keyed on `recentSprints` don't
+  // re-run whenever this render's `??` would allocate a fresh `[]`.
+  const recentSprints = useMemo(() => snapshot?.recentSprints ?? [], [snapshot?.recentSprints]);
 
   // Transient "✓ now on <sprint-name>" line above the menu. Two sources feed it:
   //   1. The shared `selection.lastSwitch` record — fires for picker / sprint-detail `m` /

--- a/src/application/ui/tui/views/pick-project-view.tsx
+++ b/src/application/ui/tui/views/pick-project-view.tsx
@@ -40,7 +40,9 @@ export const PickProjectView = (): React.JSX.Element => {
     return r.value;
   }, []);
 
-  const projects = state.kind === 'ok' ? state.value : [];
+  // Stable identity for the loading-state fallback so the downstream `useMemo` keyed on
+  // `projects` doesn't re-run on every render while loading.
+  const projects = useMemo(() => (state.kind === 'ok' ? state.value : []), [state]);
 
   // Pre-seed the cursor to the already-selected project (set by launch from the persisted
   // last-selection). On reload we re-cap the index against the current list length.

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -266,7 +266,12 @@ export const PickSprintView = (): React.JSX.Element => {
     [deps.sprintRepo, deps.projectRepo]
   );
 
-  const data: PickerData = state.kind === 'ok' ? state.value : { sprints: [], projectsById: new Map() };
+  // Stabilise the loading-state placeholder so `useMemo(buildGroups, [data, …])` keeps its
+  // identity across renders while the fetch is pending.
+  const data: PickerData = useMemo(
+    () => (state.kind === 'ok' ? state.value : { sprints: [], projectsById: new Map() }),
+    [state]
+  );
 
   const groups = useMemo(() => buildGroups(data, selection.projectId, scopeAll), [data, selection.projectId, scopeAll]);
   // Only inject the `+ Create new sprint` action row when a project is selected — without one

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -232,7 +232,8 @@ export const ProjectDetailView = (): React.JSX.Element => {
   });
 
   // Claim the global-key mute while the confirm prompt is mounted.
-  useEffect(() => (confirmRemove !== undefined ? ui.claimPrompt() : undefined), [confirmRemove, ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (confirmRemove !== undefined ? claimPrompt() : undefined), [confirmRemove, claimPrompt]);
 
   const handleRemoveConfirmed = async (target: Repository, confirmed: boolean): Promise<void> => {
     setConfirmRemove(undefined);

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -92,7 +92,8 @@ export const ProjectsView = (): React.JSX.Element => {
   });
 
   // Claim the global-key mute while the confirm prompt is mounted.
-  useEffect(() => (confirmDelete !== undefined ? ui.claimPrompt() : undefined), [confirmDelete, ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (confirmDelete !== undefined ? claimPrompt() : undefined), [confirmDelete, claimPrompt]);
 
   const handleDeleteConfirmed = async (target: Project, confirmed: boolean): Promise<void> => {
     setConfirmDelete(undefined);

--- a/src/application/ui/tui/views/sessions-view.tsx
+++ b/src/application/ui/tui/views/sessions-view.tsx
@@ -39,7 +39,8 @@ export const SessionsView = (): React.JSX.Element => {
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
   // Claim the global-key mute while the confirm prompt is mounted.
-  useEffect(() => (confirmCancel !== undefined ? ui.claimPrompt() : undefined), [confirmCancel, ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (confirmCancel !== undefined ? claimPrompt() : undefined), [confirmCancel, claimPrompt]);
 
   useInput((input) => {
     if (ui.helpOpen || ui.promptActive || confirmCancel !== undefined) return;

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -292,12 +292,13 @@ export const SettingsView = (): React.JSX.Element => {
   // Tie the prompt-active claim to the editing-field state so React's effect cleanup matches
   // the claim 1:1. Earlier we toggled imperatively from inside event handlers and the boolean
   // got clobbered by the PromptHost when its queue was empty.
+  const claimPrompt = ui.claimPrompt;
   useEffect(
     () =>
       editingField !== undefined || customModelField !== undefined || pendingPreset !== undefined
-        ? ui.claimPrompt()
+        ? claimPrompt()
         : undefined,
-    [editingField, customModelField, pendingPreset, ui.claimPrompt]
+    [editingField, customModelField, pendingPreset, claimPrompt]
   );
 
   const closeEditor = (): void => {

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -182,7 +182,9 @@ export const SprintDetailView = (): React.JSX.Element => {
   // navigation.
 
   const sprint = state.kind === 'ok' ? state.value.sprint : undefined;
-  const tasks = state.kind === 'ok' ? state.value.tasks : [];
+  // Stable identity for the empty-tasks fallback so the downstream `useMemo` doesn't re-fire
+  // on every render while loading.
+  const tasks = useMemo(() => (state.kind === 'ok' ? state.value.tasks : []), [state]);
   const focusList = useMemo(() => (sprint !== undefined ? buildFocusList(sprint, tasks) : []), [sprint, tasks]);
 
   const [cursorIdx, setCursorIdx] = useState(0);
@@ -373,11 +375,13 @@ export const SprintDetailView = (): React.JSX.Element => {
   });
 
   // Mute global keys while the confirm prompt is mounted.
-  useEffect(() => (confirmRemove !== undefined ? ui.claimPrompt() : undefined), [confirmRemove, ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  const claimEscape = ui.claimEscape;
+  useEffect(() => (confirmRemove !== undefined ? claimPrompt() : undefined), [confirmRemove, claimPrompt]);
 
   // Claim `esc` while the detail card is open so the local handler can close the card without
   // the global `router.pop()` racing it and dumping the user back to the Sprints list.
-  useEffect(() => (inDetail ? ui.claimEscape() : undefined), [inDetail, ui.claimEscape]);
+  useEffect(() => (inDetail ? claimEscape() : undefined), [inDetail, claimEscape]);
 
   const handleRemoveConfirmed = async (target: Ticket, confirmed: boolean): Promise<void> => {
     setConfirmRemove(undefined);

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -81,6 +81,9 @@ export const SprintsView = (): React.JSX.Element => {
     return () => {
       cancelled = true;
     };
+    // `focusedSprint?.id` is the only piece of focusedSprint we read; depending on the full
+    // object would re-fire whenever the sprint list reloads with semantically-identical data.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- id is the load axis
   }, [focusedSprint?.id, deps.taskRepo]);
 
   const stuckTasks = focusedSprintTasks.filter((t) => t.status === 'blocked' || t.status === 'in_progress');
@@ -96,7 +99,8 @@ export const SprintsView = (): React.JSX.Element => {
   ]);
 
   // Claim the global-key mute while the confirm prompt is mounted.
-  useEffect(() => (confirmDelete !== undefined ? ui.claimPrompt() : undefined), [confirmDelete, ui.claimPrompt]);
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (confirmDelete !== undefined ? claimPrompt() : undefined), [confirmDelete, claimPrompt]);
 
   const launchCreateSprint = async (): Promise<void> => {
     if (selection.projectId === undefined) {


### PR DESCRIPTION
## Summary

- **Conditional Hooks fix** — moved 7 hooks above the early-return in `execute-view.tsx`. Caught by `eslint-plugin-react-hooks` (`rules-of-hooks: error`). **Suspected — not proven — root of the recurring 8h V8 OOM**: when `SessionDescriptor` flickers undefined↔defined (via `SessionManager`'s TTL/LRU eviction), the React hook list desyncs and subscriptions registered after the early return don't pair with cleanups across re-mounts.
- **25 exhaustive-deps warnings cleared** — stable-callback extraction (`ui.claimPrompt` / `claimEscape`) across 9 views, `prompt-host`, `use-edit-field`; ref-capture in `use-async-load` mirroring the `use-event-bus` filterRef pattern; \`useMemo\` wraps for unstable \`?? []\` fallbacks; explicit dep on \`scroll-region\`'s `useLayoutEffect`. Two disables with rationale (`step-trace`'s in-place ring-buffer, `sprints-view`'s id-axis).
- **Plugins wired permanently** — `eslint-plugin-react-hooks` + `eslint-plugin-sonarjs` subset in \`eslint.config.ts\` so this category can't regress. \`Plugin\` cast at the boundary to satisfy \`exactOptionalPropertyTypes\`.

## Test plan

- [x] \`pnpm typecheck\` green
- [x] \`pnpm lint\` 0 errors / 0 warnings
- [x] \`pnpm test\` 2363 tests pass
- [ ] Burn-in: next long implement run completes without OOM (the real validation)