### PR TITLE
fix: TUI readability/scroll, non-Claude eval resilience, refine signal hardening

### DIFF
--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -8,3 +8,5 @@
 - [project_global_modal_overlay_pattern.md](project_global_modal_overlay_pattern.md) — per-view inline vs App-Layout-level overlay modal; Layout-level wins for sprint-scoped overlays (~3 files vs 15)
 - [project_display_clip_markers.md](project_display_clip_markers.md) — audit-[03] display-clip marker tokens (`…` / `▼ more`); truncate at display boundary, never at persistence
 - [project_implement_role_meta_sidecar.md](project_implement_role_meta_sidecar.md) — stamp-role-meta leaves persist per-round AI attribution to rounds/<N>/<role>/meta.json; preStampedRoundNum ctx seam isolates round claiming
+- [project_recoverable_turn_error_policy.md](project_recoverable_turn_error_policy.md) — gen-eval turn errors block the task (self-blocked exit) instead of aborting the run; Aborted/RateLimit still propagate; via isRecoverableTurnError
+- [project_provider_stream_session_fields.md](project_provider_stream_session_fields.md) — empirical session-id/usage JSONL field names: codex thread_id on thread.started; copilot sessionId on result record

--- a/.claude/agent-memory/implementer/project_provider_stream_session_fields.md
+++ b/.claude/agent-memory/implementer/project_provider_stream_session_fields.md
@@ -1,0 +1,15 @@
+---
+name: provider-stream-session-fields
+description: empirically-confirmed session-id and usage JSONL field names for codex-cli 0.130 and copilot 1.0.51
+metadata:
+  type: project
+---
+
+Empirically captured (2026-05-26) the real `--json` / `--output-format=json` stdout of the installed AI CLIs, for the file-based provider contract parsers in `src/integration/ai/providers/<tool>/`:
+
+- **codex-cli 0.130.x** (`headless.ts` `consumeMetaLines`): session id is `thread_id` on the leading `{"type":"thread.started","thread_id":"<uuid>"}` record — NOT `session_id`. Usage is on the trailing `{"type":"turn.completed","usage":{"input_tokens","output_tokens",...}}`. The `thread_id` UUID is what `codex exec resume <id>` accepts, so it round-trips through `session.resume`. Parser recognises `thread_id` first, then legacy `session_id`/`sessionId` for back-compat.
+- **copilot 1.0.51** (`parse-stream.ts` / `headless.ts`): session id is `sessionId` on the TRAILING `{"type":"result",...,"sessionId":"<uuid>"}` record (not a leading meta line). The existing `sessionId` recognition is correct; first-`sessionId`-wins is safe because only the `result` record carries that key. `result.usage` has no token counts (premiumRequests/durations only); `outputTokens` appears on `assistant.message` records. No code change was needed for copilot — only a doc-comment fix.
+
+**Why:** the lead's diagnosis said codex session-id capture was broken (always undefined → no resume, no TokenUsageEvent). Confirmed against the binary.
+
+**How to apply:** if codex/copilot session capture or token usage looks broken again, re-capture live stdout (`printf 'say hi' | codex exec --skip-git-repo-check --json -` ; `copilot --output-format=json -p "say hi"`) before editing the parser — vendors tweak these shapes between releases. There is no `timeout` on macOS; run the capture bare.

--- a/.claude/agent-memory/implementer/project_recoverable_turn_error_policy.md
+++ b/.claude/agent-memory/implementer/project_recoverable_turn_error_policy.md
@@ -1,0 +1,15 @@
+---
+name: recoverable-turn-error-policy
+description: gen-eval turn errors block the task instead of aborting the run, except Aborted/RateLimit which propagate
+metadata:
+  type: project
+---
+
+The gen-eval `loop` primitive propagates any body `Result.error`, which aborts the whole per-task subchain AND every remaining todo task. To stop one bad AI turn from taking down the entire implement run, `runGeneratorTurnUseCase` / `runEvaluatorTurnUseCase` (in `src/business/task/`) classify a failed `callImplement`/`callEvaluate` via `isRecoverableTurnError(err)` (in `src/business/task/turn-error-policy.ts`):
+
+- `Aborted` / `RateLimit` codes → still `Result.error` (propagate, abort the run). Aborted = user cancel (CLAUDE.md transparent-propagation rule); RateLimit = adapter already exhausted 429 retries.
+- everything else (ParseError schema/json, InvalidStateError signals-missing / spawn-exit-N, MigrationGapError) → `Result.ok` with a `self-blocked` exit. The validator's message is preserved in the block reason.
+
+**Why:** non-Claude providers (codex/copilot) trip the strict signals.json contract far more often than Claude, especially the evaluator (default evaluator is codex).
+
+**How to apply:** The evaluator's recoverable failure MUST reach a `blocked` task, NOT `malformed` — `settle-attempt` treats `malformed` (no blockedReason) as done-with-warning, which would mark an UNGRADED change `done`. `EvaluatorTurnExit` was widened with a `self-blocked` variant (it's a subset of `GenEvalExit`). The evaluator leaf maps `out.exit` onto `ctx.lastExit`; `finalize-gen-eval`'s `mapExit` turns `self-blocked` into `{verdict:'failed', blockedReason}`, and `commit-task` is guarded on `lastBlockReason === undefined` so the ungraded change is never committed. See [[project_implement_role_meta_sidecar]] for the round/role ctx seams.

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -196,8 +196,9 @@ export const evaluatorLeaf = (deps: EvaluatorLeafDeps, taskId: TaskId): Element<
 
           // Validate `signals.json` against the evaluator contract. Failure surfaces a
           // domain error (signals-missing / invalid-json / schema-mismatch / migration-gap)
-          // with a precise hint — the surrounding loop's critique injection picks it up on
-          // the next round.
+          // with a precise hint. `runEvaluatorTurnUseCase` converts a recoverable validation
+          // failure into a `self-blocked` exit (task settles as blocked — the ungraded change is
+          // NOT marked done; run continues); only a fatal `Aborted`/`RateLimit` propagates.
           const validated = await validateSignalsFile(outputDir, evaluatorOutputContract);
           if (!validated.ok) return Result.error(validated.error);
           const signals = validated.value;

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -269,8 +269,9 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
 
           // Validate `signals.json` against the generator contract. Failure surfaces a
           // domain error (signals-missing / invalid-json / schema-mismatch / migration-gap)
-          // with a precise hint — the surrounding loop's critique injection picks it up on
-          // the next round.
+          // with a precise hint. `runGeneratorTurnUseCase` converts a recoverable validation
+          // failure into a `self-blocked` exit (task settles as blocked, run continues); only
+          // a fatal `Aborted`/`RateLimit` propagates and aborts the run.
           const validated = await validateSignalsFile(outputDir, generatorOutputContract);
           if (!validated.ok) return Result.error(validated.error);
           const signals = validated.value;

--- a/src/application/flows/refine/leaves/refine-ticket-interactive.ts
+++ b/src/application/flows/refine/leaves/refine-ticket-interactive.ts
@@ -1,4 +1,5 @@
-import { dirname } from 'node:path';
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -15,7 +16,7 @@ import { leaf } from '@src/application/chain/build/leaf.ts';
 import { renderSidecars } from '@src/integration/ai/contract/_engine/render-sidecars.ts';
 import { validateSignalsFile } from '@src/integration/ai/contract/_engine/validate-signals-file.ts';
 import type { RefineCtx } from '@src/application/flows/refine/ctx.ts';
-import { refineOutputContract } from '@src/application/flows/refine/leaves/refine.contract.ts';
+import { partitionRefineSignals, refineOutputContract } from '@src/application/flows/refine/leaves/refine.contract.ts';
 import type { IssuePusher } from '@src/business/scm/issue-pusher.ts';
 import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 
@@ -88,6 +89,65 @@ export interface RefineTicketInteractiveDeps {
 
 /** Footer appended to every pushed body so future readers know where it came from. */
 const REFINED_FOOTER = (now: string): string => `\n\n---\n_Refined by ralphctl on ${now}_`;
+
+/**
+ * Refine-specific signals-missing message. The shared `validateSignalsFile` hint is generic
+ * ("inspect the per-spawn directory…"); for refine the common real cause is the user exiting
+ * the interactive AI session before it finished writing `signals.json`. Rewrite the
+ * `signals-missing` error with an actionable, refine-framed message so the TUI's failure card
+ * tells the user exactly what happened and what to do — the ticket is untouched, re-run and let
+ * the AI finish. Every other error (invalid-json / schema-mismatch / migration-gap / I/O, and
+ * `AbortError` if it ever reached here) passes through verbatim.
+ */
+const remapRefineSignalsError = <E extends { readonly message?: string }>(error: E): E => {
+  if (error instanceof InvalidStateError && error.message.includes('signals-missing')) {
+    return new InvalidStateError({
+      entity: 'refine-ticket-interactive',
+      currentState: 'post-spawn',
+      attemptedAction: 'validate-signals',
+      message:
+        'Refinement not saved — the AI session ended before writing signals.json. The ticket is unchanged; re-run refine and let the AI finish writing before you exit.',
+      hint: 'The interactive AI must write signals.json (carrying the refined-ticket) before it exits. Closing the session early leaves nothing for the harness to read.',
+    }) as unknown as E;
+  }
+  return error;
+};
+
+/**
+ * Best-effort warn-log for malformed auxiliary signals the lenient refine contract dropped.
+ * `validateSignalsFile` only returns the survivors, so to name what was discarded the leaf
+ * re-reads `signals.json` and runs the same per-element partition the contract schema uses
+ * (see {@link partitionRefineSignals}). Diagnostics only — never blocks refinement and never
+ * throws; any read / parse hiccup here is swallowed (the authoritative validation already
+ * succeeded by the time this runs).
+ */
+const warnDroppedSignals = async (deps: RefineTicketInteractiveDeps, outputDir: AbsolutePath): Promise<void> => {
+  try {
+    const bytes = await fs.readFile(join(String(outputDir), 'signals.json'), 'utf8');
+    const raw: unknown = JSON.parse(bytes);
+    // Legacy bare-array shape (migrations[0] target) or the canonical { signals } wrapper.
+    const inner = Array.isArray(raw) ? raw : (raw as { signals?: unknown }).signals;
+    if (!Array.isArray(inner)) return;
+    // Match `validateSignalsFile`'s timestamp leniency so a signal missing only `timestamp`
+    // (which the validator stamps and keeps) is not mis-reported here as dropped.
+    const now = new Date().toISOString();
+    const defaulted = inner.map((sig) => {
+      if (typeof sig !== 'object' || sig === null) return sig;
+      const s = sig as Record<string, unknown>;
+      return typeof s.timestamp === 'string' && s.timestamp.length > 0 ? sig : { ...s, timestamp: now };
+    });
+    const { dropped } = partitionRefineSignals(defaulted);
+    if (dropped.length === 0) return;
+    const summary = dropped.map((d) => `[${String(d.index)}] type=${d.type ?? '?'} (${d.reason})`).join('; ');
+    deps.logger
+      .named('refine.signals')
+      .warn(`dropped ${String(dropped.length)} malformed auxiliary signal(s) — refinement kept`, {
+        dropped: summary,
+      });
+  } catch {
+    // Diagnostics only — never let a re-read failure disturb a successful refinement.
+  }
+};
 
 interface RefineTicketInteractiveInput {
   readonly sprint: Sprint;
@@ -180,10 +240,16 @@ export const refineTicketInteractiveLeaf = (
 
         // Validate signals.json against the refine contract. Failure surfaces a domain error
         // (signals-missing / invalid-json / schema-mismatch / migration-gap) with a precise
-        // hint.
+        // hint. The refine contract is resilient — malformed auxiliary signals are dropped, not
+        // fatal — so the only validation failures left are genuine: a missing file, unparseable
+        // JSON, or zero / two valid `refined-ticket` entries.
         const validated = await validateSignalsFile(outputDir, refineOutputContract);
-        if (!validated.ok) return Result.error(validated.error);
+        if (!validated.ok) return Result.error(remapRefineSignalsError(validated.error));
         const signals = validated.value;
+
+        // Diagnostics — name any malformed auxiliary signals the lenient contract just dropped.
+        // Refinement still succeeds; the warn keeps the drop out of the silent zone.
+        await warnDroppedSignals(deps, outputDir);
 
         // Fan out every validated signal to the application bus so the TUI's `ai-signal`
         // subscribers render live updates. Source tag identifies the leaf for multi-leaf

--- a/src/application/flows/refine/leaves/refine.contract.ts
+++ b/src/application/flows/refine/leaves/refine.contract.ts
@@ -14,10 +14,26 @@ import type { AiOutputContract } from '@src/integration/ai/contract/_engine/type
  *   - narrative fan-out: `learning`, `note`, `decision`
  *   - exactly one `refined-ticket` carrying the AI's proposed requirements body
  *
+ * **Resilient by design — refine-only.** The `refined-ticket` is the sole essential output
+ * (it projects onto the `Ticket` entity via `refineTicketUseCase`); `learning` / `note` /
+ * `decision` are nice-to-haves fanned out to the EventBus for display. A drifting prompt or a
+ * flaky model occasionally emits a malformed auxiliary signal (e.g. a `decision` carrying
+ * `body` where the schema wants `text`). Under the shared strict-union validation a single
+ * malformed auxiliary element used to fail the whole `safeParse`, silently discarding a
+ * perfectly-good refinement. To prevent that, `signalsSchema` here parses **per element**:
+ * each array entry is `safeParse`d against the four known signal schemas; failures are dropped
+ * (the leaf logs a `warn` naming them — see {@link partitionRefineSignals}); valid entries are
+ * kept. The `.refine` then enforces exactly one `refined-ticket` over the survivors.
+ *
+ * This leniency is deliberately local to the refine path — `validateSignalsFile` itself stays
+ * strict for every other flow (implement / evaluate / readiness), which want hard rejection.
+ *
  * `refined-ticket` is constrained to exactly one occurrence so the leaf has a single
- * deterministic body to thread into `refineTicketUseCase`. The Zod `refine` rejects a payload
- * with zero or two `refined-ticket` entries with a clear message; the leaf surfaces the issue
- * via `validateSignalsFile`.
+ * deterministic body to thread into `refineTicketUseCase`. The `.refine` rejects a payload
+ * whose survivors carry zero or two `refined-ticket` entries with a clear message; the leaf
+ * surfaces the issue via `validateSignalsFile`. A malformed `refined-ticket` itself is dropped
+ * by the per-element parse, which then trips the zero-`refined-ticket` rejection — a malformed
+ * essential signal is a real failure the user must know about, not silently swallowed.
  *
  * Sidecars: none. The body is projected onto the `Ticket` entity directly — no operator-facing
  * file is rendered. `renderSidecars` is still invoked (with an empty rule set) so the leaf's
@@ -32,11 +48,63 @@ import type { AiOutputContract } from '@src/integration/ai/contract/_engine/type
 
 type RefineSignal = LearningSignal | NoteSignal | DecisionSignal | RefinedTicketSignal;
 
+const refineSignalElementSchema = z.union([
+  learningSignalSchema,
+  noteSignalSchema,
+  decisionSignalSchema,
+  refinedTicketSignalSchema,
+]);
+
 const exactlyOneRefinedTicket = (signals: ReadonlyArray<{ readonly type: string }>): boolean =>
   signals.filter((s) => s.type === 'refined-ticket').length === 1;
 
+/** One element dropped by {@link partitionRefineSignals} because it failed per-element parse. */
+export interface DroppedRefineSignal {
+  /** Zero-based index of the element in the on-disk `signals` array. */
+  readonly index: number;
+  /** The element's declared `type`, when it was a string — for the warn message. */
+  readonly type: string | undefined;
+  /** Compact reason (the Zod issue summary) for why the element was dropped. */
+  readonly reason: string;
+}
+
+/**
+ * Lenient per-element partition of a raw `signals` array. Each entry is `safeParse`d against
+ * the four refine signal schemas; survivors land in `kept`, failures in `dropped` (carrying
+ * the declared `type` and a compact reason for the leaf's warn log). The single source of
+ * truth for the leniency — both `signalsSchema` and the leaf's warn path call through here so
+ * "what the schema kept" and "what the leaf reports dropped" can never diverge.
+ *
+ * @public
+ */
+export const partitionRefineSignals = (
+  raw: readonly unknown[]
+): { readonly kept: readonly RefineSignal[]; readonly dropped: readonly DroppedRefineSignal[] } => {
+  const kept: RefineSignal[] = [];
+  const dropped: DroppedRefineSignal[] = [];
+  raw.forEach((element, index) => {
+    const parsed = refineSignalElementSchema.safeParse(element);
+    if (parsed.success) {
+      kept.push(parsed.data as RefineSignal);
+      return;
+    }
+    const declaredType =
+      typeof element === 'object' && element !== null && typeof (element as { type?: unknown }).type === 'string'
+        ? (element as { type: string }).type
+        : undefined;
+    dropped.push({ index, type: declaredType, reason: parsed.error.issues[0]?.message ?? 'invalid signal shape' });
+  });
+  return { kept, dropped };
+};
+
+/**
+ * Lenient signals schema — accepts any array, drops elements that fail per-element parse,
+ * then enforces exactly one surviving `refined-ticket`. See the module doc for why this is
+ * deliberately more forgiving than the shared strict-union path.
+ */
 const signalsArraySchemaRaw = z
-  .array(z.union([learningSignalSchema, noteSignalSchema, decisionSignalSchema, refinedTicketSignalSchema]))
+  .array(z.unknown())
+  .transform((raw) => partitionRefineSignals(raw).kept)
   .refine(exactlyOneRefinedTicket, 'exactly one refined-ticket signal per refine spawn');
 
 /**

--- a/src/application/ui/tui/components/field-list.tsx
+++ b/src/application/ui/tui/components/field-list.tsx
@@ -21,6 +21,12 @@ export interface Field {
 
 export interface FieldListProps {
   readonly fields: readonly Field[];
+  /**
+   * Fixed label column width. When omitted the column auto-sizes to the widest label in the
+   * `fields` array (label length + colon + 1 space of padding), with `FIELD_LABEL_WIDTH` as
+   * the floor so callers with short labels still get the standard rhythm. Pass an explicit
+   * value to override (e.g. when two adjacent `FieldList` instances must share a column width).
+   */
   readonly labelWidth?: number;
 }
 
@@ -33,28 +39,43 @@ const padLabel = (label: string, width: number): string => {
   return withColon.padEnd(width, ' ');
 };
 
-export const FieldList = ({ fields, labelWidth = FIELD_LABEL_WIDTH }: FieldListProps): React.JSX.Element => (
-  <Box flexDirection="column">
-    {fields.map((f, i) => (
-      <Box key={`${f.label}-${String(i)}`} flexDirection="column">
-        <Box>
-          <Text dimColor>{padLabel(f.label, labelWidth)}</Text>
+/**
+ * Compute the label column width from the field set when no explicit width was given.
+ * Formula: max(label.length) + 2 (colon + one trailing space), floored at FIELD_LABEL_WIDTH.
+ * The extra space keeps a breathing gap between the longest label and its value.
+ */
+const resolveWidth = (fields: readonly Field[], explicit?: number): number => {
+  if (explicit !== undefined) return explicit;
+  if (fields.length === 0) return FIELD_LABEL_WIDTH;
+  const maxLen = fields.reduce((m, f) => Math.max(m, f.label.length), 0);
+  return Math.max(FIELD_LABEL_WIDTH, maxLen + 2);
+};
+
+export const FieldList = ({ fields, labelWidth }: FieldListProps): React.JSX.Element => {
+  const width = resolveWidth(fields, labelWidth);
+  return (
+    <Box flexDirection="column">
+      {fields.map((f, i) => (
+        <Box key={`${f.label}-${String(i)}`} flexDirection="column">
           <Box>
-            {typeof f.value === 'string' || typeof f.value === 'number' ? (
-              <Text dimColor={f.dim ?? false}>{f.value}</Text>
-            ) : (
-              f.value
-            )}
+            <Text dimColor>{padLabel(f.label, width)}</Text>
+            <Box>
+              {typeof f.value === 'string' || typeof f.value === 'number' ? (
+                <Text dimColor={f.dim ?? false}>{f.value}</Text>
+              ) : (
+                f.value
+              )}
+            </Box>
           </Box>
+          {f.hint !== undefined && (
+            <Box paddingLeft={width}>
+              <Text dimColor italic>
+                {f.hint}
+              </Text>
+            </Box>
+          )}
         </Box>
-        {f.hint !== undefined && (
-          <Box paddingLeft={labelWidth}>
-            <Text dimColor italic>
-              {f.hint}
-            </Text>
-          </Box>
-        )}
-      </Box>
-    ))}
-  </Box>
-);
+      ))}
+    </Box>
+  );
+};

--- a/src/application/ui/tui/components/scroll-region.tsx
+++ b/src/application/ui/tui/components/scroll-region.tsx
@@ -50,6 +50,13 @@ export const ScrollRegion = ({ children, disabled = false }: ScrollRegionProps):
   const maxOffset = (): number => Math.max(0, sizeRef.current.content - sizeRef.current.viewport);
   const clamp = (next: number): number => Math.max(0, Math.min(next, maxOffset()));
 
+  // No dep array: runs after every render so sizeRef stays current as content grows or
+  // shrinks (e.g. live trace entries arriving during an Implement run). The concern about
+  // "every render → setOffset → render" looping does NOT apply here: setOffset only fires
+  // when offset > max, i.e. when we need to clamp down. Once clamped, offset ≤ max on the
+  // next render so setOffset is not called again. Measurement reads Yoga computed heights
+  // which change only when layout changes; reading them is side-effect-free and cheap.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     if (viewportRef.current) {
       sizeRef.current.viewport = measureElement(viewportRef.current).height;
@@ -59,10 +66,7 @@ export const ScrollRegion = ({ children, disabled = false }: ScrollRegionProps):
     }
     const max = maxOffset();
     if (offset > max) setOffset(max);
-    // `offset` is the only externally-visible state this effect reads; including it in the dep
-    // list keeps the clamp correct AND tames the previous "no-deps" form which the React-Hooks
-    // linter flagged as an infinite-update risk (every render → setOffset → render).
-  }, [offset]);
+  });
 
   useInput(
     (input, key) => {

--- a/src/business/task/run-evaluator-turn.ts
+++ b/src/business/task/run-evaluator-turn.ts
@@ -9,6 +9,7 @@ import {
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
 import { computePlateauVerdict, type PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
+import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts';
 
 /**
  * Run one evaluator turn of the gen-eval loop. Drives a single AI evaluate call, inspects the
@@ -17,6 +18,11 @@ import { computePlateauVerdict, type PlateauTurnRecord } from '@src/business/tas
  * terminally (passed, malformed, or plateau).
  *
  * Decisions owned by this use case:
+ *  - `callEvaluate` returned a recoverable error (the reviewer never produced a usable
+ *     `signals.json` — wrong shape, wrong place, non-zero spawn exit) → `self-blocked` exit so
+ *     the task settles as `blocked` (NOT `malformed`, which settle-attempt treats as done-with-
+ *     warning and would mark an ungraded change `done`). Fatal errors (`Aborted`/`RateLimit`)
+ *     propagate as `Result.error` to abort the whole run — see {@link isRecoverableTurnError}.
  *  - No evaluation signal at all → `malformed` exit.
  *  - `evaluation.status === 'passed'` → `passed` exit.
  *  - `evaluation.status === 'malformed'` → `malformed` exit.
@@ -38,6 +44,7 @@ import { computePlateauVerdict, type PlateauTurnRecord } from '@src/business/tas
  */
 export type EvaluatorTurnExit =
   | { readonly kind: 'passed' }
+  | { readonly kind: 'self-blocked'; readonly reason: string }
   | { readonly kind: 'malformed'; readonly detail: string }
   | { readonly kind: 'plateau'; readonly dimensions: readonly string[] };
 
@@ -100,8 +107,23 @@ export const runEvaluatorTurnUseCase = async (
 
   const signalsResult = await props.callEvaluate(props.task);
   if (!signalsResult.ok) {
-    log.error('evaluate call failed', { taskId: props.task.id, error: signalsResult.error.message });
-    return Result.error(signalsResult.error);
+    const err = signalsResult.error;
+    // Fatal errors (user abort, rate-limit-after-retries) must abort the whole run — propagate.
+    // Everything else is a recoverable signals-contract failure: self-block THIS task so it
+    // settles as `blocked` (the generator's work is NOT committed/marked-done ungraded — commit
+    // is gated on no block reason). Routing to `malformed` instead would mark the change done.
+    if (!isRecoverableTurnError(err)) {
+      log.error('evaluate call failed (fatal — propagating)', { taskId: props.task.id, error: err.message });
+      return Result.error(err);
+    }
+    log.warn('evaluator did not produce a valid signals.json — blocking task', {
+      taskId: props.task.id,
+      error: err.message,
+    });
+    return Result.ok({
+      task: props.task,
+      exit: { kind: 'self-blocked', reason: `evaluator did not produce a valid signals.json: ${err.message}` },
+    });
   }
   const signals = signalsResult.value;
 

--- a/src/business/task/run-generator-turn.ts
+++ b/src/business/task/run-generator-turn.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@src/business/observability/logger.ts';
 import { type InProgressTask, recordRunningAttemptVerification } from '@src/domain/entity/task.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
+import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts';
 
 /**
  * Run one generator turn of the gen-eval loop. Drives a single AI implement call, inspects the
@@ -68,8 +69,23 @@ export const runGeneratorTurnUseCase = async (
 
   const signalsResult = await props.callImplement(props.task);
   if (!signalsResult.ok) {
-    log.error('implement call failed', { taskId: props.task.id, error: signalsResult.error.message });
-    return Result.error(signalsResult.error);
+    const err = signalsResult.error;
+    // Fatal errors (user abort, rate-limit-after-retries) must abort the whole run — propagate.
+    // Everything else is a recoverable signals-contract failure: block THIS task (so it surfaces
+    // and re-runs next launch) instead of taking down every remaining task. The error message
+    // lands in the block reason so the operator/progress.md shows WHY the turn failed.
+    if (!isRecoverableTurnError(err)) {
+      log.error('implement call failed (fatal — propagating)', { taskId: props.task.id, error: err.message });
+      return Result.error(err);
+    }
+    log.warn('generator did not produce a valid signals.json — blocking task', {
+      taskId: props.task.id,
+      error: err.message,
+    });
+    return Result.ok({
+      task: props.task,
+      exit: { kind: 'self-blocked', reason: `generator did not produce a valid signals.json: ${err.message}` },
+    });
   }
   const signals = signalsResult.value;
 

--- a/src/business/task/turn-error-policy.ts
+++ b/src/business/task/turn-error-policy.ts
@@ -1,0 +1,29 @@
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+
+/**
+ * Decide whether an AI-turn error (from `callImplement` / `callEvaluate`) is a *recoverable*
+ * contract failure that should block the in-flight task, or a *fatal* error that must propagate
+ * and abort the whole chain.
+ *
+ * Why this split exists: the gen-eval `loop` primitive propagates any body `Result.error`,
+ * which aborts the entire per-task subchain — and with it every remaining todo task. Non-Claude
+ * providers (codex / copilot) trip the strict `signals.json` contract far more often than Claude
+ * (wrong shape, wrong place, or not written at all), so a single bad turn used to take down the
+ * whole implement run. Converting these to a per-task block surfaces the failure (HARNESS-
+ * PRINCIPLES §5 "blocked surfaces them") while letting the other tasks run.
+ *
+ * Two error codes MUST still propagate (return `false`):
+ *   - `Aborted`   — user cancellation (Ctrl-C / TUI abort). CLAUDE.md §"AbortError is the one
+ *                   error chains propagate transparently." A guard converting it to a block
+ *                   would swallow the cancel.
+ *   - `RateLimit` — the adapter already exhausted its internal 429 retries; continuing to the
+ *                   next task would just re-hit the limit, so let it abort the run.
+ *
+ * Everything else — `InvalidStateError` signals-missing / spawn-exit-N (`invalid-state`),
+ * `ParseError` invalid-json / schema-mismatch (`parse-error`), `MigrationGapError`
+ * (`migration-gap`), and any other domain error — is treated as recoverable: block this task,
+ * keep the run going.
+ */
+export const isRecoverableTurnError = (err: DomainError): boolean =>
+  err.code !== ErrorCode.Aborted && err.code !== ErrorCode.RateLimit;

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -57,9 +57,11 @@ import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-
  * validates it post-spawn — the provider never touches signals.json. When `session.bodyFile`
  * is set, the adapter mirrors the raw body there for diagnostic capture (best-effort).
  *
- * Session id capture: codex emits JSONL meta events on stdout that carry `session_id` on the
- * leading config / startup record. The adapter line-buffers stdout, picks the first id out,
- * and discards the rest of the stream (the body is read from the tempfile).
+ * Session id capture: codex emits JSONL meta events on stdout. On codex-cli 0.130.x the id
+ * arrives as `thread_id` on the leading `{type:"thread.started"}` record (legacy `session_id` /
+ * `sessionId` are still recognised). The adapter line-buffers stdout, picks the first id out,
+ * and discards the rest of the stream (the body is read from the tempfile). The captured id is
+ * what `codex exec resume <id>` accepts, so it round-trips through `session.resume`.
  *
  * Permissions: only the two locked profiles (READ_ONLY / FULL_AUTO) are supported, since
  * those cover every wired chain. Half-permission combos surface `InvalidStateError` —
@@ -288,14 +290,21 @@ interface CodexMetaUpdate {
 }
 
 /**
- * Line-extract `session_id` / `model` / token-usage fields from codex's JSONL stdout. Returns
+ * Line-extract session-id / `model` / token-usage fields from codex's JSONL stdout. Returns
  * the residual tail (unterminated trailing chars). `onMeta` is invoked once per recognised
  * line carrying any of the fields; the caller dedupes (sessionId / model = first wins; usage
  * = last wins).
  *
- * Codex's `--json` stream is JSONL: the leading `{type:"config"}` record carries `session_id`,
- * subsequent `{type:"task_complete"|"thread_meta"|...}` records may carry `model` and/or a
- * token-count object. Schema-tolerant: any unrecognised structure is skipped silently.
+ * Codex's `--json` stream is JSONL. On codex-cli 0.130.x the session id arrives on the leading
+ * `{type:"thread.started", thread_id:"<uuid>"}` record — NOT a `session_id` field. We also keep
+ * recognising the legacy `session_id` / `sessionId` keys (older / future builds, and forward
+ * compat) so either shape populates the id. Token usage arrives on the trailing
+ * `{type:"turn.completed", usage:{input_tokens, output_tokens, …}}` record. Schema-tolerant:
+ * any unrecognised structure is skipped silently.
+ *
+ * The captured `thread_id` UUID is exactly what `codex exec resume <id>` accepts ("conversation/
+ * session id (UUID) or thread name"), so it round-trips back through `session.resume` to continue
+ * the conversation across gen-eval rounds.
  */
 const consumeMetaLines = (buffer: string, onMeta: (update: CodexMetaUpdate) => void): string => {
   let remaining = buffer;
@@ -308,7 +317,10 @@ const consumeMetaLines = (buffer: string, onMeta: (update: CodexMetaUpdate) => v
     if (trimmed.length === 0 || !trimmed.startsWith('{')) continue;
     try {
       const obj = JSON.parse(trimmed) as Record<string, unknown>;
-      const id = stringField(obj, 'session_id', 'sessionId');
+      // `thread_id` is the 0.130.x field (on the `thread.started` record); `session_id` /
+      // `sessionId` cover legacy / forward-compat builds. First non-empty id wins (deduped by
+      // the caller), so listing `thread_id` first matches the stream order.
+      const id = stringField(obj, 'thread_id', 'session_id', 'sessionId');
       const model = stringField(obj, 'model');
       const usageObj = obj['usage'];
       const source = isRecord(usageObj) ? usageObj : obj;
@@ -382,8 +394,8 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         if (update.model !== undefined && model === undefined) {
           model = update.model;
         }
-        // Last-write-wins on usage — codex's `task_complete` record carries the cumulative
-        // figure; earlier records (config / streaming chunks) report partials or nothing.
+        // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+        // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
         if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
         if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
       });
@@ -437,8 +449,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     // `session.outputDir`; the harness validates it post-spawn. The provider never writes
     // signals.json itself. The codex output tempfile body remains the forensic source for
     // `session.bodyFile` mirroring below.
-    // Persist captured session id as a sibling `sessionId` file. Codex emits the id on the
-    // leading JSONL config record; missing → skip (no empty marker). See persistSessionIdFile.
+    // Persist captured session id as a sibling `sessionId` file. Codex emits the id as
+    // `thread_id` on the leading `thread.started` JSONL record; missing → skip (no empty
+    // marker). See persistSessionIdFile.
     const sidWrote = await persistSessionIdFile(session.signalsFile, sessionId);
     if (sidWrote !== undefined && !sidWrote.ok) {
       deps.eventBus.publish({

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -371,9 +371,11 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         at: IsoTimestamp.now(),
       });
     }
-    // Persist captured session id as a sibling `sessionId` file. Copilot streams the id on a
-    // leading JSON meta line; if it was missing (banner-only streams, crash before meta) we
-    // skip rather than write an empty marker. See persistSessionIdFile for the contract.
+    // Persist captured session id as a sibling `sessionId` file. Copilot 1.0.51 emits the id as
+    // `sessionId` on the TRAILING `{type:"result"}` record (not a leading meta line); the parser
+    // captures it via first-`sessionId`-wins, and only that record carries the key so there is no
+    // false positive. If missing (banner-only streams, crash before the result record) we skip
+    // rather than write an empty marker. See persistSessionIdFile for the contract.
     const sidWrote = await persistSessionIdFile(session.signalsFile, sessionId);
     if (sidWrote !== undefined && !sidWrote.ok) {
       deps.eventBus.publish({

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -20,6 +20,7 @@ import type { TaskRepository } from '@src/domain/repository/task/task-repository
 import type { Task } from '@src/domain/entity/task.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import {
   absolutePath,
   FIXED_LATER,
@@ -904,6 +905,89 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(startEntries[1]).toContain(String(f.tasks[1]?.id));
   });
 
+  it('evaluator signals-contract failure on task 1 blocks task 1 but the run continues to task 2', async () => {
+    // Regression: a non-Claude evaluator that fails to produce a usable signals.json (wrong
+    // shape, wrong place, non-zero spawn exit) used to abort the WHOLE implement run via the
+    // loop's error propagation. It must now self-block ONLY task 1 (settled `blocked`, NOT
+    // `done` — the generator's ungraded change is never committed) and let task 2 run.
+    const f = await buildFixture(2, 1);
+    tracking(f);
+    const sprintRepo = inMemorySprintRepo(f.sprint);
+    const taskRepo = inMemoryTaskRepo(f.tasks);
+
+    // Generator always succeeds; the evaluator FAILS its signals.json on its first call only.
+    const generatorFake = createFakeAiProvider({
+      signals: { implement: [taskVerified('work landed')] },
+    });
+    const baseEvaluator = createFakeAiProvider({
+      signals: { evaluate: [evaluationPassed()] },
+    });
+    let evalCalls = 0;
+    // Wrap the evaluator so the FIRST evaluate spawn returns a signals-contract failure
+    // (mirrors a codex/copilot reviewer writing a malformed/absent signals.json); later
+    // evaluates pass through and write a valid passing verdict.
+    const evaluatorFake: HeadlessAiProvider = {
+      async generate(session) {
+        evalCalls += 1;
+        if (evalCalls === 1) {
+          return Result.error(
+            new InvalidStateError({
+              entity: 'codex-provider',
+              currentState: 'signals-missing',
+              attemptedAction: 'complete evaluation',
+              message: 'signals.json not found in outputDir',
+            })
+          );
+        }
+        return baseEvaluator.generate(session);
+      },
+    };
+
+    const baseDeps = buildDeps(
+      sprintRepo.repo,
+      inMemoryExecutionRepo(f.execution).repo,
+      taskRepo.repo,
+      generatorFake,
+      f.dir
+    );
+    const deps: ImplementDeps = { ...baseDeps, generatorProvider: generatorFake, evaluatorProvider: evaluatorFake };
+
+    const flow = createImplementFlow(deps, {
+      sprintId: f.sprint.id,
+      todoTasks: f.tasks,
+      repositories: FAKE_REPOSITORIES,
+      generatorProviderId: 'claude-code',
+      generatorModel: 'claude-opus-4-7',
+      evaluatorProviderId: 'openai-codex',
+      evaluatorModel: 'gpt-5.5',
+      progressFile: absolutePath(f.progressFile),
+      sprintDir: absolutePath(f.dir),
+    });
+
+    const runner = createRunner({
+      id: 'r-impl-eval-block',
+      element: flow,
+      initialCtx: { sprintId: f.sprint.id } satisfies ImplementCtx,
+    });
+    await runner.start();
+
+    // The whole run does NOT abort — it completes.
+    expect(runner.status).toBe('completed');
+    // Both tasks got an evaluate turn (task 1's failed, task 2's passed).
+    expect(evalCalls).toBe(2);
+
+    const persisted = taskRepo.tasks();
+    expect(persisted[0]?.status).toBe('blocked');
+    if (persisted[0]?.status === 'blocked') {
+      // The validator's precise message lands in the block reason for the operator.
+      expect(persisted[0].blockedReason).toContain('evaluator did not produce a valid signals.json');
+      expect(persisted[0].blockedReason).toContain('signals.json not found in outputDir');
+    }
+    expect(persisted[1]?.status).toBe('done');
+    // A mixed run (one done) still transitions the sprint to review.
+    expect(sprintRepo.current().status).toBe('review');
+  });
+
   it('proposed <commit-message> signal: harness commits with subject+body, not the default factory', async () => {
     const f = await buildFixture(1);
     tracking(f);
@@ -1591,10 +1675,11 @@ describe('createImplementFlow — gen-eval loop', () => {
   // An overnight run could hit a model output that's plain prose with no harness tags —
   // missed prompt cue, model degradation, etc. Under the audit-[09] contract, the evaluator's
   // `signals.json` MUST carry exactly one `evaluation` signal (`exactlyOne('evaluation')`
-  // refinement). A silent evaluator violates the schema; the leaf surfaces a ParseError and
-  // the chain terminates cleanly without running away. Wave 6 will swap the prompt to push
-  // the AI toward the new contract; until then, the failure surface is the operator's signal.
-  it('AI emits zero harness signals: chain terminates with a schema failure, no infinite loop', async () => {
+  // refinement). A silent evaluator violates the schema; the evaluator turn converts that
+  // recoverable ParseError into a self-block, so the TASK settles `blocked` (surfaced + re-
+  // runnable) while the CHAIN completes cleanly without running away. This is the resilience
+  // fix: one bad turn must not abort the whole run.
+  it('AI emits zero harness signals: task blocks on the schema failure, chain completes, no infinite loop', async () => {
     const f = await buildFixture(1, 1);
     tracking(f);
     const sprintRepo = inMemorySprintRepo(f.sprint);
@@ -1646,16 +1731,26 @@ describe('createImplementFlow — gen-eval loop', () => {
     });
     await runner.start();
 
-    // Schema violation in the evaluator surfaces as a ParseError — chain terminates failed,
-    // not completed. The point of THIS test is that the chain doesn't hang in a runaway loop:
-    // each role is called at most maxTurns (3) times.
-    expect(runner.status).toBe('failed');
+    // Schema violation in the evaluator surfaces as a recoverable ParseError → self-block →
+    // the task settles `blocked` and the chain COMPLETES (does not abort). The point of THIS
+    // test is that the chain doesn't hang in a runaway loop: each role is called at most
+    // maxTurns (3) times.
+    expect(runner.status).toBe('completed');
     expect(implCalls).toBeLessThanOrEqual(3);
     expect(evalCalls).toBeLessThanOrEqual(3);
     // Generator runs at least once; evaluator runs at least once (it's what surfaces the
     // schema error). Confirms the chain didn't short-circuit before invoking the AI at all.
     expect(implCalls).toBeGreaterThanOrEqual(1);
     expect(evalCalls).toBeGreaterThanOrEqual(1);
+
+    // The lone task is blocked, not done — its ungraded change is never marked complete.
+    const finalTask = taskRepo.tasks()[0];
+    expect(finalTask?.status).toBe('blocked');
+    if (finalTask?.status === 'blocked') {
+      expect(finalTask.blockedReason).toContain('evaluator did not produce a valid signals.json');
+    }
+    // No task settled `done`, so the sprint stays `active` for a clean re-run.
+    expect(sprintRepo.current().status).toBe('active');
   });
 
   // ─── Multi-repo project: each task gets its repo's cwd ────────────────────────────

--- a/tests/e2e/flows/refine.test.ts
+++ b/tests/e2e/flows/refine.test.ts
@@ -8,7 +8,9 @@ import { createInMemoryEventBus } from '@src/integration/observability/in-memory
 import { addTicket, type Sprint } from '@src/domain/entity/sprint.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import { createFsSprintRepository } from '@src/integration/persistence/sprint/repository.ts';
 import type { PendingTicket } from '@src/domain/entity/ticket.ts';
+import { readSprintDir } from '@tests/helpers/sprint-dir-snapshot.ts';
 import type {
   InteractiveAiProvider,
   InteractiveAiProviderInput,
@@ -95,6 +97,21 @@ const fakeInteractiveAi = (
   return { session, calls };
 };
 
+/**
+ * Fake `InteractiveAiProvider` that writes a caller-supplied `signals.json` payload verbatim.
+ * `payload(input)` returns either the raw object to JSON-stringify into `outputFile`, or
+ * `undefined` to leave the file absent entirely (simulating an AI that exited before writing).
+ */
+const fakeInteractiveAiRaw = (payload: (input: InteractiveAiProviderInput) => unknown): InteractiveAiProvider => ({
+  async run(input) {
+    const body = payload(input);
+    if (body !== undefined) {
+      await fs.writeFile(String(input.outputFile), JSON.stringify(body), 'utf8');
+    }
+    return Result.ok({});
+  },
+});
+
 describe('createRefineFlow — interactive', () => {
   let dir: string;
   beforeEach(async () => {
@@ -108,6 +125,31 @@ describe('createRefineFlow — interactive', () => {
     const r = AbsolutePath.parse(join(dir, 'refinement'));
     if (!r.ok) throw new Error('test setup');
     return r.value;
+  };
+
+  /**
+   * Real filesystem-backed sprint repo rooted at the test tmpdir, with `sprint` pre-persisted
+   * to disk so refine's `load-sprint` reads it back. Filesystem-truth: every assertion reads
+   * the sprint dir off disk, not from an in-memory double whose shape can drift from production.
+   */
+  const realFsRepo = async (sprint: Sprint): Promise<{ repo: SprintRepository; root: AbsolutePath }> => {
+    const root = AbsolutePath.parse(dir);
+    if (!root.ok) throw new Error('test setup');
+    const repo = createFsSprintRepository({ root: root.value });
+    const saved = await repo.save(sprint);
+    if (!saved.ok) throw new Error(`fixture: initial save failed: ${saved.error.message}`);
+    return { repo, root: root.value };
+  };
+
+  const readTicketsFromDisk = async (
+    root: AbsolutePath,
+    sprintId: SprintId
+  ): Promise<ReadonlyArray<{ readonly title: string; readonly status: string; readonly requirements?: string }>> => {
+    const snap = await readSprintDir(join(String(root), 'sprints', String(sprintId)));
+    const json = snap.json<{ tickets: ReadonlyArray<{ title: string; status: string; requirements?: string }> }>(
+      'sprint.json'
+    );
+    return json.tickets;
   };
 
   it('refines every pending ticket via interactive session, persists after each one', async () => {
@@ -458,5 +500,155 @@ describe('createRefineFlow — interactive', () => {
     expect(runner.status).toBe('failed');
     // No save persisted — the leaf erred before approveTicketRequirements ran.
     expect(saves).toHaveLength(0);
+  });
+
+  // ── Filesystem-truth: happy / resilience / missing, asserted against real persistence ──
+
+  it('filesystem-truth: a valid refined-ticket lands the ticket as approved with body on disk', async () => {
+    const { sprint, tickets } = draftWithPending(1);
+    const { repo, root } = await realFsRepo(sprint);
+    const eventBus = createInMemoryEventBus();
+
+    const refinedBody = '## Refined requirements\n\n- AC1: the body is persisted verbatim';
+    const ai = fakeInteractiveAiRaw(() => ({
+      schemaVersion: 1,
+      signals: [{ type: 'refined-ticket', body: refinedBody, timestamp: '2026-05-22T10:00:00.000Z' }],
+    }));
+
+    const flow = createRefineFlow(
+      {
+        sprintRepo: repo,
+        interactiveAi: ai,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        writeFile: createAtomicWriteFile(),
+        runInTerminal: passthroughRunInTerminal,
+        eventBus,
+        logger: noopLogger,
+        skillsAdapter: noopSkillsAdapter,
+        skillSource: emptySkillSource,
+        clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
+      },
+      {
+        sprintId: sprint.id,
+        pendingTickets: tickets,
+        providerId: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        refinementRoot: refinementRoot(),
+      }
+    );
+
+    const runner = createRunner({ id: 'r-refine-fs-ok', element: flow, initialCtx: { sprintId: sprint.id } });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+    // Read the sprint back off disk — the ticket is approved with the AI's body persisted.
+    const onDisk = await readTicketsFromDisk(root, sprint.id);
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0]?.status).toBe('approved');
+    expect(onDisk[0]?.requirements).toBe(refinedBody);
+  });
+
+  it('filesystem-truth: resilience — a malformed auxiliary signal is dropped, refinement survives', async () => {
+    const { sprint, tickets } = draftWithPending(1);
+    const { repo, root } = await realFsRepo(sprint);
+    const eventBus = createInMemoryEventBus();
+    const aiSignalTypes: string[] = [];
+    eventBus.subscribe((e) => {
+      if (e.type === 'ai-signal') aiSignalTypes.push(e.signal.type);
+    });
+
+    const refinedBody = '## Refined\n\n- the essential refined-ticket survives a bad sibling';
+    const ai = fakeInteractiveAiRaw(() => ({
+      schemaVersion: 1,
+      signals: [
+        { type: 'refined-ticket', body: refinedBody, timestamp: '2026-05-22T10:00:00.000Z' },
+        // Malformed: `decision` carries `body` where the schema wants `text`. The exact drift
+        // that previously discarded the whole refinement. Now it is dropped, not fatal.
+        { type: 'decision', body: 'wrong field', timestamp: '2026-05-22T10:00:00.000Z' },
+      ],
+    }));
+
+    const flow = createRefineFlow(
+      {
+        sprintRepo: repo,
+        interactiveAi: ai,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        writeFile: createAtomicWriteFile(),
+        runInTerminal: passthroughRunInTerminal,
+        eventBus,
+        logger: noopLogger,
+        skillsAdapter: noopSkillsAdapter,
+        skillSource: emptySkillSource,
+        clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
+      },
+      {
+        sprintId: sprint.id,
+        pendingTickets: tickets,
+        providerId: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        refinementRoot: refinementRoot(),
+      }
+    );
+
+    const runner = createRunner({ id: 'r-refine-fs-resilient', element: flow, initialCtx: { sprintId: sprint.id } });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+    // Only the valid refined-ticket fanned out; the malformed decision was dropped.
+    expect(aiSignalTypes).toEqual(['refined-ticket']);
+    // The refinement still landed on disk.
+    const onDisk = await readTicketsFromDisk(root, sprint.id);
+    expect(onDisk[0]?.status).toBe('approved');
+    expect(onDisk[0]?.requirements).toBe(refinedBody);
+  });
+
+  it('filesystem-truth: missing signals.json fails clearly and leaves the ticket pending on disk', async () => {
+    const { sprint, tickets } = draftWithPending(1);
+    const { repo, root } = await realFsRepo(sprint);
+    const eventBus = createInMemoryEventBus();
+
+    // AI exits cleanly but never writes signals.json (the user closed the session early).
+    const ai = fakeInteractiveAiRaw(() => undefined);
+
+    const flow = createRefineFlow(
+      {
+        sprintRepo: repo,
+        interactiveAi: ai,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        writeFile: createAtomicWriteFile(),
+        runInTerminal: passthroughRunInTerminal,
+        eventBus,
+        logger: noopLogger,
+        skillsAdapter: noopSkillsAdapter,
+        skillSource: emptySkillSource,
+        clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
+      },
+      {
+        sprintId: sprint.id,
+        pendingTickets: tickets,
+        providerId: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        refinementRoot: refinementRoot(),
+      }
+    );
+
+    const runner = createRunner({ id: 'r-refine-fs-missing', element: flow, initialCtx: { sprintId: sprint.id } });
+    // Capture the failure error off the runner's event stream — this is the exact message the
+    // TUI's failure card renders (`descriptor.error.message`).
+    let failureMessage: string | undefined;
+    runner.subscribe((event) => {
+      if (event.type === 'failed') failureMessage = event.error.message;
+    });
+    await runner.start();
+
+    // The flow fails — this is a real failure the user must know about, not a silent success.
+    expect(runner.status).toBe('failed');
+    // The surfaced error is the refine-specific, actionable signals-missing message.
+    expect(failureMessage).toContain('Refinement not saved');
+    expect(failureMessage).toContain('signals.json');
+    // The ticket on disk is unchanged — still pending, no requirements body.
+    const onDisk = await readTicketsFromDisk(root, sprint.id);
+    expect(onDisk[0]?.status).toBe('pending');
+    expect(onDisk[0]?.requirements ?? '').toBe('');
   });
 });

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -167,6 +167,43 @@ describe('createCodexProvider', () => {
     expect(fsStub.unlinks).toEqual([FIXED_OUT]);
   });
 
+  it('captures the session id from `thread_id` on a {type:"thread.started"} record (codex 0.130.x)', async () => {
+    // Real codex-cli 0.130.0 stdout: the session id arrives as `thread_id` on the leading
+    // `thread.started` record — NOT a `session_id` field. Confirmed against the installed binary.
+    const cap = createCapturingBus();
+    const sess = session();
+    const { spawn } = makeSpawn([
+      {
+        stdoutChunks: [
+          '{"type":"thread.started","thread_id":"019e6373-c4f1-7ac2-89f9-e9e4f3f6b231"}\n',
+          '{"type":"turn.started"}\n',
+          '{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"Done."}}\n',
+        ],
+        exitCode: 0,
+      },
+    ]);
+    const fsStub = stubFs('completed task; wrote signals.json.');
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.sessionId).toBe('019e6373-c4f1-7ac2-89f9-e9e4f3f6b231');
+
+    // And it round-trips to disk so the next gen-eval round can resume the thread.
+    const sidPath = join(dirname(String(sess.signalsFile)), 'session-id.txt');
+    const sidContent = await fs.readFile(sidPath, 'utf8');
+    expect(sidContent).toBe('019e6373-c4f1-7ac2-89f9-e9e4f3f6b231\n');
+  });
+
   it('forwards session.cwd to the spawned child (context-file autoload, parity with claude/copilot)', async () => {
     const cap = createCapturingBus();
     const cwd = absolutePath('/tmp/codex-target-repo');
@@ -427,6 +464,44 @@ describe('createCodexProvider — TokenUsageEvent emission', () => {
     expect(evt.sessionId).toBe('sess-u');
     expect(evt.inputTokens).toBe(900);
     expect(evt.outputTokens).toBe(300);
+  });
+
+  it('captures usage from a real {type:"turn.completed", usage:{…}} record keyed off thread_id', async () => {
+    // Faithful repro of codex-cli 0.130.0 stdout: thread.started carries the id, turn.completed
+    // carries the cumulative usage. With the id now populated the TokenUsageEvent fires.
+    const cap = createCapturingBus();
+    const sess = session();
+    const { spawn } = makeSpawn([
+      {
+        stdoutChunks: [
+          '{"type":"thread.started","thread_id":"019e6373-c4f1-7ac2-89f9-e9e4f3f6b231"}\n',
+          '{"type":"turn.started"}\n',
+          '{"type":"turn.completed","usage":{"input_tokens":27669,"cached_input_tokens":25344,"output_tokens":582,"reasoning_output_tokens":516}}\n',
+        ],
+        exitCode: 0,
+      },
+    ]);
+    const fsStub = stubFs('<task-complete/>');
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+
+    const tokenEvents = cap.events.filter((e): e is TokenUsageEvent => e.type === 'token-usage');
+    expect(tokenEvents).toHaveLength(1);
+    const evt = tokenEvents[0]!;
+    expect(evt.provider).toBe('openai-codex');
+    expect(evt.sessionId).toBe('019e6373-c4f1-7ac2-89f9-e9e4f3f6b231');
+    expect(evt.inputTokens).toBe(27669);
+    expect(evt.outputTokens).toBe(582);
   });
 
   it('does NOT emit a TokenUsageEvent on spawn failure (non-zero exit)', async () => {

--- a/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
@@ -5,7 +5,6 @@ import { Result } from '@src/domain/result.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
-import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import type { AppEvent, AiSignalEvent } from '@src/business/observability/events.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
@@ -189,34 +188,46 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     expect(result.value.ctx.lastEvaluation?.status).toBe('failed');
   });
 
+  // A recoverable signals-contract failure (missing / malformed / schema-mismatch / refinement)
+  // no longer aborts the run via Result.error — the evaluator turn converts it into a
+  // `self-blocked` exit so ONLY this task blocks (settled `blocked`, NOT done-with-warning, so
+  // the generator's ungraded change is never committed). The leaf returns `Result.ok` with
+  // `ctx.lastExit` set; the precise validator message is preserved in the block reason.
+  const expectSelfBlock = (
+    result: Awaited<ReturnType<ReturnType<typeof evaluatorLeaf>['execute']>>,
+    messageFragment: string
+  ): void => {
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.lastExit?.kind).toBe('self-blocked');
+    if (result.value.ctx.lastExit?.kind === 'self-blocked') {
+      expect(result.value.ctx.lastExit.reason).toContain('evaluator did not produce a valid signals.json');
+      expect(result.value.ctx.lastExit.reason).toContain(messageFragment);
+    }
+  };
+
   // ── 2. signals.json missing ───────────────────────────────────────────────────
-  it('ok-missing: surfaces signals-missing as InvalidStateError', async () => {
+  it('ok-missing: self-blocks with signals-missing in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([[signalsFilePath(), { kind: 'ok-missing' }]]);
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(InvalidStateError);
-    expect(result.error.error.message).toContain('signals-missing');
+    expectSelfBlock(result, 'signals-missing');
   });
 
   // ── 3. Malformed JSON ─────────────────────────────────────────────────────────
-  it('ok-raw with invalid JSON: surfaces ParseError(invalid-json)', async () => {
+  it('ok-raw with invalid JSON: self-blocks with malformed JSON in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [signalsFilePath(), { kind: 'ok-raw', rawBody: '{ this is not json' }],
     ]);
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('malformed JSON');
+    expectSelfBlock(result, 'malformed JSON');
   });
 
   // ── 4. Schema fails Zod (wrong shape) ─────────────────────────────────────────
-  it('ok with generator-only commit-message signal: surfaces ParseError(schema-mismatch)', async () => {
+  it('ok with generator-only commit-message signal: self-blocks with schema in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [
@@ -234,14 +245,11 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     ]);
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('schema');
+    expectSelfBlock(result, 'schema');
   });
 
   // ── 5a. Schema fails refine — zero evaluations ───────────────────────────────
-  it('ok with zero evaluation signals: refinement rejects', async () => {
+  it('ok with zero evaluation signals: refinement rejects → self-block', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [
@@ -257,14 +265,11 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     ]);
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('exactly one evaluation');
+    expectSelfBlock(result, 'exactly one evaluation');
   });
 
   // ── 5b. Schema fails refine — two evaluations ────────────────────────────────
-  it('ok with two evaluation signals: refinement rejects', async () => {
+  it('ok with two evaluation signals: refinement rejects → self-block', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [
@@ -280,10 +285,7 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     ]);
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('exactly one evaluation');
+    expectSelfBlock(result, 'exactly one evaluation');
   });
 
   // ── 7 (migration). Legacy top-level-array shape ───────────────────────────────
@@ -316,7 +318,7 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
   });
 
   // ── 8. Spawn error ────────────────────────────────────────────────────────────
-  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+  it('spawn-error: self-blocks the task with the spawn error message, no validation attempted', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const spawnError = new InvalidStateError({
       entity: 'provider',
@@ -328,9 +330,9 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     const leaf = evaluatorLeaf(buildDeps(fixtures).deps, task.id);
 
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBe(spawnError);
+    // A non-zero spawn (InvalidStateError, recoverable) blocks this task rather than aborting
+    // the whole run; the spawn error message is preserved in the block reason.
+    expectSelfBlock(result, 'simulated spawn failure');
 
     // No signals.json file should exist on disk (the mock didn't write one) and no sidecar.
     await expect(fs.access(signalsFilePath())).rejects.toThrow();

--- a/tests/integration/application/flows/implement/leaves/generator-contract.test.ts
+++ b/tests/integration/application/flows/implement/leaves/generator-contract.test.ts
@@ -5,7 +5,6 @@ import { Result } from '@src/domain/result.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
-import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import type { AppEvent, AiSignalEvent } from '@src/business/observability/events.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
@@ -196,34 +195,46 @@ describe('generatorLeaf — audit-[09] contract', () => {
     await expect(fs.access(sidecarPath())).rejects.toThrow();
   });
 
+  // A recoverable signals-contract failure (missing / malformed / schema-mismatch / refinement)
+  // no longer aborts the run via Result.error — the generator turn converts it into a
+  // `self-blocked` exit so ONLY this task blocks. The leaf returns `Result.ok` with
+  // `ctx.lastExit` / `ctx.lastBlockReason` set, and the precise validator message is preserved
+  // in the block reason so the operator sees WHY the turn failed.
+  const expectSelfBlock = (
+    result: Awaited<ReturnType<ReturnType<typeof generatorLeaf>['execute']>>,
+    messageFragment: string
+  ): void => {
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.lastExit).toEqual({
+      kind: 'self-blocked',
+      reason: expect.stringContaining('generator did not produce a valid signals.json') as unknown as string,
+    });
+    expect(result.value.ctx.lastBlockReason).toContain(messageFragment);
+  };
+
   // ── 2. signals.json missing ───────────────────────────────────────────────────
-  it('ok-missing: surfaces signals-missing as InvalidStateError', async () => {
+  it('ok-missing: self-blocks with signals-missing in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([[signalsFilePath(), { kind: 'ok-missing' }]]);
     const leaf = generatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(InvalidStateError);
-    expect(result.error.error.message).toContain('signals-missing');
+    expectSelfBlock(result, 'signals-missing');
   });
 
   // ── 3. Malformed JSON ─────────────────────────────────────────────────────────
-  it('ok-raw with invalid JSON: surfaces ParseError(invalid-json)', async () => {
+  it('ok-raw with invalid JSON: self-blocks with malformed JSON in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [signalsFilePath(), { kind: 'ok-raw', rawBody: '{ this is not json' }],
     ]);
     const leaf = generatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('malformed JSON');
+    expectSelfBlock(result, 'malformed JSON');
   });
 
   // ── 4. Schema fails Zod (wrong shape) ─────────────────────────────────────────
-  it('ok with evaluator-only signal: surfaces ParseError(schema-mismatch)', async () => {
+  it('ok with evaluator-only signal: self-blocks with schema in the reason', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [
@@ -241,14 +252,11 @@ describe('generatorLeaf — audit-[09] contract', () => {
     ]);
     const leaf = generatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('schema');
+    expectSelfBlock(result, 'schema');
   });
 
   // ── 5. Schema fails refine (atMostOne commit-message) ─────────────────────────
-  it('ok with two commit-message signals: refinement rejects', async () => {
+  it('ok with two commit-message signals: refinement rejects → self-block', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const fixtures = new Map<string, SpawnFixture>([
       [
@@ -267,10 +275,7 @@ describe('generatorLeaf — audit-[09] contract', () => {
     ]);
     const leaf = generatorLeaf(buildDeps(fixtures).deps, task.id);
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('at most one commit-message');
+    expectSelfBlock(result, 'at most one commit-message');
   });
 
   // ── 7 (migration). Legacy top-level-array shape ───────────────────────────────
@@ -310,7 +315,7 @@ describe('generatorLeaf — audit-[09] contract', () => {
   });
 
   // ── 8. Spawn error ────────────────────────────────────────────────────────────
-  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+  it('spawn-error: self-blocks the task with the spawn error message, no validation attempted', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const spawnError = new InvalidStateError({
       entity: 'provider',
@@ -322,9 +327,9 @@ describe('generatorLeaf — audit-[09] contract', () => {
     const leaf = generatorLeaf(buildDeps(fixtures).deps, task.id);
 
     const result = await leaf.execute(baseCtx(task));
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.error).toBe(spawnError);
+    // A non-zero spawn (InvalidStateError, recoverable) blocks this task rather than aborting
+    // the whole run; the spawn error message is preserved in the block reason.
+    expectSelfBlock(result, 'simulated spawn failure');
 
     // No signals.json file should exist on disk (the mock didn't write one) and no sidecar.
     await expect(fs.access(signalsFilePath())).rejects.toThrow();

--- a/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
+++ b/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
@@ -166,7 +166,7 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
   });
 
   // ── 2. signals.json missing ───────────────────────────────────────────────────
-  it('ok-missing: surfaces signals-missing as InvalidStateError', async () => {
+  it('signals-missing: surfaces a refine-specific actionable InvalidStateError', async () => {
     await ensureUnitDir();
     // AI exits cleanly but never writes signals.json.
     const provider = fakeAi(async () => {});
@@ -177,7 +177,46 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.error).toBeInstanceOf(InvalidStateError);
-    expect(result.error.error.message).toContain('signals-missing');
+    // The leaf rewrites the generic `signals-missing` token into an actionable, refine-framed
+    // message — what happened (session ended early), what is safe (ticket unchanged), what to
+    // do (re-run and let the AI finish).
+    expect(result.error.error.message).toContain('Refinement not saved');
+    expect(result.error.error.message).toContain('signals.json');
+    expect(result.error.error.message).toContain('ticket is unchanged');
+  });
+
+  // ── 2b. Resilience: valid refined-ticket + malformed auxiliary signal ──────────
+  it('resilience: keeps the refinement when only auxiliary signals are malformed', async () => {
+    await ensureUnitDir();
+    // One valid refined-ticket plus a malformed `decision` (carries `body` where the schema
+    // wants `text`). The lenient refine contract drops the decision and keeps the refinement.
+    await fs.writeFile(
+      signalsFilePath(),
+      JSON.stringify({
+        schemaVersion: 1,
+        signals: [
+          refinedTicketSignal('## Refined\n\n- the essential body survives'),
+          { type: 'decision', body: 'wrong field — should be text', timestamp: '2026-05-22T10:00:00.000Z' },
+        ],
+      }),
+      'utf8'
+    );
+    const { events, eventBus } = captureBus();
+    const provider = fakeAi(async () => {});
+    const { ctx, ticket } = buildCtx();
+    const leaf = refineTicketInteractiveLeaf(buildDeps(provider, eventBus), ticket);
+
+    const result = await leaf.execute(ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Only the valid refined-ticket fanned out — the malformed decision was dropped.
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['refined-ticket']);
+
+    const approved = result.value.ctx.refinedTickets?.[0];
+    expect(approved?.status).toBe('approved');
+    expect(approved?.requirements).toBe('## Refined\n\n- the essential body survives');
   });
 
   // ── 3. Malformed JSON ─────────────────────────────────────────────────────────
@@ -195,15 +234,17 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
     expect(result.error.error.message).toContain('malformed JSON');
   });
 
-  // ── 4. Schema fails Zod (wrong shape) ─────────────────────────────────────────
-  it('ok with generator-only commit-message signal: surfaces ParseError(schema-mismatch)', async () => {
+  // ── 4. Unknown signal kind with no valid refined-ticket → still fails ─────────
+  it('ok with only a generator-only commit-message signal: surfaces ParseError', async () => {
     await ensureUnitDir();
     await fs.writeFile(
       signalsFilePath(),
       JSON.stringify({
         schemaVersion: 1,
         // `commit-message` is intentionally not part of the refine contract — the generator
-        // emits it. A refine-side `commit-message` MUST be rejected by Zod.
+        // emits it. The lenient contract drops it as an unknown element; with no surviving
+        // `refined-ticket` the `.refine` then rejects, so this is still a real failure
+        // (not a silent success) — the user must know nothing was refined.
         signals: [{ type: 'commit-message', subject: 'feat: x', timestamp: '2026-05-22T10:00:00.000Z' }],
       }),
       'utf8'
@@ -216,7 +257,32 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.error).toBeInstanceOf(ParseError);
-    expect(result.error.error.message).toContain('schema');
+    expect(result.error.error.message).toContain('exactly one refined-ticket');
+  });
+
+  // ── 4b. Malformed refined-ticket (the essential signal) → still fails ─────────
+  it('malformed refined-ticket: dropped, then rejected as zero refined-tickets', async () => {
+    await ensureUnitDir();
+    await fs.writeFile(
+      signalsFilePath(),
+      JSON.stringify({
+        schemaVersion: 1,
+        // The refined-ticket carries `text` where the schema wants `body`. The lenient parse
+        // drops it like any malformed element — but a malformed ESSENTIAL signal must surface
+        // as a real failure, which the exactly-one refinement enforces (zero survivors).
+        signals: [{ type: 'refined-ticket', text: 'wrong field', timestamp: '2026-05-22T10:00:00.000Z' }],
+      }),
+      'utf8'
+    );
+    const provider = fakeAi(async () => {});
+    const { ctx, ticket } = buildCtx();
+    const leaf = refineTicketInteractiveLeaf(buildDeps(provider), ticket);
+
+    const result = await leaf.execute(ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('exactly one refined-ticket');
   });
 
   // ── 5a. Schema fails refine — zero refined-tickets ────────────────────────────

--- a/tests/unit/business/task/run-evaluator-turn.test.ts
+++ b/tests/unit/business/task/run-evaluator-turn.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { recordRunningAttemptVerification } from '@src/domain/entity/task.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
 import { FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
@@ -237,18 +240,62 @@ describe('runEvaluatorTurnUseCase', () => {
     if (result.ok) expect(result.value.exit).toBeUndefined();
   });
 
-  it('spawn error (callEvaluate fails) bubbles up as a Result.error — no crash', async () => {
+  it('recoverable evaluate failure (bad signals.json) self-blocks the task — does NOT propagate', async () => {
+    // A non-Claude reviewer that never wrote a usable signals.json surfaces a domain error.
+    // The turn must self-block so the task settles `blocked` (finalize maps self-blocked →
+    // blockedReason → settle marks blocked) — NOT `malformed`, which settle treats as
+    // done-with-warning and would mark an UNGRADED change `done`.
     const task = verifiedTask();
-    const evError = new Error('spawn ENOENT') as unknown as Error & { readonly _tag: 'fake' };
+    const err = new InvalidStateError({
+      entity: 'codex-provider',
+      currentState: 'signals-missing',
+      attemptedAction: 'complete evaluation',
+      message: 'signals.json not found in outputDir',
+    });
     const result = await runEvaluatorTurnUseCase({
       task,
       plateauThreshold: 2,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      callEvaluate: async () => Result.error(evError as any),
+      callEvaluate: async () => Result.error(err),
+      evaluationFile: EVAL_FILE,
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.exit?.kind).toBe('self-blocked');
+      if (result.value.exit?.kind === 'self-blocked') {
+        expect(result.value.exit.reason).toContain('evaluator did not produce a valid signals.json');
+        expect(result.value.exit.reason).toContain('signals.json not found in outputDir');
+      }
+      expect(result.value.task).toBe(task); // unchanged — no evaluation recorded
+    }
+  });
+
+  it('propagates an AbortError (user cancel) instead of self-blocking', async () => {
+    const task = verifiedTask();
+    const err = new AbortError({ elementName: 'codex-provider', reason: 'aborted by caller' });
+    const result = await runEvaluatorTurnUseCase({
+      task,
+      plateauThreshold: 2,
+      callEvaluate: async () => Result.error(err),
       evaluationFile: EVAL_FILE,
       logger: noopLogger,
     });
     expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(err);
+  });
+
+  it('propagates a RateLimitError (retries already exhausted) instead of self-blocking', async () => {
+    const task = verifiedTask();
+    const err = new RateLimitError({ subCode: 'spawn-stderr', message: 'rate-limit retries exhausted' });
+    const result = await runEvaluatorTurnUseCase({
+      task,
+      plateauThreshold: 2,
+      callEvaluate: async () => Result.error(err),
+      evaluationFile: EVAL_FILE,
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(err);
   });
 
   it('continues (no exit) when failed but with a fresh critique and no prior turns', async () => {

--- a/tests/unit/business/task/run-generator-turn.test.ts
+++ b/tests/unit/business/task/run-generator-turn.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
-import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
@@ -40,9 +42,41 @@ describe('runGeneratorTurnUseCase', () => {
     }
   });
 
-  it('forwards the AI provider error', async () => {
+  it('blocks the task (self-blocked exit) on a recoverable signals-contract failure — does NOT propagate', async () => {
+    // A non-Claude provider that wrote a malformed signals.json surfaces a ParseError. The
+    // turn must self-block THIS task (so it surfaces + re-runs) rather than abort the whole run.
     const task = makeInProgressTaskWithRunningAttempt();
-    const err = new ValidationError({ field: 'ai', value: 0, message: 'boom' });
+    const err = new ParseError({ subCode: 'schema-mismatch', message: 'signals-invalid (schema) at root' });
+    const result = await runGeneratorTurnUseCase({
+      task,
+      callImplement: async () => Result.error(err),
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.exit?.kind).toBe('self-blocked');
+      // The precise validator message lands in the block reason for the operator / progress.md.
+      expect(result.value.exit?.reason).toContain('generator did not produce a valid signals.json');
+      expect(result.value.exit?.reason).toContain('signals-invalid (schema) at root');
+      expect(result.value.task).toBe(task); // unchanged — no verification recorded
+    }
+  });
+
+  it('propagates an AbortError (user cancel) instead of blocking', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const err = new AbortError({ elementName: 'codex-provider', reason: 'aborted by caller' });
+    const result = await runGeneratorTurnUseCase({
+      task,
+      callImplement: async () => Result.error(err),
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(err);
+  });
+
+  it('propagates a RateLimitError (retries already exhausted) instead of blocking', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const err = new RateLimitError({ subCode: 'spawn-stderr', message: 'rate-limit retries exhausted' });
     const result = await runGeneratorTurnUseCase({
       task,
       callImplement: async () => Result.error(err),


### PR DESCRIPTION
Bundle of fixes from a debugging session across the TUI, the implement gen-eval loop, and the refine flow.

## `fix(tui)` — settings labels + execute-view scroll (`91bd7f6c`)
- **Settings labels cut off:** `FieldList` clipped labels to a fixed 14-col width (e.g. `Effort (defa…`, `Apply: Claud…`). It now auto-sizes the label column to the widest label present (with `FIELD_LABEL_WIDTH` as the floor).
- **Execute view wouldn't scroll:** `ScrollRegion` only re-measured content height when `offset` changed, so a live-growing view kept a stale height of ~0 → `maxOffset` 0 → `↑/↓` inert despite the advertised hint. Now re-measures every render (the downward clamp is self-terminating, no loop).

## `fix(implement)` — non-Claude eval failures no longer abort the whole run (`d8e58ec4`)
- A missing / malformed / schema-invalid `signals.json` from a generator or evaluator turn propagated through the `loop` and aborted the **entire** implement run. Non-Claude models violate the strict contract far more often, so this hit "especially in evaluation."
- Now a recoverable turn failure **blocks that one task** (surfaced + re-runnable) while the run continues; `AbortError`/`RateLimitError` still propagate. The evaluator's recoverable path routes to a self-block (not the `malformed` verdict, which settle treats as done-with-warning) so ungraded work is never marked done.
- Also fixes codex session-id capture: codex-cli 0.130.0 emits the id as `thread_id` on a `thread.started` record, not `session_id` — without it codex never resumed across rounds and never reported token usage.

## `fix(refine)` — keep the refinement when only auxiliary signals are malformed (`683e253d`)
- A single malformed auxiliary signal (e.g. a `decision` emitted with `body` instead of `text`) failed the refine contract's strict union and silently discarded the **whole** refinement. The refine `signalsSchema` is now lenient: per-element parse, drop malformed auxiliary signals (logged), keep the valid ones, still require exactly one valid `refined-ticket` (a malformed `refined-ticket` drops → zero survivors → loud failure).
- The signals-missing error is rewritten into an actionable message so exiting the interactive session early no longer looks like a silent bounce.
- Adds filesystem-truth e2e tests: happy path, malformed-aux survives, missing-signals fails with the ticket unchanged.

`/verify` green at each step (typecheck + lint + 2445 tests).