### PR TITLE
Improve AI session observability and project-detail editing UX

### DIFF
--- a/src/application/ui/tui/runtime/use-event-bus.ts
+++ b/src/application/ui/tui/runtime/use-event-bus.ts
@@ -1,3 +1,9 @@
+// Retention audit: BOUNDED — `useEventBusBuffer` keeps a rolling window of `AppEvent` object refs
+// (default 100, trimmed via `.slice(-limit)` on every push). Memory footprint scales with `limit`
+// not session lifetime — each entry is a single ref to an already-allocated AppEvent (the bus does
+// not deep-clone), so worst-case retention is `limit` × ~one event object. Sound because the FIFO
+// trim runs synchronously inside the setState reducer; no path skips it.
+
 /**
  * Hooks that subscribe React components to the application {@link EventBus}.
  *
@@ -36,14 +42,13 @@ export const useEventBusBuffer = <T extends AppEvent>(bus: EventBus, opts: UseEv
   filterRef.current = opts.filter;
 
   useEffect(() => {
-    const unsub = bus.subscribe((event) => {
+    return bus.subscribe((event) => {
       if (!filterRef.current(event)) return;
       setItems((prev) => {
         const next = [...prev, event];
         return next.length > limit ? next.slice(next.length - limit) : next;
       });
     });
-    return unsub;
   }, [bus, limit]);
 
   return items;

--- a/src/application/ui/tui/runtime/use-sink-stream.ts
+++ b/src/application/ui/tui/runtime/use-sink-stream.ts
@@ -1,3 +1,9 @@
+// Retention audit: BOUNDED — `useSinkStream` keeps a trailing window of `T` refs sourced from the
+// upstream `BusSink` (default 100, trimmed via `.slice(-limit)` on push, and the initial replay is
+// also `.slice(-limit)`). Memory footprint is `limit` × ref-to-T; the sink itself owns the master
+// buffer so the component-side window is incremental, not duplicative. Sound because both the
+// mount-time seed and the per-publish reducer apply the same `limit` ceiling.
+
 /**
  * Hooks that subscribe to a {@link BusSink} and re-render on new values. The store-style API
  * keeps the most recent N entries in component state so a panel can show a live tail without
@@ -26,13 +32,12 @@ export const useSinkStream = <T>(bus: BusSink<T>, opts: UseSinkStreamOptions = {
 
   useEffect(() => {
     if (replay) setItems(bus.entries.slice(-limit));
-    const unsub = bus.subscribe((value) => {
+    return bus.subscribe((value) => {
       setItems((prev) => {
         const next = [...prev, value];
         return next.length > limit ? next.slice(next.length - limit) : next;
       });
     });
-    return unsub;
   }, [bus, limit, replay]);
 
   return items;

--- a/src/application/ui/tui/runtime/use-task-round-tracker.ts
+++ b/src/application/ui/tui/runtime/use-task-round-tracker.ts
@@ -1,3 +1,10 @@
+// Retention audit: BOUNDED via `TASK_ROUND_CAP = 500` LRU on insertion order (was UNBOUNDED before
+// the cap landed — keyed by stable taskId, so a long sprint with many planned tasks would have
+// accumulated entries indefinitely). Each entry is a tiny `{ roundN, totalCap }` pair (~24 bytes),
+// so 500 keys × ref overhead is well under 100 KB. Sound because the monotonic guard still runs
+// first (no-op on stale events, so they never bump LRU order), and the eviction loop only fires
+// on net-new insertions past the cap — mirrors the `use-token-usage.ts` pattern.
+
 /**
  * Per-task gen-eval round tracker — subscribes to `task-round-started` AppEvents and folds
  * them into a Map<taskId, { roundN, totalCap }> indexed by taskId. The latest round per task
@@ -16,6 +23,15 @@
 import { useEffect, useState } from 'react';
 import type { AppEvent, TaskRoundStartedEvent } from '@src/business/observability/events.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
+
+/**
+ * Hard cap on retained per-task round entries. A planner can legitimately emit dozens to low
+ * hundreds of tasks per sprint; 500 leaves comfortable headroom while pinning worst-case memory
+ * for a runaway sprint or a stuck process that accumulates state across many sessions. Eviction
+ * order is insertion (delete + re-set on update so the most recently bumped taskId stays hot),
+ * matching the LRU pattern in `use-token-usage.ts`.
+ */
+export const TASK_ROUND_CAP = 500;
 
 export interface TaskRound {
   readonly roundN: number;
@@ -38,7 +54,7 @@ export const useTaskRoundTracker = (bus: EventBus): ReadonlyMap<string, TaskRoun
   const [rounds, setRounds] = useState<ReadonlyMap<string, TaskRound>>(() => new Map());
 
   useEffect(() => {
-    const unsub = bus.subscribe((event) => {
+    return bus.subscribe((event) => {
       if (!isTaskRoundStarted(event)) return;
       setRounds((prev) => {
         const existing = prev.get(event.taskId);
@@ -46,11 +62,19 @@ export const useTaskRoundTracker = (bus: EventBus): ReadonlyMap<string, TaskRoun
         // not regress the high-water mark.
         if (existing !== undefined && existing.roundN >= event.roundN) return prev;
         const next = new Map(prev);
+        // Delete + re-set so an updated taskId jumps to the end of insertion order; the LRU
+        // eviction below then drops the actually-oldest entry, not whichever taskId hashed
+        // first in Map's insertion order.
+        next.delete(event.taskId);
         next.set(event.taskId, { roundN: event.roundN, totalCap: event.totalCap });
+        while (next.size > TASK_ROUND_CAP) {
+          const oldest = next.keys().next().value;
+          if (oldest === undefined) break;
+          next.delete(oldest);
+        }
         return next;
       });
     });
-    return unsub;
   }, [bus]);
 
   return rounds;

--- a/src/application/ui/tui/runtime/use-token-usage.ts
+++ b/src/application/ui/tui/runtime/use-token-usage.ts
@@ -1,3 +1,9 @@
+// Retention audit: BOUNDED — `TOKEN_USAGE_SESSION_CAP = 100` enforces an LRU on the per-sessionId
+// Map. Each entry is a small `TokenUsage` value object (~100 bytes: provider/model strings plus a
+// handful of numbers), so the cap pins memory at roughly 10 KB regardless of session count. Sound
+// because every insert path goes through the same delete-then-set-then-evict reducer, and the
+// TokenBudgetCard only ever reads the most recent session anyway — evicted entries are unread.
+
 /**
  * Per-session token-usage tracker — subscribes to `TokenUsageEvent` on the EventBus and folds
  * the latest emission per `sessionId` into a `Map<sessionId, TokenUsage>`. Latest event wins

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -3,7 +3,7 @@
  * `r` jumps to this project's sprints; `n` opens the flow launcher with this project current.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
@@ -37,6 +37,15 @@ interface ProjectDetailProps extends Readonly<Record<string, unknown>> {
   readonly projectId: ProjectId;
 }
 
+type RepoFieldKey = 'name' | 'setupScript' | 'verifyScript';
+type Field =
+  | { readonly kind: 'project'; readonly field: 'displayName' }
+  | { readonly kind: 'repo'; readonly field: RepoFieldKey; readonly repo: Repository };
+
+type EditTarget =
+  | { readonly kind: 'project' }
+  | { readonly kind: 'repo'; readonly field: RepoFieldKey; readonly repo: Repository };
+
 export const ProjectDetailView = (): React.JSX.Element => {
   const deps = useDeps();
   const router = useRouter();
@@ -45,7 +54,6 @@ export const ProjectDetailView = (): React.JSX.Element => {
   useViewHints([
     { keys: 'r', label: 'sprints' },
     { keys: 'a', label: 'add repo' },
-    { keys: 'e', label: 'edit project / repo field' },
     { keys: 'd', label: 'remove repo' },
     { keys: 'c', label: 'detect scripts' },
     { keys: 'S', label: 'detect skills' },
@@ -76,7 +84,34 @@ export const ProjectDetailView = (): React.JSX.Element => {
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
   const project = state.kind === 'ok' ? state.value : undefined;
-  const repos = project?.repositories ?? [];
+
+  // Flat field cursor — every editable row gets one stable index. Top-to-bottom order matches
+  // the rendered card layout: project displayName first, then each repo's name / setup / verify
+  // in turn. The cursor advances through the same array the renderer walks. `repos` is derived
+  // from `project` so we close over the project itself, not the derived array (the linter would
+  // flag the derived value as a fresh reference per render).
+  const fields = useMemo<readonly Field[]>(() => {
+    if (project === undefined) return [];
+    return [
+      { kind: 'project', field: 'displayName' },
+      ...project.repositories.flatMap((r): readonly Field[] => [
+        { kind: 'repo', field: 'name', repo: r },
+        { kind: 'repo', field: 'setupScript', repo: r },
+        { kind: 'repo', field: 'verifyScript', repo: r },
+      ]),
+    ];
+  }, [project]);
+
+  const focused = fields[Math.min(cursorIdx, Math.max(0, fields.length - 1))];
+
+  // Reset the cursor when the underlying project changes — both the first successful load
+  // (loading → ok) and a re-route to a different projectId. Without this, switching from a
+  // project with 4 fields to one with 1 would leave the cursor pinned at index 3 (clamped) and
+  // visually parked on the only available row, but a subsequent reload back to the larger
+  // project would resume mid-list — surprising.
+  useEffect(() => {
+    if (state.kind === 'ok') setCursorIdx(0);
+  }, [state.kind, projectId]);
 
   const launchPerRepoFlow = async (flowId: 'detect-scripts' | 'detect-skills', target: Repository): Promise<void> => {
     if (project === undefined) return;
@@ -105,11 +140,6 @@ export const ProjectDetailView = (): React.JSX.Element => {
     void result.runner.start();
     router.push({ id: 'execute', props: { sessionId: result.runner.id } });
   };
-
-  type RepoFieldKey = 'name' | 'setupScript' | 'verifyScript';
-  type EditTarget =
-    | { readonly kind: 'project' }
-    | { readonly kind: 'repo'; readonly field: RepoFieldKey; readonly repo: Repository };
 
   const renderEditPrompt = (target: EditTarget): OpenEditPromptInput | undefined => {
     if (project === undefined) return undefined;
@@ -166,35 +196,12 @@ export const ProjectDetailView = (): React.JSX.Element => {
   };
 
   const handleEdit = (): void => {
-    if (project === undefined) return;
+    if (project === undefined || focused === undefined) return;
     setFeedback(undefined);
-    const focusedRepo = repos[Math.min(cursorIdx, Math.max(0, repos.length - 1))];
-    const options: ReadonlyArray<{ readonly label: string; readonly value: EditTarget }> = [
-      { label: `Project: displayName  (${project.displayName})`, value: { kind: 'project' } },
-      ...(focusedRepo !== undefined
-        ? ([
-            { label: `Repo "${focusedRepo.name}": name`, value: { kind: 'repo', field: 'name', repo: focusedRepo } },
-            {
-              label: `Repo "${focusedRepo.name}": setupScript`,
-              value: { kind: 'repo', field: 'setupScript', repo: focusedRepo },
-            },
-            {
-              label: `Repo "${focusedRepo.name}": verifyScript`,
-              value: { kind: 'repo', field: 'verifyScript', repo: focusedRepo },
-            },
-          ] as const)
-        : []),
-    ];
-    new Promise<EditTarget>((resolve, reject) => {
-      queue.enqueue({ kind: 'choice', message: 'Edit which field?', options, resolve, reject });
-    })
-      .then((target) => {
-        const cfg = renderEditPrompt(target);
-        if (cfg !== undefined) void edit.openEditPrompt(cfg);
-      })
-      .catch(() => {
-        // user cancelled the field picker — nothing to do.
-      });
+    const target: EditTarget =
+      focused.kind === 'project' ? { kind: 'project' } : { kind: 'repo', field: focused.field, repo: focused.repo };
+    const cfg = renderEditPrompt(target);
+    if (cfg !== undefined) void edit.openEditPrompt(cfg);
   };
 
   useInput((input, key) => {
@@ -203,31 +210,28 @@ export const ProjectDetailView = (): React.JSX.Element => {
       router.push({ id: 'add-repository', props: { projectId: project.id } });
       return;
     }
-    if (input === 'e') {
+    if (input === 'e' || key.return) {
       handleEdit();
       return;
     }
-    if ((key.downArrow || input === 'j') && repos.length > 0) {
-      setCursorIdx((c) => Math.min(repos.length - 1, c + 1));
+    if (key.downArrow || input === 'j') {
+      setCursorIdx((c) => Math.min(Math.max(0, fields.length - 1), c + 1));
       return;
     }
-    if ((key.upArrow || input === 'k') && repos.length > 0) {
+    if (key.upArrow || input === 'k') {
       setCursorIdx((c) => Math.max(0, c - 1));
       return;
     }
-    if (input === 'd' && repos.length > 0) {
-      const target = repos[Math.min(cursorIdx, repos.length - 1)];
-      if (target !== undefined) setConfirmRemove(target);
+    if (input === 'd' && focused?.kind === 'repo') {
+      setConfirmRemove(focused.repo);
       return;
     }
-    if (input === 'c' && repos.length > 0) {
-      const target = repos[Math.min(cursorIdx, repos.length - 1)];
-      if (target !== undefined) void launchPerRepoFlow('detect-scripts', target);
+    if (input === 'c' && focused?.kind === 'repo') {
+      void launchPerRepoFlow('detect-scripts', focused.repo);
       return;
     }
-    if (input === 'S' && repos.length > 0) {
-      const target = repos[Math.min(cursorIdx, repos.length - 1)];
-      if (target !== undefined) void launchPerRepoFlow('detect-skills', target);
+    if (input === 'S' && focused?.kind === 'repo') {
+      void launchPerRepoFlow('detect-skills', focused.repo);
     }
   });
 
@@ -275,11 +279,7 @@ export const ProjectDetailView = (): React.JSX.Element => {
           </Box>
         </Box>
       ) : (
-        <Body
-          project={state.value}
-          cursorIdx={Math.min(cursorIdx, Math.max(0, repos.length - 1))}
-          feedback={feedback ?? edit.feedback}
-        />
+        <Body project={state.value} focused={focused} feedback={feedback ?? edit.feedback} />
       )}
     </ViewShell>
   );
@@ -299,76 +299,93 @@ const removeRepoFromProject = async (
 
 interface BodyProps {
   readonly project: Project;
-  readonly cursorIdx: number;
+  readonly focused: Field | undefined;
   readonly feedback: string | undefined;
 }
 
-const Body = ({ project, cursorIdx, feedback }: BodyProps): React.JSX.Element => (
-  <Box flexDirection="column">
-    <Card title="Project" tone="primary">
+/** Wrap a field value with the action-cursor glyph + primary color when focused. Mirrors the
+ *  pattern from settings-view.tsx so the focus signal stays consistent across detail views. */
+const focusable = (focused: boolean, node: React.ReactNode): React.ReactNode => (
+  <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
+    {focused ? `${glyphs.actionCursor} ` : '  '}
+    {node}
+  </Text>
+);
+
+const noneText = (
+  <Text dimColor italic>
+    (none)
+  </Text>
+);
+
+interface RepoCardProps {
+  readonly repo: Repository;
+  readonly focused: Field | undefined;
+}
+
+const RepoCard = ({ repo, focused }: RepoCardProps): React.JSX.Element => {
+  const repoFocused = focused?.kind === 'repo' && focused.repo.id === repo.id;
+  const nameFocused = repoFocused && focused.field === 'name';
+  const setupFocused = repoFocused && focused.field === 'setupScript';
+  const verifyFocused = repoFocused && focused.field === 'verifyScript';
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={inkColors.rule}
+      paddingX={spacing.cardPadX}
+      marginTop={1}
+    >
+      <Text bold {...(nameFocused ? { color: inkColors.primary } : {})}>
+        {nameFocused ? `${glyphs.actionCursor} ` : '  '}
+        {repo.name} <Text dimColor>({repo.slug})</Text>
+      </Text>
       <FieldList
         fields={[
-          { label: 'Name', value: <Text bold>{project.displayName}</Text> },
-          { label: 'Slug', value: project.slug },
-          { label: 'Id', value: <Text dimColor>{project.id}</Text> },
-          ...(project.description !== undefined ? [{ label: 'Description', value: project.description }] : []),
-          { label: 'Repositories', value: String(project.repositories.length) },
+          { label: 'Path', value: <Text dimColor>{repo.path}</Text> },
+          { label: 'Setup', value: focusable(setupFocused, repo.setupScript ?? noneText) },
+          { label: 'Verify', value: focusable(verifyFocused, repo.verifyScript ?? noneText) },
         ]}
       />
-    </Card>
-    <Box marginTop={spacing.section} flexDirection="column">
-      <Text bold>{glyphs.badge} Repositories</Text>
-      {project.repositories.map((repo, idx) => {
-        const focused = idx === cursorIdx;
-        return (
-          <Box
-            key={repo.id}
-            flexDirection="column"
-            borderStyle="round"
-            borderColor={focused ? inkColors.primary : inkColors.rule}
-            borderDimColor={!focused}
-            paddingX={spacing.cardPadX}
-            marginTop={1}
-          >
-            <Text bold {...(focused ? { color: inkColors.primary } : {})}>
-              {focused ? `${glyphs.actionCursor} ` : '  '}
-              {repo.name} <Text dimColor>({repo.slug})</Text>
-            </Text>
-            <FieldList
-              fields={[
-                { label: 'Path', value: <Text dimColor>{repo.path}</Text> },
-                {
-                  label: 'Setup',
-                  value: repo.setupScript ?? (
-                    <Text dimColor italic>
-                      (none)
-                    </Text>
-                  ),
-                },
-                {
-                  label: 'Verify',
-                  value: repo.verifyScript ?? (
-                    <Text dimColor italic>
-                      (none)
-                    </Text>
-                  ),
-                },
-              ]}
-            />
-          </Box>
-        );
-      })}
-      <Box paddingX={spacing.indent} marginTop={spacing.section}>
-        <Text dimColor>
-          {glyphs.bullet} a add {glyphs.bullet} ↑/↓ select {glyphs.bullet} e edit field {glyphs.bullet} c detect scripts{' '}
-          {glyphs.bullet} S detect skills {glyphs.bullet} d remove (keeps ≥ 1)
-        </Text>
-      </Box>
-      {feedback !== undefined && (
-        <Box paddingX={spacing.indent} marginTop={1}>
-          <Text color={feedback.startsWith('✗') ? inkColors.error : inkColors.primary}>{feedback}</Text>
-        </Box>
-      )}
     </Box>
-  </Box>
-);
+  );
+};
+
+const Body = ({ project, focused, feedback }: BodyProps): React.JSX.Element => {
+  const projectNameFocused = focused?.kind === 'project';
+  return (
+    <Box flexDirection="column">
+      <Card title="Project" tone="primary">
+        <FieldList
+          fields={[
+            {
+              label: 'Name',
+              value: focusable(projectNameFocused, <Text bold>{project.displayName}</Text>),
+            },
+            { label: 'Slug', value: project.slug },
+            { label: 'Id', value: <Text dimColor>{project.id}</Text> },
+            ...(project.description !== undefined ? [{ label: 'Description', value: project.description }] : []),
+            { label: 'Repositories', value: String(project.repositories.length) },
+          ]}
+        />
+      </Card>
+      <Box marginTop={spacing.section} flexDirection="column">
+        <Text bold>{glyphs.badge} Repositories</Text>
+        {project.repositories.map((repo) => (
+          <RepoCard key={repo.id} repo={repo} focused={focused} />
+        ))}
+        <Box paddingX={spacing.indent} marginTop={spacing.section}>
+          <Text dimColor>
+            a add {glyphs.bullet} ↑/↓ navigate {glyphs.bullet} e/↵ edit field {glyphs.bullet} c detect scripts{' '}
+            {glyphs.bullet} S detect skills {glyphs.bullet} d remove (keeps ≥ 1)
+          </Text>
+        </Box>
+        {feedback !== undefined && (
+          <Box paddingX={spacing.indent} marginTop={1}>
+            <Text color={feedback.startsWith('✗') ? inkColors.error : inkColors.primary}>{feedback}</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/integration/ai/providers/_engine/truncate-debug-field.ts
+++ b/src/integration/ai/providers/_engine/truncate-debug-field.ts
@@ -1,0 +1,25 @@
+/**
+ * Truncate a free-form string for inclusion in a debug-level `LogEvent.meta` payload.
+ *
+ * The headless provider adapters (`claude/`, `copilot/`, `codex/`) publish one debug event per
+ * recognised stream line so operators can `tail -f` chain.log under `RALPHCTL_LOG_LEVEL=debug`
+ * without drowning in untruncated JSON. Stream payloads are unbounded by design — a single
+ * assistant turn can carry several KB of text, and tool inputs (e.g. file diffs) can be larger
+ * still — so every field that originated from the AI stream is funnelled through this helper.
+ *
+ * Semantics:
+ *  - `undefined` / empty / whitespace-only input → `undefined` (caller omits the key entirely
+ *    via the `...(v !== undefined ? { k: v } : {})` spread pattern used across the adapters).
+ *  - Strings at or below `max` length pass through verbatim.
+ *  - Strings over `max` length are sliced to `max` and appended with `'…'` (one Unicode code
+ *    point, not three ASCII dots) so the truncation is visually obvious in chain.log.
+ *
+ * `max` defaults to 120 — long enough to recognise a tool name + a short argument preview at a
+ * glance, short enough that ten debug lines per turn stay under a single screen.
+ */
+export const truncateField = (value: string | undefined, max = 120): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  if (value.length === 0) return undefined;
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
+};

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -23,8 +23,10 @@ import {
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
 import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
 import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
 
 /**
  * Real {@link HeadlessAiProvider} backed by the Claude Code CLI.
@@ -77,6 +79,137 @@ import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classif
  */
 
 const RATE_LIMIT_RE = /rate.?limit/i;
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
+const asString = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+
+/**
+ * Stringify a tool's `input` object into a one-line preview suitable for chain.log. JSON
+ * encoding keeps array / nested-object shapes readable; we never feed multi-line previews into
+ * the debug stream because the bus → logger pipeline writes one record per call.
+ */
+const previewArgs = (input: unknown): string | undefined => {
+  if (input === undefined || input === null) return undefined;
+  if (typeof input === 'string') return input;
+  try {
+    const json = JSON.stringify(input);
+    return json === undefined || json === '{}' || json === '[]' ? undefined : json;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Coerce a `tool_result` block's `content` (Claude permits either a plain string or an array of
+ * content sub-blocks each with a `text` field) into a single preview string.
+ */
+const previewToolResult = (content: unknown): string | undefined => {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const texts: string[] = [];
+    for (const part of content) {
+      if (isRecord(part)) {
+        const t = asString(part['text']);
+        if (t !== undefined) texts.push(t);
+      }
+    }
+    if (texts.length > 0) return texts.join('\n');
+  }
+  return undefined;
+};
+
+/**
+ * Per-line debug publisher. Inspects Claude's stream-json envelope and fans out one
+ * `{ type: 'log', level: 'debug' }` event per recognised content block:
+ *
+ *  - `type:"assistant"` lines: emit ONE `claude-provider: assistant` event whose `meta.text` is
+ *    the concatenation of every `text` block in `message.content[]`, truncated to 120 chars.
+ *    Tool-use blocks nested in the same line each surface as their own `tool_use` event with
+ *    `{ tool: <name>, args: <truncated JSON preview> }` (the `args` key is omitted when the
+ *    block carries no input — matches the contract "omit args when none").
+ *  - `type:"user"` lines: emit one `tool_result` event per `tool_result` content block, with
+ *    `{ tool: <name | tool_use_id>, status: 'ok' | 'error', preview: <truncated content> }`.
+ *  - `type:"system"`, `type:"result"`, unknown / malformed lines: silently skipped — they are
+ *    accounted for by other telemetry (system → init logging; result → token-usage event).
+ *
+ * The `RALPHCTL_LOG_LEVEL=info` filter (applied by the bus → logger consumer at
+ * `createEventBusLogger`) drops every event published here under the default verbosity. The
+ * events only surface in chain.log when the operator explicitly lifts the floor to `debug`.
+ */
+const publishStreamLineEvents = (eventBus: EventBus, line: ClaudeStreamLine): void => {
+  const json = line.json;
+  if (json === undefined) return;
+  const type = asString(json['type']);
+  if (type !== 'assistant' && type !== 'user') return;
+
+  const message = json['message'];
+  if (!isRecord(message)) return;
+  const content = message['content'];
+  if (!Array.isArray(content)) return;
+
+  if (type === 'assistant') {
+    const texts: string[] = [];
+    const toolUses: Array<{ readonly name: string; readonly input: unknown }> = [];
+    for (const block of content) {
+      if (!isRecord(block)) continue;
+      const blockType = asString(block['type']);
+      if (blockType === 'text') {
+        const t = asString(block['text']);
+        if (t !== undefined) texts.push(t);
+      } else if (blockType === 'tool_use') {
+        const name = asString(block['name']) ?? '';
+        toolUses.push({ name, input: block['input'] });
+      }
+    }
+    if (texts.length > 0) {
+      const text = truncateField(texts.join('\n'));
+      if (text !== undefined) {
+        eventBus.publish({
+          type: 'log',
+          level: 'debug',
+          message: 'claude-provider: assistant',
+          meta: { text },
+          at: IsoTimestamp.now(),
+        });
+      }
+    }
+    for (const tool of toolUses) {
+      const args = truncateField(previewArgs(tool.input));
+      eventBus.publish({
+        type: 'log',
+        level: 'debug',
+        message: 'claude-provider: tool_use',
+        meta: {
+          tool: tool.name,
+          ...(args !== undefined ? { args } : {}),
+        },
+        at: IsoTimestamp.now(),
+      });
+    }
+    return;
+  }
+
+  // type === 'user' — emit one event per tool_result block.
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (asString(block['type']) !== 'tool_result') continue;
+    const tool = asString(block['name']) ?? asString(block['tool_use_id']) ?? '';
+    const status = block['is_error'] === true ? 'error' : 'ok';
+    const preview = truncateField(previewToolResult(block['content']));
+    eventBus.publish({
+      type: 'log',
+      level: 'debug',
+      message: 'claude-provider: tool_result',
+      meta: {
+        tool,
+        status,
+        ...(preview !== undefined ? { preview } : {}),
+      },
+      at: IsoTimestamp.now(),
+    });
+  }
+};
 
 /**
  * Headless permission mapping. Every session uses `--permission-mode bypassPermissions` paired
@@ -282,6 +415,11 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 
   const onLine = (line: ClaudeStreamLine): void => {
     parser.ingest(line);
+    // Per-line debug fan-out. The bus → logger consumer (`createEventBusLogger`) honours
+    // `RALPHCTL_LOG_LEVEL`, so these events stay invisible at the default `info` floor and
+    // only land in chain.log when an operator explicitly bumps the floor to `debug`. No
+    // extra gating needed at this site.
+    publishStreamLineEvents(deps.eventBus, line);
   };
 
   // Bound once so the onIdle banner-show id and the classifier's banner-clear id match.

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -26,6 +26,8 @@ import {
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
 
 /**
  * {@link HeadlessAiProvider} backed by the OpenAI Codex CLI (`codex` v0.130.0+).
@@ -69,6 +71,27 @@ import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-
  * flag, so the headless adapter cannot currently translate `canAccessNetwork`; sessions run
  * without the native live-web-search tool even though the shared permission model keeps the
  * bit for cross-provider parity.
+ *
+ * Per-line debug events: the headless adapter publishes one
+ * `{ type: 'log', level: 'debug', message: 'codex-provider: assistant' | 'tool_use' | 'tool_result' }`
+ * event per recognised `item.completed` record on codex's JSONL stream. The mapping (best-effort
+ * on codex-cli 0.130.x — re-audit on vendor bumps):
+ *
+ *   - `item.completed` with `item.type === 'agent_message'` → `assistant` event (`meta.text`
+ *     pulled from `item.text`).
+ *   - `item.completed` with `item.type === 'command_execution'` → `tool_use` event
+ *     (`meta.tool = 'command_execution'`, `meta.args = item.command`).
+ *   - `item.completed` with `item.type === 'function_call'` → `tool_use` event
+ *     (`meta.tool = item.name`, `meta.args = item.arguments`).
+ *   - `item.completed` with `item.type === 'function_call_output'` → `tool_result` event
+ *     (`meta.tool = item.name | item.call_id`, `meta.status = 'ok' | 'error'`,
+ *     `meta.preview = item.output`).
+ *   - `thread.started`, `turn.started`, `turn.completed`, unknown / malformed lines: silently
+ *     skipped — they are accounted for by the session-id / token-usage telemetry above.
+ *
+ * The bus → logger consumer (`createEventBusLogger`) honours `RALPHCTL_LOG_LEVEL`, so these
+ * events stay invisible at the default `info` floor and only land in chain.log when an
+ * operator explicitly bumps the floor to `debug`.
  *
  * Test seam: `spawn` is overridable so tests script stdout / stderr / exit code without
  * launching the real `codex` binary. `readFile` / `unlink` are also injectable for unit
@@ -286,7 +309,11 @@ interface CodexMetaUpdate {
  * session id (UUID) or thread name"), so it round-trips back through `session.resume` to continue
  * the conversation across gen-eval rounds.
  */
-const consumeMetaLines = (buffer: string, onMeta: (update: CodexMetaUpdate) => void): string => {
+const consumeMetaLines = (
+  buffer: string,
+  onMeta: (update: CodexMetaUpdate) => void,
+  onLine?: (obj: Record<string, unknown>) => void
+): string => {
   let remaining = buffer;
   while (true) {
     const nl = remaining.indexOf('\n');
@@ -295,30 +322,120 @@ const consumeMetaLines = (buffer: string, onMeta: (update: CodexMetaUpdate) => v
     remaining = remaining.slice(nl + 1);
     const trimmed = line.trim();
     if (trimmed.length === 0 || !trimmed.startsWith('{')) continue;
+    let obj: Record<string, unknown>;
     try {
       // Why: codex stream records arrive line-by-line at high volume; downstream
       // `stringField` / `numberField` helpers narrowly type-check the fields we care
       // about (`thread_id`, `session_id`, `model`, `usage.*`). Unknown shapes are skipped.
-      const obj = JSON.parse(trimmed) as Record<string, unknown>;
-      // `thread_id` is the 0.130.x field (on the `thread.started` record); `session_id` /
-      // `sessionId` cover legacy / forward-compat builds. First non-empty id wins (deduped by
-      // the caller), so listing `thread_id` first matches the stream order.
-      const id = stringField(obj, 'thread_id', 'session_id', 'sessionId');
-      const model = stringField(obj, 'model');
-      const usageObj = obj['usage'];
-      const source = isRecord(usageObj) ? usageObj : obj;
-      const i = numberField(source, 'input_tokens', 'inputTokens', 'prompt_tokens');
-      const o = numberField(source, 'output_tokens', 'outputTokens', 'completion_tokens');
-      if (id === undefined && model === undefined && i === undefined && o === undefined) continue;
-      onMeta({
-        ...(id !== undefined ? { sessionId: id } : {}),
-        ...(model !== undefined ? { model } : {}),
-        ...(i !== undefined ? { inputTokens: i } : {}),
-        ...(o !== undefined ? { outputTokens: o } : {}),
-      });
+      obj = JSON.parse(trimmed) as Record<string, unknown>;
     } catch {
       // non-JSON line — codex occasionally prints banner text alongside json records; skip
+      continue;
     }
+    // Per-line debug fan-out (assistant / tool_use / tool_result) BEFORE the meta extractors,
+    // so a single `item.completed` record both updates meta accumulators (when applicable)
+    // and surfaces as one debug event in chain.log.
+    if (onLine !== undefined) onLine(obj);
+    // `thread_id` is the 0.130.x field (on the `thread.started` record); `session_id` /
+    // `sessionId` cover legacy / forward-compat builds. First non-empty id wins (deduped by
+    // the caller), so listing `thread_id` first matches the stream order.
+    const id = stringField(obj, 'thread_id', 'session_id', 'sessionId');
+    const model = stringField(obj, 'model');
+    const usageObj = obj['usage'];
+    const source = isRecord(usageObj) ? usageObj : obj;
+    const i = numberField(source, 'input_tokens', 'inputTokens', 'prompt_tokens');
+    const o = numberField(source, 'output_tokens', 'outputTokens', 'completion_tokens');
+    if (id === undefined && model === undefined && i === undefined && o === undefined) continue;
+    onMeta({
+      ...(id !== undefined ? { sessionId: id } : {}),
+      ...(model !== undefined ? { model } : {}),
+      ...(i !== undefined ? { inputTokens: i } : {}),
+      ...(o !== undefined ? { outputTokens: o } : {}),
+    });
+  }
+};
+
+/**
+ * Emit one structured debug event per recognised codex `item.completed` record. See the
+ * module-level comment for the shape mapping. Returns early when the JSON record is not an
+ * `item.completed` envelope — `thread.started` / `turn.started` / `turn.completed` (and any
+ * unknown line type) intentionally produce no event because they have no assistant / tool
+ * payload to surface.
+ */
+const publishCodexStreamLineEvents = (eventBus: EventBus, obj: Record<string, unknown>): void => {
+  if (stringField(obj, 'type') !== 'item.completed') return;
+  const item = obj['item'];
+  if (!isRecord(item)) return;
+  const itemType = stringField(item, 'type');
+  if (itemType === 'agent_message') {
+    const text = truncateField(stringField(item, 'text'));
+    if (text !== undefined) {
+      eventBus.publish({
+        type: 'log',
+        level: 'debug',
+        message: 'codex-provider: assistant',
+        meta: { text },
+        at: IsoTimestamp.now(),
+      });
+    }
+    return;
+  }
+  if (itemType === 'command_execution') {
+    const args = truncateField(stringField(item, 'command'));
+    eventBus.publish({
+      type: 'log',
+      level: 'debug',
+      message: 'codex-provider: tool_use',
+      meta: {
+        tool: 'command_execution',
+        ...(args !== undefined ? { args } : {}),
+      },
+      at: IsoTimestamp.now(),
+    });
+    return;
+  }
+  if (itemType === 'function_call') {
+    const tool = stringField(item, 'name') ?? '';
+    const rawArgs = item['arguments'];
+    const argsPreview = typeof rawArgs === 'string' ? rawArgs : safeJson(rawArgs);
+    const args = truncateField(argsPreview);
+    eventBus.publish({
+      type: 'log',
+      level: 'debug',
+      message: 'codex-provider: tool_use',
+      meta: {
+        tool,
+        ...(args !== undefined ? { args } : {}),
+      },
+      at: IsoTimestamp.now(),
+    });
+    return;
+  }
+  if (itemType === 'function_call_output') {
+    const tool = stringField(item, 'name') ?? stringField(item, 'call_id') ?? '';
+    const status = item['is_error'] === true || stringField(item, 'status') === 'error' ? 'error' : 'ok';
+    const preview = truncateField(stringField(item, 'output'));
+    eventBus.publish({
+      type: 'log',
+      level: 'debug',
+      message: 'codex-provider: tool_result',
+      meta: {
+        tool,
+        status,
+        ...(preview !== undefined ? { preview } : {}),
+      },
+      at: IsoTimestamp.now(),
+    });
+  }
+};
+
+const safeJson = (v: unknown): string | undefined => {
+  if (v === undefined || v === null) return undefined;
+  try {
+    const s = JSON.stringify(v);
+    return s === '{}' || s === '[]' ? undefined : s;
+  } catch {
+    return undefined;
   }
 };
 
@@ -363,25 +480,29 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   const { code, signal } = await runHeadlessSpawn({
     child,
     onStdout: (chunk) => {
-      stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, (update) => {
-        if (update.sessionId !== undefined && sessionId === undefined) {
-          sessionId = update.sessionId;
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'debug',
-            message: 'codex-provider: session id captured',
-            meta: { sessionId: update.sessionId },
-            at: IsoTimestamp.now(),
-          });
-        }
-        if (update.model !== undefined && model === undefined) {
-          model = update.model;
-        }
-        // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
-        // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
-        if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
-        if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
-      });
+      stdoutLineBuf = consumeMetaLines(
+        stdoutLineBuf + chunk,
+        (update) => {
+          if (update.sessionId !== undefined && sessionId === undefined) {
+            sessionId = update.sessionId;
+            deps.eventBus.publish({
+              type: 'log',
+              level: 'debug',
+              message: 'codex-provider: session id captured',
+              meta: { sessionId: update.sessionId },
+              at: IsoTimestamp.now(),
+            });
+          }
+          if (update.model !== undefined && model === undefined) {
+            model = update.model;
+          }
+          // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+          // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
+          if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
+          if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
+        },
+        (obj) => publishCodexStreamLineEvents(deps.eventBus, obj)
+      );
     },
     onStderr: (chunk) => {
       stderrBuf += chunk;

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -25,6 +25,7 @@ import {
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
 
 /**
  * {@link HeadlessAiProvider} backed by the GitHub Copilot CLI (`copilot`, v1.0.12+).
@@ -62,6 +63,18 @@ import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-
  * the provider never touches signals.json. When `session.bodyFile` is set, the raw accumulated
  * body is mirrored there for forensic capture — best-effort, a write failure here is logged
  * but does not fail the spawn.
+ *
+ * Per-line debug events: the headless adapter publishes one
+ * `{ type: 'log', level: 'debug', message: 'copilot-provider: assistant' }` event per
+ * recognised assistant body line (driven off `CopilotStreamLine.bodyText`, which the parser
+ * extracts from `assistant.message_delta` / `assistant.message` and the speculative SSE shapes
+ * in `parse-stream.ts`). The Copilot CLI's `--output-format=json` stream as of 1.0.51 does
+ * NOT surface `tool_use` / `tool_result` records in any shape the adapter can recognise — tool
+ * invocations are flattened into the `assistant.message` text body. The adapter therefore
+ * emits the assistant analogue only; the tool_use / tool_result analogues described in the
+ * shared per-line debug contract simply have no source in Copilot's stream JSON. Re-audit when
+ * a future Copilot release surfaces structured tool records (compare against
+ * `_engine/copilot-stream.ts` and `parse-stream.ts`).
  *
  * Test seam: `spawn` is a {@link ProviderSpawn} override so tests script stdout / stderr /
  * exit code without launching the real binary.
@@ -264,6 +277,18 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       }
       if (line.bodyText !== undefined && line.bodyText.length > 0) {
         events.push({ assistant: true, text: line.bodyText });
+        // Per-line assistant debug event. The bus → logger consumer drops debug events at
+        // the default `info` floor; only `RALPHCTL_LOG_LEVEL=debug` operators see them.
+        const text = truncateField(line.bodyText);
+        if (text !== undefined) {
+          deps.eventBus.publish({
+            type: 'log',
+            level: 'debug',
+            message: 'copilot-provider: assistant',
+            meta: { text },
+            at: IsoTimestamp.now(),
+          });
+        }
       } else if (line.sessionId === undefined && line.model === undefined && line.usage === undefined) {
         // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
         // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:

--- a/tests/e2e/cli/doctor.test.ts
+++ b/tests/e2e/cli/doctor.test.ts
@@ -33,6 +33,13 @@ describe('ralphctl doctor', () => {
   it('reflects seeded entities in the project + sprint probe details', async () => {
     const projectRepo = createFsProjectRepository({ root: cli.paths.dataRoot });
     await projectRepo.save(makeProject({ displayName: 'Demo' }));
+    // Read-fence the save before invoking doctor. `writeJsonAtomic` lands the project via a
+    // temp-file + rename, and the rename isn't guaranteed to be visible to a sibling reader
+    // on the same event-loop turn on every platform — macOS `/var/folders` (with realpath
+    // symlinks) and some Linux runners have surfaced this as an intermittent "0 project(s)"
+    // failure. Listing here forces the file to be reachable before doctor reads the dir.
+    const listed = await projectRepo.list();
+    expect(listed.ok).toBe(true);
 
     const result = await runCliCaptured(cli, ['doctor']);
     expect(result.stdout).toContain('1 project(s)');

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -597,6 +597,70 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
     expect(args[args.indexOf('--resume') + 1]).toBe('sess-xyz');
   });
 
+  it('publishes one debug LogEvent per assistant / tool_use / tool_result block; skips system + malformed lines; truncates payloads to 120 chars', async () => {
+    const cap = createCapturingBus();
+    const sess = session();
+
+    const longText = 'A'.repeat(200); // expect truncation to 120 + '…'
+    const assistantText = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: longText }] },
+      session_id: 'sess-debug',
+    });
+    const assistantToolUse = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: { command: 'ls -la' } }],
+      },
+      session_id: 'sess-debug',
+    });
+    const userToolResult = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'total 0\n', is_error: false }],
+      },
+      session_id: 'sess-debug',
+    });
+    const systemLine = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-debug', model: 'sonnet' });
+    const malformed = '{not-json-at-all';
+    const resultEvt = JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: 'sess-debug' });
+
+    const { spawn } = makeSpawn([
+      {
+        stdoutChunks: [
+          `${systemLine}\n${assistantText}\n${assistantToolUse}\n${userToolResult}\n${malformed}\n${resultEvt}\n`,
+        ],
+        exitCode: 0,
+      },
+    ]);
+
+    const provider = createClaudeProvider({ rateLimitRetries: 0, eventBus: cap.bus, spawn });
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+
+    const streamEvents = cap.logs.filter(
+      (e) =>
+        e.level === 'debug' &&
+        (e.message === 'claude-provider: assistant' ||
+          e.message === 'claude-provider: tool_use' ||
+          e.message === 'claude-provider: tool_result')
+    );
+    expect(streamEvents).toHaveLength(3);
+
+    const assistantEvt = streamEvents.find((e) => e.message === 'claude-provider: assistant');
+    expect(assistantEvt?.meta).toEqual({ text: `${'A'.repeat(120)}…` });
+
+    const toolUseEvt = streamEvents.find((e) => e.message === 'claude-provider: tool_use');
+    expect(toolUseEvt?.meta?.['tool']).toBe('Bash');
+    expect(toolUseEvt?.meta?.['args']).toBe('{"command":"ls -la"}');
+
+    const toolResultEvt = streamEvents.find((e) => e.message === 'claude-provider: tool_result');
+    expect(toolResultEvt?.meta?.['status']).toBe('ok');
+    expect(toolResultEvt?.meta?.['preview']).toBe('total 0\n');
+  });
+
   it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
     // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
     // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -370,6 +370,71 @@ describe('createCodexProvider', () => {
     expect(fsStub.unlinks).toEqual([FIXED_OUT]);
   });
 
+  it('publishes one debug LogEvent per recognised item.completed (agent_message / function_call / function_call_output); skips thread.started / turn.completed / malformed; truncates payloads to 120 chars', async () => {
+    const cap = createCapturingBus();
+    const sess = session();
+
+    const longText = 'C'.repeat(200);
+    const longArgs = `{"path":"${'D'.repeat(200)}"}`;
+    const longOutput = 'E'.repeat(200);
+
+    const threadStarted = JSON.stringify({ type: 'thread.started', thread_id: 'sess-debug' });
+    const agentMsg = JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item_1', type: 'agent_message', text: longText },
+    });
+    const funcCall = JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item_2', type: 'function_call', name: 'apply_patch', arguments: longArgs },
+    });
+    const funcOut = JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item_3', type: 'function_call_output', call_id: 'item_2', output: longOutput, status: 'completed' },
+    });
+    const turnCompleted = JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 5 } });
+    const malformed = '{not-json-at-all';
+
+    const fsStub = stubFs('body content');
+    const { spawn } = makeSpawn([
+      {
+        stdoutChunks: [`${threadStarted}\n${agentMsg}\n${funcCall}\n${funcOut}\n${turnCompleted}\n${malformed}\n`],
+        exitCode: 0,
+      },
+    ]);
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+
+    const streamEvents = cap.logs.filter(
+      (e) =>
+        e.level === 'debug' &&
+        (e.message === 'codex-provider: assistant' ||
+          e.message === 'codex-provider: tool_use' ||
+          e.message === 'codex-provider: tool_result')
+    );
+    expect(streamEvents).toHaveLength(3);
+
+    const assistantEvt = streamEvents.find((e) => e.message === 'codex-provider: assistant');
+    expect(assistantEvt?.meta).toEqual({ text: `${'C'.repeat(120)}…` });
+
+    const toolUseEvt = streamEvents.find((e) => e.message === 'codex-provider: tool_use');
+    expect(toolUseEvt?.meta?.['tool']).toBe('apply_patch');
+    expect(toolUseEvt?.meta?.['args']).toBe(`${longArgs.slice(0, 120)}…`);
+
+    const toolResultEvt = streamEvents.find((e) => e.message === 'codex-provider: tool_result');
+    expect(toolResultEvt?.meta?.['status']).toBe('ok');
+    expect(toolResultEvt?.meta?.['preview']).toBe(`${'E'.repeat(120)}…`);
+  });
+
   it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
     // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
     // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -392,6 +392,48 @@ describe('createCopilotProvider', () => {
     expect(contents).not.toContain('stale prior content');
   });
 
+  it('publishes one assistant debug LogEvent per recognised body line; skips system/malformed; truncates payloads to 120 chars; does not surface tool_use/tool_result (gap documented in adapter header)', async () => {
+    const cap = createCapturingBus();
+    const sess = session();
+
+    const longText = 'B'.repeat(200);
+    const assistantLine = JSON.stringify({
+      type: 'assistant.message',
+      data: { content: longText },
+    });
+    // These shapes are NOT recognised by the Copilot parser today — Copilot's stream JSON does
+    // not surface structured tool records, per the adapter header comment. The lines pass
+    // through onLine but produce no structured per-line debug event.
+    const synthToolUse = JSON.stringify({ type: 'tool_use', name: 'Bash', input: { command: 'ls' } });
+    const synthToolResult = JSON.stringify({ type: 'tool_result', tool: 'Bash', is_error: false, content: 'ok' });
+    const systemLine = JSON.stringify({ type: 'system', subtype: 'init', sessionId: 'sess-debug' });
+    const malformed = '{not-json-at-all';
+
+    const { spawn } = makeSpawn([
+      {
+        stdoutChunks: [`${systemLine}\n${assistantLine}\n${synthToolUse}\n${synthToolResult}\n${malformed}\n`],
+        exitCode: 0,
+      },
+    ]);
+
+    const provider = createCopilotProvider({ rateLimitRetries: 0, eventBus: cap.bus, spawn });
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+
+    const assistantEvents = cap.logs.filter((e) => e.level === 'debug' && e.message === 'copilot-provider: assistant');
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents[0]?.meta).toEqual({ text: `${'B'.repeat(120)}…` });
+
+    // tool_use / tool_result analogues are absent in Copilot's stream — assert no structured
+    // debug event leaked from the synthetic shapes nor from the system/malformed lines.
+    const toolDebugs = cap.logs.filter(
+      (e) =>
+        e.level === 'debug' &&
+        (e.message === 'copilot-provider: tool_use' || e.message === 'copilot-provider: tool_result')
+    );
+    expect(toolDebugs).toHaveLength(0);
+  });
+
   it('non-zero exit (code 143) with signals.json present recovers and sets recoveredFromExit', async () => {
     // Faithful repro of the captured incident: macOS Node surfaces an idle-watchdog SIGTERM
     // as (code=143, signal=null), not (code=null, signal='SIGTERM'). The AI had already

--- a/tests/integration/application/ui/tui/_harness.tsx
+++ b/tests/integration/application/ui/tui/_harness.tsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import { afterEach } from 'vitest';
 import { cleanup, render } from 'ink-testing-library';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 
 type RenderResult = ReturnType<typeof render>;
 import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
@@ -137,6 +138,49 @@ export const renderView = (child: React.ReactNode, opts: HarnessOptions): Harnes
     result,
     routeIds: () => routes.map((r) => r.id),
   };
+};
+
+/**
+ * Wait until a view has finished its initial async load and its post-mount effects have
+ * settled, so a test can safely send input next.
+ *
+ * Two distinct issues this addresses:
+ *
+ * 1. **Async hydration race.** Views that hydrate state via async repositories (typically
+ *    `findById` / `list` in `useEffect`) show a `<Spinner label="Loading…" />` until the data
+ *    resolves; while in that state, their `useInput` handlers short-circuit so any keystroke
+ *    sent by a test gets silently dropped. A fixed `tick(N)` after `renderView` races that
+ *    load on cold module imports (CI coverage step pays JIT + c8-instrumentation cost on
+ *    every import).
+ *
+ * 2. **Post-commit effect race.** Many views run a follow-up `useEffect` after the first
+ *    successful load — e.g. resetting a cursor / focus index, kicking off a derived fetch.
+ *    React fires those effects AFTER the commit that flips loading→ok, so the first paint
+ *    of the loaded UI happens before they run. Without a trailing settle, a test that
+ *    presses a key immediately can have its `setState` overridden by the still-pending
+ *    effect.
+ *
+ * The implementation polls until the frame is non-empty and no longer contains the loading
+ * label (handles #1), then yields one extra tick to let post-commit effects flush (handles
+ * #2). Pass an optional `extra` predicate to also assert on a specific rendered element
+ * before proceeding — useful when "not loading" isn't a strong enough signal.
+ *
+ * **Use this instead of `tick(N)` immediately after `renderView`.**
+ */
+export const waitForViewReady = async (
+  result: { lastFrame: () => string | undefined },
+  extra?: (frame: string) => boolean
+): Promise<void> => {
+  await waitFor(() => {
+    const frame = result.lastFrame() ?? '';
+    if (frame.length === 0) return false;
+    if (frame.includes('Loading…')) return false;
+    return extra ? extra(frame) : true;
+  });
+  // Flush one tick so any `useEffect` queued by the loading→ok commit (cursor / focus /
+  // derived-state syncs) runs before the test sends its first keystroke. Without this the
+  // input race described in (2) above resurfaces.
+  await tick();
 };
 
 /**

--- a/tests/integration/application/ui/tui/_keys.ts
+++ b/tests/integration/application/ui/tui/_keys.ts
@@ -25,3 +25,22 @@ export const CTRL_W = '';
 export const tick = async (ms = 30): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+/**
+ * Poll `predicate` until it returns true or `timeoutMs` elapses. Use this in place of a fixed
+ * `tick(N)` when the test depends on an async settling step whose timing isn't bounded by a
+ * single Ink render tick — e.g. waiting for a stubbed repo `findById` to resolve before the
+ * view's `useInput` handler is responsive, or waiting for an async `openEditPrompt` to enqueue
+ * a prompt after a keystroke. Cheap on the happy path (~10ms first poll), bounded on cold CI.
+ */
+export const waitFor = async (
+  predicate: () => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<void> => {
+  const { timeoutMs = 1000, intervalMs = 10 } = opts;
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start >= timeoutMs) return;
+    await tick(intervalMs);
+  }
+};

--- a/tests/integration/application/ui/tui/runtime/use-task-round-tracker.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/use-task-round-tracker.test.tsx
@@ -12,7 +12,7 @@ import { render } from 'ink-testing-library';
 import { Text } from 'ink';
 import { describe, expect, it } from 'vitest';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
-import { useTaskRoundTracker } from '@src/application/ui/tui/runtime/use-task-round-tracker.ts';
+import { TASK_ROUND_CAP, useTaskRoundTracker } from '@src/application/ui/tui/runtime/use-task-round-tracker.ts';
 import { isoTimestamp } from '@tests/fixtures/domain.ts';
 
 const NOW = isoTimestamp('2026-05-09T10:00:00.000Z');
@@ -69,5 +69,56 @@ describe('useTaskRoundTracker', () => {
 
     expect(last.size).toBe(0);
     r.unmount();
+  });
+
+  it('caps retained tasks at TASK_ROUND_CAP and evicts the oldest on overflow', async () => {
+    const bus = createInMemoryEventBus();
+    let last: ReadonlyMap<string, { roundN: number; totalCap: number }> = new Map();
+    const r = render(<Probe bus={bus} onState={(rounds) => (last = rounds)} />);
+
+    const overflow = 50;
+    const total = TASK_ROUND_CAP + overflow;
+    for (let i = 0; i < total; i += 1) {
+      bus.publish({
+        type: 'task-round-started',
+        taskId: `task-${String(i)}`,
+        attemptN: 1,
+        roundN: 1,
+        totalCap: 5,
+        at: NOW,
+      });
+    }
+    await new Promise((res) => setTimeout(res, 5));
+
+    expect(last.size).toBe(TASK_ROUND_CAP);
+    // The `overflow` oldest taskIds were evicted; the most recent TASK_ROUND_CAP remain.
+    expect(last.has('task-0')).toBe(false);
+    expect(last.has(`task-${String(overflow - 1)}`)).toBe(false);
+    expect(last.has(`task-${String(overflow)}`)).toBe(true);
+    expect(last.has(`task-${String(total - 1)}`)).toBe(true);
+    r.unmount();
+  });
+
+  it('releases the bus subscription on unmount so post-unmount publishes are ignored', async () => {
+    const bus = createInMemoryEventBus();
+    let last: ReadonlyMap<string, { roundN: number; totalCap: number }> = new Map();
+    const r = render(<Probe bus={bus} onState={(rounds) => (last = rounds)} />);
+
+    bus.publish({ type: 'task-round-started', taskId: 't1', attemptN: 1, roundN: 1, totalCap: 5, at: NOW });
+    await new Promise((res) => setTimeout(res, 5));
+    expect(last.size).toBe(1);
+
+    r.unmount();
+
+    // Snapshot what the component last saw, then publish more events. If the subscription had
+    // leaked the hook would still call setState and update `last`; we assert it does not.
+    const snapshot = last;
+    bus.publish({ type: 'task-round-started', taskId: 't2', attemptN: 1, roundN: 1, totalCap: 5, at: NOW });
+    bus.publish({ type: 'task-round-started', taskId: 't3', attemptN: 1, roundN: 1, totalCap: 5, at: NOW });
+    await new Promise((res) => setTimeout(res, 5));
+
+    expect(last).toBe(snapshot);
+    expect(last.has('t2')).toBe(false);
+    expect(last.has('t3')).toBe(false);
   });
 });

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Smoke tests for ProjectDetailView. Renders the project info card + each repo as a
- * focusable card. `a` pushes the add-repository wizard.
+ * focusable card. `a` pushes the add-repository wizard. The view uses a flat field cursor
+ * (displayName → repo1.name → repo1.setupScript → repo1.verifyScript → repo2.name → …) and
+ * `e` / ↵ open the field editor directly without a choice prompt.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -9,8 +11,10 @@ import { ProjectDetailView } from '@src/application/ui/tui/views/project-detail-
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
-import { makeProject } from '@tests/fixtures/domain.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
+import { FIXED_PROJECT_ID, makeProject, makeRepository, repositoryId, slug } from '@tests/fixtures/domain.ts';
+import { DOWN, ENTER, UP, tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeProjectRepo = (project: Project): ProjectRepository =>
@@ -27,6 +31,26 @@ const stubDeps = (project: Project): AppDeps =>
   ({
     projectRepo: fakeProjectRepo(project),
   }) as unknown as AppDeps;
+
+const SECOND_REPO_ID = repositoryId('01900000-0000-7000-8000-000000000099');
+
+const makeTwoRepoProject = (): Project => {
+  const repo1 = makeRepository();
+  const repo2 = makeRepository({ id: SECOND_REPO_ID, slug: 'second', name: 'second-repo', path: '/tmp/second' });
+  return makeProject({ repositories: [repo1, repo2] });
+};
+
+/**
+ * Locate the line in `frame` that contains BOTH labels — e.g. "Name" + the project's
+ * displayName. The status bar and the in-card field both mention the name, so a single-needle
+ * search is ambiguous; pairing with the column label disambiguates to the focusable row.
+ */
+const lineWithLabelAndValue = (frame: string, label: string, value: string): string | undefined =>
+  frame.split('\n').find((l) => l.includes(label) && l.includes(value));
+
+/** Return the line that holds a repository's bold name row — `   <cursor> <name> (<slug>)`. */
+const repoNameLine = (frame: string, repoName: string, repoSlug: string): string | undefined =>
+  frame.split('\n').find((l) => l.includes(`${repoName} (${repoSlug})`));
 
 describe('ProjectDetailView', () => {
   it('renders the project name + slug + repository roster', async () => {
@@ -55,5 +79,182 @@ describe('ProjectDetailView', () => {
     await tick();
     expect(routeIds()).toContain('add-repository');
     result.unmount();
+  });
+
+  it('initial focus lands on the project displayName row', async () => {
+    const project = makeProject({ displayName: 'Mainline' });
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    const nameRow = lineWithLabelAndValue(frame, 'Name', 'Mainline');
+    expect(nameRow).toBeDefined();
+    expect(nameRow).toContain(glyphs.actionCursor);
+  });
+
+  it('↓ moves focus from displayName to repo 1 name', async () => {
+    const project = makeProject({ displayName: 'Mainline' });
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+    });
+    await tick(40);
+    result.stdin.write(DOWN);
+    await tick();
+    const frame = result.lastFrame() ?? '';
+    // Project Name row should no longer carry the cursor glyph.
+    const nameRow = lineWithLabelAndValue(frame, 'Name', 'Mainline');
+    expect(nameRow).toBeDefined();
+    expect(nameRow).not.toContain(glyphs.actionCursor);
+    // Repo 1 name row should now carry it.
+    const repoLine = repoNameLine(frame, 'main-repo', 'main-repo');
+    expect(repoLine).toBeDefined();
+    expect(repoLine).toContain(glyphs.actionCursor);
+  });
+
+  it('e on a focused setupScript opens the editor directly (no choice prompt)', async () => {
+    const project = makeTwoRepoProject();
+    const queue = createPromptQueue();
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+      queue,
+    });
+    await tick(40);
+    // displayName → repo1.name → repo1.setupScript (two DOWNs lands on setupScript).
+    result.stdin.write(DOWN);
+    await tick();
+    result.stdin.write(DOWN);
+    await tick();
+    result.stdin.write('e');
+    await tick();
+    // setupScript is a long/multi-line edit field → textarea, not text. The point of the test
+    // is that the queue head is NOT a 'choice' prompt — we go straight into the editor.
+    expect(queue.head?.kind).not.toBe('choice');
+    expect(queue.head?.kind).toBe('textarea');
+    expect(queue.head?.message ?? '').toContain('setupScript');
+    result.unmount();
+  });
+
+  it('c / S / d are silent no-ops on the project displayName row; a still opens the wizard', async () => {
+    const project = makeProject({});
+    const queue = createPromptQueue();
+    const { result, routeIds } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+      queue,
+    });
+    await tick(40);
+    // c / S / d on the project row must NOT push a new route nor queue a prompt and must NOT
+    // mount the confirm-remove panel (which would replace the field-list region).
+    result.stdin.write('c');
+    await tick();
+    result.stdin.write('S');
+    await tick();
+    result.stdin.write('d');
+    await tick();
+    expect(routeIds()).not.toContain('execute');
+    expect(queue.head).toBeUndefined();
+    const after = result.lastFrame() ?? '';
+    expect(after).not.toContain('Remove repository');
+    expect(after).not.toContain('✗');
+    // `a` is still active even on the project row.
+    result.stdin.write('a');
+    await tick();
+    expect(routeIds()).toContain('add-repository');
+  });
+
+  it('↑ at the first field and ↓ at the last field do not wrap', async () => {
+    const project = makeTwoRepoProject();
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+    });
+    await tick(40);
+    // Already at index 0 → UP stays put.
+    result.stdin.write(UP);
+    await tick();
+    let frame = result.lastFrame() ?? '';
+    let nameRow = lineWithLabelAndValue(frame, 'Name', project.displayName);
+    expect(nameRow).toContain(glyphs.actionCursor);
+
+    // Walk to the last field: 2 repos × 3 fields + 1 project field = 7 fields, so 6 DOWN
+    // presses. The last field is second-repo verifyScript.
+    for (let i = 0; i < 6; i++) {
+      result.stdin.write(DOWN);
+      await tick();
+    }
+    // The cursor should be on the Verify row of `second-repo` (the LAST repo card). One extra
+    // DOWN at the bottom must NOT move focus elsewhere.
+    const frameAtBottom = result.lastFrame() ?? '';
+    // Locate second-repo's card: its repo-name line and the two field rows below it. The Verify
+    // row of the LAST repo is the last `Verify:` line in the frame.
+    const verifyLines = frameAtBottom.split('\n').filter((l) => l.includes('Verify:'));
+    expect(verifyLines.length).toBe(2);
+    expect(verifyLines[verifyLines.length - 1]).toContain(glyphs.actionCursor);
+
+    result.stdin.write(DOWN);
+    await tick();
+    const afterBoundary = result.lastFrame() ?? '';
+    const verifyLinesAfter = afterBoundary.split('\n').filter((l) => l.includes('Verify:'));
+    expect(verifyLinesAfter[verifyLinesAfter.length - 1]).toContain(glyphs.actionCursor);
+
+    // Walk back up and an extra UP — must stay on displayName.
+    for (let i = 0; i < 6; i++) {
+      result.stdin.write(UP);
+      await tick();
+    }
+    result.stdin.write(UP);
+    await tick();
+    frame = result.lastFrame() ?? '';
+    nameRow = lineWithLabelAndValue(frame, 'Name', project.displayName);
+    expect(nameRow).toContain(glyphs.actionCursor);
+  });
+
+  it('project with no repositories shows only the displayName as focusable', async () => {
+    // Bypass createProject's `≥1 repo` aggregate invariant — this is a UI-only test and we want
+    // to verify the cursor model degrades gracefully to a one-element list.
+    const empty: Project = {
+      id: FIXED_PROJECT_ID,
+      slug: slug('solo'),
+      displayName: 'Solo',
+      repositories: [],
+    };
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(empty),
+      initial: { id: 'project-detail', props: { projectId: empty.id } },
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    const nameRow = lineWithLabelAndValue(frame, 'Name', 'Solo');
+    expect(nameRow).toBeDefined();
+    expect(nameRow).toContain(glyphs.actionCursor);
+    // No "main-repo" / repository card in the frame.
+    expect(frame).not.toContain('main-repo');
+    // DOWN cannot move — cursor stays on the project Name row.
+    result.stdin.write(DOWN);
+    await tick();
+    const after = result.lastFrame() ?? '';
+    const nameRowAfter = lineWithLabelAndValue(after, 'Name', 'Solo');
+    expect(nameRowAfter).toContain(glyphs.actionCursor);
+  });
+
+  it('↵ on the focused project displayName opens the project rename editor', async () => {
+    // Belt-and-braces: the requirements list `e` OR Enter as the edit trigger. Make sure ENTER
+    // alone works on the initial focus and routes through the same path.
+    const project = makeProject({ displayName: 'Mainline' });
+    const queue = createPromptQueue();
+    const { result } = renderView(<ProjectDetailView />, {
+      deps: stubDeps(project),
+      initial: { id: 'project-detail', props: { projectId: project.id } },
+      queue,
+    });
+    await tick(40);
+    result.stdin.write(ENTER);
+    await tick();
+    expect(queue.head?.kind).toBe('text');
+    expect(queue.head?.message ?? '').toContain('Rename project');
   });
 });

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -14,7 +14,7 @@ import type { ProjectRepository } from '@src/domain/repository/project/project-r
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { FIXED_PROJECT_ID, makeProject, makeRepository, repositoryId, slug } from '@tests/fixtures/domain.ts';
-import { DOWN, ENTER, UP, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, ENTER, UP, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeProjectRepo = (project: Project): ProjectRepository =>
@@ -251,9 +251,14 @@ describe('ProjectDetailView', () => {
       initial: { id: 'project-detail', props: { projectId: project.id } },
       queue,
     });
-    await tick(40);
+    // Wait for the project to load — useInput bails out while `project === undefined`, so a
+    // fixed `tick(40)` races the async `findById` on a cold module import.
+    await waitFor(() => {
+      const frame = result.lastFrame() ?? '';
+      return frame.includes('Mainline') && frame.includes(glyphs.actionCursor);
+    });
     result.stdin.write(ENTER);
-    await tick();
+    await waitFor(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     expect(queue.head?.message ?? '').toContain('Rename project');
   });

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -15,7 +15,7 @@ import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { FIXED_PROJECT_ID, makeProject, makeRepository, repositoryId, slug } from '@tests/fixtures/domain.ts';
 import { DOWN, ENTER, UP, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeProjectRepo = (project: Project): ProjectRepository =>
   ({
@@ -59,7 +59,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(project),
       initial: { id: 'project-detail', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Mainline');
     expect(frame).toContain('mainline');
@@ -74,7 +74,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(project),
       initial: { id: 'project-detail', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     result.stdin.write('a');
     await tick();
     expect(routeIds()).toContain('add-repository');
@@ -87,7 +87,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(project),
       initial: { id: 'project-detail', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     const frame = result.lastFrame() ?? '';
     const nameRow = lineWithLabelAndValue(frame, 'Name', 'Mainline');
     expect(nameRow).toBeDefined();
@@ -100,7 +100,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(project),
       initial: { id: 'project-detail', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     result.stdin.write(DOWN);
     await tick();
     const frame = result.lastFrame() ?? '';
@@ -122,7 +122,7 @@ describe('ProjectDetailView', () => {
       initial: { id: 'project-detail', props: { projectId: project.id } },
       queue,
     });
-    await tick(40);
+    await waitForViewReady(result);
     // displayName → repo1.name → repo1.setupScript (two DOWNs lands on setupScript).
     result.stdin.write(DOWN);
     await tick();
@@ -146,7 +146,7 @@ describe('ProjectDetailView', () => {
       initial: { id: 'project-detail', props: { projectId: project.id } },
       queue,
     });
-    await tick(40);
+    await waitForViewReady(result);
     // c / S / d on the project row must NOT push a new route nor queue a prompt and must NOT
     // mount the confirm-remove panel (which would replace the field-list region).
     result.stdin.write('c');
@@ -172,7 +172,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(project),
       initial: { id: 'project-detail', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     // Already at index 0 → UP stays put.
     result.stdin.write(UP);
     await tick();
@@ -226,7 +226,7 @@ describe('ProjectDetailView', () => {
       deps: stubDeps(empty),
       initial: { id: 'project-detail', props: { projectId: empty.id } },
     });
-    await tick(40);
+    await waitForViewReady(result);
     const frame = result.lastFrame() ?? '';
     const nameRow = lineWithLabelAndValue(frame, 'Name', 'Solo');
     expect(nameRow).toBeDefined();
@@ -251,12 +251,7 @@ describe('ProjectDetailView', () => {
       initial: { id: 'project-detail', props: { projectId: project.id } },
       queue,
     });
-    // Wait for the project to load — useInput bails out while `project === undefined`, so a
-    // fixed `tick(40)` races the async `findById` on a cold module import.
-    await waitFor(() => {
-      const frame = result.lastFrame() ?? '';
-      return frame.includes('Mainline') && frame.includes(glyphs.actionCursor);
-    });
+    await waitForViewReady(result);
     result.stdin.write(ENTER);
     await waitFor(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');

--- a/tests/unit/integration/ai/providers/_engine/truncate-debug-field.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/truncate-debug-field.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
+
+describe('truncateField', () => {
+  it('passes a short string through unchanged', () => {
+    expect(truncateField('hello')).toBe('hello');
+  });
+
+  it('passes an exact-cap string through unchanged (boundary, no ellipsis)', () => {
+    const exact = 'a'.repeat(120);
+    expect(truncateField(exact)).toBe(exact);
+    expect(truncateField(exact, 120)).toBe(exact);
+  });
+
+  it('truncates over-cap strings to max length + the U+2026 horizontal ellipsis', () => {
+    const over = 'b'.repeat(121);
+    const out = truncateField(over);
+    expect(out).toBe(`${'b'.repeat(120)}…`);
+    // The ellipsis is one code point ('…' / U+2026), not three ASCII dots.
+    expect(out?.endsWith('…')).toBe(true);
+    expect(out?.endsWith('...')).toBe(false);
+  });
+
+  it('honours a custom max cap', () => {
+    expect(truncateField('hello world', 5)).toBe('hello…');
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(truncateField(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string input', () => {
+    expect(truncateField('')).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,6 +53,12 @@ export default defineConfig({
           include: ['tests/**/*.test.{ts,tsx}'],
           exclude: ['tests/integration/application/ui/tui/**'],
           pool: 'forks',
+          // E2E tests under `tests/e2e/cli/` spawn real child processes (git / gh / glab /
+          // provider CLIs) inside the in-process CLI run, and pay full module-import cost on
+          // a cold `node_modules` (Cold-install smoke job). Vitest's implicit 5 s default
+          // budget is too tight for that, and the resulting test-timeout failures masquerade
+          // as logic flakes. 15 s matches the `tui` project; raise here in lockstep with it.
+          testTimeout: 15000,
         },
       },
     ],


### PR DESCRIPTION
This branch extends all three headless AI provider adapters to emit structured debug events per recognised stream line, giving operators visibility into tool calls and intermediate assistant text during a long-running implement turn. It also caps `useTaskRoundTracker` with LRU eviction — bringing it in line with the other three TUI bus-subscriber hooks that were already bounded — and replaces the project-detail field-picker modal with a flat, keyboard-navigable field cursor that mirrors the settings view.

## Changes

- Claude, Codex, and Copilot headless adapters each publish one `{ type: 'log', level: 'debug' }` event per recognised stream line; a shared `truncateField` helper caps message text at 120 chars.
- Claude surfaces nested `tool_use` / `tool_result` blocks as individual events; Codex maps `agent_message`, `command_execution`, and `function_call` subtypes; Copilot intentionally emits only the assistant analogue (its CLI flattens tool calls into the assistant message body).
- `useTaskRoundTracker` now exports `TASK_ROUND_CAP = 500` and applies the same delete-then-set-then-evict LRU reducer already used by `use-token-usage.ts`; all four hook files carry a short audit-verdict comment naming their bound and rationale.
- Project-detail view replaces the "Edit which field?" choice prompt with a flat ↑/↓-navigable field list — project `displayName` first, then each repo's `name` / `setupScript` / `verifyScript` in turn.
- `e` and Enter open the focused field's editor directly; per-repo actions (`c` / `S` / `d`) derive their target repo from the focused row and silently no-op when focus is on the project row.
- Row-level highlighting (color + leading cursor glyph) replaces per-card border focus, matching the settings view's `valueFor` pattern.

## Test plan

- [ ] Run `RALPHCTL_LOG_LEVEL=debug ralphctl implement` on a real task and confirm per-line debug events appear in log output for each provider.
- [ ] Confirm no debug events appear at the default log level.
- [ ] Open a project with multiple repos; navigate ↑/↓ in project-detail view and verify the row highlight tracks correctly, clamping at both ends without wrapping.
- [ ] Press `e` on a repo `setupScript` row — confirm the editor opens directly with no field-picker modal.
- [ ] Press `c` / `S` / `d` while the cursor is on the project `displayName` row — confirm the action silently no-ops.
- [ ] Run the full test suite; new tests for all three areas (`use-task-round-tracker`, `project-detail-view`, and provider debug events) should pass.

Closes #153
Closes #158
Closes #161