### PR TITLE
feat(prompts): per-provider conventions partial + de-Claude contract section

### DIFF
--- a/src/integration/ai/contract/_engine/render-contract-section.ts
+++ b/src/integration/ai/contract/_engine/render-contract-section.ts
@@ -68,8 +68,8 @@ export const renderContractSection = (params: RenderContractSectionParams): stri
   lines.push('other files — the harness renders every operator-readable sidecar from the validated');
   lines.push('signals.');
   lines.push('');
-  lines.push('Use the `Write` tool with the absolute path above — your cwd is the project repo, not');
-  lines.push('the spawn output directory, so a relative `signals.json` would land in the wrong place.');
+  lines.push('Always write to the **absolute path** shown above — do not use a relative path, which');
+  lines.push('would resolve against your working directory and may land in the wrong place.');
   lines.push('');
   if (params.sidecars.length > 0) {
     lines.push('Files the harness will render from your signals (you must NOT write these):');

--- a/src/integration/ai/prompts/_partials/conventions-agents-md.md
+++ b/src/integration/ai/prompts/_partials/conventions-agents-md.md
@@ -1,0 +1,63 @@
+## AGENTS.md conventions
+
+`AGENTS.md` is the cross-tool agent context file — recognised by OpenAI Codex and increasingly by other
+agent runtimes. It is format-loose: no required heading schema, no hard line cap. Write it as clear
+prose or bullets, organised into named sections, so any agent runtime that loads it can navigate it
+without tool-specific knowledge.
+
+**Structure rules:**
+
+- Open with a brief one- or two-sentence project description (no formal H1 required, though a title
+  heading is fine).
+- Use H2 sections to group related rules — `## Build`, `## Testing`, `## Architecture`, etc.
+- Keep sections short and scannable; avoid walls of prose. Bullets work well.
+- No depth limit on headings, but rarely need more than `##`/`###`.
+- No hard line cap, but keep the file under ~150 lines — longer files dilute the signal-to-noise
+  ratio for models with a limited context window.
+
+**Tone and framing:**
+
+Write `AGENTS.md` as a plain, tool-agnostic specification. Avoid Claude-specific vocabulary
+(`<tool>`, `slash commands`, hooks, `CLAUDE.md` cross-references) and Copilot-specific vocabulary
+(Chat context, `@workspace`). The content should read equally well regardless of which agent runtime
+is consuming it.
+
+**Inclusion test** — include a rule only when an agent would get it wrong without being told. Skip
+anything derivable from the language, the manifest, or the directory structure. Skip generic
+engineering advice the model already follows by default.
+
+**Sample stub** (adapt; do not copy verbatim):
+
+```markdown
+# Project Name
+
+TypeScript monorepo. Use the workspace-aware install command; individual-package installs
+break the shared lockfile.
+
+## Build
+
+- `<build command>` — compiles all packages to `dist/`.
+- Environment: copy `.env.example` to `.env` and fill in required values before running.
+
+## Testing
+
+- `<test command>` — runs unit + integration tests.
+- Integration tests require a running database; start it with `<database start command>`.
+- Do not mock the database layer — use real fixtures from `tests/fixtures/`.
+
+## Architecture
+
+- Clean Architecture: `domain → business → integration → application`. No reverse imports.
+- No barrel files (`index.ts` re-exports) — every import names its symbol explicitly.
+
+## Conventions
+
+- Business operations return a `Result` type — do not throw for domain errors.
+- All file writes go through the atomic-write helper in `business/io/`; direct `fs.writeFile`
+  is banned from business code.
+
+## Security
+
+- Do not log authentication tokens or request bodies, even at debug level.
+- Never commit `.env` files — they contain real credentials for development services.
+```

--- a/src/integration/ai/prompts/_partials/conventions-claude-md.md
+++ b/src/integration/ai/prompts/_partials/conventions-claude-md.md
@@ -1,0 +1,58 @@
+## CLAUDE.md conventions
+
+`CLAUDE.md` is Claude Code's native project context file — loaded automatically from the repository root
+at the start of every session. Write it as a compact reference document an agent re-reads on every
+invocation, not as a tutorial or README.
+
+**Structure rules:**
+
+- Exactly one H1 (`# Project Name`) as the opening line.
+- At most seven H2 sections (`## Build & Run`, `## Testing`, `## Architecture`, …). Fewer is better.
+- No H4 headings or deeper — three heading levels (`#`, `##`, `###`) is the practical maximum.
+- Prefer tight bullet lists over prose paragraphs; each bullet should be one verifiable claim.
+- Hard line cap: 200 lines. Claude Code truncates longer files, so brevity is load-bearing.
+
+**"Read on demand" pattern** — for sections that an agent rarely needs mid-task, list them under a
+`## References` heading with paths rather than embedding the content inline:
+
+```
+## References
+
+- `.claude/docs/ARCHITECTURE.md` — module layout and layering rules
+- `.claude/docs/DESIGN-SYSTEM.md` — TUI tokens and component copy rules
+```
+
+This keeps the primary file short while keeping the information reachable.
+
+**Inclusion test** — include a rule only when an agent would get it wrong without being told. Skip
+language conventions the model already knows. Skip anything derivable from directory structure or
+manifest files.
+
+**Sample stub** (adapt; do not copy verbatim):
+
+```markdown
+# Project Name
+
+Node.js 20 + TypeScript. Run `<install command>` once, then `<dev command>` to start.
+
+## Build & Run
+
+- `<build command>` — compiles to `dist/`.
+- Required env: `DATABASE_URL` (Postgres connection string).
+
+## Testing
+
+- `<test command>` — unit + integration. Integration tests require a running database.
+- Do not mock the database layer — prior incidents show mock/prod divergence is a real risk.
+
+## Architecture
+
+- Four-module Clean Architecture: `domain → business → integration → application`.
+- No barrel `index.ts` files under `src/` — name every import explicitly.
+- Business code must not import I/O-bearing `node:*` modules — pure `node:path` / `node:url` ok.
+
+## Conventions
+
+- Return `Result<T, DomainError>` from every business operation — do not throw.
+- Em-dash (`—`) for explanatory clauses in comments and docs.
+```

--- a/src/integration/ai/prompts/_partials/conventions-copilot-instructions.md
+++ b/src/integration/ai/prompts/_partials/conventions-copilot-instructions.md
@@ -1,0 +1,53 @@
+## .github/copilot-instructions.md conventions
+
+`.github/copilot-instructions.md` is GitHub Copilot's native project context file — injected into every
+Copilot Chat and Copilot Coding Agent session. Write it as a set of **decision-rationale pairs**: each
+rule states what to do and, on the same line or the next bullet, _why_ — because Copilot performs better
+when it understands the motivation behind a constraint, not just the constraint itself.
+
+**Structure rules:**
+
+- No required heading schema — free prose and bullets both work. H2 sections help scanability.
+- Lead every non-obvious rule with a "what + why" pair. Example: "Never mock the database layer
+  in integration tests — prior incidents show mock/prod divergence masks real migration failures."
+- Keep the file under 100–150 lines; Copilot context injection has a token budget.
+- Prefer present-tense imperatives: "Use X", "Do not Y", "Prefer Z over W".
+- Reference file paths with backticks so Copilot can navigate to them.
+
+**Tone and framing:**
+
+Copilot instructions read best when they frame constraints as informed decisions rather than
+arbitrary mandates. Where a rule exists because of a past incident, a performance requirement, or a
+security boundary, name it — this helps the model distinguish "this rule is load-bearing" from "this is
+a style preference."
+
+**Inclusion test** — include a rule only when an agent would get it wrong without being told. Skip
+anything derivable from the language, the manifest, or the directory structure. Skip generic engineering
+advice the model already follows by default.
+
+**Sample stub** (adapt; do not copy verbatim):
+
+```markdown
+## Architecture
+
+- Four-module Clean Architecture: `domain → business → integration → application` — inner layers
+  must not import outer ones. ESLint enforces this; a lint failure means a layering violation.
+- No barrel `index.ts` files — every import names what it pulls in. This keeps dead-code analysis
+  accurate; barrel files silently re-export unused symbols.
+
+## Testing
+
+- Integration tests hit a real database, not a mock — the team has been burned by mock/prod
+  divergence masking broken migrations. Use the test fixtures in `tests/fixtures/` to seed state.
+
+## Conventions
+
+- Every business operation returns `Result<T, DomainError>` — do not throw. Throws are reserved for
+  programmer errors (invariant violations inside leaf projections).
+- Em-dash (`—`) for explanatory clauses in comments and documentation — not a hyphen.
+
+## Security
+
+- Never log request bodies or auth tokens — even at debug level. The logger is structured and ships
+  to a third-party aggregator; sensitive fields would be retained.
+```

--- a/src/integration/ai/prompts/readiness/definition.ts
+++ b/src/integration/ai/prompts/readiness/definition.ts
@@ -26,6 +26,10 @@ import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/templat
  *    non-empty body.
  *  - `detectedArtefacts` — bullet list of artefact paths discovered by the probe, or an explicit
  *    "no artefacts detected" line when the probe came back absent.
+ *  - `targetFileConventions` — per-provider style guide for the target context file (CLAUDE.md /
+ *    `.github/copilot-instructions.md` / AGENTS.md). Loaded from the matching conventions
+ *    partial via {@link conventionsPartialName} and passed as a rendered string so the template
+ *    can embed it inside `<target_file_conventions>` before the output contract section.
  */
 export interface ReadinessPromptParams {
   readonly repositoryPath: string;
@@ -33,6 +37,12 @@ export interface ReadinessPromptParams {
   readonly wireTag: string;
   readonly existingContextFile: string;
   readonly detectedArtefacts: string;
+  /**
+   * Per-provider style guide body — loaded from the conventions partial selected by
+   * {@link conventionsPartialName}. Placed in the template before `<output_contract>` so the
+   * AI reads format conventions before it sees the output shape.
+   */
+  readonly targetFileConventions: string;
   /**
    * Audit-[09] output contract section — rendered from the readiness `AiOutputContract` by
    * `renderContractSectionFor(readinessOutputContract)`. Tells the AI to write `signals.json`
@@ -55,6 +65,24 @@ export const wireTagFor = (tool: AssistantTool): string => {
       return 'copilot-instructions';
     case 'codex':
       return 'agents-md';
+  }
+};
+
+/**
+ * Map an {@link AssistantTool} to the partial name that holds its target-file conventions.
+ * The partial is loaded by `buildReadinessPrompt` and passed as `targetFileConventions` so
+ * the AI receives per-provider style guidance before it sees the output contract shape.
+ */
+export const conventionsPartialName = (
+  tool: AssistantTool
+): 'conventions-claude-md' | 'conventions-copilot-instructions' | 'conventions-agents-md' => {
+  switch (tool) {
+    case 'claude-code':
+      return 'conventions-claude-md';
+    case 'copilot':
+      return 'conventions-copilot-instructions';
+    case 'codex':
+      return 'conventions-agents-md';
   }
 };
 
@@ -105,6 +133,11 @@ export const readinessPromptDef: PromptDefinition<ReadinessPromptParams> = {
     detectedArtefacts: {
       placeholder: 'DETECTED_ARTEFACTS',
       description: 'Bullet list of artefact paths discovered by the probe, or "no artefacts detected".',
+    },
+    targetFileConventions: {
+      placeholder: 'TARGET_FILE_CONVENTIONS',
+      description:
+        'Per-provider style guide for the target context file (CLAUDE.md / .github/copilot-instructions.md / AGENTS.md). Loaded from the matching conventions partial.',
     },
     outputContractSection: {
       placeholder: 'OUTPUT_CONTRACT_SECTION',
@@ -194,16 +227,27 @@ export interface BuildReadinessPromptInput {
 /**
  * Top-level builder — accepts domain types, renders the param strings, calls `buildPrompt`.
  * The chain leaf consumes this via function injection.
+ *
+ * Loads the per-provider conventions partial manually (rather than via `partials` auto-load)
+ * so the partial name can be computed dynamically from `currentTool` at call time. The loaded
+ * body is passed as `targetFileConventions` — a regular string parameter — which the template
+ * embeds inside `<target_file_conventions>` before the output contract section.
  */
 export const buildReadinessPrompt = async (
   deps: TemplateLoader,
   input: BuildReadinessPromptInput
-): Promise<Result<Prompt, BuildPromptError>> =>
-  buildPrompt(deps, readinessPromptDef, {
+): Promise<Result<Prompt, BuildPromptError>> => {
+  const partialName = conventionsPartialName(input.currentTool);
+  const conventionsResult = await deps.load(partialName);
+  if (!conventionsResult.ok) return Result.error(conventionsResult.error);
+
+  return buildPrompt(deps, readinessPromptDef, {
     repositoryPath: input.repositoryPath,
     currentTool: renderCurrentTool(input.currentTool),
     wireTag: wireTagFor(input.currentTool),
     existingContextFile: renderExistingContextFile(input.existingContextFile),
     detectedArtefacts: renderDetectedArtefacts(collectArtefactPaths(input.probedState)),
+    targetFileConventions: conventionsResult.value.trim(),
     outputContractSection: input.outputContractSection,
   });
+};

--- a/src/integration/ai/prompts/readiness/template.md
+++ b/src/integration/ai/prompts/readiness/template.md
@@ -30,6 +30,9 @@ warranted. Write all signals to the `signals.json` path described in `<output_co
 <wire_tag>{{WIRE_TAG}}</wire_tag>
 <detected_artefacts>{{DETECTED_ARTEFACTS}}</detected_artefacts>
 <existing_context_file>{{EXISTING_CONTEXT_FILE}}</existing_context_file>
+<target_file_conventions>
+{{TARGET_FILE_CONVENTIONS}}
+</target_file_conventions>
 {{HARNESS_CONTEXT}}
 </inputs>
 

--- a/tests/integration/ai/prompts/readiness/definition.test.ts
+++ b/tests/integration/ai/prompts/readiness/definition.test.ts
@@ -8,6 +8,7 @@ import { extractPlaceholders } from '@src/integration/ai/prompts/_engine/extract
 import {
   buildReadinessPrompt,
   collectArtefactPaths,
+  conventionsPartialName,
   readinessPromptDef,
   renderDetectedArtefacts,
   renderExistingContextFile,
@@ -166,6 +167,7 @@ describe('buildReadinessPrompt — end-to-end against the real template', () => 
       wireTag: 'claude-md',
       existingContextFile: 'x',
       detectedArtefacts: 'x',
+      targetFileConventions: 'x',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
     });
     expect(result.ok).toBe(false);
@@ -214,5 +216,58 @@ describe('buildReadinessPrompt — end-to-end against the real template', () => 
     expect(body).toContain('"agents-md"');
     expect(body).not.toContain('"claude-md"');
     expect(body).not.toContain('"copilot-instructions"');
+  });
+});
+
+describe('conventionsPartialName', () => {
+  it('maps claude-code → conventions-claude-md', () => {
+    expect(conventionsPartialName('claude-code')).toBe('conventions-claude-md');
+  });
+  it('maps copilot → conventions-copilot-instructions', () => {
+    expect(conventionsPartialName('copilot')).toBe('conventions-copilot-instructions');
+  });
+  it('maps codex → conventions-agents-md', () => {
+    expect(conventionsPartialName('codex')).toBe('conventions-agents-md');
+  });
+});
+
+describe('buildReadinessPrompt — per-tool conventions partial selection', () => {
+  it('injects CLAUDE.md conventions for claude-code (distinctive first-line phrase)', async () => {
+    const result = await buildReadinessPrompt(deps, {
+      repositoryPath: '/repo/main',
+      currentTool: 'claude-code',
+      probedState: absentState(FIXED_NOW),
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+    });
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.message}`);
+    const body = result.value as unknown as string;
+    // Distinctive text from conventions-claude-md.md
+    expect(body).toContain("Claude Code's native project context file");
+  });
+
+  it('injects Copilot conventions for copilot (distinctive first-line phrase)', async () => {
+    const result = await buildReadinessPrompt(deps, {
+      repositoryPath: '/repo/main',
+      currentTool: 'copilot',
+      probedState: absentState(FIXED_NOW),
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+    });
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.message}`);
+    const body = result.value as unknown as string;
+    // Distinctive text from conventions-copilot-instructions.md
+    expect(body).toContain("GitHub Copilot's native project context file");
+  });
+
+  it('injects AGENTS.md conventions for codex (distinctive first-line phrase)', async () => {
+    const result = await buildReadinessPrompt(deps, {
+      repositoryPath: '/repo/main',
+      currentTool: 'codex',
+      probedState: absentState(FIXED_NOW),
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+    });
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.message}`);
+    const body = result.value as unknown as string;
+    // Distinctive text from conventions-agents-md.md
+    expect(body).toContain('cross-tool agent context file');
   });
 });


### PR DESCRIPTION
## Summary

- **Closes #159** — readiness flow now selects one of three new conventions partials (`conventions-claude-md` / `conventions-copilot-instructions` / `conventions-agents-md`) by `currentTool` and embeds it inside a `<target_file_conventions>` block before the output contract. Each partial is a generic, downstream-agnostic style guide (line caps, structure rules, framing, sample stub) for its target file, so the AI matches the right tone per provider instead of writing every output like a `CLAUDE.md`.
- **Closes #160** — `renderContractSection` no longer leaks Claude's `Write` tool name to Copilot / Codex on every spawn, and no longer makes the (incorrect) cwd claim that's wrong for refine / plan / ideate / readiness / create-pr. Replaced with provider-agnostic absolute-path guidance.

## Implementation notes

- New helper `conventionsPartialName(tool)` in `prompts/readiness/definition.ts` maps the `AssistantTool` to its partial name. `buildReadinessPrompt` loads the body manually (rather than via the auto-loaded `def.partials` map) so the partial name can be computed from `currentTool` at call time, and passes the trimmed body as a regular `targetFileConventions` string parameter.
- New placeholder `{{TARGET_FILE_CONVENTIONS}}` added to `readiness/template.md` inside the `<inputs>` block, before `{{HARNESS_CONTEXT}}` — the AI reads format conventions before being told the output shape.
- `render-contract-section.ts` rewording drops both the `Write` tool name AND the cwd claim. The absolute-path guidance subsumes the operational point ("don't let a relative path strand the file").

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new errors (293 pre-existing warnings)
- [x] `pnpm test` — 2574 / 2574 passing
- [x] New per-tool round-trip tests in `readiness/definition.test.ts` assert each provider's prompt embeds a distinctive phrase from its conventions partial
- [x] `template-coverage.test.ts` meta-test still passes (the new placeholder is reflected on both sides of the parity check)