### PR TITLE
fix(detect-cli): resolve CLI shims on Windows so AI flows can launch

### DIFF
--- a/src/integration/io/command-exists.ts
+++ b/src/integration/io/command-exists.ts
@@ -1,22 +1,32 @@
 import { spawn } from 'node:child_process';
 
 /**
- * Check whether a named executable resolves on the current `PATH`. Implementation: spawn
- * `<name> --version` with stdio fully suppressed; resolution depends on the spawn outcome:
+ * Check whether a named executable resolves on the current `PATH`. Cross-platform — the single
+ * detection mechanism both the doctor probes and the launch-time fail-fast route through, so the
+ * two surfaces can never disagree about whether a CLI is installed.
  *
- *   - `error` event with `ENOENT`     → not on PATH (resolves `false`)
- *   - `error` event with anything else → resolves `false` (treat as missing)
- *   - process exits cleanly            → resolves `true`
- *   - process exits non-zero           → resolves `true` (the binary exists; `--version`
- *                                        may not be supported but the executable was found)
+ *   - Windows: spawn `where <name>`. `where.exe` is a real System32 binary (so no shell is
+ *     needed) and it resolves every executable kind on `PATHEXT` — `.exe`, `.cmd`, `.ps1`,
+ *     `.bat` — which is what npm / winget shims install (`claude.cmd`, `gh.cmd`, …). A bare
+ *     `spawn(name)` cannot launch a `.cmd` shim, and the POSIX `command -v` builtin does not
+ *     exist in `cmd.exe`, so neither is safe here.
+ *   - POSIX: spawn `command -v <name>` under a shell. `command` is a POSIX shell builtin
+ *     (hence `shell: true`) mandated to report PATH presence without executing the target.
  *
- * This is intentionally lightweight — no `which` shelling, no PATH parsing, no Windows fork.
- * Doctor uses it to tell the user "you don't have <provider> CLI installed" before they try
- * to run a flow that depends on it.
+ * Resolution policy (identical on both platforms):
+ *
+ *   - exit code 0       → on PATH (resolves `true`)
+ *   - exit code non-zero → not on PATH (resolves `false`)
+ *   - `error` event      → treat as missing (resolves `false`)
+ *
+ * No version check, no auth probe, no execution of the target binary — just presence.
  */
 export const commandExists = (name: string): Promise<boolean> =>
   new Promise((resolve) => {
-    const child = spawn(name, ['--version'], { stdio: 'ignore' });
+    const child =
+      process.platform === 'win32'
+        ? spawn('where', [name], { stdio: 'ignore' })
+        : spawn('command', ['-v', name], { stdio: 'ignore', shell: true });
     let settled = false;
     const settle = (value: boolean): void => {
       if (settled) return;
@@ -24,5 +34,5 @@ export const commandExists = (name: string): Promise<boolean> =>
       resolve(value);
     };
     child.on('error', () => settle(false));
-    child.on('exit', () => settle(true));
+    child.on('exit', (code) => settle(code === 0));
   });

--- a/src/integration/system/detect-cli.ts
+++ b/src/integration/system/detect-cli.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { commandExists } from '@src/integration/io/command-exists.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
 import type {
   DetectInstalledProvidersOptions,
@@ -134,35 +134,20 @@ export const renderProviderInstallGuidance = (
 };
 
 /**
- * Default `which`-equivalent. Spawns `command -v <binary>` with `stdio: 'pipe'` (suppressing
- * output) and resolves based on the exit code. POSIX-portable: `command -v` is a shell builtin
- * mandated by the spec, available in every POSIX shell.
+ * Default `which`-equivalent — delegates to the shared cross-platform {@link commandExists}
+ * probe (`where` on Windows, `command -v` on POSIX). Routing provider detection and the
+ * doctor's PATH checks through one mechanism guarantees they can never disagree — notably on
+ * Windows, where the POSIX `command -v` builtin is absent from `cmd.exe` and a bare spawn
+ * cannot launch the `.cmd` / `.ps1` shims that npm / winget install.
  *
- * Resolution policy:
- *   - exit code 0      → true (binary exists on PATH)
- *   - exit code non-0  → false (not on PATH)
- *   - spawn error      → false (treat as missing)
- *
- * No version check, no auth probe — just presence.
+ * Resolution policy: on PATH → true; absent or spawn error → false. No version / auth probe.
  */
-const defaultWhich: WhichFn = (binary) =>
-  new Promise((resolve) => {
-    const child = spawn('command', ['-v', binary], { stdio: 'pipe', shell: true });
-    let settled = false;
-    const settle = (value: boolean): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-    };
-    child.on('error', () => settle(false));
-    child.on('exit', (code) => settle(code === 0));
-  });
+const defaultWhich: WhichFn = commandExists;
 
 /**
  * Probe PATH for every supported provider's CLI binary; return the set of providers whose
  * binary resolves. Pure (no logging, no side effects beyond the `which` calls). Probes run in
- * parallel — three lightweight `command -v` invocations land well under any user-perceptible
- * threshold.
+ * parallel — three lightweight PATH lookups land well under any user-perceptible threshold.
  *
  * Used at three sites:
  *   - fresh-install seeding (welcome view) — pick a preset from the single / zero / 2+ result

--- a/tests/unit/integration/io/command-exists.test.ts
+++ b/tests/unit/integration/io/command-exists.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { commandExists } from '@src/integration/io/command-exists.ts';
+
+describe('commandExists', () => {
+  // `node` is guaranteed on PATH — the test suite itself is running under it. This exercises the
+  // real platform-specific probe (`where` on Windows, `command -v` on POSIX) end-to-end, which
+  // is the regression that broke Windows launches: the old `command -v` path resolved `false`
+  // for every binary under `cmd.exe`.
+  it('resolves true for a binary that is on PATH', async () => {
+    expect(await commandExists('node')).toBe(true);
+  });
+
+  it('resolves false for a binary that is not on PATH', async () => {
+    expect(await commandExists('ralphctl-definitely-not-a-real-binary-xyz')).toBe(false);
+  });
+
+  it('resolves false (never rejects) for a name with no match', async () => {
+    await expect(commandExists('another-missing-binary-9f3a2b')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A Windows user could not launch any AI flow (refine / plan / implement / readiness): every launch failed with `CLI claude not on PATH`, **even though `claude` was installed** — the `doctor` flow correctly reported `[PASS] claude found on PATH`.

## Root cause

Two different CLI-detection code paths disagreed on Windows:

- **Doctor** → `commandExists` (`integration/io/command-exists.ts`) spawned `<binary> --version` directly → worked.
- **Launch fail-fast** → `detectInstalledProviders` → `defaultWhich` (`integration/system/detect-cli.ts`) ran `command -v <binary>` under a shell. `command -v` is a **POSIX shell builtin that does not exist in Windows `cmd.exe`**, so every probe exited non-zero and the helper reported every provider as "not installed" → all AI flows blocked.

## Fix

Unify both surfaces on one cross-platform probe in `commandExists`:

- **Windows** → `where <name>` (`where.exe` is a real binary, resolves every `PATHEXT` kind incl. npm/winget `.cmd` / `.ps1` shims).
- **POSIX** → `command -v <name>` (unchanged).

`defaultWhich` now delegates to `commandExists`, so the doctor and the launch-time fail-fast can never disagree again. No behavior change on macOS / Linux.

## Tests
- New `tests/unit/integration/io/command-exists.test.ts` regression test.
- `pnpm typecheck` ✅ 0 errors · `pnpm lint` ✅ 0 errors · `pnpm test` ✅ 2591 passing.