### PR TITLE
chore(release): 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-05-29
+
+### Fixed
+
+- **CLI shim resolution on Windows.** `detect-cli` now resolves `.cmd` and `.ps1` wrapper shims
+  so AI flows (`claude`, `gh`, `codex`) launch correctly on Windows (#174).
+
 ## [0.8.4] - 2026-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.8.5
- Promote `## [Unreleased]` CHANGELOG section to `## [0.8.5]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green