### PR TITLE
fix(windows): reliable cross-platform process spawning + correct copilot binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ to [Semantic Versioning](https://semver.org/).
   arguments. The `doctor` probes (`run-command`) and the setup/verify-script runner are covered
   by the same fix. Fixes the immediate `refine` crash (`session exited with code 1`) and the
   previously-unreachable `implement` / `create-pr` failures on Windows.
+- **Copilot provider probes the correct binary.** `detect-cli` now maps `github-copilot` to the
+  standalone GitHub Copilot CLI (`copilot`) — the binary the provider adapter actually spawns —
+  instead of `gh` (the separate SCM dependency). The launch fail-fast, fresh-install detection,
+  apply-preset warnings, and install guidance (`npm install -g @github/copilot` / `brew install
+copilot-cli` / `winget install GitHub.Copilot`) now reference the standalone CLI rather than the
+  deprecated `gh-copilot` extension, so a Copilot user with `gh` but not `copilot` is no longer
+  passed by the pre-flight check and then failed at spawn. The duplicated `PROVIDER_BINARY` map in
+  the `doctor` flow is unified onto the single source of truth in `detect-cli`.
 
 ## [0.8.5] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Process spawning works on Windows across every flow.** All external-CLI spawns
+  (`claude` / `codex` / `gh` / `glab` / `git`, headless and interactive) now route through a
+  single `cross-spawn`-backed primitive (`integration/io/cross-platform-spawn.ts`). This
+  resolves the npm/winget `.cmd` shims that a bare `child_process.spawn` cannot launch on
+  Node 24 Windows, and escapes arguments correctly without a shell — so paths containing
+  spaces (`C:\Users\First Last\repo`) and prompts containing `& | % "` no longer break the
+  spawn. Replaces the earlier interactive-only `shell: true` workaround, which mis-quoted such
+  arguments. The `doctor` probes (`run-command`) and the setup/verify-script runner are covered
+  by the same fix. Fixes the immediate `refine` crash (`session exited with code 1`) and the
+  previously-unreachable `implement` / `create-pr` failures on Windows.
+
 ## [0.8.5] - 2026-05-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,14 @@ processes racing the same sprint. Stale-takeover via `RALPHCTL_LOCK_TIMEOUT_MS` 
 **Atomic file writes** via `business/io/write-file.ts` for all persisted state. Direct `fs.writeFile` is
 fenced from business code by the layer rules.
 
+**Cross-platform process spawning** goes through `integration/io/cross-platform-spawn.ts`
+(`crossPlatformSpawn`, backed by `cross-spawn`) — the single primitive every external-CLI spawn
+(`claude` / `codex` / `gh` / `glab` / `git`, headless + interactive) delegates to. Never call
+`node:child_process.spawn` directly for a binary: on Node 24 Windows a bare spawn cannot launch the
+npm/winget `.cmd` shims, and `shell: true` mis-quotes arguments with spaces or `& | % "`. The
+exception is the setup/verify-script runner (`shell-script-runner.ts`), which intentionally keeps
+`shell: true` because it runs a user-authored command _string_, not a binary + args.
+
 **`AbortError` is the one error chains propagate transparently.** User-initiated cancellation (Ctrl+C, the
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
 or fallback catches errors, it MUST exempt `AbortError`.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "commander": "^14.0.3",
+    "cross-spawn": "^7.0.6",
     "ink": "^7.0.3",
     "react": "^19.2.6",
     "typescript-result": "^3.5.2",
@@ -68,6 +69,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^25.8.0",
     "@types/react": "^19.2.14",
     "@vitest/coverage-v8": "^4.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       ink:
         specifier: ^7.0.3
         version: 7.0.4(@types/react@19.2.15)(react@19.2.6)
@@ -27,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^25.8.0
         version: 25.9.1
@@ -962,6 +968,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2719,6 +2728,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@types/deep-eql@4.0.2': {}
 

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -17,8 +17,8 @@ import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts'
 import type { WriteFile } from '@src/business/io/write-file.ts';
 import { createAppendFile } from '@src/integration/io/append-file-adapter.ts';
 import type { AppendFile } from '@src/business/io/append-file.ts';
-import { spawn as nodeSpawn } from 'node:child_process';
 import type { Spawn } from '@src/integration/io/spawn.ts';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
 import { createInteractiveAiProvider } from '@src/application/bootstrap/interactive-provider-factory.ts';
@@ -276,7 +276,7 @@ const isTruthyEnvFlag = (value: string | undefined): boolean => typeof value ===
  * — the same fake currently scripted for the headless provider.
  */
 const defaultPipeSpawn: Spawn = (command, args, options) =>
-  nodeSpawn(command, [...args], {
+  crossPlatformSpawn(command, args, {
     ...options,
     stdio: [...options.stdio],
   }) as ReturnType<Spawn>;

--- a/src/application/flows/doctor/flow.ts
+++ b/src/application/flows/doctor/flow.ts
@@ -5,6 +5,7 @@ import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sp
 import type { AiProvider } from '@src/domain/entity/settings.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { RunCommand } from '@src/integration/io/run-command.ts';
+import { PROVIDER_BINARY } from '@src/integration/system/detect-cli.ts';
 import { pathIsDirectory, pathIsWritable } from '@src/integration/io/fs.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
@@ -18,12 +19,6 @@ import {
   type ProbeResult,
 } from '@src/application/flows/doctor/ctx.ts';
 import type { DoctorDeps } from '@src/application/flows/doctor/deps.ts';
-
-const PROVIDER_BINARY: Record<AiProvider, string> = {
-  'claude-code': 'claude',
-  'github-copilot': 'copilot',
-  'openai-codex': 'codex',
-};
 
 const PROVIDER_LABEL: Record<AiProvider, string> = {
   'claude-code': 'Claude Code',

--- a/src/integration/ai/providers/_engine/claude-interactive-deps.ts
+++ b/src/integration/ai/providers/_engine/claude-interactive-deps.ts
@@ -12,6 +12,8 @@ export interface InteractiveClaudeDeps {
   readonly spawn?: InteractiveSpawn;
   /** Override the binary name for tests / packaging. Defaults to `'claude'`. */
   readonly command?: string;
+  /** Test seam for prompt-file reads. Defaults to `fs.readFile`. */
+  readonly readFile?: (path: string) => Promise<string>;
   /**
    * Test seam: generate the UUID passed to Claude's `--session-id <uuid>` flag. Production
    * uses {@link uuidv7}; tests stub a deterministic value so argv assertions stay stable.

--- a/src/integration/ai/providers/_engine/codex-interactive-deps.ts
+++ b/src/integration/ai/providers/_engine/codex-interactive-deps.ts
@@ -10,6 +10,8 @@ export interface InteractiveCodexDeps {
   readonly eventBus: EventBus;
   /** Test seam: defaults to `node:child_process.spawn`. */
   readonly spawn?: InteractiveSpawn;
-  /** Override the shell name for tests / packaging. Defaults to `'bash'`. */
+  /** Override the binary name for tests / packaging. Defaults to `'codex'`. */
   readonly command?: string;
+  /** Test seam for prompt-file reads. Defaults to `fs.readFile`. */
+  readonly readFile?: (path: string) => Promise<string>;
 }

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -1,5 +1,5 @@
-import { spawn as nodeSpawn } from 'node:child_process';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
@@ -551,7 +551,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], {
+  crossPlatformSpawn(command, args, {
     stdio: [...options.stdio],
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
   }) as ChildProcessWithoutNullStreams;

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'node:fs';
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { dirname } from 'node:path';
 import { Result } from '@src/domain/result.ts';
@@ -21,15 +22,23 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  * write its final answer to {@link InteractiveAiProviderInput.outputFile}, and the caller
  * reads that file back after this session resolves.
  *
- * The Claude CLI accepts the prompt as a positional argument. We pass the prompt FILE path
- * via shell-style command substitution so very large prompts don't blow the argv length
- * limit. Concretely we invoke:
+ * The prompt is read from `promptFile` in Node.js and passed directly as a positional
+ * argument so the Claude CLI receives it as the initial conversation message:
  *
  *   claude --add-dir <cwd> --add-dir <dirname(outputFile)> [--add-dir <extra>...]
- *          --model <model> --permission-mode acceptEdits "$(cat <promptFile>)"
+ *          --model <model> --permission-mode acceptEdits --session-id <uuid> <prompt>
  *
- * via `bash -lc`. This keeps the adapter portable: no need for the Claude CLI to support a
- * `--prompt-file` flag.
+ * The previous approach ran `bash -lc "claude ... \"$(cat promptFile)\""`. That broke on
+ * Windows because:
+ *   1. Git Bash cannot execute `claude.cmd` shims (npm/winget installs) without the .cmd
+ *      extension, so the inner `claude` command exited with code 1.
+ *   2. Windows paths contain backslashes which break bash path resolution inside the
+ *      shell command string (`$(cat 'C:\Users\...')` is not a valid Unix path in bash).
+ *
+ * By reading the file in Node.js and spawning Claude directly, the bash dependency is
+ * eliminated entirely. On Windows the default spawn uses `shell: true` so Node's
+ * `cmd.exe /c` wrapper resolves `.cmd` / `.ps1` shims that npm and winget install.
+ * On POSIX, direct spawn (no shell) is used — claude is a native binary.
  *
  * Permission strategy: `acceptEdits` auto-approves the `Edit`/`Write` tools — but ONLY for
  * paths inside one of the `--add-dir` roots. To make refine / plan / ideate "just work" for
@@ -47,11 +56,21 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], { stdio: options.stdio, cwd: options.cwd });
+  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
+  // (claude.cmd / gh.cmd / codex.cmd) that npm and winget install. On POSIX, spawn
+  // directly — native binaries need no shell wrapper.
+  nodeSpawn(command, [...args], {
+    stdio: options.stdio,
+    cwd: options.cwd,
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  });
+
+const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 
 export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): InteractiveAiProvider => {
   const spawnFn: InteractiveSpawn = deps.spawn ?? defaultSpawn;
-  const command = deps.command ?? 'bash';
+  const command = deps.command ?? 'claude';
+  const readFile = deps.readFile ?? defaultReadFile;
   const newSessionId = deps.newSessionId ?? uuidv7;
 
   return {
@@ -63,6 +82,22 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
             currentState: 'model-validation',
             attemptedAction: 'run',
             message: `interactive-claude: '${input.model}' is not a known Claude model`,
+          })
+        );
+      }
+
+      // Read the prompt file in Node.js so its content can be passed as a direct argv
+      // element to claude. This avoids the bash $(cat ...) expansion that broke on Windows
+      // (backslash paths + .cmd shim resolution issues).
+      let prompt: string;
+      try {
+        prompt = await readFile(String(input.promptFile));
+      } catch (cause) {
+        return Result.error(
+          new StorageError({
+            subCode: 'io',
+            message: `interactive-claude: failed to read prompt file ${String(input.promptFile)} — ${stringifyError(cause)}`,
+            cause,
           })
         );
       }
@@ -88,7 +123,7 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
           seen.add(p);
           return true;
         })
-        .flatMap((p) => ['--add-dir', shellQuote(p)]);
+        .flatMap((p) => ['--add-dir', p]);
 
       // Pre-generate the session id and pass it via `--session-id <uuid>`. This is the
       // interactive analogue of the headless `session-id.txt` sidechannel: the parent can't read
@@ -97,17 +132,16 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
       // Persisted to `<dirname(outputFile)>/session-id.txt` post-exit and returned on success.
       const sessionId = newSessionId();
 
-      const inner = [
-        'claude',
+      const args = [
         ...dirFlags,
         '--model',
-        shellQuote(input.model),
+        input.model,
         '--permission-mode',
         'acceptEdits',
         '--session-id',
-        shellQuote(sessionId),
-        `"$(cat ${shellQuote(String(input.promptFile))})"`,
-      ].join(' ');
+        sessionId,
+        prompt,
+      ];
 
       deps.eventBus.publish({
         type: 'log',
@@ -119,7 +153,7 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
 
       let child: ChildProcess;
       try {
-        child = spawnFn(command, ['-lc', inner], { stdio: 'inherit', cwd: String(input.cwd) });
+        child = spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd) });
       } catch (cause) {
         return Result.error(
           new StorageError({
@@ -171,5 +205,4 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
   };
 };
 
-const shellQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
-import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess } from 'node:child_process';
 import { dirname } from 'node:path';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { Result } from '@src/domain/result.ts';
 import type {
   InteractiveAiProvider,
@@ -36,9 +37,9 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  *      shell command string (`$(cat 'C:\Users\...')` is not a valid Unix path in bash).
  *
  * By reading the file in Node.js and spawning Claude directly, the bash dependency is
- * eliminated entirely. On Windows the default spawn uses `shell: true` so Node's
- * `cmd.exe /c` wrapper resolves `.cmd` / `.ps1` shims that npm and winget install.
- * On POSIX, direct spawn (no shell) is used — claude is a native binary.
+ * eliminated entirely. The spawn routes through `crossPlatformSpawn` (cross-spawn), which
+ * resolves `claude.cmd` / `.ps1` shims on Windows and escapes the positional prompt argument
+ * correctly without a shell — so a prompt containing spaces or `& | % "` round-trips safely.
  *
  * Permission strategy: `acceptEdits` auto-approves the `Edit`/`Write` tools — but ONLY for
  * paths inside one of the `--add-dir` roots. To make refine / plan / ideate "just work" for
@@ -56,14 +57,10 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
-  // (claude.cmd / gh.cmd / codex.cmd) that npm and winget install. On POSIX, spawn
-  // directly — native binaries need no shell wrapper.
-  nodeSpawn(command, [...args], {
-    stdio: options.stdio,
-    cwd: options.cwd,
-    ...(process.platform === 'win32' ? { shell: true } : {}),
-  });
+  // Route through the shared cross-platform primitive so `claude.cmd` shims resolve on
+  // Windows and the positional prompt argument (which may contain spaces or shell
+  // metacharacters) is escaped correctly — without a shell. See cross-platform-spawn.ts.
+  crossPlatformSpawn(command, args, { stdio: options.stdio, cwd: options.cwd });
 
 const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -1,6 +1,6 @@
-import { spawn as nodeSpawn } from 'node:child_process';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { promises as fs } from 'node:fs';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
@@ -619,7 +619,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], {
+  crossPlatformSpawn(command, args, {
     stdio: [...options.stdio],
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
   }) as ChildProcessWithoutNullStreams;

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
-import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess } from 'node:child_process';
 import { dirname } from 'node:path';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { Result } from '@src/domain/result.ts';
 import type {
   InteractiveAiProvider,
@@ -34,9 +35,9 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
  *      shell command string (`$(cat 'C:\Users\...')` is not a valid Unix path in bash).
  *
  * By reading the file in Node.js and spawning Codex directly, the bash dependency is
- * eliminated. On Windows the default spawn uses `shell: true` so Node's `cmd.exe /c`
- * wrapper resolves `.cmd` / `.ps1` shims that npm and winget install. On POSIX, direct
- * spawn (no shell) is used — codex is a native binary.
+ * eliminated. The spawn routes through `crossPlatformSpawn` (cross-spawn), which resolves
+ * `codex.cmd` / `.ps1` shims on Windows and escapes the positional prompt argument correctly
+ * without a shell — so a prompt containing spaces or `& | % "` round-trips safely.
  *
  * Audit [09]: harness-driven sessions want zero per-tool noise. `-a never` makes the sandbox
  * the only gate — anything outside the workspace fails immediately rather than prompting,
@@ -50,13 +51,10 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
-  // (codex.cmd) that npm and winget install. On POSIX, spawn directly.
-  nodeSpawn(command, [...args], {
-    stdio: options.stdio,
-    cwd: options.cwd,
-    ...(process.platform === 'win32' ? { shell: true } : {}),
-  });
+  // Route through the shared cross-platform primitive so `codex.cmd` shims resolve on
+  // Windows and the positional prompt argument is escaped correctly — without a shell.
+  // See cross-platform-spawn.ts.
+  crossPlatformSpawn(command, args, { stdio: options.stdio, cwd: options.cwd });
 
 const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'node:fs';
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { dirname } from 'node:path';
 import { Result } from '@src/domain/result.ts';
@@ -20,10 +21,22 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
  * caller reads that file back after this session resolves.
  *
  * Codex's top-level (non-`exec`) command starts the TUI and accepts an optional positional
- * prompt — `codex "explain this codebase"`. We inline `"$(cat <promptFile>)"` via `bash -lc`
- * so very large prompt files don't hit argv length limits. `-s workspace-write -a never`
- * matches Claude's `--permission-mode acceptEdits` intent: file writes inside the workspace
- * run without a confirmation step (so the AI can drop its answer in `outputFile`).
+ * prompt — `codex "explain this codebase"`. The prompt is read from `promptFile` in Node.js
+ * and passed directly as a positional argument. `-s workspace-write -a never` matches
+ * Claude's `--permission-mode acceptEdits` intent: file writes inside the workspace run
+ * without a confirmation step (so the AI can drop its answer in `outputFile`).
+ *
+ * The previous approach ran `bash -lc "codex ... \"$(cat promptFile)\""`. That broke on
+ * Windows because:
+ *   1. Git Bash cannot execute `codex.cmd` shims (npm/winget installs) without the .cmd
+ *      extension, so the inner `codex` command exited with code 1.
+ *   2. Windows paths contain backslashes which break bash path resolution inside the
+ *      shell command string (`$(cat 'C:\Users\...')` is not a valid Unix path in bash).
+ *
+ * By reading the file in Node.js and spawning Codex directly, the bash dependency is
+ * eliminated. On Windows the default spawn uses `shell: true` so Node's `cmd.exe /c`
+ * wrapper resolves `.cmd` / `.ps1` shims that npm and winget install. On POSIX, direct
+ * spawn (no shell) is used — codex is a native binary.
  *
  * Audit [09]: harness-driven sessions want zero per-tool noise. `-a never` makes the sandbox
  * the only gate — anything outside the workspace fails immediately rather than prompting,
@@ -37,11 +50,20 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], { stdio: options.stdio, cwd: options.cwd });
+  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
+  // (codex.cmd) that npm and winget install. On POSIX, spawn directly.
+  nodeSpawn(command, [...args], {
+    stdio: options.stdio,
+    cwd: options.cwd,
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  });
+
+const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 
 export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): InteractiveAiProvider => {
   const spawnFn: InteractiveSpawn = deps.spawn ?? defaultSpawn;
-  const command = deps.command ?? 'bash';
+  const command = deps.command ?? 'codex';
+  const readFile = deps.readFile ?? defaultReadFile;
 
   return {
     async run(input: InteractiveAiProviderInput) {
@@ -52,6 +74,22 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
             currentState: 'model-validation',
             attemptedAction: 'run',
             message: `interactive-codex: '${input.model}' is not a known Codex model`,
+          })
+        );
+      }
+
+      // Read the prompt file in Node.js so its content can be passed as a direct argv
+      // element to codex. This avoids the bash $(cat ...) expansion that broke on Windows
+      // (backslash paths + .cmd shim resolution issues).
+      let prompt: string;
+      try {
+        prompt = await readFile(String(input.promptFile));
+      } catch (cause) {
+        return Result.error(
+          new StorageError({
+            subCode: 'io',
+            message: `interactive-codex: failed to read prompt file ${String(input.promptFile)} — ${stringifyError(cause)}`,
+            cause,
           })
         );
       }
@@ -75,21 +113,20 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
           seen.add(p);
           return true;
         })
-        .flatMap((p) => ['--add-dir', shellQuote(p)]);
+        .flatMap((p) => ['--add-dir', p]);
 
-      const inner = [
-        'codex',
+      const args = [
         '--cd',
-        shellQuote(String(input.cwd)),
+        String(input.cwd),
         ...dirFlags,
         '--model',
-        shellQuote(input.model),
+        input.model,
         '-s',
         'workspace-write',
         '-a',
         'never',
-        `"$(cat ${shellQuote(String(input.promptFile))})"`,
-      ].join(' ');
+        prompt,
+      ];
 
       deps.eventBus.publish({
         type: 'log',
@@ -101,7 +138,7 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
 
       let child: ChildProcess;
       try {
-        child = spawnFn(command, ['-lc', inner], { stdio: 'inherit', cwd: String(input.cwd) });
+        child = spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd) });
       } catch (cause) {
         return Result.error(
           new StorageError({
@@ -145,5 +182,4 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
   };
 };
 
-const shellQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,5 +1,5 @@
-import { spawn as nodeSpawn } from 'node:child_process';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
@@ -418,7 +418,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 };
 
 const defaultSpawn: ProviderSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], {
+  crossPlatformSpawn(command, args, {
     stdio: [...options.stdio],
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
   }) as ChildProcessWithoutNullStreams;

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -45,7 +45,13 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  nodeSpawn(command, [...args], { stdio: options.stdio, cwd: options.cwd });
+  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
+  // (copilot.cmd / gh.cmd) that npm and winget install. On POSIX, spawn directly.
+  nodeSpawn(command, [...args], {
+    stdio: options.stdio,
+    cwd: options.cwd,
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  });
 
 const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
-import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess } from 'node:child_process';
 import { dirname } from 'node:path';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import { Result } from '@src/domain/result.ts';
 import type {
   InteractiveAiProvider,
@@ -45,13 +46,10 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  */
 
 const defaultSpawn: InteractiveSpawn = (command, args, options) =>
-  // On Windows, spawn with shell:true so Node's cmd.exe wrapper resolves .cmd shims
-  // (copilot.cmd / gh.cmd) that npm and winget install. On POSIX, spawn directly.
-  nodeSpawn(command, [...args], {
-    stdio: options.stdio,
-    cwd: options.cwd,
-    ...(process.platform === 'win32' ? { shell: true } : {}),
-  });
+  // Route through the shared cross-platform primitive so `copilot.cmd` shims resolve on
+  // Windows and the seeded prompt argument is escaped correctly — without a shell.
+  // See cross-platform-spawn.ts.
+  crossPlatformSpawn(command, args, { stdio: options.stdio, cwd: options.cwd });
 
 const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');
 

--- a/src/integration/io/cross-platform-spawn.ts
+++ b/src/integration/io/cross-platform-spawn.ts
@@ -1,0 +1,35 @@
+import spawn from 'cross-spawn';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+
+/**
+ * The single cross-platform process-spawn primitive. Every adapter that launches an external
+ * binary (`claude` / `codex` / `gh` / `glab` / `git`) MUST route through here instead of
+ * calling `node:child_process.spawn` directly.
+ *
+ * Why this exists — Windows `.cmd` shims:
+ *   npm / winget install the AI and SCM CLIs as `.cmd` (or `.ps1`) shims, not native `.exe`
+ *   binaries. On Node ≥ 22 (the CVE-2024-27980 fix), a bare `spawn('claude', …)` of a
+ *   `.cmd` / `.bat` file **throws `EINVAL`** unless `shell: true` is set — so direct spawns
+ *   fail outright on Windows. The naive workaround (`shell: true` on win32) then re-parses
+ *   argv through `cmd.exe`, which corrupts any argument containing a space
+ *   (`C:\Users\First Last\repo` — the Windows norm) or a shell metacharacter (`& | % "`),
+ *   and opens a command-injection seam.
+ *
+ *   `cross-spawn` solves both at once: it resolves the real shim target via `PATHEXT` and
+ *   escapes arguments correctly **without** invoking a shell. It is the de-facto standard
+ *   (npm, jest, execa all depend on it), so the Windows-quoting edge cases are handled by
+ *   battle-tested code rather than re-implemented here.
+ *
+ * No behaviour change on macOS / Linux — cross-spawn delegates straight to
+ * `child_process.spawn` for native binaries.
+ *
+ * The option shape mirrors `node:child_process.SpawnOptions`; callers pass their own narrowed
+ * options (stdio tuple, `'inherit'`, `cwd`, `env`, `detached`, …) and cast the returned
+ * `ChildProcess` to their adapter-local type, exactly as they previously did with `nodeSpawn`.
+ *
+ * NOTE: this is for the **binary + args** case. Running a user-authored shell command *string*
+ * (e.g. `pnpm install && pnpm test` in the setup/verify-script runner) intentionally keeps
+ * `shell: true` and does NOT route through here — that path needs shell interpretation.
+ */
+export const crossPlatformSpawn = (command: string, args: readonly string[], options: SpawnOptions): ChildProcess =>
+  spawn(command, [...args], options);

--- a/src/integration/io/git-runner.ts
+++ b/src/integration/io/git-runner.ts
@@ -1,8 +1,8 @@
-import { spawn as nodeSpawn } from 'node:child_process';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Spawn } from '@src/integration/io/spawn.ts';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 
 /**
  * Async wrapper around `git` invocations. Pure transport: no shell expansion, no
@@ -133,6 +133,6 @@ export const createGitRunner = (deps: GitRunnerDeps = {}): GitRunner => {
 };
 
 const defaultSpawn: Spawn = (command, args, options) =>
-  nodeSpawn(command, [...args], { ...options, stdio: [...options.stdio] }) as ReturnType<Spawn>;
+  crossPlatformSpawn(command, args, { ...options, stdio: [...options.stdio] }) as ReturnType<Spawn>;
 
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));

--- a/src/integration/io/run-command.ts
+++ b/src/integration/io/run-command.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 
 /**
  * Result of running an external command. `ok` is true iff the process spawned and exited 0.
@@ -17,18 +17,64 @@ export interface RunCommandResult {
  * One-shot command runner used by sanity probes (doctor) — captures stdout/stderr and exit
  * code without surfacing process-spawn errors as exceptions. Stripped of the cwd/env knobs
  * the longer-running runners need; probes only ever ask "did `gh auth status` exit clean?".
+ *
+ * Spawns through {@link crossPlatformSpawn} rather than `execFile` so Windows `.cmd` shims
+ * resolve — `gh` / `codex` are installed as `gh.cmd` / `codex.cmd` by npm/winget, which a bare
+ * `execFile` cannot launch. A 5s wall-clock timeout kills a wedged probe and resolves with
+ * `ok: false`.
  */
 export type RunCommand = (name: string, args: readonly string[]) => Promise<RunCommandResult>;
 
+const PROBE_TIMEOUT_MS = 5000;
+
 export const runCommand: RunCommand = (name, args) =>
   new Promise((resolve) => {
-    execFile(name, [...args], { timeout: 5000, encoding: 'utf8' }, (err, stdout, stderr) => {
-      if (err === null) {
-        resolve({ ok: true, code: 0, stdout, stderr });
-        return;
+    let child;
+    try {
+      child = crossPlatformSpawn(name, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch {
+      // Synchronous spawn failure (e.g. invalid command shape) — treat as missing binary.
+      resolve({ ok: false, code: null, stdout: '', stderr: '' });
+      return;
+    }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let settled = false;
+
+    const settle = (result: RunCommandResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead
       }
-      // err.code is `'ENOENT'` when the binary is missing, the numeric exit code otherwise.
-      const code = typeof err.code === 'number' ? err.code : null;
-      resolve({ ok: false, code, stdout, stderr });
+      settle({
+        ok: false,
+        code: null,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
+    }, PROBE_TIMEOUT_MS);
+
+    child.stdout?.on('data', (c: Buffer) => stdoutChunks.push(c));
+    child.stderr?.on('data', (c: Buffer) => stderrChunks.push(c));
+
+    // ENOENT / EINVAL etc. — the binary couldn't be spawned at all.
+    child.on('error', () => settle({ ok: false, code: null, stdout: '', stderr: '' }));
+
+    child.on('close', (code) => {
+      settle({
+        ok: code === 0,
+        code,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
     });
   });

--- a/src/integration/system/detect-cli.ts
+++ b/src/integration/system/detect-cli.ts
@@ -9,15 +9,19 @@ import type {
 
 /**
  * Map provider id → the binary the user must have on PATH for that provider to function.
- * `claude` and `codex` are the standalone CLIs; for `github-copilot` we probe `gh` (the GitHub
- * CLI), which is the entry point ralphctl reaches the Copilot extension through.
+ * All three are standalone CLIs: `claude`, `codex`, and `copilot` (the GitHub Copilot CLI,
+ * `copilot` v1.0.12+ — `npm install -g @github/copilot`). This MUST match the binary each
+ * provider adapter actually spawns (`providers/<tool>/{headless,interactive}.ts`); probing
+ * `gh` here while the adapter spawns `copilot` would let the launch fail-fast pass and then
+ * the real spawn fail (`gh` is a separate SCM dependency for create-pr / issue sync, not the
+ * Copilot AI backend).
  *
  * Single source of truth — used by `detectInstalledProviders`, the apply-preset warning surface,
  * and the fail-fast launch helper.
  */
 export const PROVIDER_BINARY: Readonly<Record<AiProvider, string>> = {
   'claude-code': 'claude',
-  'github-copilot': 'gh',
+  'github-copilot': 'copilot',
   'openai-codex': 'codex',
 };
 
@@ -51,17 +55,11 @@ export const PROVIDER_INSTALL_GUIDANCE: Readonly<Record<AiProvider, ProviderInst
     },
   },
   'github-copilot': {
-    docsUrl: 'https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+    docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
     commandsByPlatform: {
-      darwin: ['brew install gh && gh extension install github/gh-copilot', 'gh extension install github/gh-copilot'],
-      linux: [
-        'install gh from https://github.com/cli/cli/blob/trunk/docs/install_linux.md, then: gh extension install github/gh-copilot',
-        'gh extension install github/gh-copilot',
-      ],
-      win32: [
-        'winget install --id GitHub.cli && gh extension install github/gh-copilot',
-        'gh extension install github/gh-copilot',
-      ],
+      darwin: ['brew install copilot-cli', 'npm install -g @github/copilot'],
+      linux: ['npm install -g @github/copilot', 'brew install copilot-cli'],
+      win32: ['winget install GitHub.Copilot', 'npm install -g @github/copilot'],
     },
   },
   'openai-codex': {

--- a/tests/e2e/cli/settings.test.ts
+++ b/tests/e2e/cli/settings.test.ts
@@ -159,7 +159,7 @@ describe('ralphctl settings', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('github-copilot');
       expect(result.stderr).toContain('ai.implement.evaluator.provider');
-      expect(result.stderr).toContain('gh extension install github/gh-copilot');
+      expect(result.stderr).toContain('npm install -g @github/copilot');
     });
   });
 });

--- a/tests/e2e/flows/settings.test.ts
+++ b/tests/e2e/flows/settings.test.ts
@@ -179,7 +179,7 @@ describe('settings use-cases — read/write through the JSON adapter', () => {
     if (!(err instanceof ValidationError)) return;
     expect(err.field).toBe('ai.implement.evaluator.provider');
     expect(err.message).toContain('ai.implement.evaluator.provider');
-    expect(err.hint).toContain('gh extension install github/gh-copilot');
+    expect(err.hint).toContain('npm install -g @github/copilot');
   });
 
   it('settings-set rejects an invalid record without writing to disk', async () => {

--- a/tests/integration/ai/providers/claude/interactive.test.ts
+++ b/tests/integration/ai/providers/claude/interactive.test.ts
@@ -35,6 +35,9 @@ const makeSpawn = (): CapturingSpawnState => {
   };
 };
 
+const STUB_PROMPT = 'You are helping refine a ticket. Do X.';
+const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
+
 const PROMPT_FILE = absolutePath('/tmp/claude-prompt.md');
 const OUTPUT_FILE = absolutePath('/tmp/claude-output.md');
 const CWD = absolutePath('/tmp/claude-interactive-cwd');
@@ -43,7 +46,7 @@ describe('createInteractiveClaudeProvider', () => {
   it('rejects an unknown model with InvalidStateError', async () => {
     const cap = createCapturingBus();
     const { spawn } = makeSpawn();
-    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
     const r = await provider.run({
       cwd: CWD,
       promptFile: PROMPT_FILE,
@@ -56,6 +59,52 @@ describe('createInteractiveClaudeProvider', () => {
     expect(r.error.message).toContain("'gpt-5'");
   });
 
+  it('returns StorageError when the prompt file cannot be read', async () => {
+    const cap = createCapturingBus();
+    const { spawn } = makeSpawn();
+    const failRead = (): Promise<string> => Promise.reject(new Error('ENOENT: no such file'));
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: failRead });
+
+    const r = await provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: CLAUDE_MODELS[0]!,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('storage-error');
+    expect(r.error.message).toContain('failed to read prompt file');
+  });
+
+  it('spawns claude directly (no bash wrapper) and passes prompt content as positional arg', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+
+    const runPromise = provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: CLAUDE_MODELS[0]!,
+    });
+    emitExit(0);
+    const result = await runPromise;
+    expect(result.ok).toBe(true);
+
+    expect(calls).toHaveLength(1);
+    // No bash wrapper — command is claude directly.
+    expect(calls[0]!.command).toBe('claude');
+    const args = calls[0]!.args;
+    // --permission-mode and prompt content are present as raw argv elements.
+    expect(args).toContain('--permission-mode');
+    expect(args).toContain('acceptEdits');
+    expect(args).toContain(STUB_PROMPT);
+    // No -lc / bash remnants.
+    expect(args).not.toContain('-lc');
+    expect(args).not.toContain('bash');
+  });
+
   it('auto-mounts dirname(outputFile) and dirname(promptFile) so framework-controlled writes never prompt', async () => {
     // This is the bug fix: the user was hit by "Create file?" prompts inside refine because
     // the output file lives under `~/.ralphctl/data/sprints/…` (outside the project cwd)
@@ -63,7 +112,7 @@ describe('createInteractiveClaudeProvider', () => {
     // now mounts the prompt/output dirs unconditionally.
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const sprintRefinementDir = '/Users/x/.ralphctl/data/sprints/abc/refinement/foo';
     const runPromise = provider.run({
@@ -77,21 +126,21 @@ describe('createInteractiveClaudeProvider', () => {
     expect(result.ok).toBe(true);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.command).toBe('bash');
-    expect(calls[0]!.args[0]).toBe('-lc');
-    const inner = calls[0]!.args[1] ?? '';
-    expect(inner).toContain(`--add-dir '${String(CWD)}'`);
-    expect(inner).toContain(`--add-dir '${sprintRefinementDir}'`);
-    expect(inner).toContain('--permission-mode acceptEdits');
+    expect(calls[0]!.command).toBe('claude');
+    const args = calls[0]!.args;
+    // Flat argv: --add-dir followed by the path value.
+    expect(args).toContain('--add-dir');
+    expect(args).toContain(String(CWD));
+    expect(args).toContain(sprintRefinementDir);
     // Prompt and output share a dir → emitted exactly once (deduped).
-    const occurrences = inner.match(/--add-dir '\/Users\/x\/\.ralphctl\/data\/sprints\/abc\/refinement\/foo'/g) ?? [];
+    const occurrences = args.filter((a) => a === sprintRefinementDir);
     expect(occurrences).toHaveLength(1);
   });
 
   it('keeps caller-supplied additionalRoots and folds duplicates with the auto-mounted dirs', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const extraRepo = absolutePath('/Users/x/repos/sibling-repo');
     const runPromise = provider.run({
@@ -104,19 +153,20 @@ describe('createInteractiveClaudeProvider', () => {
     emitExit(0);
     await runPromise;
 
-    const inner = calls[0]!.args[1] ?? '';
-    expect(inner).toContain(`--add-dir '${String(CWD)}'`);
-    expect(inner).toContain(`--add-dir '${String(extraRepo)}'`);
-    expect(inner).toContain(`--add-dir '/tmp'`); // dirname of prompt and output
+    const args = calls[0]!.args;
+    expect(args).toContain(String(CWD));
+    expect(args).toContain(String(extraRepo));
+    // dirname of /tmp/claude-prompt.md and /tmp/claude-output.md is /tmp
+    expect(args).toContain('/tmp');
     // CWD must appear once even though additionalRoots also lists it.
-    const cwdHits = inner.match(/--add-dir '\/tmp\/claude-interactive-cwd'/g) ?? [];
+    const cwdHits = args.filter((a) => a === String(CWD));
     expect(cwdHits).toHaveLength(1);
   });
 
   it('returns InvalidStateError when the session exits non-zero', async () => {
     const cap = createCapturingBus();
     const { spawn, emitExit } = makeSpawn();
-    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
       cwd: CWD,

--- a/tests/integration/ai/providers/codex/interactive.test.ts
+++ b/tests/integration/ai/providers/codex/interactive.test.ts
@@ -35,6 +35,9 @@ const makeSpawn = (): CapturingSpawnState => {
   };
 };
 
+const STUB_PROMPT = 'Refine this Codex task.';
+const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
+
 const PROMPT_FILE = absolutePath('/tmp/codex-prompt.md');
 const OUTPUT_FILE = absolutePath('/tmp/codex-output.md');
 const CWD = absolutePath('/tmp/codex-interactive-cwd');
@@ -43,7 +46,7 @@ describe('createInteractiveCodexProvider', () => {
   it('rejects an unknown model with InvalidStateError', async () => {
     const cap = createCapturingBus();
     const { spawn } = makeSpawn();
-    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
     const r = await provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: 'gpt-4.1' });
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -51,10 +54,28 @@ describe('createInteractiveCodexProvider', () => {
     expect(r.error.message).toContain("'gpt-4.1'");
   });
 
-  it('spawns bash -lc with codex --cd <cwd> --model <m> -s workspace-write -a never "$(cat <promptFile>)"', async () => {
+  it('returns StorageError when the prompt file cannot be read', async () => {
+    const cap = createCapturingBus();
+    const { spawn } = makeSpawn();
+    const failRead = (): Promise<string> => Promise.reject(new Error('ENOENT'));
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: failRead });
+
+    const r = await provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: CODEX_MODELS[0]!,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('storage-error');
+    expect(r.error.message).toContain('failed to read prompt file');
+  });
+
+  it('spawns codex directly (no bash wrapper) with --cd, --add-dir, -s, -a, and prompt content', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
       cwd: CWD,
@@ -67,22 +88,27 @@ describe('createInteractiveCodexProvider', () => {
     expect(result.ok).toBe(true);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.command).toBe('bash');
-    expect(calls[0]!.args[0]).toBe('-lc');
-    const inner = calls[0]!.args[1];
-    expect(inner).toContain('codex');
-    expect(inner).toContain(`--cd '${String(CWD)}'`);
-    expect(inner).toContain(`--model '${CODEX_MODELS[0]!}'`);
-    expect(inner).toContain('-s workspace-write');
-    expect(inner).toContain('-a never');
-    expect(inner).toContain(`"$(cat '${String(PROMPT_FILE)}')"`);
+    // No bash wrapper — command is codex directly.
+    expect(calls[0]!.command).toBe('codex');
+    const args = calls[0]!.args;
+    expect(args).toContain('--cd');
+    expect(args).toContain(String(CWD));
+    expect(args).toContain('--model');
+    expect(args).toContain(CODEX_MODELS[0]!);
+    expect(args).toContain('-s');
+    expect(args).toContain('workspace-write');
+    expect(args).toContain('-a');
+    expect(args).toContain('never');
+    expect(args).toContain(STUB_PROMPT);
+    // No bash remnants.
+    expect(args).not.toContain('-lc');
     expect(calls[0]!.cwd).toBe(String(CWD));
   });
 
   it('emits --add-dir for cwd, every additionalRoot, and the prompt / output dirs (deduped)', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const repoA = absolutePath('/tmp/codex-repo-a');
     const repoB = absolutePath('/tmp/codex-repo-b');
@@ -98,20 +124,21 @@ describe('createInteractiveCodexProvider', () => {
     const result = await runPromise;
     expect(result.ok).toBe(true);
 
-    const inner = calls[0]!.args[1]!;
-    expect(inner).toContain(`--add-dir '${String(CWD)}'`);
-    expect(inner).toContain(`--add-dir '${String(repoA)}'`);
-    expect(inner).toContain(`--add-dir '${String(repoB)}'`);
-    // dirname(promptFile) === dirname(outputFile) === '/tmp' here — dedupe collapses them
-    // to a single `--add-dir '/tmp'`. Asserting the count keeps the dedupe load-bearing.
-    const addDirOccurrences = inner.match(/--add-dir/g) ?? [];
-    expect(addDirOccurrences).toHaveLength(4);
+    const args = calls[0]!.args;
+    expect(args).toContain('--add-dir');
+    expect(args).toContain(String(CWD));
+    expect(args).toContain(String(repoA));
+    expect(args).toContain(String(repoB));
+    // dirname(promptFile) === dirname(outputFile) === '/tmp' — dedupe collapses them
+    // to a single --add-dir entry. Count via flag occurrences stays load-bearing.
+    const addDirCount = args.filter((a) => a === '--add-dir').length;
+    expect(addDirCount).toBe(4); // cwd + repoA + repoB + /tmp (deduped prompt/output dir)
   });
 
   it('returns InvalidStateError when the session exits non-zero', async () => {
     const cap = createCapturingBus();
     const { spawn, emitExit } = makeSpawn();
-    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn });
+    const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
       cwd: CWD,

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -322,11 +322,12 @@ describe('SettingsView', () => {
       // footer across multiple lines depending on terminal width, but the install command must
       // still be present as a contiguous token sequence.
       const frame = (result.lastFrame() ?? '').replace(/\s+/g, ' ');
-      // Footer renders the OS-preferred command (brew on macOS, winget on Windows, the curl
-      // installer / gh-install hint on Linux). Assert on the OS-invariant prefix and the
-      // command fragment that every option references.
+      // Footer renders the OS-preferred command (brew on macOS, winget on Windows, npm on
+      // Linux). Assert on the OS-invariant prefix plus an alternation over the per-OS Copilot
+      // CLI install fragments — proving the install COMMAND rendered (not just the provider
+      // label, which already contains "copilot").
       expect(frame).toMatch(/install github-copilot: \S/);
-      expect(frame).toContain('gh-copilot');
+      expect(frame).toMatch(/copilot-cli|@github\/copilot|GitHub\.Copilot/);
       expect(frame).toMatch(/install openai-codex: \S/);
       expect(frame).toContain('codex');
     });

--- a/tests/integration/application/ui/tui/views/welcome-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/welcome-view.test.tsx
@@ -17,7 +17,7 @@ const detectRef = vi.hoisted(() => ({ installed: new Set<string>() }));
 vi.mock('@src/integration/system/detect-cli.ts', () => ({
   detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> =>
     new Set(detectRef.installed) as ReadonlySet<AiProvider>,
-  PROVIDER_BINARY: { 'claude-code': 'claude', 'github-copilot': 'gh', 'openai-codex': 'codex' },
+  PROVIDER_BINARY: { 'claude-code': 'claude', 'github-copilot': 'copilot', 'openai-codex': 'codex' },
 }));
 
 import { WelcomeView } from '@src/application/ui/tui/views/welcome-view.tsx';

--- a/tests/unit/application/ui/shared/launch/check-cli.test.ts
+++ b/tests/unit/application/ui/shared/launch/check-cli.test.ts
@@ -64,12 +64,12 @@ describe('checkCli', () => {
     expect(result).toBeUndefined();
   });
 
-  it('names gh as the missing binary for github-copilot', async () => {
+  it('names copilot as the missing binary for github-copilot', async () => {
     const settings = withFlowProvider('refine', 'github-copilot');
     const result = await checkCli('refine', settings, { detect: detectFor([]) });
     expect(result).toBeDefined();
     if (result === undefined || result.ok) return;
-    expect(result.reason).toContain('CLI gh not on PATH');
+    expect(result.reason).toContain('CLI copilot not on PATH');
     expect(result.reason).toContain('refine');
   });
 
@@ -194,7 +194,7 @@ describe('checkCli', () => {
       { provider: 'claude-code' as const, docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup' },
       {
         provider: 'github-copilot' as const,
-        docsUrl: 'https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+        docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
       },
       { provider: 'openai-codex' as const, docsUrl: 'https://github.com/openai/codex' },
     ];

--- a/tests/unit/integration/io/cross-platform-spawn.test.ts
+++ b/tests/unit/integration/io/cross-platform-spawn.test.ts
@@ -25,16 +25,47 @@ describe('crossPlatformSpawn', () => {
     expect(Buffer.concat(stdout).toString('utf8')).toBe('hello');
   });
 
-  it('emits an error event for a binary that does not exist', async () => {
+  it('passes an argument containing spaces and shell metacharacters verbatim (no shell re-split)', async () => {
+    // The load-bearing guarantee of the whole cross-platform-spawn change: arguments reach the
+    // child EXACTLY as given — no `shell: true` re-splitting, no metacharacter interpretation.
+    // A regression to a shell-wrapped spawn makes this fail loudly (the shell consumes `&`/`|`
+    // and the arg never reaches argv[1]), so this is the canary against re-introducing the
+    // CVE-2024-27980 footgun. Platform-independent: it spawns the Node binary, not a `.cmd` shim.
+    const nasty = 'a b & c | d % e "f" $g';
+    const child = crossPlatformSpawn(execPath, ['-e', 'process.stdout.write(process.argv[1])', nasty], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const stdout: Buffer[] = [];
+    child.stdout?.on('data', (c: Buffer) => stdout.push(c));
+
+    const code = await new Promise<number | null>((resolve) => {
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(0);
+    expect(Buffer.concat(stdout).toString('utf8')).toBe(nasty);
+  });
+
+  it('emits an error event (before close) for a binary that does not exist', async () => {
     const child = crossPlatformSpawn('this-binary-does-not-exist-ralphctl', [], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    const errored = await new Promise<boolean>((resolve) => {
-      child.on('error', () => resolve(true));
-      child.on('close', () => resolve(false));
+    // Record the terminal-event order rather than racing a single boolean: the only guarantee
+    // the production consumers rely on (run-command.ts / the provider adapters both treat either
+    // terminal event as failure) is that an `error` event fires for an un-spawnable binary. We
+    // await `close` (always terminal) and assert `error` was seen — decoupled from which fires
+    // first, but still proving the error signal exists.
+    const order: string[] = [];
+    await new Promise<void>((resolve) => {
+      child.on('error', () => order.push('error'));
+      child.on('close', () => {
+        order.push('close');
+        resolve();
+      });
     });
 
-    expect(errored).toBe(true);
+    expect(order).toContain('error');
   });
 });

--- a/tests/unit/integration/io/cross-platform-spawn.test.ts
+++ b/tests/unit/integration/io/cross-platform-spawn.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { execPath } from 'node:process';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
+
+/**
+ * The primitive is a thin wrapper over cross-spawn, so the meaningful coverage is that it
+ * actually launches a real process cross-platform and streams its output back. We spawn the
+ * current Node binary (`execPath`) — guaranteed present on every platform the suite runs on —
+ * rather than a `.cmd` shim, which can't be assumed in CI.
+ */
+describe('crossPlatformSpawn', () => {
+  it('spawns a real process and resolves its stdout + exit code', async () => {
+    const child = crossPlatformSpawn(execPath, ['-e', "process.stdout.write('hello')"], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const stdout: Buffer[] = [];
+    child.stdout?.on('data', (c: Buffer) => stdout.push(c));
+
+    const code = await new Promise<number | null>((resolve) => {
+      child.on('close', resolve);
+    });
+
+    expect(code).toBe(0);
+    expect(Buffer.concat(stdout).toString('utf8')).toBe('hello');
+  });
+
+  it('emits an error event for a binary that does not exist', async () => {
+    const child = crossPlatformSpawn('this-binary-does-not-exist-ralphctl', [], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const errored = await new Promise<boolean>((resolve) => {
+      child.on('error', () => resolve(true));
+      child.on('close', () => resolve(false));
+    });
+
+    expect(errored).toBe(true);
+  });
+});

--- a/tests/unit/integration/system/detect-cli.test.ts
+++ b/tests/unit/integration/system/detect-cli.test.ts
@@ -15,10 +15,10 @@ const whichFor =
     present.has(binary);
 
 describe('detectInstalledProviders', () => {
-  it('maps providers to claude / gh / codex binaries', () => {
+  it('maps providers to claude / copilot / codex binaries', () => {
     expect(PROVIDER_BINARY).toEqual({
       'claude-code': 'claude',
-      'github-copilot': 'gh',
+      'github-copilot': 'copilot',
       'openai-codex': 'codex',
     });
   });
@@ -35,7 +35,7 @@ describe('detectInstalledProviders', () => {
 
   it('returns every provider when every binary is on PATH', async () => {
     const installed = await detectInstalledProviders({
-      which: whichFor(new Set(['claude', 'gh', 'codex'])),
+      which: whichFor(new Set(['claude', 'copilot', 'codex'])),
     });
     expect([...installed].sort()).toEqual(['claude-code', 'github-copilot', 'openai-codex']);
   });
@@ -47,7 +47,7 @@ describe('detectInstalledProviders', () => {
       return false;
     };
     await detectInstalledProviders({ which });
-    expect(calls.sort()).toEqual(['claude', 'codex', 'gh']);
+    expect(calls.sort()).toEqual(['claude', 'codex', 'copilot']);
   });
 });
 
@@ -65,7 +65,9 @@ describe('PROVIDER_INSTALL_GUIDANCE', () => {
   it('recommends brew first on macOS where the vendor publishes a cask', () => {
     expect(PROVIDER_INSTALL_GUIDANCE['claude-code'].commandsByPlatform.darwin[0]).toContain('brew install');
     expect(PROVIDER_INSTALL_GUIDANCE['openai-codex'].commandsByPlatform.darwin[0]).toContain('brew install');
-    expect(PROVIDER_INSTALL_GUIDANCE['github-copilot'].commandsByPlatform.darwin[0]).toContain('brew install gh');
+    expect(PROVIDER_INSTALL_GUIDANCE['github-copilot'].commandsByPlatform.darwin[0]).toContain(
+      'brew install copilot-cli'
+    );
   });
 
   it('recommends winget first on Windows where the vendor publishes a winget package', () => {
@@ -91,9 +93,7 @@ describe('primaryInstallCommand', () => {
     expect(primaryInstallCommand('claude-code', 'win32')).toBe('winget install Anthropic.ClaudeCode');
     expect(primaryInstallCommand('openai-codex', 'darwin')).toBe('brew install --cask codex');
     expect(primaryInstallCommand('openai-codex', 'linux')).toBe('curl -fsSL https://chatgpt.com/codex/install.sh | sh');
-    expect(primaryInstallCommand('github-copilot', 'darwin')).toBe(
-      'brew install gh && gh extension install github/gh-copilot'
-    );
+    expect(primaryInstallCommand('github-copilot', 'darwin')).toBe('brew install copilot-cli');
   });
 });
 
@@ -120,11 +120,11 @@ describe('renderProviderInstallGuidance', () => {
     );
     expect(renderProviderInstallGuidance('github-copilot', 'win32')).toBe(
       [
-        'github-copilot CLI (gh) not on PATH',
+        'github-copilot CLI (copilot) not on PATH',
         'Install options (win32):',
-        '  • winget install --id GitHub.cli && gh extension install github/gh-copilot',
-        '  • gh extension install github/gh-copilot',
-        'Docs: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli',
+        '  • winget install GitHub.Copilot',
+        '  • npm install -g @github/copilot',
+        'Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
       ].join('\n')
     );
   });


### PR DESCRIPTION
## Problem

A Windows user could not run any AI flow. `refine` crashed immediately with `interactive-claude: session exited with code 1`, and the headless flows (`implement` / `readiness` / `detect-*` / `create-pr`) would have failed too. Root cause is broader than one flow.

## Root causes

1. **`bash -lc "$(cat …)"` wrapping** (interactive providers) — Git Bash can't execute `.cmd` shims and Windows backslash paths break `$(cat 'C:\…')`.
2. **Bare `child_process.spawn` of `.cmd` shims** — on Node 24, spawning `claude.cmd` / `gh.cmd` / `codex.cmd` without `shell: true` throws `EINVAL` (CVE-2024-27980 fix). Affected all 3 headless providers, gh/glab via `wire`, and the `execFile`-based doctor probes.
3. **`shell: true` is itself a footgun** — it re-parses argv through `cmd.exe`, corrupting any argument with a space (`C:\Users\First Last\repo`) or shell metachar (`& | % "`).
4. **Copilot probed the wrong binary** — `detect-cli` mapped `github-copilot` → `gh`, but the adapter spawns the standalone `copilot` CLI. A user with `gh` but not `copilot` passed the pre-flight check then failed at spawn; install guidance pointed at the deprecated `gh-copilot` extension.

## Fix

- **Single cross-platform spawn primitive** `integration/io/cross-platform-spawn.ts` (`crossPlatformSpawn`, backed by `cross-spawn`). Resolves `.cmd`/`.bat` via PATHEXT and escapes argv correctly **without a shell**. Every binary+args spawn routes through it: 6 AI providers (headless + interactive), git-runner, `wire.defaultPipeSpawn` (gh/glab + issue sync), and the doctor `run-command` probes (reimplemented off `execFile`).
- **Setup/verify-script runner unchanged** — it intentionally keeps `shell: true` because it runs a user-authored command *string*, not a binary + args.
- **Copilot binary corrected** — `detect-cli` maps `github-copilot` → `copilot`; install guidance updated to the standalone CLI (`npm install -g @github/copilot` / `brew install copilot-cli` / `winget install GitHub.Copilot`). `doctor`'s duplicate `PROVIDER_BINARY` map unified onto the single source of truth.

`cross-spawn` is already present transitively (eslint), deduped at 7.0.6. No behavior change on macOS/Linux.

## Verification

- `pnpm typecheck` ✅ · `pnpm lint` ✅ 0 errors · `pnpm test` ✅ **2597 passing**
- Built artifact (`node dist/cli.mjs doctor`) probes every `.cmd`-shim CLI correctly; cross-spawn confirmed bundled into `dist/cli.mjs`.
- New deterministic test proves an arg with spaces + `& | % "` passes **verbatim** (fails loudly if `shell: true` regresses).
- Adversarial multi-agent review (6 dimensions): **zero confirmed defects in the code**; confirmed findings were test-coverage gaps, now closed.

## Commits

1. `fix(interactive)` — remove the bash dependency from interactive providers
2. `fix(spawn)` — route all external-CLI spawns through the cross-platform primitive
3. `fix(detect-cli)` — probe the standalone copilot CLI, not gh