### PR TITLE
chore(release): 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-05-29
+
 ### Fixed
 
 - **Process spawning works on Windows across every flow.** All external-CLI spawns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.8.6
- Promote `## [Unreleased]` CHANGELOG section to `## [0.8.6]`

This release ships the Windows cross-platform spawn fix (#176): all external-CLI spawns route through a single `cross-spawn` primitive, and the copilot provider probes the correct standalone `copilot` binary.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (2597 passing)
- [ ] CI green