### PR TITLE
feat: parallel task execution via dependency waves

### DIFF
--- a/.claude/agent-memory/docs-keeper/project_high_drift_areas.md
+++ b/.claude/agent-memory/docs-keeper/project_high_drift_areas.md
@@ -33,9 +33,23 @@ Based on the P0–P4 harness overhaul audit (2026-05-21), sections that had the 
 13. **KERNEL-DESIGN.md — Element interface** — any interface field additions (like `label?`) need to be
     reflected in both the code block and the prose; `TraceEntry` too.
 
-**Why:** These areas cluster around the observability/TUI surface and the chain framework primitives,
-both of which evolve in every sprint.
+14. **CLAUDE.md § Performance & Limits — "Implement is strictly sequential"** — was false after
+    parallel execution landed; task-graph validation wiring note also stale. Always re-read this
+    section after any implement-flow structural change.
+15. **ARCHITECTURE.md § Future Work** — tends to list items that have already shipped without
+    being removed; always cross-check against git log.
+16. **REQUIREMENTS.md § Things deliberately deferred** — same pattern: deferred items stay listed
+    after they ship. Check against the commit log for each feature branch.
+17. **ARCHITECTURE.md § Data Models — Task.dependsOn field name** — field was `blockedBy` in older
+    versions; docs had not been updated. Always grep the entity source for field names before writing.
+18. **ARCHITECTURE.md § Harness Signals table — SkillSuggestionsSignal** — said "no flow consumer
+    yet" but the readiness flow now acts on it. Signal table entries often lag behind flow changes.
+
+**Why:** These areas cluster around the observability/TUI surface, the chain framework primitives,
+and the implement-flow — all of which evolve in every sprint. Items 14–18 specifically from the
+`feat/parallelism-wiring-memory` drop (2026-05-30).
 
 **How to apply:** On the next feature drop, check these sections first before reading git log. In
 particular, always grep `events.ts` for the AppEvent union (compare to every doc that lists it),
-and diff `element.ts` + `trace.ts` against the KERNEL-DESIGN.md interface blocks.
+diff `element.ts` + `trace.ts` against KERNEL-DESIGN.md, and re-read CLAUDE.md § Performance &
+Limits after any implement-flow structural change.

--- a/.claude/agent-memory/implementer/project_nested_runner_subchain_adapter.md
+++ b/.claude/agent-memory/implementer/project_nested_runner_subchain_adapter.md
@@ -1,0 +1,35 @@
+---
+name: nested-runner-subchain-adapter
+description: Reusing a self-contained sub-chain across host flows via a nested-runner adapter element (NOT a 6th chain primitive)
+metadata:
+  type: project
+---
+
+To compose a self-contained sub-chain (its own ctx + leaves) into multiple host flows WITHOUT widening
+each host ctx with the sub-chain's full shape, write a thin `Element<TCtx>` adapter that maps host ctx →
+fresh sub-ctx and runs the sub-chain through a NESTED `createRunner` (same `AbortSignal` forwarded).
+
+**Why:** A nested runner inside an element is NOT a sixth chain primitive — it's an adapter, not a new
+primitive. It lets close-sprint AND review reuse one `createDistillLearningsSubChain` while their ctxs only
+gain a single `distillRequested: boolean` flag (the sub-chain carries `entries`/`candidates`/`acceptedIds`
+internally). See `src/application/flows/_shared/memory/distill-step.ts` (`createDistillStep`).
+
+**How to apply:**
+
+- Adapter is a factory `(deps, opts, name?) => Element<TCtx>` where `opts` carries everything static the
+  sub-chain needs that does NOT vary by host ctx (projectId, roots, repository, AI settings); the host ctx
+  contributes only the gate flag. Place it next to the sub-chain in `_shared/`.
+- Forward abort: `signal?.addEventListener('abort', () => runner.abort(), { once: true })`, removed in
+  `finally`. The nested runner's own `AbortController` is the bridge target.
+- Capture sub-trace via `runner.subscribe` (subscribe BEFORE `start()` → live `step` events) and re-emit
+  through the host `onTrace` so TUI rail + chain.log see sub-steps inline.
+- Error mapping uses `runner.status`: `aborted` → return `Result.error(AbortError)` (transparent
+  propagation; the host `sequential` then skips the rest — leaves the sprint re-runnable). The runner routes
+  any `Aborted`-coded error to `aborted`, so a `failed` status is structurally AbortError-exempt — that's
+  where best-effort fallback (warn + `Result.ok`) lives.
+- Wire it into the flow as a spread-conditional element: `...(deps.distill !== undefined ? [step] : [])` so
+  the step is omitted entirely when its optional deps bag is absent.
+- Per-provider interactive AI: `interactiveAiFor: (provider) => InteractiveAiProvider` lives on `AppDeps`
+  (wired in `wire.ts` via `createInteractiveAiProviderFor`); launchers assemble the sub-chain deps from it
+  plus launcher-level `runInTerminal` (Ink-aware, can't live in `wire()`). See related
+  [[project_chain_deps_reachability_fence]].

--- a/.claude/agent-memory/implementer/project_task_field_names_vs_plan.md
+++ b/.claude/agent-memory/implementer/project_task_field_names_vs_plan.md
@@ -1,0 +1,16 @@
+---
+name: task-field-names-vs-plan
+description: Task entity uses name/dependsOn, NOT title/blockedBy — plan docs use the latter loosely; map them
+metadata:
+  type: project
+---
+
+The `Task` entity (`src/domain/entity/task.ts`) field names differ from how design/plan docs casually refer to them:
+
+- Prose field is **`name`** (+ optional `description`) — there is NO `title` field.
+- Dependency edges are **`dependsOn: readonly TaskId[]`** — there is NO `blockedBy` field on `Task`.
+- Ordering field is **`order: number`** (1-indexed, set by `parseTaskList` as `i + 1`).
+
+**Why:** Design/plan docs and CLAUDE.md both reference `Task.blockedBy` and "title/description" — those are loose/aspirational names. `validateTaskGraph` / `nextAvailableTask` / `scheduleIntoWaves` all operate on `dependsOn`.
+
+**How to apply:** When implementing a spec that says "title" → read `task.name`; "blockedBy" → read `task.dependsOn`. `deriveTaskKind` scans `name + description`. The `makeTodoTask` fixture (`tests/fixtures/domain.ts`) accepts `name`, `order`, `dependsOn` overrides but NOT `description` (use `createTask` directly, or cast a `{name, description}` literal as `Task` for pure-classifier tests since only those two fields are read).

--- a/.claude/agent-memory/implementer/project_wave_scheduler_above_chain.md
+++ b/.claude/agent-memory/implementer/project_wave_scheduler_above_chain.md
@@ -1,0 +1,20 @@
+---
+name: wave-scheduler-above-chain
+description: runWaves is an above-the-chain orchestrator (NOT an Element) driving N per-branch createRunner instances; the first real ALS fan-out consumer
+metadata:
+  type: project
+---
+
+`src/application/chain/run/wave-scheduler.ts` (`runWaves<TCtx>`) is the parallel-implement execution core.
+
+**Why:** Implements "Approach C" — an above-the-chain async orchestrator. Per §14 it adds ZERO chain primitives: it deliberately does NOT implement the `Element` interface and must never be `.children`-walked or composed into a `sequential`/`loop`. It sits ABOVE the five primitives, sequencing whole sub-chains.
+
+**How to apply (for T8/T9a/T9b and any future caller):**
+
+- It is GENERIC — imports nothing flow-specific. The caller injects `config.merge(base, outcomes) => TCtx` (T8's `mergeImplementWave` is the implement reducer) and `config.onBranchRunner(runner, branch)` to bridge each branch runner to the EventBus (`bridgeRunnerToEventBus`, `chainId = task-<id>`).
+- Each branch runs on its OWN `createRunner({ id: branch.id, … })`. The runner already wraps `element.execute` in `runWithSession(id, …)` internally — so passing `branch.id` as the runner id IS the per-branch ALS session scope. This is the first real ALS fan-out consumer; don't re-wrap in another `runWithSession`.
+- Pool bound: a `Set<Promise<BranchRun>>` + `Promise.race` drain, cap re-clamped to `[1,5]` (`MAX_CONCURRENCY_CEILING=5`, mirrors the settings clamp). Waves are STRICTLY sequential — wave k+1 awaits all of k settling AND `merge` folding.
+- Combined trace is assembled in branch-DECLARATION order (per-index slots), never completion order.
+- Abort: outer-signal abort forwards `runner.abort()` to every branch, awaits all settle (cleanup runs), returns `Result.error({error: AbortError, trace})` VERBATIM — never folded into a branch outcome. `aborted` always kills immediately.
+- Rate-limit: `config.onFatal: 'kill' | 'drain'` (default `'drain'`). `'drain'` lets in-flight siblings finish then stops launching the rest of the wave; `'kill'` aborts siblings now. Fatal classification reuses `isRecoverableTurnError` (`business/task/turn-error-policy.ts`): `aborted`/`rate-limit` are fatal, everything else absorbed into the branch's `BranchOutcome`.
+- Exports tagged `@public` (knip whitelist) since the real caller lands in T9b. See [[project_recoverable_turn_error_policy.md]] for the related per-task block policy.

--- a/.claude/agent-memory/tester/MEMORY.md
+++ b/.claude/agent-memory/tester/MEMORY.md
@@ -259,6 +259,15 @@ Four leaves directly unit-tested in `src/application/chains/leaves/`:
 - The snapshot-existing-tasks leaf dynamically imports `storage-paths.ts` and reads `RALPHCTL_ROOT` at call time;
   the snapshot is best-effort (silently skipped when the file doesn't exist), so no env-var setup is needed.
 
+### Parallel implement real-git e2e test (2026-05-30)
+
+`tests/e2e/flows/implement-parallel-realgit.test.ts` — proves parallel path against a REAL git repo.
+**Real bug found (since FIXED via `gitDeleteBranch`; assertion now green):** `gitWorktreeRemove --force`
+left the `wt-*` branch refs behind — see [[project_parallel_worktree_branch_leak_bug]].
+Happy-path assertions that DID pass: runner `completed`, all 3 tasks `done`, sprint `review`,
+4 commits on sprint branch (wave order A/B before C), worktree DIRECTORIES cleaned up.
+Provider pattern: `session.cwd` is the worktree path in the parallel path — write real files there.
+
 ### Sprint-selection redesign tests (2026-05-22)
 
 New test files under `tests/integration/application/ui/tui/views/` and `tests/unit/`:

--- a/.claude/agent-memory/tester/project_parallel_worktree_branch_leak_bug.md
+++ b/.claude/agent-memory/tester/project_parallel_worktree_branch_leak_bug.md
@@ -1,0 +1,62 @@
+---
+name: project_parallel_worktree_branch_leak_bug
+description: RESOLVED 2026-05-30 — gitWorktreeRemove left wt-* branch refs behind; fixed by gitDeleteBranch in cleanupWorktree
+metadata:
+  type: project
+---
+
+## Bug: `gitWorktreeRemove` leaves `ralphctl/<sprint>/wt-<taskId>` branch refs behind
+
+**STATUS: RESOLVED (2026-05-30).** Fixed by adding `gitDeleteBranch` to `git-operations.ts` and
+calling it best-effort in `cleanupWorktree` after `gitWorktreeRemove` (commit `211ec057`). The e2e
+assertion is now GREEN. The lesson stands: a real-git e2e caught what every fake-`GitRunner` unit
+test structurally could not. Original analysis preserved below.
+
+**Found by:** `tests/e2e/flows/implement-parallel-realgit.test.ts` happy-path assertion (2026-05-30)
+
+**What fails:** After a successful parallel implement run, `git branch -a` still shows 3 local branches:
+
+- `ralphctl/<sprint-id>/wt-<taskA-id>`
+- `ralphctl/<sprint-id>/wt-<taskB-id>`
+- `ralphctl/<sprint-id>/wt-<taskC-id>`
+
+`git worktree list` correctly shows only the main worktree (the directory cleanup works), but
+the branch refs created by `git worktree add -b <ref> <path>` are never deleted.
+
+**Root cause:** `cleanupWorktree()` in `src/application/flows/implement/wave-branch.ts` calls
+`gitWorktreeRemove(runner, repoRoot, worktreePath)` which runs `git worktree remove --force <path>`.
+That command removes the worktree DIRECTORY and the `.git/worktrees/<name>` admin record,
+but git does NOT automatically delete the associated branch ref.
+
+**What the contract requires (CLAUDE.md, T6 design):**
+
+> "Worktrees were created during the run and cleaned up after
+> (`git worktree list` shows none left; the `ralphctl/<sprint>/wt-*` refs are gone)."
+
+**Fix:** After `gitWorktreeRemove` succeeds in `cleanupWorktree()`, add:
+
+```typescript
+await runner.run(repoRoot, ['branch', '-D', branchRef]);
+```
+
+where `branchRef` is already in scope in `withWorktree` (it's the `branchRef` parameter
+passed to `gitWorktreeAdd`). Treat a non-zero exit as best-effort (same pattern as
+the rest of `cleanupWorktree`).
+
+Alternatively: add `gitDeleteBranch(runner, repoRoot, branchName): Promise<Result<void, StorageError>>`
+to `src/integration/io/git-operations.ts` and call it from `cleanupWorktree`.
+
+**File: line:**
+
+- `src/application/flows/implement/wave-branch.ts` — `cleanupWorktree()` function (~line 227)
+- `src/integration/io/git-operations.ts` — `gitWorktreeRemove()` (~line 350) — NOT the right fix here; the issue is the caller not deleting the branch afterward.
+
+**Test status:** RESOLVED — `cleanupWorktree` now calls `gitDeleteBranch` (best-effort) after the
+worktree remove; the e2e assertion in `tests/e2e/flows/implement-parallel-realgit.test.ts` passes.
+
+**Why:** Stale `wt-*` branches accumulate over multiple sprint runs, polluting `git branch` output
+and risking confusion with the sprint branch namespace. They also prevent `gitWorktreeAdd -b` from
+succeeding on a relaunch if the prior worktree directory was removed but the branch was not
+(git's `-b` flag fails if the branch already exists — which is intentional per the T6 design).
+The prune step before add would NOT save this — prune only cleans `.git/worktrees/<name>` records
+for missing directories, not orphaned branch refs.

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -568,9 +568,24 @@ CI smoke-tests `node dist/cli.mjs --version` from arbitrary cwd plus a real `npm
   drift will surface here first. Same gap as v0.6.x; deferred.
 - **Bundle-mode detection robustness** — `import.meta.url.endsWith('/cli.mjs')` would silently no-op if the
   published bin is renamed. Candidate replacement: `existsSync(<here>/manifest.json)`.
-- **Concurrency > 1** — `settings.concurrency.maxParallelTasks` is wired but the implement chain still runs
-  one task at a time (dependency-ordered, not concurrent). Concurrent per-task fan-out within a dependency
-  level needs a new chain primitive and is deferred.
+- **Parallel task execution (opt-in)** — `settings.concurrency.maxParallelTasks` (range 1–5, Zod-clamped;
+  default `1`) controls the parallel cap. `=== 1` is the serial path, byte-for-byte unchanged. `> 1`
+  activates `runWaves` (`src/application/chain/run/wave-scheduler.ts`), an above-the-chain orchestrator
+  that is NOT a new chain primitive — it sits above the five primitives and sequences whole sub-chains.
+  Each dependency wave's tasks run concurrently up to the cap; waves stay strictly sequential (wave k+1
+  starts only after every branch of wave k settled and merged). Each task runs in its own isolated git
+  worktree at `<sprintDir>/worktrees/wt-<taskId>`, forked from the sprint-branch tip. The repo's
+  `setupScript` runs inside each fresh worktree; a setup failure blocks only that task, never the wave.
+  Each worktree's commit is folded onto the shared sprint branch via one serialised fold queue (`git merge
+--ff-only` else `cherry-pick`), so multi-task parallel sprints land as one PR. A fold conflict (two
+  same-wave tasks touching the same file) transitions the second task to `blocked`; a relaunch
+  re-forks from the advanced tip and usually succeeds. Waves partition on dependency edges, not file
+  overlap. The sprint lock spans prologue + waves + epilogue with the same lock key as the serial path.
+  Commits durably folded before an abort are preserved and never re-executed on relaunch. Concurrent
+  `progress.md` / learnings-ledger appends are serialised through one in-process mutex. New files:
+  `src/application/chain/run/wave-scheduler.ts`,
+  `src/application/flows/implement/{parallel-element,wave-branch,merge-wave}.ts`,
+  plus git worktree verbs in `src/integration/io/git-operations.ts`.
 - **Cross-provider escalation** — plateau escalation today stays within a provider (e.g. Sonnet → Opus);
   switching providers mid-task carries auth/context/tool hazards and is deferred.
 - **Learning-ledger retrieval / embeddings** — the distill step reads the full ledger (no retrieval engine).

--- a/.claude/docs/HARNESS-PRINCIPLES.md
+++ b/.claude/docs/HARNESS-PRINCIPLES.md
@@ -109,7 +109,7 @@ contracts define testable success up-front."_
 - Blocked transition: `src/application/flows/implement/leaves/` (settle-attempt leaf)
 - Task status enum includes `blocked`: `src/domain/entity/task.ts`
 - **Outer attempt loop.** `per-task-subchain.ts` wraps the full per-attempt segment in a
-  `loop('task-attempts-<id>', …, { maxIterations: maxAttempts, shouldStop: terminal })` so a single
+  `loop('task-attempts-<id>', …, { maxIterations: task.maxAttempts, shouldStop })` so a single
   launch can run up to `maxAttempts` rounds per task. Escalation fires within this outer loop
   (at most once per task), then a second plateau blocks. `maxAttempts === 1` is byte-for-byte
   the prior one-attempt-per-launch behaviour.
@@ -267,6 +267,12 @@ harness when new model releases; strip non-load-bearing pieces."_
 
 - Cross-phase skill: `src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md` (bundled skill)
 - No audit cadence yet — nothing enforces a per-model-release walk of this doc.
+
+**Note — parallelism as above-the-chain orchestration.** The `maxParallelTasks > 1` parallel
+execution was deliberately implemented as `runWaves` — an async orchestrator that sits
+**above** the five chain primitives, not as a sixth primitive (`forEachItem` / `parallel`). The
+five-primitive rule (`element` / `leaf` / `sequential` / `loop` / `guard`) is unchanged.
+`runWaves` never implements `Element` and must never be composed into a `sequential`/`loop`/`guard`.
 
 **Next step.** The `ralphctl-minimal-scaffolding` skill captures the principle; what's missing is a ritual.
 Add a checklist block to the "How to use this doc" section (below) and gate it on a team process (e.g.

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -108,12 +108,15 @@ Status flow: `draft → planned → active → review → done`.
 
 ## Implement flow
 
-- [x] **Dependency-ordered execution** — tasks are scheduled by `scheduleIntoWaves` (topological
-      Kahn's-by-level over `Task.dependsOn`, `Task.order` ASC within each level); `validateTaskGraph`
-      runs at BOTH parse time and implement-launch time, so a cyclic or dangling graph fails fast with
-      the rendered issue. The scheduled levels are flattened into one serial queue — tasks run strictly
-      one at a time, each dependency leading the tasks that rely on it. `maxParallelTasks` stays the
-      pre-existing setting (default `1`, no concurrent execution).
+- [x] **Dependency-ordered execution with opt-in parallelism** — tasks are scheduled by `scheduleIntoWaves`
+      (topological Kahn's-by-level over `Task.dependsOn`, `Task.order` ASC within each level);
+      `validateTaskGraph` runs at BOTH parse time and implement-launch time, so a cyclic or dangling
+      graph fails fast with the rendered issue. When `settings.concurrency.maxParallelTasks === 1`
+      (default), levels flatten into one serial queue — byte-for-byte the prior behaviour. When
+      `maxParallelTasks > 1` (1–5), `runWaves` runs each wave's tasks concurrently up to that cap;
+      waves stay strictly sequential. Each task runs in its own isolated git worktree
+      (`<sprintDir>/worktrees/wt-<taskId>`); commits are folded onto one sprint branch (one PR). A fold
+      conflict transitions the second task to `blocked`; relaunching re-forks from the advanced tip.
 - [x] **Per-task generator-evaluator loop** — the attempt body is
       `start-attempt → pre-task-verify → gen-eval inner loop (generator/evaluator per turn) → finalize → post-task-verify → commit (guarded) → settle-attempt → append-learnings → progress-journal`,
       wrapped in an outer `loop` over attempts.
@@ -288,8 +291,10 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
 
 ## Things deliberately deferred
 
-- **Concurrent task fan-out** — `settings.concurrency.maxParallelTasks` is wired but only `1` is supported
-  today; tasks within a dependency level run serially. Concurrent fan-out needs a new chain primitive.
+- **File-overlap-aware wave partitioning** — today, two same-wave tasks that touch the same file resolve
+  at fold time (first folds, second's cherry-pick conflicts → `blocked`; relaunch re-forks from the
+  advanced tip and usually succeeds). Pre-partitioning waves by file overlap to eliminate the conflict
+  case is deferred.
 - **Cross-provider escalation** — escalation today stays within a provider (e.g. Sonnet → Opus); switching
   providers mid-task carries auth/context/tool hazards and is deferred.
 - **Real-provider e2e tests** — every Claude / Copilot / Codex provider test uses a fake `spawn`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Opt-in parallel task execution via `settings.concurrency.maxParallelTasks` (1–5).** Default `1`
+  keeps the existing serial behaviour byte-for-byte. When set to `> 1`, the `runWaves` orchestrator
+  (above the chain primitives, not a new primitive) runs each dependency wave's tasks concurrently up
+  to the configured cap; waves remain strictly sequential. Each task runs in its own isolated git
+  worktree (`<sprintDir>/worktrees/wt-<taskId>`) with a fresh `setupScript` run; commits are folded
+  onto the single shared sprint branch (one PR per sprint, same as serial mode). A fold conflict when
+  two same-wave tasks edit the same file transitions the second task to `blocked`; relaunching
+  re-forks from the advanced branch tip and usually succeeds without conflict.
+
 - **Task-graph validation wired at parse + launch.** `scheduleIntoWaves`
   (Kahn's-by-level over `Task.dependsOn`, sorted by `Task.order` ASC within each level) is now the
   single topological scheduler — called at parse time in `parse-task-list.ts` (removing the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ when CLI vendors tweak JSON shape.
 
 ## Performance & Limits
 
-**Implement runs tasks one at a time in dependency order.** `Task.order` (set as `i + 1` at parse
+**Implement runs tasks in dependency order; parallel execution is opt-in.** `Task.order` (set as `i + 1` at parse
 time by `parseTaskList` in `src/integration/ai/prompts/_engine/parse-task-list.ts`) is the
 intra-level tiebreak; `Task.dependsOn` carries the dependency edges (the planner emits them as
 `blockedBy` in the wire format and `parseTaskList` resolves them onto `dependsOn`). Graph validity —
@@ -331,13 +331,28 @@ and enforced at **both** boundaries: `parseTaskList` calls `scheduleIntoWaves` (
 dependency level, `Task.order` ASC within each level) and rejects the task list on a bad graph, and
 `resolveImplementQueue` (`src/application/ui/shared/launch/implement.ts`) re-runs `scheduleIntoWaves`
 at launch so a cyclic / dangling sprint fails fast with the rendered `TaskGraphIssue` rather than
-silently surfacing as an empty "No tasks to implement" queue. The scheduled levels are then
-**flattened into one serial queue** — tasks execute strictly one at a time, with each dependency
-guaranteed to lead the tasks that rely on it. Launch then applies a status-only stable override:
-`in_progress` tasks first (so a resumed sprint picks up the previously aborted task before any fresh
-work), then `todo`; V8's stable sort preserves dependency order within each status group.
-`settings.concurrency.maxParallelTasks` remains the pre-existing setting (default `1`, still no concurrent
-execution as of 0.8.x) — concurrent fan-out within a dependency level needs a new chain primitive (deferred).
+silently surfacing as an empty "No tasks to implement" queue. When `settings.concurrency.maxParallelTasks === 1`
+(the default), the scheduled levels flatten into one serial queue — byte-for-byte the prior behaviour.
+When `maxParallelTasks > 1` (range 1–5, Zod-clamped), the above-the-chain orchestrator `runWaves`
+(`src/application/chain/run/wave-scheduler.ts`) runs each dependency wave's tasks concurrently up to
+that cap; waves stay strictly sequential (wave k+1 starts only after every branch of wave k settled and
+merged). Each task runs in its own isolated git worktree at `<sprintDir>/worktrees/wt-<taskId>`,
+forked from the sprint-branch tip; the repo's `setupScript` runs inside each fresh worktree (a
+worktree has none of the main repo's build artefacts). A setup failure blocks only that task — it
+never hard-aborts the wave. Each worktree's commit is folded onto the single shared sprint branch
+(`git merge --ff-only`, else `cherry-pick`) through one serialised in-process fold queue, so a
+multi-task parallel sprint lands as one PR. When two same-wave tasks touch the same file the first
+folds cleanly; the second's cherry-pick conflicts → that task transitions to `blocked` (`cherry-pick
+--abort`, siblings stay `done`); a relaunch re-forks from the advanced tip and usually succeeds.
+Waves partition on dependency edges, not file overlap — conflict is resolved at fold time, not
+scheduling time. The sprint lock (`repoLockFile(locksRoot, sprintDir)`) spans prologue + waves +
+epilogue using the same lock key as the serial path, so a serial and a parallel run of the same
+sprint mutually exclude. Commits durably folded before an abort are preserved by the epilogue and
+never re-executed on relaunch. Concurrent appends to `progress.md` and the learnings ledger are
+serialised through one in-process mutex (no torn lines under fan-out). Launch then applies a
+status-only stable override: `in_progress` tasks first (so a resumed sprint picks up the previously
+aborted task before any fresh work), then `todo`; V8's stable sort preserves dependency order within
+each status group.
 
 **Rate-limit retry is adapter-side.** The headless provider wrapper at
 `src/integration/ai/providers/_engine/rate-limit-backoff.ts` sleeps with exponential delay between 429

--- a/src/application/chain/run/wave-scheduler.ts
+++ b/src/application/chain/run/wave-scheduler.ts
@@ -1,0 +1,338 @@
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts';
+
+import type { Element, ElementFailure } from '@src/application/chain/element.ts';
+import type { Trace } from '@src/application/chain/trace.ts';
+import { type Runner, createRunner } from '@src/application/chain/run/runner.ts';
+
+/**
+ * Hard ceiling on in-flight branches, regardless of what the caller passes. Mirrors the
+ * `settings.concurrency.maxParallelTasks` clamp (`[1,5]`) — the parallel cap. Re-clamped
+ * here so a mis-wired caller can never blow past the budget the rest of the harness was sized
+ * against.
+ */
+const MAX_CONCURRENCY_CEILING = 5;
+
+const clampConcurrency = (n: number): number => {
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(MAX_CONCURRENCY_CEILING, Math.max(1, Math.trunc(n)));
+};
+
+/**
+ * One unit of parallel work inside a wave. The caller supplies a stable `id` (used both as the
+ * branch's `runWithSession` scope and as the `chainId = task-<id>` the EventBus bridge keys on)
+ * plus the `element` to run on that branch's own {@link Runner}.
+ *
+ * @public
+ */
+export interface WaveBranch<TCtx> {
+  /** Stable identifier — the branch's session-scope id and the bus bridge's `chainId`. */
+  readonly id: string;
+  /** The chain to execute for this branch, on its own runner / abort controller / trace ring. */
+  readonly element: Element<TCtx>;
+}
+
+/**
+ * The settled result of one {@link WaveBranch}. The caller's `merge` reducer folds an array of
+ * these (in branch-declaration order) back into the carried ctx between waves.
+ *
+ *  - `status === 'completed'` → `ctx` is the branch's final ctx; `error` is absent.
+ *  - `status === 'failed'`    → a NON-fatal branch error was absorbed; `ctx` is the branch's
+ *                               last ctx (its `initialCtx` if it never advanced), `error` carries
+ *                               the absorbed `DomainError` so the reducer can record the block.
+ *
+ * Fatal errors (`aborted` / `rate-limit`) never surface as a `BranchOutcome` — they short-circuit
+ * the whole wave (see {@link runWaves}).
+ *
+ * @public
+ */
+export interface BranchOutcome<TCtx> {
+  readonly id: string;
+  readonly status: 'completed' | 'failed';
+  readonly ctx: TCtx;
+  readonly error?: DomainError;
+}
+
+/**
+ * Configuration for {@link runWaves}. Everything ctx-specific is injected so the scheduler stays
+ * generic — it imports nothing from any flow.
+ *
+ * @public
+ */
+export interface WaveScheduleConfig<TCtx> {
+  /** Desired max in-flight branches per wave. Re-clamped to `[1,5]` internally. */
+  readonly maxConcurrency: number;
+  /**
+   * Fan-in reducer. Given the ctx carried into the wave and the wave's settled branch outcomes
+   * (in branch-declaration order), produce the ctx carried into the NEXT wave. Pure; the caller
+   * supplies the flow-specific merge semantics (e.g. the implement task-overlay reducer).
+   */
+  readonly merge: (base: TCtx, outcomes: ReadonlyArray<BranchOutcome<TCtx>>) => TCtx;
+  /**
+   * Blast radius of an exhausted-retry `rate-limit` in one branch.
+   *  - `'drain'` (default): let the already-in-flight siblings finish, then stop launching the
+   *    rest of the wave (their commits still fold).
+   *  - `'kill'`: abort the in-flight siblings immediately, same as `aborted`.
+   *
+   * `aborted` ALWAYS kills immediately regardless of this knob.
+   */
+  readonly onFatal?: 'kill' | 'drain';
+  /**
+   * Hook invoked once per branch, with that branch's freshly-created {@link Runner}, BEFORE it
+   * starts. The caller bridges it to the EventBus (`bridgeRunnerToEventBus(runner, bus, …)` with
+   * `chainId = task-<id>`). The scheduler owns the runner lifecycle; the hook only observes.
+   */
+  readonly onBranchRunner?: (runner: Runner<TCtx>, branch: WaveBranch<TCtx>) => void;
+}
+
+/** Internal per-branch bookkeeping: the runner, a never-rejecting settle promise, captured error. */
+interface BranchRun<TCtx> {
+  readonly branch: WaveBranch<TCtx>;
+  readonly runner: Runner<TCtx>;
+  /** Resolves to this same run when the runner reaches a terminal state. Never rejects. */
+  readonly settled: Promise<BranchRun<TCtx>>;
+  /** The `failed`-event error, captured off the runner's stream; `null` for a clean / aborted run. */
+  capturedError: DomainError | null;
+}
+
+/** Classify a settled branch error: `aborted` / `rate-limit` are fatal, everything else absorbed. */
+const isFatal = (err: DomainError): boolean => !isRecoverableTurnError(err);
+
+/**
+ * Above-the-chain async orchestrator that drives N independent {@link Runner} instances — one per
+ * {@link WaveBranch} — bounded by `maxConcurrency` (re-clamped `[1,5]`), wave by wave.
+ *
+ * **§14 — NOT an `Element`.** `runWaves` deliberately does not implement the `Element` interface
+ * and must never be `.children`-walked or composed into a `sequential`/`loop`/`guard`. It sits
+ * ABOVE the five chain primitives, sequencing whole sub-chains; the primitives stay untouched.
+ *
+ * Scheduling contract:
+ *  - **Bounded fan-out.** Within a wave, at most `maxConcurrency` branches are in flight. A
+ *    hand-rolled `Set<Promise>` + `Promise.race` drains the pool: launch up to the cap, race for
+ *    the next settle, refill, repeat.
+ *  - **Strictly sequential waves.** Wave `k+1` does not begin until EVERY branch of wave `k` has
+ *    settled AND `config.merge` has folded them into the carried ctx.
+ *  - **Deterministic trace.** The combined trace is assembled in branch-DECLARATION order across
+ *    all waves — never completion order — so the trace is reproducible run to run.
+ *
+ * Failure contract (CLAUDE.md "AbortError is the one error chains propagate transparently"):
+ *  - A NON-fatal branch failure is absorbed: siblings keep running, the error is captured in that
+ *    branch's {@link BranchOutcome} (`status: 'failed'`) for the reducer to record as a block.
+ *  - **Abort:** when `signal` aborts, forward it into every in-flight branch via
+ *    `runner.abort()`, await all branches to settle (`Promise.allSettled` semantics — `settled`
+ *    never rejects) so each branch's chain runs its own cleanup (e.g. worktree teardown), then
+ *    return `Result.error({ error: AbortError, trace })` VERBATIM — the AbortError is never folded
+ *    into a per-branch "blocked" outcome.
+ *  - **Rate-limit:** an exhausted-retry `rate-limit` in one branch is fatal. With
+ *    `onFatal: 'drain'` (default) the in-flight siblings finish and then the rest of the wave is
+ *    not launched; with `onFatal: 'kill'` the siblings are aborted immediately. Either way the
+ *    `rate-limit` error is returned verbatim once everything has settled.
+ *
+ * @public
+ */
+export const runWaves = async <TCtx>(
+  waves: ReadonlyArray<ReadonlyArray<WaveBranch<TCtx>>>,
+  initialCtx: TCtx,
+  config: WaveScheduleConfig<TCtx>,
+  signal?: AbortSignal
+): Promise<Result<{ readonly ctx: TCtx; readonly trace: Trace }, ElementFailure>> => {
+  const cap = clampConcurrency(config.maxConcurrency);
+  const onFatal = config.onFatal ?? 'drain';
+
+  const combinedTrace: Trace[] = [];
+  let ctx = initialCtx;
+
+  for (const wave of waves) {
+    // Waves are STRICTLY sequential by design: wave k+1 must not start until every
+    // branch of wave k has settled and `merge` has folded them into `ctx`.
+    const waveResult = await runOneWave(wave, ctx, cap, onFatal, config, signal);
+
+    // Append every started branch's trace in DECLARATION order — never completion order.
+    combinedTrace.push(...waveResult.traces);
+
+    if (waveResult.fatal !== null) {
+      return Result.error({ error: waveResult.fatal, trace: combinedTrace.flat() });
+    }
+
+    ctx = config.merge(ctx, waveResult.outcomes);
+  }
+
+  return Result.ok({ ctx, trace: combinedTrace.flat() });
+};
+
+interface WaveResult<TCtx> {
+  /** Settled outcomes for the branches that ran, in declaration order. */
+  readonly outcomes: ReadonlyArray<BranchOutcome<TCtx>>;
+  /** Per-started-branch traces, in declaration order. */
+  readonly traces: readonly Trace[];
+  /** A fatal error (`aborted`/`rate-limit`) that short-circuits the whole schedule, if any. */
+  readonly fatal: DomainError | null;
+}
+
+/**
+ * Run one wave with bounded fan-out. Returns the wave's settled outcomes + traces in declaration
+ * order plus any fatal error that aborts the whole schedule.
+ *
+ * Pool drain: maintain a `Set<Promise<BranchRun>>` of in-flight settle promises (each resolves to
+ * its owning run). Launch up to `cap`, `Promise.race` for the next settle, remove it, inspect for
+ * a fatal error, then refill from the pending queue — until everything settled or a stop fired.
+ */
+const runOneWave = async <TCtx>(
+  wave: ReadonlyArray<WaveBranch<TCtx>>,
+  base: TCtx,
+  cap: number,
+  onFatal: 'kill' | 'drain',
+  config: WaveScheduleConfig<TCtx>,
+  signal?: AbortSignal
+): Promise<WaveResult<TCtx>> => {
+  // If the outer signal is already aborted, never launch a single branch.
+  if (signal?.aborted) {
+    return { outcomes: [], traces: [], fatal: new AbortError({ elementName: 'wave-scheduler' }) };
+  }
+
+  const pool = createWavePool(wave, base, cap, onFatal, config);
+
+  // Forward an outer-signal abort into every in-flight branch. Abort always kills immediately
+  // (regardless of `onFatal`); `settled` promises still resolve, so the drain below awaits every
+  // branch's own cleanup before returning.
+  const onAbort = (): void => pool.abortAll(new AbortError({ elementName: 'wave-scheduler' }));
+  signal?.addEventListener('abort', onAbort, { once: true });
+
+  pool.fill();
+  while (pool.inFlightCount() > 0) {
+    // The drain is inherently sequential — one settle at a time, then refill.
+    const settledRun = await pool.next();
+    pool.classify(settledRun);
+    pool.fill();
+  }
+
+  signal?.removeEventListener('abort', onAbort);
+  return pool.assemble();
+};
+
+/**
+ * Encapsulates one wave's launch / drain state machine. Mutable by design (a pool of in-flight
+ * promises is inherently stateful); kept out of `runOneWave` to keep that function's branching
+ * within the cognitive-complexity budget.
+ */
+const createWavePool = <TCtx>(
+  wave: ReadonlyArray<WaveBranch<TCtx>>,
+  base: TCtx,
+  cap: number,
+  onFatal: 'kill' | 'drain',
+  config: WaveScheduleConfig<TCtx>
+) => {
+  // Per-index slots → outcomes + traces assembled in declaration order regardless of completion
+  // order. `undefined` = branch never started (drained / killed before launch).
+  const runs: Array<BranchRun<TCtx> | undefined> = new Array(wave.length).fill(undefined);
+  const inFlight = new Set<Promise<BranchRun<TCtx>>>();
+  let nextIndex = 0;
+  let fatal: DomainError | null = null;
+  let stopLaunching = false;
+
+  const launch = (index: number): void => {
+    const run = createBranchRun(wave[index]!, base);
+    runs[index] = run;
+    config.onBranchRunner?.(run.runner, run.branch);
+    inFlight.add(run.settled);
+  };
+
+  return {
+    inFlightCount: (): number => inFlight.size,
+
+    /** Launch branches up to the cap, unless a stop (fatal / abort) has fired. */
+    fill: (): void => {
+      while (nextIndex < wave.length && inFlight.size < cap && !stopLaunching) launch(nextIndex++);
+    },
+
+    /** Await the next settled branch and drop it from the in-flight set. */
+    next: async (): Promise<BranchRun<TCtx>> => {
+      const settledRun = await Promise.race(inFlight);
+      inFlight.delete(settledRun.settled);
+      return settledRun;
+    },
+
+    /** Classify a settled branch: record the first fatal, stop launching, kill siblings if needed. */
+    classify: (settledRun: BranchRun<TCtx>): void => {
+      const err = settledRun.capturedError;
+      if (err === null || !isFatal(err)) return;
+      if (fatal === null) fatal = err; // first fatal wins
+      stopLaunching = true;
+      // `aborted` always kills immediately; `rate-limit` honours `onFatal` ('drain' lets siblings finish).
+      if (err.code === 'aborted' || onFatal === 'kill') {
+        for (const run of runs) run?.runner.abort('fatal-sibling');
+      }
+    },
+
+    /** Forward an outer-signal abort: record AbortError, stop launching, kill every branch now. */
+    abortAll: (abortErr: AbortError): void => {
+      stopLaunching = true;
+      if (fatal === null) fatal = abortErr;
+      for (const run of runs) run?.runner.abort('outer-signal-aborted');
+    },
+
+    /** Assemble outcomes + traces in declaration order once the wave has fully drained. */
+    assemble: (): WaveResult<TCtx> => {
+      const outcomes: Array<BranchOutcome<TCtx>> = [];
+      const traces: Trace[] = [];
+      // On an abort short-circuit we never fold branch outcomes — the AbortError returns verbatim.
+      const abortedFatal = fatal !== null && fatal.code === 'aborted';
+      for (const run of runs) {
+        if (run === undefined) continue;
+        traces.push(run.runner.trace);
+        if (!abortedFatal) outcomes.push(toOutcome(run));
+      }
+      return { outcomes, traces, fatal };
+    },
+  };
+};
+
+/**
+ * Create a branch's {@link Runner} and the `settled` promise that resolves (to the run itself)
+ * when the runner terminates. The runner already wraps `element.execute` in
+ * `runWithSession(id, …)` and owns its own `AbortController` + trace ring + listener set — so each
+ * branch is fully isolated. `runner.start()` resolves on terminal and never rejects, so `settled`
+ * never rejects either.
+ */
+const createBranchRun = <TCtx>(branch: WaveBranch<TCtx>, base: TCtx): BranchRun<TCtx> => {
+  const runner = createRunner<TCtx>({ id: branch.id, element: branch.element, initialCtx: base });
+  const run: BranchRun<TCtx> = {
+    branch,
+    runner,
+    capturedError: null,
+    // Placeholder; reassigned immediately below now that `run` exists to resolve to / capture onto.
+    settled: Promise.resolve(undefined as unknown as BranchRun<TCtx>),
+  };
+
+  const unsub = runner.subscribe((event) => {
+    if (event.type === 'failed') run.capturedError = event.error;
+  });
+
+  // start() resolves when the run reaches a terminal state; detach the listener then, resolve to
+  // the run so the pool drain can identify the race winner and read its captured error.
+  (run as { settled: Promise<BranchRun<TCtx>> }).settled = runner
+    .start()
+    .finally(unsub)
+    .then(() => run);
+
+  return run;
+};
+
+/** Map a terminal {@link Runner} to a {@link BranchOutcome}. */
+const toOutcome = <TCtx>(run: BranchRun<TCtx>): BranchOutcome<TCtx> => {
+  if (run.runner.status === 'completed') {
+    return { id: run.branch.id, status: 'completed', ctx: run.runner.ctx };
+  }
+  // A NON-fatal failure is absorbed: capture the error so the reducer can record the block. A
+  // runner that reports 'aborted' without a captured error was a fatal-sibling kill in 'kill'
+  // mode (or an outer-signal abort) — surface it as a no-op `failed` with no error rather than
+  // pretending it completed, so the reducer can leave the task to be reset/re-run.
+  return {
+    id: run.branch.id,
+    status: 'failed',
+    ctx: run.runner.ctx,
+    ...(run.capturedError !== null ? { error: run.capturedError } : {}),
+  };
+};

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -1,5 +1,6 @@
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { Task } from '@src/domain/entity/task.ts';
+import { scheduleIntoWaves } from '@src/domain/entity/task-graph.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Element } from '@src/application/chain/element.ts';
@@ -130,6 +131,13 @@ export interface CreateImplementFlowOpts {
  *     ),
  *   ])
  *
+ * The prologue leaves (`load-and-assert-sprint` … `preflight-tasks`) and epilogue leaves
+ * (`save-tasks`, the review-transition guard) are sourced from {@link buildImplementPrologue} /
+ * {@link buildImplementEpilogue} — the SAME leaf instances the parallel launcher consumes via
+ * {@link planImplementWaves}, spliced INLINE here (not nested) so the serial `implement-locked`
+ * shape is byte-for-byte unchanged. The `implement-prologue` / `implement-epilogue` wrapper names
+ * exist only in the parallel plan, never in this serial tree.
+ *
  * See `per-task-subchain.ts` for the per-task body and `gen-eval-loop.ts` for the inner
  * generator-evaluator loop.
  *
@@ -183,52 +191,26 @@ export interface CreateImplementFlowOpts {
  *   launch ended before the cap because the operator aborted) is still picked up by re-running
  *   the chain.
  */
-export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFlowOpts): Element<ImplementCtx> => {
-  // Promise-shaped accessor read by `finalize-gen-eval` and the gen-eval loop's
-  // `shouldContinue` predicate. Re-resolved per call so a mid-run config edit (lower maxTurns,
-  // toggle escalation) takes effect on the next iteration rather than requiring a restart.
-  const readConfig = (): Promise<{
-    readonly maxTurns: number;
-    readonly escalateOnPlateau: boolean;
-    readonly escalationMap: Readonly<Record<string, string>>;
-  }> =>
-    Promise.resolve({
-      maxTurns: deps.config.harness.maxTurns,
-      escalateOnPlateau: deps.config.harness.escalateOnPlateau,
-      escalationMap: deps.config.harness.escalationMap,
-    });
-
+/**
+ * Build the prologue segment — everything from `load-and-assert-sprint` through `preflight-tasks`,
+ * the once-per-run setup that runs BEFORE any task executes:
+ *
+ *   load-and-assert-sprint → activate → load-execution → load-tasks → resolve-branch →
+ *   working-tree-clean-checks → progress-journal-activate → setup-script-runner → preflight-tasks
+ *
+ * Returned as `sequential('implement-prologue', [...])` so the parallel launcher can run it
+ * once on a dedicated runner under the held lock before fanning the task waves out. The serial
+ * `createImplementFlow` does NOT nest this wrapper — it splices the same leaf instances inline
+ * (via `.children`) so the serial observable chain shape stays byte-for-byte unchanged.
+ *
+ * @public
+ */
+export const buildImplementPrologue = (deps: ImplementDeps, opts: CreateImplementFlowOpts): Element<ImplementCtx> => {
   // Per-repo derived shapes — unique cwds drive `resolve-branch`, the clean-check fan-out, and
   // the per-repo preflight; the setup-script entries are repo + setupScript pairs scoped to the
   // tasks the sprint actually runs. See `sprint-repo-plan.ts` for the rationale.
   const uniqueRepoCwds = uniqueRepoCwdsForTasks(opts.repositories, opts.todoTasks);
   const setupRepoEntries = setupRepoEntriesForTasks(opts.repositories, opts.todoTasks);
-
-  const perTaskChains = opts.todoTasks.map((task) =>
-    createPerTaskSubchain(
-      deps,
-      {
-        sprintDir: opts.sprintDir,
-        progressFile: opts.progressFile,
-        terminalLeafName: IMPLEMENT_TASK_TERMINAL_LEAF,
-        generator: {
-          providerId: opts.generatorProviderId,
-          model: opts.generatorModel,
-          ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
-        },
-        evaluator: {
-          providerId: opts.evaluatorProviderId,
-          model: opts.evaluatorModel,
-          ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
-        },
-        memoryRoot: opts.memoryRoot,
-        projectId: opts.projectId,
-      },
-      task,
-      resolveRepoOrThrow(opts.repositories, task),
-      readConfig
-    )
-  );
 
   // Default to 'prompt' so the interactive recovery menu (Keep / Stash / Reset / Cancel) fires;
   // the business-layer default stays 'cancel' for non-interactive callers in isolation.
@@ -248,7 +230,7 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
     uniqueRepoCwds
   );
 
-  const inner = sequential<ImplementCtx>('implement-locked', [
+  return sequential<ImplementCtx>('implement-prologue', [
     loadAndAssertSprintSubChain<ImplementCtx>({ sprintRepo: deps.sprintRepo }, ['planned', 'active']),
     activateSprintLeaf({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
     loadSprintExecutionLeaf<ImplementCtx>({ sprintExecutionRepo: deps.sprintExecutionRepo }),
@@ -281,7 +263,25 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
       { repos: setupRepoEntries, sprintDir: opts.sprintDir }
     ),
     sequential<ImplementCtx>('preflight-tasks', preflightLeaves),
-    sequential<ImplementCtx>('implement-tasks', perTaskChains),
+  ]);
+};
+
+/**
+ * Build the epilogue segment — the once-per-run teardown that runs AFTER every task has settled:
+ *
+ *   save-tasks → transition-sprint-to-review(when any task done)
+ *
+ * Returned as `sequential('implement-epilogue', [...])` so the parallel launcher can run it
+ * once on a dedicated runner under the held lock — including on the abort/fatal path, where the
+ * `save-tasks` leaf must still persist the partially-merged ctx so folded commits are durably
+ * recorded. The serial `createImplementFlow` does NOT nest this wrapper — it splices the same leaf
+ * instances inline (via `.children`) so the serial observable chain shape stays byte-for-byte
+ * unchanged.
+ *
+ * @public
+ */
+export const buildImplementEpilogue = (deps: ImplementDeps, opts: CreateImplementFlowOpts): Element<ImplementCtx> =>
+  sequential<ImplementCtx>('implement-epilogue', [
     saveTasksLeaf<ImplementCtx>({ taskRepo: deps.taskRepo }),
     // Only transition to review when at least one task actually settled `done`. If every task
     // got blocked (e.g. pre-existing build failure, repeated self-block), the sprint has
@@ -299,6 +299,128 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
         ),
       ])
     ),
+  ]);
+
+/**
+ * The decomposed implement run — prologue / per-task waves / epilogue as separate elements plus
+ * the sprint-wide lock key. Produced by {@link planImplementWaves}; consumed by the parallel
+ * launcher to run the prologue, then `runWaves` over the per-task waves, then the epilogue,
+ * all under ONE held `fileLocker.withLock(lockKey)`.
+ *
+ * The serial `createImplementFlow` keeps its own internal `withRepoLock`-wrapped chain — the
+ * serial `===1` path keeps the lock inside the flow. This plan exists purely so the `>1`
+ * parallel path can be wired without re-deriving the segments.
+ *
+ * @public
+ */
+export interface ImplementWavePlan {
+  /**
+   * `sequential('implement-prologue', [...])` — the once-per-run setup (load → setup → preflight).
+   * Run once on its own runner before the waves.
+   */
+  readonly prologue: Element<ImplementCtx>;
+  /**
+   * Dependency layers from `scheduleIntoWaves(opts.todoTasks)` — each inner array is a set of
+   * tasks with no intra-wave dependency, safe to run concurrently. The parallel path forks one
+   * branch per task in a wave and hands the wave to `runWaves`. Waves are strictly ordered: every dependency of a
+   * task in wave `k` was scheduled in some wave `< k`.
+   */
+  readonly waves: ReadonlyArray<readonly Task[]>;
+  /**
+   * `sequential('implement-epilogue', [...])` — the once-per-run teardown (save → transition).
+   * Run once on its own runner after the waves (including on the abort/fatal path, so folded
+   * commits are durably persisted).
+   */
+  readonly epilogue: Element<ImplementCtx>;
+  /**
+   * Sprint-wide lock key — the sprint dir. The parallel launcher hoists ONE held lock on this
+   * key across prologue + waves + epilogue — the lock is hoisted for the `>1` path. Mirrors
+   * the `worktreePath` the serial path's internal `withRepoLock` uses.
+   */
+  readonly lockKey: AbsolutePath;
+}
+
+/**
+ * Decompose an implement run into its reusable segments for the parallel launcher.
+ *
+ * Returns the extracted {@link buildImplementPrologue} / {@link buildImplementEpilogue} segments,
+ * the dependency-scheduled task waves (`scheduleIntoWaves(opts.todoTasks)`), and the sprint-wide
+ * lock key. Lands NO parallel behaviour itself — it only computes the plan; the parallel launcher
+ * is the consumer that runs the prologue, fans the waves out via `runWaves`, and runs the epilogue under one held
+ * lock.
+ *
+ * On an unschedulable task set (cycle / self-edge / dangling dependency) the wave schedule fails.
+ * `launchImplement` already validates + schedules the full task set upfront (see
+ * `resolveImplementQueue`), so by the time the launcher builds a plan from the resumable queue the
+ * graph is known sound; the `Result.ok` branch is therefore the expected path. A `TaskGraphIssue`
+ * is propagated as an empty wave list so a mis-sequenced caller fails closed (no tasks scheduled)
+ * rather than throwing at construction time.
+ *
+ * @public
+ */
+export const planImplementWaves = (deps: ImplementDeps, opts: CreateImplementFlowOpts): ImplementWavePlan => {
+  const schedule = scheduleIntoWaves(opts.todoTasks);
+  return {
+    prologue: buildImplementPrologue(deps, opts),
+    waves: schedule.ok ? schedule.value : [],
+    epilogue: buildImplementEpilogue(deps, opts),
+    lockKey: opts.sprintDir,
+  };
+};
+
+export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFlowOpts): Element<ImplementCtx> => {
+  // Promise-shaped accessor read by `finalize-gen-eval` and the gen-eval loop's
+  // `shouldContinue` predicate. Re-resolved per call so a mid-run config edit (lower maxTurns,
+  // toggle escalation) takes effect on the next iteration rather than requiring a restart.
+  const readConfig = (): Promise<{
+    readonly maxTurns: number;
+    readonly escalateOnPlateau: boolean;
+    readonly escalationMap: Readonly<Record<string, string>>;
+  }> =>
+    Promise.resolve({
+      maxTurns: deps.config.harness.maxTurns,
+      escalateOnPlateau: deps.config.harness.escalateOnPlateau,
+      escalationMap: deps.config.harness.escalationMap,
+    });
+
+  const perTaskChains = opts.todoTasks.map((task) =>
+    createPerTaskSubchain(
+      deps,
+      {
+        sprintDir: opts.sprintDir,
+        progressFile: opts.progressFile,
+        terminalLeafName: IMPLEMENT_TASK_TERMINAL_LEAF,
+        generator: {
+          providerId: opts.generatorProviderId,
+          model: opts.generatorModel,
+          ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
+        },
+        evaluator: {
+          providerId: opts.evaluatorProviderId,
+          model: opts.evaluatorModel,
+          ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
+        },
+        memoryRoot: opts.memoryRoot,
+        projectId: opts.projectId,
+      },
+      task,
+      resolveRepoOrThrow(opts.repositories, task),
+      readConfig
+    )
+  );
+
+  // Serial path: the lock stays inside the flow — the `implement-locked` body is the SAME flat list of leaf instances it
+  // has always been — the prologue/epilogue segment builders supply those instances via `.children`
+  // (spliced inline, not nested), so the serial observable chain shape stays byte-for-byte
+  // unchanged. The `implement-prologue` / `implement-epilogue` wrapper names exist ONLY in the
+  // segments the parallel launcher consumes via `planImplementWaves`; they never appear in this serial tree.
+  const prologueLeaves = buildImplementPrologue(deps, opts).children ?? [];
+  const epilogueLeaves = buildImplementEpilogue(deps, opts).children ?? [];
+
+  const inner = sequential<ImplementCtx>('implement-locked', [
+    ...prologueLeaves,
+    sequential<ImplementCtx>('implement-tasks', perTaskChains),
+    ...epilogueLeaves,
   ]);
 
   // Lock key: the sprint dir. One implement run at a time per sprint — across all repos the

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -87,6 +87,19 @@ export interface PerTaskSubchainOpts {
   readonly memoryRoot: AbsolutePath;
   /** Owning project's id — selects the per-project learnings ledger subdirectory. */
   readonly projectId: string;
+  /**
+   * Whether the per-task prologue includes the `branch-preflight-<taskId>` leaf. Default `true`
+   * (the serial implement path: every per-task sub-chain re-asserts the working tree is on the
+   * resolved sprint branch before committing, so an AI generator turn that `git checkout`-ed away
+   * can't land a wrong-branch commit).
+   *
+   * The parallel launcher sets this `false`: each task runs in its own git worktree checked
+   * out on a dedicated `ralphctl/<sprintId>/wt-<taskId>` ref, so there is no shared sprint branch
+   * to drift FROM. A preflight there would compare against the wrong ref and fail spuriously —
+   * branch enforcement is moot per-worktree, the fold step is what lands commits on the shared
+   * sprint branch.
+   */
+  readonly includeBranchPreflight?: boolean;
 }
 
 // `installSkillsLeaf` writes the bundled skill set to `<repo>/<parentDir>/skills/ralphctl-*/`.
@@ -125,12 +138,20 @@ export const createPerTaskSubchain = (
   }>
 ): Element<ImplementCtx> => {
   const taskId = task.id;
+  // The serial path keeps `branch-preflight` (default true) so a wrong-branch commit never lands;
+  // the parallel launcher omits it (each task runs in its own dedicated worktree ref). Spliced via
+  // a conditional spread so the serial element tree is byte-for-byte unchanged when included.
+  const includeBranchPreflight = opts.includeBranchPreflight ?? true;
   return sequential<ImplementCtx>(`task-${String(taskId)}`, [
-    branchPreflightLeaf(
-      { gitRunner: deps.gitRunner, logger: deps.logger },
-      { cwd: repo.path },
-      `branch-preflight-${String(taskId)}`
-    ),
+    ...(includeBranchPreflight
+      ? [
+          branchPreflightLeaf(
+            { gitRunner: deps.gitRunner, logger: deps.logger },
+            { cwd: repo.path },
+            `branch-preflight-${String(taskId)}`
+          ),
+        ]
+      : []),
     buildTaskWorkspaceLeaf(
       { templateLoader: deps.templateLoader, logger: deps.logger },
       {
@@ -254,7 +275,7 @@ export const createPerTaskSubchain = (
           { cwd: repo.path },
           taskId
         ),
-        // WRITE side of procedural memory. Reads the STILL-POPULATED `currentAttemptLearnings`
+        // WRITE side of Theme 6 (audit-[B5]). Reads the STILL-POPULATED `currentAttemptLearnings`
         // accumulator and appends one NDJSON line per learning to the project's ledger. MUST run
         // BEFORE `progress-journal` — the journal clears that accumulator after it renders. Append
         // only (the read side dedups by stable id); best-effort (a failed append logs + proceeds).

--- a/src/application/flows/implement/merge-wave.ts
+++ b/src/application/flows/implement/merge-wave.ts
@@ -1,0 +1,185 @@
+import type { Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+
+import type { BranchOutcome } from '@src/application/chain/run/wave-scheduler.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { RepoExecConfig } from '@src/application/flows/implement/leaves/resolve-repo.ts';
+
+/**
+ * Classification of every {@link ImplementCtx} field for the parallel-wave fan-in.
+ *
+ *  - `'sprint'`       — sprint-scoped invariant; carried straight from `base` (the ctx that
+ *                       entered the wave). Same across every branch.
+ *  - `'tasks'`        — the task list; the only field a wave actually mutates. Folded as a
+ *                       task-keyed overlay of every branch's settled task copy onto `base.tasks`.
+ *  - `'per-task'`     — single-slot state scoped to ONE in-flight task. Meaningless between waves
+ *                       (each branch carried its own); reset to `undefined` in the merged ctx.
+ *  - `'signal-accum'` — per-attempt signal accumulators. Likewise per-branch; reset to `undefined`.
+ */
+type MergeClass = 'sprint' | 'tasks' | 'per-task' | 'signal-accum';
+
+// Named so the classification map reads as labels, not repeated string literals.
+const SPRINT = 'sprint' satisfies MergeClass;
+const TASKS = 'tasks' satisfies MergeClass;
+const PER_TASK = 'per-task' satisfies MergeClass;
+const SIGNAL_ACCUM = 'signal-accum' satisfies MergeClass;
+
+/**
+ * THE exhaustiveness guard. A single object literal keyed over EVERY field of
+ * {@link ImplementCtx}, `satisfies Record<keyof ImplementCtx, MergeClass>`. It is derived from the
+ * interface, not a hand-maintained list: add a new field to `ImplementCtx` and this object stops
+ * satisfying the constraint until the new field is classified here — a compile-time forcing
+ * function so a future ctx field can never silently skip the merge/fork projection below.
+ *
+ * The merge/fork logic reads NOTHING from this object at runtime — it exists purely so the
+ * classification is type-checked. The actual projection is hand-written below (and must be kept in
+ * agreement with these labels), which is exactly the pairing the guard enforces.
+ */
+const _exhaustive = {
+  // sprint-scoped → from base
+  sprintId: SPRINT,
+  sprint: SPRINT,
+  execution: SPRINT,
+  progressFile: SPRINT,
+  // task list → overlay
+  tasks: TASKS,
+  // per-task single-slot → undefined
+  taskWorkspaceRoot: PER_TASK,
+  currentTaskId: PER_TASK,
+  currentTask: PER_TASK,
+  genEvalTurn: PER_TASK,
+  currentRoundNum: PER_TASK,
+  lastEvaluation: PER_TASK,
+  plateauHistory: PER_TASK,
+  lastExit: PER_TASK,
+  lastVerdict: PER_TASK,
+  lastBlockReason: PER_TASK,
+  lastWarning: PER_TASK,
+  lastShouldFailAttempt: PER_TASK,
+  lastVerifyResult: PER_TASK,
+  lastPreVerifyOutcome: PER_TASK,
+  priorPostVerifyOutcome: PER_TASK,
+  lastCommitSha: PER_TASK,
+  proposedCommitMessage: PER_TASK,
+  expectedBranch: PER_TASK,
+  priorGeneratorSessionId: PER_TASK,
+  priorEvaluatorSessionId: PER_TASK,
+  // signal accumulators → undefined
+  currentAttemptDecisions: SIGNAL_ACCUM,
+  currentAttemptChanges: SIGNAL_ACCUM,
+  currentAttemptLearnings: SIGNAL_ACCUM,
+  currentAttemptNotes: SIGNAL_ACCUM,
+} satisfies Record<keyof ImplementCtx, MergeClass>;
+
+// Reference the guard so it is not dead-code-eliminated / lint-flagged; its whole purpose is the
+// compile-time `satisfies` check above.
+void _exhaustive;
+
+/**
+ * Whether a branch genuinely SETTLED its task, versus the scheduler killing it before it advanced.
+ *
+ * Per the {@link runWaves} contract, a branch the scheduler killed (fatal-sibling kill, or a wave
+ * the launcher never reached) surfaces as `{ status: 'failed', error: undefined }`. That is "did
+ * not complete" — NOT a real `blocked`. Only branches that actually ran their chain to a terminal
+ * state carry an authoritative task copy worth overlaying:
+ *
+ *  - `status: 'completed'`                  → the branch's chain settled the task (done OR blocked).
+ *  - `status: 'failed'` WITH an `error`     → a non-fatal branch error was absorbed; the branch's
+ *                                             ctx holds the task transition (typically `blocked`).
+ *  - `status: 'failed'` WITHOUT an `error`  → killed mid-flight / never started; leave base as-is so
+ *                                             the launcher resets the task to `todo` and re-runs it.
+ */
+const branchSettled = <TCtx>(outcome: BranchOutcome<TCtx>): boolean =>
+  outcome.status === 'completed' || outcome.error !== undefined;
+
+/**
+ * Fan-in reducer for one implement wave. Matches `WaveScheduleConfig<ImplementCtx>['merge']` so the
+ * launcher can hand it straight to `runWaves`.
+ *
+ * Every wave partitions tasks DISJOINTLY (the scheduler runs one branch per task, and a wave only
+ * groups tasks with no intra-wave dependency), so the task overlay is commutative: shuffling
+ * `outcomes` produces an identical merged ctx. The reducer therefore needs no ordering guarantees
+ * from the scheduler beyond "these outcomes all belong to the same wave."
+ *
+ *  - sprint-scoped fields → carried verbatim from `base`.
+ *  - `tasks` → `base.tasks` with each settled branch's task copy overlaid by id; an unsettled
+ *    (killed) branch contributes nothing, leaving its base task untouched for reset/re-run.
+ *  - per-task + signal-accum fields → reset to `undefined`; they have no meaning between waves.
+ *
+ * @public
+ */
+export const mergeImplementWave = (
+  base: ImplementCtx,
+  outcomes: ReadonlyArray<BranchOutcome<ImplementCtx>>
+): ImplementCtx => {
+  // Build the task-keyed overlay ONLY from branches that genuinely settled their task. A killed
+  // branch (`failed` / no error) is skipped so its base task survives untouched and re-runs.
+  const byId = new Map<TaskId, Task>();
+  for (const outcome of outcomes) {
+    if (!branchSettled(outcome)) continue;
+    for (const task of outcome.ctx.tasks ?? []) byId.set(task.id, task);
+  }
+
+  const tasks = base.tasks?.map((t) => byId.get(t.id) ?? t);
+
+  return {
+    // sprint-scoped → base
+    sprintId: base.sprintId,
+    ...(base.sprint !== undefined ? { sprint: base.sprint } : {}),
+    ...(base.execution !== undefined ? { execution: base.execution } : {}),
+    ...(base.progressFile !== undefined ? { progressFile: base.progressFile } : {}),
+    // task list → overlay
+    ...(tasks !== undefined ? { tasks } : {}),
+    // per-task + signal-accum classes intentionally omitted → undefined in the merged ctx.
+  };
+};
+
+/**
+ * Per-branch fork of the implement ctx, scoped to ONE task's worktree run. Produced by the launcher
+ * before it builds the branch's per-task sub-chain, then handed to the wave scheduler as the
+ * branch's `initialCtx`.
+ *
+ * Returns BOTH the forked ctx and a worktree-pointed {@link RepoExecConfig}. The repo path is NOT an
+ * `ImplementCtx` field — it lives on the implement flow's construction opts (`CreateImplementFlowOpts.
+ * repositories`), bound into the per-task leaves at build time. So redirecting a branch onto its
+ * worktree means handing the caller a `RepoExecConfig` whose `path` is the worktree path; the caller
+ * uses it to construct the branch element. Returning it here keeps the per-branch derivation in one
+ * pure place rather than splitting ctx-clearing from repo-redirection across the launcher.
+ *
+ * Projection:
+ *  - sprint-scoped fields → carried from `base` (same sprint, execution, progress file).
+ *  - per-task single-slot + signal-accum classes → cleared (`undefined`); a fresh branch starts a
+ *    fresh task with no carried per-attempt state.
+ *  - `priorPostVerifyOutcome` → DROPPED (accepted cost): a parallel branch starts on its own
+ *    worktree with no carried pre-task-verify baseline, so the pre-task-verify short-circuit is
+ *    lost and verifyScript re-runs per task. This is the documented parallel trade-off.
+ *  - `expectedBranch` → LEFT UNDEFINED (corrected). An earlier draft wrote `expectedBranch: ''`
+ *    intending to disable per-task `branch-preflight`, but that leaf short-circuits on `undefined`,
+ *    not `''` — the empty string would NOT actually disable it. The branch element omits
+ *    `branch-preflight` entirely (each worktree is checked out on its own ref, so the preflight is
+ *    moot and would fail), so the field is simply cleared like the rest of the per-task class: no
+ *    downstream reader can mis-fire on a stale `''`.
+ *  - repo path → the task's worktree path on the returned `RepoExecConfig`.
+ *
+ * @public
+ */
+export const forkCtx = (
+  base: ImplementCtx,
+  repo: RepoExecConfig,
+  worktreePath: AbsolutePath
+): { readonly ctx: ImplementCtx; readonly repo: RepoExecConfig } => {
+  const ctx: ImplementCtx = {
+    // sprint-scoped → base
+    sprintId: base.sprintId,
+    ...(base.sprint !== undefined ? { sprint: base.sprint } : {}),
+    ...(base.execution !== undefined ? { execution: base.execution } : {}),
+    ...(base.progressFile !== undefined ? { progressFile: base.progressFile } : {}),
+    ...(base.tasks !== undefined ? { tasks: base.tasks } : {}),
+    // per-task + signal-accum classes cleared (omitted → undefined); `priorPostVerifyOutcome`
+    // dropped (accepted cost). `expectedBranch` is intentionally NOT set here — see the docstring:
+    // the branch element omits `branch-preflight`, so leaving it `undefined` is correct.
+  };
+
+  return { ctx, repo: { ...repo, path: worktreePath } };
+};

--- a/src/application/flows/implement/parallel-element.ts
+++ b/src/application/flows/implement/parallel-element.ts
@@ -1,0 +1,247 @@
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import type { OnTrace, TraceEntry } from '@src/application/chain/trace.ts';
+import { createRunner, type Runner } from '@src/application/chain/run/runner.ts';
+import { runWaves, type WaveBranch } from '@src/application/chain/run/wave-scheduler.ts';
+import { bridgeRunnerToEventBus } from '@src/application/observability/chain-runner-bridge.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { FileLocker } from '@src/integration/io/file-locker.ts';
+import { repoLockFile } from '@src/integration/io/lock-paths.ts';
+
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementWavePlan } from '@src/application/flows/implement/flow.ts';
+import { mergeImplementWave } from '@src/application/flows/implement/merge-wave.ts';
+
+/** Static config the parallel orchestrator needs beyond the wave plan + branch builder. */
+export interface ParallelImplementConfig {
+  readonly fileLocker: FileLocker;
+  readonly locksRoot: AbsolutePath;
+  readonly eventBus: EventBus;
+  /** Clamped `[1,5]` `settings.concurrency.maxParallelTasks` — passed verbatim to `runWaves`. */
+  readonly maxConcurrency: number;
+  /** `flowId` for the per-branch + per-segment EventBus bridge — always `'implement'`. */
+  readonly flowId: string;
+  /** Stable id factory for the prologue / epilogue sub-runners (distinct from branch ids). */
+  readonly sessionId: () => string;
+  /**
+   * Builds the per-wave branch arrays — injected so the orchestrator is testable without the full
+   * per-task subchain. The launcher passes `() => buildWaveBranches(deps, opts, plan.waves, …)`.
+   * Each branch element forks the carried ctx onto its worktree at EXECUTE time, so this factory is
+   * called ONCE; the branch elements are reusable across the run.
+   */
+  readonly buildWaves: () => ReadonlyArray<ReadonlyArray<WaveBranch<ImplementCtx>>>;
+}
+
+const PARALLEL_ELEMENT_NAME = 'implement-parallel';
+
+/**
+ * The `>1` parallel implement orchestrator. A hand-written {@link Element} — NOT a chain
+ * primitive (§14: `runWaves` is the above-the-chain scheduler, this element only sequences the
+ * prologue / waves / epilogue around it). The launcher runs it on ONE `createRunner` so the TUI
+ * subscribes to a single runner, exactly as it does for the serial path.
+ *
+ * Everything runs under ONE held `fileLocker.withLock(<sprint-dir lock>)` — the lock is
+ * hoisted to the launcher for the parallel path; the serial path keeps it inside the flow. The
+ * same lock KEY the serial path uses (`repoLockFile(locksRoot, sprintDir)`) so a serial and a
+ * parallel run of the same sprint still mutually exclude.
+ *
+ * Sequence inside the lock:
+ *
+ *   1. prologue runner — `plan.prologue` over the incoming ctx (load → setup → preflight). On
+ *      failure the prologue's error propagates; the epilogue still runs (below) so any pre-existing
+ *      `tasks.json` survives, but no waves ran.
+ *   2. `runWaves(branches, prologueCtx, { merge: mergeImplementWave, onFatal: 'drain', … }, signal)`
+ *      — fans one branch per task per wave; each branch folds onto the shared sprint branch through
+ *      the single fold queue.
+ *   3. epilogue runner — ALWAYS runs, on the partially-merged ctx, even when `runWaves` returned an
+ *      abort / fatal error (THE B4 durability gate). The epilogue's `saveTasksLeaf` persists every
+ *      task whose commit was folded before the failure, so those commits are recorded in
+ *      `tasks.json` and never re-execute as duplicates on relaunch.
+ *
+ * After the epilogue, the `runWaves` error (AbortError verbatim, or a rate-limit) propagates so the
+ * sprint stays runnable — in-progress / un-settled tasks reset to `todo` on the next launch via the
+ * existing resume logic.
+ *
+ * @public
+ */
+export const createParallelImplementElement = (
+  plan: ImplementWavePlan,
+  config: ParallelImplementConfig
+): Element<ImplementCtx> => ({
+  name: PARALLEL_ELEMENT_NAME,
+  async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
+    const lockPath = repoLockFile(config.locksRoot, plan.lockKey);
+    if (!lockPath.ok) {
+      const entry: TraceEntry = {
+        elementName: PARALLEL_ELEMENT_NAME,
+        status: 'failed',
+        durationMs: 0,
+        error: lockPath.error,
+      };
+      onTrace?.(entry);
+      return Result.error({ error: lockPath.error, trace: [entry] });
+    }
+
+    const acquired = await config.fileLocker.withLock(lockPath.value, async () =>
+      runUnderLock(plan, config, ctx, signal, onTrace)
+    );
+    if (!acquired.ok) {
+      // Lock contention — surface verbatim. No waves ran, nothing to persist.
+      const entry: TraceEntry = {
+        elementName: PARALLEL_ELEMENT_NAME,
+        status: 'failed',
+        durationMs: 0,
+        error: acquired.error,
+      };
+      onTrace?.(entry);
+      return Result.error({ error: acquired.error, trace: [entry] });
+    }
+    return acquired.value;
+  },
+});
+
+/**
+ * The body that runs INSIDE the held lock: prologue → waves → epilogue (always). Split out so the
+ * lock-acquisition branching stays small. The held lock is released by `withLock`'s `finally` only
+ * after this resolves — so the epilogue persist completes under the lock.
+ */
+const runUnderLock = async (
+  plan: ImplementWavePlan,
+  config: ParallelImplementConfig,
+  ctx: ImplementCtx,
+  signal: AbortSignal | undefined,
+  onTrace: OnTrace | undefined
+): Promise<ElementResult<ImplementCtx>> => {
+  // ── Prologue ────────────────────────────────────────────────────────────────────────────────
+  const prologue = await runSubElement(plan.prologue, ctx, config, signal, onTrace);
+  if (!prologue.ok) {
+    // Prologue failed (e.g. dirty tree, setup script non-zero, abort). No waves ran. Still run the
+    // epilogue so any pre-existing `tasks.json` is re-saved verbatim under the lock, then propagate.
+    await runSubElement(plan.epilogue, ctx, config, undefined, onTrace);
+    return prologue;
+  }
+  const prologueCtx = prologue.value.ctx;
+
+  // ── Waves ───────────────────────────────────────────────────────────────────────────────────
+  // Accumulate each branch's DURABLY-SETTLED task copy as branches reach a terminal state. A branch
+  // whose runner COMPLETED ran its fold step to completion (commit landed, or fold-conflict → the
+  // task settled `blocked`) — its `runner.ctx.tasks` is authoritative. We capture this independently
+  // of `runWaves` because on an aborted wave `runWaves` returns the AbortError verbatim WITHOUT the
+  // partially-merged ctx (it never folds the aborted wave's outcomes). This map is the launcher's
+  // own record of "what actually folded", used to build the epilogue ctx on the abort/fatal path —
+  // THE B4 durability gate.
+  const durablyFolded = new Map<TaskId, Task>();
+  const waves = config.buildWaves();
+
+  const wavesResult = await runWaves<ImplementCtx>(
+    waves,
+    prologueCtx,
+    {
+      maxConcurrency: config.maxConcurrency,
+      merge: mergeImplementWave,
+      onFatal: 'drain',
+      onBranchRunner: (runner) => {
+        bridgeRunnerToEventBus(runner as Runner<unknown>, config.eventBus, { flowId: config.flowId });
+        captureDurableFold(runner, durablyFolded);
+      },
+    },
+    signal
+  );
+
+  // ── Epilogue (ALWAYS — the B4 durability gate) ────────────────────────────────────────────────
+  // On success: persist `runWaves`'s fully-merged ctx. On abort/fatal: persist the prologue ctx
+  // overlaid with whatever branches durably folded BEFORE the failure, so their `done` (or
+  // `blocked`) status is recorded and their commits never re-execute as duplicates.
+  const epilogueCtx = wavesResult.ok ? wavesResult.value.ctx : overlayDurable(prologueCtx, durablyFolded);
+  const epilogue = await runSubElement(plan.epilogue, epilogueCtx, config, undefined, onTrace);
+
+  if (!wavesResult.ok) {
+    // Propagate the `runWaves` error VERBATIM (AbortError stays an AbortError so the sprint stays
+    // runnable). The epilogue already persisted the durable folds above.
+    return Result.error(wavesResult.error);
+  }
+  // Epilogue failure on the success path is a real persistence error — surface it.
+  if (!epilogue.ok) return epilogue;
+  return Result.ok({ ctx: epilogue.value.ctx, trace: [] });
+};
+
+/**
+ * Subscribe to a branch runner and capture its DURABLY-SETTLED task copies into the shared overlay
+ * once it reaches a terminal state. ONLY a runner that `completed` is captured: a `completed`
+ * branch ran its fold step to the end, so its task either folded (`done`) or fold-conflicted
+ * (`blocked`) — either way the transition is durable. An `aborted` / `failed` branch is skipped so
+ * its task falls back to `base` (resets to `todo` and re-runs).
+ */
+const captureDurableFold = (runner: Runner<ImplementCtx>, into: Map<TaskId, Task>): void => {
+  const unsub = runner.subscribe((event) => {
+    if (event.type !== 'completed') {
+      if (event.type === 'failed' || event.type === 'aborted') unsub();
+      return;
+    }
+    for (const task of event.ctx.tasks ?? []) into.set(task.id, task);
+    unsub();
+  });
+};
+
+/** Overlay the durably-folded task copies onto a base ctx's `tasks` by id (the abort-path epilogue ctx). */
+const overlayDurable = (base: ImplementCtx, folded: ReadonlyMap<TaskId, Task>): ImplementCtx => {
+  if (base.tasks === undefined) return base;
+  return { ...base, tasks: base.tasks.map((t) => folded.get(t.id) ?? t) };
+};
+
+/**
+ * Run one of the plan's segment elements (prologue / epilogue) on its OWN sub-runner, bridge it to
+ * the EventBus, and re-emit its trace through the host `onTrace` so the TUI rail + chain.log see the
+ * sub-steps inline. Returns the segment's terminal {@link ElementResult}. The sub-runner's own
+ * `AbortController` is wired to the host signal so a host abort tears the segment down too.
+ *
+ * Why a sub-runner rather than `element.execute(ctx, signal, onTrace)` directly: the sub-runner
+ * gives the segment its own `runWithSession` scope + EventBus bridge (`chain-started` / `-completed`
+ * events), matching how the serial path's single runner frames the whole chain. The prologue and
+ * epilogue thus appear as their own bridged chains, which the TUI already knows how to render.
+ */
+const runSubElement = async (
+  element: Element<ImplementCtx>,
+  initialCtx: ImplementCtx,
+  config: ParallelImplementConfig,
+  signal: AbortSignal | undefined,
+  onTrace: OnTrace | undefined
+): Promise<ElementResult<ImplementCtx>> => {
+  const runner = createRunner<ImplementCtx>({ id: config.sessionId(), element, initialCtx });
+  bridgeRunnerToEventBus(runner as Runner<unknown>, config.eventBus, { flowId: config.flowId });
+  // Re-emit every sub-step through the host onTrace so the host trace stays continuous, and capture
+  // a `failed` event's error off the stream (the runner does not expose its failure error directly).
+  const captured: TraceEntry[] = [];
+  let failureError: DomainError | undefined;
+  const unsubTrace = runner.subscribe((event) => {
+    if (event.type === 'step') {
+      captured.push(event.entry);
+      onTrace?.(event.entry);
+    } else if (event.type === 'failed') {
+      failureError = event.error;
+    }
+  });
+  // Forward a host abort into the sub-runner.
+  const onAbort = (): void => runner.abort('host-aborted');
+  if (signal?.aborted) runner.abort('host-aborted');
+  else signal?.addEventListener('abort', onAbort, { once: true });
+
+  await runner.start();
+  signal?.removeEventListener('abort', onAbort);
+  unsubTrace();
+
+  if (runner.status === 'completed') return Result.ok({ ctx: runner.ctx, trace: captured });
+  // Aborted or failed: synthesise the failure result. `aborted` → AbortError (propagated verbatim
+  // upstream so the sprint stays runnable); `failed` → the captured failure error off the stream.
+  const error: DomainError =
+    runner.status === 'aborted' || failureError === undefined
+      ? new AbortError({ elementName: element.name })
+      : failureError;
+  return Result.error({ error, trace: captured });
+};

--- a/src/application/flows/implement/wave-branch.ts
+++ b/src/application/flows/implement/wave-branch.ts
@@ -1,0 +1,601 @@
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
+import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { HarnessSignal } from '@src/domain/signal.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { join } from 'node:path';
+
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import type { OnTrace, TraceEntry } from '@src/application/chain/trace.ts';
+import { sequential } from '@src/application/chain/build/sequential.ts';
+import type { WaveBranch } from '@src/application/chain/run/wave-scheduler.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { Sink } from '@src/business/observability/sink.ts';
+import type { HarnessSignalSink } from '@src/business/observability/harness-signal-sink.ts';
+import { broadcastSink } from '@src/integration/observability/sinks/broadcast-sink.ts';
+import type { GitRunner } from '@src/integration/io/git-runner.ts';
+import {
+  gitDeleteBranch,
+  gitFoldBranch,
+  gitWorktreeAdd,
+  gitWorktreePrune,
+  gitWorktreeRef,
+  gitWorktreeRemove,
+} from '@src/integration/io/git-operations.ts';
+
+import type { AppendFile } from '@src/business/io/append-file.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import type { CreateImplementFlowOpts, RepoExecConfig } from '@src/application/flows/implement/flow.ts';
+import { forkCtx } from '@src/application/flows/implement/merge-wave.ts';
+import { resolveRepoOrThrow } from '@src/application/flows/implement/leaves/resolve-repo.ts';
+import {
+  createPerTaskSubchain,
+  type PerTaskSubchainOpts,
+} from '@src/application/flows/implement/leaves/per-task-subchain.ts';
+
+/**
+ * Async mutex serialising worktree folds onto the shared sprint branch. Folds MUST be
+ * one-at-a-time: two concurrent `git merge --ff-only` / `git cherry-pick` invocations onto the
+ * same branch would corrupt each other's merge state. The single held sprint lock already
+ * serialises the WHOLE parallel run against OTHER processes, but within ONE run the per-task
+ * branches race each other — this queue is the in-process gate.
+ *
+ * `run(fn)` returns a promise that resolves with `fn`'s value once every previously-queued fold
+ * has settled. Tasks fold in `base.tasks` order because the launcher enqueues them in that order
+ * (each wave's branches are declared in task order, and a branch only reaches its fold step after
+ * its own subchain settled — but the queue's FIFO ordering is what guarantees serialization, not
+ * ordering across waves, which the scheduler already enforces).
+ *
+ * @public
+ */
+export interface FoldQueue {
+  run<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Build a fresh fold queue. Each `run(fn)` chains onto the prior call's settle promise, so the
+ * critical sections never overlap regardless of how many branches call concurrently. A rejecting
+ * `fn` does not poison the queue — the tail advances on settle (ok or throw) so a conflicted fold
+ * doesn't wedge the siblings behind it.
+ *
+ * @public
+ */
+export const createFoldQueue = (): FoldQueue => {
+  let tail: Promise<unknown> = Promise.resolve();
+  return {
+    run<T>(fn: () => Promise<T>): Promise<T> {
+      const result = tail.then(fn, fn);
+      // Advance the tail on settle (success OR failure) so a rejected fold doesn't block the queue.
+      tail = result.then(
+        () => undefined,
+        () => undefined
+      );
+      return result;
+    },
+  };
+};
+
+/**
+ * Wrap an {@link AppendFile} so concurrent calls serialise through one in-process mutex. The
+ * parallel path runs N branches at once, and several of them append to the SAME shared files —
+ * `<sprintDir>/progress.md` (the journal) and `<memoryRoot>/<projectId>/learnings.ndjson` (the
+ * learning ledger). Two overlapping `fs.appendFile` calls to one file can interleave their writes
+ * and tear an NDJSON / journal line; the read side (ledger dedup, the human reading `progress.md`)
+ * tolerates duplicate lines but NOT torn ones. Funnelling every append through one {@link FoldQueue}
+ * makes each line atomic with respect to the others — cheap (a promise chain), and it also yields a
+ * deterministic FIFO append order. Per-task artefacts (`prompt.md`, `signals.json`) are written to
+ * task-scoped paths and never collide, so only the append port needs this.
+ *
+ * @public
+ */
+export const serializeAppendFile = (inner: AppendFile): AppendFile => {
+  const queue = createFoldQueue();
+  return (path, text) => queue.run(() => inner(path, text));
+};
+
+/**
+ * Project a fold-conflicted `done` task to `blocked`. A cherry-pick conflict means the worktree's
+ * committed work is sound but cannot land on the shared sprint branch without manual resolution —
+ * the task must surface as `blocked` so the operator sees it and a relaunch re-attempts it.
+ *
+ * The domain `markTaskBlocked` guards against re-blocking a `done` task (it only accepts
+ * `todo`/`in_progress`), and there is no `done → blocked` lifecycle transition — re-blocking a
+ * verified task is a parallel-fold concern the domain pre-dates. This is an application-layer ctx
+ * projection (the merge/fork reducers already manipulate ctx task shapes directly): strip the
+ * `DoneTask`-only `finalAttemptN`, stamp `status: 'blocked'` + the conflict reason.
+ */
+const blockTaskForFoldConflict = (task: Task, reason: string): BlockedTask => {
+  // Drop the `DoneTask`-only `finalAttemptN` (absent on `BlockedTask`) and any existing
+  // `blockedReason`; re-stamp `status` + the conflict reason. The rest of the `TaskBase` fields
+  // (id, name, attempts, dependsOn, …) carry across unchanged.
+  const {
+    status: _status,
+    finalAttemptN: _finalAttemptN,
+    blockedReason: _blockedReason,
+    ...rest
+  } = task as Task & {
+    readonly finalAttemptN?: number;
+    readonly blockedReason?: string;
+  };
+  void _status;
+  void _finalAttemptN;
+  void _blockedReason;
+  return { ...rest, status: 'blocked', blockedReason: reason };
+};
+
+/**
+ * Per-branch harness-signal sink keyed on the branch's `taskId`. Replaces the launcher's
+ * old single-slot `currentTaskId` tracker — which keyed off the dead `task-attempt-started` event
+ * (zero production publishers) and so always attributed signals to `undefined`. With concurrent
+ * branches a single shared mutable slot would cross-attribute signals anyway; binding the taskId
+ * at branch-build time is the only correct model.
+ *
+ * Fans every `<change>` / `<learning>` / `<note>` signal to the app-wide sink (TUI bus + the
+ * opt-in events.ndjson tee) AND republishes it as a `harness-signal` EventBus event stamped with
+ * THIS branch's taskId, so the per-task TUI panel groups it under the right task.
+ *
+ * @public
+ */
+export const perBranchSignalSink = (
+  appSink: HarnessSignalSink,
+  eventBus: EventBus,
+  taskId: TaskId
+): HarnessSignalSink => {
+  const busMirror: Sink<HarnessSignal> = {
+    emit(signal) {
+      if (signal.type !== 'change' && signal.type !== 'learning' && signal.type !== 'note') return;
+      eventBus.publish({
+        type: 'harness-signal',
+        signalKind: signal.type,
+        taskId: String(taskId),
+        text: signal.text,
+        at: IsoTimestamp.now(),
+      });
+    },
+  };
+  return broadcastSink<HarnessSignal>([appSink, busMirror]);
+};
+
+/** Inputs the launcher derives once and shares across every branch of every wave. */
+export interface BuildWaveBranchesDeps {
+  readonly implement: ImplementDeps;
+  /** App-wide harness-signal sink (TUI bus + opt-in events.ndjson). Fanned per branch. */
+  readonly appSignals: HarnessSignalSink;
+  readonly eventBus: EventBus;
+  /** Shared fold mutex — every branch's fold step serialises through this one queue. */
+  readonly foldQueue: FoldQueue;
+}
+
+/**
+ * One git worktree per task: setup → per-worktree setup script → forked per-task subchain → fold →
+ * cleanup. The element is a hand-written {@link Element} (NOT a chain primitive — §14) rather than a
+ * plain `sequential`, because worktree-cleanup MUST run on EVERY exit path including abort: a plain
+ * `sequential` skips downstream children once a child aborts, which would strand the worktree. This
+ * adapter runs cleanup in a `finally`-style guarantee and forwards the inner result (AbortError
+ * verbatim).
+ *
+ *  - setup: prune stale bookkeeping + drop any leaked ref (both defensive), then
+ *    `git worktree add -b <ref> <path>` forked from the sprint branch tip.
+ *  - setup script: run the repo's `setupScript` IN the worktree (a fresh checkout has no build
+ *    deps). Failure blocks ONLY this task; it never hard-aborts the wave. Skipped when the repo
+ *    configures no setup script.
+ *  - body: the forked per-task subchain (rooted on the worktree via `forkCtx`, branch-preflight
+ *    omitted) followed by the serialised fold.
+ *  - cleanup: `git worktree remove --force` + `branch -D <ref>` — best-effort (the commits are
+ *    already folded; a left-over worktree is scratch). A cleanup failure is logged, never fails the branch.
+ */
+const withWorktree = (
+  deps: BuildWaveBranchesDeps,
+  repoRoot: AbsolutePath,
+  worktreePath: AbsolutePath,
+  branchRef: string,
+  taskId: TaskId,
+  setupScript: string | undefined,
+  body: Element<ImplementCtx>
+): Element<ImplementCtx> => ({
+  name: `worktree(${String(taskId)})`,
+  children: [body],
+  async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
+    const gitRunner = deps.implement.gitRunner;
+    const setupError = await setupWorktree(gitRunner, repoRoot, worktreePath, branchRef, taskId, onTrace);
+    if (setupError !== undefined) {
+      // A worktree that never got created has nothing to clean up — return the setup failure as-is
+      // (non-fatal → the wave reducer leaves this task untouched so it resets/re-runs).
+      return setupError;
+    }
+
+    let result: ElementResult<ImplementCtx>;
+    try {
+      // Per-worktree setup runs INSIDE the freshly-created worktree, before the task's subchain.
+      // A git worktree is an empty checkout with no build artefacts, so the per-task verifyScript
+      // would fail spuriously without it. `undefined` (block this task) short-circuits the body;
+      // cleanup below still runs.
+      const setupBlocked = await runWorktreeSetupScript(deps, worktreePath, setupScript, taskId, ctx, signal, onTrace);
+      result = setupBlocked ?? (await body.execute(ctx, signal, onTrace));
+    } finally {
+      // Cleanup ALWAYS runs — success, non-fatal failure, or abort. The worktree's commits are
+      // already folded by the body's fold step, so a forced remove only drops scratch state.
+      await cleanupWorktree(gitRunner, repoRoot, worktreePath, branchRef, taskId, onTrace, deps.implement);
+    }
+    return result;
+  },
+});
+
+/**
+ * Run the repo's `setupScript` inside the freshly-created worktree, before the per-task subchain.
+ * A git worktree is a bare checkout: `node_modules`, `target/`, `.venv`, build caches — none of it
+ * is present (those paths are git-ignored and not copied). The per-task `verifyScript` runs pre-
+ * AND post-task in THIS worktree, so without a per-worktree setup it would fail as
+ * `baseline-broken` / `regressed` and block legitimate work. The prologue's once-per-repo setup
+ * preps the MAIN repo, not these throwaway worktrees, so it cannot cover this.
+ *
+ * Returns `undefined` when there is no setup script or it succeeds (the caller proceeds to the
+ * body). On failure (non-zero exit, timeout, or spawn error) it BLOCKS only this task and returns a
+ * narrowed `Result.ok` carrying the blocked task — siblings run in their own worktrees and are
+ * untouched, and the wave is NEVER hard-aborted (unlike the prologue's main-repo setup gate, whose
+ * hard-abort semantics are wrong for one isolated worktree). A user abort that races the setup
+ * propagates verbatim, never a block.
+ */
+const runWorktreeSetupScript = async (
+  deps: BuildWaveBranchesDeps,
+  worktreePath: AbsolutePath,
+  setupScript: string | undefined,
+  taskId: TaskId,
+  ctx: ImplementCtx,
+  signal: AbortSignal | undefined,
+  onTrace: OnTrace | undefined
+): Promise<ElementResult<ImplementCtx> | undefined> => {
+  if (setupScript === undefined || setupScript.trim() === '') return undefined;
+  const name = `worktree-setup-script-${String(taskId)}`;
+  // Don't burn an install while the user is already aborting.
+  if (signal?.aborted) return abortedStep(name, 0, onTrace);
+
+  const start = performance.now();
+  const ran = await deps.implement.shellScriptRunner.run(worktreePath, setupScript);
+  const durationMs = performance.now() - start;
+
+  if (ran.ok && ran.value.passed) {
+    onTrace?.({ elementName: name, status: 'completed', durationMs });
+    return undefined;
+  }
+  // A user abort that raced the setup propagates verbatim — the shell runner surfaces a kill as
+  // `passed: false`, not an abort, so re-check the signal before treating it as a real failure.
+  if (signal?.aborted) return abortedStep(name, durationMs, onTrace);
+
+  const detail = ran.ok ? `exit ${String(ran.value.exitCode ?? 'null')}` : ran.error.message;
+  const reason = `worktree setup script failed (${detail}) — the task could not be prepared in its isolated worktree`;
+  return blockTaskInWorktree(deps, ctx, taskId, name, durationMs, reason, onTrace);
+};
+
+/**
+ * Block THIS task after a per-worktree setup failure and narrow the ctx to it. Setup runs before
+ * the subchain, so the task is still `todo`/`in_progress` — `markTaskBlocked` (which accepts only
+ * those states) is the clean domain transition (no hand-projection like `blockTaskForFoldConflict`,
+ * which exists only because a fold conflict re-blocks an already-`done` task). Returns `Result.ok`
+ * so the branch runner COMPLETES with the block in its ctx — `mergeImplementWave` overlays it and
+ * `captureDurableFold` records it, so the block survives even an abort of a sibling wave.
+ */
+const blockTaskInWorktree = (
+  deps: BuildWaveBranchesDeps,
+  ctx: ImplementCtx,
+  taskId: TaskId,
+  name: string,
+  durationMs: number,
+  reason: string,
+  onTrace: OnTrace | undefined
+): ElementResult<ImplementCtx> => {
+  deps.implement.logger.warn('worktree setup script failed — task blocked', { taskId: String(taskId), reason });
+  const entry: TraceEntry = { elementName: name, status: 'failed', durationMs };
+  onTrace?.(entry);
+  const task = ctx.tasks?.find((t) => t.id === taskId);
+  // No task in ctx (shouldn't happen — the wave carries the full list), or the task isn't in a
+  // blockable state: carry ctx through so the reducer leaves base untouched and it resets/re-runs.
+  if (task === undefined) return Result.ok({ ctx, trace: [entry] });
+  const blocked = markTaskBlocked(task, reason);
+  if (!blocked.ok) return Result.ok({ ctx, trace: [entry] });
+  // Narrow to THIS task only — the merge overlay is by-id; emitting siblings risks clobbering a
+  // concurrently-merged copy (the same narrowing contract the branch body applies after its subchain).
+  return Result.ok({ ctx: { ...ctx, tasks: [blocked.value] }, trace: [entry] });
+};
+
+/**
+ * Create the worktree. Returns `undefined` on success (the subchain advances ctx), or a failed
+ * {@link ElementResult} on `worktree add` failure so the branch fails without ever materialising a
+ * worktree to clean up.
+ */
+const setupWorktree = async (
+  gitRunner: GitRunner,
+  repoRoot: AbsolutePath,
+  worktreePath: AbsolutePath,
+  branchRef: string,
+  taskId: TaskId,
+  onTrace: ((entry: TraceEntry) => void) | undefined
+): Promise<ElementResult<ImplementCtx> | undefined> => {
+  const name = `worktree-setup-${String(taskId)}`;
+  const start = performance.now();
+  // Prune defensively first: a crashed prior run can leave a stale `.git/worktrees/<name>` record
+  // whose directory has vanished, which would make `worktree add` fail. Prune is idempotent.
+  await gitWorktreePrune(gitRunner, repoRoot);
+  // Defensively drop a LEAKED `wt-<task>` ref before re-adding. `cleanupWorktree` deletes the ref
+  // after `worktree remove`, but a process that crashed between those two steps (or a delete that
+  // failed) leaves the ref behind — and `git worktree add -b <same-ref>` then fails loudly with
+  // 'branch already exists'. Prune only reaps `.git/worktrees/<name>` records for missing dirs, not
+  // orphaned refs, so it cannot heal this on its own. Best-effort: a live ref (no leak) just isn't
+  // there to delete, and a ref checked out elsewhere refuses deletion — in which case the `add`
+  // below fails loudly, which is the correct signal that something genuinely conflicts.
+  await gitDeleteBranch(gitRunner, repoRoot, branchRef);
+  const added = await gitWorktreeAdd(gitRunner, repoRoot, worktreePath, branchRef);
+  const durationMs = performance.now() - start;
+  if (!added.ok) {
+    const entry: TraceEntry = { elementName: name, status: 'failed', durationMs, error: added.error };
+    onTrace?.(entry);
+    return Result.error({ error: added.error, trace: [entry] });
+  }
+  onTrace?.({ elementName: name, status: 'completed', durationMs });
+  return undefined;
+};
+
+const cleanupWorktree = async (
+  gitRunner: GitRunner,
+  repoRoot: AbsolutePath,
+  worktreePath: AbsolutePath,
+  branchRef: string,
+  taskId: TaskId,
+  onTrace: ((entry: TraceEntry) => void) | undefined,
+  deps: ImplementDeps
+): Promise<void> => {
+  const name = `worktree-cleanup-${String(taskId)}`;
+  const start = performance.now();
+  const removed = await gitWorktreeRemove(gitRunner, repoRoot, worktreePath);
+  const durationMs = performance.now() - start;
+  if (!removed.ok) {
+    // Best-effort: a left-over worktree is scratch (commits already folded). Surface as a warn so
+    // the operator can prune it manually, but never fail the branch over teardown.
+    deps.logger.warn('worktree cleanup failed', {
+      taskId: String(taskId),
+      worktreePath: String(worktreePath),
+      error: removed.error.message,
+    });
+    onTrace?.({ elementName: name, status: 'failed', durationMs, error: removed.error });
+    return;
+  }
+  // `worktree remove` leaves the throwaway `wt-<task>` branch ref behind; drop it so a relaunch
+  // can recreate the worktree with `add -b <same-ref>`. Best-effort — a surviving ref is harmless
+  // scratch (the commit is already folded), so a delete failure is logged, never fatal.
+  const branchDeleted = await gitDeleteBranch(gitRunner, repoRoot, branchRef);
+  if (!branchDeleted.ok) {
+    deps.logger.warn('worktree branch cleanup failed', {
+      taskId: String(taskId),
+      branchRef,
+      error: branchDeleted.error.message,
+    });
+  }
+  onTrace?.({ elementName: name, status: 'completed', durationMs });
+};
+
+/**
+ * The serialised fold step. Folds the worktree branch onto the shared sprint branch through the
+ * shared {@link FoldQueue} (one fold at a time across all branches), in `base.tasks` order.
+ *
+ *  - Only `done` tasks fold — a `blocked` task's worktree carries no landable commit (the commit
+ *    guard skipped), so there is nothing to fold and folding would be a no-op fast-forward.
+ *  - A cherry-pick CONFLICT (`gitFoldBranch` returns a `StorageError`) transitions THIS task to
+ *    `blocked` in the branch ctx and returns `Result.ok` carrying the blocked task — so the branch
+ *    runner COMPLETES (its `runner.ctx` holds the block) and `mergeImplementWave` overlays it. The
+ *    already-folded siblings stay landed (`gitFoldBranch` already ran `cherry-pick --abort`, so the
+ *    sprint branch is left clean). A conflict is a domain decision (the work can't land), not an
+ *    infrastructure abort — mirrors how the subchain settles a self-block without failing the chain.
+ *  - AbortError is exempt: a mid-fold abort returns `Result.error(AbortError)` verbatim, never a block.
+ */
+/** Build an `aborted` step result (AbortError propagated verbatim) — shared by the fold + setup steps. */
+const abortedStep = (name: string, durationMs: number, onTrace: OnTrace | undefined): ElementResult<ImplementCtx> => {
+  const error = new AbortError({ elementName: name });
+  const entry: TraceEntry = { elementName: name, status: 'aborted', durationMs, error };
+  onTrace?.(entry);
+  return Result.error({ error, trace: [entry] });
+};
+
+const foldStep = (
+  deps: BuildWaveBranchesDeps,
+  repoRoot: AbsolutePath,
+  branchRef: string,
+  taskId: TaskId
+): Element<ImplementCtx> => ({
+  name: `fold-${String(taskId)}`,
+  async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
+    const name = `fold-${String(taskId)}`;
+    if (signal?.aborted) return abortedStep(name, 0, onTrace);
+
+    const task = ctx.tasks?.find((t) => t.id === taskId);
+    // Only a task the subchain settled `done` has a commit worth folding. Anything else (blocked,
+    // or never settled) skips the fold and carries ctx through unchanged.
+    if (task === undefined || task.status !== 'done') {
+      const entry: TraceEntry = { elementName: name, status: 'completed', durationMs: 0 };
+      onTrace?.(entry);
+      return Result.ok({ ctx, trace: [entry] });
+    }
+
+    const start = performance.now();
+    const folded = await deps.foldQueue.run(() => gitFoldBranch(deps.implement.gitRunner, repoRoot, branchRef));
+    const durationMs = performance.now() - start;
+
+    if (folded.ok) {
+      const entry: TraceEntry = { elementName: name, status: 'completed', durationMs };
+      onTrace?.(entry);
+      return Result.ok({ ctx, trace: [entry] });
+    }
+    // A user abort that raced the fold propagates verbatim, never becomes a per-task block.
+    // `gitFoldBranch` only ever returns a `StorageError`, so the only abort source is the outer signal.
+    if (signal?.aborted) return abortedStep(name, durationMs, onTrace);
+
+    return conflictFold(deps, ctx, task, branchRef, taskId, name, durationMs, folded.error, onTrace);
+  },
+});
+
+/**
+ * Handle a non-abort fold failure (a cherry-pick conflict). Blocks THIS task, leaves siblings
+ * folded. Returns `Result.ok` with the blocked task so the branch runner COMPLETES and its
+ * `runner.ctx` carries the block — `mergeImplementWave` overlays a `completed` branch's task copy.
+ * (A `Result.error` here would leave `runner.ctx` at its pre-fold value, re-surfacing the task as
+ * `done` in the merge, which would orphan the unmerged commit.)
+ */
+const conflictFold = (
+  deps: BuildWaveBranchesDeps,
+  ctx: ImplementCtx,
+  task: Task,
+  branchRef: string,
+  taskId: TaskId,
+  name: string,
+  durationMs: number,
+  error: DomainError,
+  onTrace: OnTrace | undefined
+): ElementResult<ImplementCtx> => {
+  const reason = `fold conflict — worktree branch '${branchRef}' could not land on the sprint branch: ${error.message}`;
+  const blocked = blockTaskForFoldConflict(task, reason);
+  const tasks = ctx.tasks?.map((t) => (t.id === taskId ? blocked : t)) ?? [blocked];
+  deps.implement.logger.warn('fold conflict — task blocked', { taskId: String(taskId), branchRef });
+  const entry: TraceEntry = { elementName: name, status: 'failed', durationMs, error };
+  onTrace?.(entry);
+  return Result.ok({ ctx: { ...ctx, tasks }, trace: [entry] });
+};
+
+/**
+ * Build the per-wave `WaveBranch[]` arrays for the parallel implement path.
+ *
+ * One {@link WaveBranch} per task: its element is the worktree adapter wrapping a `sequential` of
+ * the forked per-task subchain + the serialised fold. `forkCtx` clears per-task ctx and points the
+ * `RepoExecConfig` at the task's worktree; the subchain is built with `branch-preflight` OMITTED
+ * (each worktree is checked out on its own ref). A per-branch {@link HarnessSignalSink} keyed on
+ * the branch's `taskId` is injected so concurrent branches' signals attribute correctly.
+ *
+ * Each branch runs on its own runner (provided by `runWaves`) whose `initialCtx` is the wave's
+ * carried base ctx. The branch element forks that carried ctx onto the worktree at EXECUTE time
+ * (via `forkCtx`) so it always sees the most recently merged sprint / tasks state.
+ *
+ * @public
+ */
+export const buildWaveBranches = (
+  deps: BuildWaveBranchesDeps,
+  opts: CreateImplementFlowOpts,
+  waves: ReadonlyArray<readonly Task[]>,
+  readConfig: PerTaskReadConfig
+): ReadonlyArray<ReadonlyArray<WaveBranch<ImplementCtx>>> =>
+  waves.map((wave) => wave.map((task) => buildOneBranch(deps, opts, task, readConfig)));
+
+type PerTaskReadConfig = () => Promise<{
+  readonly maxTurns: number;
+  readonly escalateOnPlateau: boolean;
+  readonly escalationMap: Readonly<Record<string, string>>;
+}>;
+
+const buildOneBranch = (
+  deps: BuildWaveBranchesDeps,
+  opts: CreateImplementFlowOpts,
+  task: Task,
+  readConfig: PerTaskReadConfig
+): WaveBranch<ImplementCtx> => {
+  const repo = resolveRepoOrThrow(opts.repositories, task);
+  const worktreePath = worktreePathFor(opts.sprintDir, task.id);
+  const branchRef = gitWorktreeRef(String(opts.sprintId), String(task.id));
+
+  // Per-branch deps clone — only the harness-signal sink differs, keyed on this task's id so
+  // concurrent branches don't cross-attribute their `<change>`/`<learning>`/`<note>` signals.
+  const branchDeps: ImplementDeps = {
+    ...deps.implement,
+    signals: perBranchSignalSink(deps.appSignals, deps.eventBus, task.id),
+  };
+
+  const subchainOpts: PerTaskSubchainOpts = {
+    sprintDir: opts.sprintDir,
+    progressFile: opts.progressFile,
+    terminalLeafName: 'uninstall-skills',
+    generator: {
+      providerId: opts.generatorProviderId,
+      model: opts.generatorModel,
+      ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
+    },
+    evaluator: {
+      providerId: opts.evaluatorProviderId,
+      model: opts.evaluatorModel,
+      ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
+    },
+    memoryRoot: opts.memoryRoot,
+    projectId: opts.projectId,
+    includeBranchPreflight: false,
+  };
+
+  // The per-task subchain is built fresh on the FORKED ctx + worktree repo each time the branch
+  // executes (so a re-merged wave ctx flows in). `buildSubchain` captures everything needed.
+  const buildSubchain = (worktreeRepo: RepoExecConfig): Element<ImplementCtx> =>
+    createPerTaskSubchain(branchDeps, subchainOpts, task, worktreeRepo, readConfig);
+
+  return {
+    id: `task-${String(task.id)}`,
+    element: buildWorktreeBranch(deps, repo, task, worktreePath, branchRef, buildSubchain),
+  };
+};
+
+/**
+ * Assemble the worktree-wrapped branch element from a subchain FACTORY. The factory receives the
+ * worktree-pointed {@link RepoExecConfig} and returns the per-task body element to run inside the
+ * worktree. Exposed (not inlined) so tests can substitute a fake subchain — the worktree
+ * setup/fold/cleanup + ctx-fork wiring is exercised independently of the real per-task chain.
+ *
+ * `forkCtx` produces the worktree-pointed ctx + repo at EXECUTE time (so a re-merged wave ctx flows
+ * in); the worktree adapter runs setup, then the body (`subchain → fold`), then cleanup-on-every-
+ * path (including abort).
+ *
+ * @public
+ */
+export const buildWorktreeBranch = (
+  deps: BuildWaveBranchesDeps,
+  repo: RepoExecConfig,
+  task: Task,
+  worktreePath: AbsolutePath,
+  branchRef: string,
+  buildSubchain: (worktreeRepo: RepoExecConfig) => Element<ImplementCtx>
+): Element<ImplementCtx> => {
+  const body: Element<ImplementCtx> = {
+    name: `task-${String(task.id)}-branch-body`,
+    children: [],
+    async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
+      // Fork the carried base ctx onto the worktree at EXECUTE time, so the branch sees the most
+      // recent merged ctx (sprint/tasks). `forkCtx` clears per-task state + drops the
+      // verify-baseline; the returned repo points at the worktree.
+      const { ctx: forkedCtx, repo: worktreeRepo } = forkCtx(ctx, repo, worktreePath);
+      const subchain = buildSubchain(worktreeRepo);
+      const fold = foldStep(deps, repo.path, branchRef, task.id);
+      const inner = sequential<ImplementCtx>(`task-${String(task.id)}-fold-and-settle`, [subchain, fold]);
+      const result = await inner.execute(forkedCtx, signal, onTrace);
+      if (!result.ok) return result;
+      // Narrow this branch's outcome ctx to carry ONLY its OWN task. `forkCtx` seeds `tasks` with the
+      // full base list (so the subchain leaves can look up sibling deps), but the subchain only
+      // settles THIS task; the others remain at their pre-wave status. `mergeImplementWave` overlays
+      // EVERY task in each branch's outcome ctx onto `base.tasks` by id — so leaving the siblings in
+      // would let a later-processed branch overwrite an earlier branch's settled task with a stale
+      // copy. Emitting only the owned task makes the overlay disjoint + commutative (the wave-merge contract).
+      const own = result.value.ctx.tasks?.find((t) => t.id === task.id);
+      const narrowed: ImplementCtx = { ...result.value.ctx, ...(own !== undefined ? { tasks: [own] } : {}) };
+      return Result.ok({ ctx: narrowed, trace: result.value.trace });
+    },
+  };
+  return withWorktree(deps, repo.path, worktreePath, branchRef, task.id, repo.setupScript, body);
+};
+
+/**
+ * Per-task worktree directory: `<sprintDir>/worktrees/wt-<taskId>`. Sprint-scoped + cleaned up per
+ * task, so worktrees never leak into the user's repo tree and prune cleanly with the sprint dir.
+ * @public
+ */
+export const worktreePathFor = (sprintDir: AbsolutePath, taskId: TaskId): AbsolutePath => {
+  const path = AbsolutePath.parse(join(String(sprintDir), 'worktrees', `wt-${String(taskId)}`));
+  // `sprintDir` is already a validated absolute path and the suffix is path-safe (UUID-shaped
+  // taskId), so this parse cannot fail in practice — throw on the programmer-error path if it does.
+  if (!path.ok) throw path.error;
+  return path.value;
+};

--- a/src/application/ui/cli/commands/settings.ts
+++ b/src/application/ui/cli/commands/settings.ts
@@ -48,7 +48,7 @@ const parseProviderKey = (key: string): { readonly flow: FlowId; readonly role?:
  *   harness.escalateOnPlateau                          boolean (escalate generator model on plateau)
  *   harness.escalationMap.<fromModel>                  upgraded model id; empty input clears the entry
  *   logging.level                                      silent | debug | info | warn | error
- *   concurrency.maxParallelTasks                       positive integer
+ *   concurrency.maxParallelTasks                       1–5 (1 = serial; >1 = parallel, one git worktree per task)
  *   ui.notifications.enabled                           boolean
  *
  * Note: `ai.provider` and `ai.models.<flow>` (v1 grammar) are rejected as unknown keys —

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -4,8 +4,18 @@ import { createRunner, type Runner } from '@src/application/chain/run/runner.ts'
 import {
   createImplementFlow,
   IMPLEMENT_TASK_TERMINAL_LEAF,
+  planImplementWaves,
+  type CreateImplementFlowOpts,
   type RepoExecConfig,
 } from '@src/application/flows/implement/flow.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import {
+  buildWaveBranches,
+  createFoldQueue,
+  serializeAppendFile,
+  type BuildWaveBranchesDeps,
+} from '@src/application/flows/implement/wave-branch.ts';
+import { createParallelImplementElement } from '@src/application/flows/implement/parallel-element.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { Result } from '@src/domain/result.ts';
@@ -92,6 +102,70 @@ export const resolveImplementQueue = (tasks: readonly Task[]): Result<readonly T
   return Result.ok(queue);
 };
 
+/**
+ * Clamp `settings.concurrency.maxParallelTasks` to `[1,5]` — the parallel cap. `=== 1`
+ * selects the serial implement path; `> 1` selects the parallel worktree-fan-out path. The settings
+ * schema already validates `[1,5]`, but the launcher re-clamps defensively (a hand-edited settings
+ * file or a future schema change can never push the harness past the budget it was sized against).
+ *
+ * @public
+ */
+export const clampParallel = (n: number): number => {
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(5, Math.max(1, Math.trunc(n)));
+};
+
+/**
+ * Build the `>1` parallel implement element. Computes the wave plan from the same deps/opts the
+ * serial path uses, then wraps the prologue → `runWaves` → epilogue orchestration in the
+ * {@link createParallelImplementElement} adapter — run on ONE outer runner under ONE held lock.
+ *
+ * `appSignals` is the launcher's app-wide harness-signal sink (NOT the serial-path-wrapped one);
+ * `buildWaveBranches` fans a per-branch sink off it keyed on each branch's `taskId`.
+ */
+const buildParallelElement = (
+  implementDeps: ImplementDeps,
+  implementOpts: CreateImplementFlowOpts,
+  appSignals: HarnessSignalSink,
+  maxParallel: number,
+  sessionId: () => string
+): Element<ImplementCtx> => {
+  const readConfig = (): Promise<{
+    readonly maxTurns: number;
+    readonly escalateOnPlateau: boolean;
+    readonly escalationMap: Readonly<Record<string, string>>;
+  }> =>
+    Promise.resolve({
+      maxTurns: implementDeps.config.harness.maxTurns,
+      escalateOnPlateau: implementDeps.config.harness.escalateOnPlateau,
+      escalationMap: implementDeps.config.harness.escalationMap,
+    });
+
+  // Serialise every append for the WHOLE parallel run — prologue, all branches, and the epilogue
+  // share ONE mutex. Concurrent branches append to the same `progress.md` journal and project
+  // learnings ledger; funnelling them through one queue keeps each line atomic (no torn NDJSON /
+  // journal lines under fan-out). The serial path keeps the raw port — it has no concurrency.
+  const parallelDeps: ImplementDeps = { ...implementDeps, appendFile: serializeAppendFile(implementDeps.appendFile) };
+
+  const branchDeps: BuildWaveBranchesDeps = {
+    implement: parallelDeps,
+    appSignals,
+    eventBus: parallelDeps.eventBus,
+    foldQueue: createFoldQueue(),
+  };
+  const plan = planImplementWaves(parallelDeps, implementOpts);
+
+  return createParallelImplementElement(plan, {
+    fileLocker: implementDeps.fileLocker,
+    locksRoot: implementDeps.locksRoot,
+    eventBus: implementDeps.eventBus,
+    maxConcurrency: maxParallel,
+    flowId: 'implement',
+    sessionId,
+    buildWaves: () => buildWaveBranches(branchDeps, implementOpts, plan.waves, readConfig),
+  });
+};
+
 export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult> => {
   const { deps, snapshot, extras, settings, skillsAdapter, skillSource, bridge, sessionId } = ctx;
   // Apply per-role overrides (from CLI flags via `LaunchExtras.implementRoleOverrides`) onto
@@ -134,31 +208,32 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   // explicitly opts in.
   const chainLog = deps.app.chainLogSink({ file: eventsNdjsonPath.value, bus: deps.app.eventBus });
 
-  // Per-task signal mirror: `<change>` / `<learning>` / `<note>` signals are republished as
-  // structured `harness-signal` events on the EventBus so the TUI panels (and the opt-in
-  // events.ndjson tee) see them with a queryable shape. Track the current task id via the
-  // bus's `task-attempt-started` events.
-  let currentTaskId: string | undefined;
-  const unsubTaskTracker = deps.app.eventBus.subscribe((event) => {
-    if (event.type === 'task-attempt-started') currentTaskId = event.taskId;
-  });
-  const perTaskSignalBusMirror: Sink<HarnessSignal> = {
+  // Signal mirror: `<change>` / `<learning>` / `<note>` signals are republished as structured
+  // `harness-signal` events on the EventBus so the TUI panels (and the opt-in events.ndjson tee)
+  // see them with a queryable shape.
+  //
+  // The OLD single-slot `currentTaskId` tracker (keyed off the bus's `task-attempt-started` event)
+  // is DELETED: that event has zero production publishers, so the slot was always `undefined` —
+  // every serial-path `harness-signal` was already unattributed. The parallel `>1` path attaches a
+  // PER-BRANCH sink keyed on the branch's `taskId` (see `wave-branch.ts`), the only correct model
+  // under concurrency. The serial path keeps emitting unattributed events, byte-for-byte with
+  // today's behaviour — renderers that group by task simply skip unattributed entries.
+  const serialSignalBusMirror: Sink<HarnessSignal> = {
     emit(signal) {
       if (signal.type !== 'change' && signal.type !== 'learning' && signal.type !== 'note') return;
       deps.app.eventBus.publish({
         type: 'harness-signal',
         signalKind: signal.type,
-        ...(currentTaskId !== undefined ? { taskId: currentTaskId } : {}),
         text: signal.text,
         at: IsoTimestamp.now(),
       });
     },
   };
-  // Fan out every harness signal to the existing app sink (TUI bus + subscribers) and the
-  // per-task event-bus mirror. Decisions are now accumulated on ctx by the gen-eval leaves
-  // and rendered into `progress.md` by the journal leaf (audit-[07]) — no more on-disk
-  // decisions.log.
-  const signals: HarnessSignalSink = broadcastSink<HarnessSignal>([deps.app.signals, perTaskSignalBusMirror]);
+  // Fan out every harness signal to the existing app sink (TUI bus + subscribers) and the serial
+  // event-bus mirror. Decisions are accumulated on ctx by the gen-eval leaves and rendered into
+  // `progress.md` by the journal leaf (audit-[07]). The parallel path builds its own per-branch
+  // sinks in `wave-branch.ts` from `deps.app.signals`, so this `signals` is the serial-path sink.
+  const signals: HarnessSignalSink = broadcastSink<HarnessSignal>([deps.app.signals, serialSignalBusMirror]);
 
   const repositories = new Map<RepositoryId, RepoExecConfig>();
   for (const r of snapshot.project.repositories) {
@@ -188,45 +263,61 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   const generatorEffort = resolveEffortForRow(implementPair.generator, effectiveSettings.ai.effort);
   const evaluatorEffort = resolveEffortForRow(implementPair.evaluator, effectiveSettings.ai.effort);
 
-  const element: Element<ImplementCtx> = createImplementFlow(
-    {
-      sprintRepo: deps.app.sprintRepo,
-      sprintExecutionRepo: deps.app.sprintExecutionRepo,
-      taskRepo: deps.app.taskRepo,
-      generatorProvider,
-      evaluatorProvider,
-      templateLoader: deps.app.templateLoader,
-      signals,
-      eventBus: deps.app.eventBus,
-      logger: deps.app.logger,
-      clock: deps.app.clock,
-      config: effectiveSettings,
-      gitRunner: deps.app.gitRunner,
-      shellScriptRunner: deps.app.shellScriptRunner,
-      fileLocker: deps.app.fileLocker,
-      locksRoot: deps.storage.locksRoot,
-      skillsAdapter,
-      skillSource,
-      interactive: deps.interactive,
-      writeFile: deps.app.writeFile,
-      appendFile: deps.app.appendFile,
-    },
-    {
-      sprintId: snapshot.sprint.id,
-      todoTasks,
-      repositories,
-      progressFile: progressPath.value,
-      sprintDir: sprintDirPath.value,
-      generatorProviderId: implementPair.generator.provider,
-      generatorModel: implementPair.generator.model,
-      ...(generatorEffort !== undefined ? { generatorEffort } : {}),
-      evaluatorProviderId: implementPair.evaluator.provider,
-      evaluatorModel: implementPair.evaluator.model,
-      ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
-      memoryRoot: deps.storage.memoryRoot,
-      projectId: String(snapshot.project.id),
-    }
-  );
+  const implementDeps: ImplementDeps = {
+    sprintRepo: deps.app.sprintRepo,
+    sprintExecutionRepo: deps.app.sprintExecutionRepo,
+    taskRepo: deps.app.taskRepo,
+    generatorProvider,
+    evaluatorProvider,
+    templateLoader: deps.app.templateLoader,
+    signals,
+    eventBus: deps.app.eventBus,
+    logger: deps.app.logger,
+    clock: deps.app.clock,
+    config: effectiveSettings,
+    gitRunner: deps.app.gitRunner,
+    shellScriptRunner: deps.app.shellScriptRunner,
+    fileLocker: deps.app.fileLocker,
+    locksRoot: deps.storage.locksRoot,
+    skillsAdapter,
+    skillSource,
+    interactive: deps.interactive,
+    writeFile: deps.app.writeFile,
+    appendFile: deps.app.appendFile,
+  };
+  const implementOpts = {
+    sprintId: snapshot.sprint.id,
+    todoTasks,
+    repositories,
+    progressFile: progressPath.value,
+    sprintDir: sprintDirPath.value,
+    generatorProviderId: implementPair.generator.provider,
+    generatorModel: implementPair.generator.model,
+    ...(generatorEffort !== undefined ? { generatorEffort } : {}),
+    evaluatorProviderId: implementPair.evaluator.provider,
+    evaluatorModel: implementPair.evaluator.model,
+    ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
+    memoryRoot: deps.storage.memoryRoot,
+    projectId: String(snapshot.project.id),
+  };
+
+  // Parallel cap: clamp `settings.concurrency.maxParallelTasks` to `[1,5]`. `=== 1` →
+  // today's serial path (the chain owns its own internal `withRepoLock`); the meta-run caller
+  // (`createRunFlow`) also stays on this path — it constructs `createImplementFlow` directly and
+  // never reaches this launcher. `> 1` → the parallel path: one held lock hoisted to the launcher
+  // across prologue + waves + epilogue, one worktree per task, folds serialised onto the
+  // single shared sprint branch → one PR.
+  const maxParallel = clampParallel(effectiveSettings.concurrency.maxParallelTasks);
+
+  // Parallel path fans per-branch signal sinks off the RAW app sink (`deps.app.signals`), NOT the
+  // serial-wrapped `signals` (which carries the unattributed serial bus mirror) — so concurrent
+  // branches emit `harness-signal` events with their own `taskId` and don't also double-publish
+  // unattributed ones.
+  const element: Element<ImplementCtx> =
+    maxParallel === 1
+      ? createImplementFlow(implementDeps, implementOpts)
+      : buildParallelElement(implementDeps, implementOpts, deps.app.signals, maxParallel, sessionId);
+
   const runner = createRunner<ImplementCtx>({
     id: sessionId(),
     element,
@@ -241,7 +332,6 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     if (evt.type === 'completed' || evt.type === 'failed' || evt.type === 'aborted') {
       chainLog.stop();
       void chainLog.flush();
-      unsubTaskTracker();
       unsubRunner();
     }
   });

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -272,8 +272,13 @@ export const SettingsSchema = z.object({
     level: LogLevelSchema,
   }),
   concurrency: z.object({
-    /** Max tasks running in parallel within one sprint. `1` = strict serial execution. */
-    maxParallelTasks: z.number().int().min(1),
+    /**
+     * Max tasks running in parallel within one sprint. `1` = strict serial execution.
+     * Capped at `5`: above that, contention on the shared sprint branch's fold queue and on
+     * the AI providers' rate limits dominates, and worktree churn outweighs the throughput
+     * gain. The wave scheduler re-clamps to this same ceiling defensively.
+     */
+    maxParallelTasks: z.number().int().min(1).max(5),
   }),
   ui: z
     .object({

--- a/src/integration/io/git-operations.ts
+++ b/src/integration/io/git-operations.ts
@@ -294,6 +294,189 @@ export const gitCreateAndCheckoutBranch = async (
   return Result.ok(undefined);
 };
 
+// `git worktree add` can be slow: it materialises a full checkout (and may need to populate the
+// index from a large tree). The default 30s runner ceiling is comfortable for status / commit /
+// rev-parse but tight for a fresh worktree on a big repo, so add gets a roomier budget. The other
+// worktree verbs (remove / prune / fold) are bounded by index work, not a full checkout, and keep
+// the runner default.
+const WORKTREE_ADD_TIMEOUT_MS = 120_000;
+
+/**
+ * Canonical worktree branch ref for one parallel task: `ralphctl/<sprintId>/wt-<taskId>`.
+ *
+ * One nesting level below the shared sprint branch (`ralphctl/<sprintId>`) so the whole sprint's
+ * worktree refs share a prefix and prune cleanly. Pure — no validation here; sprint / task ids are
+ * UUID-shaped upstream, so the result is always a valid git ref name.
+ */
+export const gitWorktreeRef = (sprintId: string, taskId: string): string => `ralphctl/${sprintId}/wt-${taskId}`;
+
+/**
+ * Create a new worktree at `worktreePath` checked out on a freshly-created branch `branchName`,
+ * forked from the current `HEAD` of `repoRoot` (the shared sprint branch). `git worktree add -b
+ * <branch> <path>` — the `-b` form fails loudly if the branch already exists, which is the
+ * behaviour we want: a stale ref from a crashed prior run must be pruned first, never silently
+ * reused.
+ *
+ * Roomier timeout than the runner default — a fresh checkout can outlast 30s on a large repo.
+ */
+export const gitWorktreeAdd = async (
+  runner: GitRunner,
+  repoRoot: AbsolutePath,
+  worktreePath: AbsolutePath,
+  branchName: string
+): Promise<Result<void, StorageError>> => {
+  const result = await runner.run(repoRoot, ['worktree', 'add', '-b', branchName, String(worktreePath)], {
+    timeoutMs: WORKTREE_ADD_TIMEOUT_MS,
+  });
+  if (!result.ok) return Result.error(result.error);
+  if (result.value.exitCode !== 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git worktree add failed: ${(result.value.stderr || result.value.stdout).trim()}`,
+      })
+    );
+  }
+  return Result.ok(undefined);
+};
+
+/**
+ * Remove the worktree rooted at `worktreePath` with `--force` — drops the checkout even when the
+ * worktree has uncommitted or untracked changes. Used on every exit path (success, abort, fatal)
+ * so a dead worktree never strands the sprint repo. `--force` is deliberate: the worktree's
+ * commits have already been folded onto the sprint branch by the time we remove it, so anything
+ * left in the working tree is scratch.
+ */
+export const gitWorktreeRemove = async (
+  runner: GitRunner,
+  repoRoot: AbsolutePath,
+  worktreePath: AbsolutePath
+): Promise<Result<void, StorageError>> => {
+  const result = await runner.run(repoRoot, ['worktree', 'remove', '--force', String(worktreePath)]);
+  if (!result.ok) return Result.error(result.error);
+  if (result.value.exitCode !== 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git worktree remove failed: ${(result.value.stderr || result.value.stdout).trim()}`,
+      })
+    );
+  }
+  return Result.ok(undefined);
+};
+
+/**
+ * Force-delete a local branch ref (`git branch -D <name>`). Used to drop the throwaway
+ * `ralphctl/<sprint>/wt-<task>` ref a worktree was created on: `git worktree remove` deletes the
+ * worktree directory and its `.git/worktrees/<name>` record but LEAVES the branch behind, so a
+ * later `worktree add -b <same-ref>` (e.g. on relaunch after an aborted task) would otherwise fail
+ * with "branch already exists". `gitWorktreePrune` does not cover this — it only touches worktree
+ * records, not orphaned refs.
+ */
+export const gitDeleteBranch = async (
+  runner: GitRunner,
+  cwd: AbsolutePath,
+  branchName: string
+): Promise<Result<void, StorageError>> => {
+  const result = await runner.run(cwd, ['branch', '-D', branchName]);
+  if (!result.ok) return Result.error(result.error);
+  if (result.value.exitCode !== 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git branch -D failed: ${(result.value.stderr || result.value.stdout).trim()}`,
+      })
+    );
+  }
+  return Result.ok(undefined);
+};
+
+/**
+ * Prune worktree administrative bookkeeping for worktrees whose directory has already vanished.
+ * `git worktree prune` is idempotent and cheap — it only touches `.git/worktrees/<name>` records,
+ * the same pointer-file machinery `git-exclude.ts` resolves through. Safe to call defensively
+ * before re-adding a worktree whose path was deleted out from under git.
+ */
+export const gitWorktreePrune = async (
+  runner: GitRunner,
+  repoRoot: AbsolutePath
+): Promise<Result<void, StorageError>> => {
+  const result = await runner.run(repoRoot, ['worktree', 'prune']);
+  if (!result.ok) return Result.error(result.error);
+  if (result.value.exitCode !== 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git worktree prune failed: ${(result.value.stderr || result.value.stdout).trim()}`,
+      })
+    );
+  }
+  return Result.ok(undefined);
+};
+
+/**
+ * Fold a worktree branch onto the current branch of `repoRoot` (the shared sprint branch),
+ * preserving linear history so the sprint lands as one branch → one PR.
+ *
+ *   1. `git merge --ff-only <branch>` — the common case: the worktree forked from the sprint tip
+ *      and no sibling has folded since, so a fast-forward moves the sprint branch pointer with no
+ *      new commit. Linear by construction.
+ *   2. On ff failure (a sibling folded first, so the sprint branch has advanced), cherry-pick the
+ *      commits unique to `<branch>` — `git cherry-pick <merge-base>..<branch>` — replaying them on
+ *      top of the now-advanced sprint branch. Still linear; still one branch.
+ *
+ * A cherry-pick conflict SURFACES AS AN ERROR (the caller maps it to task `blocked`). Before
+ * returning the error we `git cherry-pick --abort` so the sprint branch is left clean and the
+ * already-folded siblings stay landed — the conflicted task is the only casualty.
+ *
+ * Folds must be serialised by the caller (one held lock, `base.tasks` order); this function does
+ * not lock — concurrent folds onto the same branch would corrupt the merge state.
+ */
+export const gitFoldBranch = async (
+  runner: GitRunner,
+  repoRoot: AbsolutePath,
+  branchName: string
+): Promise<Result<void, StorageError>> => {
+  const ff = await runner.run(repoRoot, ['merge', '--ff-only', branchName]);
+  if (!ff.ok) return Result.error(ff.error);
+  if (ff.value.exitCode === 0) return Result.ok(undefined);
+
+  // Not fast-forwardable — the sprint branch advanced under us. Replay the branch's unique
+  // commits via cherry-pick of `<merge-base>..<branch>`.
+  const base = await runner.run(repoRoot, ['merge-base', 'HEAD', branchName]);
+  if (!base.ok) return Result.error(base.error);
+  if (base.value.exitCode !== 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git merge-base failed: ${(base.value.stderr || base.value.stdout).trim()}`,
+      })
+    );
+  }
+  const mergeBase = base.value.stdout.trim();
+  if (!HEX_SHA_RE.test(mergeBase)) {
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `git merge-base returned non-SHA output: '${mergeBase}'` })
+    );
+  }
+
+  const pick = await runner.run(repoRoot, ['cherry-pick', `${mergeBase}..${branchName}`]);
+  if (!pick.ok) return Result.error(pick.error);
+  if (pick.value.exitCode !== 0) {
+    // Conflict (or any cherry-pick failure). Abort so the sprint branch is left clean — folded
+    // siblings stay landed; only this task is blocked. Abort is best-effort: surface the original
+    // cherry-pick failure regardless of whether the abort itself errored.
+    await runner.run(repoRoot, ['cherry-pick', '--abort']);
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git cherry-pick failed (conflict folding ${branchName}): ${(pick.value.stderr || pick.value.stdout).trim()}`,
+      })
+    );
+  }
+  return Result.ok(undefined);
+};
+
 const validateCommitMessage = (message: string): Result<string, StorageError> => {
   if (message.length === 0) {
     return Result.error(new StorageError({ subCode: 'io', message: 'commit message must not be empty' }));

--- a/tests/e2e/flows/implement-parallel-realgit.test.ts
+++ b/tests/e2e/flows/implement-parallel-realgit.test.ts
@@ -1,0 +1,1087 @@
+/**
+ * Real-git end-to-end test for the parallel implement path.
+ *
+ * Every existing implement test uses a fake GitRunner or fake chain elements. This test
+ * exercises the parallel path against a REAL git repository so we can trust the worktree
+ * lifecycle (add/fold/remove), real commits, branch history, and cleanup before shipping.
+ *
+ * What is faked:
+ *   - HeadlessAiProvider — on generate(), writes a REAL file into the worktree's cwd and
+ *     emits the harness signals required for the chain to commit and settle the task `done`.
+ *   - ShellScriptRunner — passes unconditionally (exit 0 stub).
+ *   - All in-memory repositories (sprint / execution / task) — standard pattern from the
+ *     serial e2e tests.
+ *
+ * What is REAL:
+ *   - git (via the real GitRunner backed by cross-platform-spawn)
+ *   - worktree add / fold / remove / prune
+ *   - cherry-pick fold (the second-task-same-wave fold path)
+ *   - file commits on the sprint branch
+ *   - worktree cleanup on every exit path
+ */
+
+import { promises as fs } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { SprintExecution } from '@src/domain/entity/sprint-execution.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sprint-execution-repository.ts';
+import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { HarnessSignal } from '@src/domain/signal.ts';
+
+import { createSprintExecution, setExecutionBranch } from '@src/domain/entity/sprint-execution.ts';
+import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { createGitRunner } from '@src/integration/io/git-runner.ts';
+import type { ShellScriptRunner } from '@src/integration/io/shell-script-runner.ts';
+import { createFileLocker } from '@src/integration/io/file-locker.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
+import { createAppendFile } from '@src/integration/io/append-file-adapter.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+
+import { createRunner } from '@src/application/chain/run/runner.ts';
+import { createParallelImplementElement } from '@src/application/flows/implement/parallel-element.ts';
+import { planImplementWaves } from '@src/application/flows/implement/flow.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import type { RepoExecConfig } from '@src/application/flows/implement/flow.ts';
+import { buildWaveBranches, createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
+
+import {
+  absolutePath,
+  FIXED_LATER,
+  FIXED_NOW,
+  FIXED_REPOSITORY_ID,
+  makeApprovedTicket,
+  makePlannedSprint,
+  makeTodoTask,
+} from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
+import { noopSkillsAdapter, emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
+import { createFakeProject, type FakeProject } from '@tests/helpers/fake-project.ts';
+
+// ─── skip on Windows — worktrees are posix-heavy ────────────────────────────
+if (process.platform === 'win32') {
+  describe.skip('parallel implement — real git worktrees (skipped on Windows)', () => {
+    it.skip('placeholder', () => undefined);
+  });
+} else {
+  runTests();
+}
+
+function runTests(): void {
+  // ─── Shared constants ──────────────────────────────────────────────────────
+  const SPRINT_BRANCH = 'ralphctl/test-sprint';
+  const FAKE_PROJECT_ID = 'proj-parallel-realgit';
+
+  // ─── In-memory repository fakes ───────────────────────────────────────────
+  const inMemorySprintRepo = (initial: Sprint): { repo: SprintRepository; current: () => Sprint } => {
+    let current: Sprint = initial;
+    return {
+      repo: {
+        async findById(id: SprintId) {
+          if (current.id === id) return Result.ok(current);
+          return Result.error(new NotFoundError({ entity: 'sprint', id: String(id) }));
+        },
+        async save(sprint: Sprint) {
+          current = sprint;
+          return Result.ok(undefined);
+        },
+        async list() {
+          return Result.ok([current]);
+        },
+      } as unknown as SprintRepository,
+      current: () => current,
+    };
+  };
+
+  const inMemoryExecutionRepo = (
+    initial: SprintExecution
+  ): { repo: SprintExecutionRepository; current: () => SprintExecution } => {
+    let current = initial;
+    return {
+      repo: {
+        async findById(id: SprintId) {
+          if (current.sprintId === id) return Result.ok(current);
+          return Result.error(new NotFoundError({ entity: 'sprint-execution', id: String(id) }));
+        },
+        async save(next: SprintExecution) {
+          current = next;
+          return Result.ok(undefined);
+        },
+        async remove() {
+          return Result.ok(undefined);
+        },
+      } as unknown as SprintExecutionRepository,
+      current: () => current,
+    };
+  };
+
+  const inMemoryTaskRepo = (
+    initial: readonly Task[]
+  ): { repo: TaskRepository; tasks: () => readonly Task[]; saveAlls: ReadonlyArray<readonly Task[]> } => {
+    let store: Task[] = [...initial];
+    const saveAlls: Array<readonly Task[]> = [];
+    return {
+      repo: {
+        async findBySprintId() {
+          return Result.ok(store as readonly Task[]);
+        },
+        async findById(_sprintId: SprintId, taskId: TaskId) {
+          const t = store.find((tt) => tt.id === taskId);
+          if (t === undefined) return Result.error(new NotFoundError({ entity: 'task', id: String(taskId) }));
+          return Result.ok(t);
+        },
+        async update(_sprintId: SprintId, task: Task) {
+          const idx = store.findIndex((t) => t.id === task.id);
+          if (idx >= 0) store[idx] = task;
+          else store = [...store, task];
+          return Result.ok(undefined);
+        },
+        async saveAll(_sprintId: SprintId, tasks: readonly Task[]) {
+          store = [...tasks];
+          saveAlls.push(tasks);
+          return Result.ok(undefined);
+        },
+      } as unknown as TaskRepository,
+      tasks: () => store,
+      get saveAlls() {
+        return saveAlls;
+      },
+    };
+  };
+
+  // ─── Real-file-writing fake AI provider ───────────────────────────────────
+  /**
+   * For the parallel path the `session.cwd` is the WORKTREE PATH (not the main repo root).
+   * When "generating", the fake writes a distinct file under `session.cwd` so the real git
+   * commit leaf finds a dirty tree, stages, and commits it. This exercises the full real-git
+   * commit path inside each worktree.
+   *
+   * For the evaluator the fake just emits `evaluationPassed` — no file write needed (the
+   * evaluator runs in a read-only posture and doesn't need to land any new files for the
+   * chain to advance).
+   */
+  const MARKERS = {
+    implement: '# Task Execution Protocol',
+    evaluate: 'independent code reviewer',
+  } as const;
+
+  const taskVerified = (output: string): HarnessSignal => ({ type: 'task-verified', output, timestamp: FIXED_NOW });
+  const evaluationPassed = (): HarnessSignal => ({
+    type: 'evaluation',
+    status: 'passed',
+    dimensions: [],
+    timestamp: FIXED_NOW,
+  });
+
+  interface RealFileWritingFakeProvider extends HeadlessAiProvider {
+    readonly recordedCwds: string[];
+  }
+
+  /**
+   * Fake provider that:
+   *  - On `implement` prompt: writes `<task-file-prefix>.txt` into `session.cwd` (the worktree
+   *    dir in the parallel path) so real git sees a dirty tree, and emits `taskVerified`.
+   *  - On `evaluate` prompt: emits `evaluationPassed` only (no file write needed).
+   *
+   * `taskFilePrefix` is unique per task so sibling tasks don't write the same filename and
+   * create false conflicts on the fold step — we want clean folds in the happy path.
+   */
+  const createRealFileWritingProvider = (taskFilePrefix: string): RealFileWritingFakeProvider => {
+    const recordedCwds: string[] = [];
+    return {
+      recordedCwds,
+      async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+        recordedCwds.push(String(session.cwd));
+
+        const prompt = session.prompt;
+        const isImplement = prompt.includes(MARKERS.implement);
+        const isEvaluate = prompt.includes(MARKERS.evaluate);
+
+        let signals: HarnessSignal[];
+
+        if (isImplement) {
+          // Write a REAL file so git sees a dirty worktree and the commit leaf lands.
+          const targetFile = join(String(session.cwd), `${taskFilePrefix}.txt`);
+          await fs.writeFile(targetFile, `Task ${taskFilePrefix} output written by fake AI\n`, 'utf8');
+          signals = [taskVerified(`${taskFilePrefix} done`)];
+        } else if (isEvaluate) {
+          signals = [evaluationPassed()];
+        } else {
+          // Unknown prompt — emit empty signals (will surface as a non-fatal failure; test
+          // will catch this via the final status assertion rather than a hard throw).
+          signals = [];
+        }
+
+        const wrote = await writeJsonAtomic(String(session.signalsFile), signals);
+        if (!wrote.ok) return Result.error(wrote.error) as Result<ProviderOutput, DomainError>;
+
+        return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 }) as Result<ProviderOutput, DomainError>;
+      },
+    };
+  };
+
+  // ─── Recording shell script runner ───────────────────────────────────────
+  /**
+   * A ShellScriptRunner spy that records every (cwd, script) call it receives and always
+   * returns `passed: true`. Tests can inspect `calls` after a run to assert which cwds the
+   * harness invoked setup in (e.g. to prove per-worktree setup ran inside each worktree, not
+   * inside the main repo).
+   */
+  interface RecordingShellCall {
+    readonly cwd: string;
+    readonly script: string;
+  }
+  interface RecordingShellScriptRunner extends ShellScriptRunner {
+    readonly calls: readonly RecordingShellCall[];
+  }
+  const createRecordingShell = (): RecordingShellScriptRunner => {
+    const calls: RecordingShellCall[] = [];
+    return {
+      get calls(): readonly RecordingShellCall[] {
+        return calls;
+      },
+      async run(
+        cwd: AbsolutePath,
+        script: string
+      ): Promise<Result<{ passed: boolean; exitCode: number; output: string; durationMs: number }, StorageError>> {
+        calls.push({ cwd: String(cwd), script });
+        return Result.ok({ passed: true, exitCode: 0, output: '', durationMs: 0 });
+      },
+    };
+  };
+  /** Backwards-compatible pass-through for tests that don't need call recording. */
+  const passingShell: ShellScriptRunner = createRecordingShell();
+
+  // ─── Fixture setup helpers ────────────────────────────────────────────────
+  interface ParallelFixture {
+    readonly repo: FakeProject;
+    readonly sprintDir: string;
+    readonly progressFile: string;
+    readonly ralphctlRoot: string;
+    readonly memoryRoot: string;
+    cleanup(): Promise<void>;
+  }
+
+  const buildParallelFixture = async (): Promise<ParallelFixture> => {
+    const repo = await createFakeProject({
+      seed: {
+        'README.md': '# parallel-test-repo\n',
+        '.gitignore': 'node_modules/\n',
+      },
+    });
+
+    // Create and check out the sprint branch in the real repo.
+    await repo.git('checkout', '-b', SPRINT_BRANCH);
+
+    // Directory for ralphctl state (sprint dir, locks, etc.)
+    const raw = await fs.mkdtemp(join(tmpdir(), 'ralphctl-parallel-state-'));
+    const ralphctlRoot = await realpath(raw);
+    const sprintDir = join(ralphctlRoot, 'sprint');
+    const progressFile = join(sprintDir, 'progress.md');
+    // Per-run, under the same unique mkdtemp root → no shared `/tmp` path, no cross-exec
+    // collision on the learnings ledger, and torn down with `ralphctlRoot` in cleanup.
+    const memoryRoot = join(ralphctlRoot, 'memory');
+    await fs.mkdir(sprintDir, { recursive: true });
+    await fs.mkdir(memoryRoot, { recursive: true });
+
+    return {
+      repo,
+      sprintDir,
+      progressFile,
+      ralphctlRoot,
+      memoryRoot,
+      async cleanup() {
+        await repo.cleanup();
+        await fs.rm(ralphctlRoot, { recursive: true, force: true });
+      },
+    };
+  };
+
+  // ─── Build ImplementDeps using a REAL GitRunner ───────────────────────────
+  const buildRealGitDeps = (
+    sprintRepo: SprintRepository,
+    executionRepo: SprintExecutionRepository,
+    taskRepo: TaskRepository,
+    provider: HeadlessAiProvider,
+    locksRootPath: string,
+    shellScriptRunner: ShellScriptRunner = passingShell
+  ): ImplementDeps => {
+    const realGit = createGitRunner();
+    return {
+      sprintRepo,
+      sprintExecutionRepo: executionRepo,
+      taskRepo,
+      generatorProvider: provider,
+      evaluatorProvider: provider,
+      templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+      signals: createInMemorySink<HarnessSignal>(),
+      eventBus: createInMemoryEventBus(),
+      logger: noopLogger,
+      clock: () => FIXED_LATER,
+      config: {
+        harness: {
+          maxTurns: 5,
+          maxAttempts: 1,
+          rateLimitRetries: 0,
+          plateauThreshold: 2,
+          escalateOnPlateau: false,
+          escalationMap: {},
+        },
+      },
+      gitRunner: realGit,
+      shellScriptRunner,
+      fileLocker: createFileLocker(),
+      locksRoot: absolutePath(locksRootPath),
+      skillsAdapter: noopSkillsAdapter,
+      skillSource: emptySkillSource,
+      interactive: {
+        async askText() {
+          throw new Error('askText not expected in parallel real-git test');
+        },
+        async askTextArea() {
+          throw new Error('askTextArea not expected');
+        },
+        async askChoice() {
+          throw new Error('askChoice not expected — sprint branch is pre-set');
+        },
+        async askMultiChoice() {
+          throw new Error('askMultiChoice not expected');
+        },
+        async askConfirm() {
+          throw new Error('askConfirm not expected');
+        },
+      },
+      writeFile: createAtomicWriteFile(),
+      appendFile: createAppendFile(),
+    };
+  };
+
+  // ─── Parse AbsolutePath safely ────────────────────────────────────────────
+  const ap = (s: string): AbsolutePath => {
+    const r = AbsolutePath.parse(s);
+    if (!r.ok) throw new Error(`absolutePath parse failed: ${r.error.message}`);
+    return r.value;
+  };
+
+  // ─── Count commits on a branch ────────────────────────────────────────────
+  const countCommitsOnBranch = async (repoPath: string, branch: string): Promise<number> => {
+    const { execSync } = await import('node:child_process');
+    const out = execSync(`git -C "${repoPath}" log --oneline "${branch}"`, { encoding: 'utf8' });
+    const lines = out
+      .trim()
+      .split('\n')
+      .filter((l) => l.length > 0);
+    return lines.length;
+  };
+
+  const listWorktrees = async (repoPath: string): Promise<string[]> => {
+    const { execSync } = await import('node:child_process');
+    const out = execSync(`git -C "${repoPath}" worktree list --porcelain`, { encoding: 'utf8' });
+    // Each worktree block starts with "worktree <path>". The first entry is the main worktree.
+    return out
+      .split('\n\n')
+      .map((block) => {
+        const line = block.trim().split('\n')[0] ?? '';
+        return line.startsWith('worktree ') ? line.slice('worktree '.length).trim() : '';
+      })
+      .filter((p) => p.length > 0);
+  };
+
+  const getCommitFiles = async (repoPath: string, branch: string): Promise<string[]> => {
+    const { execSync } = await import('node:child_process');
+    // Get all files added across ALL commits on this branch (excluding the initial commit)
+    // by listing files added by each commit after the initial one.
+    const log = execSync(`git -C "${repoPath}" log --name-only --format="%H" "${branch}"`, { encoding: 'utf8' });
+    const lines = log
+      .trim()
+      .split('\n')
+      .filter((l) => l.length > 0 && !l.match(/^[0-9a-f]{40}/));
+    return lines;
+  };
+
+  // ─── Tests ────────────────────────────────────────────────────────────────
+  describe('parallel implement — real git worktrees', () => {
+    let cleanupFns: Array<() => Promise<void>>;
+
+    beforeEach(() => {
+      cleanupFns = [];
+    });
+
+    afterEach(async () => {
+      for (const fn of cleanupFns) await fn().catch(() => undefined);
+    });
+
+    it('happy path: 3 tasks in 2 waves all settle done, 3 real commits on sprint branch, worktrees cleaned up', async () => {
+      const fixture = await buildParallelFixture();
+      cleanupFns.push(() => fixture.cleanup());
+
+      const repoPath = fixture.repo.path;
+      const sprintDirPath = ap(fixture.sprintDir);
+      const progressPath = ap(fixture.progressFile);
+
+      // ── Domain fixtures ────────────────────────────────────────────────
+      const ticket = makeApprovedTicket({ title: 'parallel-test-ticket' });
+      const sprint = makePlannedSprint({ tickets: [ticket] });
+      // Pre-set the sprint branch so resolveBranchLeaf takes the resume path without prompting.
+      const execution = setExecutionBranch(createSprintExecution({ sprintId: sprint.id }), SPRINT_BRANCH);
+
+      // 3 tasks: A (order 1, no deps), B (order 2, no deps), C (order 3, depends on A)
+      // → wave 0 = {A, B}, wave 1 = {C}
+      const taskA = makeTodoTask({
+        name: 'task-a',
+        order: 1,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const taskB = makeTodoTask({
+        name: 'task-b',
+        order: 2,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const taskC = makeTodoTask({
+        name: 'task-c',
+        order: 3,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+        dependsOn: [taskA.id],
+      });
+      const tasks = [taskA, taskB, taskC];
+
+      const sprintStore = inMemorySprintRepo(sprint);
+      const execStore = inMemoryExecutionRepo(execution);
+      const taskStore = inMemoryTaskRepo(tasks);
+
+      // One fake provider per task so each writes a distinct file, enabling clean ff folds.
+      const providerA = createRealFileWritingProvider('task-a-output');
+      const providerB = createRealFileWritingProvider('task-b-output');
+      const providerC = createRealFileWritingProvider('task-c-output');
+
+      // The parallel path builds per-task subchains; each subchain gets its own branch-specific
+      // provider injected via the branch's ImplementDeps. We need a single ImplementDeps for the
+      // prologue/epilogue, then per-branch overrides for the per-task bodies.
+      // The design uses the SAME provider pair injected into ImplementDeps for all branches by
+      // default (wave-branch.ts clones deps, overriding only signals). To inject per-task providers,
+      // we build a combined provider that dispatches by task name embedded in session.cwd.
+      const combinedProvider: HeadlessAiProvider = {
+        async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+          // The session.cwd is the worktree path: <sprintDir>/worktrees/wt-<taskId>
+          // Use it to identify the task. The fake file-writing providers are keyed on the
+          // task file prefix which embeds the task name. We dispatch based on cwd suffix.
+          const cwd = String(session.cwd);
+          const taskIdA = String(taskA.id);
+          const taskIdB = String(taskB.id);
+          const taskIdC = String(taskC.id);
+
+          if (cwd.includes(`wt-${taskIdA}`)) return providerA.generate(session);
+          if (cwd.includes(`wt-${taskIdB}`)) return providerB.generate(session);
+          if (cwd.includes(`wt-${taskIdC}`)) return providerC.generate(session);
+
+          // Prologue/epilogue steps that call the provider (e.g. detect-scripts) don't exist
+          // in the implement path — if we hit this, something unexpected called generate.
+          // Also: for the serial flow fixture baseline the deps use FAKE_CWD — use providerA
+          // as fallback for any non-worktree cwd (shouldn't fire in parallel path).
+          return providerA.generate(session);
+        },
+      };
+
+      const locksRoot = join(fixture.ralphctlRoot, 'locks');
+      await fs.mkdir(locksRoot, { recursive: true });
+
+      // Recording shell runner — spy on which cwds the harness invokes setup in.
+      const recordingShell = createRecordingShell();
+
+      const implementDeps = buildRealGitDeps(
+        sprintStore.repo,
+        execStore.repo,
+        taskStore.repo,
+        combinedProvider,
+        locksRoot,
+        recordingShell
+      );
+
+      // Repository map pointing at the REAL repo — with a sentinel setupScript so we can prove
+      // per-worktree setup ran inside each worktree. The script just echoes a line; the
+      // recording shell intercepts the call and records the cwd without actually running anything.
+      const SETUP_SCRIPT = 'echo ralphctl-setup-ran';
+      const repoMap = new Map([
+        [FIXED_REPOSITORY_ID, { path: ap(repoPath), name: 'test-repo', setupScript: SETUP_SCRIPT } as RepoExecConfig],
+      ]);
+
+      const implementOpts = {
+        sprintId: sprint.id,
+        todoTasks: tasks,
+        repositories: repoMap,
+        progressFile: progressPath,
+        sprintDir: sprintDirPath,
+        generatorProviderId: 'claude-code',
+        generatorModel: 'claude-opus-4-8',
+        evaluatorProviderId: 'claude-code',
+        evaluatorModel: 'claude-opus-4-8',
+        memoryRoot: ap(fixture.memoryRoot),
+        projectId: FAKE_PROJECT_ID,
+        // Skip the interactive dirty-tree menu — we own the repo and it's clean.
+        dirtyTreePolicy: 'cancel' as const,
+      };
+
+      // Build the plan (prologue / waves / epilogue)
+      const plan = planImplementWaves(implementDeps, implementOpts);
+
+      // Verify the wave structure: wave 0 = {A, B}, wave 1 = {C}
+      expect(plan.waves).toHaveLength(2);
+      expect(plan.waves[0]).toHaveLength(2);
+      expect(plan.waves[1]).toHaveLength(1);
+      expect(plan.waves[0]?.[0]?.name).toBe('task-a');
+      expect(plan.waves[0]?.[1]?.name).toBe('task-b');
+      expect(plan.waves[1]?.[0]?.name).toBe('task-c');
+
+      const foldQueue = createFoldQueue();
+      const branchDeps = {
+        implement: implementDeps,
+        appSignals: createInMemorySink<HarnessSignal>(),
+        eventBus: createInMemoryEventBus(),
+        foldQueue,
+      };
+
+      const readConfig = () =>
+        Promise.resolve({
+          maxTurns: 5,
+          escalateOnPlateau: false,
+          escalationMap: {} as Record<string, string>,
+        });
+
+      const parallelElement = createParallelImplementElement(plan, {
+        fileLocker: implementDeps.fileLocker,
+        locksRoot: implementDeps.locksRoot,
+        eventBus: implementDeps.eventBus,
+        maxConcurrency: 3,
+        flowId: 'implement',
+        sessionId: () => `session-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`,
+        buildWaves: () => buildWaveBranches(branchDeps, implementOpts, plan.waves, readConfig),
+      });
+
+      const runner = createRunner<ImplementCtx>({
+        id: 'r-parallel-realgit-happy',
+        element: parallelElement,
+        initialCtx: { sprintId: sprint.id },
+      });
+
+      await runner.start();
+
+      // ── Assert runner completed ────────────────────────────────────────
+      if (runner.status !== 'completed') {
+        const trace = runner.trace.map((e) => `${e.elementName}:${e.status}`).join('\n');
+        throw new Error(`Runner status is '${runner.status}' — expected 'completed'.\nTrace:\n${trace}`);
+      }
+      expect(runner.status).toBe('completed');
+
+      // ── Assert all 3 tasks are done ────────────────────────────────────
+      const finalTasks = taskStore.tasks();
+      expect(finalTasks).toHaveLength(3);
+      for (const t of finalTasks) {
+        expect(t.status).toBe('done');
+      }
+
+      // ── Assert sprint transitioned to review ───────────────────────────
+      expect(sprintStore.current().status).toBe('review');
+
+      // ── Assert 3 real commits on the sprint branch ─────────────────────
+      // Initial commit + 3 task commits = 4 total. (The initial commit was 'chore: initial commit'
+      // from createFakeProject; the sprint branch started from there.) Wave 0 folds tasks A+B
+      // (one ff, one cherry-pick); wave 1 folds task C.
+      const commitCount = await countCommitsOnBranch(repoPath, SPRINT_BRANCH);
+      // 1 initial + 3 task commits
+      expect(commitCount).toBe(4);
+
+      // ── Assert each task's file exists on the sprint branch ────────────
+      const committedFiles = await getCommitFiles(repoPath, SPRINT_BRANCH);
+      expect(committedFiles.some((f) => f.includes('task-a-output.txt'))).toBe(true);
+      expect(committedFiles.some((f) => f.includes('task-b-output.txt'))).toBe(true);
+      expect(committedFiles.some((f) => f.includes('task-c-output.txt'))).toBe(true);
+
+      // ── Assert task-c comes AFTER task-a in the commit log ────────────
+      // (wave ordering: A and B must be committed before C)
+      const { execSync } = await import('node:child_process');
+      const logOrder = execSync(`git -C "${repoPath}" log --name-only --format="%s" "${SPRINT_BRANCH}"`, {
+        encoding: 'utf8',
+      });
+      // git log is newest-first, so C should appear before A/B
+      const idxA = logOrder.indexOf('task-a-output.txt');
+      const idxB = logOrder.indexOf('task-b-output.txt');
+      const idxC = logOrder.indexOf('task-c-output.txt');
+      expect(idxC).toBeGreaterThan(-1);
+      expect(idxA).toBeGreaterThan(-1);
+      expect(idxB).toBeGreaterThan(-1);
+      // C is newest (latest commit) so it appears EARLIER in git log (lower index).
+      // A and B from wave 0 appear later (higher index, older).
+      // Wave ordering: C came after A, so C should appear before A in git log (newest-first).
+      // (This may vary if cherry-pick changes order — but wave-sequential execution guarantees
+      //  wave 0 (A,B) lands before wave 1 (C) starts.)
+      expect(idxC).toBeLessThan(idxA);
+      expect(idxC).toBeLessThan(idxB);
+
+      // ── Assert worktrees cleaned up ────────────────────────────────────
+      // After the run completes, `git worktree list` should show ONLY the main worktree.
+      const worktrees = await listWorktrees(repoPath);
+      expect(worktrees).toHaveLength(1);
+      // The single remaining worktree should be the main repo root.
+      expect(worktrees[0]).toBe(repoPath);
+
+      // ── Regression: the throwaway wt-* branch refs are deleted on cleanup ──
+      //
+      // `git worktree remove --force <path>` drops the worktree directory + its
+      // `.git/worktrees/<name>` record but LEAVES the branch `git worktree add -b <ref>` created.
+      // Stale `ralphctl/<sprint>/wt-<taskId>` refs would then accumulate and — worse — make a
+      // relaunch after an aborted task fail (`worktree add -b <same-ref>` errors "branch exists").
+      // `cleanupWorktree` now calls `gitDeleteBranch` (best-effort) after a successful remove.
+      // This real-git test is what caught the original miss; the fake-GitRunner unit tests could not.
+      const branchListRaw = execSync(`git -C "${repoPath}" branch -a`, { encoding: 'utf8' });
+      const taskIds = [String(taskA.id), String(taskB.id), String(taskC.id)];
+      for (const taskId of taskIds) {
+        expect(branchListRaw).not.toContain(`wt-${taskId}`);
+      }
+
+      // ── Assert main working tree is clean and was never stashed ────────
+      const statusOut = execSync(`git -C "${repoPath}" status --porcelain`, { encoding: 'utf8' });
+      expect(statusOut.trim()).toBe('');
+
+      const stashList = execSync(`git -C "${repoPath}" stash list`, { encoding: 'utf8' });
+      expect(stashList.trim()).toBe('');
+
+      // ── Assert per-worktree setup script ran inside each worktree ───────
+      //
+      // The recording shell spy intercepts every `shellScriptRunner.run()` call:
+      //   - 1 call from the prologue's `setupScriptRunnerLeaf` (main repo, cwd = repoPath)
+      //   - 3 calls from `wave-branch.ts` `runWorktreeSetupScript` (one per task, each in its
+      //     own worktree directory)
+      // Total = 4. The 3 worktree calls prove per-worktree setup ran inside each worktree, NOT
+      // in the main repo root. Setup running in the wrong cwd would be a regression: the worktree
+      // is an isolated checkout that may have missing build artifacts, and setup must prep THAT
+      // tree, not the one already set up by the prologue.
+      expect(recordingShell.calls).toHaveLength(4);
+      for (const call of recordingShell.calls) {
+        expect(call.script).toBe(SETUP_SCRIPT);
+      }
+      // Exactly 1 call in the main repo root (prologue).
+      const prologueCalls = recordingShell.calls.filter((c) => c.cwd === repoPath);
+      expect(prologueCalls).toHaveLength(1);
+      // Exactly 3 calls in worktree paths (per-worktree setup).
+      const worktreeCalls = recordingShell.calls.filter((c) => c.cwd.includes('worktrees/wt-'));
+      expect(worktreeCalls).toHaveLength(3);
+      // One distinct worktree path per task (no two tasks share a worktree).
+      const worktreeCwds = new Set(worktreeCalls.map((c) => c.cwd));
+      expect(worktreeCwds.size).toBe(3);
+
+      // ── Assert sprint branch is a single linear chain (no merge commits) ─
+      //
+      // The fold logic uses `git merge --ff-only` (fast-forward) or `git cherry-pick` — neither
+      // produces a merge commit. A merge commit would mean the worktree was merged with a
+      // real `git merge`, which would violate the "preserve linear history" contract.
+      const mergeCommits = execSync(`git -C "${repoPath}" log --merges --oneline "${SPRINT_BRANCH}"`, {
+        encoding: 'utf8',
+      }).trim();
+      expect(mergeCommits).toBe('');
+    }, 120_000); // This test involves real git operations (worktree add × 3) — give it generous headroom.
+
+    it('abort mid-run: worktrees are cleaned up and sprint stays runnable (tasks reset to todo)', async () => {
+      const fixture = await buildParallelFixture();
+      cleanupFns.push(() => fixture.cleanup());
+
+      const repoPath = fixture.repo.path;
+      const sprintDirPath = ap(fixture.sprintDir);
+      const progressPath = ap(fixture.progressFile);
+
+      const ticket = makeApprovedTicket({ title: 'abort-test-ticket' });
+      const sprint = makePlannedSprint({ tickets: [ticket] });
+      const execution = setExecutionBranch(createSprintExecution({ sprintId: sprint.id }), SPRINT_BRANCH);
+
+      // Two independent tasks — wave 0 = {A, B}. We abort after the worktrees are set up.
+      const taskA = makeTodoTask({
+        name: 'abort-task-a',
+        order: 1,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const taskB = makeTodoTask({
+        name: 'abort-task-b',
+        order: 2,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const tasks = [taskA, taskB];
+
+      const sprintStore = inMemorySprintRepo(sprint);
+      const execStore = inMemoryExecutionRepo(execution);
+      const taskStore = inMemoryTaskRepo(tasks);
+
+      // Abort controller — we fire it after the AI starts (during generate())
+      const abortController = new AbortController();
+
+      // Slow provider: blocks until aborted, then returns an error.
+      // This keeps branches in-flight long enough for the abort signal to fire.
+      let generateCallCount = 0;
+      const slowAbortableProvider: HeadlessAiProvider = {
+        async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+          generateCallCount += 1;
+          // On the first generate call, trigger the abort immediately.
+          if (generateCallCount === 1) {
+            abortController.abort();
+          }
+          // Simulate time passing — the abort should arrive while we're "thinking."
+          await new Promise<void>((resolve) => setTimeout(resolve, 50));
+          // Write a file and emit signals so the chain CAN complete if not aborted.
+          const targetFile = join(String(session.cwd), `abort-test-output-${String(generateCallCount)}.txt`);
+          await fs.writeFile(targetFile, 'abort test\n', 'utf8');
+          const signals: HarnessSignal[] = [taskVerified('abort test')];
+          const wrote = await writeJsonAtomic(String(session.signalsFile), signals);
+          if (!wrote.ok) return Result.error(wrote.error) as Result<ProviderOutput, DomainError>;
+          return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 }) as Result<ProviderOutput, DomainError>;
+        },
+      };
+
+      const locksRoot = join(fixture.ralphctlRoot, 'locks');
+      await fs.mkdir(locksRoot, { recursive: true });
+
+      const implementDeps = buildRealGitDeps(
+        sprintStore.repo,
+        execStore.repo,
+        taskStore.repo,
+        slowAbortableProvider,
+        locksRoot
+      );
+      const repoMap = new Map([[FIXED_REPOSITORY_ID, { path: ap(repoPath), name: 'test-repo' } as RepoExecConfig]]);
+
+      const implementOpts = {
+        sprintId: sprint.id,
+        todoTasks: tasks,
+        repositories: repoMap,
+        progressFile: progressPath,
+        sprintDir: sprintDirPath,
+        generatorProviderId: 'claude-code',
+        generatorModel: 'claude-opus-4-8',
+        evaluatorProviderId: 'claude-code',
+        evaluatorModel: 'claude-opus-4-8',
+        memoryRoot: ap(fixture.memoryRoot),
+        projectId: FAKE_PROJECT_ID,
+        dirtyTreePolicy: 'cancel' as const,
+      };
+
+      const plan = planImplementWaves(implementDeps, implementOpts);
+      const foldQueue = createFoldQueue();
+      const branchDeps = {
+        implement: implementDeps,
+        appSignals: createInMemorySink<HarnessSignal>(),
+        eventBus: createInMemoryEventBus(),
+        foldQueue,
+      };
+
+      const readConfig = () =>
+        Promise.resolve({
+          maxTurns: 5,
+          escalateOnPlateau: false,
+          escalationMap: {} as Record<string, string>,
+        });
+
+      const parallelElement = createParallelImplementElement(plan, {
+        fileLocker: implementDeps.fileLocker,
+        locksRoot: implementDeps.locksRoot,
+        eventBus: implementDeps.eventBus,
+        maxConcurrency: 3,
+        flowId: 'implement',
+        sessionId: () => `session-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`,
+        buildWaves: () => buildWaveBranches(branchDeps, implementOpts, plan.waves, readConfig),
+      });
+
+      const runner = createRunner<ImplementCtx>({
+        id: 'r-parallel-realgit-abort',
+        element: parallelElement,
+        initialCtx: { sprintId: sprint.id },
+      });
+
+      // Pass abort signal to runner.start() — when the runner starts, forward abort.
+      const runnerAbortController = new AbortController();
+      const externalSignal = abortController.signal;
+      externalSignal.addEventListener('abort', () => runner.abort('test-abort'), { once: true });
+
+      await runner.start();
+
+      // The runner should be aborted (or in some cases completed if abort raced a finish).
+      // Either way: worktrees MUST be cleaned up.
+      const worktrees = await listWorktrees(repoPath);
+      expect(worktrees).toHaveLength(1);
+      expect(worktrees[0]).toBe(repoPath);
+
+      // The main working tree must be clean (no stash).
+      const { execSync } = await import('node:child_process');
+      const statusOut = execSync(`git -C "${repoPath}" status --porcelain`, { encoding: 'utf8' });
+      expect(statusOut.trim()).toBe('');
+      const stashList = execSync(`git -C "${repoPath}" stash list`, { encoding: 'utf8' });
+      expect(stashList.trim()).toBe('');
+
+      // Sprint must NOT have transitioned to review on abort (it's still active or planned).
+      expect(sprintStore.current().status).not.toBe('review');
+
+      void runnerAbortController;
+    }, 90_000);
+
+    it('fold conflict adversarial: task B conflicts on fold → B blocked, A stays done, sprint branch clean and linear', async () => {
+      //
+      // Setup:
+      //   1. Initial commit seeds `shared.txt` = "original content\n".
+      //   2. Task A (wave 0, order 1): overwrites `shared.txt` with "modified by task-a\n"
+      //      and commits. Folds first via ff-only (sprint branch had not advanced yet) —
+      //      the sprint branch now points at A's commit.
+      //   3. Task B (wave 0, order 2): ALSO overwrites `shared.txt` with "modified by task-b\n"
+      //      and commits. Its worktree forked from the sprint-branch tip BEFORE A's fold, so
+      //      `git merge --ff-only` fails (branch has advanced). `gitFoldBranch` then tries
+      //      `git cherry-pick <merge-base>..wt-B` — conflict on `shared.txt`. Cherry-pick is
+      //      aborted; sprint branch is left clean with only A's commit.
+      //
+      // Assertions:
+      //   - Task A: `done`
+      //   - Task B: `blocked`, blockedReason contains "fold conflict"
+      //   - Sprint branch: only A's commit (not B's), no merge commits, clean working tree
+      //   - Worktrees: cleaned up (only main worktree)
+      //   - No stale wt-* branch refs
+      //   - Sprint status: transitions to `review` (the wave completed — A landed done, B blocked)
+      //
+      const fixture = await buildParallelFixture();
+      cleanupFns.push(() => fixture.cleanup());
+
+      const repoPath = fixture.repo.path;
+      const sprintDirPath = ap(fixture.sprintDir);
+      const progressPath = ap(fixture.progressFile);
+
+      // Seed `shared.txt` on the sprint branch (the fixture already checked it out).
+      // Both tasks will overwrite this file, creating a real cherry-pick conflict when
+      // the second one tries to fold — it cannot fast-forward because task A already advanced
+      // the sprint branch pointer, and cherry-pick of task B's commit will conflict on this file.
+      await fixture.repo.writeFile('shared.txt', 'original content\n');
+      await fixture.repo.git('add', 'shared.txt');
+      await fixture.repo.git('commit', '-m', 'chore: seed shared.txt');
+
+      const ticket = makeApprovedTicket({ title: 'conflict-test-ticket' });
+      const sprint = makePlannedSprint({ tickets: [ticket] });
+      const execution = setExecutionBranch(createSprintExecution({ sprintId: sprint.id }), SPRINT_BRANCH);
+
+      // Two tasks in wave 0 (no dependency edge between them) targeting the same repo.
+      // Task A (order 1) folds first; task B (order 2) conflicts.
+      const taskA = makeTodoTask({
+        name: 'conflict-task-a',
+        order: 1,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const taskB = makeTodoTask({
+        name: 'conflict-task-b',
+        order: 2,
+        ticketId: ticket.id,
+        repositoryId: FIXED_REPOSITORY_ID,
+      });
+      const tasks = [taskA, taskB];
+
+      const sprintStore = inMemorySprintRepo(sprint);
+      const execStore = inMemoryExecutionRepo(execution);
+      const taskStore = inMemoryTaskRepo(tasks);
+
+      // Fake provider: both tasks write to the SAME file (`shared.txt`) with conflicting content.
+      // No additional unique file — the conflict on `shared.txt` must be real.
+      const conflictProvider: HeadlessAiProvider = {
+        async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+          const prompt = session.prompt;
+          const isEvaluate = prompt.includes(MARKERS.evaluate);
+
+          let signals: HarnessSignal[];
+
+          if (isEvaluate) {
+            signals = [evaluationPassed()];
+          } else {
+            // Both tasks overwrite `shared.txt` with DIFFERENT content — this is the conflict.
+            // Task A writes "modified by task-a\n"; task B writes "modified by task-b\n".
+            // Their worktrees both forked from the same initial sprint-branch tip, so when
+            // task A folds (ff-only), the sprint branch advances. Task B's cherry-pick then
+            // conflicts on `shared.txt`.
+            const cwd = String(session.cwd);
+            const isTaskA = cwd.includes(`wt-${String(taskA.id)}`);
+            const sharedFile = join(cwd, 'shared.txt');
+            const content = isTaskA ? 'modified by task-a\n' : 'modified by task-b\n';
+            await fs.writeFile(sharedFile, content, 'utf8');
+            const taskName = isTaskA ? 'task-a' : 'task-b';
+            signals = [taskVerified(`${taskName} done`)];
+          }
+
+          const wrote = await writeJsonAtomic(String(session.signalsFile), signals);
+          if (!wrote.ok) return Result.error(wrote.error) as Result<ProviderOutput, DomainError>;
+          return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 }) as Result<ProviderOutput, DomainError>;
+        },
+      };
+
+      const locksRoot = join(fixture.ralphctlRoot, 'locks');
+      await fs.mkdir(locksRoot, { recursive: true });
+
+      const implementDeps = buildRealGitDeps(
+        sprintStore.repo,
+        execStore.repo,
+        taskStore.repo,
+        conflictProvider,
+        locksRoot
+      );
+
+      // No setupScript — the conflict scenario doesn't need per-worktree setup.
+      const repoMap = new Map([[FIXED_REPOSITORY_ID, { path: ap(repoPath), name: 'test-repo' } as RepoExecConfig]]);
+
+      const implementOpts = {
+        sprintId: sprint.id,
+        todoTasks: tasks,
+        repositories: repoMap,
+        progressFile: progressPath,
+        sprintDir: sprintDirPath,
+        generatorProviderId: 'claude-code',
+        generatorModel: 'claude-opus-4-8',
+        evaluatorProviderId: 'claude-code',
+        evaluatorModel: 'claude-opus-4-8',
+        memoryRoot: ap(fixture.memoryRoot),
+        projectId: FAKE_PROJECT_ID,
+        dirtyTreePolicy: 'cancel' as const,
+      };
+
+      const plan = planImplementWaves(implementDeps, implementOpts);
+
+      // Confirm both tasks landed in wave 0 (no dependency edge — same wave).
+      expect(plan.waves).toHaveLength(1);
+      expect(plan.waves[0]).toHaveLength(2);
+
+      const foldQueue = createFoldQueue();
+      const branchDeps = {
+        implement: implementDeps,
+        appSignals: createInMemorySink<HarnessSignal>(),
+        eventBus: createInMemoryEventBus(),
+        foldQueue,
+      };
+
+      const readConfig = () =>
+        Promise.resolve({
+          maxTurns: 5,
+          escalateOnPlateau: false,
+          escalationMap: {} as Record<string, string>,
+        });
+
+      const parallelElement = createParallelImplementElement(plan, {
+        fileLocker: implementDeps.fileLocker,
+        locksRoot: implementDeps.locksRoot,
+        eventBus: implementDeps.eventBus,
+        maxConcurrency: 3,
+        flowId: 'implement',
+        sessionId: () => `session-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`,
+        buildWaves: () => buildWaveBranches(branchDeps, implementOpts, plan.waves, readConfig),
+      });
+
+      const runner = createRunner<ImplementCtx>({
+        id: 'r-parallel-realgit-conflict',
+        element: parallelElement,
+        initialCtx: { sprintId: sprint.id },
+      });
+
+      await runner.start();
+
+      // Runner must complete (never error/abort) — a fold conflict is a domain block, not a chain failure.
+      if (runner.status !== 'completed') {
+        const trace = runner.trace.map((e) => `${e.elementName}:${e.status}`).join('\n');
+        throw new Error(`Runner status is '${runner.status}' — expected 'completed'.\nTrace:\n${trace}`);
+      }
+      expect(runner.status).toBe('completed');
+
+      const finalTasks = taskStore.tasks();
+      expect(finalTasks).toHaveLength(2);
+
+      const finalA = finalTasks.find((t) => t.id === taskA.id);
+      const finalB = finalTasks.find((t) => t.id === taskB.id);
+
+      // Both tasks run concurrently in wave 0. The fold queue is FIFO: whichever task's
+      // subchain completes first wins the ff-only merge and lands `done`; the other's
+      // cherry-pick conflicts → `blocked`. Since both tasks wrote the SAME file with
+      // DIFFERENT content, exactly one must land and the other must conflict.
+      //
+      // We cannot predict which task folds first (it depends on goroutine scheduling),
+      // so we assert the OUTCOME invariants rather than task-specific statuses.
+      const doneTask = finalTasks.find((t) => t.status === 'done');
+      const blockedTask = finalTasks.find((t) => t.status === 'blocked');
+
+      // Exactly one task must be done and exactly one must be blocked.
+      expect(doneTask).toBeDefined();
+      expect(blockedTask).toBeDefined();
+      // The blocked task's reason must mention the conflict so the operator knows what happened.
+      if (blockedTask?.status === 'blocked') {
+        expect(blockedTask.blockedReason).toMatch(/fold conflict/i);
+      }
+
+      // Sanity: both tasks must have settled (neither still todo or in_progress).
+      expect(finalA?.status).not.toBe('todo');
+      expect(finalA?.status).not.toBe('in_progress');
+      expect(finalB?.status).not.toBe('todo');
+      expect(finalB?.status).not.toBe('in_progress');
+
+      const { execSync } = await import('node:child_process');
+
+      // The content on the sprint branch must be whichever task folded first.
+      // It must be one of the two values — not the original seed content (which was overwritten)
+      // and not a conflict marker (which would mean cherry-pick --abort didn't run).
+      const sharedContent = execSync(`git -C "${repoPath}" show "${SPRINT_BRANCH}:shared.txt"`, {
+        encoding: 'utf8',
+      });
+      const taskAContent = 'modified by task-a';
+      const taskBContent = 'modified by task-b';
+      const landedContent = sharedContent.trim();
+      expect([taskAContent, taskBContent]).toContain(landedContent);
+
+      // The folded content must correspond to the task that ended `done`.
+      // If task A is done, sprint branch must have task A's content (and vice versa).
+      const expectedContent = doneTask?.id === taskA.id ? taskAContent : taskBContent;
+      expect(landedContent).toBe(expectedContent);
+
+      // Sprint branch must be clean (no in-progress cherry-pick state).
+      const cherryPickHead = join(repoPath, '.git', 'CHERRY_PICK_HEAD');
+      await expect(fs.access(cherryPickHead)).rejects.toThrow(); // file must not exist
+
+      const statusOut = execSync(`git -C "${repoPath}" status --porcelain`, { encoding: 'utf8' });
+      expect(statusOut.trim()).toBe('');
+
+      // No merge commits — history is still linear.
+      const mergeCommits = execSync(`git -C "${repoPath}" log --merges --oneline "${SPRINT_BRANCH}"`, {
+        encoding: 'utf8',
+      }).trim();
+      expect(mergeCommits).toBe('');
+
+      // Worktrees cleaned up.
+      const worktrees = await listWorktrees(repoPath);
+      expect(worktrees).toHaveLength(1);
+      expect(worktrees[0]).toBe(repoPath);
+
+      // No stale wt-* branch refs.
+      const branchListRaw = execSync(`git -C "${repoPath}" branch -a`, { encoding: 'utf8' });
+      expect(branchListRaw).not.toContain(`wt-${String(taskA.id)}`);
+      expect(branchListRaw).not.toContain(`wt-${String(taskB.id)}`);
+
+      // Sprint transitions to review: wave completed (A done, B blocked — both tasks settled).
+      expect(sprintStore.current().status).toBe('review');
+    }, 120_000);
+  });
+}

--- a/tests/integration/application/flows/implement/parallel-element.test.ts
+++ b/tests/integration/application/flows/implement/parallel-element.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AppEvent } from '@src/business/observability/events.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { FileLocker } from '@src/integration/io/file-locker.ts';
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import type { WaveBranch } from '@src/application/chain/run/wave-scheduler.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementWavePlan } from '@src/application/flows/implement/flow.ts';
+import {
+  createParallelImplementElement,
+  type ParallelImplementConfig,
+} from '@src/application/flows/implement/parallel-element.ts';
+
+import { absolutePath, makeDoneTask, makePlannedSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
+
+const SPRINT_DIR = absolutePath('/data/sprints/s1');
+const LOCKS_ROOT = absolutePath('/state/locks');
+
+const stubBus = (events: AppEvent[]): EventBus => ({
+  publish: (e) => events.push(e),
+  subscribe: () => () => {},
+});
+
+/** A real-ish file locker that records lock/unlock order and holds the lock across `fn`. */
+const recordingLocker = (log: string[]): FileLocker => ({
+  async withLock(_lockPath, fn) {
+    log.push('lock-acquire');
+    try {
+      const value = await fn();
+      return Result.ok(value) as never;
+    } finally {
+      log.push('lock-release');
+    }
+  },
+});
+
+/** A file locker that always fails to acquire (contention). */
+const failingLocker = (): FileLocker => ({
+  async withLock() {
+    return Result.error(new StorageError({ subCode: 'lock', message: 'contended' }));
+  },
+});
+
+/** A trivial element that tags ctx and records its run in `log`. */
+const tagElement = (name: string, log: string[], tag?: (ctx: ImplementCtx) => ImplementCtx): Element<ImplementCtx> => ({
+  name,
+  async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+    log.push(name);
+    return Result.ok({ ctx: tag ? tag(ctx) : ctx, trace: [] });
+  },
+});
+
+/** Mutable cell recording the task list the epilogue stand-in was handed (mimics `saveTasksLeaf`). */
+interface Persisted {
+  tasks: readonly Task[] | undefined;
+}
+
+/** An epilogue stand-in that records the `tasks` it was handed (mimics `saveTasksLeaf`). */
+const recordingEpilogue = (log: string[], persisted: Persisted): Element<ImplementCtx> => ({
+  name: 'implement-epilogue',
+  async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+    log.push('epilogue');
+    persisted.tasks = ctx.tasks;
+    return Result.ok({ ctx, trace: [] });
+  },
+});
+
+/**
+ * A branch element that completes immediately, settling its task `done`. Mirrors the real branch
+ * contract: the outcome ctx carries ONLY the branch's OWN task (so the merge overlay is disjoint).
+ */
+const doneBranch = (task: Task, log: string[]): WaveBranch<ImplementCtx> => ({
+  id: `task-${String(task.id)}`,
+  element: {
+    name: `branch-${String(task.id)}`,
+    async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+      log.push(`branch-${task.name}`);
+      const done: Task = { ...makeDoneTask({ name: task.name }), id: task.id };
+      return Result.ok({ ctx: { ...ctx, tasks: [done] }, trace: [] });
+    },
+  },
+});
+
+/** A branch element that hangs until aborted (mimics a long task killed mid-flight). */
+const hangingBranch = (task: Task, log: string[], cleanups: string[]): WaveBranch<ImplementCtx> => ({
+  id: `task-${String(task.id)}`,
+  element: {
+    name: `branch-${String(task.id)}`,
+    async execute(_ctx, signal): Promise<ElementResult<ImplementCtx>> {
+      log.push(`branch-${task.name}`);
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) return resolve();
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      cleanups.push(task.name); // a stand-in for worktree cleanup
+      const error = new AbortError({ elementName: `branch-${String(task.id)}` });
+      return Result.error({
+        error,
+        trace: [{ elementName: `branch-${String(task.id)}`, status: 'aborted', durationMs: 0, error }],
+      });
+    },
+  },
+});
+
+const plan = (
+  prologue: Element<ImplementCtx>,
+  epilogue: Element<ImplementCtx>,
+  waves: ReadonlyArray<readonly Task[]>
+): ImplementWavePlan => ({ prologue, epilogue, waves, lockKey: SPRINT_DIR });
+
+const baseConfig = (
+  over: Partial<ParallelImplementConfig> & { buildWaves: ParallelImplementConfig['buildWaves'] },
+  locker: FileLocker,
+  bus: EventBus
+): ParallelImplementConfig => ({
+  fileLocker: locker,
+  locksRoot: LOCKS_ROOT,
+  eventBus: bus,
+  maxConcurrency: 3,
+  flowId: 'implement',
+  sessionId: (() => {
+    let n = 0;
+    return () => `sub-${String(n++)}`;
+  })(),
+  ...over,
+});
+
+const ctxWith = (tasks: readonly Task[]): ImplementCtx => {
+  const sprint = makePlannedSprint();
+  return { sprintId: sprint.id, sprint, tasks };
+};
+
+describe('createParallelImplementElement — happy path under one held lock', () => {
+  it('runs prologue → waves → epilogue inside ONE held lock, in that order', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const log: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const locker = recordingLocker(lockLog);
+    const bus = stubBus([]);
+
+    const prologue = tagElement('implement-prologue', log);
+    const epilogue = recordingEpilogue(log, persisted);
+    const branches = [[doneBranch(t1, log), doneBranch(t2, log)]];
+
+    const element = createParallelImplementElement(
+      plan(prologue, epilogue, [[t1, t2]]),
+      baseConfig({ buildWaves: () => branches }, locker, bus)
+    );
+    const result = await element.execute(ctxWith([t1, t2]));
+
+    expect(result.ok).toBe(true);
+    // Prologue before any branch; epilogue after both branches; all between lock acquire + release.
+    expect(log[0]).toBe('implement-prologue');
+    expect(log[log.length - 1]).toBe('epilogue');
+    expect(lockLog).toEqual(['lock-acquire', 'lock-release']);
+    // Epilogue persisted both tasks done.
+    expect(persisted.tasks?.every((t) => t.status === 'done')).toBe(true);
+  });
+});
+
+describe('createParallelImplementElement — B4 abort durability gate', () => {
+  it('persists task-1 (folded) as done on abort during task-2; tasks 2/3 stay todo; AbortError verbatim', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const t3 = makeTodoTask({ name: 't3' });
+    const log: string[] = [];
+    const cleanups: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const locker = recordingLocker(lockLog);
+    const bus = stubBus([]);
+    const ac = new AbortController();
+
+    // Wave of 3: t1 folds done immediately; t2 + t3 hang. Abort fires after t1 completes.
+    const branches = [
+      [completeThenAbort(t1, log, ac), hangingBranch(t2, log, cleanups), hangingBranch(t3, log, cleanups)],
+    ];
+
+    const prologue = tagElement('implement-prologue', log);
+    const epilogue = recordingEpilogue(log, persisted);
+
+    const element = createParallelImplementElement(
+      plan(prologue, epilogue, [[t1, t2, t3]]),
+      baseConfig({ buildWaves: () => branches, maxConcurrency: 3 }, locker, bus)
+    );
+    const result = await element.execute(ctxWith([t1, t2, t3]), ac.signal);
+
+    // AbortError propagates verbatim so the sprint stays runnable.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+
+    // THE B4 GATE: the epilogue STILL ran (under the lock) on the partially-merged ctx, so task-1's
+    // fold is durably recorded as done; tasks 2 + 3 reset to todo (never folded) and re-run.
+    expect(log).toContain('epilogue');
+    expect(persisted.tasks?.find((t) => t.id === t1.id)?.status).toBe('done');
+    expect(persisted.tasks?.find((t) => t.id === t2.id)?.status).toBe('todo');
+    expect(persisted.tasks?.find((t) => t.id === t3.id)?.status).toBe('todo');
+    // The hanging branches ran their cleanup (worktree teardown stand-in).
+    expect(cleanups.sort()).toEqual(['t2', 't3']);
+    // Everything stayed inside the single held lock.
+    expect(lockLog).toEqual(['lock-acquire', 'lock-release']);
+  });
+});
+
+/** A branch that settles task `done`, then trips the abort controller so siblings get killed. */
+const completeThenAbort = (task: Task, log: string[], ac: AbortController): WaveBranch<ImplementCtx> => ({
+  id: `task-${String(task.id)}`,
+  element: {
+    name: `branch-${String(task.id)}`,
+    async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+      log.push(`branch-${task.name}`);
+      const done: Task = { ...makeDoneTask({ name: task.name }), id: task.id };
+      // Fire the abort on the next microtask so this branch completes first, THEN siblings are killed.
+      queueMicrotask(() => ac.abort());
+      return Result.ok({ ctx: { ...ctx, tasks: [done] }, trace: [] });
+    },
+  },
+});
+
+describe('createParallelImplementElement — prologue failure', () => {
+  it('still runs the epilogue under the lock, then propagates the prologue error', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const log: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const bus = stubBus([]);
+
+    const failingPrologue: Element<ImplementCtx> = {
+      name: 'implement-prologue',
+      async execute(): Promise<ElementResult<ImplementCtx>> {
+        log.push('implement-prologue');
+        const error = new StorageError({ subCode: 'io', message: 'dirty tree' });
+        return Result.error({
+          error,
+          trace: [{ elementName: 'implement-prologue', status: 'failed', durationMs: 0, error }],
+        });
+      },
+    };
+    const epilogue = recordingEpilogue(log, persisted);
+    const buildWaves = vi.fn(() => [] as ReadonlyArray<ReadonlyArray<WaveBranch<ImplementCtx>>>);
+
+    const element = createParallelImplementElement(
+      plan(failingPrologue, epilogue, [[t1]]),
+      baseConfig({ buildWaves }, recordingLocker(lockLog), bus)
+    );
+    const result = await element.execute(ctxWith([t1]));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(StorageError);
+    // Waves never built (no prologue success); epilogue still ran under the lock.
+    expect(buildWaves).not.toHaveBeenCalled();
+    expect(log).toEqual(['implement-prologue', 'epilogue']);
+    expect(lockLog).toEqual(['lock-acquire', 'lock-release']);
+  });
+});
+
+describe('createParallelImplementElement — lock contention', () => {
+  it('surfaces the lock failure without running prologue / waves / epilogue', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const log: string[] = [];
+    const buildWaves = vi.fn(() => [] as ReadonlyArray<ReadonlyArray<WaveBranch<ImplementCtx>>>);
+
+    const element = createParallelImplementElement(
+      plan(tagElement('implement-prologue', log), tagElement('implement-epilogue', log), [[t1]]),
+      baseConfig({ buildWaves }, failingLocker(), stubBus([]))
+    );
+    const result = await element.execute(ctxWith([t1]));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(StorageError);
+    expect(log).toEqual([]);
+    expect(buildWaves).not.toHaveBeenCalled();
+  });
+});
+
+describe('createParallelImplementElement — uses the sprint-dir lock key', () => {
+  it('locks on repoLockFile(locksRoot, sprintDir) — same key the serial path uses', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    let lockedPath: AbsolutePath | undefined;
+    const locker: FileLocker = {
+      async withLock(lockPath, fn) {
+        lockedPath = lockPath;
+        return Result.ok(await fn()) as never;
+      },
+    };
+    const element = createParallelImplementElement(
+      plan(tagElement('implement-prologue', []), recordingEpilogue([], { tasks: undefined }), [[t1]]),
+      baseConfig({ buildWaves: () => [[doneBranch(t1, [])]] }, locker, stubBus([]))
+    );
+    await element.execute(ctxWith([t1]));
+
+    // The lock path is derived from the sprint-dir lock key (a `repo-<hash>.lock` under locksRoot).
+    expect(lockedPath).toBeDefined();
+    expect(String(lockedPath)).toContain(String(LOCKS_ROOT));
+    expect(String(lockedPath)).toMatch(/repo-[0-9a-f]{16}\.lock$/);
+  });
+});
+
+describe('createParallelImplementElement — lock contention (subCode)', () => {
+  it('returns StorageError with subCode lock and never calls buildWaves when lock is contended', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const buildWaves = vi.fn(() => [] as ReadonlyArray<ReadonlyArray<WaveBranch<ImplementCtx>>>);
+    const log: string[] = [];
+
+    const element = createParallelImplementElement(
+      plan(tagElement('implement-prologue', log), tagElement('implement-epilogue', log), [[t1]]),
+      baseConfig({ buildWaves }, failingLocker(), stubBus([]))
+    );
+    const result = await element.execute(ctxWith([t1]));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(StorageError);
+    expect((result.error.error as StorageError).subCode).toBe('lock');
+    // No prologue/epilogue ran and no branch was built.
+    expect(log).toEqual([]);
+    expect(buildWaves).not.toHaveBeenCalled();
+  });
+});
+
+describe('createParallelImplementElement — no EventBus subscriber leak after wave settles', () => {
+  it('returns live-listener count to baseline (0 net) after execute resolves', async () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const log: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const locker = recordingLocker(lockLog);
+
+    // Counting EventBus: subscribe increments the live counter; the returned unsubscribe
+    // decrements it. After execute() the counter must be back to 0.
+    let liveListeners = 0;
+    const countingBus: EventBus = {
+      publish: () => {},
+      subscribe: (handler) => {
+        liveListeners++;
+        let active = true;
+        const wrapped = (e: AppEvent): void => {
+          if (active) handler(e);
+        };
+        // We must satisfy the EventBus contract: subscribe returns an unsubscribe fn.
+        // The bus itself doesn't hold `wrapped` — bridgeRunnerToEventBus holds the unsub.
+        void wrapped;
+        return () => {
+          if (active) {
+            active = false;
+            liveListeners--;
+          }
+        };
+      },
+    };
+
+    const prologue = tagElement('implement-prologue', log);
+    const epilogue = recordingEpilogue(log, persisted);
+    const branches = [[doneBranch(t1, log)]];
+
+    const element = createParallelImplementElement(
+      plan(prologue, epilogue, [[t1]]),
+      baseConfig({ buildWaves: () => branches }, locker, countingBus)
+    );
+    await element.execute(ctxWith([t1]));
+
+    // All bridged subscriptions (prologue sub-runner, branch runner, epilogue sub-runner) must have
+    // self-detached on terminal — zero net listeners left over.
+    expect(liveListeners).toBe(0);
+  });
+});
+
+describe('createParallelImplementElement — 2-wave durable fold survives abort of wave 1', () => {
+  it('epilogue receives wave-0 task as done and final result is AbortError when wave 1 is aborted', async () => {
+    const t1 = makeTodoTask({ name: 't1' }); // wave 0 — completes
+    const t2 = makeTodoTask({ name: 't2' }); // wave 1 — hangs until abort
+    const log: string[] = [];
+    const cleanups: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const locker = recordingLocker(lockLog);
+    const bus = stubBus([]);
+
+    const ac = new AbortController();
+
+    // Wave 0: t1 completes immediately and then schedules the outer abort so wave 1 gets killed.
+    const wave0Branch: WaveBranch<ImplementCtx> = {
+      id: `task-${String(t1.id)}`,
+      element: {
+        name: `branch-${String(t1.id)}`,
+        async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+          log.push('branch-t1');
+          const done: Task = { ...makeDoneTask({ name: t1.name }), id: t1.id };
+          // Defer the abort so wave 0 settles first and its ctx is folded into prologueCtx
+          // before wave 1 kicks off.
+          queueMicrotask(() => ac.abort());
+          return Result.ok({ ctx: { ...ctx, tasks: [done] }, trace: [] });
+        },
+      },
+    };
+
+    const wave1Branch = hangingBranch(t2, log, cleanups);
+
+    // 2-wave plan: wave 0 has t1, wave 1 has t2.
+    const waves = [[wave0Branch], [wave1Branch]];
+
+    const prologue = tagElement('implement-prologue', log);
+    const epilogue = recordingEpilogue(log, persisted);
+
+    const element = createParallelImplementElement(
+      plan(prologue, epilogue, [[t1], [t2]]),
+      baseConfig({ buildWaves: () => waves }, locker, bus)
+    );
+    const result = await element.execute(ctxWith([t1, t2]), ac.signal);
+
+    // The outer result is an AbortError so the sprint stays runnable.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+
+    // THE B4 GATE across waves: the epilogue ran and its ctx has t1 durably folded as done.
+    expect(log).toContain('epilogue');
+    expect(persisted.tasks?.find((t) => t.id === t1.id)?.status).toBe('done');
+    // t2 never folded (aborted mid-flight) → stays todo in the overlay.
+    expect(persisted.tasks?.find((t) => t.id === t2.id)?.status).toBe('todo');
+
+    // Everything stayed inside the single held lock.
+    expect(lockLog).toEqual(['lock-acquire', 'lock-release']);
+  });
+});

--- a/tests/unit/application/chain/run/wave-scheduler.test.ts
+++ b/tests/unit/application/chain/run/wave-scheduler.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import type { TraceEntry } from '@src/application/chain/trace.ts';
+import {
+  type BranchOutcome,
+  type WaveBranch,
+  type WaveScheduleConfig,
+  runWaves,
+} from '@src/application/chain/run/wave-scheduler.ts';
+
+interface Ctx {
+  readonly trail: readonly string[];
+}
+
+const BASE: Ctx = { trail: [] };
+
+/** Build a completed trace entry for a fake element. */
+const doneEntry = (name: string): TraceEntry => ({ elementName: name, status: 'completed', durationMs: 0 });
+
+/**
+ * A leaf-ish element with full instrumentation control: it bumps a shared in-flight gauge on entry,
+ * waits for a caller-controlled gate, then settles (ok or with a supplied error) and decrements the
+ * gauge. Honours the runner's abort signal so a kill tears it down promptly + runs `onCleanup`.
+ */
+interface FakeElementOpts {
+  readonly name: string;
+  readonly gauge: { count: number; max: number };
+  readonly settle: Promise<void>;
+  readonly error?: () => DomainError;
+  readonly onCleanup?: () => void;
+}
+
+const fakeElement = (opts: FakeElementOpts): Element<Ctx> => ({
+  name: opts.name,
+  async execute(ctx, signal, onTrace): Promise<ElementResult<Ctx>> {
+    opts.gauge.count += 1;
+    opts.gauge.max = Math.max(opts.gauge.max, opts.gauge.count);
+    try {
+      await Promise.race([
+        opts.settle,
+        new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        }),
+      ]);
+    } finally {
+      opts.gauge.count -= 1;
+    }
+
+    if (signal?.aborted) {
+      opts.onCleanup?.();
+      const error = new AbortError({ elementName: opts.name });
+      const entry: TraceEntry = { elementName: opts.name, status: 'aborted', durationMs: 0, error };
+      onTrace?.(entry);
+      return Result.error({ error, trace: [entry] });
+    }
+    if (opts.error) {
+      const error = opts.error();
+      const entry: TraceEntry = { elementName: opts.name, status: 'failed', durationMs: 0, error };
+      onTrace?.(entry);
+      return Result.error({ error, trace: [entry] });
+    }
+    const entry = doneEntry(opts.name);
+    onTrace?.(entry);
+    return Result.ok({ ctx: { trail: [...ctx.trail, opts.name] }, trace: [entry] });
+  },
+});
+
+/** Immediately-completing element — for synchronous-ish ordering / sequential-degrade tests. */
+const okElement = (name: string): Element<Ctx> => ({
+  name,
+  async execute(ctx, _signal, onTrace): Promise<ElementResult<Ctx>> {
+    const entry = doneEntry(name);
+    onTrace?.(entry);
+    return Result.ok({ ctx: { trail: [...ctx.trail, name] }, trace: [entry] });
+  },
+});
+
+/** A deferred handle so a test can release a branch's gate at a precise moment. */
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+/** Default config: pass-through merge that records nothing extra; concat each outcome's trail. */
+const mergeConcat: WaveScheduleConfig<Ctx>['merge'] = (base, outcomes) => ({
+  trail: [...base.trail, ...outcomes.flatMap((o) => o.ctx.trail.filter((t) => !base.trail.includes(t)))],
+});
+
+const cfg = (over: Partial<WaveScheduleConfig<Ctx>> = {}): WaveScheduleConfig<Ctx> => ({
+  maxConcurrency: 5,
+  merge: mergeConcat,
+  ...over,
+});
+
+describe('runWaves — pool bound', () => {
+  it('never exceeds maxConcurrency in flight across a 30-branch wave', async () => {
+    const gauge = { count: 0, max: 0 };
+    // Each branch resolves on a microtask tick; the gauge records the high-water mark.
+    const branches: Array<WaveBranch<Ctx>> = Array.from({ length: 30 }, (_, i) => ({
+      id: `t${String(i)}`,
+      element: fakeElement({ name: `b${String(i)}`, gauge, settle: Promise.resolve() }),
+    }));
+
+    const result = await runWaves([branches], BASE, cfg({ maxConcurrency: 5 }));
+
+    expect(result.ok).toBe(true);
+    expect(gauge.max).toBeLessThanOrEqual(5);
+    expect(gauge.max).toBeGreaterThan(0);
+  });
+
+  it('re-clamps maxConcurrency above 5 down to 5', async () => {
+    const gauge = { count: 0, max: 0 };
+    const gate = deferred();
+    const branches: Array<WaveBranch<Ctx>> = Array.from({ length: 12 }, (_, i) => ({
+      id: `t${String(i)}`,
+      element: fakeElement({ name: `b${String(i)}`, gauge, settle: gate.promise }),
+    }));
+
+    const run = runWaves([branches], BASE, cfg({ maxConcurrency: 99 }));
+    // Let the pool prime before the gate opens.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(gauge.max).toBeLessThanOrEqual(5);
+    gate.resolve();
+    const result = await run;
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('runWaves — strictly sequential waves', () => {
+  it('does not start wave k+1 before wave k fully settles and merges', async () => {
+    const order: string[] = [];
+    const gaugeA = { count: 0, max: 0 };
+    const gaugeB = { count: 0, max: 0 };
+    const gateA = deferred();
+
+    const waveA: Array<WaveBranch<Ctx>> = [{ id: 'a', element: fakeElementTracked('a', gaugeA, gateA.promise, order) }];
+    const waveB: Array<WaveBranch<Ctx>> = [
+      { id: 'b', element: fakeElementTracked('b', gaugeB, Promise.resolve(), order) },
+    ];
+
+    const config = cfg({
+      merge: (base, outcomes) => {
+        order.push('merge');
+        return mergeConcat(base, outcomes);
+      },
+    });
+
+    const run = runWaves([waveA, waveB], BASE, config);
+    await Promise.resolve();
+    await Promise.resolve();
+    // Wave B must not have started, and merge must not have run, while A is still gated.
+    expect(order).toEqual(['enter:a']);
+
+    gateA.resolve();
+    const result = await run;
+    expect(result.ok).toBe(true);
+    // Wave A fully settled (enter+exit) AND merge ran before wave B entered; B then settles + merges.
+    expect(order).toEqual(['enter:a', 'exit:a', 'merge', 'enter:b', 'exit:b', 'merge']);
+  });
+});
+
+/** Like `fakeElement` but records enter/exit markers + a merge marker is pushed by the test. */
+const fakeElementTracked = (
+  name: string,
+  gauge: { count: number; max: number },
+  settle: Promise<void>,
+  order: string[]
+): Element<Ctx> => ({
+  name,
+  async execute(ctx): Promise<ElementResult<Ctx>> {
+    gauge.count += 1;
+    order.push(`enter:${name}`);
+    await settle;
+    gauge.count -= 1;
+    order.push(`exit:${name}`);
+    return Result.ok({ ctx: { trail: [...ctx.trail, name] }, trace: [doneEntry(name)] });
+  },
+});
+
+describe('runWaves — deterministic trace', () => {
+  it('assembles the combined trace in branch-declaration order, not completion order', async () => {
+    const gauge = { count: 0, max: 0 };
+    // b0 settles LAST, b2 settles FIRST — completion order is the reverse of declaration order.
+    const gates = [deferred(), deferred(), deferred()];
+    const branches: Array<WaveBranch<Ctx>> = [0, 1, 2].map((i) => ({
+      id: `t${String(i)}`,
+      element: fakeElement({ name: `b${String(i)}`, gauge, settle: gates[i]!.promise }),
+    }));
+
+    const run = runWaves([branches], BASE, cfg());
+    await Promise.resolve();
+    gates[2]!.resolve();
+    await Promise.resolve();
+    gates[1]!.resolve();
+    await Promise.resolve();
+    gates[0]!.resolve();
+    const result = await run;
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Declaration order b0, b1, b2 — independent of the b2→b1→b0 completion order.
+    expect(result.value.trace.map((e) => e.elementName)).toEqual(['b0', 'b1', 'b2']);
+  });
+});
+
+describe('runWaves — non-fatal absorption', () => {
+  it('absorbs a non-fatal branch failure and lets siblings continue', async () => {
+    const gauge = { count: 0, max: 0 };
+    const branches: Array<WaveBranch<Ctx>> = [
+      { id: 'ok1', element: fakeElement({ name: 'ok1', gauge, settle: Promise.resolve() }) },
+      {
+        id: 'bad',
+        element: fakeElement({
+          name: 'bad',
+          gauge,
+          settle: Promise.resolve(),
+          error: () => new ValidationError({ field: 'x', value: 0, message: 'boom' }),
+        }),
+      },
+      { id: 'ok2', element: fakeElement({ name: 'ok2', gauge, settle: Promise.resolve() }) },
+    ];
+
+    const captured: Array<BranchOutcome<Ctx>> = [];
+    const config = cfg({
+      merge: (base, outcomes) => {
+        captured.push(...outcomes);
+        return mergeConcat(base, outcomes);
+      },
+    });
+
+    const result = await runWaves([branches], BASE, config);
+
+    expect(result.ok).toBe(true);
+    expect(captured.map((o) => `${o.id}:${o.status}`)).toEqual(['ok1:completed', 'bad:failed', 'ok2:completed']);
+    expect(captured.find((o) => o.id === 'bad')?.error).toBeInstanceOf(ValidationError);
+  });
+});
+
+describe('runWaves — abort wins with bounded settle + cleanup', () => {
+  it('forwards an outer abort, settles in-flight branches with a bounded wait, runs their cleanup, returns AbortError verbatim', async () => {
+    const gauge = { count: 0, max: 0 };
+    const cleanups: string[] = [];
+    // These branches never resolve on their own — only an abort can settle them. If the abort were
+    // NOT forwarded, `runWaves` would hang forever; the test's own timeout would catch that. We
+    // additionally assert the settle is prompt (resolves on the next macrotask, no real wait).
+    const branches: Array<WaveBranch<Ctx>> = [0, 1].map((i) => ({
+      id: `t${String(i)}`,
+      element: fakeElement({
+        name: `b${String(i)}`,
+        gauge,
+        settle: new Promise<void>(() => {}),
+        onCleanup: () => cleanups.push(`b${String(i)}`),
+      }),
+    }));
+
+    const ac = new AbortController();
+    const run = runWaves([branches], BASE, cfg(), ac.signal);
+
+    // Let the pool prime, then abort.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(gauge.count).toBe(2);
+    ac.abort();
+
+    // Bounded settle: the whole run resolves before this 100ms guard, proving the abort propagated
+    // and we did not block on the never-resolving `settle` promise.
+    const settledInTime = await Promise.race([
+      run.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 100)),
+    ]);
+    expect(settledInTime).toBe(true);
+
+    const result = await run;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // AbortError returned verbatim (NOT folded into a per-branch outcome).
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    // Every in-flight branch settled (gauge drained) and its cleanup actually ran.
+    expect(gauge.count).toBe(0);
+    expect(cleanups.sort()).toEqual(['b0', 'b1']);
+  });
+
+  it('never launches a branch when the outer signal is already aborted', async () => {
+    const gauge = { count: 0, max: 0 };
+    const ac = new AbortController();
+    ac.abort();
+    const branches: Array<WaveBranch<Ctx>> = [
+      { id: 'a', element: fakeElement({ name: 'a', gauge, settle: Promise.resolve() }) },
+    ];
+
+    const result = await runWaves([branches], BASE, cfg(), ac.signal);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(gauge.max).toBe(0);
+  });
+});
+
+describe('runWaves — rate-limit fatal', () => {
+  it("'drain' (default) lets in-flight siblings finish, then stops launching the rest of the wave", async () => {
+    const gauge = { count: 0, max: 0 };
+    const siblingGate = deferred();
+    const siblingFinished = vi.fn();
+
+    // Wave of 4, cap 2: t0 hits rate-limit immediately; t1 is in flight and must finish; t2/t3
+    // must never launch.
+    const launched: string[] = [];
+    const mk = (id: string, error?: () => DomainError, gate?: Promise<void>): WaveBranch<Ctx> => ({
+      id,
+      element: {
+        name: id,
+        async execute(ctx, signal): Promise<ElementResult<Ctx>> {
+          launched.push(id);
+          gauge.count += 1;
+          await (gate ?? Promise.resolve());
+          gauge.count -= 1;
+          if (signal?.aborted) {
+            const e = new AbortError({ elementName: id });
+            return Result.error({ error: e, trace: [{ elementName: id, status: 'aborted', durationMs: 0, error: e }] });
+          }
+          if (error) {
+            const e = error();
+            return Result.error({ error: e, trace: [{ elementName: id, status: 'failed', durationMs: 0, error: e }] });
+          }
+          if (id === 't1') siblingFinished();
+          return Result.ok({ ctx, trace: [doneEntry(id)] });
+        },
+      },
+    });
+
+    const branches = [
+      mk('t0', () => new RateLimitError({ subCode: 'spawn-exit' })),
+      mk('t1', undefined, siblingGate.promise),
+      mk('t2'),
+      mk('t3'),
+    ];
+
+    const run = runWaves([branches], BASE, cfg({ maxConcurrency: 2, onFatal: 'drain' }));
+    await Promise.resolve();
+    await Promise.resolve();
+    // The in-flight sibling t1 has not finished yet (gated); release it now.
+    siblingGate.resolve();
+    const result = await run;
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(RateLimitError);
+    // t1 finished cleanly (drained), t2/t3 never launched.
+    expect(siblingFinished).toHaveBeenCalledTimes(1);
+    expect(launched.sort()).toEqual(['t0', 't1']);
+  });
+
+  it("'kill' aborts in-flight siblings immediately on a rate-limit", async () => {
+    const gauge = { count: 0, max: 0 };
+    const cleanups: string[] = [];
+    const branches: Array<WaveBranch<Ctx>> = [
+      {
+        id: 't0',
+        element: fakeElement({
+          name: 't0',
+          gauge,
+          settle: Promise.resolve(),
+          error: () => new RateLimitError({ subCode: 'spawn-exit' }),
+        }),
+      },
+      {
+        id: 't1',
+        element: fakeElement({
+          name: 't1',
+          gauge,
+          settle: new Promise<void>(() => {}),
+          onCleanup: () => cleanups.push('t1'),
+        }),
+      },
+    ];
+
+    const result = await runWaves([branches], BASE, cfg({ maxConcurrency: 2, onFatal: 'kill' }));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(RateLimitError);
+    expect(gauge.count).toBe(0);
+    expect(cleanups).toEqual(['t1']);
+  });
+});
+
+describe('runWaves — maxConcurrency === 1 degrades to fully sequential', () => {
+  it('runs branches one at a time in declaration order', async () => {
+    const gauge = { count: 0, max: 0 };
+    const branches: Array<WaveBranch<Ctx>> = ['a', 'b', 'c', 'd'].map((id) => ({
+      id,
+      element: fakeElement({ name: id, gauge, settle: Promise.resolve() }),
+    }));
+
+    const result = await runWaves([branches], BASE, cfg({ maxConcurrency: 1 }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(gauge.max).toBe(1);
+    expect(result.value.trace.map((e) => e.elementName)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('treats a single multi-branch wave with cap 1 identically to N singleton waves', async () => {
+    const branches: Array<WaveBranch<Ctx>> = ['a', 'b'].map((id) => ({ id, element: okElement(id) }));
+    const wide = await runWaves([branches], BASE, cfg({ maxConcurrency: 1 }));
+    const singletons = await runWaves([[branches[0]!], [branches[1]!]], BASE, cfg({ maxConcurrency: 1 }));
+
+    expect(wide.ok && singletons.ok).toBe(true);
+    if (!wide.ok || !singletons.ok) return;
+    expect(wide.value.trace.map((e) => e.elementName)).toEqual(singletons.value.trace.map((e) => e.elementName));
+  });
+});
+
+describe('runWaves — onBranchRunner hook', () => {
+  it('invokes onBranchRunner once per branch with the branch and a runner whose id matches', async () => {
+    const seen: Array<{ id: string; runnerId: string }> = [];
+    const branches: Array<WaveBranch<Ctx>> = ['a', 'b'].map((id) => ({ id, element: okElement(id) }));
+
+    await runWaves(
+      [branches],
+      BASE,
+      cfg({ onBranchRunner: (runner, branch) => seen.push({ id: branch.id, runnerId: runner.id }) })
+    );
+
+    expect(seen).toEqual([
+      { id: 'a', runnerId: 'a' },
+      { id: 'b', runnerId: 'b' },
+    ]);
+  });
+});

--- a/tests/unit/application/flows/implement/flow-shape.test.ts
+++ b/tests/unit/application/flows/implement/flow-shape.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Task } from '@src/domain/entity/task.ts';
+import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { guard } from '@src/application/chain/build/guard.ts';
+import { sequential } from '@src/application/chain/build/sequential.ts';
+import { loadSprintExecutionLeaf } from '@src/application/flows/_shared/sprint/load-execution.ts';
+import { loadTasksLeaf } from '@src/application/flows/_shared/task/load.ts';
+import { saveTasksLeaf } from '@src/application/flows/_shared/task/save.ts';
+import { loadAndAssertSprintSubChain } from '@src/application/flows/_shared/sprint/load-and-assert-sprint.ts';
+import { activateSprintLeaf } from '@src/application/flows/implement/leaves/activate-sprint.ts';
+import { appendJournalSeparatorLeaf } from '@src/application/flows/_shared/progress/append-journal-separator.ts';
+import { createPerTaskSubchain } from '@src/application/flows/implement/leaves/per-task-subchain.ts';
+import { type DirtyTreePolicy } from '@src/application/flows/implement/leaves/preflight-task.ts';
+import { resolveBranchLeaf } from '@src/application/flows/implement/leaves/resolve-branch.ts';
+import { resolveRepoOrThrow } from '@src/application/flows/implement/leaves/resolve-repo.ts';
+import { setupScriptRunnerLeaf } from '@src/application/flows/implement/leaves/setup-script-runner.ts';
+import {
+  buildPreflightLeaves,
+  buildWorkingTreeCleanLeaves,
+  setupRepoEntriesForTasks,
+  uniqueRepoCwdsForTasks,
+} from '@src/application/flows/implement/leaves/sprint-repo-plan.ts';
+import { transitionSprintToReviewLeaf } from '@src/application/flows/implement/leaves/transition-sprint-to-review.ts';
+import { withRepoLock } from '@src/application/flows/implement/leaves/with-repo-lock.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import {
+  buildImplementEpilogue,
+  buildImplementPrologue,
+  type CreateImplementFlowOpts,
+  createImplementFlow,
+  IMPLEMENT_TASK_TERMINAL_LEAF,
+  planImplementWaves,
+  type RepoExecConfig,
+} from '@src/application/flows/implement/flow.ts';
+
+import { absolutePath, FIXED_REPOSITORY_ID, makeTodoTask } from '@tests/fixtures/domain.ts';
+
+/**
+ * A serialisable snapshot of an element tree: name + optional label + recursively-snapshotted
+ * children. Walking `Element.children` (never executing) is exactly what the TUI does to render the
+ * upfront plan, so this captures the OBSERVABLE chain shape — the thing the serial-shape fence must
+ * keep byte-for-byte stable through the prologue/epilogue extraction. Names, labels, child count,
+ * and nesting are all compared.
+ */
+interface ShapeNode {
+  readonly name: string;
+  readonly label?: string;
+  readonly children?: readonly ShapeNode[];
+}
+
+const snapshot = <TCtx>(element: Element<TCtx>): ShapeNode => {
+  const kids = element.children;
+  return {
+    name: element.name,
+    ...(element.label !== undefined ? { label: element.label } : {}),
+    ...(kids !== undefined ? { children: kids.map((c) => snapshot(c)) } : {}),
+  };
+};
+
+const names = (node: ShapeNode): readonly string[] => [node.name, ...(node.children ?? []).flatMap((c) => names(c))];
+
+const findByName = (node: ShapeNode, target: string): ShapeNode | undefined => {
+  if (node.name === target) return node;
+  for (const c of node.children ?? []) {
+    const hit = findByName(c, target);
+    if (hit !== undefined) return hit;
+  }
+  return undefined;
+};
+
+// ── Stub deps + opts ────────────────────────────────────────────────────────────────────
+// The flow + segment builders only CONSTRUCT the element tree in these tests — no leaf ever
+// executes — so integration ports can be inert stubs. The cast is sound: every factory captures
+// its deps in a closure read lazily inside `execute`, which these tests never call. The one field
+// read EAGERLY at construction is `config.harness.{maxTurns,plateauThreshold,...}` (the gen-eval
+// loop bakes the turn budget into the element), so the stub supplies a real harness config.
+const stubDeps = (): ImplementDeps =>
+  ({
+    config: {
+      harness: {
+        maxTurns: 5,
+        maxAttempts: 3,
+        rateLimitRetries: 0,
+        plateauThreshold: 2,
+        escalateOnPlateau: false,
+        escalationMap: {},
+      },
+    },
+  }) as unknown as ImplementDeps;
+
+const makeOpts = (todoTasks: readonly Task[]): CreateImplementFlowOpts => {
+  const repositories = new Map<RepositoryId, RepoExecConfig>([
+    [FIXED_REPOSITORY_ID, { path: absolutePath('/repos/main'), name: 'main-repo', verifyScript: 'verify' }],
+  ]);
+  return {
+    sprintId: makeTodoTask().ticketId as never, // unused at construction; placeholder shape only
+    todoTasks,
+    repositories,
+    progressFile: absolutePath('/sprints/s1/progress.md'),
+    sprintDir: absolutePath('/sprints/s1'),
+    generatorProviderId: 'claude-code',
+    generatorModel: 'claude-opus-4-8',
+    evaluatorProviderId: 'openai-codex',
+    evaluatorModel: 'gpt-5.5',
+    memoryRoot: absolutePath('/data/memory'),
+    projectId: 'proj-1',
+  };
+};
+
+/**
+ * The pre-refactor serial chain shape, reconstructed inline from the exact same leaf factories the flow
+ * used to call directly (a flat `implement-locked` list wrapped in `with-repo-lock`). The central
+ * safety claim is that the prologue/epilogue extraction did NOT change this shape; asserting the
+ * live `createImplementFlow` equals this independent reconstruction proves it byte-for-byte without
+ * coupling the test to every leaf's exact name string. If a future edit drifts the serial structure,
+ * this reference and the live flow diverge and the assertion fails.
+ *
+ * This mirrors `flow.ts` as it stood before the refactor: prologue leaves inline, then `implement-tasks`,
+ * then epilogue leaves inline — no `implement-prologue` / `implement-epilogue` wrappers.
+ */
+const reconstructPreRefactorSerialFlow = (
+  deps: ImplementDeps,
+  opts: CreateImplementFlowOpts
+): Element<ImplementCtx> => {
+  const readConfig = (): Promise<{
+    readonly maxTurns: number;
+    readonly escalateOnPlateau: boolean;
+    readonly escalationMap: Readonly<Record<string, string>>;
+  }> =>
+    Promise.resolve({
+      maxTurns: deps.config.harness.maxTurns,
+      escalateOnPlateau: deps.config.harness.escalateOnPlateau,
+      escalationMap: deps.config.harness.escalationMap,
+    });
+
+  const uniqueRepoCwds = uniqueRepoCwdsForTasks(opts.repositories, opts.todoTasks);
+  const setupRepoEntries = setupRepoEntriesForTasks(opts.repositories, opts.todoTasks);
+
+  const perTaskChains = opts.todoTasks.map((task) =>
+    createPerTaskSubchain(
+      deps,
+      {
+        sprintDir: opts.sprintDir,
+        progressFile: opts.progressFile,
+        terminalLeafName: IMPLEMENT_TASK_TERMINAL_LEAF,
+        generator: {
+          providerId: opts.generatorProviderId,
+          model: opts.generatorModel,
+          ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
+        },
+        evaluator: {
+          providerId: opts.evaluatorProviderId,
+          model: opts.evaluatorModel,
+          ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
+        },
+        memoryRoot: opts.memoryRoot,
+        projectId: opts.projectId,
+      },
+      task,
+      resolveRepoOrThrow(opts.repositories, task),
+      readConfig
+    )
+  );
+
+  const dirtyTreePolicy: DirtyTreePolicy = opts.dirtyTreePolicy ?? 'prompt';
+  const preflightLeaves = buildPreflightLeaves(
+    { gitRunner: deps.gitRunner, interactive: deps.interactive, clock: deps.clock, logger: deps.logger },
+    uniqueRepoCwds,
+    dirtyTreePolicy
+  );
+  const workingTreeCleanLeaves = buildWorkingTreeCleanLeaves(
+    { gitRunner: deps.gitRunner, logger: deps.logger },
+    uniqueRepoCwds
+  );
+
+  const inner = sequential<ImplementCtx>('implement-locked', [
+    loadAndAssertSprintSubChain<ImplementCtx>({ sprintRepo: deps.sprintRepo }, ['planned', 'active']),
+    activateSprintLeaf({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
+    loadSprintExecutionLeaf<ImplementCtx>({ sprintExecutionRepo: deps.sprintExecutionRepo }),
+    loadTasksLeaf<ImplementCtx>({ taskRepo: deps.taskRepo }),
+    resolveBranchLeaf(
+      {
+        gitRunner: deps.gitRunner,
+        sprintExecutionRepo: deps.sprintExecutionRepo,
+        interactive: deps.interactive,
+        logger: deps.logger,
+      },
+      { cwds: uniqueRepoCwds }
+    ),
+    sequential<ImplementCtx>('working-tree-clean-checks', workingTreeCleanLeaves),
+    appendJournalSeparatorLeaf<ImplementCtx>(
+      { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
+      { progressFile: opts.progressFile, status: 'activated', name: 'progress-journal-activate' }
+    ),
+    setupScriptRunnerLeaf(
+      {
+        shellScriptRunner: deps.shellScriptRunner,
+        clock: deps.clock,
+        eventBus: deps.eventBus,
+        sprintExecutionRepo: deps.sprintExecutionRepo,
+        logger: deps.logger,
+      },
+      { repos: setupRepoEntries, sprintDir: opts.sprintDir }
+    ),
+    sequential<ImplementCtx>('preflight-tasks', preflightLeaves),
+    sequential<ImplementCtx>('implement-tasks', perTaskChains),
+    saveTasksLeaf<ImplementCtx>({ taskRepo: deps.taskRepo }),
+    guard<ImplementCtx>(
+      'transition-sprint-to-review-when-any-done',
+      (ctx) => ctx.tasks?.some((t) => t.status === 'done') === true,
+      sequential<ImplementCtx>('transition-to-review-and-journal', [
+        transitionSprintToReviewLeaf({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
+        appendJournalSeparatorLeaf<ImplementCtx>(
+          { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
+          { progressFile: opts.progressFile, status: 'review', name: 'progress-journal-review' }
+        ),
+      ])
+    ),
+  ]);
+
+  return sequential<ImplementCtx>('implement', [
+    withRepoLock(
+      { fileLocker: deps.fileLocker, locksRoot: deps.locksRoot, worktreePath: opts.sprintDir, eventBus: deps.eventBus },
+      inner
+    ),
+  ]);
+};
+
+describe('createImplementFlow — serial chain shape (serial-shape byte-for-byte fence)', () => {
+  it('matches the pre-refactor serial tree byte-for-byte (the central safety claim)', () => {
+    const task = makeTodoTask({ name: 'do-work' });
+    const opts = makeOpts([task]);
+
+    const live = snapshot(createImplementFlow(stubDeps(), opts));
+    const reference = snapshot(reconstructPreRefactorSerialFlow(stubDeps(), opts));
+
+    expect(live).toStrictEqual(reference);
+  });
+
+  it('matches the pre-refactor serial tree byte-for-byte for a multi-task sprint', () => {
+    const t1 = makeTodoTask({ name: 't1', order: 1 });
+    const t2 = makeTodoTask({ name: 't2', order: 2 });
+    const opts = makeOpts([t1, t2]);
+
+    const live = snapshot(createImplementFlow(stubDeps(), opts));
+    const reference = snapshot(reconstructPreRefactorSerialFlow(stubDeps(), opts));
+
+    expect(live).toStrictEqual(reference);
+  });
+
+  it('keeps the lock wrapper outside a single flat implement-locked body', () => {
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+    const shape = snapshot(createImplementFlow(stubDeps(), opts));
+
+    // The top node is `implement`; its only child wraps a single `implement-locked` sequential.
+    expect(shape.name).toBe('implement');
+    expect(shape.children?.length).toBe(1);
+    const lock = shape.children?.[0];
+    expect(lock?.name).toBe('with-repo-lock(implement-locked)');
+    expect(lock?.children?.length).toBe(1);
+    expect(lock?.children?.[0]?.name).toBe('implement-locked');
+  });
+
+  it('does NOT leak the implement-prologue / implement-epilogue wrapper names into the serial tree', () => {
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+    const allNames = names(snapshot(createImplementFlow(stubDeps(), opts)));
+
+    expect(allNames).not.toContain('implement-prologue');
+    expect(allNames).not.toContain('implement-epilogue');
+    expect(allNames).toContain('implement-locked');
+    expect(allNames).toContain('implement-tasks');
+  });
+
+  it('is the serial element (never the parallel orchestrator) — the meta-run caller stays serial', () => {
+    // `createImplementFlow` is what BOTH the `maxParallelTasks === 1` launcher path AND the meta-run
+    // composer (`createRunFlow`) build. The parallel orchestrator is a DIFFERENT element named
+    // `implement-parallel`, reached only via the `> 1` launcher dispatch — never here. This fence
+    // proves the meta-run caller (and the serial path) can never accidentally pick up the parallel
+    // worktree-fan-out element.
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+    const shape = snapshot(createImplementFlow(stubDeps(), opts));
+
+    expect(shape.name).toBe('implement');
+    expect(names(shape)).not.toContain('implement-parallel');
+  });
+
+  it('fans out one task-<id> sub-chain per todo task, in order', () => {
+    const t1 = makeTodoTask({ name: 't1', order: 1 });
+    const t2 = makeTodoTask({ name: 't2', order: 2 });
+    const implementTasks = findByName(snapshot(createImplementFlow(stubDeps(), makeOpts([t1, t2]))), 'implement-tasks');
+
+    expect(implementTasks?.children?.map((c) => c.name)).toStrictEqual([
+      `task-${String(t1.id)}`,
+      `task-${String(t2.id)}`,
+    ]);
+  });
+});
+
+describe('buildImplementPrologue / buildImplementEpilogue', () => {
+  it('prologue produces exactly the leaves spliced inline BEFORE implement-tasks in the serial flow', () => {
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+
+    const prologue = buildImplementPrologue(stubDeps(), opts);
+    expect(prologue.name).toBe('implement-prologue');
+    const prologueChildren = (prologue.children ?? []).map((c) => snapshot(c));
+
+    const locked = findByName(snapshot(createImplementFlow(stubDeps(), opts)), 'implement-locked');
+    const lockedChildren = locked?.children ?? [];
+    const idx = lockedChildren.findIndex((c) => c.name === 'implement-tasks');
+    const inlinePrologue = lockedChildren.slice(0, idx);
+
+    expect(prologueChildren).toStrictEqual(inlinePrologue);
+  });
+
+  it('epilogue produces exactly the leaves spliced inline AFTER implement-tasks in the serial flow', () => {
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+
+    const epilogue = buildImplementEpilogue(stubDeps(), opts);
+    expect(epilogue.name).toBe('implement-epilogue');
+    const epilogueChildren = (epilogue.children ?? []).map((c) => snapshot(c));
+
+    const locked = findByName(snapshot(createImplementFlow(stubDeps(), opts)), 'implement-locked');
+    const lockedChildren = locked?.children ?? [];
+    const idx = lockedChildren.findIndex((c) => c.name === 'implement-tasks');
+    const inlineEpilogue = lockedChildren.slice(idx + 1);
+
+    expect(epilogueChildren).toStrictEqual(inlineEpilogue);
+  });
+});
+
+describe('planImplementWaves', () => {
+  it('returns the prologue, epilogue, lockKey, and dependency-scheduled waves', () => {
+    const task = makeTodoTask({ name: 'do-work' });
+    const opts = makeOpts([task]);
+
+    const plan = planImplementWaves(stubDeps(), opts);
+
+    expect(plan.prologue.name).toBe('implement-prologue');
+    expect(plan.epilogue.name).toBe('implement-epilogue');
+    expect(plan.lockKey).toBe(opts.sprintDir);
+    expect(plan.waves.map((w) => w.map((t) => String(t.id)))).toStrictEqual([[String(task.id)]]);
+  });
+
+  it('its prologue/epilogue segments equal the standalone segment builders', () => {
+    const opts = makeOpts([makeTodoTask({ name: 'do-work' })]);
+    const plan = planImplementWaves(stubDeps(), opts);
+
+    expect(snapshot(plan.prologue)).toStrictEqual(snapshot(buildImplementPrologue(stubDeps(), opts)));
+    expect(snapshot(plan.epilogue)).toStrictEqual(snapshot(buildImplementEpilogue(stubDeps(), opts)));
+  });
+
+  it('schedules tasks into dependency layers (diamond → 3 waves)', () => {
+    const a = makeTodoTask({ name: 'a', order: 1 });
+    const b = makeTodoTask({ name: 'b', order: 2, dependsOn: [a.id] });
+    const c = makeTodoTask({ name: 'c', order: 3, dependsOn: [a.id] });
+    const d = makeTodoTask({ name: 'd', order: 4, dependsOn: [b.id, c.id] });
+
+    const plan = planImplementWaves(stubDeps(), makeOpts([a, b, c, d]));
+
+    expect(plan.waves.map((w) => w.map((t) => String(t.id)))).toStrictEqual([
+      [String(a.id)],
+      [String(b.id), String(c.id)],
+      [String(d.id)],
+    ]);
+  });
+
+  it('fails closed with an empty wave list when the task graph is unschedulable (no throw)', () => {
+    const x = makeTodoTask({ name: 'x', order: 1 });
+    const selfEdged: Task = { ...x, dependsOn: [x.id] }; // self-edge → scheduleIntoWaves errors
+    const plan = planImplementWaves(stubDeps(), makeOpts([selfEdged]));
+
+    expect(plan.waves).toStrictEqual([]);
+    // The segments + lock key are still produced — only the schedule is empty.
+    expect(plan.prologue.name).toBe('implement-prologue');
+    expect(plan.epilogue.name).toBe('implement-epilogue');
+    expect(plan.lockKey).toBe(makeOpts([selfEdged]).sprintDir);
+  });
+});

--- a/tests/unit/application/flows/implement/merge-wave.test.ts
+++ b/tests/unit/application/flows/implement/merge-wave.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Task } from '@src/domain/entity/task.ts';
+import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+
+import {
+  absolutePath,
+  makeDoneTask,
+  makeExecution,
+  makeInProgressTaskWithRunningAttempt,
+  makePlannedSprint,
+  makeTodoTask,
+} from '@tests/fixtures/domain.ts';
+
+import type { BranchOutcome } from '@src/application/chain/run/wave-scheduler.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { RepoExecConfig } from '@src/application/flows/implement/leaves/resolve-repo.ts';
+import { forkCtx, mergeImplementWave } from '@src/application/flows/implement/merge-wave.ts';
+
+const blockedFrom = (task: ReturnType<typeof makeInProgressTaskWithRunningAttempt>): Task => {
+  const result = markTaskBlocked(task, 'plateau persists after escalation');
+  if (!result.ok) throw new Error('fixture: markTaskBlocked failed');
+  return result.value;
+};
+
+const sprint = makePlannedSprint();
+
+/**
+ * A base ctx with every sprint-scoped field populated plus a handful of per-task / signal-accum
+ * fields set, so a test can assert they are CLEARED in the merged / forked ctx.
+ */
+const makeBaseCtx = (tasks: readonly Task[]): ImplementCtx => ({
+  sprintId: sprint.id,
+  sprint,
+  execution: makeExecution(sprint.id),
+  progressFile: absolutePath('/sprints/s1/progress.md'),
+  tasks,
+  // per-task single-slot state (should NOT survive a merge or a fork)
+  currentTaskId: tasks[0]?.id,
+  genEvalTurn: 3,
+  lastBlockReason: 'stale per-task state',
+  expectedBranch: 'feature/sprint-1',
+  priorPostVerifyOutcome: { cwd: absolutePath('/repo'), outcome: 'success' },
+  // signal accumulators (should NOT survive a merge or a fork)
+  currentAttemptChanges: ['edited a.ts'],
+  currentAttemptDecisions: ['chose approach X'],
+  currentAttemptLearnings: [{ text: 'learned Y' }],
+  currentAttemptNotes: ['noted Z'],
+});
+
+/** A completed branch whose chain settled `task` into its final state. */
+const completedBranch = (id: string, base: ImplementCtx, settled: Task): BranchOutcome<ImplementCtx> => ({
+  id,
+  status: 'completed',
+  ctx: { ...base, tasks: [settled] },
+});
+
+/** A non-fatal failed branch: an absorbed error, branch ctx carries the (blocked) task transition. */
+const absorbedFailureBranch = (
+  id: string,
+  base: ImplementCtx,
+  settled: Task,
+  error: DomainError
+): BranchOutcome<ImplementCtx> => ({
+  id,
+  status: 'failed',
+  ctx: { ...base, tasks: [settled] },
+  error,
+});
+
+/** A killed branch per the wave-scheduler contract: `failed` with NO error — did not complete. */
+const killedBranch = (id: string, base: ImplementCtx, untouched: Task): BranchOutcome<ImplementCtx> => ({
+  id,
+  status: 'failed',
+  ctx: { ...base, tasks: [untouched] },
+});
+
+describe('mergeImplementWave', () => {
+  it('overlays each settled branch task onto base.tasks by id', () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const base = makeBaseCtx([t1, t2]);
+
+    const t1Done = makeDoneTask({ name: 't1' });
+    const t2Done = makeDoneTask({ name: 't2' });
+    // Re-key the settled copies onto the base task ids so the overlay matches.
+    const t1Settled: Task = { ...t1Done, id: t1.id };
+    const t2Settled: Task = { ...t2Done, id: t2.id };
+
+    const merged = mergeImplementWave(base, [
+      completedBranch('task-1', base, t1Settled),
+      completedBranch('task-2', base, t2Settled),
+    ]);
+
+    expect(merged.tasks?.find((t) => t.id === t1.id)?.status).toBe('done');
+    expect(merged.tasks?.find((t) => t.id === t2.id)?.status).toBe('done');
+  });
+
+  it('is commutative over disjoint branches — shuffling outcomes yields an identical merged ctx', () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const t3 = makeTodoTask({ name: 't3' });
+    const base = makeBaseCtx([t1, t2, t3]);
+
+    const settle = (src: Task, model: Task): Task => ({ ...model, id: src.id });
+    const o1 = completedBranch('task-1', base, settle(t1, makeDoneTask({ name: 't1' })));
+    const o2 = absorbedFailureBranch(
+      'task-2',
+      base,
+      settle(t2, blockedFrom(makeInProgressTaskWithRunningAttempt())),
+      new InvalidStateError({ entity: 'task', currentState: 'x', attemptedAction: 'y', message: 'absorbed' })
+    );
+    const o3 = completedBranch('task-3', base, settle(t3, makeDoneTask({ name: 't3' })));
+
+    const inOrder = mergeImplementWave(base, [o1, o2, o3]);
+    const shuffledA = mergeImplementWave(base, [o3, o1, o2]);
+    const shuffledB = mergeImplementWave(base, [o2, o3, o1]);
+
+    expect(shuffledA).toStrictEqual(inOrder);
+    expect(shuffledB).toStrictEqual(inOrder);
+  });
+
+  it('carries sprint-scoped fields straight from base', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const merged = mergeImplementWave(base, [completedBranch('task-1', base, { ...makeDoneTask(), id: t1.id })]);
+
+    expect(merged.sprintId).toBe(base.sprintId);
+    expect(merged.sprint).toBe(base.sprint);
+    expect(merged.execution).toBe(base.execution);
+    expect(merged.progressFile).toBe(base.progressFile);
+  });
+
+  it('clears per-task single-slot and signal-accum fields in the merged ctx', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const merged = mergeImplementWave(base, [completedBranch('task-1', base, { ...makeDoneTask(), id: t1.id })]);
+
+    // per-task single-slot
+    expect(merged.currentTaskId).toBeUndefined();
+    expect(merged.genEvalTurn).toBeUndefined();
+    expect(merged.lastBlockReason).toBeUndefined();
+    expect(merged.expectedBranch).toBeUndefined();
+    expect(merged.priorPostVerifyOutcome).toBeUndefined();
+    // signal accumulators
+    expect(merged.currentAttemptChanges).toBeUndefined();
+    expect(merged.currentAttemptDecisions).toBeUndefined();
+    expect(merged.currentAttemptLearnings).toBeUndefined();
+    expect(merged.currentAttemptNotes).toBeUndefined();
+  });
+
+  it('leaves a killed branch task untouched (failed / no error) so it resets/re-runs', () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const base = makeBaseCtx([t1, t2]);
+
+    // task-1 genuinely settled to done; task-2 was killed mid-flight.
+    const t1Settled: Task = { ...makeDoneTask({ name: 't1' }), id: t1.id };
+    // A killed branch's ctx still nominally carries SOME task copy — but it must be ignored.
+    const t2Stale: Task = { ...makeDoneTask({ name: 't2-should-be-ignored' }), id: t2.id };
+
+    const merged = mergeImplementWave(base, [
+      completedBranch('task-1', base, t1Settled),
+      killedBranch('task-2', base, t2Stale),
+    ]);
+
+    expect(merged.tasks?.find((t) => t.id === t1.id)?.status).toBe('done');
+    // task-2 must be the ORIGINAL base task (still todo), not the killed branch's stale copy.
+    const t2Merged = merged.tasks?.find((t) => t.id === t2.id);
+    expect(t2Merged).toBe(t2);
+    expect(t2Merged?.status).toBe('todo');
+  });
+
+  it('overlays an absorbed non-fatal failure (failed WITH error) — it genuinely settled the task', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const blocked: Task = { ...blockedFrom(makeInProgressTaskWithRunningAttempt()), id: t1.id };
+
+    const merged = mergeImplementWave(base, [
+      absorbedFailureBranch(
+        'task-1',
+        base,
+        blocked,
+        new InvalidStateError({ entity: 'task', currentState: 'x', attemptedAction: 'y', message: 'absorbed' })
+      ),
+    ]);
+
+    expect(merged.tasks?.find((t) => t.id === t1.id)?.status).toBe('blocked');
+  });
+
+  it('returns base.tasks unchanged when there are no outcomes', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const merged = mergeImplementWave(base, []);
+
+    expect(merged.tasks?.map((t) => t.id)).toStrictEqual([t1.id]);
+    expect(merged.tasks?.[0]?.status).toBe('todo');
+  });
+});
+
+describe('forkCtx', () => {
+  const repo: RepoExecConfig = {
+    path: absolutePath('/repos/main'),
+    name: 'main-repo',
+    verifyScript: 'pnpm verify',
+  };
+  const worktree = absolutePath('/repos/.worktrees/wt-task-1');
+
+  it('points the returned RepoExecConfig.path at the worktree path, preserving the rest', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const { repo: forkedRepo } = forkCtx(base, repo, worktree);
+
+    expect(forkedRepo.path).toBe(worktree);
+    expect(forkedRepo.name).toBe('main-repo');
+    expect(forkedRepo.verifyScript).toBe('pnpm verify');
+    // The input repo is not mutated — forkCtx is a pure projection.
+    expect(repo.path).toBe(absolutePath('/repos/main'));
+  });
+
+  it('carries sprint-scoped fields and the task list from base', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const { ctx } = forkCtx(base, repo, worktree);
+
+    expect(ctx.sprintId).toBe(base.sprintId);
+    expect(ctx.sprint).toBe(base.sprint);
+    expect(ctx.execution).toBe(base.execution);
+    expect(ctx.progressFile).toBe(base.progressFile);
+    expect(ctx.tasks).toBe(base.tasks);
+  });
+
+  it('clears per-task single-slot and signal-accum fields, dropping priorPostVerifyOutcome', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const { ctx } = forkCtx(base, repo, worktree);
+
+    expect(ctx.currentTaskId).toBeUndefined();
+    expect(ctx.genEvalTurn).toBeUndefined();
+    expect(ctx.lastBlockReason).toBeUndefined();
+    // Accepted cost: the pre-task-verify short-circuit baseline is dropped.
+    expect(ctx.priorPostVerifyOutcome).toBeUndefined();
+    expect(ctx.currentAttemptChanges).toBeUndefined();
+    expect(ctx.currentAttemptDecisions).toBeUndefined();
+    expect(ctx.currentAttemptLearnings).toBeUndefined();
+    expect(ctx.currentAttemptNotes).toBeUndefined();
+  });
+
+  it('leaves expectedBranch undefined (corrected — branch element omits branch-preflight)', () => {
+    const t1 = makeTodoTask();
+    const base = makeBaseCtx([t1]);
+    const { ctx } = forkCtx(base, repo, worktree);
+
+    // An earlier draft wrote `expectedBranch: ''` to disable per-task branch-preflight, but that leaf
+    // short-circuits on `undefined`, not `''`. The branch element omits branch-preflight, so the
+    // field is simply cleared with the rest of the per-task class.
+    expect(ctx.expectedBranch).toBeUndefined();
+    expect('expectedBranch' in ctx).toBe(false);
+  });
+});
+
+/**
+ * Compile-time guard demonstration. `mergeImplementWave`'s `_exhaustive` object is
+ * `satisfies Record<keyof ImplementCtx, MergeClass>`. Adding a new field to `ImplementCtx` WITHOUT
+ * classifying it in that object is a TYPE ERROR (the object stops satisfying the constraint), so a
+ * future ctx field can never silently bypass the merge/fork projection.
+ *
+ * The block below documents what a deliberately-unclassified field would look like. It cannot be
+ * left uncommented in a green suite (by design it would fail typecheck), so it is preserved here as
+ * the contract record:
+ *
+ *   // In ctx.ts, adding:  readonly someNewField?: string | undefined;
+ *   // …without adding `someNewField: '…'` to `_exhaustive` produces, at `pnpm typecheck`:
+ *   //   error TS2353 / TS2741: Property 'someNewField' is missing in type '…'
+ *   //   but required in type 'Record<keyof ImplementCtx, MergeClass>'.
+ *
+ * This `expectTypeOf`-free note is the test surface for the guard — the actual enforcement is the
+ * `satisfies` in merge-wave.ts, verified every `pnpm typecheck`.
+ */
+describe('exhaustiveness guard (compile-time)', () => {
+  it('is enforced by the satisfies Record<keyof ImplementCtx, MergeClass> in merge-wave.ts', () => {
+    // Runtime no-op: the guarantee is structural (typecheck-time), asserted by the doc above.
+    expect(true).toBe(true);
+  });
+});

--- a/tests/unit/application/flows/implement/wave-branch.test.ts
+++ b/tests/unit/application/flows/implement/wave-branch.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { HarnessSignal } from '@src/domain/signal.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { AppEvent } from '@src/business/observability/events.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { HarnessSignalSink } from '@src/business/observability/harness-signal-sink.ts';
+import type { AppendFile } from '@src/business/io/append-file.ts';
+import type { GitRunner, GitRunResult } from '@src/integration/io/git-runner.ts';
+import type { ShellScriptRunner, ShellScriptResult } from '@src/integration/io/shell-script-runner.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import { createRunner } from '@src/application/chain/run/runner.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import type { RepoExecConfig } from '@src/application/flows/implement/leaves/resolve-repo.ts';
+import {
+  buildWorktreeBranch,
+  createFoldQueue,
+  perBranchSignalSink,
+  serializeAppendFile,
+  worktreePathFor,
+  type BuildWaveBranchesDeps,
+} from '@src/application/flows/implement/wave-branch.ts';
+
+import { absolutePath, makeDoneTask, makePlannedSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
+
+// ── createFoldQueue ─────────────────────────────────────────────────────────────────────────
+
+describe('createFoldQueue', () => {
+  it('serialises concurrent runs — no two critical sections overlap', async () => {
+    const queue = createFoldQueue();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const work = async (): Promise<void> => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight -= 1;
+    };
+    await Promise.all([queue.run(work), queue.run(work), queue.run(work), queue.run(work)]);
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('runs in FIFO enqueue order', async () => {
+    const queue = createFoldQueue();
+    const order: number[] = [];
+    const mk = (n: number) => async (): Promise<void> => {
+      await Promise.resolve();
+      order.push(n);
+    };
+    await Promise.all([queue.run(mk(1)), queue.run(mk(2)), queue.run(mk(3))]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('a rejecting fn does not wedge the queue — later runs still execute', async () => {
+    const queue = createFoldQueue();
+    const ran: string[] = [];
+    const first = queue.run(async () => {
+      throw new Error('boom');
+    });
+    const second = queue.run(async () => {
+      ran.push('second');
+    });
+    await expect(first).rejects.toThrow('boom');
+    await second;
+    expect(ran).toEqual(['second']);
+  });
+});
+
+// ── worktreePathFor ─────────────────────────────────────────────────────────────────────────
+
+describe('worktreePathFor', () => {
+  it('roots the worktree under <sprintDir>/worktrees/wt-<taskId>', () => {
+    const sprintDir = absolutePath('/data/sprints/s1');
+    const task = makeTodoTask();
+    expect(String(worktreePathFor(sprintDir, task.id))).toBe(`/data/sprints/s1/worktrees/wt-${String(task.id)}`);
+  });
+});
+
+// ── branch element (worktree setup / fold / cleanup / conflict) ───────────────────────────────
+
+const ok = (stdout = '', exitCode = 0, stderr = ''): Result<GitRunResult, StorageError> =>
+  Result.ok({ stdout, stderr, exitCode });
+
+const conflict = (): Result<GitRunResult, StorageError> => ok('CONFLICT (content)', 1, 'cherry-pick failed');
+
+/** A git runner that records argv and replies based on the FIRST arg (worktree/merge/cherry-pick). */
+const fakeGit = (over?: {
+  foldConflict?: boolean;
+  removeFails?: boolean;
+}): { runner: GitRunner; calls: string[][] } => {
+  const calls: string[][] = [];
+  const runner: GitRunner = {
+    async run(_cwd, args) {
+      calls.push([...args]);
+      const [a, b] = args;
+      if (a === 'worktree' && b === 'remove') return over?.removeFails === true ? conflict() : ok();
+      if (a === 'merge' && b === '--ff-only') return over?.foldConflict === true ? ok('not ff', 1) : ok();
+      if (a === 'merge-base') return ok('a'.repeat(40));
+      if (a === 'cherry-pick') return over?.foldConflict === true ? conflict() : ok();
+      return ok(); // worktree add / prune / etc.
+    },
+  };
+  return { runner, calls };
+};
+
+const stubBus = (events: AppEvent[]): EventBus => ({
+  publish: (e) => events.push(e),
+  subscribe: () => () => {},
+});
+
+const makeBranchDeps = (
+  runner: GitRunner,
+  appSignals: HarnessSignalSink,
+  eventBus: EventBus,
+  shellScriptRunner?: ShellScriptRunner
+): BuildWaveBranchesDeps => ({
+  implement: {
+    gitRunner: runner,
+    logger: noopLogger,
+    ...(shellScriptRunner !== undefined ? { shellScriptRunner } : {}),
+  } as unknown as ImplementDeps,
+  appSignals,
+  eventBus,
+  foldQueue: createFoldQueue(),
+});
+
+/** A fake shell-script runner that records (cwd, script) per call and replies with a fixed result. */
+const okShell = (passed = true, exitCode = 0): Result<ShellScriptResult, StorageError> =>
+  Result.ok({ passed, exitCode, output: '', durationMs: 1 });
+
+const fakeShell = (
+  result: Result<ShellScriptResult, StorageError> = okShell()
+): { runner: ShellScriptRunner; calls: Array<{ cwd: string; script: string }> } => {
+  const calls: Array<{ cwd: string; script: string }> = [];
+  const runner: ShellScriptRunner = {
+    async run(cwd, script) {
+      calls.push({ cwd: String(cwd), script });
+      return result;
+    },
+  };
+  return { runner, calls };
+};
+
+const repo: RepoExecConfig = { path: absolutePath('/repos/main'), name: 'main-repo' };
+const repoWithSetup: RepoExecConfig = {
+  path: absolutePath('/repos/main'),
+  name: 'main-repo',
+  setupScript: 'pnpm install',
+};
+
+/** A fake subchain that settles the given task into the supplied final copy on ctx.tasks. */
+const settlingSubchain = (taskId: TaskId, settled: Task): ((worktreeRepo: RepoExecConfig) => Element<ImplementCtx>) => {
+  return (worktreeRepo) => ({
+    name: `fake-subchain-${String(taskId)}`,
+    async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+      // Assert the subchain received the worktree-pointed repo.
+      expect(String(worktreeRepo.path)).toContain('worktrees');
+      const tasks = (ctx.tasks ?? []).map((t) => (t.id === taskId ? settled : t));
+      return Result.ok({ ctx: { ...ctx, tasks }, trace: [] });
+    },
+  });
+};
+
+const runBranch = async (
+  element: Element<ImplementCtx>,
+  base: ImplementCtx
+): Promise<{ status: string; ctx: ImplementCtx }> => {
+  const runner = createRunner<ImplementCtx>({ id: 'branch', element, initialCtx: base });
+  await runner.start();
+  return { status: runner.status, ctx: runner.ctx };
+};
+
+const baseCtx = (tasks: readonly Task[]): ImplementCtx => {
+  const sprint = makePlannedSprint();
+  return { sprintId: sprint.id, sprint, tasks };
+};
+
+describe('buildWorktreeBranch — happy path', () => {
+  it('sets up the worktree, runs the subchain on the worktree repo, folds the done task, and cleans up', async () => {
+    const task = makeTodoTask();
+    const done: Task = { ...makeDoneTask(), id: task.id };
+    const { runner, calls } = fakeGit();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ralphctl/s1/wt-x', settlingSubchain(task.id, done));
+    const { status, ctx } = await runBranch(branch, baseCtx([task]));
+
+    expect(status).toBe('completed');
+    expect(ctx.tasks?.find((t) => t.id === task.id)?.status).toBe('done');
+    // Worktree add (setup), a ff-only fold, and a forced remove (cleanup) all ran.
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'add')).toBe(true);
+    expect(calls.some((c) => c[0] === 'merge' && c[1] === '--ff-only')).toBe(true);
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'remove' && c[2] === '--force')).toBe(true);
+  });
+
+  it('never stashes the main repo', async () => {
+    const task = makeTodoTask();
+    const { runner, calls } = fakeGit();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+    const branch = buildWorktreeBranch(
+      deps,
+      repo,
+      task,
+      wt,
+      'ref',
+      settlingSubchain(task.id, { ...makeDoneTask(), id: task.id })
+    );
+    await runBranch(branch, baseCtx([task]));
+    expect(calls.some((c) => c[0] === 'stash')).toBe(false);
+  });
+});
+
+describe('buildWorktreeBranch — fold conflict → blocked', () => {
+  it('blocks the task on a cherry-pick conflict and still cleans up; siblings unaffected', async () => {
+    const task = makeTodoTask();
+    const done: Task = { ...makeDoneTask(), id: task.id };
+    const { runner, calls } = fakeGit({ foldConflict: true });
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ref', settlingSubchain(task.id, done));
+    const { status, ctx } = await runBranch(branch, baseCtx([task]));
+
+    // The branch COMPLETES (a conflict is a domain block, not an infra failure) and its ctx carries
+    // the blocked task — so the merge reducer overlays the block (siblings stay landed).
+    expect(status).toBe('completed');
+    const settled = ctx.tasks?.find((t) => t.id === task.id);
+    expect(settled?.status).toBe('blocked');
+    // Cleanup ran even on the conflict path.
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'remove')).toBe(true);
+  });
+});
+
+describe('buildWorktreeBranch — does not fold a non-done task', () => {
+  it('skips the fold when the subchain settled the task blocked', async () => {
+    const task = makeTodoTask();
+    // Subchain leaves the task as-is (todo) — e.g. self-blocked path with no commit.
+    const { runner, calls } = fakeGit();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+    const passthroughSubchain = (): Element<ImplementCtx> => ({
+      name: 'passthrough',
+      async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+        return Result.ok({ ctx, trace: [] });
+      },
+    });
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ref', passthroughSubchain);
+    const { status } = await runBranch(branch, baseCtx([task]));
+
+    expect(status).toBe('completed');
+    // No fold (no merge --ff-only) because the task never reached `done`; cleanup still ran.
+    expect(calls.some((c) => c[0] === 'merge')).toBe(false);
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'remove')).toBe(true);
+  });
+});
+
+// ── per-branch signal sink attribution ────────────────────────────────────────────────────────
+
+describe('perBranchSignalSink — taskId attribution under concurrency', () => {
+  const change = (text: string): HarnessSignal => ({ type: 'change', text, timestamp: IsoTimestamp.now() });
+
+  it('stamps each branch sink with ITS OWN taskId — two branches do not cross-attribute', () => {
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const events: AppEvent[] = [];
+    const bus = stubBus(events);
+    const appSeen: HarnessSignal[] = [];
+    const appSink: HarnessSignalSink = { emit: (s) => appSeen.push(s) };
+
+    const sink1 = perBranchSignalSink(appSink, bus, t1.id);
+    const sink2 = perBranchSignalSink(appSink, bus, t2.id);
+
+    // Interleave emissions to simulate concurrent branches.
+    sink1.emit(change('from-1-a'));
+    sink2.emit(change('from-2-a'));
+    sink1.emit(change('from-1-b'));
+
+    const harness = events.filter((e) => e.type === 'harness-signal');
+    expect(harness).toHaveLength(3);
+    // Each event carries the taskId of the branch that emitted it — never the other branch's.
+    const byText = new Map(harness.map((e) => [e.type === 'harness-signal' ? e.text : '', e]));
+    expect(byText.get('from-1-a')).toMatchObject({ taskId: String(t1.id) });
+    expect(byText.get('from-1-b')).toMatchObject({ taskId: String(t1.id) });
+    expect(byText.get('from-2-a')).toMatchObject({ taskId: String(t2.id) });
+    // Every signal also reached the app-wide sink.
+    expect(appSeen).toHaveLength(3);
+  });
+
+  it('ignores non-text-bearing signal kinds (only change/learning/note mirror to the bus)', () => {
+    const t1 = makeTodoTask();
+    const events: AppEvent[] = [];
+    const sink = perBranchSignalSink({ emit: vi.fn() }, stubBus(events), t1.id);
+
+    sink.emit({ type: 'decision', text: 'a decision', timestamp: IsoTimestamp.now() });
+    sink.emit({ type: 'learning', text: 'a learning', timestamp: IsoTimestamp.now() });
+
+    const harness = events.filter((e) => e.type === 'harness-signal');
+    expect(harness.map((e) => (e.type === 'harness-signal' ? e.signalKind : ''))).toEqual(['learning']);
+  });
+});
+
+describe('buildWorktreeBranch — abort runs cleanup', () => {
+  it('runs worktree cleanup even when the subchain is aborted mid-flight, and never stashes', async () => {
+    const task = makeTodoTask();
+    const { runner, calls } = fakeGit();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    // A subchain that hangs until aborted.
+    const hangingSubchain = (): Element<ImplementCtx> => ({
+      name: 'hang',
+      async execute(_ctx, signal): Promise<ElementResult<ImplementCtx>> {
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) return resolve();
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        const error = new AbortError({ elementName: 'hang' });
+        return Result.error({ error, trace: [{ elementName: 'hang', status: 'aborted', durationMs: 0, error }] });
+      },
+    });
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ref', hangingSubchain);
+    const r = createRunner<ImplementCtx>({ id: 'b', element: branch, initialCtx: baseCtx([task]) });
+    const started = r.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    r.abort();
+    await started;
+
+    expect(r.status).toBe('aborted');
+    // Cleanup MUST have run despite the abort; no fold (task never settled done); no stash.
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'remove')).toBe(true);
+    expect(calls.some((c) => c[0] === 'merge')).toBe(false);
+    expect(calls.some((c) => c[0] === 'stash')).toBe(false);
+  });
+});
+
+// ── per-worktree setup script ─────────────────────────────────────────────────────────────────
+
+describe('buildWorktreeBranch — per-worktree setup script', () => {
+  it('runs setupScript IN the worktree cwd before the subchain, then folds the done task', async () => {
+    const task = makeTodoTask();
+    const done: Task = { ...makeDoneTask(), id: task.id };
+    const { runner, calls } = fakeGit();
+    const shell = fakeShell(okShell(true));
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]), shell.runner);
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repoWithSetup, task, wt, 'ref', settlingSubchain(task.id, done));
+    const { status, ctx } = await runBranch(branch, baseCtx([task]));
+
+    expect(status).toBe('completed');
+    expect(ctx.tasks?.find((t) => t.id === task.id)?.status).toBe('done');
+    // Setup ran exactly once, in the WORKTREE cwd (not the main repo), with the repo's script.
+    expect(shell.calls).toHaveLength(1);
+    expect(shell.calls[0]!.cwd).toContain('worktrees');
+    expect(shell.calls[0]!.cwd).not.toBe(String(repo.path));
+    expect(shell.calls[0]!.script).toBe('pnpm install');
+    // The fold still ran because the task settled `done`.
+    expect(calls.some((c) => c[0] === 'merge' && c[1] === '--ff-only')).toBe(true);
+  });
+
+  it('blocks ONLY this task and skips the subchain when setupScript exits non-zero; cleanup still runs', async () => {
+    const task = makeTodoTask();
+    const { runner, calls } = fakeGit();
+    const shell = fakeShell(okShell(false, 1));
+    let bodyRan = false;
+    const trackingSubchain = (): Element<ImplementCtx> => ({
+      name: 'body',
+      async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+        bodyRan = true;
+        return Result.ok({ ctx, trace: [] });
+      },
+    });
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]), shell.runner);
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repoWithSetup, task, wt, 'ref', trackingSubchain);
+    const { status, ctx } = await runBranch(branch, baseCtx([task]));
+
+    // The branch COMPLETES (a setup failure is a per-task domain block, not an infra abort) and its
+    // ctx carries ONLY the blocked task, so `mergeImplementWave` overlays the block.
+    expect(status).toBe('completed');
+    const settled = ctx.tasks?.find((t) => t.id === task.id);
+    expect(settled?.status).toBe('blocked');
+    expect(bodyRan).toBe(false); // subchain skipped — never ran in an unprepared worktree
+    expect(calls.some((c) => c[0] === 'merge')).toBe(false); // no fold for a blocked task
+    expect(calls.some((c) => c[0] === 'worktree' && c[1] === 'remove')).toBe(true); // cleanup ran
+  });
+
+  it('blocks the task when setupScript cannot even spawn (Result.error)', async () => {
+    const task = makeTodoTask();
+    const { runner } = fakeGit();
+    const shell = fakeShell(Result.error(new StorageError({ subCode: 'io', message: 'shell binary missing' })));
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]), shell.runner);
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repoWithSetup, task, wt, 'ref', () => ({
+      name: 'unreached',
+      async execute(ctx): Promise<ElementResult<ImplementCtx>> {
+        return Result.ok({ ctx, trace: [] });
+      },
+    }));
+    const { status, ctx } = await runBranch(branch, baseCtx([task]));
+
+    expect(status).toBe('completed');
+    expect(ctx.tasks?.find((t) => t.id === task.id)?.status).toBe('blocked');
+  });
+
+  it('skips setup entirely (no shell call) when the repo configures no setupScript', async () => {
+    const task = makeTodoTask();
+    const done: Task = { ...makeDoneTask(), id: task.id };
+    const { runner } = fakeGit();
+    const shell = fakeShell();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]), shell.runner);
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ref', settlingSubchain(task.id, done));
+    const { status } = await runBranch(branch, baseCtx([task]));
+
+    expect(status).toBe('completed');
+    expect(shell.calls).toHaveLength(0); // no setupScript → setup step is a no-op
+  });
+});
+
+// ── defensive branch-ref pre-delete (idempotent relaunch after a crashed run) ──────────────────
+
+describe('setupWorktree — defensive leaked-ref delete before add', () => {
+  it('deletes the wt-<task> ref BEFORE `worktree add -b` so a leaked ref never wedges relaunch', async () => {
+    const task = makeTodoTask();
+    const done: Task = { ...makeDoneTask(), id: task.id };
+    const { runner, calls } = fakeGit();
+    const deps = makeBranchDeps(runner, { emit: vi.fn() }, stubBus([]));
+    const wt = worktreePathFor(absolutePath('/data/sprints/s1'), task.id);
+
+    const branch = buildWorktreeBranch(deps, repo, task, wt, 'ralphctl/s1/wt-x', settlingSubchain(task.id, done));
+    await runBranch(branch, baseCtx([task]));
+
+    const firstDeleteIdx = calls.findIndex((c) => c[0] === 'branch' && c[1] === '-D' && c[2] === 'ralphctl/s1/wt-x');
+    const addIdx = calls.findIndex((c) => c[0] === 'worktree' && c[1] === 'add');
+    expect(firstDeleteIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(firstDeleteIdx).toBeLessThan(addIdx); // defensive delete precedes the add
+  });
+});
+
+// ── serializeAppendFile ────────────────────────────────────────────────────────────────────────
+
+describe('serializeAppendFile', () => {
+  it('serialises concurrent appends — critical sections never overlap, FIFO order preserved', async () => {
+    const completed: string[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    // An inner append that yields twice mid-write — overlapping calls would interleave here.
+    const inner: AppendFile = async (_path, text) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight -= 1;
+      completed.push(text);
+      return Result.ok(undefined);
+    };
+    const append = serializeAppendFile(inner);
+    const p = absolutePath('/data/sprints/s1/progress.md');
+    await Promise.all([append(p, 'a'), append(p, 'b'), append(p, 'c'), append(p, 'd')]);
+
+    expect(maxInFlight).toBe(1); // never two appends writing at once
+    expect(completed).toEqual(['a', 'b', 'c', 'd']); // FIFO enqueue order
+  });
+
+  it('a rejecting append does not wedge the serializer — later appends still run', async () => {
+    const ran: string[] = [];
+    let first = true;
+    const inner: AppendFile = async (_path, text) => {
+      if (first) {
+        first = false;
+        throw new Error('disk full');
+      }
+      ran.push(text);
+      return Result.ok(undefined);
+    };
+    const append = serializeAppendFile(inner);
+    const p = absolutePath('/x');
+    await expect(append(p, 'boom')).rejects.toThrow('disk full');
+    await append(p, 'after');
+    expect(ran).toEqual(['after']);
+  });
+});

--- a/tests/unit/application/ui/shared/launch/clamp-parallel.test.ts
+++ b/tests/unit/application/ui/shared/launch/clamp-parallel.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The parallel cap. `clampParallel` decides the implement dispatch: `=== 1` → serial path,
+ * `> 1` → parallel worktree-fan-out path. The settings schema already validates `[1,5]`, but the
+ * launcher re-clamps defensively so a hand-edited file or future schema change can't push past the
+ * budget the wave scheduler (and provider rate limits) were sized against.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { clampParallel } from '@src/application/ui/shared/launch/implement.ts';
+
+describe('clampParallel', () => {
+  it('keeps 1 (serial default) unchanged', () => {
+    expect(clampParallel(1)).toBe(1);
+  });
+
+  it('keeps in-range values 2..5', () => {
+    expect(clampParallel(2)).toBe(2);
+    expect(clampParallel(5)).toBe(5);
+  });
+
+  it('caps above 5 down to 5 (the hard ceiling)', () => {
+    expect(clampParallel(6)).toBe(5);
+    expect(clampParallel(100)).toBe(5);
+  });
+
+  it('floors below 1 up to 1', () => {
+    expect(clampParallel(0)).toBe(1);
+    expect(clampParallel(-3)).toBe(1);
+  });
+
+  it('truncates fractional values', () => {
+    expect(clampParallel(3.9)).toBe(3);
+  });
+
+  it('falls back to 1 (serial) on a non-finite value', () => {
+    expect(clampParallel(Number.NaN)).toBe(1);
+    expect(clampParallel(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+});

--- a/tests/unit/domain/entity/settings-max-parallel-tasks.test.ts
+++ b/tests/unit/domain/entity/settings-max-parallel-tasks.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Clamp contract for `settings.concurrency.maxParallelTasks`: the schema accepts `[1, 5]` and
+ * rejects anything above the parallel ceiling. The wave scheduler re-clamps to the same bound,
+ * but the schema is the first line of defence against a hand-edited settings file asking for
+ * more concurrency than the harness supports.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SettingsSchema } from '@src/domain/entity/settings.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+
+const withMaxParallel = (maxParallelTasks: number): unknown => ({
+  ...DEFAULT_SETTINGS,
+  concurrency: { ...DEFAULT_SETTINGS.concurrency, maxParallelTasks },
+});
+
+describe('settings.concurrency.maxParallelTasks clamp', () => {
+  it('rejects 6 (above the ceiling of 5)', () => {
+    const parsed = SettingsSchema.safeParse(withMaxParallel(6));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts 5 (the ceiling)', () => {
+    const parsed = SettingsSchema.safeParse(withMaxParallel(5));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.concurrency.maxParallelTasks).toBe(5);
+  });
+
+  it('accepts 1 (the serial default, unchanged)', () => {
+    const parsed = SettingsSchema.safeParse(withMaxParallel(1));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.concurrency.maxParallelTasks).toBe(1);
+  });
+});

--- a/tests/unit/integration/io/git-worktree.test.ts
+++ b/tests/unit/integration/io/git-worktree.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import {
+  gitDeleteBranch,
+  gitFoldBranch,
+  gitWorktreeAdd,
+  gitWorktreePrune,
+  gitWorktreeRef,
+  gitWorktreeRemove,
+} from '@src/integration/io/git-operations.ts';
+import type { GitRunner, GitRunOptions, GitRunResult } from '@src/integration/io/git-runner.ts';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`test setup: bad path ${p}`);
+  return r.value;
+};
+
+const repoRoot = abs('/repo');
+const worktreePath = abs('/repo/.ralphctl-worktrees/wt-task-1');
+
+interface RecordedCall {
+  readonly args: readonly string[];
+  readonly opts: GitRunOptions | undefined;
+}
+
+interface ScriptedCall {
+  readonly args: readonly string[];
+  readonly result: Result<GitRunResult, StorageError>;
+}
+
+/**
+ * Scripted fake runner: asserts the argv of each call in order, returns the canned result, and
+ * records the `opts` so timeout overrides can be asserted.
+ */
+const scriptRunner = (calls: ScriptedCall[]): { runner: GitRunner; received: RecordedCall[] } => {
+  const received: RecordedCall[] = [];
+  let i = 0;
+  const runner: GitRunner = {
+    async run(_, args, opts) {
+      received.push({ args, opts });
+      const next = calls[i++];
+      if (next === undefined) {
+        throw new Error(`unscripted git call: ${args.join(' ')}`);
+      }
+      if (JSON.stringify(next.args) !== JSON.stringify(args)) {
+        throw new Error(`expected git ${next.args.join(' ')} but got git ${args.join(' ')}`);
+      }
+      return next.result;
+    },
+  };
+  return { runner, received };
+};
+
+const ok = (stdout = '', exitCode = 0, stderr = ''): Result<GitRunResult, StorageError> =>
+  Result.ok({ stdout, stderr, exitCode });
+
+describe('gitWorktreeRef', () => {
+  it('builds the canonical ralphctl/<sprintId>/wt-<taskId> ref', () => {
+    expect(gitWorktreeRef('sprint-abc', 'task-7')).toBe('ralphctl/sprint-abc/wt-task-7');
+  });
+});
+
+describe('gitWorktreeAdd', () => {
+  it('runs `worktree add -b <branch> <path>` with a bumped timeout', async () => {
+    const branch = gitWorktreeRef('s1', 't1');
+    const { runner, received } = scriptRunner([
+      { args: ['worktree', 'add', '-b', branch, String(worktreePath)], result: ok() },
+    ]);
+    const result = await gitWorktreeAdd(runner, repoRoot, worktreePath, branch);
+    expect(result.ok).toBe(true);
+    expect(received[0]?.args).toEqual(['worktree', 'add', '-b', branch, String(worktreePath)]);
+    // The add verb must raise the per-call timeout above the runner default.
+    expect(received[0]?.opts?.timeoutMs).toBeGreaterThan(30_000);
+  });
+
+  it('surfaces a non-zero exit as StorageError', async () => {
+    const branch = gitWorktreeRef('s1', 't1');
+    const { runner } = scriptRunner([
+      {
+        args: ['worktree', 'add', '-b', branch, String(worktreePath)],
+        result: ok('', 128, "fatal: a branch named 'ralphctl/s1/wt-t1' already exists"),
+      },
+    ]);
+    const result = await gitWorktreeAdd(runner, repoRoot, worktreePath, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('already exists');
+  });
+
+  it('propagates a runner transport error verbatim', async () => {
+    const branch = gitWorktreeRef('s1', 't1');
+    const { runner } = scriptRunner([
+      {
+        args: ['worktree', 'add', '-b', branch, String(worktreePath)],
+        result: Result.error(new StorageError({ subCode: 'io', message: 'failed to spawn git: ENOENT' })),
+      },
+    ]);
+    const result = await gitWorktreeAdd(runner, repoRoot, worktreePath, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('failed to spawn git');
+  });
+});
+
+describe('gitWorktreeRemove', () => {
+  it('runs `worktree remove --force <path>`', async () => {
+    const { runner, received } = scriptRunner([
+      { args: ['worktree', 'remove', '--force', String(worktreePath)], result: ok() },
+    ]);
+    const result = await gitWorktreeRemove(runner, repoRoot, worktreePath);
+    expect(result.ok).toBe(true);
+    expect(received[0]?.args).toEqual(['worktree', 'remove', '--force', String(worktreePath)]);
+  });
+
+  it('surfaces a non-zero exit as StorageError', async () => {
+    const { runner } = scriptRunner([
+      {
+        args: ['worktree', 'remove', '--force', String(worktreePath)],
+        result: ok('', 1, 'fatal: validation failed'),
+      },
+    ]);
+    const result = await gitWorktreeRemove(runner, repoRoot, worktreePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('validation failed');
+  });
+});
+
+describe('gitDeleteBranch', () => {
+  it('runs `branch -D <name>`', async () => {
+    const branch = gitWorktreeRef('s1', 't1');
+    const { runner, received } = scriptRunner([{ args: ['branch', '-D', branch], result: ok() }]);
+    const result = await gitDeleteBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(true);
+    expect(received[0]?.args).toEqual(['branch', '-D', branch]);
+  });
+
+  it('surfaces a non-zero exit as StorageError', async () => {
+    const branch = gitWorktreeRef('s1', 't1');
+    const { runner } = scriptRunner([
+      { args: ['branch', '-D', branch], result: ok('', 1, "error: branch '...' not found") },
+    ]);
+    const result = await gitDeleteBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('not found');
+  });
+});
+
+describe('gitWorktreePrune', () => {
+  it('runs `worktree prune`', async () => {
+    const { runner, received } = scriptRunner([{ args: ['worktree', 'prune'], result: ok() }]);
+    const result = await gitWorktreePrune(runner, repoRoot);
+    expect(result.ok).toBe(true);
+    expect(received[0]?.args).toEqual(['worktree', 'prune']);
+  });
+
+  it('surfaces a non-zero exit as StorageError', async () => {
+    const { runner } = scriptRunner([{ args: ['worktree', 'prune'], result: ok('', 1, 'boom') }]);
+    const result = await gitWorktreePrune(runner, repoRoot);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('gitFoldBranch', () => {
+  const branch = gitWorktreeRef('s1', 't1');
+
+  it('fast-forwards when the merge is ff-able (no cherry-pick path)', async () => {
+    const { runner, received } = scriptRunner([{ args: ['merge', '--ff-only', branch], result: ok() }]);
+    const result = await gitFoldBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(true);
+    // Only the ff merge runs — no merge-base / cherry-pick.
+    expect(received.map((c) => c.args)).toEqual([['merge', '--ff-only', branch]]);
+  });
+
+  it('falls back to cherry-pick of <merge-base>..<branch> when ff fails', async () => {
+    const mergeBase = 'a1b2c3d4e5f6a7b8c9d0';
+    const { runner, received } = scriptRunner([
+      { args: ['merge', '--ff-only', branch], result: ok('', 1, 'fatal: Not possible to fast-forward') },
+      { args: ['merge-base', 'HEAD', branch], result: ok(`${mergeBase}\n`) },
+      { args: ['cherry-pick', `${mergeBase}..${branch}`], result: ok() },
+    ]);
+    const result = await gitFoldBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(true);
+    expect(received.map((c) => c.args)).toEqual([
+      ['merge', '--ff-only', branch],
+      ['merge-base', 'HEAD', branch],
+      ['cherry-pick', `${mergeBase}..${branch}`],
+    ]);
+  });
+
+  it('surfaces a cherry-pick conflict as an error and aborts to leave the branch clean', async () => {
+    const mergeBase = 'a1b2c3d4e5f6a7b8c9d0';
+    const { runner, received } = scriptRunner([
+      { args: ['merge', '--ff-only', branch], result: ok('', 1, 'not ff') },
+      { args: ['merge-base', 'HEAD', branch], result: ok(`${mergeBase}\n`) },
+      {
+        args: ['cherry-pick', `${mergeBase}..${branch}`],
+        result: ok('', 1, 'CONFLICT (content): Merge conflict in src/a.ts'),
+      },
+      { args: ['cherry-pick', '--abort'], result: ok() },
+    ]);
+    const result = await gitFoldBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('cherry-pick failed');
+      expect(result.error.message).toContain(branch);
+    }
+    // The conflict must trigger an abort so siblings stay landed.
+    expect(received.map((c) => c.args)).toContainEqual(['cherry-pick', '--abort']);
+  });
+
+  it('rejects a non-SHA merge-base output', async () => {
+    const { runner } = scriptRunner([
+      { args: ['merge', '--ff-only', branch], result: ok('', 1, 'not ff') },
+      { args: ['merge-base', 'HEAD', branch], result: ok('not-a-sha\n') },
+    ]);
+    const result = await gitFoldBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('non-SHA');
+  });
+
+  it('surfaces a merge-base failure as StorageError', async () => {
+    const { runner } = scriptRunner([
+      { args: ['merge', '--ff-only', branch], result: ok('', 1, 'not ff') },
+      { args: ['merge-base', 'HEAD', branch], result: ok('', 128, 'fatal: no merge base') },
+    ]);
+    const result = await gitFoldBranch(runner, repoRoot, branch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('merge-base failed');
+  });
+});


### PR DESCRIPTION
Opt-in parallel implementation: each dependency wave's tasks run concurrently in isolated git worktrees, folded onto one sprint branch so a multi-task sprint still lands as a single PR. Default `maxParallelTasks` stays `1` (serial path byte-for-byte unchanged, zero regression).

## How it works
- `settings.concurrency.maxParallelTasks` (clamped `[1,5]`): `=== 1` → serial path; `> 1` → parallel.
- An above-the-chain `runWaves` orchestrator (not a new chain primitive) runs each dependency wave's tasks concurrently, one git worktree per task, forked from the sprint-branch tip. Waves stay strictly sequential.
- Each worktree's commit is folded (`merge --ff-only` else `cherry-pick`) onto the single sprint branch through one fold queue → one PR.

## Production hardening (closed the original "experimental" gaps)
- **Per-worktree `setupScript`** runs in each fresh worktree (a worktree has no build deps); failure blocks only that task, never the wave.
- **Fold conflict** → that task is blocked (siblings stay done); relaunch re-forks from the advanced tip and retries.
- **Lock parity** with the serial path (same sprint lock key → serial and parallel runs of one sprint mutually exclude).
- **Abort** propagates `AbortError` verbatim; durably-folded commits persist on abort → no duplicate execution on relaunch.
- **Serialised** `progress.md` / learnings-ledger appends; **defensive** leaked worktree-ref cleanup; ≤5 concurrency cap.

## Tests
Full suite green (2825 tests, 0 skipped). New/extended coverage: real-git e2e (worktree lifecycle, per-worktree setup, fold-conflict with a real cherry-pick conflict, no leaked refs, linear history), wave-scheduler abort/fatal classification, merge fan-in, lock-contention, no-listener-leak, durable-fold-on-abort.

## Deferred (documented, not bugs)
File-overlap-aware wave partitioning (today: conflicting task blocks + re-runs) and cross-provider mid-task escalation.