### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -377,7 +377,7 @@ of the stack — the leaf or use-case wrapping them catches and converts to `Res
 │           └── review/                ← apply-feedback per-round forensics
 └── state/
     └── locks/
-        └── repo-<worktree-hash>.lock ← cross-process advisory lock (one per working tree, keyed by sha1 of the absolute repo path)
+        └── repo-<worktree-hash>.lock/ ← cross-process advisory lock directory (one per sprint, keyed by sha1 of the sprint dir path — implement and review share the same key)
 ```
 
 Path resolution lives in `src/application/bootstrap/storage-paths.ts` (`resolveStoragePaths`,

--- a/.claude/docs/KERNEL-DESIGN.md
+++ b/.claude/docs/KERNEL-DESIGN.md
@@ -302,8 +302,10 @@ const perTask = sequential('task-<id>', [
 // resumed sprint picks up the prior aborted task before any fresh work.
 const orderedTasks = [...tasks].sort((a, b) => (a.status === b.status ? 0 : a.status === 'in_progress' ? -1 : 1));
 
-// The whole run is wrapped in `withRepoLock(...)` keyed on the sprint dir — one implement
-// run at a time per sprint (it owns sprint-scoped state: tasks.json, progress.md, execution.json).
+// The whole run is wrapped in `withRepoLock(...)` (src/application/flows/_shared/with-repo-lock.ts),
+// a ctx-generic helper keyed on the sprint dir — shared by both implement (serial path) and review,
+// so an implement run and a review run of the same sprint mutually exclude. The parallel implement
+// path holds the same lock key directly in parallel-element.ts (spanning prologue + waves + epilogue).
 sequential('implement', [
   withRepoLock(
     {

--- a/.claude/docs/KERNEL-DESIGN.md
+++ b/.claude/docs/KERNEL-DESIGN.md
@@ -108,8 +108,12 @@ Semantics:
   elements get `skipped`.
 - Emits one trace entry per child element. Composites never report a self-entry.
 
-The implement chain uses a `sequential` of bridge leaves to iterate per-task subchains in topological order;
-there is no concurrent fan-out primitive (concurrent fan-out within a dependency level is deferred).
+The implement chain uses a `sequential` of bridge leaves to iterate per-task subchains in topological order
+(serial path, `maxParallelTasks === 1`). Concurrent fan-out within a dependency level ships in 0.9.0 via the
+**above-the-chain** orchestrator `runWaves` (`src/application/chain/run/wave-scheduler.ts`), which sequences
+whole sub-chains above the primitives — deliberately not a sixth primitive. The five-primitive set
+(`element` / `leaf` / `sequential` / `loop` / `guard`) is unchanged; `runWaves` never implements `Element`
+and must never be composed into a `sequential` / `loop` / `guard`.
 
 ## loop — generator-evaluator primitive
 

--- a/.claude/docs/MANUAL-TEST-PLAYBOOK.md
+++ b/.claude/docs/MANUAL-TEST-PLAYBOOK.md
@@ -263,6 +263,32 @@ leaves whose `name` contains an absolute repo path).
 
 ---
 
+## Scenario 13 — cross-process advisory lock
+
+**Setup:** a sprint with at least one task remaining (`todo`). Two separate terminal tabs.
+
+1. In terminal A, start the **Implement** flow on the sprint — let it reach the first AI session (so the
+   lock is held and the heartbeat is running)
+2. Within ~5 seconds (before any crash-reclaim threshold), start the **same** Implement flow on the
+   **same sprint** in terminal B
+3. **Expected:** terminal B immediately shows a warn banner — "Repository lock held by another process —
+   could not acquire after retries" — and the chain halts. Terminal A continues running normally.
+4. Kill terminal A's process (`Ctrl+C`)
+5. Wait ~30 seconds for the default crash-reclaim window (`DEFAULT_STALE_AFTER_MS`) to elapse — the
+   heartbeat stops, the lock directory goes stale
+6. Re-start the Implement flow in terminal B
+7. **Expected:** terminal B acquires the lock and resumes normally (the previously `in_progress` task
+   resets to `todo` and re-enters the queue)
+
+**Negative tests:**
+
+- Do NOT manually delete the `<stateRoot>/locks/repo-<hash>.lock/` directory while a holder is alive —
+  the compromised-lock path should trigger an `AbortError` tear-down, not a silent hang.
+- Verify no double-execution: tasks completed in terminal A before the kill must remain `done` after
+  terminal B resumes.
+
+---
+
 ## Known issues (file under here, link the fix commit)
 
 - (none currently)
@@ -277,8 +303,10 @@ can't reach. Things still NOT covered:
 - Real provider integration: every Claude / Copilot / Codex provider test uses a fake `spawn`. JSON-shape
   drift will surface here first.
 - File-system corner cases (NFS / SMB mounts, case-insensitive FS).
-- Concurrency under load — the implement flow runs strictly sequential, but cross-process locks (the
-  `<stateRoot>/locks/repo-<hash>.lock` file) are best tested with two real ralphctl processes.
+- Concurrency under load — the implement flow runs strictly sequential (or parallel when
+  `maxParallelTasks > 1`), but cross-process lock contention (the `<stateRoot>/locks/repo-<hash>.lock/`
+  directory) and the heartbeat crash-reclaim path are best tested with two real ralphctl processes
+  (see Scenario 13).
 
 If you find a class of bug that recurs, add a scenario for it here rather than fixing it once and waiting
 for the next regression.

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # RalphCTL — Acceptance Criteria
 
-Testable acceptance criteria, current as of v0.8.x. Read on demand — this file is not auto-imported into every
+Testable acceptance criteria, current as of v0.9.x. Read on demand — this file is not auto-imported into every
 Claude session. Source of truth for narrative constraints lives elsewhere; pointers below.
 
 | For…                              | Read…                                  |

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -38,10 +38,11 @@ it done; when a behaviour regresses, untick it.
       `<root>/{config,data,state}/…`. Per-sprint directory contains `sprint.json` + `execution.json` +
       `tasks.json` + `progress.md` + per-flow sandbox folders. `events.ndjson` lands here too when
       `RALPHCTL_DEBUG_TRACE=1` (opt-in debug sink, no-op otherwise).
-- [ ] **Cross-process repo lock** — `<stateRoot>/locks/repo-<hash>.lock` (sha1 of the repo worktree path)
-      blocks two ralphctl processes from racing the same working tree. Stale-takeover fires after the locker's fixed 30s
-      threshold
-      (`DEFAULT_STALE_AFTER_MS`, clamped 1ms..1h) — not env-configurable.
+- [ ] **Cross-process repo lock** — `<stateRoot>/locks/repo-<hash>.lock/` (lock directory, sha1 of the sprint dir path)
+      blocks two ralphctl processes from racing the same sprint. Both implement and review key on the sprint dir, so they
+      mutually exclude. A **heartbeat** keeps a live holder's lock perpetually fresh — stale-takeover fires only after a
+      crashed holder's mtime passes `DEFAULT_STALE_AFTER_MS` (30s, clamped 2000ms..1h) — not env-configurable. A
+      compromised lock aborts the in-flight run as an `AbortError`.
 - [ ] **`@public` JSDoc tag whitelist** — `pnpm deadcode` exits 0 on a clean tree; symbols intentionally kept
       after dead-code cleanup are tagged `@public`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ to [Semantic Versioning](https://semver.org/).
   single topological scheduler — called at parse time in `parse-task-list.ts` (removing the
   private Kahn pass) and at implement-launch time in `launch/implement.ts`. A cycle or
   dangling-dependency reference fails fast before any task runs. Launch order is now
-  dependency-resolved then `in_progress`-first within the resumable set. Tasks still run strictly
-  one at a time (`maxParallelTasks` stays the pre-existing setting, default `1`).
+  dependency-resolved then `in_progress`-first within the resumable set.
 
 - **Up-to-`maxAttempts` per launch via outer `loop`.** `per-task-subchain.ts`
   wraps the full per-attempt segment in a `loop('task-attempts-<id>', …, { maxIterations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-01
+
 ### Added
 
 - **Opt-in parallel task execution via `settings.concurrency.maxParallelTasks` (1–5).** Default `1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,31 @@ maxAttempts, shouldStop })` so a single launch runs up to `maxAttempts` rounds p
   `distill-learnings`; shared module: `flows/_shared/memory/`; pure classifier:
   `deriveTaskKind` in `business/task/`.
 
+### Fixed
+
+- **Cross-process repo lock no longer goes stale while its holder is alive.** The advisory lock
+  (`file-locker.ts`) is now backed by `proper-lockfile` — a directory lock (atomic `mkdir`,
+  NFS-safe) kept fresh by a background heartbeat. Previously staleness was judged on age since
+  acquisition (30s default) with no heartbeat, so a long-running implement run — which holds the
+  lock for its whole duration — became takeover-eligible while still alive, letting a second
+  `ralphctl` process race the same sprint branch and break the single-PR guarantee. A live holder
+  is now never falsely stolen no matter how long the run lasts; a crashed holder is reclaimed once
+  its mtime passes `staleAfterMs` (which now bounds crash-reclaim latency only). The `FileLocker`
+  port contract is unchanged. Chosen over OS `flock` because ralphctl is cross-platform (no native
+  addon) and may run on NFS.
+
+- **A repo lock lost mid-run now aborts the in-flight run.** `withLock` hands its callback an
+  `AbortSignal` that fires when the held lock is compromised (heartbeat could not refresh / a
+  takeover occurred); the serial and parallel implement paths merge it with the host abort signal
+  (`combineAbortSignals`), so a compromised lock tears the chain down as an `AbortError` instead of
+  continuing to mutate a branch another process may now own.
+
+- **The `review` flow now holds the repo lock.** Review commits to the sprint branch and runs
+  verify, but previously ran with no cross-process lock. Its chain is now wrapped in `withRepoLock`
+  keyed on the sprint directory — the same key the implement flow uses — so an implement run and a
+  review run of one sprint mutually exclude. `withRepoLock` is now a ctx-generic helper shared by
+  both flows (`flows/_shared/`).
+
 ## [0.8.6] - 2026-05-29
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,12 @@ Only the latest version is supported — no backporting, no parallel branches.
 The sections below give per-version context for what changed and why, in case
 you're crossing a big jump and want to know what to expect.
 
+## 0.8.x → 0.9.0
+
+Nothing to do on upgrade. Parallel task execution is opt-in — `settings.concurrency.maxParallelTasks`
+defaults to `1` (serial, byte-for-byte unchanged); set it to 2–5 to enable. See
+[CHANGELOG](./CHANGELOG.md#090---2026-06-01).
+
 ## 0.8.0 → 0.8.6
 
 Nothing to do. The 0.8.x point releases only add silent, best-effort settings

--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ with [GitHub Copilot](https://docs.github.com/en/copilot/github-copilot-in-the-c
 > _"I'm helping!"_ — Ralph Wiggum
 
 > [!NOTE]
-> **Active development.** New features and polish ship regularly. The 0.8.x
-> line continues a burst of structural changes — thanks for sticking with us
-> through it. Upgrades are simple: install the latest version, redo your
-> config, proceed. See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
+> **Active development.** New features and polish ship regularly. **0.9.0** adds
+> opt-in parallel task execution — independent tasks within a dependency wave run
+> concurrently, each in its own git worktree, folded back onto one branch.
+> Upgrades are simple: install the latest version, redo your config, proceed.
+> See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
 
 ---
 
 ## What is ralphctl?
 
 AI coding agents are powerful but lose context on long tasks, need babysitting when things break, and have no way to
-coordinate changes across multiple repositories. ralphctl wraps your chosen AI CLI — currently Claude Code — in a
+coordinate changes across multiple repositories. ralphctl wraps your chosen AI CLI — Claude Code, with GitHub Copilot
+and OpenAI Codex in preview — in a
 structured harness that decomposes your work into dependency-ordered tasks, drives each one through
 a [generator-evaluator loop](https://www.anthropic.com/engineering/harness-design-long-running-apps) that catches issues
 before moving on, and persists context across sessions so nothing gets lost.
@@ -122,13 +124,15 @@ ralphctl settings set ai.implement.evaluator.model    <model-id>
 
 **Refine** is implementation-agnostic: the AI clarifies requirements with you, ticket by ticket, and flips each one from
 `pending` to `approved`. **Plan** requires every ticket approved — the AI explores the affected repos and generates a
-dependency-ordered task graph. **Implement** drives those tasks one at a time through a generator-evaluator cycle: a
-second AI pass reviews each task against its spec before the harness marks it done and moves to the next.
+dependency-ordered task graph. **Implement** drives those tasks in dependency order through a generator-evaluator cycle:
+a second AI pass reviews each task against its spec before the harness marks it done and moves on. Independent tasks in
+the same dependency wave can run in parallel (opt-in) when you want a sprint to finish faster.
 
 Key properties:
 
-- **Dependency-ordered execution** — tasks run strictly one at a time in topological order; no task starts until its
-  blockers are done
+- **Dependency-ordered execution** — tasks run in topological order; no task starts until its blockers are done.
+  Opt-in parallelism (`concurrency.maxParallelTasks` > 1) runs independent tasks within a dependency wave concurrently,
+  each in its own git worktree folded onto one branch — default stays serial
 - **Generator-evaluator cycle** — an independent AI reviewer checks each task; if it fails, the generator gets the
   critique and iterates (up to `harness.maxAttempts` tries before the task is flagged `blocked`)
 - **Context persistence** — sprint state, branch, progress history, and per-task context survive across sessions;
@@ -145,17 +149,19 @@ For the full architectural picture see [`.claude/docs/ARCHITECTURE.md`](./.claud
 > [!IMPORTANT]
 > Not all three AI providers are equally production-ready inside ralphctl.
 
-| Provider                                  | Status                                  | Headless flag                                               | Native context file               |
-| ----------------------------------------- | --------------------------------------- | ----------------------------------------------------------- | --------------------------------- |
-| **Claude Code** (`claude-code`)           | **Stable — primary verified provider**  | `--permission-mode bypassPermissions` + per-tool deny list  | `CLAUDE.md` at repo root          |
-| **GitHub Copilot CLI** (`github-copilot`) | Preview — not officially verified by us | `--autopilot --allow-all` + `--max-autopilot-continues=200` | `.github/copilot-instructions.md` |
-| **OpenAI Codex** (`openai-codex`)         | Preview — not officially verified by us | `-s workspace-write` (topology-scoped)                      | `AGENTS.md`                       |
+| Provider                                  | Status                                                                          | Headless flag                                               | Native context file               |
+| ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------------------------- |
+| **Claude Code** (`claude-code`)           | **Stable — primary verified provider**                                          | `--permission-mode bypassPermissions` + per-tool deny list  | `CLAUDE.md` at repo root          |
+| **GitHub Copilot CLI** (`github-copilot`) | Preview — maturing; works well day-to-day, not yet formally verified end-to-end | `--autopilot --allow-all` + `--max-autopilot-continues=200` | `.github/copilot-instructions.md` |
+| **OpenAI Codex** (`openai-codex`)         | Preview — maturing; works well day-to-day, not yet formally verified end-to-end | `-s workspace-write` (topology-scoped)                      | `AGENTS.md`                       |
 
-"Preview" means the integration exists and the TUI lets you select it, but end-to-end harness behaviour against those
-providers has not been formally verified. Copilot and Codex no-op some features (bundled skill injection, `bodyFile`
-forensic artifacts). Codex cannot fine-grained-deny edits on existing repo files — its sandbox modes are binary, so
-path scope (cwd + `--add-dir`) is the only safety envelope. If you hit a rough edge on a preview provider,
-please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
+"Preview" means the integration is in active use and increasingly solid — recent releases run Copilot and Codex well
+across the everyday flows — but harness behaviour against them hasn't been put through the same formal end-to-end
+verification as Claude Code. A couple of features still no-op on them (bundled skill injection, `bodyFile` forensic
+artifacts), and Codex can't fine-grained-deny edits on existing repo files — its sandbox modes are binary, so path
+scope (cwd + `--add-dir`) is the only safety envelope. Parallel execution is provider-agnostic: it works with whichever
+provider each implement role is configured to use, under the same per-provider caveats. If you hit a rough edge on a
+preview provider, please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
 One-shot configuration for any provider: `ralphctl settings apply-preset <name>` where `<name>` is
 `mixed`, `claude-only`, `copilot-only`, or `codex-only`.
@@ -168,6 +174,8 @@ One-shot configuration for any provider: `ralphctl settings apply-preset <name>`
 - **Catch mistakes before they compound** — independent AI review after each task, iterating until quality passes or
   budget is exhausted
 - **Coordinate across repositories** — one sprint can span multiple repos with automatic dependency tracking
+- **Finish sprints faster (opt-in)** — run independent tasks within a dependency wave in parallel, each in its own git
+  worktree, folded back onto one sprint branch (still one PR); default stays serial, zero change
 - **Branch per sprint** — optional shared branch across every affected repo; `ralphctl create-pr --sprint <id>` opens a
   PR / MR via `gh` or `glab` when you're done
 - **Recover from rate limits** — exponential backoff and session resume keep the in-flight task's full context when the
@@ -221,6 +229,17 @@ ralphctl settings set harness.maxAttempts 2          # Cap fix attempts per task
 ralphctl settings set harness.maxTurns    8          # Generator-evaluator turns per attempt (1–10)
 ralphctl settings set harness.rateLimitRetries 3     # Adapter-side 429 retries (0–10)
 ```
+
+**Run tasks in parallel** (optional — default is serial):
+
+```bash
+ralphctl settings set concurrency.maxParallelTasks 3   # 1–5; 1 = serial (default), >1 = parallel git worktrees
+```
+
+When `> 1`, independent tasks within a dependency wave run concurrently — each in its own git worktree, with its own
+`setupScript` run, folded back onto the single sprint branch (still one PR per sprint). A task whose worktree setup
+fails is blocked on its own without stopping its siblings; if two same-wave tasks edit the same file, the second is
+blocked at fold time and a relaunch retries it. Dependencies are always respected — only independent tasks overlap.
 
 ### Data directory
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version `0.8.6` → `0.9.0`
- Promote `## [Unreleased]` CHANGELOG section to `## [0.9.0] - 2026-06-01`

Headline of 0.9.0: **opt-in parallel task execution** (`concurrency.maxParallelTasks` 1–5; default 1 = serial, unchanged) via isolated git worktrees folded onto one sprint branch — plus the procedural-memory ledger + distill, task-graph scheduling, and up-to-`maxAttempts`-per-launch work already on `main`.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (2825 passed) — green locally
- [ ] CI green
- [ ] **HOLD: do not merge / tag / publish — left open for manual verification + testing**