### PR TITLE
fix: heartbeat-based repo lock (proper-lockfile) + compromise-abort + review lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,8 +274,12 @@ produce one per distinct provider. No symlinks, no pointer schemes. Don't introd
 
 **Cross-process advisory lock** at `<stateRoot>/locks/repo-<hash>.lock` (sha1 of the repository worktree
 path, first 16 hex) serializes whole-flow runs against one working tree so two ralphctl processes can't race
-the same repo. Stale-takeover fires after the locker's `staleAfterMs` threshold (default 30s, clamped
-1–3600000 ms in `file-locker.ts`); it is not env-configurable.
+the same repo. Backed by `proper-lockfile` (`file-locker.ts`): the lock is a directory (atomic `mkdir`,
+NFS-safe) kept fresh by a background heartbeat, so a LIVE holder is never falsely stolen no matter how long
+the run lasts — a crashed holder stops heartbeating and is reclaimed once its mtime passes `staleAfterMs`
+(default 30s, clamped 2000–3600000 ms; bounds crash-reclaim latency only). Not env-configurable. The
+`onCompromised` path (a held lock lost mid-run) surfaces a `lock-compromised` warning rather than throwing;
+aborting the in-flight run on compromise is a deferred follow-up.
 
 **Atomic file writes** via `business/io/write-file.ts` for all persisted state. Direct `fs.writeFile` is
 fenced from business code by the layer rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,9 +277,13 @@ path, first 16 hex) serializes whole-flow runs against one working tree so two r
 the same repo. Backed by `proper-lockfile` (`file-locker.ts`): the lock is a directory (atomic `mkdir`,
 NFS-safe) kept fresh by a background heartbeat, so a LIVE holder is never falsely stolen no matter how long
 the run lasts — a crashed holder stops heartbeating and is reclaimed once its mtime passes `staleAfterMs`
-(default 30s, clamped 2000–3600000 ms; bounds crash-reclaim latency only). Not env-configurable. The
-`onCompromised` path (a held lock lost mid-run) surfaces a `lock-compromised` warning rather than throwing;
-aborting the in-flight run on compromise is a deferred follow-up.
+(default 30s, clamped 2000–3600000 ms; bounds crash-reclaim latency only). Not env-configurable. A held lock
+lost mid-run (`onCompromised`) surfaces a `lock-compromised` warning AND aborts the in-flight run: the
+lock-compromised signal is merged into the chain's abort signal (`combineAbortSignals`), so a lost lock tears
+the run down as an `AbortError` instead of continuing to mutate a resource a competitor may now own. The lock
+is held across the whole run by the implement flow (serial path via `withRepoLock`, parallel path holds the
+key directly) and by the review flow (`withRepoLock`, same sprint-dir key — implement and review of one
+sprint mutually exclude). `withRepoLock` (`flows/_shared/`) is the one ctx-generic wrapper both use.
 
 **Atomic file writes** via `business/io/write-file.ts` for all persisted state. Direct `fs.writeFile` is
 fenced from business code by the layer rules.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "commander": "^15.0.0",
     "cross-spawn": "^7.0.6",
     "ink": "^7.0.3",
+    "proper-lockfile": "^4.1.2",
     "react": "^19.2.6",
     "typescript-result": "^3.5.2",
     "zod": "^4.4.3"
@@ -71,6 +72,7 @@
     "@eslint/js": "^10.0.1",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^25.8.0",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.14",
     "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       ink:
         specifier: ^7.0.3
         version: 7.0.5(@types/react@19.2.15)(react@19.2.6)
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -36,6 +39,9 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.9.1
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.15
@@ -985,8 +991,14 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@typescript-eslint/eslint-plugin@8.60.0':
     resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
@@ -1412,6 +1424,9 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1723,6 +1738,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1763,6 +1781,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -2742,9 +2764,15 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
+
+  '@types/retry@0.12.5': {}
 
   '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -3246,6 +3274,8 @@ snapshots:
 
   globals@17.6.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   hermes-estree@0.25.1: {}
@@ -3578,6 +3608,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   punycode@2.3.1: {}
 
   react-reconciler@0.33.0(react@19.2.6):
@@ -3611,6 +3647,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.12.0: {}
 
   rfdc@1.4.1: {}
 

--- a/src/application/chain/run/combine-signals.ts
+++ b/src/application/chain/run/combine-signals.ts
@@ -1,0 +1,13 @@
+/**
+ * Combine a chain's host abort signal with a secondary one (e.g. the `FileLocker`'s
+ * lock-compromised signal) into a single signal that aborts when EITHER fires. When the host
+ * signal is absent, the secondary is returned unchanged.
+ *
+ * Used so a compromised whole-run lock tears the chain down the same way a user Ctrl+C does: the
+ * lock holder threads its compromise signal in here and passes the result to `element.execute`,
+ * so a lock lost mid-run propagates as an ordinary `AbortError` through the chain.
+ *
+ * @public
+ */
+export const combineAbortSignals = (host: AbortSignal | undefined, secondary: AbortSignal): AbortSignal =>
+  host === undefined ? secondary : AbortSignal.any([host, secondary]);

--- a/src/application/flows/_meta/run/flow.ts
+++ b/src/application/flows/_meta/run/flow.ts
@@ -101,6 +101,7 @@ export const createRunFlow = (deps: RunDeps, opts: CreateRunFlowOpts): Element<R
   });
   const reviewFlow = createReviewFlow(deps.review, {
     sprintId: opts.sprintId,
+    sprintDir: opts.sprintDir,
     reviewRoot: opts.reviewRoot,
     commitCwd: opts.commitCwd,
     additionalRoots: opts.additionalRoots,

--- a/src/application/flows/_shared/with-repo-lock.ts
+++ b/src/application/flows/_shared/with-repo-lock.ts
@@ -1,34 +1,37 @@
 import { Result } from '@src/domain/result.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element, ElementResult } from '@src/application/chain/element.ts';
 import type { TraceEntry } from '@src/application/chain/trace.ts';
 import { combineAbortSignals } from '@src/application/chain/run/combine-signals.ts';
 import type { FileLocker } from '@src/integration/io/file-locker.ts';
 import { repoLockFile } from '@src/integration/io/lock-paths.ts';
-import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 /**
- * Higher-order element that wraps an inner chain in a repository-level advisory lock. Used
- * by the implement and review chains to serialise whole-flow runs against the same working tree:
+ * Ctx-generic higher-order element that wraps an inner chain in a cross-process advisory lock, so a
+ * whole-flow run serialises against any other ralphctl process holding the same lock key. The
+ * wrapper never reads the carried ctx — it only passes it through to the inner chain — so every
+ * flow that needs the lock uses this ONE helper:
  *
- *   ralphctl run repo=A          ralphctl run repo=A          ralphctl run repo=B
- *      ↓                            ↓                            ↓
- *   acquire repo-A.lock          waits for repo-A.lock        acquires repo-B.lock
- *      ↓                            ↓                            ↓
- *   per-task chain runs          per-task chain runs (after)  runs in parallel
+ *   - implement (serial path) and review both wrap their chain here, keyed on the per-sprint
+ *     directory, so an implement run and a review run of the SAME sprint mutually exclude.
+ *   - the parallel implement path holds the same lock key directly (`parallel-element.ts`) because
+ *     it must span prologue + waves + epilogue, which a single-inner wrapper cannot express.
  *
- * Lock filename is keyed by a hash of the worktree path (see `repoLockFile`), so two
- * different `Repository` aggregates pointing at the same physical clone still serialise.
+ * The lock key is a hash of whatever `worktreePath` the caller passes (see `repoLockFile`); both
+ * implement and review pass the sprint directory. The lock-compromised signal is merged into the
+ * inner chain's abort signal (see `combineAbortSignals`), so a lock lost mid-run tears the chain
+ * down as an `AbortError` rather than continuing to mutate a resource a competitor may now own.
  *
  * Failure modes:
- *   - Lock acquisition fails (max retries, contention) → leaf returns
- *     `StorageError({ subCode: 'lock' })` and the chain halts with a clear message.
+ *   - Lock acquisition fails (contention past the retry budget) → returns
+ *     `StorageError({ subCode: 'lock' })`, the chain halts, and a warn banner is published.
  *   - Lock-path construction fails (path validation) → same `StorageError`.
- *   - Inner element returns `Result.error` → the lock is still released (the locker's
- *     `withLock` runs its `finally` even when the wrapped function throws).
+ *   - Inner element returns `Result.error` → the lock is still released (the locker's `withLock`
+ *     runs its `finally` even when the wrapped function throws).
+ *
+ * @public
  */
 
 export interface WithRepoLockOpts {
@@ -38,14 +41,14 @@ export interface WithRepoLockOpts {
   readonly eventBus: EventBus;
 }
 
-export const withRepoLock = (opts: WithRepoLockOpts, inner: Element<ImplementCtx>): Element<ImplementCtx> => ({
+export const withRepoLock = <TCtx>(opts: WithRepoLockOpts, inner: Element<TCtx>): Element<TCtx> => ({
   name: `with-repo-lock(${inner.name})`,
   // Expose the wrapped chain through the composite-pattern `children` slot so `flattenLeaves`
   // walks into it when the TUI builds its planned-leaf list. Without this the wrapper looked
   // like an opaque single leaf and the Flow-steps panel rendered only "with-repo-lock(…)" —
   // never the real setup / per-task / teardown sequence inside the lock.
   children: [inner],
-  async execute(ctx, signal, onTrace): Promise<ElementResult<ImplementCtx>> {
+  async execute(ctx, signal, onTrace): Promise<ElementResult<TCtx>> {
     const lockPath = repoLockFile(opts.locksRoot, opts.worktreePath);
     if (!lockPath.ok) {
       const entry: TraceEntry = {
@@ -91,14 +94,7 @@ export const withRepoLock = (opts: WithRepoLockOpts, inner: Element<ImplementCtx
     }
     // The locker returns the inner's Result-shaped result directly; bubble it up unchanged so
     // the inner trace surfaces in the parent.
-    if (!acquired.value.ok) {
-      const wrappedFailure = new StorageError({
-        subCode: 'lock',
-        message: `with-repo-lock: inner chain failed under ${String(lockPath.value)}`,
-      });
-      void wrappedFailure;
-      return acquired.value;
-    }
+    if (!acquired.value.ok) return acquired.value;
     return Result.ok(acquired.value.value);
   },
 });

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -26,7 +26,7 @@ import {
   uniqueRepoCwdsForTasks,
 } from '@src/application/flows/implement/leaves/sprint-repo-plan.ts';
 import { transitionSprintToReviewLeaf } from '@src/application/flows/implement/leaves/transition-sprint-to-review.ts';
-import { withRepoLock } from '@src/application/flows/implement/leaves/with-repo-lock.ts';
+import { withRepoLock } from '@src/application/flows/_shared/with-repo-lock.ts';
 
 export type { RepoExecConfig };
 

--- a/src/application/flows/implement/leaves/with-repo-lock.ts
+++ b/src/application/flows/implement/leaves/with-repo-lock.ts
@@ -5,6 +5,7 @@ import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element, ElementResult } from '@src/application/chain/element.ts';
 import type { TraceEntry } from '@src/application/chain/trace.ts';
+import { combineAbortSignals } from '@src/application/chain/run/combine-signals.ts';
 import type { FileLocker } from '@src/integration/io/file-locker.ts';
 import { repoLockFile } from '@src/integration/io/lock-paths.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
@@ -58,7 +59,12 @@ export const withRepoLock = (opts: WithRepoLockOpts, inner: Element<ImplementCtx
     }
     const start = performance.now();
     const bannerId = `lock-${String(lockPath.value)}`;
-    const acquired = await opts.fileLocker.withLock(lockPath.value, async () => inner.execute(ctx, signal, onTrace));
+    // Thread the lock-compromised signal into the inner chain (merged with the host abort signal)
+    // so a lock lost mid-run tears the chain down as an AbortError instead of mutating the repo
+    // a competitor may now own.
+    const acquired = await opts.fileLocker.withLock(lockPath.value, async (lockSignal) =>
+      inner.execute(ctx, combineAbortSignals(signal, lockSignal), onTrace)
+    );
     const durationMs = performance.now() - start;
 
     if (!acquired.ok) {

--- a/src/application/flows/implement/parallel-element.ts
+++ b/src/application/flows/implement/parallel-element.ts
@@ -8,6 +8,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Element, ElementResult } from '@src/application/chain/element.ts';
 import type { OnTrace, TraceEntry } from '@src/application/chain/trace.ts';
 import { createRunner, type Runner } from '@src/application/chain/run/runner.ts';
+import { combineAbortSignals } from '@src/application/chain/run/combine-signals.ts';
 import { runWaves, type WaveBranch } from '@src/application/chain/run/wave-scheduler.ts';
 import { bridgeRunnerToEventBus } from '@src/application/observability/chain-runner-bridge.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -88,8 +89,8 @@ export const createParallelImplementElement = (
       return Result.error({ error: lockPath.error, trace: [entry] });
     }
 
-    const acquired = await config.fileLocker.withLock(lockPath.value, async () =>
-      runUnderLock(plan, config, ctx, signal, onTrace)
+    const acquired = await config.fileLocker.withLock(lockPath.value, async (lockSignal) =>
+      runUnderLock(plan, config, ctx, combineAbortSignals(signal, lockSignal), onTrace)
     );
     if (!acquired.ok) {
       // Lock contention — surface verbatim. No waves ran, nothing to persist.

--- a/src/application/flows/review/flow.ts
+++ b/src/application/flows/review/flow.ts
@@ -3,6 +3,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { loop } from '@src/application/chain/build/loop.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
+import { withRepoLock } from '@src/application/flows/_shared/with-repo-lock.ts';
 import { loadAndAssertSprintSubChain } from '@src/application/flows/_shared/sprint/load-and-assert-sprint.ts';
 import type { ReviewCtx } from '@src/application/flows/review/ctx.ts';
 import type { ReviewDeps } from '@src/application/flows/review/deps.ts';
@@ -15,6 +16,12 @@ const DEFAULT_MAX_ROUNDS = 50;
 
 export interface CreateReviewFlowOpts {
   readonly sprintId: SprintId;
+  /**
+   * Per-sprint directory — the cross-process lock key (`<dataRoot>/sprints/<id>/`). Review commits
+   * to the sprint branch and runs verify, so it holds the SAME `withRepoLock` key the implement
+   * flow uses, making an implement run and a review run of one sprint mutually exclude.
+   */
+  readonly sprintDir: AbsolutePath;
   /**
    * Parent dir for per-round AI session forensics — `<sprintDir>/review/`. The per-round
    * leaf materialises `round-<N>/` subfolders here. The AI session's cwd is the per-round
@@ -85,7 +92,7 @@ export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): 
     }
   );
 
-  return sequential<ReviewCtx>('review', [
+  const chain = sequential<ReviewCtx>('review', [
     loadAndAssertSprintSubChain<ReviewCtx>({ sprintRepo: deps.sprintRepo }, ['review']),
     ensureFeedbackFileLeaf(opts.feedbackFile),
     loop<ReviewCtx>('review-loop', reviewRound, {
@@ -95,4 +102,17 @@ export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): 
     ...(deps.distill !== undefined ? [createDistillStep<ReviewCtx>(deps.distill.deps, deps.distill.opts)] : []),
     transitionSprintToDoneLeaf<ReviewCtx>({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
   ]);
+
+  // Hold the cross-process repo lock for the whole review run — keyed on the sprint dir, the SAME
+  // key the implement flow uses, so a review and an implement of one sprint mutually exclude
+  // (review commits to the sprint branch). Mirrors the serial implement path's wrapping.
+  return withRepoLock<ReviewCtx>(
+    {
+      fileLocker: deps.fileLocker,
+      locksRoot: deps.locksRoot,
+      worktreePath: opts.sprintDir,
+      eventBus: deps.eventBus,
+    },
+    chain
+  );
 };

--- a/src/application/ui/shared/launch/review.ts
+++ b/src/application/ui/shared/launch/review.ts
@@ -105,6 +105,7 @@ export const launchReview = async (ctx: LaunchContext): Promise<LaunchResult> =>
     },
     {
       sprintId: snapshot.sprint.id,
+      sprintDir: sprintDir.value,
       reviewRoot: reviewRoot.value,
       commitCwd: commitRepo.path,
       additionalRoots: affected.map((r) => r.path),

--- a/src/integration/io/file-locker.ts
+++ b/src/integration/io/file-locker.ts
@@ -66,8 +66,14 @@ export interface FileLocker {
    * Acquire the lock at `lockPath`, run `fn`, then release. The release runs in a `finally`
    * so a thrown `fn` still clears the lock. Returns the function's result wrapped in
    * `Result.ok`, or a `StorageError` if the lock could not be acquired.
+   *
+   * `fn` receives an `AbortSignal` that aborts if the held lock is **compromised** mid-run (lost
+   * to a takeover / a heartbeat the library could not refresh in time). Long-running holders
+   * should thread it into their work so a compromised lock tears the run down rather than
+   * continuing to mutate a resource another process may now own. Callers that don't need it may
+   * ignore the parameter.
    */
-  withLock<T>(lockPath: AbsolutePath, fn: () => Promise<T>): Promise<Result<T, StorageError>>;
+  withLock<T>(lockPath: AbsolutePath, fn: (signal: AbortSignal) => Promise<T>): Promise<Result<T, StorageError>>;
 }
 
 export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
@@ -78,8 +84,14 @@ export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
 
-  const withLock = async <T>(lockPath: AbsolutePath, fn: () => Promise<T>): Promise<Result<T, StorageError>> => {
+  const withLock = async <T>(
+    lockPath: AbsolutePath,
+    fn: (signal: AbortSignal) => Promise<T>
+  ): Promise<Result<T, StorageError>> => {
     const path = String(lockPath);
+    // Aborts if the held lock is compromised — handed to `fn` so a long-running holder can tear
+    // its work down instead of mutating a resource a competitor may have taken over.
+    const compromised = new AbortController();
     let release: () => Promise<void>;
     try {
       // `proper-lockfile` needs the parent directory to exist before it can `mkdir` the lock dir.
@@ -94,9 +106,12 @@ export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
         update: heartbeatMs,
         // Constant-backoff retry mirrors the previous `maxRetries × retryDelayMs` (~5s) budget.
         retries: { retries: maxRetries, factor: 1, minTimeout: retryDelayMs, maxTimeout: retryDelayMs },
-        // The library default for `onCompromised` THROWS (which would crash the process). Surface
-        // it as a warning instead; the held `fn` is left to run (abort-on-compromise is future work).
-        onCompromised: (cause) => opts.onWarning?.({ kind: 'lock-compromised', path, cause }),
+        // The library default for `onCompromised` THROWS (which would crash the process). Abort the
+        // in-flight `fn` first (a compromised lock may now be held elsewhere), then surface a warning.
+        onCompromised: (cause) => {
+          if (!compromised.signal.aborted) compromised.abort(cause);
+          opts.onWarning?.({ kind: 'lock-compromised', path, cause });
+        },
       });
     } catch (cause) {
       return Result.error(
@@ -110,7 +125,7 @@ export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
       );
     }
     try {
-      const value = await fn();
+      const value = await fn(compromised.signal);
       return Result.ok(value) as Result<T, StorageError>;
     } finally {
       try {

--- a/src/integration/io/file-locker.ts
+++ b/src/integration/io/file-locker.ts
@@ -1,63 +1,64 @@
 import { promises as fs } from 'node:fs';
 import { dirname } from 'node:path';
+import properLockfile from 'proper-lockfile';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { isNodeErrnoCode } from '@src/integration/io/fs.ts';
 
 /**
- * Advisory cooperative file lock. The holder writes a JSON file at the lock path containing
- * its PID and an ISO timestamp; competitors see `EEXIST` and either wait or take over if the
- * holder is stale. Used to serialize:
- *   - `progress.md` writes (per-sprint)
- *   - `feedback.md` writes (per-sprint)
- *   - whole-flow runs against a working tree (per-repository)
+ * Advisory cooperative file lock, backed by `proper-lockfile`. The holder creates a lock
+ * directory (atomic `mkdir`, so it works on NFS where `O_EXCL` open is unreliable) and a
+ * background timer keeps its mtime fresh — a **heartbeat**. Competitors see the directory and
+ * either wait (retry) or take over only once the heartbeat has gone stale. Used to serialize:
+ *   - `tasks.json` writes (per-sprint)
+ *   - whole-flow runs against a working tree (per-repository / per-sprint)
  *
- * Stale-takeover criteria:
- *   - timestamp older than `staleAfterMs`, OR
- *   - PID no longer running (signal 0 liveness check on the same machine)
+ * **Why a heartbeat (and not an age-on-acquire timestamp).** The implement flow holds one lock
+ * across the WHOLE run (prologue → waves → epilogue), which can take many minutes. A lock judged
+ * stale purely by "age since acquisition" would become takeover-eligible mid-run while its
+ * holder is alive and folding — letting a second process race the same sprint branch. The
+ * heartbeat keeps a LIVE holder's lock perpetually fresh, so it is never falsely stolen no
+ * matter how long the run lasts; a CRASHED holder stops heartbeating and is reclaimed once the
+ * mtime passes `staleAfterMs`. `staleAfterMs` therefore bounds crash-reclaim latency only.
  *
- * All failures map to `StorageError({ subCode: 'lock' })`. The release path runs in a
- * `finally` so the lock is always cleared, even if the wrapped function throws.
+ * All failures map to `StorageError({ subCode: 'lock' })`. The release runs in a `finally` so the
+ * lock is always cleared, even when the wrapped function throws.
+ *
+ * Nothing reads the on-disk lock format — its shape is wholly internal to this module, so the
+ * backing library owns it. (Pre-`proper-lockfile` runs wrote a JSON *file* at the lock path;
+ * this writes a *directory*. A leftover old-format file from an in-flight upgrade self-heals via
+ * the stale-reclaim path once `staleAfterMs` elapses.)
  */
-
-interface LockInfo {
-  readonly pid: number;
-  readonly timestamp: string;
-}
 
 const DEFAULT_RETRY_DELAY_MS = 50;
 const DEFAULT_MAX_RETRIES = 100;
 const DEFAULT_STALE_AFTER_MS = 30_000;
-const STALE_LOWER_BOUND_MS = 1;
+// `proper-lockfile` does not enforce a floor, but a too-small `stale` would let a lock be judged
+// stale between heartbeats. Keep a sane floor and refresh well inside the window (see below).
+const STALE_LOWER_BOUND_MS = 2_000;
 const STALE_UPPER_BOUND_MS = 3_600_000;
+const MIN_HEARTBEAT_MS = 1_000;
 
 export interface FileLockerOptions {
-  /** How long (ms) before a lock file is considered stale. Clamped to 1..3_600_000. Default 30_000. */
+  /** How long (ms) before a lock is considered stale — i.e. crash-reclaim latency. Clamped 2_000..3_600_000. Default 30_000. */
   readonly staleAfterMs?: number;
-  /** Retry delay (ms) when contending for an active lock. Default 50. */
+  /** Retry delay (ms) when contending for an actively-held lock. Default 50. */
   readonly retryDelayMs?: number;
   /** Maximum retry attempts before giving up. Default 100 (~5s at 50ms). */
   readonly maxRetries?: number;
-  /** Test seam: defaults to `Date.now`. */
-  readonly now?: () => number;
-  /** Test seam: defaults to `process.pid`. */
-  readonly pid?: () => number;
-  /** Test seam: defaults to a `process.kill(pid, 0)` liveness probe. */
-  readonly isPidAlive?: (pid: number) => boolean;
-  /** Test seam: defaults to `setTimeout`. */
-  readonly sleep?: (ms: number) => Promise<void>;
   /**
-   * Optional callback for non-fatal lock errors — currently only "failed to remove our own
-   * lock file on release". Fires for genuine errors (EACCES, EROFS, …), NOT for the expected
-   * stale-takeover case (ENOENT, another process unlinked it before us). Use to surface stale
-   * `.lock` files that would otherwise block subsequent runs invisibly. Default: no-op.
+   * Optional callback for non-fatal lock anomalies:
+   *   - `'release-unlink-failed'` — the lock could not be removed on release (e.g. EACCES, EROFS),
+   *     so a stale lock directory may linger and block the next run until cleared.
+   *   - `'lock-compromised'` — a HELD lock was lost mid-run (heartbeat could not refresh in time,
+   *     or the lock directory was removed/taken over). Mutual exclusion may no longer hold; the
+   *     in-flight function is NOT aborted here — surfaced loudly for the operator. Default: no-op.
    */
-  readonly onWarning?: (warning: {
-    readonly kind: 'release-unlink-failed';
-    readonly path: string;
-    readonly cause: unknown;
-  }) => void;
+  readonly onWarning?: (
+    warning:
+      | { readonly kind: 'release-unlink-failed'; readonly path: string; readonly cause: unknown }
+      | { readonly kind: 'lock-compromised'; readonly path: string; readonly cause: unknown }
+  ) => void;
 }
 
 export interface FileLocker {
@@ -70,68 +71,56 @@ export interface FileLocker {
 }
 
 export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
-  const staleAfterMs = clampStaleAfter(opts.staleAfterMs);
+  const stale = clampStaleAfter(opts.staleAfterMs);
+  // Refresh ~3× per stale window, floored at 1s and capped at `proper-lockfile`'s `stale/2` max,
+  // so a live holder's mtime is renewed comfortably before any competitor could judge it stale.
+  const heartbeatMs = Math.min(Math.floor(stale / 2), Math.max(MIN_HEARTBEAT_MS, Math.floor(stale / 3)));
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
-  const now = opts.now ?? Date.now;
-  const pid = opts.pid ?? ((): number => process.pid);
-  const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
-  const sleep = opts.sleep ?? defaultSleep;
-
-  const acquire = async (lockPath: string): Promise<Result<void, StorageError>> => {
-    const info: LockInfo = { pid: pid(), timestamp: new Date(now()).toISOString() };
-    let retries = 0;
-    while (retries < maxRetries) {
-      try {
-        await fs.mkdir(dirname(lockPath), { recursive: true });
-        await fs.writeFile(lockPath, JSON.stringify(info), { flag: 'wx', mode: 0o600 });
-        return Result.ok(undefined);
-      } catch (cause) {
-        if (errnoCode(cause) !== 'EEXIST') {
-          return Result.error(
-            new StorageError({
-              subCode: 'lock',
-              message: `failed to acquire lock: ${stringifyError(cause)}`,
-              path: lockPath,
-              cause,
-            })
-          );
-        }
-        if (await isStale(lockPath, staleAfterMs, now, isPidAlive)) {
-          // Best-effort takeover: another process may grab it first; either way we loop.
-          await fs.unlink(lockPath).catch(() => {});
-          continue;
-        }
-        retries++;
-        await sleep(retryDelayMs);
-      }
-    }
-    return Result.error(
-      new StorageError({
-        subCode: 'lock',
-        message: `failed to acquire lock after ${String(maxRetries)} retries`,
-        path: lockPath,
-        hint: 'another ralphctl process is using this resource — wait, or remove the .lock file if stale',
-      })
-    );
-  };
 
   const withLock = async <T>(lockPath: AbsolutePath, fn: () => Promise<T>): Promise<Result<T, StorageError>> => {
     const path = String(lockPath);
-    const acquired = await acquire(path);
-    if (!acquired.ok) return Result.error(acquired.error);
+    let release: () => Promise<void>;
+    try {
+      // `proper-lockfile` needs the parent directory to exist before it can `mkdir` the lock dir.
+      await fs.mkdir(dirname(path), { recursive: true });
+      release = await properLockfile.lock(path, {
+        // The lock paths (`repo-<hash>.lock`, `tasks.json.lock`) are not real files — lock them
+        // lexically (`realpath: false`) and pin the on-disk lock directory to the path verbatim
+        // (`lockfilePath: path`) so it is not suffixed into `<path>.lock`.
+        realpath: false,
+        lockfilePath: path,
+        stale,
+        update: heartbeatMs,
+        // Constant-backoff retry mirrors the previous `maxRetries × retryDelayMs` (~5s) budget.
+        retries: { retries: maxRetries, factor: 1, minTimeout: retryDelayMs, maxTimeout: retryDelayMs },
+        // The library default for `onCompromised` THROWS (which would crash the process). Surface
+        // it as a warning instead; the held `fn` is left to run (abort-on-compromise is future work).
+        onCompromised: (cause) => opts.onWarning?.({ kind: 'lock-compromised', path, cause }),
+      });
+    } catch (cause) {
+      return Result.error(
+        new StorageError({
+          subCode: 'lock',
+          message: acquireErrorMessage(cause, maxRetries),
+          path,
+          cause,
+          hint: 'another ralphctl process is using this resource — wait, or remove the .lock file if stale',
+        })
+      );
+    }
     try {
       const value = await fn();
       return Result.ok(value) as Result<T, StorageError>;
     } finally {
       try {
-        await fs.unlink(path);
+        await release();
       } catch (cause) {
-        // ENOENT is the expected stale-takeover case (another process unlinked our lock). Any
-        // other errno — EACCES, EROFS, EBUSY — means we left a `.lock` file behind that will
-        // block the next run until the operator clears it. Surface via the optional warning
-        // hook; we don't fail the whole call because `fn` already produced a value.
-        if (!isNodeErrnoCode(cause, 'ENOENT')) {
+        // `ERELEASED` (already released) and `ENOTACQUIRED` (the lock was compromised / taken over,
+        // so it is no longer in our registry) are expected and benign. Any other errno — EACCES,
+        // EROFS — means a lock directory was left behind that will block the next run; surface it.
+        // We never fail the whole call, because `fn` already produced a value.
+        if (!isBenignReleaseError(cause)) {
           opts.onWarning?.({ kind: 'release-unlink-failed', path, cause });
         }
       }
@@ -141,50 +130,19 @@ export const createFileLocker = (opts: FileLockerOptions = {}): FileLocker => {
   return { withLock };
 };
 
-const isStale = async (
-  lockPath: string,
-  staleAfterMs: number,
-  now: () => number,
-  isPidAlive: (pid: number) => boolean
-): Promise<boolean> => {
-  let raw: string;
-  try {
-    raw = await fs.readFile(lockPath, 'utf8');
-  } catch {
-    return true;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return true;
-  }
-  // Narrow guard: a malformed lock file (wrong shape, missing fields, wrong types) is
-  // indistinguishable from a stale lock — treat it as stale so the next acquire takes over.
-  if (typeof parsed !== 'object' || parsed === null) return true;
-  const rec = parsed as { timestamp?: unknown; pid?: unknown };
-  if (typeof rec.timestamp !== 'string' || typeof rec.pid !== 'number') return true;
-  const ts = Date.parse(rec.timestamp);
-  if (!Number.isFinite(ts)) return true;
-  if (now() - ts > staleAfterMs) return true;
-  return !isPidAlive(rec.pid);
-};
-
 const clampStaleAfter = (value: number | undefined): number => {
   if (value === undefined || !Number.isFinite(value) || value <= 0) return DEFAULT_STALE_AFTER_MS;
   return Math.min(STALE_UPPER_BOUND_MS, Math.max(STALE_LOWER_BOUND_MS, Math.floor(value)));
 };
 
-const defaultIsPidAlive = (pid: number): boolean => {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-};
+/** `ELOCKED` = contention exhausted the retry budget; anything else is an unexpected acquire fault. */
+const acquireErrorMessage = (cause: unknown, maxRetries: number): string =>
+  errnoCode(cause) === 'ELOCKED'
+    ? `failed to acquire lock after ${String(maxRetries)} retries`
+    : `failed to acquire lock: ${stringifyError(cause)}`;
 
-const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const BENIGN_RELEASE_CODES = new Set(['ERELEASED', 'ENOTACQUIRED']);
+const isBenignReleaseError = (cause: unknown): boolean => BENIGN_RELEASE_CODES.has(errnoCode(cause) ?? '');
 
 const errnoCode = (cause: unknown): string | undefined => {
   if (typeof cause === 'object' && cause !== null) {

--- a/tests/e2e/flows/review.test.ts
+++ b/tests/e2e/flows/review.test.ts
@@ -215,6 +215,7 @@ describe('createReviewFlow', () => {
       },
       {
         sprintId: sprint.id,
+        sprintDir: absolutePath(dir),
         reviewRoot: absolutePath(join(dir, 'review')),
         commitCwd: FAKE_CWD,
         additionalRoots: [FAKE_CWD],
@@ -265,6 +266,7 @@ describe('createReviewFlow', () => {
       },
       {
         sprintId: sprint.id,
+        sprintDir: absolutePath(dir),
         reviewRoot: absolutePath(join(dir, 'review')),
         commitCwd: FAKE_CWD,
         additionalRoots: [FAKE_CWD],
@@ -333,6 +335,7 @@ describe('createReviewFlow', () => {
       },
       {
         sprintId: sprint.id,
+        sprintDir: absolutePath(dir),
         reviewRoot,
         // Commit / verify still target a single repo today. The launcher picks the first
         // sprint-affected repo; the test mirrors that.
@@ -410,6 +413,7 @@ describe('createReviewFlow', () => {
       },
       {
         sprintId: sprint.id,
+        sprintDir: absolutePath(dir),
         reviewRoot: absolutePath(join(dir, 'review')),
         commitCwd: FAKE_CWD,
         additionalRoots: [FAKE_CWD],

--- a/tests/integration/application/flows/_shared/memory/distill-step.test.ts
+++ b/tests/integration/application/flows/_shared/memory/distill-step.test.ts
@@ -490,6 +490,7 @@ describe('createDistillStep on the review auto-done path', () => {
       },
       {
         sprintId,
+        sprintDir: absolutePath(String(root.root)),
         reviewRoot,
         commitCwd: absolutePath(repoPath),
         additionalRoots: [absolutePath(repoPath)],

--- a/tests/integration/application/flows/implement/parallel-element.test.ts
+++ b/tests/integration/application/flows/implement/parallel-element.test.ts
@@ -32,7 +32,7 @@ const recordingLocker = (log: string[]): FileLocker => ({
   async withLock(_lockPath, fn) {
     log.push('lock-acquire');
     try {
-      const value = await fn();
+      const value = await fn(new AbortController().signal);
       return Result.ok(value) as never;
     } finally {
       log.push('lock-release');
@@ -291,7 +291,7 @@ describe('createParallelImplementElement — uses the sprint-dir lock key', () =
     const locker: FileLocker = {
       async withLock(lockPath, fn) {
         lockedPath = lockPath;
-        return Result.ok(await fn()) as never;
+        return Result.ok(await fn(new AbortController().signal)) as never;
       },
     };
     const element = createParallelImplementElement(

--- a/tests/integration/io/file-locker.test.ts
+++ b/tests/integration/io/file-locker.test.ts
@@ -12,6 +12,19 @@ const lockPathIn = (root: string, name: string): AbsolutePath => {
   return parsed.value;
 };
 
+/** Poll `predicate` until true or `timeoutMs` elapses. Returns silently either way. */
+const waitFor = async (predicate: () => boolean, timeoutMs: number): Promise<void> => {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+};
+
+// The locker is backed by `proper-lockfile`: the on-disk lock is a DIRECTORY at the lock path
+// (atomic `mkdir`), kept fresh by a background heartbeat. A live holder is never falsely stolen;
+// a holder that stops heartbeating (crash) goes stale and is reclaimed. These tests exercise that
+// model through the public `withLock` API only — there are no `now`/`pid`/`sleep` seams.
 describe('createFileLocker', () => {
   let root: string;
 
@@ -24,15 +37,16 @@ describe('createFileLocker', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it('runs the wrapped function and removes the lock file when done', async () => {
+  it('runs the wrapped function and removes the lock directory when done', async () => {
     const locker = createFileLocker();
     const lock = lockPathIn(root, 'a.lock');
     let called = false;
 
     const result = await locker.withLock(lock, async () => {
       called = true;
-      // While inside the critical section, the lock file exists.
-      await expect(fs.readFile(String(lock), 'utf8')).resolves.toContain('"pid"');
+      // While inside the critical section, the lock directory exists.
+      const stat = await fs.stat(String(lock));
+      expect(stat.isDirectory()).toBe(true);
       return 42;
     });
 
@@ -55,62 +69,35 @@ describe('createFileLocker', () => {
   });
 
   it('rejects with StorageError(subCode=lock) when contended past the retry budget', async () => {
-    const lockPath = join(root, 'c.lock');
-    // Pre-write a fresh, live lock owned by this process; takeover never fires.
-    await fs.writeFile(lockPath, JSON.stringify({ pid: process.pid, timestamp: new Date().toISOString() }), {
-      flag: 'wx',
-    });
+    // Pre-create a FRESH lock directory (mtime ≈ now): not stale, so takeover never fires and the
+    // contender exhausts its retry budget.
+    const held = lockPathIn(root, 'c.lock');
+    await fs.mkdir(String(held));
 
-    const locker = createFileLocker({ maxRetries: 3, retryDelayMs: 1, sleep: async () => {} });
-    const lock = lockPathIn(root, 'c.lock');
-    const result = await locker.withLock(lock, async () => 'unreached');
+    const locker = createFileLocker({ maxRetries: 2, retryDelayMs: 1 });
+    const result = await locker.withLock(held, async () => 'unreached');
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.subCode).toBe('lock');
-      expect(result.error.message).toContain('after 3 retries');
+      expect(result.error.message).toContain('after 2 retries');
     }
   });
 
-  it('takes over a stale lock whose timestamp exceeds staleAfterMs', async () => {
-    const lockPath = join(root, 'd.lock');
-    await fs.writeFile(lockPath, JSON.stringify({ pid: process.pid, timestamp: new Date(0).toISOString() }), {
-      flag: 'wx',
-    });
+  it('reclaims a stale lock whose holder stopped heartbeating (crash)', async () => {
+    // A crashed holder leaves a lock directory whose mtime no longer advances. Simulate it: an
+    // existing lock dir backdated well past the stale window is taken over on the next acquire.
+    const stale = lockPathIn(root, 'd.lock');
+    await fs.mkdir(String(stale));
+    const old = new Date(Date.now() - 10_000);
+    await fs.utimes(String(stale), old, old);
 
-    const locker = createFileLocker({ staleAfterMs: 1, sleep: async () => {} });
-    const lock = lockPathIn(root, 'd.lock');
-    const result = await locker.withLock(lock, async () => 'taken-over');
-
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value).toBe('taken-over');
-  });
-
-  it('takes over a lock whose holder PID is no longer alive', async () => {
-    const lockPath = join(root, 'e.lock');
-    const deadPid = 999_999;
-    await fs.writeFile(lockPath, JSON.stringify({ pid: deadPid, timestamp: new Date().toISOString() }), { flag: 'wx' });
-
-    const locker = createFileLocker({
-      isPidAlive: (pid) => pid !== deadPid,
-      sleep: async () => {},
-    });
-    const lock = lockPathIn(root, 'e.lock');
-    const result = await locker.withLock(lock, async () => 'reclaimed');
+    const locker = createFileLocker({ staleAfterMs: 2_000 });
+    const result = await locker.withLock(stale, async () => 'reclaimed');
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value).toBe('reclaimed');
-  });
-
-  it('treats malformed lock-file contents as stale and takes over', async () => {
-    const lockPath = join(root, 'f.lock');
-    await fs.writeFile(lockPath, 'not-json', { flag: 'wx' });
-
-    const locker = createFileLocker({ sleep: async () => {} });
-    const lock = lockPathIn(root, 'f.lock');
-    const result = await locker.withLock(lock, async () => 'ok');
-
-    expect(result.ok).toBe(true);
+    await expect(fs.access(String(stale))).rejects.toThrow();
   });
 
   it('serialises concurrent withLock calls on the same path', async () => {
@@ -118,9 +105,8 @@ describe('createFileLocker', () => {
     const lock = lockPathIn(root, 'g.lock');
     const order: string[] = [];
 
-    // Start `a` first and await a microtask so its acquire() actually runs and writes the
-    // lock file before `b` begins. Without the await, both promises start in the same tick
-    // and the OS-level EEXIST race becomes non-deterministic across test runs.
+    // Start `a` first and yield a few ms so its acquire() materialises the lock directory before
+    // `b` begins — then `b` must wait (retry) until `a` releases.
     const a = locker.withLock(lock, async () => {
       order.push('a-start');
       await new Promise((r) => setTimeout(r, 20));
@@ -137,43 +123,34 @@ describe('createFileLocker', () => {
     expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
   });
 
-  it('does NOT fire onWarning for ENOENT during release (expected stale-takeover)', async () => {
-    // The wrapped function deletes our lock before the locker tries to. That's the legitimate
-    // stale-takeover case: another process unlinked it first. ENOENT must be swallowed without
-    // firing the warning, because operators don't need to chase a non-error.
-    const warnings: Array<{ readonly kind: string; readonly path: string; readonly cause: unknown }> = [];
+  it('does not fire onWarning on a clean acquire/release cycle', async () => {
+    const warnings: Array<{ readonly kind: string }> = [];
     const locker = createFileLocker({ onWarning: (w) => warnings.push(w) });
-    const lock = lockPathIn(root, 'enoent.lock');
-    const result = await locker.withLock(lock, async () => {
-      await fs.unlink(String(lock)); // simulate another process taking over
-    });
+    const lock = lockPathIn(root, 'clean.lock');
+
+    const result = await locker.withLock(lock, async () => 'ok');
+
     expect(result.ok).toBe(true);
     expect(warnings).toHaveLength(0);
   });
 
-  it('fires onWarning when release-unlink fails with a non-ENOENT error', async () => {
-    // Replace fs.unlink with a stub that raises EACCES. Verifies the hook surfaces real
-    // unlink errors (permission denied / read-only fs) so a stale `.lock` doesn't silently
-    // block the next run.
-    const warnings: Array<{ readonly kind: string; readonly path: string; readonly cause: unknown }> = [];
-    const locker = createFileLocker({ onWarning: (w) => warnings.push(w) });
-    const lock = lockPathIn(root, 'eacces.lock');
+  it('surfaces a lock-compromised warning (without throwing) when the held lock is removed', async () => {
+    // Remove the lock directory out from under the holder. The heartbeat's next mtime refresh
+    // fails, so proper-lockfile flags the lock compromised. The library default for that is to
+    // THROW (which would crash the process) — our adapter must instead surface a warning. A small
+    // staleAfterMs makes the heartbeat tick ~1s so the test does not have to wait the 30s default.
+    const warnings: Array<{ readonly kind: string; readonly cause: unknown }> = [];
+    const locker = createFileLocker({ staleAfterMs: 2_000, onWarning: (w) => warnings.push(w) });
+    const lock = lockPathIn(root, 'compromised.lock');
 
-    const fsMutable = fs as { unlink: typeof fs.unlink };
-    const originalUnlink = fsMutable.unlink;
-    const fakeError: NodeJS.ErrnoException = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
-    fsMutable.unlink = (async () => {
-      throw fakeError;
-    }) as typeof fs.unlink;
-    try {
-      const result = await locker.withLock(lock, async () => 'ok' as const);
-      expect(result.ok).toBe(true);
-    } finally {
-      fsMutable.unlink = originalUnlink;
-    }
+    const result = await locker.withLock(lock, async () => {
+      await fs.rm(String(lock), { recursive: true, force: true });
+      await waitFor(() => warnings.some((w) => w.kind === 'lock-compromised'), 5_000);
+      return 'survived';
+    });
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]?.kind).toBe('release-unlink-failed');
-    expect(warnings[0]?.cause).toBe(fakeError);
-  });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe('survived');
+    expect(warnings.some((w) => w.kind === 'lock-compromised')).toBe(true);
+  }, 8_000);
 });

--- a/tests/integration/io/file-locker.test.ts
+++ b/tests/integration/io/file-locker.test.ts
@@ -134,23 +134,27 @@ describe('createFileLocker', () => {
     expect(warnings).toHaveLength(0);
   });
 
-  it('surfaces a lock-compromised warning (without throwing) when the held lock is removed', async () => {
+  it('aborts the wrapped function signal and warns when the held lock is compromised', async () => {
     // Remove the lock directory out from under the holder. The heartbeat's next mtime refresh
     // fails, so proper-lockfile flags the lock compromised. The library default for that is to
-    // THROW (which would crash the process) — our adapter must instead surface a warning. A small
-    // staleAfterMs makes the heartbeat tick ~1s so the test does not have to wait the 30s default.
+    // THROW (which would crash the process) — our adapter instead aborts the signal handed to `fn`
+    // AND surfaces a warning. A small staleAfterMs makes the heartbeat tick ~1s so the test does
+    // not have to wait the 30s default.
     const warnings: Array<{ readonly kind: string; readonly cause: unknown }> = [];
     const locker = createFileLocker({ staleAfterMs: 2_000, onWarning: (w) => warnings.push(w) });
     const lock = lockPathIn(root, 'compromised.lock');
 
-    const result = await locker.withLock(lock, async () => {
+    let sawAbort = false;
+    const result = await locker.withLock(lock, async (signal) => {
       await fs.rm(String(lock), { recursive: true, force: true });
-      await waitFor(() => warnings.some((w) => w.kind === 'lock-compromised'), 5_000);
-      return 'survived';
+      await waitFor(() => signal.aborted, 5_000);
+      sawAbort = signal.aborted;
+      return 'observed';
     });
 
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value).toBe('survived');
+    if (result.ok) expect(result.value).toBe('observed');
+    expect(sawAbort).toBe(true);
     expect(warnings.some((w) => w.kind === 'lock-compromised')).toBe(true);
   }, 8_000);
 });

--- a/tests/unit/application/flows/implement/flow-shape.test.ts
+++ b/tests/unit/application/flows/implement/flow-shape.test.ts
@@ -23,7 +23,7 @@ import {
   uniqueRepoCwdsForTasks,
 } from '@src/application/flows/implement/leaves/sprint-repo-plan.ts';
 import { transitionSprintToReviewLeaf } from '@src/application/flows/implement/leaves/transition-sprint-to-review.ts';
-import { withRepoLock } from '@src/application/flows/implement/leaves/with-repo-lock.ts';
+import { withRepoLock } from '@src/application/flows/_shared/with-repo-lock.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
 import {


### PR DESCRIPTION
## Why

The cross-process repo lock judged staleness on **age-since-acquire** (30s default) with **no heartbeat**, and the implement flow holds that lock across the whole run (minutes). So a long run became takeover-eligible while still alive — a second `ralphctl` process could steal the lock and race the same sprint branch, breaking the single-PR guarantee. Investigating also surfaced that the **review flow committed to the sprint branch with no lock at all**.

## What

1. **`fix`: heartbeat lock via `proper-lockfile`.** `FileLocker` now uses a directory lock (atomic `mkdir`, NFS-safe) kept fresh by a background heartbeat — a live holder is never falsely stolen no matter how long the run; a crashed holder is reclaimed once its mtime goes stale. Port contract unchanged (no call-site changes); `staleAfterMs` now bounds crash-reclaim latency only. Chosen over `flock` because ralphctl is cross-platform (no native addon) and may run on NFS.

2. **`feat`: abort the in-flight run on lock compromise.** `withLock` hands `fn` an `AbortSignal` that fires if the held lock is lost mid-run; the serial + parallel implement paths merge it with the host abort signal (`combineAbortSignals`), so a compromised lock tears the chain down as an `AbortError` instead of mutating a branch a competitor may now own.

3. **`fix`: review holds the repo lock (uniform with implement).** Review commits to the sprint branch but ran unlocked. Its chain is now wrapped in `withRepoLock` keyed on the sprint dir — the **same key implement uses** — so the two mutually exclude. `withRepoLock` was generified to `<TCtx>` and moved to `flows/_shared/` so implement (serial) and review share one helper.

## Verification

- typecheck ✓ · lint ✓ (0 errors) · knip ✓ · **347 files / 2823 tests** ✓
- `file-locker` unit suite rewritten for the directory/heartbeat model (incl. deterministic crash-reclaim + compromise-abort).
- `implement`, `parallel-realgit`, `review`, `meta-run`, `distill-step` e2e/integration suites drive the real locker/lock-wrapper end-to-end.

## Notes

- Adds runtime dep `proper-lockfile` (+ `@types/proper-lockfile`).
- Targets `main`; the 0.9.0 version bump stays on `release/0.9.0`, which will rebase on top of this once merged.