### PR TITLE
Lock/abort hardening + blocked-dependency recovery + TUI/refine UX

### DIFF
--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -88,7 +88,8 @@ Status flow: `draft → planned → active → review → done`.
 - [ ] **`planned → active`** — `implement` activates a `planned` sprint on first launch; an already-`active`
       sprint passes through idempotently.
 - [ ] **`active → review`** — `implement` transitions the sprint to `review` once every task has settled
-      (`done` or `blocked`).
+      (`done` or `blocked`) AND at least one task settled `done`. An all-blocked run stays `active`
+      (`shouldTransitionToReview` in `implement/flow.ts`).
 - [ ] **`review → done`** — `sprint close <id>` (CLI) and the close-sprint flow (TUI) accept only
       `review`-status sprints.
 - [ ] **No `task add / edit / remove`** — bulk task mutation outside the planner is intentional. The CLI
@@ -133,6 +134,7 @@ Status flow: `draft → planned → active → review → done`.
 - [x] **`verifyScript` gates per-task settlement with pre/post attribution** — runs before the AI (pre-task)
       and after commit (post-task). Attribution: `clean` / `regressed` / `baseline-broken` / `fixed-baseline`.
       A `baseline-broken` result does not block the AI; a `regressed` result transitions task to `blocked`.
+      `Repository.verifyTimeout` is forwarded as `timeoutMs` to both calls; absent → 5-min runner default.
 - [ ] **Branch management** — `resolveBranchLeaf` prompts on first run; persists on `SprintExecution.branch`;
       per-task preflight verifies the right branch is checked out.
 - [x] **Resume of aborted runs** — tasks left in `in_progress` from a prior crash reset to `todo` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Tasks-column windowing in the Execute view.** The middle Tasks column now renders an anchored
+  window of cards centred on the active task (`computeAnchoredWindow`) rather than mapping the entire
+  task list. With 3+ tasks the unwindowed column overflowed and pushed the Recent-log panel and footer
+  off-screen. Dim `▴ N more above` / `▾ N more below` overflow cues replace the clipped tail.
+
+- **Cascade-unblock for upstream-blocked dependents.** Unblocking a task now automatically re-arms
+  the whole subtree the dependency gate parked as "blocked upstream". Previously each blocked dependent
+  had to be hand-unblocked one at a time. Own-failure blocks (evaluator / verify / budget) are never
+  auto-cleared — they need a real fix.
+
+- **Block-reason surfacing in task cards.** Blocked task cards in the Execute view now show _why_ the
+  task blocked (`blockedReason` from the entity — own failure vs `blocked upstream — …`) instead of a
+  bare status badge.
+
+### Fixed
+
+- **Manual abort now kills the AI child process.** The chain `AbortSignal` is threaded all the way
+  into `implementSession()` and from there into the headless provider's SIGTERM→SIGKILL kill ladder,
+  abort-aware exit classification, and cancellable rate-limit sleep. Previously the signal was silently
+  dropped at the leaf boundary, letting the spawned `claude` / `codex` child run to natural completion
+  after a cancel — which stranded the repo lock (heartbeat kept it fresh) and left the
+  progress spinner / `[RUNNING]` badge stuck until the child finished on its own. The fix is applied
+  uniformly to all headless AI leaves: `implement` generator + evaluator, `review`, `create-pr`,
+  `readiness`, `detect-scripts`, and `detect-skills`.
+
+- **Dependent tasks no longer run blindly when their prerequisite is blocked.** A new `dependency-gate`
+  leaf at the head of every per-task subchain checks whether all `dependsOn` tasks are `done`; if any
+  prerequisite is not done (blocked or still unsettled), the dependent is transitioned to
+  `blocked upstream — …` and the rest of the subchain is skipped — no AI spawn wasted. The block is
+  transitive by construction (A blocks → B → C). Previously the wave scheduler ran dependents
+  regardless of prerequisite outcome, producing a cascade of doomed spawns that self-blocked and looked
+  like independent failures.
+
+- **Sprint no longer flips to `review` mid-run.** The `active → review` transition now requires every
+  task to be settled (`done` or `blocked`) AND at least one settled `done`. The prior predicate
+  (`some(done)`) flipped to review the instant the first task finished, silently shipping a partial
+  sprint with remaining tasks still `todo` / `in_progress`. An all-blocked run stays `active` — the
+  operator can fix the blocker and re-run implement without first backing the sprint out of review.
+
+- **Codex resume falls back to a cold spawn when the rollout is gone.** After a crash or abort the
+  Codex rollout (thread) can vanish; `codex exec resume <id>` then exits with
+  `thread/resume failed: no rollout found (code -32600)` and no `signals.json`, blocking the task.
+  The codex adapter now detects that exact error and retries once with a full cold spawn (dropping
+  `--resume`) before surfacing the failure. The fallback fires at most once per `generate()` call and
+  emits a warn-level log entry.
+
+- **`verifyTimeout` is now honoured.** `Repository.verifyTimeout` was threaded as far as the entity
+  but dropped between the launcher and `RepoExecConfig`, so a configured verify timeout had zero effect
+  and a hung verify burned the full 5-minute default on both the pre-task and post-task calls. The
+  value is now copied into `RepoExecConfig` and forwarded to both verify leaves as `timeoutMs`.
+
 ## [0.9.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Plateau "change your approach" nudge + the model ladder is live by default.** When the
+  generator-evaluator loop plateaus (the same checks keep failing with no real progress),
+  `escalateOnPlateau` (now defaulting **on**) grants one more attempt: it climbs the model ladder
+  when a stronger rung exists AND injects a "you have plateaued — change your approach" directive
+  into that attempt's generator turn. For a top-of-ladder generator (e.g. the default Opus) there is
+  no higher model, so it keeps the model and relies on the directive to break out of a non-converging
+  approach. The directive renders via a new `{{PLATEAU_DIRECTIVE_SECTION}}` in the implement prompt
+  and is generator-only (the evaluator's rubric is held constant).
+
 - **Tasks-column windowing in the Execute view.** The middle Tasks column now renders an anchored
   window of cards centred on the active task (`computeAnchoredWindow`) rather than mapping the entire
   task list. With 3+ tasks the unwindowed column overflowed and pushed the Recent-log panel and footer
@@ -59,6 +68,16 @@ to [Semantic Versioning](https://semver.org/).
   but dropped between the launcher and `RepoExecConfig`, so a configured verify timeout had zero effect
   and a hung verify burned the full 5-minute default on both the pre-task and post-task calls. The
   value is now copied into `RepoExecConfig` and forwarded to both verify leaves as `timeoutMs`.
+
+### Changed
+
+- **A plateau never blocks the task anymore.** `harness.escalateOnPlateau` now defaults to `true`
+  (was `false`). When the gen-eval loop plateaus, the harness grants one more attempt (model
+  escalation and/or the change-of-approach directive); after that single retry — or when no attempt
+  budget remains, or the generator is already at the top of the ladder — the work is preserved
+  (done-with-warning), matching the prior opt-out behaviour. The previous "plateau at the top of the
+  ladder / after escalation → blocked" paths that discarded the work are gone. Set
+  `harness.escalateOnPlateau=false` to keep the legacy done-with-warning-on-first-plateau behaviour.
 
 ## [0.9.0] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,31 @@ to [Semantic Versioning](https://semver.org/).
   and a hung verify burned the full 5-minute default on both the pre-task and post-task calls. The
   value is now copied into `RepoExecConfig` and forwarded to both verify leaves as `timeoutMs`.
 
+- **Resume no longer dead-ends a dependent scheduled ahead of its prerequisite.** The implement launch
+  queue now uses a dependency-respecting priority order: a resumed (`in_progress`) task leads only among
+  the tasks runnable at each step, never ahead of a `todo` / `in_progress` task it depends on. The prior
+  flat in-progress-first sort could place a dependent before its prerequisite in the serial queue, so the
+  new `dependency-gate` blocked the dependent `blocked upstream` before its prerequisite ran — stranding
+  it for the launch and shipping the sprint to `review` missing work.
+
+- **A task that crashes on its final attempt now lands `blocked` durably.** On resume, settling the
+  leftover `running` attempt can push the task over its attempt budget; the `blocked` transition was
+  computed but not persisted, so every relaunch re-hit the same error and the task never surfaced as
+  blocked (a stuck loop). The blocked state is now written before the error is raised, so the launch
+  queue filters it out and the operator can `unblock` it.
+
 ### Changed
+
+- **Refine writes back as an issue comment, not a description overwrite.** The refine reviewer's
+  write-back options changed: the old "approve & update" (overwrote the issue description) and
+  "approve & create" (opened a new issue from `defaultIssueOrigin`) are replaced by a single
+  **"Post as comment"** choice that appends the refined requirements as a NEW comment on the ticket's
+  linked issue, leaving the human-authored description untouched. When the reviewer edits the AI's
+  proposal, the comment carries the edited text (matching what is persisted locally). Non-interactive
+  runs opt in via `settings.scm.postRefinementComment` (default `false`). The `IssuePusher` port is now
+  comment-only (`comment(url, { body })`, backed by `gh issue comment` / `glab issue comment`); the
+  `update` / `create` methods are gone. `Project.defaultIssueOrigin` survives as a persisted field but
+  refine no longer consults it, and settings / project files written before this change parse unchanged.
 
 - **A plateau never blocks the task anymore.** `harness.escalateOnPlateau` now defaults to `true`
   (was `false`). When the gen-eval loop plateaus, the harness grants one more attempt (model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,10 @@ Sprint lifecycle: `draft → planned → active → review → done`.
 
 \*`plan` moves a draft sprint to `planned`; `implement` then activates it (`planned → active`) on first
 launch, passing an already-`active` sprint through idempotently — a draft sprint must be planned first.
-Implement transitions the sprint to `review` once every task has settled (`done` or `blocked`). The `sprint
-close` CLI command and the close-sprint flow accept only `review`-status.
+Implement transitions the sprint to `review` once every task has settled (`done` or `blocked`) AND at least
+one task settled `done` — an all-blocked run stays `active` so the operator can fix the blocker and
+re-run without backing the sprint out of review. The `sprint close` CLI command and the close-sprint flow
+accept only `review`-status.
 
 **Two-phase planning.** **Refine** (`refine` chain) is implementation-agnostic per-ticket clarification —
 no repo exploration; ticket `requirementStatus` flips `pending → approved`. **Plan** (`plan` chain) requires
@@ -204,10 +206,12 @@ each attempt is recorded as a structured `SetupRun` (outcome: `success` / `faile
 `skipped`) persisted on `SprintExecution.setupRanAt`. Non-zero exit or spawn failure hard-aborts the
 chain. Verify runs both **pre-task** (before the AI) and **post-task** (after commit) with an attribution
 algorithm (`clean` / `regressed` / `baseline-broken` / `fixed-baseline`) that avoids blocking the AI for
-pre-existing failures. Failure transitions the task to `blocked`, never `done`. Both scripts are collected
-during `detect-scripts` and persisted on `Repository.{setupScript,verifyScript}`. Persisted
-`project.json` files written before v0.7.0 used `checkScript` / `checkTimeout`; the schema accepts those
-legacy keys on read and rewrites the canonical names on the next save (no manual migration step).
+pre-existing failures. Failure transitions the task to `blocked`, never `done`. `Repository.verifyTimeout`
+caps both the pre- and post-task verify calls as `timeoutMs` on the shell runner; when absent the runner
+falls back to `DEFAULT_SHELL_TIMEOUT_MS` (5 min). Both scripts are collected during `detect-scripts` and
+persisted on `Repository.{setupScript,verifyScript,verifyTimeout}`. Persisted `project.json` files written
+before v0.7.0 used `checkScript` / `checkTimeout`; the schema accepts those legacy keys on read and
+rewrites the canonical names on the next save (no manual migration step).
 
 **Branch management.** `resolveBranchLeaf` prompts on first run; persists on `SprintExecution.branch`;
 per-task preflight verifies the right branch. `ralphctl create-pr --sprint <id>` opens PR / MR via `gh` /
@@ -298,7 +302,12 @@ exception is the setup/verify-script runner (`shell-script-runner.ts`), which in
 
 **`AbortError` is the one error chains propagate transparently.** User-initiated cancellation (Ctrl+C, the
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
-or fallback catches errors, it MUST exempt `AbortError`.
+or fallback catches errors, it MUST exempt `AbortError`. The chain's `AbortSignal` is now threaded all the
+way into `implementSession()` via `execute(input, signal)` on every headless AI leaf (generator, evaluator,
+review, create-pr, readiness, detect-scripts, detect-skills) — the signal reaches the headless provider's
+SIGTERM→SIGKILL kill ladder, abort-aware exit classification, and cancellable rate-limit sleep. Without this
+threading a cancel would let the spawned child run to natural completion, stranding the repo lock and leaving
+the progress spinner stuck.
 
 **AI sessions plug onto the repo (implement / ideate).** Cwd is the user's repo (multi-repo flows
 pick `repositories[0]`); the per-flow sandbox under `<sprintDir>/<flow>/<unit-slug>/` is mounted via
@@ -360,7 +369,14 @@ never re-executed on relaunch. Concurrent appends to `progress.md` and the learn
 serialised through one in-process mutex (no torn lines under fan-out). Launch then applies a
 status-only stable override: `in_progress` tasks first (so a resumed sprint picks up the previously
 aborted task before any fresh work), then `todo`; V8's stable sort preserves dependency order within
-each status group.
+each status group. A `dependency-gate` leaf at the head of every per-task subchain enforces the
+prerequisite contract at run time: if any `dependsOn` task is not `done` (blocked or still unsettled),
+the dependent is transitioned to `blocked upstream — …` and the subchain body is skipped — no AI
+spawn wasted. The gate is status-only and works in both the serial and parallel paths. Block is
+transitive by construction (A → B → C cascades automatically). Unblocking the root prerequisite
+cascade-unblocks the entire upstream-blocked subtree in one action (`unblockTaskUseCase` calls
+`upstreamBlockedDependents` and rewrites the list atomically); own-failure blocks are never
+auto-cleared.
 
 **Rate-limit retry is adapter-side.** The headless provider wrapper at
 `src/integration/ai/providers/_engine/rate-limit-backoff.ts` sleeps with exponential delay between 429

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,8 +324,16 @@ Refine's session is rooted at `<sprintDir>/refinement/<ticket-slug>/`; plan's at
 agents / `.mcp.json` and bias the AI toward implementation specifics (refine) or toward repositories[0]
 on a multi-repo project (plan); refine would also pollute the repo with bundled skills. Plan mounts
 **every** project repository as an equal `--add-dir` source — no repo enjoys cwd privilege, so the planner
-treats every repo symmetrically. Refine's repo path is still consulted at launch time to derive
-`defaultIssueOrigin` for the "update remote" reviewer option, but no AI session is rooted there.
+treats every repo symmetrically. No AI session is rooted in any repo for either flow.
+
+**Refine writes back as an issue comment, never an overwrite.** Refine never rewrites the issue
+description and never opens a new issue — it posts the refined requirements as a NEW comment on the
+ticket's linked issue via the comment-only `IssuePusher` (`comment(url, { body })`; `gh issue comment`
+/ `glab issue comment`). It is opt-in: the interactive reviewer's "Post as comment" choice (offered
+only when the ticket has a linked issue), or `settings.scm.postRefinementComment` (default `false`) in
+non-interactive runs. The earlier "approve & update" / "approve & create" reviewer options and the
+`defaultIssueOrigin`-driven create path were removed — `Project.defaultIssueOrigin` survives as a
+persisted field but refine no longer consults it.
 
 **Bundled skills always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already exists, the
 bundled copy is skipped and the project copy is left untouched. The skills adapter
@@ -417,8 +425,11 @@ The one plateau-break attempt does two things: (1) **model escalation** — clim
 Claude Haiku → Sonnet → Opus; Codex / Copilot `gpt-5-mini` and `gpt-5.4-mini` → `gpt-5.5`, kept in
 lockstep with `domain/value/settings-models/` by code review) when a stronger rung exists; and (2) a
 **"change your approach" directive** (`{{PLATEAU_DIRECTIVE_SECTION}}` in the implement prompt) injected
-into that attempt's generator turn, telling it to abandon the non-converging approach and try a
-fundamentally different one. For a top-of-ladder generator (e.g. the default Opus) there is no higher
+into the generator turn, telling it to abandon the non-converging approach and try a fundamentally
+different one. The directive is gated on the write-once `Task.escalatedFromModel` flag, so it renders
+on every generator turn from the escalated attempt onward (not a single turn) — intentional and
+harmless: re-telling the generator to change approach costs nothing and the once-per-task cap still
+bounds the model bump. For a top-of-ladder generator (e.g. the default Opus) there is no higher
 model, so the attempt keeps the model and relies on the directive (a same-model "nudge" — stamped
 `escalatedFromModel === escalatedToModel` so the once-per-task cap still fires).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,29 +402,34 @@ launch and re-enter the queue. No double-execution.
 Mirrored on `IterationConfig` (`src/application/chain/run/iteration-config.ts`); the chain `loop` predicates
 and the headless provider adapter read it.
 
-**Escalation on plateau.** Two opt-in `settings.harness` knobs let the gen-eval loop retry a plateaued task
-on a stronger generator model instead of immediately blocking:
+**Escalation on plateau.** On a plateau the gen-eval loop grants one more attempt rather than settling
+immediately. **A plateau never blocks the task** — it either retries once or preserves the work
+(done-with-warning). Two `settings.harness` knobs tune it:
 
-- `escalateOnPlateau` (default `false`) — flag gate; when off, plateau exits keep today's
-  done-with-warning behaviour intact.
+- `escalateOnPlateau` (default **`true`**) — flag gate; when off, a plateau keeps the legacy
+  done-with-warning-on-first-plateau behaviour (no retry).
 - `escalationMap` (default `{}`) — user overrides merged over the built-in ladder. User keys win on
   conflict (allowing redirects) and user-only keys extend the ladder. Self-loops (`{ 'foo': 'foo' }`)
   parse but emit one warn-level log record per entry at settings load.
 
-`DEFAULT_ESCALATION_MAP` (in `src/business/task/escalation-map.ts`) is a code-managed constant seeding
-the common in-provider rungs from the per-provider model catalogs (Claude Haiku → Sonnet → Opus; Codex /
-Copilot `gpt-5-mini` and `gpt-5.4-mini` → `gpt-5.5`). It is kept in lockstep with
-`domain/value/settings-models/` by code review — operators don't need to spell out these rungs to opt in,
-the empty-map default already covers them once the flag flips on.
+The one plateau-break attempt does two things: (1) **model escalation** — climbs one rung up
+`DEFAULT_ESCALATION_MAP` (`src/business/task/escalation-map.ts`, seeding the common in-provider rungs
+Claude Haiku → Sonnet → Opus; Codex / Copilot `gpt-5-mini` and `gpt-5.4-mini` → `gpt-5.5`, kept in
+lockstep with `domain/value/settings-models/` by code review) when a stronger rung exists; and (2) a
+**"change your approach" directive** (`{{PLATEAU_DIRECTIVE_SECTION}}` in the implement prompt) injected
+into that attempt's generator turn, telling it to abandon the non-converging approach and try a
+fundamentally different one. For a top-of-ladder generator (e.g. the default Opus) there is no higher
+model, so the attempt keeps the model and relies on the directive (a same-model "nudge" — stamped
+`escalatedFromModel === escalatedToModel` so the once-per-task cap still fires).
 
 Escalation is generator-only by design — the evaluator's model is held constant across the task so the
-scoring rubric does not shift mid-task, which would make plateau detection meaningless. The policy fires at
-most once per task: `Task.escalatedFromModel` / `escalatedToModel` are stamped on first escalation, and a
-second plateau on the same task transitions to `blocked` with no further escalation. Cost ceiling is
-therefore bounded — at worst one extra attempt per task on the upgraded model. Cross-provider escalation
-(e.g. swapping `claude-sonnet-4-6` → `gpt-5.5` instead of `claude-opus-4-8`) is intentionally deferred —
-the gen-eval split shipped the two-provider plumbing implement would need, but switching providers
-mid-task carries auth / context / tool-availability hazards that warrant a follow-up design pass.
+scoring rubric does not shift mid-task, which would make plateau detection meaningless. The policy fires
+at most once per task (`Task.escalatedFromModel` / `escalatedToModel` are write-once): after the single
+plateau-break attempt, a second plateau — or a plateau with no attempt budget left — preserves the work
+(done-with-warning), never blocks. Cost ceiling is bounded: at worst one extra attempt per task.
+Cross-provider escalation (e.g. `claude-opus-4-8` → `gpt-5.5`) and a multi-rung ladder are intentionally
+deferred — switching providers mid-task carries auth / context / tool-availability hazards, and the
+same-model nudge already gives a top-of-ladder generator a way to act differently.
 
 **Trace ring buffer.** The runner caps `runner.trace` at `MAX_TRACE_ENTRIES = 5_000`
 (`src/application/chain/run/runner.ts`). The `TaskRoundStarted` event (carrying `roundN`,

--- a/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
+++ b/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
@@ -101,7 +101,7 @@ interface GeneratePrContentOutput {
 export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<CreatePrCtx> =>
   leaf<CreatePrCtx, GeneratePrContentInput, GeneratePrContentOutput>('generate-pr-content', {
     useCase: {
-      execute: async (input) => {
+      execute: async (input, signal) => {
         // Derive verbatim `Closes <ref>` lines from ticket + task externalRefs — the prompt
         // embeds the rendered string and instructs the AI to mirror it at the bottom of the
         // body. Pre-computing here keeps the trailing refs deterministic instead of relying
@@ -164,6 +164,8 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           permissions: PR_AUTHORING_PERMISSIONS,
           signalsFile: signalsFilePathResult.value,
           outputDir: input.unitRoot,
+          // Thread the chain's abort signal so a TUI cancel mid-spawn kills the child.
+          ...(signal !== undefined ? { abortSignal: signal } : {}),
         };
 
         try {

--- a/src/application/flows/detect-scripts/leaves/propose.ts
+++ b/src/application/flows/detect-scripts/leaves/propose.ts
@@ -34,7 +34,8 @@ export const detectScriptsSession = (
   signalsFile: AbsolutePath,
   outputDir: AbsolutePath,
   bodyFile?: AbsolutePath,
-  effort?: string
+  effort?: string,
+  abortSignal?: AbortSignal
 ): AiSession => ({
   prompt,
   cwd: repository.path,
@@ -44,6 +45,8 @@ export const detectScriptsSession = (
   outputDir,
   ...(bodyFile !== undefined ? { bodyFile } : {}),
   ...(effort !== undefined ? { effort } : {}),
+  // Thread the chain's abort signal so a TUI cancel mid-spawn kills the child.
+  ...(abortSignal !== undefined ? { abortSignal } : {}),
 });
 
 export interface ProposeDetectScriptsLeafDeps {
@@ -129,7 +132,8 @@ const allocateRunPaths = (runsRoot: AbsolutePath): Result<RunPaths, DomainError>
  */
 const proposeUseCase = async (
   deps: ProposeDetectScriptsLeafDeps,
-  input: ProposeInput
+  input: ProposeInput,
+  abortSignal?: AbortSignal
 ): Promise<Result<ProposeOutput, DomainError>> => {
   const log = deps.logger.named('detect-scripts.propose');
   log.info(`starting repo ${input.repository.name}`, {
@@ -160,7 +164,8 @@ const proposeUseCase = async (
       paths.value.signalsFile,
       paths.value.runDir,
       paths.value.bodyFile,
-      deps.effort
+      deps.effort,
+      abortSignal
     )
   );
   if (!spawn.ok) {
@@ -220,7 +225,7 @@ const proposeUseCase = async (
 export const proposeDetectScriptsLeaf = (deps: ProposeDetectScriptsLeafDeps): Element<DetectScriptsCtx> =>
   leaf<DetectScriptsCtx, ProposeInput, ProposeOutput>('propose', {
     useCase: {
-      execute: async (input) => proposeUseCase(deps, input),
+      execute: async (input, signal) => proposeUseCase(deps, input, signal),
     },
     input: (ctx) => {
       if (ctx.repository === undefined) {

--- a/src/application/flows/detect-skills/leaves/propose.ts
+++ b/src/application/flows/detect-skills/leaves/propose.ts
@@ -37,7 +37,8 @@ export const detectSkillsSession = (
   signalsFile: AbsolutePath,
   outputDir: AbsolutePath,
   bodyFile?: AbsolutePath,
-  effort?: string
+  effort?: string,
+  abortSignal?: AbortSignal
 ): AiSession => ({
   prompt,
   cwd: repository.path,
@@ -47,6 +48,8 @@ export const detectSkillsSession = (
   outputDir,
   ...(bodyFile !== undefined ? { bodyFile } : {}),
   ...(effort !== undefined ? { effort } : {}),
+  // Thread the chain's abort signal so a TUI cancel mid-spawn kills the child.
+  ...(abortSignal !== undefined ? { abortSignal } : {}),
 });
 
 export interface ProposeDetectSkillsLeafDeps {
@@ -121,7 +124,8 @@ const allocateRunPaths = (runsRoot: AbsolutePath): Result<RunPaths, DomainError>
  */
 const proposeUseCase = async (
   deps: ProposeDetectSkillsLeafDeps,
-  input: ProposeInput
+  input: ProposeInput,
+  abortSignal?: AbortSignal
 ): Promise<Result<ProposeOutput, DomainError>> => {
   const log = deps.logger.named('detect-skills.propose');
   log.info(`starting repo ${input.repository.name}`, {
@@ -151,7 +155,8 @@ const proposeUseCase = async (
       paths.value.signalsFile,
       paths.value.runDir,
       paths.value.bodyFile,
-      deps.effort
+      deps.effort,
+      abortSignal
     )
   );
   if (!spawn.ok) {
@@ -216,7 +221,7 @@ const proposeUseCase = async (
 export const proposeDetectSkillsLeaf = (deps: ProposeDetectSkillsLeafDeps): Element<DetectSkillsCtx> =>
   leaf<DetectSkillsCtx, ProposeInput, ProposeOutput>('propose', {
     useCase: {
-      execute: async (input) => proposeUseCase(deps, input),
+      execute: async (input, signal) => proposeUseCase(deps, input, signal),
     },
     input: (ctx) => {
       if (ctx.repository === undefined) {

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -280,17 +280,41 @@ export const buildImplementPrologue = (deps: ImplementDeps, opts: CreateImplemen
  *
  * @public
  */
+/**
+ * Predicate for the active→review transition at the end of an implement run. The sprint flips
+ * to review only when the run has genuinely finished: every task has settled (`done`/`blocked`,
+ * so no `todo`/`in_progress` remains) AND at least one settled `done`. See the inline notes at
+ * the guard site for the two failure modes this guards (premature mid-run flip; all-blocked).
+ * Extracted as a pure function so the transition rule is unit-testable independent of the chain.
+ *
+ * @public
+ */
+export const shouldTransitionToReview = (tasks: ImplementCtx['tasks']): boolean => {
+  const list = tasks ?? [];
+  const someDone = list.some((t) => t.status === 'done');
+  const noneRunnable = !list.some((t) => t.status === 'todo' || t.status === 'in_progress');
+  return someDone && noneRunnable;
+};
+
 export const buildImplementEpilogue = (deps: ImplementDeps, opts: CreateImplementFlowOpts): Element<ImplementCtx> =>
   sequential<ImplementCtx>('implement-epilogue', [
     saveTasksLeaf<ImplementCtx>({ taskRepo: deps.taskRepo }),
-    // Only transition to review when at least one task actually settled `done`. If every task
-    // got blocked (e.g. pre-existing build failure, repeated self-block), the sprint has
-    // nothing to review — leaving it `active` lets the user fix the blocker and re-run
-    // implement without first manually backing the sprint out of review. Mixed runs (some
-    // done, some blocked) still transition: there's real work to review.
+    // Transition to review only when the run has genuinely finished — every task settled
+    // (`done` or `blocked`) AND at least one task settled `done`. Two failure modes this guards:
+    //   1. Premature flip: the prior `some(done)` predicate flipped to review the instant ONE
+    //      task finished, even while other tasks were still `todo` / `in_progress` — silently
+    //      shipping a partial sprint mid-run. Requiring "no runnable work left" keeps the sprint
+    //      `active` until every task has actually settled, so the operator never sees a sprint in
+    //      review with work still pending.
+    //   2. All-blocked: if nothing settled `done` (e.g. a foundational task blocked and cascaded
+    //      to its dependents), there's nothing to review — staying `active` lets the operator fix
+    //      the blocker and re-run implement without first backing the sprint out of review.
+    // A mixed end state (some done, some blocked) still transitions: the run is complete and the
+    // blocked tasks are surfaced in review for a deliberate close decision — no longer a silent
+    // mid-run partial ship.
     guard<ImplementCtx>(
-      'transition-sprint-to-review-when-any-done',
-      (ctx) => ctx.tasks?.some((t) => t.status === 'done') === true,
+      'transition-sprint-to-review-when-settled',
+      (ctx) => shouldTransitionToReview(ctx.tasks),
       sequential<ImplementCtx>('transition-to-review-and-journal', [
         transitionSprintToReviewLeaf({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
         appendJournalSeparatorLeaf<ImplementCtx>(

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -126,7 +126,7 @@ export interface CreateImplementFlowOpts {
  *         preflight-tasks,                 // interactive dirty-tree menu — one per repo, one-shot
  *         implement-tasks,                 // sequential task-<id> sub-chains
  *         save-tasks,
- *         transition-sprint-to-review(when any task done)
+ *         transition-sprint-to-review(when every task settled AND ≥1 done)
  *       ])
  *     ),
  *   ])
@@ -269,7 +269,7 @@ export const buildImplementPrologue = (deps: ImplementDeps, opts: CreateImplemen
 /**
  * Build the epilogue segment — the once-per-run teardown that runs AFTER every task has settled:
  *
- *   save-tasks → transition-sprint-to-review(when any task done)
+ *   save-tasks → transition-sprint-to-review(when every task settled AND ≥1 done)
  *
  * Returned as `sequential('implement-epilogue', [...])` so the parallel launcher can run it
  * once on a dedicated runner under the held lock — including on the abort/fatal path, where the

--- a/src/application/flows/implement/leaves/dependency-gate.ts
+++ b/src/application/flows/implement/leaves/dependency-gate.ts
@@ -1,0 +1,117 @@
+import { Result } from '@src/domain/result.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
+import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+
+/**
+ * Dependency gate — the per-task precondition that prevents the blocked-dependency dead-end.
+ *
+ * Tasks carry `dependsOn` edges; the scheduler orders dependents after their prerequisites but
+ * is **status-blind** — it schedules a dependent whether its prerequisite settled `done` or
+ * `blocked`. Without this gate a dependent of a blocked task ran anyway against a tree missing
+ * the prerequisite's work and self-blocked: a cascade of doomed AI spawns masquerading as
+ * independent failures, with the sprint silently shipping partial results.
+ *
+ * This leaf runs at the head of every per-task subchain (before `start-attempt`). It checks
+ * whether every `dependsOn` task has settled `done`; if any prerequisite is not done (blocked,
+ * or — defensively — still unsettled), it transitions THIS task straight to `blocked` with a
+ * `blocked upstream …` reason and persists it. The body guard downstream then skips the whole
+ * attempt loop, so no AI spawn is wasted. The transition is transitive by construction: if A
+ * blocks, B (→A) blocks here, then C (→B) sees B blocked and blocks too.
+ *
+ * Recovery: unblocking the root prerequisite cascade-unblocks these upstream-blocked dependents
+ * (see `unblock-task` use case), so the operator fixes one task and relaunches rather than
+ * hand-unblocking the whole subtree.
+ *
+ * No-op fast paths: a task with no `dependsOn`, a task already settled (a relaunch re-entering a
+ * blocked task), or all-prerequisites-done all return `Result.ok({})` leaving ctx untouched.
+ */
+export interface DependencyGateLeafDeps {
+  readonly taskRepo: UpdateTask;
+  readonly logger: Logger;
+}
+
+interface DependencyGateInput {
+  readonly tasks: readonly Task[];
+  readonly sprintId: SprintId;
+}
+
+interface DependencyGateOutput {
+  /** The newly-blocked task when a prerequisite was not done; absent on every no-op path. */
+  readonly blocked?: BlockedTask;
+}
+
+export const dependencyGateLeaf = (deps: DependencyGateLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
+  leaf<ImplementCtx, DependencyGateInput, DependencyGateOutput>(`dependency-gate-${String(taskId)}`, {
+    useCase: {
+      execute: async (input): Promise<Result<DependencyGateOutput, DomainError>> => {
+        const task = input.tasks.find((t) => t.id === taskId);
+        // Only a still-runnable task can be gated; an already-settled task (done/blocked, e.g. a
+        // relaunch re-entering it) is a no-op so re-runs stay idempotent.
+        if (task === undefined || (task.status !== 'todo' && task.status !== 'in_progress')) {
+          return Result.ok({});
+        }
+        if (task.dependsOn.length === 0) return Result.ok({});
+
+        const unmet = task.dependsOn
+          .map((depId) => ({ depId, dep: input.tasks.find((t) => t.id === depId) }))
+          .filter(({ dep }) => dep === undefined || dep.status !== 'done');
+        if (unmet.length === 0) return Result.ok({});
+
+        const detail = unmet
+          .map(({ depId, dep }) => (dep === undefined ? `${String(depId)} (missing)` : `${dep.name} (${dep.status})`))
+          .join(', ');
+        const reason = `blocked upstream — prerequisite not done: ${detail}`;
+
+        const blocked = markTaskBlocked(task, reason);
+        if (!blocked.ok) return Result.error(blocked.error);
+        const persisted = await deps.taskRepo.update(input.sprintId, blocked.value);
+        if (!persisted.ok) return Result.error(persisted.error);
+
+        deps.logger.named('task.dependency-gate').warn(`task '${String(taskId)}' ${reason} — skipping (no AI spawn)`, {
+          taskId: String(taskId),
+          unmet: unmet.map(({ depId }) => String(depId)),
+        });
+        return Result.ok({ blocked: blocked.value });
+      },
+    },
+    input: (ctx) => {
+      if (ctx.tasks === undefined) {
+        throw new InvalidStateError({
+          entity: 'chain',
+          currentState: 'pre-dependency-gate',
+          attemptedAction: `dependency-gate-${String(taskId)}`,
+          message: `dependency-gate-${String(taskId)}: ctx.tasks is undefined — load-tasks must run first`,
+        });
+      }
+      return { tasks: ctx.tasks, sprintId: ctx.sprintId };
+    },
+    output: (ctx, out) =>
+      out.blocked === undefined
+        ? ctx
+        : {
+            ...ctx,
+            tasks: (ctx.tasks ?? []).map((t) => (t.id === out.blocked?.id ? out.blocked : t)),
+          },
+  });
+
+/**
+ * Predicate for the body guard that wraps a per-task subchain: the task is still runnable
+ * (`todo`/`in_progress`) — i.e. the {@link dependencyGateLeaf} did NOT just block it. When the
+ * gate blocked the task this returns `false`, so the guard synthesises a `skipped` trace entry
+ * for the body instead of spawning the generator against an incomplete tree.
+ *
+ * @public
+ */
+export const isTaskRunnable = (ctx: ImplementCtx, taskId: TaskId): boolean => {
+  const task = ctx.tasks?.find((t) => t.id === taskId);
+  return task !== undefined && (task.status === 'todo' || task.status === 'in_progress');
+};

--- a/src/application/flows/implement/leaves/dependency-gate.ts
+++ b/src/application/flows/implement/leaves/dependency-gate.ts
@@ -4,7 +4,7 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
 import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
-import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import { BLOCKED_UPSTREAM_REASON_PREFIX, markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
@@ -69,7 +69,7 @@ export const dependencyGateLeaf = (deps: DependencyGateLeafDeps, taskId: TaskId)
         const detail = unmet
           .map(({ depId, dep }) => (dep === undefined ? `${String(depId)} (missing)` : `${dep.name} (${dep.status})`))
           .join(', ');
-        const reason = `blocked upstream — prerequisite not done: ${detail}`;
+        const reason = `${BLOCKED_UPSTREAM_REASON_PREFIX} — prerequisite not done: ${detail}`;
 
         const blocked = markTaskBlocked(task, reason);
         if (!blocked.ok) return Result.error(blocked.error);

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -147,7 +147,7 @@ const readProgressFile = async (path: string): Promise<string> => {
 export const evaluatorLeaf = (deps: EvaluatorLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
   leaf<ImplementCtx, EvaluatorInput, EvaluatorOutput>(`evaluator-${String(taskId)}`, {
     useCase: {
-      execute: async (input) => {
+      execute: async (input, signal) => {
         const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, input.roundNum, 'evaluator'));
         if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
         const signalsFile = signalsFilePath.value;
@@ -189,7 +189,8 @@ export const evaluatorLeaf = (deps: EvaluatorLeafDeps, taskId: TaskId): Element<
               signalsFile,
               'evaluator',
               input.priorEvaluatorSessionId,
-              deps.effort
+              deps.effort,
+              signal
             )
           );
           if (!spawn.ok) return Result.error(spawn.error);

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -241,6 +241,10 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
             outputContractSection: renderContractSectionFor(generatorOutputContract, outputDir),
             ...(deps.verifyScript !== undefined ? { verifyScript: deps.verifyScript } : {}),
             ...(priorCritique !== undefined ? { priorCritique } : {}),
+            // Plateau-break attempt: the escalation policy stamped the task (model bump and/or a
+            // change-of-approach nudge) after the gen-eval loop stalled. Surface the "change your
+            // approach" directive so the generator abandons the non-converging path.
+            ...(task.escalatedFromModel !== undefined ? { plateauBreak: true } : {}),
           });
           if (!prompt.ok) return Result.error(prompt.error) as Result<readonly HarnessSignal[], DomainError>;
           // Persist the rendered prompt under `rounds/<N>/generator/prompt.md` BEFORE the AI

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -175,7 +175,7 @@ const readProgressFile = async (path: string): Promise<string> => {
 export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
   leaf<ImplementCtx, GeneratorInput, GeneratorOutput>(`generator-${String(taskId)}`, {
     useCase: {
-      execute: async (input) => {
+      execute: async (input, signal) => {
         const roundNum = input.roundNum;
         const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, roundNum, 'generator'));
         if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
@@ -264,7 +264,8 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
               signalsFile,
               'generator',
               input.priorGeneratorSessionId,
-              deps.effort
+              deps.effort,
+              signal
             )
           );
           if (!spawn.ok) return Result.error(spawn.error);

--- a/src/application/flows/implement/leaves/implement-session.ts
+++ b/src/application/flows/implement/leaves/implement-session.ts
@@ -54,7 +54,8 @@ export const implementSession = (
   signalsFile: AbsolutePath,
   role: 'generator' | 'evaluator',
   resume?: SessionId,
-  effort?: string
+  effort?: string,
+  abortSignal?: AbortSignal
 ): AiSession => {
   // The per-round output dir is the directory containing `signalsFile` (e.g.
   // `<sandboxCwd>/rounds/<N>/<role>/`). Stamping it on the session lets every adapter's
@@ -75,5 +76,12 @@ export const implementSession = (
     ...(outputDir.ok ? { outputDir: outputDir.value } : {}),
     ...(resume !== undefined ? { resume } : {}),
     ...(effort !== undefined ? { effort } : {}),
+    // Caller-controlled abort (TUI cancel / Ctrl-C). Threaded from the leaf framework's
+    // `execute(input, signal)` second argument so the headless provider's SIGTERM→SIGKILL
+    // kill ladder, abort-aware exit classification, and cancellable rate-limit sleep all
+    // observe a user cancel mid-spawn. Without this the field is undefined and that whole
+    // machinery is dead code — a manual abort would let the child run to natural completion,
+    // stranding the repo lock and the progress spinner until the run ends on its own.
+    ...(abortSignal !== undefined ? { abortSignal } : {}),
   };
 };

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -214,6 +214,7 @@ export const createPerTaskSubchain = (
                 cwd: repo.path,
                 sprintDir: opts.sprintDir,
                 ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
+                ...(repo.verifyTimeout !== undefined ? { timeoutMs: repo.verifyTimeout } : {}),
               },
               taskId
             ),
@@ -272,6 +273,7 @@ export const createPerTaskSubchain = (
                 cwd: repo.path,
                 sprintDir: opts.sprintDir,
                 ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
+                ...(repo.verifyTimeout !== undefined ? { timeoutMs: repo.verifyTimeout } : {}),
               },
               taskId
             ),

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -11,6 +11,7 @@ import { appendLearningsLeaf } from '@src/application/flows/implement/leaves/app
 import { branchPreflightLeaf } from '@src/application/flows/implement/leaves/branch-preflight.ts';
 import { buildTaskWorkspaceLeaf } from '@src/application/flows/implement/leaves/build-task-workspace.ts';
 import { commitTaskLeaf } from '@src/application/flows/implement/leaves/commit-task.ts';
+import { dependencyGateLeaf, isTaskRunnable } from '@src/application/flows/implement/leaves/dependency-gate.ts';
 import { finalizeGenEvalLeaf } from '@src/application/flows/implement/leaves/finalize-gen-eval.ts';
 import {
   createGenEvalLoop,
@@ -29,15 +30,24 @@ import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/unins
  * Per-task subchain factory. Returns the `sequential('task-<id>', [...])` element that runs the
  * complete lifecycle for ONE task.
  *
- * The shape is a once-per-task prologue + an inner attempt loop + a once-per-task epilogue:
+ * The shape is a dependency gate + a guarded body (once-per-task prologue + inner attempt loop +
+ * once-per-task epilogue):
  *
- *   branch-preflight → workspace build → install-skills →           // once per task
- *   loop('task-attempts-<id>', sequential([                          // up to maxAttempts attempts
- *     start-attempt → pre-task-verify → gen-eval loop → finalize →
- *     post-task-verify → commit (guarded) → settle-attempt →
- *     append-learnings → progress-journal
- *   ]), { maxIterations: maxAttempts, shouldStop: terminal }) →
- *   uninstall-skills                                                 // once per task
+ *   dependency-gate →                                                // block-upstream-if prereq ≠ done
+ *   guard('task-runnable-<id>', sequential('task-body-<id>', [        // body runs only when runnable
+ *     branch-preflight → workspace build → install-skills →          // once per task
+ *     loop('task-attempts-<id>', sequential([                         // up to maxAttempts attempts
+ *       start-attempt → pre-task-verify → gen-eval loop → finalize →
+ *       post-task-verify → commit (guarded) → settle-attempt →
+ *       append-learnings → progress-journal
+ *     ]), { maxIterations: maxAttempts, shouldStop: terminal }) →
+ *     uninstall-skills                                               // once per task
+ *   ]))
+ *
+ * The leading `dependency-gate` is the blocked-dependency dead-end fix: if any `dependsOn` task
+ * is not `done`, it transitions this task to `blocked upstream …` and the `task-runnable` guard
+ * skips the entire body — so a dependent never spawns the generator against a tree missing its
+ * prerequisite's work (which used to self-block and ship the sprint partial).
  *
  * The terminal `uninstall-skills` leaf name is the value of {@link IMPLEMENT_TASK_TERMINAL_LEAF}
  * exported from `flow.ts` and is what the TUI's task-completion detector keys on — it stays
@@ -143,169 +153,180 @@ export const createPerTaskSubchain = (
   // a conditional spread so the serial element tree is byte-for-byte unchanged when included.
   const includeBranchPreflight = opts.includeBranchPreflight ?? true;
   return sequential<ImplementCtx>(`task-${String(taskId)}`, [
-    ...(includeBranchPreflight
-      ? [
-          branchPreflightLeaf(
-            { gitRunner: deps.gitRunner, logger: deps.logger },
-            { cwd: repo.path },
-            `branch-preflight-${String(taskId)}`
-          ),
-        ]
-      : []),
-    buildTaskWorkspaceLeaf(
-      { templateLoader: deps.templateLoader, logger: deps.logger },
-      {
-        sprintDir: opts.sprintDir,
-        cwd: repo.path,
-        progressFile: opts.progressFile,
-        ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
-      },
-      taskId
-    ),
-    installSkillsLeaf<ImplementCtx>(
-      { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
-      { name: `install-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
-    ),
-    // Inner attempt loop. The body is the full per-attempt segment; the loop re-enters it
-    // until `terminalTaskStatus` reports the settled task `done`/`blocked` or the `maxAttempts`
-    // cap fires. `maxAttempts === 1` runs exactly once (single-attempt-per-launch parity); a
-    // higher cap only manifests on the escalation-retry path. The 1000 ceiling on the `loop`
-    // primitive is just a backstop — `maxAttempts` (validated 1–10) is the real bound here.
-    loop<ImplementCtx>(
-      `task-attempts-${String(taskId)}`,
-      sequential<ImplementCtx>(`task-attempt-body-${String(taskId)}`, [
-        startAttemptLeaf({ taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger }, taskId),
-        // PRE-task verify — captures the baseline state of the working tree BEFORE the AI runs
-        // so the post-task-verify can attribute correctly: a red post on a green pre means the
-        // AI regressed; a red post on a red pre is a pre-existing failure (don't blame the AI).
-        // Non-blocking by policy — a red baseline just stamps `baselineBroken: true` on the
-        // attempt and lets the AI try anyway.
-        preTaskVerifyLeaf(
+    // Dependency gate (blocked-dependency dead-end fix). Runs FIRST: if any `dependsOn` task is
+    // not `done`, it transitions this task straight to `blocked upstream …` and the body guard
+    // below skips the whole lifecycle — so a dependent never spawns the generator against a tree
+    // missing its prerequisite's work. Transitive by construction (A blocks → B → C …).
+    dependencyGateLeaf({ taskRepo: deps.taskRepo, logger: deps.logger }, taskId),
+    guard<ImplementCtx>(
+      `task-runnable-${String(taskId)}`,
+      (ctx) => isTaskRunnable(ctx, taskId),
+      sequential<ImplementCtx>(`task-body-${String(taskId)}`, [
+        ...(includeBranchPreflight
+          ? [
+              branchPreflightLeaf(
+                { gitRunner: deps.gitRunner, logger: deps.logger },
+                { cwd: repo.path },
+                `branch-preflight-${String(taskId)}`
+              ),
+            ]
+          : []),
+        buildTaskWorkspaceLeaf(
+          { templateLoader: deps.templateLoader, logger: deps.logger },
           {
-            shellScriptRunner: deps.shellScriptRunner,
-            taskRepo: deps.taskRepo,
-            sprintExecutionRepo: deps.sprintExecutionRepo,
-            interactive: deps.interactive,
-            gitRunner: deps.gitRunner,
-            clock: deps.clock,
-            eventBus: deps.eventBus,
-            logger: deps.logger,
-          },
-          {
-            cwd: repo.path,
             sprintDir: opts.sprintDir,
-            ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
-          },
-          taskId
-        ),
-        // Composite: per-turn generator + evaluator, repeated until a terminal exit is set on ctx
-        // or the configured `maxTurns` budget is hit. The evaluator is guarded — if the generator
-        // self-blocked this turn it set `lastExit` and the evaluator must not run.
-        createGenEvalLoop(
-          {
-            generatorProvider: deps.generatorProvider,
-            evaluatorProvider: deps.evaluatorProvider,
-            templateLoader: deps.templateLoader,
-            signals: deps.signals,
-            writeFile: deps.writeFile,
-            clock: deps.clock,
-            logger: deps.logger,
-            eventBus: deps.eventBus,
-            readConfig,
-            maxTurns: deps.config.harness.maxTurns,
-            plateauThreshold: deps.config.harness.plateauThreshold,
-          },
-          {
             cwd: repo.path,
-            sprintDir: opts.sprintDir,
             progressFile: opts.progressFile,
             ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
-            generator: opts.generator,
-            evaluator: opts.evaluator,
           },
           taskId
         ),
-        finalizeGenEvalLeaf(
+        installSkillsLeaf<ImplementCtx>(
+          { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
+          { name: `install-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
+        ),
+        // Inner attempt loop. The body is the full per-attempt segment; the loop re-enters it
+        // until `terminalTaskStatus` reports the settled task `done`/`blocked` or the `maxAttempts`
+        // cap fires. `maxAttempts === 1` runs exactly once (single-attempt-per-launch parity); a
+        // higher cap only manifests on the escalation-retry path. The 1000 ceiling on the `loop`
+        // primitive is just a backstop — `maxAttempts` (validated 1–10) is the real bound here.
+        loop<ImplementCtx>(
+          `task-attempts-${String(taskId)}`,
+          sequential<ImplementCtx>(`task-attempt-body-${String(taskId)}`, [
+            startAttemptLeaf({ taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger }, taskId),
+            // PRE-task verify — captures the baseline state of the working tree BEFORE the AI runs
+            // so the post-task-verify can attribute correctly: a red post on a green pre means the
+            // AI regressed; a red post on a red pre is a pre-existing failure (don't blame the AI).
+            // Non-blocking by policy — a red baseline just stamps `baselineBroken: true` on the
+            // attempt and lets the AI try anyway.
+            preTaskVerifyLeaf(
+              {
+                shellScriptRunner: deps.shellScriptRunner,
+                taskRepo: deps.taskRepo,
+                sprintExecutionRepo: deps.sprintExecutionRepo,
+                interactive: deps.interactive,
+                gitRunner: deps.gitRunner,
+                clock: deps.clock,
+                eventBus: deps.eventBus,
+                logger: deps.logger,
+              },
+              {
+                cwd: repo.path,
+                sprintDir: opts.sprintDir,
+                ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
+              },
+              taskId
+            ),
+            // Composite: per-turn generator + evaluator, repeated until a terminal exit is set on ctx
+            // or the configured `maxTurns` budget is hit. The evaluator is guarded — if the generator
+            // self-blocked this turn it set `lastExit` and the evaluator must not run.
+            createGenEvalLoop(
+              {
+                generatorProvider: deps.generatorProvider,
+                evaluatorProvider: deps.evaluatorProvider,
+                templateLoader: deps.templateLoader,
+                signals: deps.signals,
+                writeFile: deps.writeFile,
+                clock: deps.clock,
+                logger: deps.logger,
+                eventBus: deps.eventBus,
+                readConfig,
+                maxTurns: deps.config.harness.maxTurns,
+                plateauThreshold: deps.config.harness.plateauThreshold,
+              },
+              {
+                cwd: repo.path,
+                sprintDir: opts.sprintDir,
+                progressFile: opts.progressFile,
+                ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
+                generator: opts.generator,
+                evaluator: opts.evaluator,
+              },
+              taskId
+            ),
+            finalizeGenEvalLeaf(
+              {
+                taskRepo: deps.taskRepo,
+                readConfig,
+                logger: deps.logger,
+                eventBus: deps.eventBus,
+                clock: deps.clock,
+                configuredGeneratorModel: opts.generator.model,
+              },
+              taskId
+            ),
+            // Verify gate sits BEFORE commit so a red verifyScript blocks the task instead of landing
+            // broken code on the sprint branch. On `verify-failed` the leaf stamps `lastBlockReason`,
+            // the guard around `commit-task` skips, and `settle-attempt` marks the task `blocked`.
+            // The AI is told to run the verify script itself via the prompt; this leaf is the
+            // harness-side enforcement.
+            postTaskVerifyLeaf(
+              {
+                shellScriptRunner: deps.shellScriptRunner,
+                taskRepo: deps.taskRepo,
+                clock: deps.clock,
+                eventBus: deps.eventBus,
+                logger: deps.logger,
+              },
+              {
+                cwd: repo.path,
+                sprintDir: opts.sprintDir,
+                ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
+              },
+              taskId
+            ),
+            guard<ImplementCtx>(
+              `commit-task-guard-${String(taskId)}`,
+              (ctx) => ctx.lastBlockReason === undefined,
+              commitTaskLeaf(
+                {
+                  gitRunner: deps.gitRunner,
+                  taskRepo: deps.taskRepo,
+                  clock: deps.clock,
+                  logger: deps.logger,
+                },
+                { cwd: repo.path },
+                taskId
+              )
+            ),
+            settleAttemptLeaf(
+              { taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger, gitRunner: deps.gitRunner },
+              { cwd: repo.path },
+              taskId
+            ),
+            // WRITE side of Theme 6 (audit-[B5]). Reads the STILL-POPULATED `currentAttemptLearnings`
+            // accumulator and appends one NDJSON line per learning to the project's ledger. MUST run
+            // BEFORE `progress-journal` — the journal clears that accumulator after it renders. Append
+            // only (the read side dedups by stable id); best-effort (a failed append logs + proceeds).
+            appendLearningsLeaf(
+              { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
+              { memoryRoot: opts.memoryRoot, projectId: opts.projectId, repoPath: repo.path, repoName: repo.name },
+              taskId
+            ),
+            // Append the per-attempt journal section to `<sprintDir>/progress.md`. Records the
+            // verdict, attempt count, round info, duration, and the deduped decision count for the
+            // just-settled attempt. Best-effort — the leaf logs and swallows failures.
+            progressJournalLeaf(
+              { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
+              { progressFile: opts.progressFile, totalRounds: deps.config.harness.maxTurns },
+              taskId
+            ),
+          ]),
           {
-            taskRepo: deps.taskRepo,
-            readConfig,
-            logger: deps.logger,
-            eventBus: deps.eventBus,
-            clock: deps.clock,
-            configuredGeneratorModel: opts.generator.model,
-          },
-          taskId
+            // The attempt count is bounded by the task's own `maxAttempts` (validated 1–10). When
+            // unset, the `loop` primitive's 1000 ceiling is the backstop and `shouldStop` (terminal
+            // status) is the real bound. The domain's `failCurrentAttempt` still transitions the
+            // task to `blocked` once attempts hit the cap, so a budget-exhausted task is never
+            // silently dropped — `shouldStop` just recognises that terminal status and exits.
+            ...(task.maxAttempts !== undefined ? { maxIterations: task.maxAttempts } : {}),
+            shouldStop: (ctx) => terminalTaskStatus(ctx, taskId),
+          }
         ),
-        // Verify gate sits BEFORE commit so a red verifyScript blocks the task instead of landing
-        // broken code on the sprint branch. On `verify-failed` the leaf stamps `lastBlockReason`,
-        // the guard around `commit-task` skips, and `settle-attempt` marks the task `blocked`.
-        // The AI is told to run the verify script itself via the prompt; this leaf is the
-        // harness-side enforcement.
-        postTaskVerifyLeaf(
-          {
-            shellScriptRunner: deps.shellScriptRunner,
-            taskRepo: deps.taskRepo,
-            clock: deps.clock,
-            eventBus: deps.eventBus,
-            logger: deps.logger,
-          },
-          {
-            cwd: repo.path,
-            sprintDir: opts.sprintDir,
-            ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
-          },
-          taskId
+        uninstallSkillsLeaf<ImplementCtx>(
+          { skillsAdapter: deps.skillsAdapter },
+          { name: `${opts.terminalLeafName}-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
         ),
-        guard<ImplementCtx>(
-          `commit-task-guard-${String(taskId)}`,
-          (ctx) => ctx.lastBlockReason === undefined,
-          commitTaskLeaf(
-            {
-              gitRunner: deps.gitRunner,
-              taskRepo: deps.taskRepo,
-              clock: deps.clock,
-              logger: deps.logger,
-            },
-            { cwd: repo.path },
-            taskId
-          )
-        ),
-        settleAttemptLeaf(
-          { taskRepo: deps.taskRepo, clock: deps.clock, logger: deps.logger, gitRunner: deps.gitRunner },
-          { cwd: repo.path },
-          taskId
-        ),
-        // WRITE side of Theme 6 (audit-[B5]). Reads the STILL-POPULATED `currentAttemptLearnings`
-        // accumulator and appends one NDJSON line per learning to the project's ledger. MUST run
-        // BEFORE `progress-journal` — the journal clears that accumulator after it renders. Append
-        // only (the read side dedups by stable id); best-effort (a failed append logs + proceeds).
-        appendLearningsLeaf(
-          { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
-          { memoryRoot: opts.memoryRoot, projectId: opts.projectId, repoPath: repo.path, repoName: repo.name },
-          taskId
-        ),
-        // Append the per-attempt journal section to `<sprintDir>/progress.md`. Records the
-        // verdict, attempt count, round info, duration, and the deduped decision count for the
-        // just-settled attempt. Best-effort — the leaf logs and swallows failures.
-        progressJournalLeaf(
-          { appendFile: deps.appendFile, clock: deps.clock, logger: deps.logger },
-          { progressFile: opts.progressFile, totalRounds: deps.config.harness.maxTurns },
-          taskId
-        ),
-      ]),
-      {
-        // The attempt count is bounded by the task's own `maxAttempts` (validated 1–10). When
-        // unset, the `loop` primitive's 1000 ceiling is the backstop and `shouldStop` (terminal
-        // status) is the real bound. The domain's `failCurrentAttempt` still transitions the
-        // task to `blocked` once attempts hit the cap, so a budget-exhausted task is never
-        // silently dropped — `shouldStop` just recognises that terminal status and exits.
-        ...(task.maxAttempts !== undefined ? { maxIterations: task.maxAttempts } : {}),
-        shouldStop: (ctx) => terminalTaskStatus(ctx, taskId),
-      }
-    ),
-    uninstallSkillsLeaf<ImplementCtx>(
-      { skillsAdapter: deps.skillsAdapter },
-      { name: `${opts.terminalLeafName}-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
+      ])
     ),
   ]);
 };

--- a/src/application/flows/implement/leaves/resolve-repo.ts
+++ b/src/application/flows/implement/leaves/resolve-repo.ts
@@ -17,6 +17,14 @@ export interface RepoExecConfig {
    */
   readonly name: string;
   readonly verifyScript?: string;
+  /**
+   * Per-spawn wall-clock cap (ms) for the verify script, from `Repository.verifyTimeout`. Threaded
+   * into both the pre- and post-task verify leaves as `timeoutMs`. When absent the shell runner
+   * falls back to `DEFAULT_SHELL_TIMEOUT_MS` (5 min). Previously this field was dropped between the
+   * Repository entity and the chain, so a user-configured verify timeout silently had no effect and
+   * a hung verify burned the full 5 min on BOTH the pre- and post-task call.
+   */
+  readonly verifyTimeout?: number;
   readonly setupScript?: string;
 }
 

--- a/src/application/flows/implement/leaves/setup-script-runner.ts
+++ b/src/application/flows/implement/leaves/setup-script-runner.ts
@@ -271,17 +271,15 @@ export const setupScriptRunnerLeaf = (
             }
 
             // pnpm 11 hardened `removeModulesDirSafe` to abort on missing TTY rather than
-            // silently re-creating `node_modules` (pnpm/pnpm#9966). When the marker fires we
-            // surface an actionable project-side hint — `npm_config_confirm_modules_purge=false`
-            // (the env shim in shell-script-runner.ts) does NOT cover this code path, so the
-            // operator has to fix it at the project level. We deliberately do NOT auto-retry
-            // with `CI=true`: that flag flips Maven Surefire, Spring Boot
-            // `@DisabledIfEnvironmentVariable("CI")` gates, pnpm's frozen-lockfile semantics,
-            // and assorted other toolchain heuristics, so a "green" retry could mask drift from
-            // the real baseline the post-task verify gate later runs without `CI=true`.
+            // silently re-creating `node_modules` (pnpm/pnpm#9966 / #11562). The shell runner
+            // now sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on every setup/verify
+            // child — the only lever that suppresses this on pnpm 11, where every
+            // `confirm-modules-purge=false` form is ignored. So this marker should fire only when
+            // `CI` has been explicitly overridden in the operator's environment; the hint points
+            // there rather than asking the project under development to adapt.
             const noTtyDetected = output.includes(PNPM_NO_TTY_ERROR_MARKER);
             const pnpmTtyHint = noTtyDetected
-              ? 'pnpm no-TTY abort detected. Fix project-side: pin pnpm < 11 in mise.toml / package.json#packageManager (pnpm/pnpm#9966), run `pnpm install` once in a terminal to resync, or add `confirm-modules-purge=false` to .npmrc.'
+              ? 'pnpm no-TTY abort. The harness sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on setup/verify to prevent this — `CI` looks overridden in your environment. Clear `CI`, or run the install once in a terminal to resync `node_modules`.'
               : undefined;
             deps.eventBus.publish({
               type: 'log',

--- a/src/application/flows/readiness/leaves/propose.ts
+++ b/src/application/flows/readiness/leaves/propose.ts
@@ -38,7 +38,8 @@ export const readinessSession = (
   signalsFile: AbsolutePath,
   bodyFile: AbsolutePath | undefined,
   outputDir: AbsolutePath,
-  effort?: string
+  effort?: string,
+  abortSignal?: AbortSignal
 ): AiSession => ({
   prompt,
   cwd,
@@ -48,6 +49,8 @@ export const readinessSession = (
   outputDir,
   ...(bodyFile !== undefined ? { bodyFile } : {}),
   ...(effort !== undefined ? { effort } : {}),
+  // Thread the chain's abort signal so a TUI cancel mid-spawn kills the child.
+  ...(abortSignal !== undefined ? { abortSignal } : {}),
 });
 
 export interface ProposeReadinessLeafDeps {
@@ -124,7 +127,8 @@ interface ProposeReadinessOutput {
 const proposeReadinessUseCase = async (
   deps: ProposeReadinessLeafDeps,
   tool: AssistantTool,
-  input: ProposeReadinessInput
+  input: ProposeReadinessInput,
+  abortSignal?: AbortSignal
 ): Promise<Result<ProposeReadinessOutput, DomainError>> => {
   const existingPath = pickExistingContextPath(tool, input.probedState);
   let existingBody: string | undefined;
@@ -145,7 +149,7 @@ const proposeReadinessUseCase = async (
           outputContractSection: renderContractSectionFor(readinessOutputContract, params.outputDir),
         }),
       buildSession: (prompt, signalsFile, bodyFile, outputDir) =>
-        readinessSession(deps.cwd, prompt, deps.model, signalsFile, bodyFile, outputDir, deps.effort),
+        readinessSession(deps.cwd, prompt, deps.model, signalsFile, bodyFile, outputDir, deps.effort, abortSignal),
       logger: deps.logger,
     },
     {
@@ -238,7 +242,7 @@ const pickExistingContextPath = (tool: AssistantTool, state: ReadinessState): st
 export const proposeReadinessLeaf = (deps: ProposeReadinessLeafDeps, tool: AssistantTool): Element<ReadinessCtx> =>
   leaf<ReadinessCtx, ProposeReadinessInput, ProposeReadinessOutput>(`propose-${tool}`, {
     useCase: {
-      execute: async (input) => proposeReadinessUseCase(deps, tool, input),
+      execute: async (input, signal) => proposeReadinessUseCase(deps, tool, input, signal),
     },
     input: (ctx) => {
       if (ctx.repository === undefined) {

--- a/src/application/flows/refine/deps.ts
+++ b/src/application/flows/refine/deps.ts
@@ -4,7 +4,6 @@ import type { IssuePusher } from '@src/business/scm/issue-pusher.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { PendingTicket } from '@src/domain/entity/ticket.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 import type { WriteFile } from '@src/business/io/write-file.ts';
@@ -39,24 +38,25 @@ export interface RefineDeps {
   readonly clock: () => IsoTimestamp;
   readonly issueFetcher?: IssueFetcher;
   /**
-   * Optional pusher for the refine flow's "Approve & update origin" path. Same lifetime as
+   * Optional pusher for the refine flow's "Post as comment" path. Same lifetime as
    * `issueFetcher`. Push failures are swallowed (log + continue) so a broken push never blocks
    * local refinement.
    */
   readonly issuePusher?: IssuePusher;
   /**
-   * Project-level default origin for "Approve & create origin" when the ticket has no `link`.
-   * Threaded down from the launcher (`snapshot.project.defaultIssueOrigin`). When unset, the
-   * 3-way prompt collapses to 2 options for tickets without a link.
+   * Non-interactive default for posting the refined requirements as a comment on the linked
+   * issue. Threaded from `settings.scm.postRefinementComment`. Consulted only when
+   * `reviewBeforeApprove` is absent (CI / headless); when the reviewer hook is wired the
+   * reviewer's explicit choice governs instead.
    */
-  readonly defaultIssueOrigin?: IssueOriginRef;
+  readonly postRefinementComment?: boolean;
   /**
    * Optional approval hook fired AFTER the AI proposes refined requirements and BEFORE the
    * ticket transitions to `approved`. Production wires this to a TUI review prompt;
    * headless / CI / tests omit it and the AI's body is auto-accepted.
    *
-   * Return shape: `{accept, alsoUpdateOrigin?}`. The middle "Approve & update origin" path
-   * sets `alsoUpdateOrigin: true`; the leaf then runs the push (best-effort).
+   * Return shape: `{accept, alsoUpdateOrigin?}`. The "Post as comment" path sets
+   * `alsoUpdateOrigin: true`; the leaf then posts the comment (best-effort).
    */
   readonly reviewBeforeApprove?: (
     proposed: string,

--- a/src/application/flows/refine/deps.ts
+++ b/src/application/flows/refine/deps.ts
@@ -55,11 +55,14 @@ export interface RefineDeps {
    * ticket transitions to `approved`. Production wires this to a TUI review prompt;
    * headless / CI / tests omit it and the AI's body is auto-accepted.
    *
-   * Return shape: `{accept, alsoUpdateOrigin?}`. The "Post as comment" path sets
-   * `alsoUpdateOrigin: true`; the leaf then posts the comment (best-effort).
+   * Return shape: `{accept, alsoUpdateOrigin?, body?}`. The "Post as comment" path sets
+   * `alsoUpdateOrigin: true`; the leaf then posts the comment (best-effort). `body` carries the
+   * reviewer's edited requirements when they edited the AI's proposal — the use case persists it
+   * (and the comment publishes it) instead of the original AI body. Omitting `body` keeps the AI's
+   * proposal verbatim.
    */
   readonly reviewBeforeApprove?: (
     proposed: string,
     ticket: PendingTicket
-  ) => Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean }>;
+  ) => Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean; readonly body?: string }>;
 }

--- a/src/application/flows/refine/flow.ts
+++ b/src/application/flows/refine/flow.ts
@@ -189,10 +189,11 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
           writeFile: deps.writeFile,
           eventBus: deps.eventBus,
           model: opts.model,
+          sprintId: String(opts.sprintId),
           ...(opts.effort !== undefined ? { effort: opts.effort } : {}),
+          ...(deps.postRefinementComment !== undefined ? { postRefinementComment: deps.postRefinementComment } : {}),
           ...(deps.reviewBeforeApprove !== undefined ? { reviewBeforeApprove: deps.reviewBeforeApprove } : {}),
           ...(deps.issuePusher !== undefined ? { issuePusher: deps.issuePusher } : {}),
-          ...(deps.defaultIssueOrigin !== undefined ? { defaultIssueOrigin: deps.defaultIssueOrigin } : {}),
         },
         ticket
       ),

--- a/src/application/flows/refine/leaves/refine-ticket-interactive.ts
+++ b/src/application/flows/refine/leaves/refine-ticket-interactive.ts
@@ -70,7 +70,7 @@ export interface RefineTicketInteractiveDeps {
   readonly reviewBeforeApprove?: (
     proposed: string,
     ticket: PendingTicket
-  ) => Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean }>;
+  ) => Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean; readonly body?: string }>;
   /**
    * Optional pusher. When the reviewer picks "Post as comment" (or, in non-interactive runs,
    * `postRefinementComment` is enabled), the leaf posts the refined requirements as a comment
@@ -292,7 +292,13 @@ export const refineTicketInteractiveLeaf = (
         const shouldComment =
           deps.reviewBeforeApprove !== undefined ? out.alsoUpdateOrigin : deps.postRefinementComment === true;
         if (!shouldComment) return Result.ok(out);
-        await maybeCommentOnOrigin(deps, out.ticket as ApprovedTicket, refinedSignal.body);
+        // Post the SETTLED requirements — `refineTicketUseCase` stored the reviewer's edited body
+        // (when they edited it) on the approved ticket. Posting `refinedSignal.body` (the AI's raw
+        // pre-edit proposal) would publish text the reviewer may have deliberately discarded to a
+        // public issue tracker, diverging from the locally-persisted ticket. `out.accepted` is true
+        // here, so `out.ticket` is an `ApprovedTicket` and `requirements` is a non-empty string.
+        const approved = out.ticket as ApprovedTicket;
+        await maybeCommentOnOrigin(deps, approved, approved.requirements);
         return Result.ok(out);
       },
     },

--- a/src/application/flows/refine/leaves/refine-ticket-interactive.ts
+++ b/src/application/flows/refine/leaves/refine-ticket-interactive.ts
@@ -6,8 +6,8 @@ import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { WriteFile } from '@src/business/io/write-file.ts';
 import { refineTicketUseCase } from '@src/business/ticket/refine-ticket.ts';
-import { replaceTicket, type Sprint } from '@src/domain/entity/sprint.ts';
-import { type ApprovedTicket, type PendingTicket, setTicketLink, type Ticket } from '@src/domain/entity/ticket.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import { type ApprovedTicket, type PendingTicket, type Ticket } from '@src/domain/entity/ticket.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { RefinedTicketSignal } from '@src/domain/signal.ts';
@@ -18,7 +18,6 @@ import { validateSignalsFile } from '@src/integration/ai/contract/_engine/valida
 import type { RefineCtx } from '@src/application/flows/refine/ctx.ts';
 import { partitionRefineSignals, refineOutputContract } from '@src/application/flows/refine/leaves/refine.contract.ts';
 import type { IssuePusher } from '@src/business/scm/issue-pusher.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 
 /**
  * Chain leaf — drives the user-in-the-loop AI session for one ticket. Integration work
@@ -73,22 +72,33 @@ export interface RefineTicketInteractiveDeps {
     ticket: PendingTicket
   ) => Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean }>;
   /**
-   * Optional pusher — supplied alongside `defaultIssueOrigin` from the launcher. When the
-   * reviewer picks "Approve & update origin", the leaf calls update / create here. Any failure
-   * is swallowed (logged + surfaced via the chain trace as a `note` would be, but the leaf
-   * still completes successfully — local refinement always lands).
+   * Optional pusher. When the reviewer picks "Post as comment" (or, in non-interactive runs,
+   * `postRefinementComment` is enabled), the leaf posts the refined requirements as a comment
+   * on the linked issue here. Any failure is swallowed (logged, but the leaf still completes
+   * successfully — local refinement always lands).
    */
   readonly issuePusher?: IssuePusher;
   /**
-   * Project-level default for "create a new issue" when the approved ticket has no `link`.
-   * When neither this nor `ticket.link` is set, the launcher's 3-way prompt hides the middle
-   * option and the leaf never sees `alsoUpdateOrigin: true`.
+   * Sprint identifier — embedded in the comment signature so a reader can trace a posted
+   * comment back to the sprint that produced it.
    */
-  readonly defaultIssueOrigin?: IssueOriginRef;
+  readonly sprintId: string;
+  /**
+   * Non-interactive default for posting the refined requirements as a comment. Consulted only
+   * when `reviewBeforeApprove` is absent (CI / headless): when `true` and the ticket has a
+   * link, the comment is posted without prompting; otherwise nothing is pushed. When the
+   * reviewer hook IS wired, the reviewer's explicit choice governs instead.
+   */
+  readonly postRefinementComment?: boolean;
 }
 
-/** Footer appended to every pushed body so future readers know where it came from. */
-const REFINED_FOOTER = (now: string): string => `\n\n---\n_Refined by ralphctl on ${now}_`;
+/**
+ * Signature appended to every posted comment so a reader can recognise it as ralphctl-authored
+ * and trace it back to the sprint that produced it. Format stays consistent across every
+ * comment: a divider, the ralphctl link, the sprint id, and the post timestamp.
+ */
+const REFINEMENT_COMMENT_SIGNATURE = (sprintId: string, timestamp: string): string =>
+  `\n\n---\n_🤖 Posted by [ralphctl](https://github.com/lukas-grigis/ralphctl) · Sprint ${sprintId} · ${timestamp}_`;
 
 /**
  * Refine-specific signals-missing message. The shared `validateSignalsFile` hint is generic
@@ -169,52 +179,35 @@ interface RefineTicketInteractiveOutput {
 }
 
 /**
- * Best-effort push to the issue tracker. On success, returns a (possibly updated) ticket —
- * after a CREATE we attach the new URL to ticket.link. On failure, logs a warning and returns
- * the input ticket unchanged. Never throws; never aborts the chain.
+ * Best-effort comment on the linked issue. Posts the refined requirements (plus a ralphctl
+ * signature) as a NEW comment — the issue description is never modified. The ticket is returned
+ * unchanged either way. On failure, logs a warning. Never throws; never aborts the chain.
+ *
+ * Only the ticket's existing `link` is targeted: a ticket with no link has nothing to comment
+ * on, so the leaf skips silently (the launcher already hides the option in that case).
  */
-const maybePushOrigin = async (
+const maybeCommentOnOrigin = async (
   deps: RefineTicketInteractiveDeps,
   ticket: ApprovedTicket,
   body: string
-): Promise<ApprovedTicket> => {
+): Promise<void> => {
   if (deps.issuePusher === undefined) {
-    deps.logger.named('refine.push').warn('no IssuePusher wired — skipping origin update');
-    return ticket;
+    deps.logger.named('refine.push').warn('no IssuePusher wired — skipping issue comment');
+    return;
   }
-  const now = new Date().toISOString().slice(0, 10);
-  const fullBody = `${body}${REFINED_FOOTER(now)}`;
-
-  if (ticket.link !== undefined) {
-    const url = String(ticket.link);
-    const result = await deps.issuePusher.update(url, { body: fullBody });
-    if (!result.ok) {
-      deps.logger.named('refine.push').warn(`origin update failed (${url}): ${result.error.message}`);
-    } else {
-      deps.logger.named('refine.push').info(`updated origin issue ${url}`);
-    }
-    return ticket;
+  if (ticket.link === undefined) {
+    deps.logger.named('refine.push').warn('comment requested but ticket has no link — skipping');
+    return;
   }
-
-  if (deps.defaultIssueOrigin !== undefined) {
-    const created = await deps.issuePusher.create(deps.defaultIssueOrigin, { title: ticket.title, body: fullBody });
-    if (!created.ok) {
-      deps.logger.named('refine.push').warn(`origin create failed: ${created.error.message}`);
-      return ticket;
-    }
-    const withLink = setTicketLink(ticket, created.value.url);
-    if (!withLink.ok) {
-      deps.logger.named('refine.push').warn(`origin create succeeded but link was invalid: ${withLink.error.message}`);
-      return ticket;
-    }
-    deps.logger.named('refine.push').info(`created origin issue ${created.value.url}`);
-    return withLink.value;
+  const now = new Date().toISOString();
+  const fullBody = `${body}${REFINEMENT_COMMENT_SIGNATURE(deps.sprintId, now)}`;
+  const url = String(ticket.link);
+  const result = await deps.issuePusher.comment(url, { body: fullBody });
+  if (!result.ok) {
+    deps.logger.named('refine.push').warn(`issue comment failed (${url}): ${result.error.message}`);
+  } else {
+    deps.logger.named('refine.push').info(`posted comment on issue ${url}`);
   }
-
-  // alsoUpdateOrigin was set but no target exists. Shouldn't happen — the launcher hides the
-  // option in this case — but degrade gracefully if it slips through.
-  deps.logger.named('refine.push').warn('alsoUpdateOrigin requested but no link / defaultIssueOrigin available');
-  return ticket;
 };
 
 export const refineTicketInteractiveLeaf = (
@@ -291,16 +284,16 @@ export const refineTicketInteractiveLeaf = (
         });
         if (!useCaseResult.ok) return Result.error(useCaseResult.error);
         const out = useCaseResult.value;
-        if (!out.accepted || !out.alsoUpdateOrigin) return Result.ok(out);
-        // Approve + push path. The approve already swapped the ticket on the sprint; if the
-        // push CREATEs an issue, we need to also write the returned URL back onto the ticket
-        // AND replace it on the sprint again (so subsequent loads see the link).
-        const approvedTicket = out.ticket as ApprovedTicket;
-        const finalTicket = await maybePushOrigin(deps, approvedTicket, refinedSignal.body);
-        if (finalTicket === approvedTicket) return Result.ok(out);
-        const replaced = replaceTicket(out.sprint, finalTicket.id, finalTicket);
-        if (!replaced.ok) return Result.error(replaced.error);
-        return Result.ok({ ...out, sprint: replaced.value, ticket: finalTicket });
+        if (!out.accepted) return Result.ok(out);
+        // Decide whether to post a comment on the linked issue. With a reviewer hook wired the
+        // reviewer's explicit choice (`alsoUpdateOrigin`) governs; in non-interactive runs the
+        // `postRefinementComment` setting governs. Commenting never mutates the ticket, so the
+        // sprint is returned exactly as the use case produced it.
+        const shouldComment =
+          deps.reviewBeforeApprove !== undefined ? out.alsoUpdateOrigin : deps.postRefinementComment === true;
+        if (!shouldComment) return Result.ok(out);
+        await maybeCommentOnOrigin(deps, out.ticket as ApprovedTicket, refinedSignal.body);
+        return Result.ok(out);
       },
     },
     input: (ctx) => {

--- a/src/application/flows/review/leaves/review-round.ts
+++ b/src/application/flows/review/leaves/review-round.ts
@@ -213,7 +213,7 @@ const ensureRoundDir = async (dir: AbsolutePath): Promise<Result<void, StorageEr
 export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeafOpts): Element<ReviewCtx> =>
   leaf<ReviewCtx, ReviewRoundInput, RunReviewRoundOutput>('review-round', {
     useCase: {
-      execute: async (input) => {
+      execute: async (input, signal) => {
         // Per-round dir at `<reviewRoot>/round-<N>/`. N is the round we're about to act on —
         // `previousRound.index` is the round just settled (or undefined on round 1), so
         // `(prev?.index ?? 0) + 1` is the active round. `mkdir -p` it now so the AI's spawn
@@ -285,6 +285,9 @@ export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeaf
               permissions: FULL_AUTO,
               signalsFile: paths.value.signalsFile,
               outputDir: paths.value.outputDir,
+              // Thread the chain's abort signal so a TUI cancel mid-spawn kills the child via
+              // the provider's SIGTERM ladder instead of letting it run to completion.
+              ...(signal !== undefined ? { abortSignal: signal } : {}),
             });
             if (!spawn.ok) return Result.error(spawn.error);
             const validated = await validateSignalsFile(paths.value.outputDir, reviewRoundOutputContract);

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -336,16 +336,17 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     }
   });
   const taskNames = new Map<string, string>(todoTasks.map((t) => [String(t.id), t.name]));
-  // Detect resumes at launch time: any in-progress task whose last attempt is still `running`
-  // (the v8 OOM / Ctrl-C / SIGTERM signature in a prior process) gets a `RecoveryContext`
-  // pinned to its id. We pre-derive here — rather than waiting for the chain's start-attempt
-  // leaf to settle — so the TUI's resume-from-aborted banner shows up *before* the chain
-  // starts executing, not after the first leaf finishes. `process-crash` is the conservative
-  // cause for the cross-process inference; P1j's signal-aware path will refine it.
+  // Detect resumes at launch time: any task whose last attempt is still `running` (the v8 OOM /
+  // Ctrl-C / SIGTERM signature in a prior process) gets a `RecoveryContext` pinned to its id. We
+  // pre-derive here — rather than waiting for the chain's start-attempt leaf to settle — so the
+  // TUI's resume-from-aborted banner shows up *before* the chain starts executing, not after the
+  // first leaf finishes. Keyed on the leftover running attempt, NOT on `status === 'in_progress'`:
+  // a crash can persist a status-corrupt `todo` task whose last attempt is still `running` (which
+  // `startAttemptUseCase` heals), and the banner must fire for it too. `process-crash` is the
+  // conservative cause for the cross-process inference; P1j's signal-aware path will refine it.
   const taskRecovering = new Map<string, RecoveryContext>();
   const nowAtLaunch = deps.app.clock();
   for (const t of todoTasks) {
-    if (t.status !== 'in_progress') continue;
     const last = t.attempts.at(-1);
     if (last === undefined || last.status !== 'running') continue;
     taskRecovering.set(String(t.id), {

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -20,7 +20,8 @@ import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { Result } from '@src/domain/result.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { renderTaskGraphIssue, scheduleIntoWaves } from '@src/domain/entity/task-graph.ts';
+import { renderTaskGraphIssue, validateTaskGraph } from '@src/domain/entity/task-graph.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
@@ -75,15 +76,25 @@ const applyImplementRoleOverrides = (
 /**
  * Resolve the ordered launch queue from a sprint's FULL task set (audit §5 human-gate).
  *
- * `scheduleIntoWaves` validates the graph first, so a cyclic / self-edge / dangling-dependency
- * sprint fails fast here with the rendered issue — a deadlock can't hide behind an innocuous
- * "No tasks to implement" message that only appears after unschedulable tasks are filtered out.
+ * `validateTaskGraph` runs first, so a cyclic / self-edge / dangling-dependency sprint fails fast
+ * here with the rendered issue — a deadlock can't hide behind an innocuous "No tasks to implement"
+ * message that only appears after unschedulable tasks are filtered out.
  *
- * On a sound DAG the waves are flattened (each wave already sorted by `Task.order`) and filtered
- * to the resumable subset (`todo` + `in_progress`), so a task never leads a dependency it relies
- * on. The in-progress-first override is then applied ON TOP via a stable sort (V8 stable) — a
- * resumed task still leads so a relaunch picks up where the prior run died before any fresh work,
- * while dependency order is preserved within each status group.
+ * On a sound DAG the queue is built by a dependency-respecting PRIORITY topological sort over the
+ * RESUMABLE subset (`todo` + `in_progress`): a task is emitted only after every resumable
+ * prerequisite it depends on has been emitted, and among the tasks that are legally runnable at
+ * each step the resumed (`in_progress`) ones lead, then `Task.order` ASC breaks the tie. A done /
+ * blocked prerequisite is NOT in the resumable subgraph, so it never blocks ordering — a resumed
+ * task whose prerequisites are all `done` still leads the queue.
+ *
+ * Why a priority topo-sort and not the old flat in-progress-first sort: the flat sort could hoist a
+ * resumed `in_progress` task AHEAD of a still-`todo` prerequisite it depends on (e.g. after a crash
+ * + manual unblock leaves `{prereq: todo, dependent: in_progress}`). In the serial path the per-task
+ * subchains run in queue order, so the dependent's `dependency-gate` would then fire BEFORE its
+ * prerequisite ran, blocking the dependent `blocked upstream` and dead-ending it for the launch.
+ * Making dependency order a hard constraint (a prerequisite always precedes its dependent) means the
+ * gate never sees a not-yet-run prerequisite — the prereq runs first, settles, and the dependent
+ * resumes behind it.
  *
  * Returns the rendered `TaskGraphIssue` string on an invalid graph, otherwise the ordered queue
  * (possibly empty when nothing is resumable — the caller reports that separately).
@@ -91,14 +102,50 @@ const applyImplementRoleOverrides = (
  * @public
  */
 export const resolveImplementQueue = (tasks: readonly Task[]): Result<readonly Task[], string> => {
-  const schedule = scheduleIntoWaves(tasks);
-  if (!schedule.ok) return Result.error(renderTaskGraphIssue(schedule.error));
-  const resumableIds = new Set(tasks.filter((t) => t.status === 'todo' || t.status === 'in_progress').map((t) => t.id));
-  const scheduled = schedule.value.flat().filter((t) => resumableIds.has(t.id));
-  const queue = [...scheduled].sort((a, b) => {
-    if (a.status === b.status) return 0;
-    return a.status === 'in_progress' ? -1 : 1;
-  });
+  // Validate the full graph first (cycle / self-edge / dangling) so a deadlock surfaces as the
+  // rendered issue rather than a silently-truncated queue.
+  const validation = validateTaskGraph(tasks);
+  if (!validation.ok) return Result.error(renderTaskGraphIssue(validation.error));
+
+  const resumable = tasks.filter((t) => t.status === 'todo' || t.status === 'in_progress');
+  const resumableIds = new Set(resumable.map((t) => t.id));
+
+  // In-degree + successors over the RESUMABLE subgraph only — a dependency that resolves to a
+  // done / blocked (non-resumable) task is already satisfied (or terminal) and must not gate the
+  // dependent here; the dependency-gate leaf handles the blocked-prerequisite case at run time.
+  const byId = new Map<TaskId, Task>(resumable.map((t) => [t.id, t]));
+  const inDegree = new Map<TaskId, number>(resumable.map((t) => [t.id, 0]));
+  const successors = new Map<TaskId, TaskId[]>(resumable.map((t) => [t.id, []]));
+  for (const t of resumable) {
+    for (const dep of t.dependsOn) {
+      if (!resumableIds.has(dep)) continue;
+      inDegree.set(t.id, (inDegree.get(t.id) ?? 0) + 1);
+      successors.get(dep)?.push(t.id);
+    }
+  }
+
+  // Resumed tasks lead, then lowest `Task.order` — applied only among the currently-runnable
+  // frontier, so it can never violate dependency order.
+  const priority = (a: Task, b: Task): number => {
+    if (a.status !== b.status) return a.status === 'in_progress' ? -1 : 1;
+    return a.order - b.order;
+  };
+
+  const queue: Task[] = [];
+  // `Task[]`, not the inferred `(TodoTask | InProgressTask)[]` from `resumable` — successors pushed
+  // below come from `byId` (typed `Task`), and the priority comparator only reads `status`/`order`.
+  const frontier: Task[] = resumable.filter((t) => (inDegree.get(t.id) ?? 0) === 0);
+  while (frontier.length > 0) {
+    frontier.sort(priority);
+    const next = frontier.shift() as Task;
+    queue.push(next);
+    for (const succId of successors.get(next.id) ?? []) {
+      const remaining = (inDegree.get(succId) ?? 0) - 1;
+      inDegree.set(succId, remaining);
+      const succ = byId.get(succId);
+      if (remaining === 0 && succ !== undefined) frontier.push(succ);
+    }
+  }
   return Result.ok(queue);
 };
 

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -241,6 +241,7 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
       path: r.path,
       name: r.name,
       ...(r.verifyScript !== undefined ? { verifyScript: r.verifyScript } : {}),
+      ...(r.verifyTimeout !== undefined ? { verifyTimeout: r.verifyTimeout } : {}),
       ...(r.setupScript !== undefined ? { setupScript: r.setupScript } : {}),
     });
   }

--- a/src/application/ui/shared/launch/refine.ts
+++ b/src/application/ui/shared/launch/refine.ts
@@ -4,32 +4,9 @@ import { createRunner, type Runner } from '@src/application/chain/run/runner.ts'
 import { createRefineFlow } from '@src/application/flows/refine/flow.ts';
 import type { RefineCtx } from '@src/application/flows/refine/ctx.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { parseGitRemoteUrl } from '@src/integration/scm/issue-fetcher.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
-import type { GitRunner } from '@src/integration/io/git-runner.ts';
 import type { LaunchContext } from '@src/application/ui/shared/launch/context.ts';
 import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
-
-/**
- * Best-effort `git remote get-url origin` → {@link IssueOriginRef}. Returns `undefined` on every
- * failure mode (no path, no repo, no `origin`, malformed URL, parser miss). The refine flow's
- * "create origin" option simply hides itself when this returns undefined — silent failure here
- * is the right shape; the user sees the 2-option prompt instead of the 3-option one.
- */
-const deriveOriginFromGit = async (
-  cwd: AbsolutePath | undefined,
-  gitRunner: GitRunner
-): Promise<IssueOriginRef | undefined> => {
-  if (cwd === undefined) return undefined;
-  const result = await gitRunner.run(cwd, ['remote', 'get-url', 'origin']);
-  if (!result.ok) return undefined;
-  if (result.value.exitCode !== 0) return undefined;
-  const url = result.value.stdout.trim();
-  if (url.length === 0) return undefined;
-  const parsed = parseGitRemoteUrl(url);
-  return parsed === null ? undefined : parsed;
-};
 
 export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> => {
   const { deps, snapshot, settings, interactiveAi, skillsAdapter, skillSource, bridge, sessionId, effort } = ctx;
@@ -38,24 +15,16 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
   if (!snapshot.sprint) return { ok: false, reason: 'No sprint selected.' };
   // Refine intentionally does not require a repo path — the AI session is rooted at the
   // per-ticket unit folder (`<sprintDir>/refinement/<ticket-slug>/`), not the repo, because
-  // refinement is implementation-agnostic. The repo path is still consulted below to derive
-  // `defaultIssueOrigin` for the "update remote" reviewer option, but that resolution is
-  // best-effort and tolerates a missing path.
+  // refinement is implementation-agnostic.
   const pending = snapshot.sprint.tickets.filter((t) => t.status === 'pending');
   const refinementRoot = AbsolutePath.parse(
     join(String(deps.storage.dataRoot), 'sprints', String(snapshot.sprint.id), 'refinement')
   );
   if (!refinementRoot.ok) return { ok: false, reason: refinementRoot.error.message };
-  // Origin resolution order:
-  //   1. Explicit `project.defaultIssueOrigin` (operator override).
-  //   2. Auto-derived from the first repo's `git remote get-url origin`.
-  //   3. Undefined → the refine flow's "create origin" option is hidden.
-  // The auto-derivation is best-effort: a missing remote / non-recognised URL / failed git
-  // command all collapse to "no derived origin" without surfacing an error to the user.
-  let defaultIssueOrigin = snapshot.project?.defaultIssueOrigin;
-  if (defaultIssueOrigin === undefined && snapshot.project !== undefined) {
-    defaultIssueOrigin = await deriveOriginFromGit(snapshot.project.repositories[0]?.path, deps.app.gitRunner);
-  }
+  // The refine flow only ever posts the refined requirements as a comment on the ticket's
+  // existing linked issue — it never opens a new issue and never overwrites a description. The
+  // out-of-box default for the comment action is opt-in via `settings.scm.postRefinementComment`.
+  const postRefinementComment = settings.scm.postRefinementComment;
   // HITL approval — runs AFTER the AI proposes refined requirements and BEFORE the ticket
   // transitions. `runInTerminal` resolves before we get here, so Ink has remounted and
   // `<PromptHost>` is subscribed by the time we enqueue the choice. Cancel = reject.
@@ -65,34 +34,39 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
   //   - Edit            → askTextArea on the current body, then re-show this prompt with the
   //                       edit applied. Cancelling the textarea keeps the previous body and
   //                       returns to the prompt — never loses the reviewer's place.
-  //   - Update remote   → terminal; persist locally AND tell the leaf to push to the source
-  //                       issue (label adapts: "Update remote (owner/repo)" when creating a new
-  //                       issue, "Update remote" when replacing an existing one). The option is
-  //                       hidden entirely when no origin is resolvable.
+  //   - Post as comment → terminal; persist locally AND tell the leaf to post the body as a
+  //                       comment on the linked issue. Shown only when the ticket has a `link`;
+  //                       a ticket with no linked issue has nothing to comment on.
   //   - Reject          → terminal; ticket stays pending.
+  //
+  // The default selection follows `settings.scm.postRefinementComment`: when enabled and the
+  // ticket has a link, "Post as comment" is listed first (the renderer highlights the first
+  // entry); otherwise "Approve" leads, so commenting is an explicit opt-in.
   //
   // `body` is returned on accept so the use case persists the (possibly edited) text rather
   // than re-using the AI's original proposal.
-  type Decision = 'approve' | 'edit' | 'update_remote' | 'reject';
+  type Decision = 'approve' | 'edit' | 'post_comment' | 'reject';
   const reviewBeforeApprove = async (
     proposed: string,
     ticket: { readonly title: string; readonly link?: unknown }
   ): Promise<{ readonly accept: boolean; readonly alsoUpdateOrigin?: boolean; readonly body?: string }> => {
     const hasLink = ticket.link !== undefined;
-    const remoteLabel = hasLink
-      ? 'Update remote'
-      : defaultIssueOrigin !== undefined
-        ? `Update remote (${defaultIssueOrigin.owner}/${defaultIssueOrigin.repo})`
-        : undefined;
-    const remoteDescription = hasLink
-      ? 'Save locally AND replace the body of the source issue.'
-      : 'Save locally AND open a new issue with this body on the configured repo.';
+    const approveOption = {
+      label: 'Approve',
+      value: 'approve' as Decision,
+      description: 'Save the refined requirements locally.',
+    };
+    const commentOption = {
+      label: 'Post as comment',
+      value: 'post_comment' as Decision,
+      description: 'Save locally AND post the body as a comment on the linked issue.',
+    };
+    // Lead with whichever option is the configured default so the renderer highlights it first.
+    const leadOptions = hasLink && postRefinementComment ? [commentOption, approveOption] : [approveOption];
     const options: Array<{ label: string; value: Decision; description?: string }> = [
-      { label: 'Approve', value: 'approve', description: 'Save the refined requirements locally.' },
+      ...leadOptions,
       { label: 'Edit', value: 'edit', description: 'Open the body in an editor; come back here to decide.' },
-      ...(remoteLabel
-        ? [{ label: remoteLabel, value: 'update_remote' as Decision, description: remoteDescription }]
-        : []),
+      ...(hasLink && !postRefinementComment ? [commentOption] : []),
       { label: 'Reject', value: 'reject', description: 'Leave the ticket pending — no changes.' },
     ];
 
@@ -104,7 +78,7 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
       switch (answered.value) {
         case 'approve':
           return { accept: true, alsoUpdateOrigin: false, body };
-        case 'update_remote':
+        case 'post_comment':
           return { accept: true, alsoUpdateOrigin: true, body };
         case 'reject':
           return { accept: false };
@@ -133,9 +107,9 @@ export const launchRefine = async (ctx: LaunchContext): Promise<LaunchResult> =>
       skillsAdapter,
       skillSource,
       reviewBeforeApprove,
+      postRefinementComment,
       ...(deps.app.issueFetcher !== undefined ? { issueFetcher: deps.app.issueFetcher } : {}),
       ...(deps.app.issuePusher !== undefined ? { issuePusher: deps.app.issuePusher } : {}),
-      ...(defaultIssueOrigin !== undefined ? { defaultIssueOrigin } : {}),
     },
     {
       sprintId: snapshot.sprint.id,

--- a/src/application/ui/shared/launch/sprint-bound.ts
+++ b/src/application/ui/shared/launch/sprint-bound.ts
@@ -51,6 +51,13 @@ export interface SprintBoundLaunchExtras extends LaunchExtras {
    * should pass it.
    */
   readonly fallbackLabel?: string;
+  /**
+   * Called when the sprint's id/name become known (same moment as `onReseat`, but receives the
+   * runner id so the caller can retroactively pin the sprint onto the session descriptor without
+   * needing a closure over the `LaunchResult` value that isn't defined at callback-creation time).
+   * Intended for callers that pass `sessions.setPinnedSprint(runnerId, id, name)` here.
+   */
+  readonly onSprintResolved?: (runnerId: string, info: { readonly id: SprintId; readonly name: string }) => void;
 }
 
 export const launchSprintBoundFlow = async (
@@ -59,13 +66,13 @@ export const launchSprintBoundFlow = async (
   snapshot: AppStateSnapshot,
   extras: SprintBoundLaunchExtras = {}
 ): Promise<LaunchResult> => {
-  const { onReseat, fallbackLabel, ...launchExtras } = extras;
+  const { onReseat, fallbackLabel, onSprintResolved, ...launchExtras } = extras;
   const result = await launchFlow(deps, flowId, snapshot, launchExtras);
   if (!result.ok) return result;
   // Late-subscribe replay makes this race-free with `result.runner.start()` — the caller is
   // free to call `start()` immediately after we return.
-  if (onReseat !== undefined) {
-    attachReseatSubscriber(result.runner, fallbackLabel, onReseat);
+  if (onReseat !== undefined || onSprintResolved !== undefined) {
+    attachReseatSubscriber(result.runner, fallbackLabel, onReseat, onSprintResolved);
   }
   return result;
 };
@@ -73,11 +80,12 @@ export const launchSprintBoundFlow = async (
 const attachReseatSubscriber = (
   runner: Runner<unknown>,
   fallbackLabel: string | undefined,
-  onReseat: (info: { readonly id: SprintId; readonly name: string }) => void
+  onReseat: ((info: { readonly id: SprintId; readonly name: string }) => void) | undefined,
+  onSprintResolved: ((runnerId: string, info: { readonly id: SprintId; readonly name: string }) => void) | undefined
 ): void => {
-  // Self-unsubscribe on terminal events so the listener (and the captured `onReseat`
-  // closure) doesn't pin the runner across a long TUI session — historically a load-bearing
-  // OOM contributor for sprint-bound flows that get re-launched repeatedly.
+  // Self-unsubscribe on terminal events so the listener (and the captured closures) don't pin
+  // the runner across a long TUI session — historically a load-bearing OOM contributor for
+  // sprint-bound flows that get re-launched repeatedly.
   const unsub: () => void = runner.subscribe((event) => {
     if (event.type === 'failed' || event.type === 'aborted') {
       unsub();
@@ -85,10 +93,15 @@ const attachReseatSubscriber = (
     }
     if (event.type !== 'completed') return;
     const ctx = event.ctx as SprintBoundCtx;
-    if (ctx.sprint !== undefined) {
-      onReseat({ id: ctx.sprint.id, name: ctx.sprint.name });
-    } else if (ctx.sprintId !== undefined) {
-      onReseat({ id: ctx.sprintId, name: fallbackLabel ?? String(ctx.sprintId) });
+    const info =
+      ctx.sprint !== undefined
+        ? { id: ctx.sprint.id, name: ctx.sprint.name }
+        : ctx.sprintId !== undefined
+          ? { id: ctx.sprintId, name: fallbackLabel ?? String(ctx.sprintId) }
+          : undefined;
+    if (info !== undefined) {
+      onReseat?.(info);
+      onSprintResolved?.(runner.id, info);
     }
     unsub();
   });

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -14,6 +14,8 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { bridgeRunnerToEventBus } from '@src/application/observability/chain-runner-bridge.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
 import { createInteractiveAiProvider } from '@src/application/bootstrap/interactive-provider-factory.ts';
@@ -89,6 +91,16 @@ export type LaunchResult =
        */
       readonly generatorModel?: string;
       readonly evaluatorModel?: string;
+      /**
+       * Project and sprint the run was launched against, pinned at launch time for the run's
+       * lifetime. Populated from the launch snapshot so every flow launched against a sprint
+       * pins it; flows started without a sprint (e.g. create-sprint) leave the sprint fields
+       * unset.
+       */
+      readonly pinnedProjectId?: ProjectId;
+      readonly pinnedProjectLabel?: string;
+      readonly pinnedSprintId?: SprintId;
+      readonly pinnedSprintLabel?: string;
     }
   | { readonly ok: false; readonly reason: string };
 
@@ -174,6 +186,10 @@ export const sessionHintsFromLaunchResult = (
   readonly taskRecovering?: ReadonlyMap<string, RecoveryContext>;
   readonly generatorModel?: string;
   readonly evaluatorModel?: string;
+  readonly pinnedProjectId?: ProjectId;
+  readonly pinnedProjectLabel?: string;
+  readonly pinnedSprintId?: SprintId;
+  readonly pinnedSprintLabel?: string;
 } => ({
   ...(result.taskNames !== undefined ? { taskNames: result.taskNames } : {}),
   ...(result.maxTurns !== undefined ? { maxTurns: result.maxTurns } : {}),
@@ -183,6 +199,10 @@ export const sessionHintsFromLaunchResult = (
   ...(result.taskRecovering !== undefined ? { taskRecovering: result.taskRecovering } : {}),
   ...(result.generatorModel !== undefined ? { generatorModel: result.generatorModel } : {}),
   ...(result.evaluatorModel !== undefined ? { evaluatorModel: result.evaluatorModel } : {}),
+  ...(result.pinnedProjectId !== undefined ? { pinnedProjectId: result.pinnedProjectId } : {}),
+  ...(result.pinnedProjectLabel !== undefined ? { pinnedProjectLabel: result.pinnedProjectLabel } : {}),
+  ...(result.pinnedSprintId !== undefined ? { pinnedSprintId: result.pinnedSprintId } : {}),
+  ...(result.pinnedSprintLabel !== undefined ? { pinnedSprintLabel: result.pinnedSprintLabel } : {}),
 });
 
 /**
@@ -355,30 +375,44 @@ export const launchFlow = async (
     ...(effort !== undefined ? { effort } : {}),
   };
 
-  switch (flowId) {
-    case 'create-sprint':
-      return launchCreateSprint(ctx);
-    case 'add-tickets':
-      return launchAddTickets(ctx);
-    case 'refine':
-      return launchRefine(ctx);
-    case 'plan':
-      return launchPlan(ctx);
-    case 'implement':
-      return launchImplement(ctx);
-    case 'review':
-      return launchReview(ctx);
-    case 'close-sprint':
-      return launchCloseSprint(ctx);
-    case 'readiness':
-      return launchReadiness(ctx);
-    case 'detect-skills':
-      return launchDetectSkills(ctx);
-    case 'detect-scripts':
-      return launchDetectScripts(ctx);
-    case 'ideate':
-      return launchIdeate(ctx);
-    default:
-      return { ok: false, reason: `Unknown flow: ${flowId}` };
-  }
+  const dispatchResult = await (async (): Promise<LaunchResult> => {
+    switch (flowId) {
+      case 'create-sprint':
+        return launchCreateSprint(ctx);
+      case 'add-tickets':
+        return launchAddTickets(ctx);
+      case 'refine':
+        return launchRefine(ctx);
+      case 'plan':
+        return launchPlan(ctx);
+      case 'implement':
+        return launchImplement(ctx);
+      case 'review':
+        return launchReview(ctx);
+      case 'close-sprint':
+        return launchCloseSprint(ctx);
+      case 'readiness':
+        return launchReadiness(ctx);
+      case 'detect-skills':
+        return launchDetectSkills(ctx);
+      case 'detect-scripts':
+        return launchDetectScripts(ctx);
+      case 'ideate':
+        return launchIdeate(ctx);
+      default:
+        return { ok: false, reason: `Unknown flow: ${flowId}` };
+    }
+  })();
+
+  if (!dispatchResult.ok) return dispatchResult;
+
+  return {
+    ...dispatchResult,
+    ...(snapshot.project !== undefined
+      ? { pinnedProjectId: snapshot.project.id, pinnedProjectLabel: snapshot.project.displayName }
+      : {}),
+    ...(snapshot.sprint !== undefined
+      ? { pinnedSprintId: snapshot.sprint.id, pinnedSprintLabel: snapshot.sprint.name }
+      : {}),
+  };
 };

--- a/src/application/ui/tui/components/breadcrumb.tsx
+++ b/src/application/ui/tui/components/breadcrumb.tsx
@@ -13,6 +13,7 @@ import { Box, Text } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 
 const breadcrumbLabel = (id: string): string => {
   switch (id) {
@@ -60,6 +61,11 @@ const breadcrumbLabel = (id: string): string => {
 export const Breadcrumb = (): React.JSX.Element => {
   const router = useRouter();
   const selection = useSelection();
+  const ui = useUiState();
+  // When an Execute view is focused, prefer its pinned project/sprint so the right-side
+  // context reflects the run's own sprint rather than the mutable global selection.
+  const effectiveProjectLabel = ui.focusedRunProjectLabel ?? selection.projectLabel;
+  const effectiveSprintLabel = ui.focusedRunSprintLabel ?? selection.sprintLabel;
   // Substitute the concrete project / sprint name for the generic stack-id label so the
   // breadcrumb reads "Home → Projects → experience hub" instead of "… → Project". Selection
   // is set immediately before `router.push` in the list views, so it matches the entry that
@@ -76,8 +82,8 @@ export const Breadcrumb = (): React.JSX.Element => {
       : labelFor(router.stack[0] ?? { id: 'home' });
 
   const right: string[] = [];
-  if (selection.projectLabel !== undefined) right.push(selection.projectLabel);
-  if (selection.sprintLabel !== undefined) right.push(selection.sprintLabel);
+  if (effectiveProjectLabel !== undefined) right.push(effectiveProjectLabel);
+  if (effectiveSprintLabel !== undefined) right.push(effectiveSprintLabel);
 
   return (
     <Box

--- a/src/application/ui/tui/components/progress-overlay.tsx
+++ b/src/application/ui/tui/components/progress-overlay.tsx
@@ -23,6 +23,7 @@ import { Box, Text, useInput } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 import { fmtDuration } from '@src/application/ui/tui/theme/duration.ts';
 
@@ -57,6 +58,7 @@ const formatAgo = (modifiedAtMs: number, now: number): string => {
 
 export const ProgressOverlay = (): React.JSX.Element => {
   const selection = useSelection();
+  const ui = useUiState();
   const storage = useStorage();
   const term = useTerminalSize();
   const [state, setState] = useState<ProgressState>({ kind: 'loading' });
@@ -65,7 +67,9 @@ export const ProgressOverlay = (): React.JSX.Element => {
   // re-mounts the overlay and refreshes the file + the timestamp.
   const [now] = useState<number>(() => Date.now());
 
-  const sprintId = selection.sprintId;
+  // When an Execute view is focused, prefer its pinned sprint so `g` opens the run's own
+  // progress file rather than whatever the global selection happens to be.
+  const sprintId = ui.focusedRunSprintId ?? selection.sprintId;
   const progressPath = useMemo(() => {
     if (sprintId === undefined) return undefined;
     return join(String(storage.dataRoot), 'sprints', String(sprintId), 'progress.md');
@@ -150,7 +154,8 @@ export const ProgressOverlay = (): React.JSX.Element => {
 
   const visibleLines = state.kind === 'ok' ? state.lines.slice(offset, offset + bodyRows) : [];
 
-  const sprintLabel = selection.sprintLabel ?? (sprintId !== undefined ? String(sprintId) : '(no sprint)');
+  const sprintLabel =
+    ui.focusedRunSprintLabel ?? selection.sprintLabel ?? (sprintId !== undefined ? String(sprintId) : '(no sprint)');
   const modifiedAgo = state.kind === 'ok' || state.kind === 'empty' ? formatAgo(state.modifiedAtMs, now) : undefined;
 
   return (

--- a/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
+++ b/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
@@ -115,6 +115,11 @@ export const TaskBlock = ({
   const evalRows = task.evaluations.slice(-maxEvaluations);
   const evalElided = task.evaluations.length - evalRows.length;
   const criteriaBullets = taskCriteria;
+  // Guard an empty / whitespace-only blockedReason (both `BlockedTask.blockedReason` and the
+  // task-blocked signal permit ''): without this an AI that self-blocks with a blank reason
+  // renders a lone warning glyph. trim() first — `collapseWhitespace('')` is '' but a
+  // whitespace-only string collapses to a single space, which `!== undefined` alone wouldn't catch.
+  const blockedReasonText = blockedReason?.trim() ?? '';
   // Most recent commit SHA for the collapsed summary line — sourced from the projection's
   // lastAttempt when a TaskProjection is supplied. Truncated to 7 chars (git's `--short`
   // default).
@@ -190,12 +195,12 @@ export const TaskBlock = ({
             return <Text dimColor> {eta}</Text>;
           })()}
       </Box>
-      {blockedReason !== undefined && (
+      {blockedReasonText.length > 0 && (
         // Shown collapsed OR expanded — a blocked card's reason is its most important line.
         <Box paddingLeft={2}>
           <Box flexGrow={1} flexShrink={1}>
             <Text color={inkColors.warning} wrap="truncate-end">
-              {glyphs.warningGlyph} {collapseWhitespace(blockedReason)}
+              {glyphs.warningGlyph} {collapseWhitespace(blockedReasonText)}
             </Text>
           </Box>
         </Box>

--- a/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
+++ b/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
@@ -58,6 +58,7 @@ export const TaskBlock = ({
   cardExpanded,
   cardFocused,
   nowMs,
+  blockedReason,
 }: {
   readonly task: TaskBucket;
   readonly running: boolean;
@@ -97,6 +98,13 @@ export const TaskBlock = ({
   readonly cardFocused: boolean;
   /** Wall-clock reference for the idle ticker (current time, ms epoch). */
   readonly nowMs: number;
+  /**
+   * Why this task is blocked — the entity's `Task.blockedReason`, supplied by the host from the
+   * polled task state (the live `TaskBucket` status is trace-derived and carries no reason). When
+   * present, a one-line reason renders under the header so the operator sees WHY a card blocked
+   * (own failure vs `blocked upstream — …`) instead of a bare status. Absent for non-blocked tasks.
+   */
+  readonly blockedReason?: string;
 }): React.JSX.Element => {
   const presentation = STATUS_PRESENTATION[task.status];
   const isSpinning = task.status === 'running';
@@ -182,6 +190,16 @@ export const TaskBlock = ({
             return <Text dimColor> {eta}</Text>;
           })()}
       </Box>
+      {blockedReason !== undefined && (
+        // Shown collapsed OR expanded — a blocked card's reason is its most important line.
+        <Box paddingLeft={2}>
+          <Box flexGrow={1} flexShrink={1}>
+            <Text color={inkColors.warning} wrap="truncate-end">
+              {glyphs.warningGlyph} {collapseWhitespace(blockedReason)}
+            </Text>
+          </Box>
+        </Box>
+      )}
       {cardExpanded && idleSnippets.length > 0 && (
         <Box paddingLeft={2}>
           <Box flexGrow={1} flexShrink={1}>

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -26,6 +26,7 @@ import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-t
 import type { SprintState, TaskProjection } from '@src/application/ui/tui/components/tasks-projection.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
 import { glyphs, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { computeAnchoredWindow } from '@src/application/ui/tui/components/windowed-anchor.ts';
 import { collectKinds, InlineKindsBar } from '@src/application/ui/tui/components/tasks-panel-internals/signal-rows.tsx';
 import { OrphanSignals, TaskBlock } from '@src/application/ui/tui/components/tasks-panel-internals/task-row.tsx';
 import { buildFlatFocusKeys } from '@src/application/ui/tui/components/tasks-panel-internals/focus-keys.ts';
@@ -40,6 +41,15 @@ export interface TasksPanelProps {
   readonly nameById?: ReadonlyMap<string, string>;
   /** Max signals per task to render; older ones drop off the top. */
   readonly maxSignalsPerTask?: number;
+  /**
+   * Optional card-count budget for the task list. When supplied and the run has more tasks than
+   * this, the panel renders an anchored window of `maxTasks` cards centred on the active /
+   * focused card (so the live work stays visible) and shows dim "▴ N more above" / "▾ N more
+   * below" cues for the hidden remainder. Without it the column grew unbounded with 3-4+ tasks
+   * and pushed the Recent-log + footer off-screen. Defaults to unbounded (every card rendered)
+   * so isolated unit renders are unchanged — the Execute view threads `layout.tasksMaxBlocks`.
+   */
+  readonly maxTasks?: number;
   /** Max orphan signals to render. */
   readonly maxOrphanSignals?: number;
   /**
@@ -114,6 +124,7 @@ export const TasksPanel = ({
   running,
   nameById,
   maxSignalsPerTask = 8,
+  maxTasks,
   maxOrphanSignals = 6,
   maxSubStepsPerTask = 12,
   maxEvaluationsPerTask = 6,
@@ -235,6 +246,14 @@ export const TasksPanel = ({
   const kinds = collectKinds(bucketed);
   const orphanSliceLen = Math.min(bucketed.orphanSignals.length, maxOrphanSignals);
   const orphanSliceStart = bucketed.orphanSignals.length - orphanSliceLen;
+  // Anchored card window: keep the active / focused card visible and cap the rendered card
+  // count to the terminal-derived budget so the column stops growing past the viewport. Absent
+  // `maxTasks` ⇒ full range (no windowing), preserving isolated-render behaviour.
+  const taskWindow = computeAnchoredWindow(
+    bucketed.tasks.length,
+    effectiveCardCursor,
+    maxTasks ?? bucketed.tasks.length
+  );
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
       <InlineKindsBar kinds={kinds} />
@@ -245,7 +264,18 @@ export const TasksPanel = ({
         expandedKeys={expandedKeys}
         sliceStart={orphanSliceStart}
       />
-      {bucketed.tasks.map((task, idx) => {
+      {taskWindow.hiddenBefore > 0 && (
+        <Box paddingX={spacing.indent}>
+          <Text dimColor>
+            {glyphs.moreAbove} {taskWindow.hiddenBefore} more above
+          </Text>
+        </Box>
+      )}
+      {bucketed.tasks.slice(taskWindow.start, taskWindow.end).map((task, sliceIdx) => {
+        // Absolute index into `bucketed.tasks` — the window slices a sub-range, but `isActive`
+        // and `cardFocused` compare against absolute indices (`activeTaskIdx`,
+        // `effectiveCardCursor`), so recover the absolute position from the slice offset.
+        const idx = taskWindow.start + sliceIdx;
         // Deliberate stylistic 8-char short-uuid fallback (NOT a width-driven clip) — keeps
         // the header readable when the launcher hasn't supplied a friendly name. The friendly
         // name path goes through `nameById` and renders verbatim; if a future design makes
@@ -290,6 +320,13 @@ export const TasksPanel = ({
           />
         );
       })}
+      {taskWindow.hiddenAfter > 0 && (
+        <Box paddingX={spacing.indent}>
+          <Text dimColor>
+            {glyphs.moreBelow} {taskWindow.hiddenAfter} more below
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -94,6 +94,12 @@ export interface TasksPanelProps {
    */
   readonly taskCriteriaById?: ReadonlyMap<string, readonly string[]>;
   /**
+   * Optional `taskId → blockedReason` map sourced from the polled task entities. When a task is
+   * blocked, its reason renders under the card header so the operator sees WHY (own failure vs
+   * `blocked upstream — …`) rather than a bare `blocked` status. Absent for runs with no blocks.
+   */
+  readonly blockedReasonById?: ReadonlyMap<string, string>;
+  /**
    * Dev-only flag — when `true`, failing evaluator rows render via
    * `<EvaluatorFailurePanel>` (per-dimension colour-coded view + critique excerpt with
    * expand affordance) instead of the canonical single-line summary. Defaults `false` so
@@ -131,6 +137,7 @@ export const TasksPanel = ({
   recoveringByTaskId,
   inputActive = false,
   taskCriteriaById,
+  blockedReasonById,
   showEvaluatorFailureUI = false,
   sprintState,
   nowMs,
@@ -293,6 +300,7 @@ export const TasksPanel = ({
         // doesn't have to mirror the bucketed order (projections are stored by `order`; bucketed
         // tasks track the runtime sequence).
         const taskProjection = sprintState?.tasks.find((t: TaskProjection) => t.id === task.id);
+        const blockedReason = blockedReasonById?.get(task.id);
         const isActive = idx === activeTaskIdx;
         return (
           <TaskBlock
@@ -317,6 +325,7 @@ export const TasksPanel = ({
             {...(recovering !== undefined ? { recovering } : {})}
             {...(taskCriteria !== undefined ? { taskCriteria } : {})}
             {...(taskProjection !== undefined ? { taskProjection } : {})}
+            {...(blockedReason !== undefined ? { blockedReason } : {})}
           />
         );
       })}

--- a/src/application/ui/tui/components/windowed-anchor.ts
+++ b/src/application/ui/tui/components/windowed-anchor.ts
@@ -1,0 +1,55 @@
+/**
+ * Anchored windowing for variable-height list columns.
+ *
+ * The Execute view renders three stacked/side-by-side lists — Flow steps, Tasks, Recent log.
+ * Flow steps and Recent log already bound their height (StepTrace anchors a running-row window;
+ * RecentEventsTail tails `slice(-maxRows)`). The Tasks column was the lone holdout: it mapped
+ * the entire task array, so an expanded active card plus a growing tail of settled cards summed
+ * to an unbounded intrinsic height that pushed Recent log + footer off-screen once 3-4 tasks
+ * were in flight.
+ *
+ * This is the shared primitive that closes the gap: given a list `total`, an `anchorIndex` (the
+ * item that must stay visible — for Tasks, the active / focused card), and a `capCount` budget
+ * (cards that fit, derived from terminal rows), it returns the slice bounds plus how many items
+ * are hidden off each edge so the caller can render an "N more" cue. We count ITEMS, not
+ * measured rows — consistent with the rail's card-counting and far simpler than Ink
+ * `measureElement`; an exact row budget buys little when cards are variable-height.
+ *
+ * Pure and stateless: the window is derived from its inputs every render, so it never jitters on
+ * an unrelated re-render (the anchor only moves when the active card advances or the user
+ * navigates). When `capCount >= total` (or `capCount <= 0`) the full range is returned with no
+ * hidden items, so an unbounded caller is a transparent no-op.
+ */
+export interface AnchoredWindow {
+  /** Inclusive start index of the visible slice. */
+  readonly start: number;
+  /** Exclusive end index of the visible slice. */
+  readonly end: number;
+  /** Count of items hidden before `start` (drives a "▴ N more above" cue). */
+  readonly hiddenBefore: number;
+  /** Count of items hidden at / after `end` (drives a "▾ N more below" cue). */
+  readonly hiddenAfter: number;
+}
+
+/**
+ * Compute the visible slice of a list, keeping `anchorIndex` inside the window and clamping the
+ * window to the list bounds. The window is centred on the anchor, then shifted so it never runs
+ * off either edge (so the last page shows a full `capCount` items rather than a short tail).
+ */
+export const computeAnchoredWindow = (total: number, anchorIndex: number, capCount: number): AnchoredWindow => {
+  if (total <= 0) return { start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 };
+  // No budget, or the whole list fits — show everything, hide nothing.
+  if (capCount <= 0 || capCount >= total) {
+    return { start: 0, end: total, hiddenBefore: 0, hiddenAfter: 0 };
+  }
+  // Clamp the anchor into range so a stale / -1 cursor can't push the window out of bounds.
+  const safeAnchor = anchorIndex < 0 ? 0 : anchorIndex >= total ? total - 1 : anchorIndex;
+  const half = Math.floor(capCount / 2);
+  // Centre on the anchor, then clamp the start to [0, total - capCount].
+  let start = safeAnchor - half;
+  if (start < 0) start = 0;
+  const maxStart = total - capCount;
+  if (start > maxStart) start = maxStart;
+  const end = start + capCount;
+  return { start, end, hiddenBefore: start, hiddenAfter: total - end };
+};

--- a/src/application/ui/tui/launch-routing.ts
+++ b/src/application/ui/tui/launch-routing.ts
@@ -36,6 +36,12 @@ export interface InitialSelection {
    * loaded `Sprint` entity (the home view fetches that lazily).
    */
   readonly sprintId?: SprintId;
+  /**
+   * Readable name of the seeded sprint, resolved from the sprints array at boot time.
+   * Absent when no sprint is seeded or when the sprint can no longer be found (removed).
+   * Prevents the breadcrumb from showing a raw identifier on the first paint.
+   */
+  readonly sprintLabel?: string;
 }
 
 export interface InitialState {
@@ -90,12 +96,16 @@ export const resolveInitialState = ({
   // Seed the most-recent sprint when the persisted one is missing; undefined when the project
   // has zero sprints.
   const seededSprintId = persistedSprintValid ? lastSprintId : projectSprints[0]?.id;
+  // Resolve the readable name so the breadcrumb shows it immediately on first paint.
+  // Falls back to absent (no label) when the sprint can no longer be found.
+  const seededSprint = seededSprintId !== undefined ? projectSprints.find((s) => s.id === seededSprintId) : undefined;
   return {
     initialView: { id: 'home' },
     initialSelection: {
       projectId: resolvedProject.id,
       projectLabel: resolvedProject.displayName,
       ...(seededSprintId !== undefined ? { sprintId: seededSprintId } : {}),
+      ...(seededSprint !== undefined ? { sprintLabel: seededSprint.name } : {}),
     },
   };
 };

--- a/src/application/ui/tui/prompts/text-area-prompt.tsx
+++ b/src/application/ui/tui/prompts/text-area-prompt.tsx
@@ -17,13 +17,21 @@
  * `PromptHost` queued-prompt frame, just recessive so the typed content owns the contrast.
  * The "▸ message" header sits above the box; the chord-hint row sits below.
  *
+ * Viewport: long bodies render through a cursor-following window. A row budget is derived from
+ * the terminal height minus a chrome reserve; when the buffer overflows it, the visible lines are
+ * sliced so the cursor's line — and the hint row below the field — always stay on screen, and a
+ * dim cue marks any content hidden above / below the window. When the whole buffer fits, every
+ * line renders with no slicing and no cue — byte-for-byte the short-body behaviour.
+ *
  * Key bindings (shown in the hint row):
  *   ↵ submit · \↵ newline · ←/→/↑/↓ cursor · home/end edge · esc {escLabel} · ctrl+w word · ctrl+u clear
+ *   (pgup/pgdn jump roughly a screenful, scrolling the window at the edges)
  */
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 
 export interface TextAreaPromptProps {
   readonly message: string;
@@ -36,6 +44,16 @@ export interface TextAreaPromptProps {
    */
   readonly escLabel?: string;
 }
+
+/**
+ * Reserve rows for the chrome around the editable text window — the prompt header above the
+ * field, the rounded border, the marginTop / marginBottom gutters, the keyboard-hint row below,
+ * the hidden-content cues, plus the surrounding prompt-host / breadcrumb / status chrome. Mirrors
+ * the reserve approach used by the review-step scrollable description; the floor keeps a tiny
+ * terminal usable — the field always shows a few rows even when the reserve would zero it out.
+ */
+const TEXT_AREA_CHROME_ROWS = 14;
+const TEXT_AREA_MIN_VIEWPORT = 4;
 
 /** Resolve which line index and column the cursor offset maps to. */
 const offsetToLineCol = (buf: string, offset: number): { line: number; col: number } => {
@@ -57,6 +75,30 @@ const lineColToOffset = (buf: string, lineIdx: number, col: number): number => {
   return offset;
 };
 
+/**
+ * Shift the window offset so the cursor's line stays inside it, preserving the previous offset
+ * (hysteresis) when the cursor is already visible. Clamped to [0, lastPossibleOffset] with no
+ * wrap-around — at the extremes the window simply stops.
+ */
+const followCursorOffset = (prevOffset: number, cursorLine: number, viewport: number, totalLines: number): number => {
+  const maxOffset = Math.max(0, totalLines - viewport);
+  let next = prevOffset;
+  if (cursorLine < next) next = cursorLine;
+  else if (cursorLine > next + viewport - 1) next = cursorLine - viewport + 1;
+  return Math.max(0, Math.min(next, maxOffset));
+};
+
+/**
+ * Detect an xterm SGR mouse report (e.g. ESC[<65;10;10M). The field is keyboard-only, but a wheel
+ * event can leak onto stdin while mouse-tracking is being torn down for a prompt; Ink strips the
+ * leading ESC, leaving "[<…M"/"[<…m" — all-printable ASCII that would otherwise be typed into the
+ * buffer. Reject it so stray wheel bytes never become text.
+ */
+const isMouseReport = (input: string): boolean => {
+  const stripped = input.startsWith(String.fromCharCode(27)) ? input.slice(1) : input;
+  return /^\[<\d+;\d+;\d+[Mm]$/.test(stripped);
+};
+
 export const TextAreaPrompt = ({
   message,
   onSubmit,
@@ -64,9 +106,13 @@ export const TextAreaPrompt = ({
   initial = '',
   escLabel = 'cancel',
 }: TextAreaPromptProps): React.JSX.Element => {
+  const term = useTerminalSize();
   const [buf, setBuf] = useState(initial);
   const [cursor, setCursor] = useState(initial.length);
   const [caretOn, setCaretOn] = useState(true);
+  // First buffer line shown in the window. Persisted so the window keeps its position
+  // (hysteresis) as the cursor moves within it; the render derives the effective offset from it.
+  const [firstVisible, setFirstVisible] = useState(0);
 
   // Mirror buffer and cursor in refs so handlers read the latest values when keystrokes arrive
   // between renders (paste + Enter, ctrl+u + Enter, fast typing). Matches TextPrompt's pattern.
@@ -77,25 +123,23 @@ export const TextAreaPrompt = ({
   // Set to current column on any horizontal move or edit; preserved across up/down moves only.
   const desiredColRef = useRef<number | null>(null);
 
-  // Atomically update both buf and cursor to avoid stale-closure races on rapid keystrokes.
-  // The transform receives (prevBuf, prevCursor) and returns [newBuf, newCursor].
+  // Atomically update both buf and cursor to avoid stale-closure races on rapid keystrokes. The
+  // refs are the synchronous source of truth: write them immediately so a keystroke that arrives
+  // before React flushes (paste + Enter, fast typing) still reads the latest value. Subscribing
+  // to terminal-size context defers React's commit, so the refs must not depend on the setState
+  // updater running synchronously — they are updated here, then mirrored into render state.
   const updateBufAndCursor = (transform: (b: string, c: number) => [string, number]): void => {
-    setBuf((prevBuf) => {
-      const prevCursor = cursorRef.current;
-      const [newBuf, newCursor] = transform(prevBuf, prevCursor);
-      bufRef.current = newBuf;
-      cursorRef.current = newCursor;
-      setCursor(newCursor);
-      return newBuf;
-    });
+    const [newBuf, newCursor] = transform(bufRef.current, cursorRef.current);
+    bufRef.current = newBuf;
+    cursorRef.current = newCursor;
+    setBuf(newBuf);
+    setCursor(newCursor);
   };
 
   const updateCursor = (next: (prev: number) => number): void => {
-    setCursor((prev) => {
-      const value = next(prev);
-      cursorRef.current = value;
-      return value;
-    });
+    const value = next(cursorRef.current);
+    cursorRef.current = value;
+    setCursor(value);
   };
 
   useEffect(() => {
@@ -104,6 +148,20 @@ export const TextAreaPrompt = ({
       clearInterval(id);
     };
   }, []);
+
+  const lines = buf.split('\n');
+  const { line: cursorLine, col: cursorCol } = offsetToLineCol(buf, cursor);
+  const viewport = Math.max(TEXT_AREA_MIN_VIEWPORT, term.rows - TEXT_AREA_CHROME_ROWS);
+  const overflows = lines.length > viewport;
+  // Effective window offset for this render — always contains the cursor line, so the caret and
+  // the hint row below stay on screen no matter how the cursor moved (edit, arrow, paste, page).
+  const windowStart = overflows ? followCursorOffset(firstVisible, cursorLine, viewport, lines.length) : 0;
+
+  // Persist the followed offset so the next interaction keeps the window where it settled. This
+  // is idempotent once the cursor is inside the window, so it cannot loop.
+  useEffect(() => {
+    if (firstVisible !== windowStart) setFirstVisible(windowStart);
+  }, [firstVisible, windowStart]);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -152,15 +210,34 @@ export const TextAreaPrompt = ({
       const b = bufRef.current;
       const c = cursorRef.current;
       const { line, col } = offsetToLineCol(b, c);
-      const lines = b.split('\n');
+      const bufLines = b.split('\n');
       const targetCol = desiredColRef.current ?? col;
       if (desiredColRef.current === null) desiredColRef.current = col;
-      if (line >= lines.length - 1) {
+      if (line >= bufLines.length - 1) {
         // Already on last line — jump to end.
         updateCursor(() => b.length);
       } else {
         updateCursor(() => lineColToOffset(b, line + 1, targetCol));
       }
+      return;
+    }
+    // PgDn / PgUp — move the cursor roughly a screenful; the window follows so the net effect is
+    // a page scroll. Clamped to the buffer's first / last line, no wrap-around.
+    if (key.pageDown) {
+      const b = bufRef.current;
+      const { line, col } = offsetToLineCol(b, cursorRef.current);
+      const total = b.split('\n').length;
+      const targetCol = desiredColRef.current ?? col;
+      if (desiredColRef.current === null) desiredColRef.current = col;
+      updateCursor(() => lineColToOffset(b, Math.min(total - 1, line + viewport), targetCol));
+      return;
+    }
+    if (key.pageUp) {
+      const b = bufRef.current;
+      const { line, col } = offsetToLineCol(b, cursorRef.current);
+      const targetCol = desiredColRef.current ?? col;
+      if (desiredColRef.current === null) desiredColRef.current = col;
+      updateCursor(() => lineColToOffset(b, Math.max(0, line - viewport), targetCol));
       return;
     }
     // Home / ctrl+a — jump to start of current line.
@@ -215,16 +292,18 @@ export const TextAreaPrompt = ({
       desiredColRef.current = null;
       return;
     }
-    // Printable characters incl. pasted text. Paste may include `\n`; keep it.
-    if (input.length > 0 && !key.meta && !key.ctrl && !key.tab) {
+    // Printable characters incl. pasted text. Paste may include `\n`; keep it. Mouse SGR reports
+    // are rejected — the field is keyboard-only and a leaked wheel event must not type stray bytes.
+    if (input.length > 0 && !key.meta && !key.ctrl && !key.tab && !isMouseReport(input)) {
       const ins = input;
       updateBufAndCursor((b, c) => [b.slice(0, c) + ins + b.slice(c), c + ins.length]);
       desiredColRef.current = null;
     }
   });
 
-  const lines = buf.split('\n');
-  const { line: cursorLine, col: cursorCol } = offsetToLineCol(buf, cursor);
+  const visible = overflows ? lines.slice(windowStart, windowStart + viewport) : lines;
+  const hasAbove = overflows && windowStart > 0;
+  const hasBelow = overflows && windowStart + viewport < lines.length;
 
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
@@ -241,11 +320,13 @@ export const TextAreaPrompt = ({
         marginTop={spacing.gutter}
         marginBottom={spacing.gutter}
       >
-        {lines.map((line, i) => {
-          const isActiveLine = i === cursorLine;
+        {hasAbove ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
+        {visible.map((line, i) => {
+          const absoluteIndex = windowStart + i;
+          const isActiveLine = absoluteIndex === cursorLine;
           return (
-            <Box key={`row-${String(i)}`}>
-              <Text dimColor>{i === 0 ? `${glyphs.arrowRight} ` : '  '}</Text>
+            <Box key={`row-${String(absoluteIndex)}`}>
+              <Text dimColor>{absoluteIndex === 0 ? `${glyphs.arrowRight} ` : '  '}</Text>
               {isActiveLine ? (
                 <>
                   <Text>{line.slice(0, cursorCol)}</Text>
@@ -269,6 +350,7 @@ export const TextAreaPrompt = ({
             </Box>
           );
         })}
+        {hasBelow ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
       </Box>
       <Text dimColor>
         ↵ submit · \↵ newline · ←/→/↑/↓ cursor · home/end edge · esc {escLabel} · ctrl+w word · ctrl+u clear

--- a/src/application/ui/tui/runtime/session-manager.ts
+++ b/src/application/ui/tui/runtime/session-manager.ts
@@ -10,6 +10,8 @@
 
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { Trace } from '@src/application/chain/trace.ts';
 import type { Runner, RunnerStatus } from '@src/application/chain/run/runner.ts';
 
@@ -83,6 +85,17 @@ export interface SessionDescriptor {
    */
   readonly generatorModel?: string;
   readonly evaluatorModel?: string;
+  /**
+   * Project and sprint the run was launched against, pinned at launch time for the run's
+   * lifetime. The execute view reads these to identify the run's own sprint independently of
+   * the mutable global selection. Undefined when the flow was not launched against a project
+   * or sprint (e.g. create-sprint leaves pinnedSprintId unset because the sprint does not
+   * yet exist at launch time).
+   */
+  readonly pinnedProjectId?: ProjectId;
+  readonly pinnedProjectLabel?: string;
+  readonly pinnedSprintId?: SprintId;
+  readonly pinnedSprintLabel?: string;
 }
 
 export interface SessionRecord {
@@ -113,11 +126,21 @@ export interface SessionManager {
     readonly taskRecovering?: ReadonlyMap<string, RecoveryContext>;
     readonly generatorModel?: string;
     readonly evaluatorModel?: string;
+    readonly pinnedProjectId?: ProjectId;
+    readonly pinnedProjectLabel?: string;
+    readonly pinnedSprintId?: SprintId;
+    readonly pinnedSprintLabel?: string;
   }): SessionRecord;
   /** Request the runner to abort. No-op if the session is already terminal. */
   abort(id: string): void;
   /** Drop a session from the registry. Used after the user dismisses a finished run. */
   remove(id: string): void;
+  /**
+   * Retroactively pin the sprint on an existing descriptor. Called by sprint-bound launchers
+   * when the sprint is created mid-run (e.g. create-sprint) so the descriptor's pinned sprint
+   * fields are updated once the id/name become known. No-op if the runner id is not found.
+   */
+  setPinnedSprint(runnerId: string, sprintId: SprintId, sprintLabel: string): void;
   /** Subscribe to "registry changed" notifications. */
   subscribe(fn: SessionListener): () => void;
 }
@@ -198,6 +221,10 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
       taskRecovering,
       generatorModel,
       evaluatorModel,
+      pinnedProjectId,
+      pinnedProjectLabel,
+      pinnedSprintId,
+      pinnedSprintLabel,
     }): SessionRecord {
       evict(clock());
       const descriptor: SessionDescriptor = {
@@ -215,6 +242,10 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
         ...(taskRecovering !== undefined ? { taskRecovering } : {}),
         ...(generatorModel !== undefined ? { generatorModel } : {}),
         ...(evaluatorModel !== undefined ? { evaluatorModel } : {}),
+        ...(pinnedProjectId !== undefined ? { pinnedProjectId } : {}),
+        ...(pinnedProjectLabel !== undefined ? { pinnedProjectLabel } : {}),
+        ...(pinnedSprintId !== undefined ? { pinnedSprintId } : {}),
+        ...(pinnedSprintLabel !== undefined ? { pinnedSprintLabel } : {}),
       };
       const record: SessionRecord = { descriptor, runner: runner as Runner<unknown> };
       records.set(runner.id, record);
@@ -275,6 +306,9 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
     },
     remove(id: string): void {
       if (records.delete(id)) notify();
+    },
+    setPinnedSprint(runnerId: string, sprintId: SprintId, sprintLabel: string): void {
+      update(runnerId, { pinnedSprintId: sprintId, pinnedSprintLabel: sprintLabel });
     },
     subscribe(fn: SessionListener): () => void {
       listeners.add(fn);

--- a/src/application/ui/tui/runtime/ui-state-context.tsx
+++ b/src/application/ui/tui/runtime/ui-state-context.tsx
@@ -18,6 +18,18 @@
 
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+
+/**
+ * Project/sprint context captured from the currently-focused Execute view. Set on mount and
+ * cleared on unmount so the breadcrumb and progress overlay reflect the run's own sprint rather
+ * than the mutable global selection while the user is watching a run.
+ */
+export interface FocusedRunCtx {
+  readonly projectLabel: string | undefined;
+  readonly sprintId: SprintId | undefined;
+  readonly sprintLabel: string | undefined;
+}
 
 /**
  * Closure returned by the focused view that, on demand, renders the markdown summary of the
@@ -94,6 +106,18 @@ interface UiStateApi {
 
   setSessionRepositoryId(id: RepositoryId | undefined): void;
   /**
+   * Pin the project/sprint context of the currently-focused Execute view. Breadcrumb and
+   * progress overlay prefer this over the global selection while a value is set. Cleared to
+   * `undefined` when the Execute view unmounts.
+   */
+  setFocusedRunContext(ctx: FocusedRunCtx | undefined): void;
+  /** Project label from the focused Execute view's pinned descriptor, or `undefined`. */
+  readonly focusedRunProjectLabel: string | undefined;
+  /** Sprint id from the focused Execute view's pinned descriptor, or `undefined`. */
+  readonly focusedRunSprintId: SprintId | undefined;
+  /** Sprint label from the focused Execute view's pinned descriptor, or `undefined`. */
+  readonly focusedRunSprintLabel: string | undefined;
+  /**
    * Register a provider for the markdown summary of the operator's currently-focused task —
    * read by the global `y` hotkey via {@link getActiveTaskSummary}. Stored in a ref (not
    * state), so registering / unregistering does not trigger a re-render on every render of the
@@ -120,6 +144,7 @@ export const UiStateProvider = ({ children }: { readonly children: React.ReactNo
   const [claims, setClaims] = useState(0);
   const [escapeClaims, setEscapeClaims] = useState(0);
   const [sessionRepositoryId, setSessionRepositoryIdState] = useState<RepositoryId | undefined>(undefined);
+  const [focusedRunCtx, setFocusedRunCtxState] = useState<FocusedRunCtx | undefined>(undefined);
 
   const toggleHelp = useCallback(() => {
     setHelpOpen((v) => !v);
@@ -157,6 +182,10 @@ export const UiStateProvider = ({ children }: { readonly children: React.ReactNo
     setSessionRepositoryIdState(id);
   }, []);
 
+  const setFocusedRunContext = useCallback((ctx: FocusedRunCtx | undefined): void => {
+    setFocusedRunCtxState(ctx);
+  }, []);
+
   // The active-task summary provider is registered through a ref so swapping it does not churn
   // the context value (which would re-render every consumer including unrelated views). The
   // hotkey reads through `getActiveTaskSummary()` on press; until then the ref is dormant.
@@ -190,6 +219,10 @@ export const UiStateProvider = ({ children }: { readonly children: React.ReactNo
       claimEscape,
       sessionRepositoryId,
       setSessionRepositoryId,
+      focusedRunProjectLabel: focusedRunCtx?.projectLabel,
+      focusedRunSprintId: focusedRunCtx?.sprintId,
+      focusedRunSprintLabel: focusedRunCtx?.sprintLabel,
+      setFocusedRunContext,
       setActiveTaskSummaryProvider,
       getActiveTaskSummary,
     }),
@@ -206,6 +239,8 @@ export const UiStateProvider = ({ children }: { readonly children: React.ReactNo
       claimEscape,
       sessionRepositoryId,
       setSessionRepositoryId,
+      focusedRunCtx,
+      setFocusedRunContext,
       setActiveTaskSummaryProvider,
       getActiveTaskSummary,
     ]

--- a/src/application/ui/tui/theme/tokens.ts
+++ b/src/application/ui/tui/theme/tokens.ts
@@ -61,6 +61,11 @@ export const glyphs = {
   // place to introduce a switch.
   clipEllipsis: '…',
   collapseExpand: '▼ more',
+  // Windowed-list overflow cues (Tasks column / any anchored window). `moreAbove` /
+  // `moreBelow` head a dim "N more" row when an anchored viewport hides cards off either
+  // edge, telling the operator the list is scrolled rather than truncated.
+  moreAbove: '▴',
+  moreBelow: '▾',
 } as const;
 
 /** Spacing rhythm. Use these everywhere in lieu of magic numbers. */

--- a/src/application/ui/tui/views/add-ticket-internals/review-scrollable-description.tsx
+++ b/src/application/ui/tui/views/add-ticket-internals/review-scrollable-description.tsx
@@ -14,16 +14,37 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useSuppressGlobalHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 
 /**
- * Reserve rows for the chrome around the scrollable description body — banner + breadcrumb +
- * section stamp at the top, plus the Title row, the Link row, the spacing gutter, the
- * ConfirmPrompt (message + pills + hint), and the status bar at the bottom. The exact rows
- * vary with banner mode and terminal width; this constant is the worst-case estimate that
- * keeps the Link row and the confirm pills visible on a default 24-row terminal. Floor on the
- * viewport ensures a tiny terminal still shows something useful.
+ * Rows of chrome reserved around the scrollable description body when the header is the compact
+ * single-line strip (the default for this view below the full-banner width threshold):
+ * breadcrumb + section stamp at the top, plus the Title row, the Link row, the spacing gutter,
+ * the ConfirmPrompt (message + pills + hint), and the status bar at the bottom. Tuned so a
+ * default 24-row terminal scrolls a long body while keeping the Link row and confirm pills in
+ * view.
  */
-const REVIEW_CHROME_ROWS = 14;
+const REVIEW_CHROME_COMPACT = 14;
+
+/**
+ * Extra rows the full wordmark banner occupies over the compact strip (round frame + art block
+ * + quote rail). On a wide terminal the banner auto-switches to the full frame; reserving only
+ * the compact estimate there is the brittle failure this layout replaces — the unaccounted rows
+ * let the body grow tall enough to push the Title / Link / confirm rows off the bottom.
+ */
+const REVIEW_CHROME_FULL_BANNER_EXTRA = 10;
+
+/**
+ * Width at/below which the banner renders its compact strip instead of the full wordmark frame.
+ * Mirrors the Banner component's own threshold so the chrome reserve tracks what is drawn.
+ */
+const BANNER_FULL_MIN_WIDTH = 100;
+
+/**
+ * Floor on the description viewport. On a terminal too short for a comfortable area the body
+ * shrinks to this many rows — still scrollable through the full text — instead of stealing rows
+ * from the Title / Link / confirm chrome, so those controls stay visible.
+ */
 const REVIEW_MIN_VIEWPORT = 4;
 
 interface ReviewScrollableDescriptionProps {
@@ -32,8 +53,15 @@ interface ReviewScrollableDescriptionProps {
 
 export const ReviewScrollableDescription = ({ text }: ReviewScrollableDescriptionProps): React.JSX.Element => {
   const term = useTerminalSize();
+  const ui = useUiState();
   const lines = useMemo<readonly string[]>(() => text.split('\n'), [text]);
-  const viewport = Math.max(REVIEW_MIN_VIEWPORT, term.rows - REVIEW_CHROME_ROWS);
+  // Mirror ViewShell → Banner: the user `b`-toggle forces the compact strip; otherwise the
+  // banner auto-switches on width. Reserve the chrome that matches whichever header is actually
+  // drawn so the surrounding rows always fit, rather than a single worst-case constant that
+  // under-reserves on a wide terminal showing the full banner.
+  const bannerIsCompact = ui.bannerCompact || term.columns < BANNER_FULL_MIN_WIDTH;
+  const chromeRows = bannerIsCompact ? REVIEW_CHROME_COMPACT : REVIEW_CHROME_COMPACT + REVIEW_CHROME_FULL_BANNER_EXTRA;
+  const viewport = Math.max(REVIEW_MIN_VIEWPORT, term.rows - chromeRows);
   const overflows = lines.length > viewport;
   const maxOffset = Math.max(0, lines.length - viewport);
   const [offset, setOffset] = useState(0);

--- a/src/application/ui/tui/views/execute-view-internals/body.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/body.tsx
@@ -52,6 +52,8 @@ export interface ExecuteBodyProps {
   readonly onCancelAttempt: () => void;
   readonly onCancelFlow: () => void;
   readonly onDismissCancelScope: () => void;
+  /** When true the run's pinned sprint is no longer available — baseline-health surfaces are dropped. */
+  readonly pinnedSprintStale: boolean;
 }
 
 export const ExecuteBody = ({
@@ -80,21 +82,23 @@ export const ExecuteBody = ({
   onCancelAttempt,
   onCancelFlow,
   onDismissCancelScope,
+  pinnedSprintStale,
 }: ExecuteBodyProps): React.JSX.Element => (
   <Box flexDirection="column">
     {/* Multi-flow chip strip — renders only when ≥2 sessions are running, so a single-
         flow run pays zero pixels. */}
     <MultiFlowStrip sessions={sessionList} activeId={sessionId} now={now} />
-    {/* Baseline-health chip — sits above the active-task header so the verify-gate
-        state is visible without scrolling. Always rendered; renders a neutral
-        "awaiting first run" pill before the first leaf has touched the data. */}
-    <Box paddingX={spacing.indent}>
-      <BaselineHealthChip
-        {...(executionState !== undefined ? { execution: executionState } : {})}
-        {...(taskState !== undefined ? { tasks: taskState } : {})}
-        now={now}
-      />
-    </Box>
+    {/* Baseline-health chip — dropped when the run's pinned sprint is no longer available
+        so stale baseline data is never shown alongside the pick-a-sprint fallback. */}
+    {!pinnedSprintStale && (
+      <Box paddingX={spacing.indent}>
+        <BaselineHealthChip
+          {...(executionState !== undefined ? { execution: executionState } : {})}
+          {...(taskState !== undefined ? { tasks: taskState } : {})}
+          now={now}
+        />
+      </Box>
+    )}
     <HeaderCard
       descriptor={descriptor}
       isRunning={isRunning}
@@ -124,6 +128,7 @@ export const ExecuteBody = ({
       taskState={taskState}
       now={now}
       tokenUsage={tokenUsage}
+      pinnedSprintStale={pinnedSprintStale}
     />
 
     <Section title="Recent log">

--- a/src/application/ui/tui/views/execute-view-internals/layout.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/layout.tsx
@@ -43,6 +43,8 @@ interface LayoutProps {
   readonly taskState: readonly Task[] | undefined;
   readonly now: number;
   readonly tokenUsage: TokenUsage | undefined;
+  /** When true the run's pinned sprint is no longer available — baseline-health card is dropped. */
+  readonly pinnedSprintStale: boolean;
 }
 
 export const ExecuteLayout = ({
@@ -62,6 +64,7 @@ export const ExecuteLayout = ({
   taskState,
   now,
   tokenUsage,
+  pinnedSprintStale,
 }: LayoutProps): React.JSX.Element => {
   const flowStepsPanel = (
     <FlowStepsRail
@@ -86,16 +89,17 @@ export const ExecuteLayout = ({
           <SectionHeader title="Tasks" />
           {tasksPanel}
         </Box>
-        {/* Right context column — baseline-health card (P1k) on top, token-budget card
-            (P2b) below. P3a ETA stacks here in a later wave.
-            `contextWidth` grows slightly at xxl (fluid 28→36 at 0.14× columns). */}
+        {/* Right context column — baseline-health card on top (dropped when pinned sprint
+            is stale), token-budget card below. */}
         <Box flexDirection="column" width={contextWidth} flexShrink={0}>
-          <BaselineHealthCard
-            {...(executionState !== undefined ? { execution: executionState } : {})}
-            {...(taskState !== undefined ? { tasks: taskState } : {})}
-            now={now}
-            width={contextWidth}
-          />
+          {!pinnedSprintStale && (
+            <BaselineHealthCard
+              {...(executionState !== undefined ? { execution: executionState } : {})}
+              {...(taskState !== undefined ? { tasks: taskState } : {})}
+              now={now}
+              width={contextWidth}
+            />
+          )}
           <Box marginTop={spacing.section}>
             <TokenBudgetCard sessionId={sessionId} {...(tokenUsage !== undefined ? { usage: tokenUsage } : {})} />
           </Box>

--- a/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
@@ -22,6 +22,8 @@ interface TasksPanelHostProps {
   readonly descriptor: SessionDescriptor;
   readonly isRunning: boolean;
   readonly maxSignalsPerTask: number;
+  /** Card-count budget for the windowed Tasks column (from `layout.tasksMaxBlocks`). */
+  readonly maxTasks: number;
   readonly inputActive: boolean;
   readonly now: number;
   readonly taskState: readonly Task[] | undefined;
@@ -32,6 +34,7 @@ export const TasksPanelHost = ({
   descriptor,
   isRunning,
   maxSignalsPerTask,
+  maxTasks,
   inputActive,
   now,
   taskState,
@@ -57,6 +60,7 @@ export const TasksPanelHost = ({
       bucketed={bucketed}
       running={isRunning}
       maxSignalsPerTask={maxSignalsPerTask}
+      maxTasks={maxTasks}
       inputActive={inputActive}
       nowMs={now}
       {...(descriptor.taskNames !== undefined ? { nameById: descriptor.taskNames } : {})}

--- a/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
@@ -53,6 +53,18 @@ export const TasksPanelHost = ({
     return m;
   }, [taskState]);
 
+  // taskId → blockedReason for blocked tasks, so the panel can render WHY a card blocked. The
+  // live TaskBucket status is trace-derived and carries no reason; the reason lives on the polled
+  // entity. Undefined when no task is blocked (keeps the panel's prop diff clean).
+  const blockedReasonById = useMemo<ReadonlyMap<string, string> | undefined>(() => {
+    if (taskState === undefined) return undefined;
+    const m = new Map<string, string>();
+    for (const t of taskState) {
+      if (t.status === 'blocked') m.set(String(t.id), t.blockedReason);
+    }
+    return m.size > 0 ? m : undefined;
+  }, [taskState]);
+
   if (bucketed === undefined) return null;
 
   return (
@@ -66,6 +78,7 @@ export const TasksPanelHost = ({
       {...(descriptor.taskNames !== undefined ? { nameById: descriptor.taskNames } : {})}
       {...(descriptor.taskRecovering !== undefined ? { recoveringByTaskId: descriptor.taskRecovering } : {})}
       {...(taskCriteriaById !== undefined ? { taskCriteriaById } : {})}
+      {...(blockedReasonById !== undefined ? { blockedReasonById } : {})}
     />
   );
 };

--- a/src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts
+++ b/src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts
@@ -32,6 +32,14 @@ export interface ResponsiveLayout {
   readonly singleColumn: boolean;
   readonly flowStepsRows: number;
   readonly tasksMaxSignals: number;
+  /**
+   * Card-count budget for the Tasks column — how many task cards the middle column may render
+   * before the anchored window ({@link computeAnchoredWindow}) hides the rest behind an
+   * "N more" cue. Derived from terminal rows so the column stops growing past the viewport and
+   * pushing the Recent-log + footer off-screen. Counts cards, not rows (cards are
+   * variable-height; the rail counts the same way).
+   */
+  readonly tasksMaxBlocks: number;
   readonly logRows: number;
   readonly threeColRailWidth: number;
   readonly labelledRailWidth: number;
@@ -54,6 +62,15 @@ export const useResponsiveLayout = ({ columns, rows, isRunning }: UseResponsiveL
   const flowStepsRows = singleColumn ? NARROW_FLOW_STEPS_ROWS : baseFlowStepsRows;
   const tasksMaxSignals = isRunning ? 6 : 12;
   const logRows = isRunning ? 6 : 10;
+  // Card budget for the Tasks column. In single-column the stack also carries the (narrow)
+  // Flow-steps + Recent-log, so the Tasks slice is tighter; in multi-column the Tasks column
+  // owns the centre and can show more. `~4 rows/card` is a deliberately conservative estimate
+  // (a collapsed card is 1-2 rows, the expanded active card is many) — the anchored window
+  // keeps the active card visible regardless, so an approximate budget is fine. Floored so a
+  // tiny terminal still shows a useful handful.
+  const tasksMaxBlocks = singleColumn
+    ? Math.max(2, Math.floor((rows - NARROW_FLOW_STEPS_ROWS - 10) / 4))
+    : Math.max(3, Math.floor((rows - 14) / 4));
 
   // The two-column branch uses the fixed `RAIL_WIDTH`; the three-column branch grows the
   // rail fluidly. We compute once and reuse so the truncation budget passed to StepTrace
@@ -70,6 +87,7 @@ export const useResponsiveLayout = ({ columns, rows, isRunning }: UseResponsiveL
     singleColumn,
     flowStepsRows,
     tasksMaxSignals,
+    tasksMaxBlocks,
     logRows,
     threeColRailWidth,
     labelledRailWidth,

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -40,14 +40,13 @@ import { useTokenUsage } from '@src/application/ui/tui/runtime/use-token-usage.t
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSession, useSessionManager, useSessions } from '@src/application/ui/tui/runtime/sessions-context.tsx';
-import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { useBuses } from '@src/application/ui/tui/runtime/sinks-context.tsx';
 import { useSinkStream } from '@src/application/ui/tui/runtime/use-sink-stream.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useEventBusBuffer } from '@src/application/ui/tui/runtime/use-event-bus.ts';
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 import type { AppEvent } from '@src/business/observability/events.ts';
-import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useUiState, type FocusedRunCtx } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
 
@@ -87,7 +86,6 @@ export const ExecuteView = (): React.JSX.Element => {
   const sessionList = useSessions();
   const router = useRouter();
   const ui = useUiState();
-  const selection = useSelection();
   const buses = useBuses();
   const signals = useSinkStream(buses.harness, { limit: HARNESS_SIGNAL_LIMIT });
   const logEntries = useSinkStream(buses.log, { limit: LOG_TAIL_LIMIT });
@@ -99,7 +97,49 @@ export const ExecuteView = (): React.JSX.Element => {
   });
   const term = useTerminalSize();
 
-  const baselineSprintId: SprintId | undefined = selection.sprintId as SprintId | undefined;
+  // Each Execute view is scoped to its session's pinned sprint so concurrent runs remain
+  // independent of each other and of the mutable global selection.
+  const pinnedSprintId = session?.descriptor?.pinnedSprintId as SprintId | undefined;
+  const pinnedProjectLabel = session?.descriptor?.pinnedProjectLabel;
+  const pinnedSprintLabel = session?.descriptor?.pinnedSprintLabel;
+
+  // Best-effort probe: mark the sprint unavailable when it has been closed or removed so
+  // the Execute view can show an inline fallback instead of stale panel data.
+  const [pinnedSprintAvailable, setPinnedSprintAvailable] = React.useState(true);
+  React.useEffect(() => {
+    if (pinnedSprintId === undefined) return undefined;
+    let cancelled = false;
+    const check = async (): Promise<void> => {
+      try {
+        const r = await deps.sprintRepo.findById(pinnedSprintId);
+        if (cancelled) return;
+        if (!r.ok || r.value.status === 'done') setPinnedSprintAvailable(false);
+      } catch {
+        // Keep available on error (absent repo in test harnesses, transient I/O failures).
+      }
+    };
+    void check();
+    return (): void => {
+      cancelled = true;
+    };
+  }, [pinnedSprintId, deps.sprintRepo]);
+
+  // Register this run's pinned project/sprint as the focused-run context so breadcrumb and
+  // progress overlay reflect the run's own sprint while this view is mounted.
+  const setFocusedRunContext = ui.setFocusedRunContext;
+  React.useEffect(() => {
+    const ctx: FocusedRunCtx = {
+      projectLabel: pinnedProjectLabel,
+      sprintId: pinnedSprintId,
+      sprintLabel: pinnedSprintLabel,
+    };
+    setFocusedRunContext(ctx);
+    return (): void => {
+      setFocusedRunContext(undefined);
+    };
+  }, [pinnedProjectLabel, pinnedSprintId, pinnedSprintLabel, setFocusedRunContext]);
+
+  const baselineSprintId: SprintId | undefined = pinnedSprintId;
   const { executionState, taskState } = useBaselineHealthData({
     baselineSprintId,
     sprintExecutionRepo: deps.sprintExecutionRepo,
@@ -121,7 +161,7 @@ export const ExecuteView = (): React.JSX.Element => {
     helpOpen: ui.helpOpen,
     promptActive: ui.promptActive,
     router,
-    sprintId: selection.sprintId as SprintId | undefined,
+    sprintId: pinnedSprintId,
   });
 
   const now = useLiveClock(isRunning);
@@ -153,7 +193,7 @@ export const ExecuteView = (): React.JSX.Element => {
   } = useCancelHandlers({
     sessions,
     sessionId,
-    sprintId: selection.sprintId as SprintId | undefined,
+    sprintId: pinnedSprintId,
     currentTask,
     taskRepo: deps.taskRepo,
     logger: deps.logger,
@@ -183,7 +223,15 @@ export const ExecuteView = (): React.JSX.Element => {
   // can't fight the help overlay (`?`), the progress overlay (`g`), or a prompt.
   const tasksInputActive = !ui.helpOpen && !ui.progressOpen && !ui.promptActive;
 
-  const tasksPanel = (
+  // When the pinned sprint is no longer available (done or removed), blank the panels that
+  // depend on it and surface a pick-a-sprint prompt so the user knows what happened.
+  const pinnedSprintStale = pinnedSprintId !== undefined && !pinnedSprintAvailable;
+
+  const tasksPanel = pinnedSprintStale ? (
+    <Box paddingX={spacing.indent}>
+      <Text dimColor>Sprint no longer available — pick a sprint to continue.</Text>
+    </Box>
+  ) : (
     <TasksPanelHost
       bucketed={bucketed}
       descriptor={descriptor}
@@ -194,6 +242,9 @@ export const ExecuteView = (): React.JSX.Element => {
       taskState={taskState}
     />
   );
+
+  const effectiveExecutionState = pinnedSprintStale ? undefined : executionState;
+  const effectiveTaskState = pinnedSprintStale ? undefined : taskState;
 
   return (
     <ViewShell
@@ -214,8 +265,8 @@ export const ExecuteView = (): React.JSX.Element => {
           elapsed={elapsed}
           layout={layout}
           termColumns={term.columns}
-          executionState={executionState}
-          taskState={taskState}
+          executionState={effectiveExecutionState}
+          taskState={effectiveTaskState}
           tokenUsage={tokenUsage}
           tasksDone={tasksDone}
           tasksTotal={tasksTotal}
@@ -231,6 +282,7 @@ export const ExecuteView = (): React.JSX.Element => {
           onCancelAttempt={onCancelAttempt}
           onCancelFlow={onCancelFlow}
           onDismissCancelScope={onDismissCancelScope}
+          pinnedSprintStale={pinnedSprintStale}
         />
       )}
     </ViewShell>

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -237,6 +237,7 @@ export const ExecuteView = (): React.JSX.Element => {
       descriptor={descriptor}
       isRunning={isRunning}
       maxSignalsPerTask={layout.tasksMaxSignals}
+      maxTasks={layout.tasksMaxBlocks}
       inputActive={tasksInputActive}
       now={now}
       taskState={taskState}

--- a/src/application/ui/tui/views/home-view.tsx
+++ b/src/application/ui/tui/views/home-view.tsx
@@ -145,6 +145,9 @@ export const HomeView = (): React.JSX.Element => {
         onReseat: ({ id, name }) => {
           selection.setSprint(id, name);
         },
+        onSprintResolved: (runnerId, { id, name }) => {
+          sessions.setPinnedSprint(runnerId, id, name);
+        },
       }
     );
     if (!result.ok) {

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -184,6 +184,9 @@ export const PickSprintView = (): React.JSX.Element => {
         onReseat: ({ id, name }) => {
           selection.setSprint(id, name);
         },
+        onSprintResolved: (runnerId, { id, name }) => {
+          sessions.setPinnedSprint(runnerId, id, name);
+        },
       }
     );
     if (!result.ok) {

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -126,6 +126,9 @@ export const SprintsView = (): React.JSX.Element => {
         onReseat: ({ id, name }) => {
           selection.setSprint(id, name);
         },
+        onSprintResolved: (runnerId, { id, name }) => {
+          sessions.setPinnedSprint(runnerId, id, name);
+        },
       }
     );
     if (!result.ok) {

--- a/src/business/scm/issue-pusher.ts
+++ b/src/business/scm/issue-pusher.ts
@@ -1,32 +1,22 @@
 import type { Result } from '@src/domain/result.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 
 /**
- * Outbound port to write back to the source issue tracker. The two operations mirror what the
- * refine flow needs:
- *   - `update`: replace the body of an existing issue addressed by URL.
- *   - `create`: open a new issue on a configured origin (used when the ticket has no `link`
- *     and the project carries a `defaultIssueOrigin`). The adapter returns the URL of the
- *     created issue so the caller can attach it to `ticket.link`.
+ * Outbound port to write back to the source issue tracker. Refine never mutates the issue
+ * body — it leaves the original description authored by a human untouched and instead appends
+ * the refined requirements as a comment on the linked issue.
  *
  * Result semantics match {@link IssueFetcher}:
- *   - `Result.ok` on success (`void` for update, `{ url }` for create).
+ *   - `Result.ok(undefined)` on success.
  *   - `Result.error(StorageError)` on system-level failure (CLI not installed, auth missing,
  *     network error, 4xx/5xx). The refine flow swallows these per the "graceful degrade" rule
  *     — local refinement is never blocked by a push failure.
  */
 export interface IssuePusher {
   /**
-   * Replace the body of the issue at `url`. The caller is responsible for the full new body
-   * (including any footer / divider markers).
+   * Post a new comment on the issue at `url`. The caller is responsible for the full comment
+   * body (including any footer / signature markers). The issue's own description is never
+   * touched.
    */
-  update(url: string, args: { readonly body: string }): Promise<Result<void, StorageError>>;
-  /**
-   * Open a new issue on the given origin. Returns the URL of the created issue.
-   */
-  create(
-    origin: IssueOriginRef,
-    args: { readonly title: string; readonly body: string }
-  ): Promise<Result<{ readonly url: string }, StorageError>>;
+  comment(url: string, args: { readonly body: string }): Promise<Result<void, StorageError>>;
 }

--- a/src/business/settings/apply-key.ts
+++ b/src/business/settings/apply-key.ts
@@ -22,7 +22,7 @@ import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
  * explicitly via `ai.implement.generator.<field>` or `ai.implement.evaluator.<field>`.
  */
 const SETTINGS_KEY_HINT =
-  'supported keys: ai.effort, ai.{flow}.{provider,model,effort} (flow in {refine,plan,readiness,ideate,createPr}), ai.implement.{generator,evaluator}.{provider,model,effort}, harness.{maxTurns,maxAttempts,rateLimitRetries,plateauThreshold,escalateOnPlateau}, harness.escalationMap.<fromModel>, logging.level, concurrency.maxParallelTasks, ui.notifications.enabled';
+  'supported keys: ai.effort, ai.{flow}.{provider,model,effort} (flow in {refine,plan,readiness,ideate,createPr}), ai.implement.{generator,evaluator}.{provider,model,effort}, harness.{maxTurns,maxAttempts,rateLimitRetries,plateauThreshold,escalateOnPlateau}, harness.escalationMap.<fromModel>, logging.level, concurrency.maxParallelTasks, scm.postRefinementComment, ui.notifications.enabled';
 
 const IMPLEMENT_ROLES: readonly AiImplementRole[] = ['generator', 'evaluator'];
 const isImplementRole = (raw: string): raw is AiImplementRole => (IMPLEMENT_ROLES as readonly string[]).includes(raw);
@@ -203,6 +203,20 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
         return Result.error(new ValidationError({ field: key, value: raw, message: `'${raw}' is not a number` }));
       }
       return Result.ok({ ...current, concurrency: { maxParallelTasks: n } });
+    }
+    case 'scm.postRefinementComment': {
+      const b = parseBool(raw);
+      if (b === undefined) {
+        return Result.error(
+          new ValidationError({
+            field: key,
+            value: raw,
+            message: `'${raw}' is not a boolean`,
+            hint: "use 'true' or 'false'",
+          })
+        );
+      }
+      return Result.ok({ ...current, scm: { ...current.scm, postRefinementComment: b } });
     }
     case 'ui.notifications.enabled': {
       const b = parseBool(raw);

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -92,7 +92,7 @@ export const DEFAULT_SETTINGS: Settings = {
     maxAttempts: 3,
     rateLimitRetries: 3,
     plateauThreshold: 2,
-    escalateOnPlateau: false,
+    escalateOnPlateau: true,
     escalationMap: {},
   },
   logging: { level: 'info' },

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -97,6 +97,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   logging: { level: 'info' },
   concurrency: { maxParallelTasks: 1 },
+  scm: { postRefinementComment: false },
   ui: { notifications: { enabled: true } },
   developer: { showEvaluatorFailureUI: false },
 };

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -20,23 +20,27 @@ import type { ValidationError } from '@src/domain/value/error/validation-error.t
  *   - `flagOn`            — `settings.harness.escalateOnPlateau`.
  *   - `userMap`           — `settings.harness.escalationMap`; merged over the built-in default.
  *
+ * A plateau NEVER blocks. It either grants one more attempt (with a stronger model and/or a
+ * change-of-approach directive) or preserves the work (done-with-warning) — never throws it away.
+ *
  * Outputs (discriminated):
- *   - `escalate`          — all conditions met; caller stamps the task + emits events.
- *   - `flag-off`          — operator opted out; caller leaves the path unchanged (today's
- *                           done-with-warning behaviour preserved).
- *   - `already-escalated` — the task already carries `escalatedFromModel`/`escalatedToModel`;
- *                           caller transitions to blocked with no new event (once-per-task cap).
- *   - `no-mapping`        — flag is on but neither the default nor the user map has a rung
- *                           above `generatorModel`; caller emits a `warn` banner and blocks.
- *   - `budget-exhausted`  — flag is on, mapping exists, but the next attempt would exceed
- *                           `maxAttempts`; caller emits a `warn` banner naming the budget
- *                           exhaustion (not the missing mapping) and blocks.
+ *   - `escalate`          — a stronger model rung exists; caller stamps the task (model bump) +
+ *                           emits events. Task stays in_progress for one more attempt.
+ *   - `nudge`             — flag on, budget remains, but no stronger rung (generator already at
+ *                           the top of the ladder). Caller stamps the task with the SAME model so
+ *                           the once-per-task cap fires, and the generator gets a change-of-approach
+ *                           directive. Task stays in_progress for one more attempt. No model change.
+ *   - `flag-off`          — operator opted out; caller leaves the path unchanged (done-with-warning).
+ *   - `already-escalated` — the task already had its one plateau-break attempt and plateaued again;
+ *                           caller preserves the work (done-with-warning), no new event.
+ *   - `budget-exhausted`  — flag on but the next attempt would exceed `maxAttempts` (no budget to
+ *                           retry); caller preserves the work (done-with-warning) naming the budget.
  */
 export type EscalationDecision =
   | { readonly kind: 'escalate'; readonly from: string; readonly to: string }
+  | { readonly kind: 'nudge'; readonly currentModel: string }
   | { readonly kind: 'flag-off' }
   | { readonly kind: 'already-escalated'; readonly from: string; readonly to: string }
-  | { readonly kind: 'no-mapping'; readonly currentModel: string }
   | { readonly kind: 'budget-exhausted'; readonly attemptsUsed: number; readonly maxAttempts: number };
 
 export interface DecideEscalationProps {
@@ -71,7 +75,9 @@ export const decideEscalation = (props: DecideEscalationProps): EscalationDecisi
   const effective = mergeEscalationMap(props.userMap);
   const to = effective[props.generatorModel];
   if (to === undefined || to === props.generatorModel) {
-    return { kind: 'no-mapping', currentModel: props.generatorModel };
+    // No stronger model to climb to (generator at the top of the ladder). Don't block — grant one
+    // more attempt on the same model with a change-of-approach directive instead.
+    return { kind: 'nudge', currentModel: props.generatorModel };
   }
   return { kind: 'escalate', from: props.generatorModel, to };
 };
@@ -145,14 +151,38 @@ export const applyEscalation = (
       });
       return Result.ok({ task: stamped.value });
     }
+    case 'nudge': {
+      // Top of the in-provider ladder: no stronger model to climb to. Keep the model but grant one
+      // more attempt with a change-of-approach directive (armed in the generator via
+      // `escalatedFromModel`). Stamp from===to so the once-per-task cap still fires on a second
+      // plateau (then `already-escalated` preserves the work). No model-escalated event — the model
+      // did not change; the banner names the nudge so the operator sees what happened.
+      const stamped = recordTaskEscalation(task, decision.currentModel, decision.currentModel);
+      if (!stamped.ok) return Result.error(stamped.error);
+      eventBus.publish({
+        type: 'banner-show',
+        id: bannerId,
+        tier: 'info',
+        message: `plateau on '${decision.currentModel}' (top of ladder) — retrying with a change-of-approach directive`,
+        cause: 'plateau',
+        at: now,
+      });
+      log.info('plateau nudge: retrying on the same model with a change-of-approach directive', {
+        taskId: String(task.id),
+        currentModel: decision.currentModel,
+      });
+      return Result.ok({ task: stamped.value });
+    }
     case 'already-escalated': {
-      const message = `plateau persists after escalation (${decision.from} → ${decision.to}); blocking task`;
+      // The one plateau-break attempt also plateaued. Preserve the work (done-with-warning) rather
+      // than blocking — matches the flag-off path; a plateau never throws the work away. The warn
+      // banner tells the operator the retry topped out.
+      const message = `plateau persists after the retry; keeping the work`;
       eventBus.publish({
         type: 'banner-show',
         id: bannerId,
         tier: 'warn',
-        message: 'plateau persists after escalation',
-        cause: `${decision.from} → ${decision.to}`,
+        message: 'plateau persists after retry — keeping the work',
         at: now,
       });
       log.warn(message, {
@@ -160,27 +190,16 @@ export const applyEscalation = (
         from: decision.from,
         to: decision.to,
       });
-      return Result.ok({ task, blockedReason: message });
-    }
-    case 'no-mapping': {
-      const message = `plateau at top of configured escalation ladder for '${decision.currentModel}'`;
-      eventBus.publish({
-        type: 'banner-show',
-        id: bannerId,
-        tier: 'warn',
-        message,
-        at: now,
-      });
-      log.warn(message, { taskId: String(task.id), currentModel: decision.currentModel });
-      return Result.ok({ task, blockedReason: message });
+      return Result.ok({ task });
     }
     case 'budget-exhausted': {
-      const message = `plateau with attempt budget exhausted (attempts=${String(decision.attemptsUsed)}, maxAttempts=${String(decision.maxAttempts)})`;
+      // Plateau on the final allowed attempt — no budget left to retry. Preserve the work.
+      const message = `plateau with attempt budget exhausted (attempts=${String(decision.attemptsUsed)}, maxAttempts=${String(decision.maxAttempts)}); keeping the work`;
       eventBus.publish({
         type: 'banner-show',
         id: bannerId,
         tier: 'warn',
-        message: 'plateau, attempt budget exhausted',
+        message: 'plateau, attempt budget exhausted — keeping the work',
         cause: `attempts=${String(decision.attemptsUsed)}/${String(decision.maxAttempts)}`,
         at: now,
       });
@@ -189,7 +208,7 @@ export const applyEscalation = (
         attemptsUsed: decision.attemptsUsed,
         maxAttempts: decision.maxAttempts,
       });
-      return Result.ok({ task, blockedReason: message });
+      return Result.ok({ task });
     }
   }
 };

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -138,7 +138,9 @@ export const finalizeGenEvalUseCase = async (
     if (!applied.ok) return Result.error(applied.error);
     taskForPersist = applied.value.task;
     if (applied.value.blockedReason !== undefined) blockedReason = applied.value.blockedReason;
-    if (decision.kind === 'escalate') shouldFailAttempt = true;
+    // Both a model escalation and a same-model nudge grant one more attempt: fail the running
+    // attempt so the task stays in_progress and the outer loop re-enters (modulo maxAttempts).
+    if (decision.kind === 'escalate' || decision.kind === 'nudge') shouldFailAttempt = true;
   }
 
   const persisted = await props.taskRepo.update(props.sprintId, taskForPersist);

--- a/src/business/task/start-attempt.ts
+++ b/src/business/task/start-attempt.ts
@@ -128,6 +128,20 @@ export const startAttemptUseCase = async (
         taskId: aborted.value.id,
         blockedReason: aborted.value.blockedReason,
       });
+      // Persist the blocked transition BEFORE surfacing the error. Without this the leftover
+      // running attempt stays on disk: the next launch re-enters this same resume path, re-settles
+      // it to blocked, re-errors — an infinite stuck loop where the task is never reported blocked
+      // and never leaves the queue. Persisting makes the block durable, so the launch queue filters
+      // it out (blocked is not resumable) and the operator can `unblock` it. A persist failure is
+      // surfaced in preference to the blocked-state error (it's the more actionable system fault).
+      const persistedBlocked = await props.taskRepo.update(props.sprintId, aborted.value);
+      if (!persistedBlocked.ok) {
+        log.error('failed to persist blocked task after resume', {
+          taskId: aborted.value.id,
+          error: persistedBlocked.error.message,
+        });
+        return Result.error(persistedBlocked.error);
+      }
       return Result.error(
         new InvalidStateError({
           entity: 'task',

--- a/src/business/task/start-attempt.ts
+++ b/src/business/task/start-attempt.ts
@@ -17,10 +17,13 @@ import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
  * Start a fresh `running` attempt on a task and persist the transition. Domain transition +
  * single-task repo update + log. The chain leaf adapts ctx → props → ctx.
  *
- * Resume semantics: if the task is already `in_progress` with a leftover `running` attempt
- * from a prior aborted chain (e.g. the user hit Ctrl+C or the host crashed mid-task), the
- * use case settles that attempt as `aborted` first, then opens a fresh attempt. This makes
- * the next Implement launch a transparent resume — no manual cleanup required.
+ * Resume semantics: if the task carries a leftover `running` attempt from a prior aborted chain
+ * (e.g. the user hit Ctrl+C or the host crashed mid-task), the use case settles that attempt as
+ * `aborted` first, then opens a fresh attempt. This makes the next Implement launch a transparent
+ * resume — no manual cleanup required. The trigger is the running attempt itself, NOT the carried
+ * status: a crash can persist a status-corrupt `todo` task whose last attempt is still `running`,
+ * and that is healed identically (the leftover attempt is aborted, the status repaired to
+ * `in_progress`, a fresh attempt opened) rather than dead-ending at `startNextAttempt`.
  *
  * Returns `BlockedTask` indirectly: when settling the prior attempt as aborted pushes the
  * task over `maxAttempts`, the domain transitions it to `blocked` and we surface that as a
@@ -51,9 +54,12 @@ export const startAttemptUseCase = async (
 
   // Resume path: a prior chain left a `running` attempt behind. Settle it as `aborted` before
   // appending a new one so the domain invariant ("only one running attempt at a time") holds.
+  // Keyed on the leftover running attempt — NOT on `status === 'in_progress'` — so a status-corrupt
+  // `todo` task whose last attempt is still `running` is recovered too (`failCurrentAttempt` repairs
+  // the status to `in_progress` as it settles) instead of dead-ending in `startNextAttempt`.
   let taskToStart: Task = props.task;
   let recovering: RecoveryContext | undefined;
-  if (props.task.status === 'in_progress' && hasRunningAttempt(props.task)) {
+  if (hasRunningAttempt(props.task)) {
     // Divergence guard: re-read the task from the repo and compare against the in-memory
     // copy before settling. A stale in-memory cache (e.g. another concurrent operation wrote
     // a new attempt or the operator manually patched tasks.json) would otherwise be silently

--- a/src/business/task/unblock-task.ts
+++ b/src/business/task/unblock-task.ts
@@ -2,8 +2,11 @@ import { Result } from '@src/domain/result.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import type { FindTasksBySprintId } from '@src/domain/repository/task/find-tasks-by-sprint-id.ts';
+import type { SaveAllTasks } from '@src/domain/repository/task/save-all-tasks.ts';
 import type { Task, TodoTask } from '@src/domain/entity/task.ts';
 import { resetTaskToTodo, unblockTask } from '@src/domain/entity/task-lifecycle.ts';
+import { upstreamBlockedDependents } from '@src/domain/entity/task-graph.ts';
 import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
@@ -14,8 +17,16 @@ import type { StorageError } from '@src/domain/value/error/storage-error.ts';
  * (crash recovery, watchdog kill). Both map to the same operator-visible "stuck" concept: the
  * task needs to be reset to `todo` so the next implement run can retry it.
  *
- * Policy: domain transition + persist + log. Idempotent — an already-`todo` task passes
- * through unchanged (mirrors {@link activateSprintUseCase}'s shape).
+ * **Cascade.** Unblocking a task ALSO re-arms its upstream-blocked dependents — the tasks the
+ * dependency gate parked because this one was not `done` (see {@link upstreamBlockedDependents}).
+ * So the operator fixes the root prerequisite, unblocks it once, and relaunches; the whole subtree
+ * the gate blocked is reset to `todo` in the same transaction rather than needing a manual unblock
+ * each. Own-failure blocks (eval/verify/budget) in the subtree are left untouched — they need a
+ * real fix. Re-arming is safe even when a dependent has a second still-blocked prerequisite: the
+ * dependency gate re-blocks it on the next run.
+ *
+ * Policy: domain transition + persist + log. Idempotent — an already-`todo` task passes through
+ * unchanged (mirrors {@link activateSprintUseCase}'s shape).
  *
  * `blocked` → {@link unblockTask} (strips `blockedReason`, resets to `todo`).
  * `in_progress` with a settled last attempt → {@link resetTaskToTodo} (crash-recovery path).
@@ -25,7 +36,8 @@ import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 export interface UnblockTaskProps {
   readonly task: Task;
   readonly sprintId: SprintId;
-  readonly taskRepo: UpdateTask;
+  /** Composite is supplied by callers; the use case needs read + atomic-rewrite for the cascade. */
+  readonly taskRepo: UpdateTask & FindTasksBySprintId & SaveAllTasks;
   readonly logger: Logger;
 }
 
@@ -41,11 +53,7 @@ export const unblockTaskUseCase = async (
     return Result.ok(props.task);
   }
 
-  log.debug('unblocking task', {
-    taskId: props.task.id,
-    sprintId: props.sprintId,
-    from: props.task.status,
-  });
+  log.debug('unblocking task', { taskId: props.task.id, sprintId: props.sprintId, from: props.task.status });
 
   // `in_progress` with a settled last attempt = crash-recovery path (Ctrl-C / watchdog kill).
   // Route through resetTaskToTodo, which guards against still-running attempts.
@@ -58,16 +66,65 @@ export const unblockTaskUseCase = async (
     });
     return Result.error(transitioned.error);
   }
+  const primary = transitioned.value;
 
-  const persisted = await props.taskRepo.update(props.sprintId, transitioned.value);
-  if (!persisted.ok) {
-    log.error('persist failed', { taskId: transitioned.value.id, error: persisted.error.message });
-    return Result.error(persisted.error);
+  // Load the sprint's tasks so we can cascade-unblock the dependency-gate subtree this task rooted.
+  const all = await props.taskRepo.findBySprintId(props.sprintId);
+  if (!all.ok) {
+    // Cascade is best-effort: if siblings can't be read, still persist the primary so the unblock
+    // isn't lost — the operator can re-run unblock to pick up any stranded dependents.
+    log.warn('could not load sibling tasks for cascade — unblocking primary only', {
+      taskId: primary.id,
+      error: all.error.message,
+    });
+    const persisted = await props.taskRepo.update(props.sprintId, primary);
+    if (!persisted.ok) {
+      log.error('persist failed', { taskId: primary.id, error: persisted.error.message });
+      return Result.error(persisted.error);
+    }
+    log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
+    return Result.ok(primary);
   }
 
-  log.info(`unblocked task '${transitioned.value.name}'`, {
-    taskId: transitioned.value.id,
-    sprintId: props.sprintId,
+  const dependentIds = new Set(upstreamBlockedDependents(all.value, primary.id));
+
+  // Common case — no upstream-blocked dependents to re-arm. Persist just the primary via the
+  // single-task `update` (no need to rewrite the whole list).
+  if (dependentIds.size === 0) {
+    const persisted = await props.taskRepo.update(props.sprintId, primary);
+    if (!persisted.ok) {
+      log.error('persist failed', { taskId: primary.id, error: persisted.error.message });
+      return Result.error(persisted.error);
+    }
+    log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
+    return Result.ok(primary);
+  }
+
+  // Cascade — rewrite the whole task list atomically so the primary AND its re-armed dependents
+  // land in one transaction.
+  const cascaded: TodoTask[] = [];
+  const nextTasks = all.value.map((t) => {
+    if (t.id === primary.id) return primary;
+    if (!dependentIds.has(t.id)) return t;
+    const reset = unblockTask(t);
+    if (!reset.ok) return t; // defensive: closure already filtered to blocked tasks
+    cascaded.push(reset.value);
+    return reset.value;
   });
-  return Result.ok(transitioned.value);
+
+  const saved = await props.taskRepo.saveAll(props.sprintId, nextTasks);
+  if (!saved.ok) {
+    log.error('persist failed', { taskId: primary.id, error: saved.error.message });
+    return Result.error(saved.error);
+  }
+
+  log.info(
+    `unblocked task '${primary.name}' (+${String(cascaded.length)} upstream dependent${cascaded.length === 1 ? '' : 's'} re-armed)`,
+    {
+      taskId: primary.id,
+      sprintId: props.sprintId,
+      cascaded: cascaded.map((t) => String(t.id)),
+    }
+  );
+  return Result.ok(primary);
 };

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -280,6 +280,22 @@ export const SettingsSchema = z.object({
      */
     maxParallelTasks: z.number().int().min(1).max(5),
   }),
+  /**
+   * Source-control-management preferences. Defaults the whole section so settings files
+   * written before this section existed parse without a schema-version bump or migration —
+   * the load path stamps the section in and the next `save()` writes it inline.
+   */
+  scm: z
+    .object({
+      /**
+       * Governs the default reviewer choice for the refine flow's "Post as comment" action,
+       * and — in non-interactive (CI / headless) runs — whether the refined requirements are
+       * posted as a comment on the linked issue at all. Defaults `false`: the original issue
+       * description is never touched, and posting a comment is strictly opt-in.
+       */
+      postRefinementComment: z.boolean().default(false),
+    })
+    .default({ postRefinementComment: false }),
   ui: z
     .object({
       notifications: z

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -253,12 +253,15 @@ export const SettingsSchema = z.object({
      */
     plateauThreshold: z.number().int().min(2).max(5).default(2),
     /**
-     * When the gen-eval loop exits on a plateau, escalate the generator's model one rung up
-     * the ladder defined by {@link escalationMap} (merged with the built-in
-     * `DEFAULT_ESCALATION_MAP`) and reissue the attempt instead of transitioning the task
-     * straight to `blocked`. Defaults `false` — the runtime wiring lands in a follow-up task.
+     * When the gen-eval loop exits on a plateau, grant one more attempt instead of settling
+     * immediately: escalate the generator one rung up the ladder ({@link escalationMap} merged
+     * with the built-in `DEFAULT_ESCALATION_MAP`) when a stronger model exists, and ALWAYS inject
+     * a "change your approach" directive into that attempt's generator turn (so a top-of-ladder
+     * model — e.g. the default Opus generator — still acts differently rather than re-iterating).
+     * A plateau never blocks: after the one retry, or when no attempt budget remains, the work is
+     * preserved (done-with-warning). Defaults `true`.
      */
-    escalateOnPlateau: z.boolean().default(false),
+    escalateOnPlateau: z.boolean().default(true),
     /**
      * User overrides for the built-in `DEFAULT_ESCALATION_MAP` (in
      * `business/task/escalation-map.ts`). Keys are the current model id, values the model id

--- a/src/domain/entity/task-graph.ts
+++ b/src/domain/entity/task-graph.ts
@@ -1,6 +1,7 @@
 import { Result } from '@src/domain/result.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import { isUpstreamBlocked } from '@src/domain/entity/task-lifecycle.ts';
 
 /**
  * Walk the attempt history (newest → oldest) and return the most recent non-empty `critique`.
@@ -44,6 +45,38 @@ export const nextAvailableTask = (tasks: readonly Task[]): Task | undefined => {
   if (ready.length === 0) return undefined;
 
   return ready.reduce((best, t) => (t.order < best.order ? t : best));
+};
+
+/**
+ * Transitive closure of UPSTREAM-blocked dependents of `rootId`: every task that is blocked
+ * solely because a prerequisite was not done ({@link isUpstreamBlocked}) and that depends —
+ * directly or through a chain of other upstream-blocked tasks — on `rootId`.
+ *
+ * Used by `unblockTaskUseCase` to cascade: unblocking a root prerequisite re-arms the whole
+ * subtree the dependency gate parked, so the operator fixes one task and relaunches instead of
+ * hand-unblocking each dependent. Own-failure blocks (eval/verify/budget) are NOT in the closure
+ * — those need a real fix, so they are never auto-cleared. `rootId` itself is excluded (the
+ * caller unblocks it directly). Re-arming is safe even if a dependent has a *second*, still-blocked
+ * prerequisite: the dependency gate re-blocks it on the next run.
+ *
+ * Pure — does not mutate.
+ *
+ * @public
+ */
+export const upstreamBlockedDependents = (tasks: readonly Task[], rootId: TaskId): readonly TaskId[] => {
+  const found = new Set<TaskId>();
+  const queue: TaskId[] = [rootId];
+  while (queue.length > 0) {
+    const cur = queue.shift() as TaskId;
+    for (const t of tasks) {
+      if (t.id === rootId || found.has(t.id)) continue;
+      if (t.dependsOn.includes(cur) && isUpstreamBlocked(t)) {
+        found.add(t.id);
+        queue.push(t.id);
+      }
+    }
+  }
+  return [...found];
 };
 
 /** Issue surfaced by {@link validateTaskGraph}. */

--- a/src/domain/entity/task-lifecycle.ts
+++ b/src/domain/entity/task-lifecycle.ts
@@ -3,6 +3,19 @@ import type { BlockedTask, Task, TodoTask } from '@src/domain/entity/task.ts';
 import { requireStatus } from '@src/domain/value/require-status.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 
+/**
+ * Reason-string prefix the dependency gate stamps on a task blocked solely because a prerequisite
+ * was not `done`. It distinguishes an UPSTREAM-cascade block (mechanically clearable — it auto-
+ * resolves once the root prerequisite is unblocked / completed) from an OWN-failure block
+ * (eval/verify/budget — needs the operator to actually fix something). {@link isUpstreamBlocked}
+ * reads it so `unblockTaskUseCase` can cascade-unblock these dependents when their root unblocks.
+ */
+export const BLOCKED_UPSTREAM_REASON_PREFIX = 'blocked upstream';
+
+/** True when `task` is blocked specifically because an upstream prerequisite was not done. */
+export const isUpstreamBlocked = (task: Task): task is BlockedTask =>
+  task.status === 'blocked' && task.blockedReason.startsWith(BLOCKED_UPSTREAM_REASON_PREFIX);
+
 export const markTaskBlocked = (task: Task, reason: string): Result<BlockedTask, InvalidStateError> => {
   const guard = requireStatus(
     'task',

--- a/src/domain/entity/task-settle.ts
+++ b/src/domain/entity/task-settle.ts
@@ -6,7 +6,7 @@ import {
   type RunningAttempt,
   type VerifiedAttempt,
 } from '@src/domain/entity/attempt.ts';
-import type { BlockedTask, DoneTask, InProgressTask, Task } from '@src/domain/entity/task.ts';
+import type { BlockedTask, DoneTask, InProgressTask, Task, TodoTask } from '@src/domain/entity/task.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { parseRequiredString } from '@src/domain/value/parsers/parse-required-string.ts';
 import { requireStatus } from '@src/domain/value/require-status.ts';
@@ -14,9 +14,9 @@ import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.t
 import { type ValidationError } from '@src/domain/value/error/validation-error.ts';
 
 const requireRunningAttempt = (
-  task: InProgressTask
+  task: TodoTask | InProgressTask
 ): Result<
-  { readonly task: InProgressTask; readonly running: RunningAttempt; readonly idx: number },
+  { readonly task: TodoTask | InProgressTask; readonly running: RunningAttempt; readonly idx: number },
   InvalidStateError
 > => {
   const idx = task.attempts.length - 1;
@@ -25,7 +25,7 @@ const requireRunningAttempt = (
     return Result.error(
       new InvalidStateError({
         entity: 'task',
-        currentState: 'in_progress',
+        currentState: task.status,
         attemptedAction: 'record-attempt',
         message: `task '${task.id}' has no running attempt to record into`,
         hint: 'Call startNextAttempt before recording.',
@@ -35,10 +35,13 @@ const requireRunningAttempt = (
   return Result.ok({ task, running: last, idx });
 };
 
-const replaceLastAttempt = (task: InProgressTask, attempt: Attempt): InProgressTask => {
+const replaceLastAttempt = (task: TodoTask | InProgressTask, attempt: Attempt): InProgressTask => {
   const next = [...task.attempts];
   next[task.attempts.length - 1] = attempt;
-  return { ...task, attempts: next };
+  // Force `in_progress`: a running attempt means the task IS in progress, so settling it always
+  // yields an `in_progress` task — even when a crash persisted a status-corrupt `todo` task whose
+  // last attempt was still `running`. This is the self-heal half of `failCurrentAttempt` below.
+  return { ...task, status: 'in_progress', attempts: next };
 };
 
 /**
@@ -88,7 +91,13 @@ export const markTaskDone = (task: Task, now: IsoTimestamp): Result<DoneTask, In
 /**
  * Settle the current attempt as `failed`/`malformed`/`aborted`. If `maxAttempts` is set and
  * reached, transitions the task to `blocked` with reason `'attempt budget exhausted'`. Otherwise
- * the task stays `in_progress` and the caller can `startNextAttempt` again.
+ * the task settles to `in_progress` and the caller can `startNextAttempt` again.
+ *
+ * The real precondition is "a running attempt exists" (enforced by `requireRunningAttempt`), not
+ * the task's nominal status — so this also heals a status-corrupt `todo` task whose last attempt is
+ * still `running` (the crash signature a prior process can persist). Such a task settles to a clean
+ * `in_progress`; a normal `todo` task with no running attempt is still rejected. The `start-attempt`
+ * use case relies on this to resume a crashed run regardless of the carried status.
  *
  * The optional `abortMeta` is forwarded to {@link completeAttempt} — meaningful only when
  * `reason === 'aborted'`. The `start-attempt` use case supplies it on the resume path so the
@@ -103,9 +112,9 @@ export const failCurrentAttempt = (
   const guard = requireStatus(
     'task',
     task,
-    ['in_progress'] as const,
+    ['todo', 'in_progress'] as const,
     'fail-current-attempt',
-    'Only `in_progress` tasks have a current attempt to fail.'
+    'Only a task carrying a running attempt can have its current attempt failed.'
   );
   if (!guard.ok) return Result.error(guard.error);
   const inner = requireRunningAttempt(guard.value);

--- a/src/integration/ai/prompts/_engine/renderers/task.ts
+++ b/src/integration/ai/prompts/_engine/renderers/task.ts
@@ -192,3 +192,26 @@ export const renderPriorCritiqueSection = (critique: string | undefined): string
     trimmed,
   ].join('\n');
 };
+
+/**
+ * "Change your approach" directive injected when this task is a plateau-break attempt — i.e. the
+ * gen-eval loop stalled (the same evaluator dimensions kept failing across rounds with no real
+ * progress) and the escalation policy granted one more attempt. Empty when not a plateau-break
+ * attempt. The point is to break the model out of iterating on a non-converging path: it is told
+ * the previous strategy is stuck and to try a fundamentally different one, rather than nudging the
+ * same diff again. Pairs with the Prior Critique section (which still carries the specific failing
+ * dimensions). Generator-only — the evaluator never sees it (its rubric is held constant).
+ */
+export const renderPlateauDirectiveSection = (plateauBreak: boolean): string => {
+  if (!plateauBreak) return '';
+  return [
+    '## ⚠ You have plateaued — change your approach',
+    '',
+    'Earlier attempts at this task stalled: the same checks kept failing across multiple rounds with',
+    'no real progress. Do NOT keep iterating on the previous approach — that path is not converging.',
+    'Step back and rethink. Re-read the task contract and the prior critique, question the assumption',
+    'that led the earlier attempts astray, and implement a **fundamentally different** solution — a',
+    'different design, data flow, or code path. Then verify the failing criteria directly before',
+    'signalling completion.',
+  ].join('\n');
+};

--- a/src/integration/ai/prompts/implement/definition.ts
+++ b/src/integration/ai/prompts/implement/definition.ts
@@ -218,9 +218,13 @@ export interface BuildImplementPromptInput {
    */
   readonly priorCritique?: string;
   /**
-   * True when this attempt is a plateau-break: the gen-eval loop stalled and the escalation policy
-   * granted one more attempt (with or without a model bump). Renders the "change your approach"
-   * directive. The generator leaf sets it from `task.escalatedFromModel !== undefined`. Default false.
+   * True once the escalation policy has fired for this task — the gen-eval loop stalled and one more
+   * attempt was granted (with or without a model bump). Renders the "change your approach" directive.
+   * The generator leaf sets it from `task.escalatedFromModel !== undefined`, which is a write-once,
+   * task-lifetime flag — so the directive renders on EVERY generator turn from the escalated attempt
+   * onward (every turn of that attempt, and any further attempt the task takes), not just one turn.
+   * That is intentional and harmless: re-telling the generator to change approach costs nothing and
+   * the once-per-task escalation cap still bounds the model bump. Default false (pre-escalation).
    */
   readonly plateauBreak?: boolean;
   /**

--- a/src/integration/ai/prompts/implement/definition.ts
+++ b/src/integration/ai/prompts/implement/definition.ts
@@ -5,6 +5,7 @@ import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/_engine/build-prompt.ts';
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
 import {
+  renderPlateauDirectiveSection,
   renderPriorCritiqueSection,
   renderProjectToolingSection,
   renderTaskDescriptionSection,
@@ -21,6 +22,7 @@ import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/templat
 export {
   renderVerifyScriptSection,
   renderPriorCritiqueSection,
+  renderPlateauDirectiveSection,
   renderProjectToolingSection,
   renderTaskDescriptionSection,
   renderTaskStepsSection,
@@ -78,6 +80,12 @@ export interface ImplementPromptParams {
    * the generator's fix attempt addresses the same dimensions the evaluator flagged.
    */
   readonly priorCritiqueSection: string;
+  /**
+   * "## ⚠ You have plateaued — change your approach" block — empty unless this is a plateau-break
+   * attempt (the gen-eval loop stalled and the escalation policy granted one more attempt). Tells
+   * the generator to abandon the non-converging approach and try a fundamentally different one.
+   */
+  readonly plateauDirectiveSection: string;
   /**
    * Audit-[09] output contract section — rendered from the generator's `AiOutputContract` by
    * `renderContractSectionFor(generatorOutputContract)`. Tells the AI to write exactly one
@@ -157,6 +165,11 @@ export const implementPromptDef: PromptDefinition<ImplementPromptParams> = {
       placeholder: 'PRIOR_CRITIQUE_SECTION',
       description: '"## Prior Critique" markdown block — empty on turn 1, the evaluator\'s failed critique on turn 2+.',
     },
+    plateauDirectiveSection: {
+      placeholder: 'PLATEAU_DIRECTIVE_SECTION',
+      description:
+        '"## ⚠ You have plateaued — change your approach" block — empty unless this is a plateau-break attempt.',
+    },
     outputContractSection: {
       placeholder: 'OUTPUT_CONTRACT_SECTION',
       description:
@@ -205,6 +218,12 @@ export interface BuildImplementPromptInput {
    */
   readonly priorCritique?: string;
   /**
+   * True when this attempt is a plateau-break: the gen-eval loop stalled and the escalation policy
+   * granted one more attempt (with or without a model bump). Renders the "change your approach"
+   * directive. The generator leaf sets it from `task.escalatedFromModel !== undefined`. Default false.
+   */
+  readonly plateauBreak?: boolean;
+  /**
    * Pre-rendered audit-[09] output contract section. The leaf composes this via
    * `renderContractSectionFor(generatorOutputContract)` before calling the builder so the
    * prompt module stays agnostic of the per-leaf contract.
@@ -233,5 +252,6 @@ export const buildImplementPrompt = async (
     progressFile: input.progressFile,
     priorProgress: input.priorProgress,
     priorCritiqueSection: renderPriorCritiqueSection(input.priorCritique),
+    plateauDirectiveSection: renderPlateauDirectiveSection(input.plateauBreak ?? false),
     outputContractSection: input.outputContractSection,
   });

--- a/src/integration/ai/prompts/implement/template.md
+++ b/src/integration/ai/prompts/implement/template.md
@@ -52,6 +52,8 @@ under its declared check type.
 
 {{VERIFICATION_CRITERIA_SECTION}}
 
+<plateau_directive>{{PLATEAU_DIRECTIVE_SECTION}}</plateau_directive>
+
 <prior_critique>{{PRIOR_CRITIQUE_SECTION}}</prior_critique>
 
 <prior_progress>

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -184,6 +184,16 @@ export const buildCodexArgs = (
   return Result.ok(args);
 };
 
+/**
+ * Stale-resume detection. Codex persists each session as a "rollout"; after a crash / abort /
+ * expiry the rollout can vanish, so a subsequent `codex exec resume <id>` exits non-zero with
+ * "thread/resume failed: no rollout found for thread id … (code -32600)". The gen-eval loop
+ * threads the prior round's session id as `session.resume`, so a lost rollout would otherwise
+ * block the task on an evaluator/generator turn that never ran. We detect that exact failure
+ * and fall back to a cold spawn instead. Matches the message verbatim plus the JSON-RPC code.
+ */
+const RESUME_STALE_RE = /no rollout found|thread\/resume failed|code -32600/i;
+
 let tempCounter = 0;
 const defaultMkTempPath = (): string => {
   tempCounter += 1;
@@ -208,7 +218,9 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
       const outputFile = mkTempPath();
       const argsResult = buildCodexArgs(session, { outputFile });
       if (!argsResult.ok) return Result.error(argsResult.error) as Result<ProviderOutput, DomainError>;
-      const args = argsResult.value;
+      let args = argsResult.value;
+      // Latch so the stale-resume cold fallback fires at most once per generate() call.
+      let coldRetried = false;
 
       try {
         const maxAttempts = deps.rateLimitRetries + 1;
@@ -262,6 +274,31 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
               }
             }
             continue;
+          }
+          // Resume resilience: a `resume` spawn that fails because codex no longer has the
+          // rollout ("no rollout found", code -32600) would otherwise block the task. Fall
+          // back to a COLD spawn (no --resume) exactly once. Decrementing `attempt` keeps the
+          // fallback from consuming a rate-limit slot; the `coldRetried` latch bounds it.
+          if (!coldRetried && session.resume !== undefined && RESUME_STALE_RE.test(outcome.error.message)) {
+            coldRetried = true;
+            deps.eventBus.publish({
+              type: 'log',
+              level: 'warn',
+              message: 'codex-provider: resume thread not found — retrying cold (dropping --resume)',
+              meta: { resume: String(session.resume) },
+              at: IsoTimestamp.now(),
+            });
+            // Drop the stale resume id so buildCodexArgs takes the cold-start path. `delete`
+            // on a spread copy (never the caller's session) — `exactOptionalPropertyTypes`
+            // forbids re-setting `resume: undefined`, so omit the key entirely.
+            const coldSession: AiSession = { ...session };
+            delete (coldSession as { resume?: unknown }).resume;
+            const coldArgs = buildCodexArgs(coldSession, { outputFile });
+            if (coldArgs.ok) {
+              args = coldArgs.value;
+              attempt--;
+              continue;
+            }
           }
           return Result.error(outcome.error) as Result<ProviderOutput, DomainError>;
         }

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -190,7 +190,14 @@ export const buildCodexArgs = (
  * "thread/resume failed: no rollout found for thread id … (code -32600)". The gen-eval loop
  * threads the prior round's session id as `session.resume`, so a lost rollout would otherwise
  * block the task on an evaluator/generator turn that never ran. We detect that exact failure
- * and fall back to a cold spawn instead. Matches the message verbatim plus the JSON-RPC code.
+ * and fall back to a cold spawn instead.
+ *
+ * The two textual alternatives match the canonical message verbatim; `code -32600` is an
+ * intentionally broad backstop (it is the generic JSON-RPC "Invalid Request" code, not unique to a
+ * lost rollout). A spurious match only ever triggers ONE benign cold respawn — the prompt is
+ * self-contained, so the cost is losing the in-thread conversation memory, never correctness — and
+ * the `coldRetried` latch bounds it. Kept broad on purpose so a future codex build that drops the
+ * textual wording but keeps the code still self-heals.
  */
 const RESUME_STALE_RE = /no rollout found|thread\/resume failed|code -32600/i;
 
@@ -279,7 +286,17 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
           // rollout ("no rollout found", code -32600) would otherwise block the task. Fall
           // back to a COLD spawn (no --resume) exactly once. Decrementing `attempt` keeps the
           // fallback from consuming a rate-limit slot; the `coldRetried` latch bounds it.
-          if (!coldRetried && session.resume !== undefined && RESUME_STALE_RE.test(outcome.error.message)) {
+          //
+          // Exempt an aborted run explicitly: a user cancel (Ctrl-C / TUI abort) must tear the run
+          // down, not spawn fresh work a competitor may now own. Today an AbortError's message
+          // wouldn't match RESUME_STALE_RE, so this is belt-and-braces — but it keeps the abort
+          // guarantee independent of how the abort path happens to word its error.
+          if (
+            !coldRetried &&
+            session.abortSignal?.aborted !== true &&
+            session.resume !== undefined &&
+            RESUME_STALE_RE.test(outcome.error.message)
+          ) {
             coldRetried = true;
             deps.eventBus.publish({
               type: 'log',

--- a/src/integration/io/shell-script-runner.ts
+++ b/src/integration/io/shell-script-runner.ts
@@ -76,31 +76,48 @@ export const createShellScriptRunner = (deps: ShellScriptRunnerDeps = {}): Shell
           cwd: String(cwd),
           shell: true,
           detached: process.platform !== 'win32',
-          // Narrow non-interactive defaults — applied per-tool so we don't silently change the
-          // meaning of user-authored scripts. Setting blanket `CI=true` would trip
-          // `@DisabledIfEnvironmentVariable("CI")` test skips in Spring Boot, change Maven
-          // Surefire behaviour, and toggle countless other toolchain heuristics. Each entry
-          // below is read by exactly one tool family:
+          // Non-interactive defaults for the spawned setup/verify child. These live on the CHILD
+          // env only — ralphctl's own process env is untouched, so they never alter how the
+          // harness itself detects CI / colour.
           //
-          //   npm_config_confirm_modules_purge=false   — pnpm only; suppresses the
-          //     `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` prompt when pnpm decides to wipe
-          //     `node_modules/` (lockfile / store mismatch). The same setting is also exposed
-          //     as `.npmrc:confirm-modules-purge=false` and `--config.confirm-modules-purge=false`.
+          //   CI=true   — setup/verify scripts run headless (no TTY). pnpm 11 hardened its
+          //     `node_modules` purge to ABORT without a TTY instead of re-creating it silently
+          //     (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, pnpm/pnpm#9966 / #11562). On
+          //     pnpm 11 EVERY `confirm-modules-purge=false` form is ignored at the abort site —
+          //     verified against 11.1.3: the `npm_config_*` env, the `PNPM_CONFIG_*` env, and a
+          //     local `.npmrc` all still abort; only `CI=true` (env) or
+          //     `--config.confirm-modules-purge=false` (a CLI flag) suppress it. We run the
+          //     user's script as an opaque shell string and cannot inject a flag into their
+          //     `pnpm` invocation, so `CI=true` is the one lever available. It is also the honest
+          //     signal — this IS an automated, non-interactive context. Set on BOTH setup and
+          //     verify (both flow through this runner), so the two phases share one env and never
+          //     drift on baseline. Caveat: JVM tests gated on
+          //     `@DisabledIfEnvironmentVariable("CI")` skip — by design for automation, and
+          //     symmetric across setup/verify. (This deliberately reverses the earlier
+          //     "do NOT reach for CI=true" policy, which assumed a narrow pnpm flag would work —
+          //     it does not on pnpm 11.)
           //
-          //   NO_COLOR=1   — the well-defined cross-tool convention (https://no-color.org)
-          //     suppresses ANSI colour codes in tool output. The harness persists script
-          //     output verbatim to `<sprintDir>/logs/{setup,verify}/...` plain-text files;
-          //     without this default the logs fill with `^[[1m^[[30m…` escape sequences that
-          //     render as garbage in editors. Honoured by Node / Python / Rust / Go / Ruby
-          //     and modern CLI tools; tools that don't recognise it ignore it harmlessly.
-          //     Exception: JVM tools (Maven / Gradle / sbt) do NOT respect `NO_COLOR` — those
-          //     are handled at script-authoring time by the `detect-scripts` prompt suggesting
-          //     `mvn -B`, `gradle --console=plain`, `sbt -no-colors`.
+          //   PNPM_CONFIG_FROZEN_LOCKFILE=false   — `CI=true` also flips pnpm's `frozen-lockfile`
+          //     default to true, which would fail a bare `pnpm install` on a drifted lockfile
+          //     (`ERR_PNPM_OUTDATED_LOCKFILE`) — trading one abort for another. The pnpm-native
+          //     `PNPM_CONFIG_` prefix IS honoured here (unlike the broken `npm_config_` form),
+          //     so this restores the pre-CI install semantics: non-frozen, exactly as before.
           //
-          // Add more entries here as we hit narrow per-tool prompts; do NOT reach for `CI=true`.
-          // Defaults sit BEFORE `...process.env` so a user who exports `NO_COLOR=` (empty) or
-          // `FORCE_COLOR=1` can override; caller-supplied `opts.env` wins last.
-          env: { npm_config_confirm_modules_purge: 'false', NO_COLOR: '1', ...process.env, ...opts.env },
+          //   NO_COLOR=1   — the cross-tool convention (https://no-color.org). Persisted
+          //     setup/verify logs are plain text; without this they fill with `^[[1m…` escape
+          //     sequences that render as garbage in editors. Honoured by Node / Python / Rust /
+          //     Go / Ruby and modern CLIs; unknown to JVM tools (Maven / Gradle / sbt) — those
+          //     are handled at script-authoring time via `mvn -B`, `gradle --console=plain`.
+          //
+          // Defaults sit BEFORE `...process.env` so a user can override any of them (e.g. export
+          // `CI=` to opt out, `NO_COLOR=` / `FORCE_COLOR=1` for colour); `opts.env` wins last.
+          env: {
+            CI: 'true',
+            PNPM_CONFIG_FROZEN_LOCKFILE: 'false',
+            NO_COLOR: '1',
+            ...process.env,
+            ...opts.env,
+          },
         });
       } catch (cause) {
         resolve(

--- a/src/integration/scm/issue-pusher.ts
+++ b/src/integration/scm/issue-pusher.ts
@@ -1,18 +1,19 @@
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { IssuePusher } from '@src/business/scm/issue-pusher.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 import { runCli } from '@src/integration/io/run-cli.ts';
 import type { Spawn } from '@src/integration/io/spawn.ts';
 import { parseIssueUrl } from '@src/integration/scm/issue-fetcher.ts';
 
 /**
  * CLI-backed `IssuePusher`. Same shape as {@link createIssueFetcher}: dispatches to `gh` or
- * `glab` based on the URL host (for updates) or the configured `provider` (for creates). Auth
- * is whatever the user already has configured for those tools — we don't store tokens.
+ * `glab` based on the URL host. Auth is whatever the user already has configured for those
+ * tools — we don't store tokens.
  *
- * The body is passed through stdin (`gh issue edit --body-file -`, `glab issue update
- * --description-file -`) so embedded newlines / markdown / quotes round-trip cleanly.
+ * The body is posted as a comment — the issue's own description is never modified. GitHub
+ * reads the comment body from stdin (`gh issue comment --body-file -`) so embedded newlines /
+ * markdown / quotes round-trip cleanly; glab takes it as a `--body` flag value (each argv
+ * element is marshalled as a separate exec arg, so no shell parsing mangles it).
  *
  * Errors:
  *  - CLI not installed → `StorageError(subCode: 'io', message: '<cli> not installed …')`
@@ -22,17 +23,17 @@ import { parseIssueUrl } from '@src/integration/scm/issue-fetcher.ts';
 
 const CLI_TIMEOUT_MS = 30_000;
 
-const updateGitHub = async (
+const commentGitHub = async (
   spawn: Spawn,
   url: string,
   body: string,
   parsed: { owner: string; repo: string; number: number }
 ): Promise<Result<void, StorageError>> => {
-  // `gh issue edit <number> --repo <owner>/<repo> --body-file -` reads body from stdin.
+  // `gh issue comment <number> --repo <owner>/<repo> --body-file -` reads body from stdin.
   const r = await runCli(
     spawn,
     'gh',
-    ['issue', 'edit', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--body-file', '-'],
+    ['issue', 'comment', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--body-file', '-'],
     { stdin: body, timeoutMs: CLI_TIMEOUT_MS }
   );
   if (!r.ok) return Result.error(r.error);
@@ -40,26 +41,26 @@ const updateGitHub = async (
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `gh issue edit failed: ${r.value.stderr.trim() || 'unknown error'} (url=${url})`,
+        message: `gh issue comment failed: ${r.value.stderr.trim() || 'unknown error'} (url=${url})`,
       })
     );
   }
   return Result.ok(undefined);
 };
 
-const updateGitLab = async (
+const commentGitLab = async (
   spawn: Spawn,
   url: string,
   body: string,
   parsed: { owner: string; repo: string; number: number }
 ): Promise<Result<void, StorageError>> => {
-  // `glab issue update <number> --repo <owner>/<repo> --description <body>` — glab doesn't
-  // accept the body via stdin, so we pass it as a flag value. Markdown / newlines survive
-  // because spawn marshals each argv element as a separate exec arg (no shell parsing).
+  // `glab issue comment <number> --repo <owner>/<repo> --body <body>` — glab doesn't accept
+  // the body via stdin, so we pass it as a flag value. Markdown / newlines survive because
+  // spawn marshals each argv element as a separate exec arg (no shell parsing).
   const r = await runCli(
     spawn,
     'glab',
-    ['issue', 'update', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--description', body],
+    ['issue', 'comment', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--body', body],
     { timeoutMs: CLI_TIMEOUT_MS }
   );
   if (!r.ok) return Result.error(r.error);
@@ -67,84 +68,11 @@ const updateGitLab = async (
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `glab issue update failed: ${r.value.stderr.trim() || 'unknown error'} (url=${url})`,
+        message: `glab issue comment failed: ${r.value.stderr.trim() || 'unknown error'} (url=${url})`,
       })
     );
   }
   return Result.ok(undefined);
-};
-
-const createGitHub = async (
-  spawn: Spawn,
-  origin: IssueOriginRef,
-  title: string,
-  body: string
-): Promise<Result<{ readonly url: string }, StorageError>> => {
-  const r = await runCli(
-    spawn,
-    'gh',
-    ['issue', 'create', '--repo', `${origin.owner}/${origin.repo}`, '--title', title, '--body-file', '-'],
-    { stdin: body, timeoutMs: CLI_TIMEOUT_MS }
-  );
-  if (!r.ok) return Result.error(r.error);
-  if (r.value.exitCode !== 0) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: `gh issue create failed: ${r.value.stderr.trim() || 'unknown error'}`,
-      })
-    );
-  }
-  // gh prints the URL on stdout when successful.
-  const url = extractUrl(r.value.stdout);
-  if (url === undefined) {
-    return Result.error(
-      new StorageError({
-        subCode: 'parse',
-        message: `gh issue create succeeded but no URL found in stdout: ${r.value.stdout.length > 200 ? `${r.value.stdout.slice(0, 199)}…` : r.value.stdout}`,
-      })
-    );
-  }
-  return Result.ok({ url });
-};
-
-const createGitLab = async (
-  spawn: Spawn,
-  origin: IssueOriginRef,
-  title: string,
-  body: string
-): Promise<Result<{ readonly url: string }, StorageError>> => {
-  const r = await runCli(
-    spawn,
-    'glab',
-    ['issue', 'create', '--repo', `${origin.owner}/${origin.repo}`, '--title', title, '--description', body],
-    { timeoutMs: CLI_TIMEOUT_MS }
-  );
-  if (!r.ok) return Result.error(r.error);
-  if (r.value.exitCode !== 0) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: `glab issue create failed: ${r.value.stderr.trim() || 'unknown error'}`,
-      })
-    );
-  }
-  const url = extractUrl(r.value.stdout);
-  if (url === undefined) {
-    return Result.error(
-      new StorageError({
-        subCode: 'parse',
-        message: `glab issue create succeeded but no URL found in stdout: ${r.value.stdout.length > 200 ? `${r.value.stdout.slice(0, 199)}…` : r.value.stdout}`,
-      })
-    );
-  }
-  return Result.ok({ url });
-};
-
-/** First http(s) URL we find on stdout. Both gh and glab emit `https://…/issues/<n>` post-create. */
-const extractUrl = (out: string): string | undefined => {
-  const m = /(https?:\/\/\S+)/u.exec(out);
-  return m?.[1];
 };
 
 export interface IssuePusherDeps {
@@ -152,7 +80,7 @@ export interface IssuePusherDeps {
 }
 
 export const createIssuePusher = (deps: IssuePusherDeps): IssuePusher => ({
-  async update(url, { body }) {
+  async comment(url, { body }) {
     const parsed = parseIssueUrl(url);
     if (parsed === null) {
       return Result.error(
@@ -162,11 +90,7 @@ export const createIssuePusher = (deps: IssuePusherDeps): IssuePusher => ({
         })
       );
     }
-    if (parsed.host === 'github') return updateGitHub(deps.spawn, url, body, parsed);
-    return updateGitLab(deps.spawn, url, body, parsed);
-  },
-  async create(origin, { title, body }) {
-    if (origin.provider === 'github') return createGitHub(deps.spawn, origin, title, body);
-    return createGitLab(deps.spawn, origin, title, body);
+    if (parsed.host === 'github') return commentGitHub(deps.spawn, url, body, parsed);
+    return commentGitLab(deps.spawn, url, body, parsed);
   },
 });

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -2092,10 +2092,10 @@ describe('createImplementFlow — gen-eval loop', () => {
   // path produces a genuine second attempt; `maxAttempts === 1` collapses to one iteration;
   // an abort propagates verbatim with no extra iteration.
 
-  it('escalation across attempts: attempt 1 plateaus + escalates → attempt 2 runs (settle fires again) → 2nd plateau blocks', async () => {
+  it('escalation across attempts: attempt 1 plateaus + escalates → attempt 2 runs (settle fires again) → 2nd plateau preserves work', async () => {
     // maxAttempts 3 so the escalation budget doesn't pre-empt the policy. Generator on a model
-    // (`claude-sonnet-4-6`) that HAS a default escalation rung (→ `claude-opus-4-8`); without a
-    // rung the policy would `no-mapping`-block on the first plateau and never reach attempt 2.
+    // (`claude-sonnet-4-6`) that HAS a default escalation rung (→ `claude-opus-4-8`). A plateau on
+    // a top-of-ladder model now nudges (same model) rather than blocking, so attempt 2 always runs.
     const f = await buildFixture(1, 3);
     tracking(f);
     const sprintRepo = inMemorySprintRepo(f.sprint);
@@ -2148,10 +2148,10 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(runner.status).toBe('completed');
 
     // Two attempts ran in ONE launch — the outer loop re-entered after the escalation kept the
-    // task in_progress. Attempt 1 settled `failed` (escalation), attempt 2 settled into the
-    // block. Both attempts are recorded on the task.
+    // task in_progress. Attempt 1 settled `failed` (escalation), attempt 2 plateaued again and —
+    // a plateau never blocks — the work is preserved (done-with-warning). Both attempts recorded.
     const finalTask = taskRepo.tasks()[0];
-    expect(finalTask?.status).toBe('blocked');
+    expect(finalTask?.status).toBe('done');
     expect(finalTask?.attempts).toHaveLength(2);
 
     // The settle leaf ran once per attempt — exactly two `settle-attempt-<id>` trace entries.
@@ -2164,13 +2164,11 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(startEntries).toHaveLength(2);
 
     // Escalation stamped exactly once: from the configured sonnet to the opus rung. A second
-    // escalation on the second plateau is suppressed (once-per-task cap) — the task blocks
-    // instead, with the already-escalated reason.
+    // escalation on the second plateau is suppressed (once-per-task cap) — the work is preserved
+    // (done-with-warning) instead of blocking.
     expect(finalTask?.escalatedFromModel).toBe('claude-sonnet-4-6');
     expect(finalTask?.escalatedToModel).toBe('claude-opus-4-8');
-    if (finalTask?.status === 'blocked') {
-      expect(finalTask.blockedReason).toContain('plateau persists after escalation');
-    }
+    expect(finalTask?.status).not.toBe('blocked');
 
     // Attempt 2's generator spawned on the ESCALATED model — proof the second iteration didn't
     // just re-run identical work. The first generator sessions ran on sonnet; a later one ran
@@ -2179,15 +2177,15 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(generatorModels).toContain('claude-sonnet-4-6');
     expect(generatorModels).toContain('claude-opus-4-8');
 
-    // No `done` task → sprint stays `active`, re-runnable after the operator addresses the block.
-    expect(sprintRepo.current().status).toBe('active');
+    // The plateau preserved the work as `done`, so the run finished and the sprint moves to review.
+    expect(sprintRepo.current().status).toBe('review');
   });
 
   it('maxAttempts === 1: the outer loop runs exactly one iteration (single-attempt-per-launch parity)', async () => {
     // Regression guard for the byte-for-byte parity claim. Even with escalation ON and a model
     // that has a rung, a `maxAttempts` of 1 must collapse the outer loop to a single iteration:
     // attempt 1 plateaus, the escalation budget is already exhausted (attempts === maxAttempts),
-    // the task blocks, and the loop stops. The escalated model is never spawned.
+    // the work is preserved (done-with-warning), and the loop stops. The escalated model is never spawned.
     const f = await buildFixture(1, 1);
     tracking(f);
     const sprintRepo = inMemorySprintRepo(f.sprint);
@@ -2244,14 +2242,15 @@ describe('createImplementFlow — gen-eval loop', () => {
     const startEntries = runner.trace.filter((e) => e.elementName === `start-attempt-${String(finalTask?.id)}`);
     expect(startEntries).toHaveLength(1);
 
-    // The task blocked at the cap (plateau + budget-exhausted), never escalated, and the
-    // escalated model was never spawned — only sonnet ran.
-    expect(finalTask?.status).toBe('blocked');
+    // Plateau on the only allowed attempt (budget-exhausted) preserves the work as `done` — never
+    // escalated, and the escalated model was never spawned — only sonnet ran.
+    expect(finalTask?.status).toBe('done');
     expect(finalTask?.escalatedToModel).toBeUndefined();
     const generatorModels = provider.recordedSessions.filter((s) => s.role === 'generator').map((s) => s.model);
     expect(generatorModels.every((m) => m === 'claude-sonnet-4-6')).toBe(true);
 
-    expect(sprintRepo.current().status).toBe('active');
+    // One done task → the run finished and the sprint moves to review.
+    expect(sprintRepo.current().status).toBe('review');
   });
 
   it('abort mid-loop: AbortError propagates and no second attempt iteration starts', async () => {

--- a/tests/e2e/flows/refine.test.ts
+++ b/tests/e2e/flows/refine.test.ts
@@ -17,7 +17,6 @@ import type {
 } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { IssueFetcher } from '@src/business/scm/issue-fetcher.ts';
 import type { IssuePusher } from '@src/business/scm/issue-pusher.ts';
-import type { IssueOriginRef } from '@src/domain/entity/project.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -308,7 +307,7 @@ describe('createRefineFlow — interactive', () => {
     expect(eventLog.some((e) => e.level === 'warn' && e.message.includes('fetch failed'))).toBe(true);
   });
 
-  it('reviewer picks "approve & update" → IssuePusher.update is called with body + footer', async () => {
+  it('reviewer picks "Post as comment" → IssuePusher.comment is called with body + signature', async () => {
     const link = (() => {
       const r = parseHttpUrl('link', 'https://github.com/x/y/issues/42');
       if (!r.ok) throw new Error('test setup');
@@ -321,20 +320,15 @@ describe('createRefineFlow — interactive', () => {
     const refinedBody = '# refined requirements\n- a real acceptance criterion';
     const fake = fakeInteractiveAi(() => refinedBody);
 
-    interface UpdateCall {
+    interface CommentCall {
       readonly url: string;
       readonly body: string;
     }
-    const updateCalls: UpdateCall[] = [];
-    const createCalls: unknown[] = [];
+    const commentCalls: CommentCall[] = [];
     const issuePusher: IssuePusher = {
-      async update(url, args) {
-        updateCalls.push({ url, body: args.body });
+      async comment(url, args) {
+        commentCalls.push({ url, body: args.body });
         return Result.ok(undefined);
-      },
-      async create(origin, args) {
-        createCalls.push({ origin, args });
-        return Result.ok({ url: 'https://example.invalid/should-not-be-called' });
       },
     };
 
@@ -364,57 +358,45 @@ describe('createRefineFlow — interactive', () => {
       }
     );
 
-    const runner = createRunner({ id: 'r-refine-update', element: flow, initialCtx: { sprintId: sprint.id } });
+    const runner = createRunner({ id: 'r-refine-comment', element: flow, initialCtx: { sprintId: sprint.id } });
     await runner.start();
 
     expect(runner.status).toBe('completed');
-    // The pusher was used in update mode exactly once, on the existing link.
-    expect(createCalls).toHaveLength(0);
-    expect(updateCalls).toHaveLength(1);
-    const call = updateCalls[0];
+    // The pusher posted a comment exactly once, on the existing link.
+    expect(commentCalls).toHaveLength(1);
+    const call = commentCalls[0];
     expect(call?.url).toBe('https://github.com/x/y/issues/42');
-    // Body carries the AI's content plus the "Refined by ralphctl" footer.
+    // Body carries the AI's content plus the ralphctl signature naming the sprint.
     expect(call?.body).toContain(refinedBody);
-    expect(call?.body).toMatch(/Refined by ralphctl/);
-    // Local sprint persisted with the approved ticket — the link stays untouched on an update.
+    expect(call?.body).toMatch(/Posted by \[ralphctl\]/);
+    expect(call?.body).toContain(`Sprint ${String(sprint.id)}`);
+    // Local sprint persisted with the approved ticket — the link is untouched (no create path).
     expect(saves).toHaveLength(1);
     const persistedTicket = saves[0]?.tickets[0];
     expect(persistedTicket?.status).toBe('approved');
     expect(String(persistedTicket?.link)).toBe('https://github.com/x/y/issues/42');
   });
 
-  it('reviewer picks "approve & create" → IssuePusher.create runs and returned URL is attached to ticket.link', async () => {
-    // Ticket starts WITHOUT a link; project carries a defaultIssueOrigin so the launcher would
-    // have shown "Approve & create origin". The reviewer picks it.
-    const { sprint, tickets } = draftWithPending(1);
-    const { repo, saves } = inMemoryRepo(sprint);
+  it('non-interactive run with postRefinementComment → comments on a linked ticket without prompting', async () => {
+    const link = (() => {
+      const r = parseHttpUrl('link', 'https://github.com/x/y/issues/99');
+      if (!r.ok) throw new Error('test setup');
+      return r.value;
+    })();
+    const { sprint, tickets } = draftWithPending(1, (_i, t) => ({ ...t, link }));
+    const { repo } = inMemoryRepo(sprint);
     const eventBus = createInMemoryEventBus();
 
     const refinedBody = '# refined\n- something';
     const fake = fakeInteractiveAi(() => refinedBody);
 
-    const defaultIssueOrigin: IssueOriginRef = { provider: 'github', owner: 'acme', repo: 'widgets' };
-    const createdUrl = 'https://github.com/acme/widgets/issues/7';
-
-    interface CreateCall {
-      readonly origin: IssueOriginRef;
-      readonly title: string;
-      readonly body: string;
-    }
-    const createCalls: CreateCall[] = [];
-    const updateCalls: unknown[] = [];
+    const commentCalls: Array<{ url: string; body: string }> = [];
     const issuePusher: IssuePusher = {
-      async update(url, args) {
-        updateCalls.push({ url, args });
+      async comment(url, args) {
+        commentCalls.push({ url, body: args.body });
         return Result.ok(undefined);
       },
-      async create(origin, args) {
-        createCalls.push({ origin, title: args.title, body: args.body });
-        return Result.ok({ url: createdUrl });
-      },
     };
-
-    const reviewBeforeApprove = async () => ({ accept: true, alsoUpdateOrigin: true });
 
     const flow = createRefineFlow(
       {
@@ -429,8 +411,8 @@ describe('createRefineFlow — interactive', () => {
         skillSource: emptySkillSource,
         clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
         issuePusher,
-        defaultIssueOrigin,
-        reviewBeforeApprove,
+        // No reviewBeforeApprove — headless. The setting alone governs.
+        postRefinementComment: true,
       },
       {
         sprintId: sprint.id,
@@ -441,23 +423,59 @@ describe('createRefineFlow — interactive', () => {
       }
     );
 
-    const runner = createRunner({ id: 'r-refine-create', element: flow, initialCtx: { sprintId: sprint.id } });
+    const runner = createRunner({ id: 'r-refine-headless', element: flow, initialCtx: { sprintId: sprint.id } });
     await runner.start();
 
     expect(runner.status).toBe('completed');
-    // Create-mode push exactly once, on the project's defaultIssueOrigin.
-    expect(updateCalls).toHaveLength(0);
-    expect(createCalls).toHaveLength(1);
-    const call = createCalls[0];
-    expect(call?.origin).toEqual(defaultIssueOrigin);
-    expect(call?.title).toBe(tickets[0]!.title);
-    expect(call?.body).toContain(refinedBody);
-    expect(call?.body).toMatch(/Refined by ralphctl/);
-    // The chain attached the returned URL to ticket.link AND persisted it.
-    expect(saves).toHaveLength(1);
-    const persistedTicket = saves[0]?.tickets[0];
-    expect(persistedTicket?.status).toBe('approved');
-    expect(String(persistedTicket?.link)).toBe(createdUrl);
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0]?.url).toBe('https://github.com/x/y/issues/99');
+    expect(commentCalls[0]?.body).toContain(refinedBody);
+  });
+
+  it('non-interactive run with postRefinementComment but no ticket link → posts nothing', async () => {
+    const { sprint, tickets } = draftWithPending(1);
+    const { repo } = inMemoryRepo(sprint);
+    const eventBus = createInMemoryEventBus();
+
+    const fake = fakeInteractiveAi(() => '# refined\n- something');
+
+    const commentCalls: unknown[] = [];
+    const issuePusher: IssuePusher = {
+      async comment(url, args) {
+        commentCalls.push({ url, args });
+        return Result.ok(undefined);
+      },
+    };
+
+    const flow = createRefineFlow(
+      {
+        sprintRepo: repo,
+        interactiveAi: fake.session,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        writeFile: createAtomicWriteFile(),
+        runInTerminal: passthroughRunInTerminal,
+        eventBus,
+        logger: noopLogger,
+        skillsAdapter: noopSkillsAdapter,
+        skillSource: emptySkillSource,
+        clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
+        issuePusher,
+        postRefinementComment: true,
+      },
+      {
+        sprintId: sprint.id,
+        pendingTickets: tickets,
+        providerId: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        refinementRoot: refinementRoot(),
+      }
+    );
+
+    const runner = createRunner({ id: 'r-refine-nolink', element: flow, initialCtx: { sprintId: sprint.id } });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+    expect(commentCalls).toHaveLength(0);
   });
 
   it('halts the chain when the AI exits without writing the output file', async () => {

--- a/tests/e2e/flows/refine.test.ts
+++ b/tests/e2e/flows/refine.test.ts
@@ -377,6 +377,73 @@ describe('createRefineFlow — interactive', () => {
     expect(String(persistedTicket?.link)).toBe('https://github.com/x/y/issues/42');
   });
 
+  it('reviewer EDITS the body then posts → the comment carries the edited body, not the AI original', async () => {
+    // Regression for the silent-divergence bug: a reviewer who edits the AI's proposal and then
+    // posts a comment must publish the EDITED text (the locally-persisted requirements), never the
+    // AI's discarded pre-edit body.
+    const link = (() => {
+      const r = parseHttpUrl('link', 'https://github.com/x/y/issues/42');
+      if (!r.ok) throw new Error('test setup');
+      return r.value;
+    })();
+    const { sprint, tickets } = draftWithPending(1, (_i, t) => ({ ...t, link }));
+    const { repo, saves } = inMemoryRepo(sprint);
+    const eventBus = createInMemoryEventBus();
+
+    const refinedBody = '# refined requirements\n- a WRONG criterion the reviewer deletes';
+    const editedBody = '# refined requirements\n- the corrected acceptance criterion';
+    const fake = fakeInteractiveAi(() => refinedBody);
+
+    const commentCalls: Array<{ url: string; body: string }> = [];
+    const issuePusher: IssuePusher = {
+      async comment(url, args) {
+        commentCalls.push({ url, body: args.body });
+        return Result.ok(undefined);
+      },
+    };
+
+    // The reviewer accepts but supplies an edited body — the use case persists it on the ticket.
+    const reviewBeforeApprove = async () => ({ accept: true, alsoUpdateOrigin: true, body: editedBody });
+
+    const flow = createRefineFlow(
+      {
+        sprintRepo: repo,
+        interactiveAi: fake.session,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        writeFile: createAtomicWriteFile(),
+        runInTerminal: passthroughRunInTerminal,
+        eventBus,
+        logger: noopLogger,
+        skillsAdapter: noopSkillsAdapter,
+        skillSource: emptySkillSource,
+        clock: () => '2026-01-01T00:00:00Z' as IsoTimestamp,
+        issuePusher,
+        reviewBeforeApprove,
+      },
+      {
+        sprintId: sprint.id,
+        pendingTickets: tickets,
+        providerId: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        refinementRoot: refinementRoot(),
+      }
+    );
+
+    const runner = createRunner({ id: 'r-refine-edit-comment', element: flow, initialCtx: { sprintId: sprint.id } });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+    expect(commentCalls).toHaveLength(1);
+    const call = commentCalls[0];
+    // The posted comment carries the EDITED body and NOT the AI's discarded original.
+    expect(call?.body).toContain(editedBody);
+    expect(call?.body).not.toContain('WRONG criterion');
+    // …and the locally-persisted requirements match what was posted (no divergence).
+    const persistedTicket = saves[0]?.tickets[0];
+    expect(persistedTicket?.status).toBe('approved');
+    expect(persistedTicket?.requirements).toBe(editedBody);
+  });
+
   it('non-interactive run with postRefinementComment → comments on a linked ticket without prompting', async () => {
     const link = (() => {
       const r = parseHttpUrl('link', 'https://github.com/x/y/issues/99');

--- a/tests/integration/ai/prompts/implement/definition.test.ts
+++ b/tests/integration/ai/prompts/implement/definition.test.ts
@@ -296,6 +296,39 @@ describe('buildImplementPrompt — end-to-end against the real template', () => 
     if (!result.ok) return;
     expect(result.value).not.toContain('## Prior Critique');
   });
+
+  it('renders the "change your approach" directive when plateauBreak is set', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildImplementPrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      progressFile: '/tmp/ralph/sprint-1/progress.md',
+      priorProgress: '',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+      plateauBreak: true,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain('You have plateaued');
+    expect(result.value).toContain('change your approach');
+    expect(result.value).toContain('fundamentally different');
+  });
+
+  it('omits the plateau directive when plateauBreak is absent (the normal case)', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildImplementPrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      progressFile: '/tmp/ralph/sprint-1/progress.md',
+      priorProgress: '',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).not.toContain('You have plateaued');
+  });
 });
 
 describe('implementPromptDef — validate-rejected paths', () => {
@@ -312,6 +345,7 @@ describe('implementPromptDef — validate-rejected paths', () => {
       projectTooling: '_(none detected)_',
       progressFile: '/tmp/ralph/sprint-1/progress.md',
       priorCritiqueSection: '',
+      plateauDirectiveSection: '',
       priorProgress: '',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       contractPath: CONTRACT_PATH,
@@ -333,6 +367,7 @@ describe('implementPromptDef — validate-rejected paths', () => {
       projectTooling: '_(none detected)_',
       progressFile: '',
       priorCritiqueSection: '',
+      plateauDirectiveSection: '',
       priorProgress: '',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       contractPath: CONTRACT_PATH,

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -385,6 +385,11 @@ describe('createCodexProvider', () => {
 
     const out = await provider.generate(sess);
     expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    // The cold spawn captured the FRESH thread id (not the lost resume id), so the next gen-eval
+    // round can resume the new thread. `sessionId` is optional on the success output, so a
+    // regression that dropped the cold-spawn id would still pass `out.ok` — assert it explicitly.
+    expect(out.value.sessionId).toBe('fresh-cold-thread');
 
     // Exactly two spawns: the failed resume, then the cold retry.
     expect(calls).toHaveLength(2);

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -352,6 +352,73 @@ describe('createCodexProvider', () => {
     expect(out.error.code).toBe('rate-limit');
   });
 
+  // Resume resilience (WS-F): a `resume` spawn that fails because codex no longer has the
+  // rollout ("no rollout found", code -32600) must fall back to a COLD spawn rather than block
+  // the task. This was the root cause of two blocked tasks in the wild (the prior session
+  // thread was lost to abort churn, so the evaluator's resume failed and the task self-blocked).
+  it('falls back to a cold spawn (drops --resume) when the resume thread is gone, salvaging the turn', async () => {
+    const cap = createCapturingBus();
+    const sess = session({ resume: 'lost-thread-019e845a' as SessionId });
+    const { spawn, calls } = makeSpawn([
+      // Attempt 1 (resume): codex can't find the rollout → exit 1 with the canonical message.
+      {
+        stderrChunks: [
+          'Error: thread/resume failed: no rollout found for thread id lost-thread-019e845a (code -32600)\n',
+        ],
+        exitCode: 1,
+      },
+      // Attempt 2 (cold fallback): clean run that captures a fresh session id.
+      { stdoutChunks: ['{"type":"thread.started","thread_id":"fresh-cold-thread"}\n'], exitCode: 0 },
+    ]);
+    const fsStub = stubFs('unused');
+
+    const provider = createCodexProvider({
+      // rateLimitRetries: 0 → maxAttempts 1. The cold fallback must still fire (it does not
+      // consume the rate-limit budget), so this also fences the `attempt--` edge case.
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    const out = await provider.generate(sess);
+    expect(out.ok).toBe(true);
+
+    // Exactly two spawns: the failed resume, then the cold retry.
+    expect(calls).toHaveLength(2);
+    // First spawn carried the resume id.
+    expect(calls[0]?.args).toContain('resume');
+    expect(calls[0]?.args).toContain('lost-thread-019e845a');
+    // Second spawn dropped resume and took the cold-start path (-C cwd + -s sandbox markers).
+    expect(calls[1]?.args).not.toContain('resume');
+    expect(calls[1]?.args).toContain('-C');
+    expect(calls[1]?.args).toContain('-s');
+    // The operator is told the fallback happened.
+    expect(cap.logs.some((l) => l.level === 'warn' && /resume thread not found/i.test(l.message))).toBe(true);
+  });
+
+  it('does NOT cold-retry a non-resume failure (plain exit 1 surfaces the error)', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls } = makeSpawn([{ stderrChunks: ['some other failure\n'], exitCode: 1 }]);
+    const fsStub = stubFs('unused');
+
+    const provider = createCodexProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn,
+      readFile: fsStub.readFile,
+      unlink: fsStub.unlink,
+      mkTempPath: fsStub.mkTempPath,
+    });
+
+    // No resume id on the session → the stale-resume fallback must not engage.
+    const out = await provider.generate(session());
+    expect(out.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
   it('cleans up the output tempfile even when the call errors', async () => {
     const cap = createCapturingBus();
     const { spawn } = makeSpawn([{ stderrChunks: ['some failure\n'], exitCode: 7 }]);

--- a/tests/integration/application/flows/implement/leaves/evaluator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator.test.ts
@@ -118,4 +118,24 @@ describe('evaluatorLeaf', () => {
     await leaf.execute(ctx);
     expect(deps.provider.recordedSessions[0]?.model).toBe('evaluator-model-fixed');
   });
+
+  // Abort wire (keystone for #1/#5): the evaluator, like the generator, must carry the chain's
+  // abort signal onto the spawned session so a TUI cancel mid-spawn kills the child via the
+  // provider's SIGTERM ladder rather than letting it run to natural completion.
+  it('threads the chain abort signal onto the spawned session so a cancel can kill the child', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const deps = buildDeps();
+    const leaf = evaluatorLeaf(deps, task.id);
+    const ctx: ImplementCtx = {
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+      currentTask: task,
+      currentRoundNum: 1,
+      taskWorkspaceRoot: root.root,
+    };
+    const controller = new AbortController();
+    const result = await leaf.execute(ctx, controller.signal);
+    expect(result.ok).toBe(true);
+    expect(deps.provider.recordedSessions[0]?.abortSignal).toBe(controller.signal);
+  });
 });

--- a/tests/integration/application/flows/implement/leaves/generator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/generator.test.ts
@@ -222,6 +222,30 @@ describe('generatorLeaf', () => {
     expect(provider.recordedSessions[0]?.model).toBe('claude-sonnet-4-6');
   });
 
+  // Plateau-break: when the escalation policy stamped the task (model bump or same-model nudge),
+  // the generator must inject the "change your approach" directive into the prompt.
+  it('injects the change-of-approach directive into prompt.md when the task is a plateau-break (escalated)', async () => {
+    const initial = makeInProgressTaskWithRunningAttempt();
+    // A same-model nudge (top-of-ladder) stamps escalatedFromModel — the directive arms on that.
+    const stamped = recordTaskEscalation(initial, 'claude-opus-4-8', 'claude-opus-4-8');
+    if (!stamped.ok) throw stamped.error;
+    const leaf = generatorLeaf(buildDeps(), stamped.value.id);
+    const result = await leaf.execute(baseCtx(stamped.value));
+    expect(result.ok).toBe(true);
+
+    const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'generator', 'prompt.md'), 'utf8');
+    expect(content).toContain('You have plateaued');
+    expect(content).toContain('change your approach');
+  });
+
+  it('omits the change-of-approach directive when the task has not escalated', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const leaf = generatorLeaf(buildDeps(), task.id);
+    await leaf.execute(baseCtx(task));
+    const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'generator', 'prompt.md'), 'utf8');
+    expect(content).not.toContain('You have plateaued');
+  });
+
   // Abort wire (keystone for #1/#5): the runner threads its AbortController signal into every
   // `element.execute(ctx, signal)`; the leaf framework forwards it as the 2nd arg of the
   // use-case `execute(input, signal)`. The generator must carry it onto the spawned session so

--- a/tests/integration/application/flows/implement/leaves/generator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/generator.test.ts
@@ -222,6 +222,30 @@ describe('generatorLeaf', () => {
     expect(provider.recordedSessions[0]?.model).toBe('claude-sonnet-4-6');
   });
 
+  // Abort wire (keystone for #1/#5): the runner threads its AbortController signal into every
+  // `element.execute(ctx, signal)`; the leaf framework forwards it as the 2nd arg of the
+  // use-case `execute(input, signal)`. The generator must carry it onto the spawned session so
+  // the headless provider arms its SIGTERM kill ladder. Before this wire the field was always
+  // undefined and a manual abort let the child run to completion (stranding lock + spinner).
+  it('threads the chain abort signal onto the spawned session so a cancel can kill the child', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const provider = createFakeAiProvider({ responses: { implement: '' } });
+    const leaf = generatorLeaf({ ...buildDeps(), provider }, task.id);
+    const controller = new AbortController();
+    const result = await leaf.execute(baseCtx(task), controller.signal);
+    expect(result.ok).toBe(true);
+    expect(provider.recordedSessions[0]?.abortSignal).toBe(controller.signal);
+  });
+
+  it('leaves the session abortSignal undefined when the runner passes no signal', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const provider = createFakeAiProvider({ responses: { implement: '' } });
+    const leaf = generatorLeaf({ ...buildDeps(), provider }, task.id);
+    const result = await leaf.execute(baseCtx(task));
+    expect(result.ok).toBe(true);
+    expect(provider.recordedSessions[0]?.abortSignal).toBeUndefined();
+  });
+
   it('publishes a banner-clear for the escalation banner when a new round starts', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const eventBus = createInMemoryEventBus();

--- a/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
+++ b/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
@@ -88,6 +88,7 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
       writeFile,
       eventBus,
       model: 'claude-sonnet-4-6',
+      sprintId: 'test-sprint',
     };
   };
 

--- a/tests/integration/application/ui/tui/_keys.ts
+++ b/tests/integration/application/ui/tui/_keys.ts
@@ -18,6 +18,11 @@ export const CTRL_J = '\n';
 export const CTRL_U = '';
 export const CTRL_W = '';
 
+// PageUp / PageDown — xterm CSI sequences Ink parses as key.pageUp / key.pageDown. Built from
+// String.fromCharCode(27) so the ESC byte survives editor round-trips without a raw control char.
+export const PAGE_UP = `${String.fromCharCode(27)}[5~`;
+export const PAGE_DOWN = `${String.fromCharCode(27)}[6~`;
+
 /**
  * Yield long enough for Ink's escape-sequence disambiguation timeout (~10ms) and a microtask
  * flush. The default is enough for state-flushing; longer for ESC where we wait for the timer.

--- a/tests/integration/application/ui/tui/components/tasks-panel-blocked-reason.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-blocked-reason.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Blocked-reason surfacing. A blocked task's card must show WHY it blocked (the entity's
+ * blockedReason) instead of a bare `blocked` status — the live TaskBucket status is trace-derived
+ * and carries no reason, so the host threads a blockedReasonById map from the polled entities.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
+import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+
+const bucket = (id: string, status: TaskBucket['status']): TaskBucket => ({
+  id,
+  status,
+  subSteps: [],
+  evaluations: [],
+  signals: [],
+  genEvalRound: 0,
+});
+
+const ID = '01933fbb-0000-7000-8000-000000000001';
+
+describe('TasksPanel blocked-reason', () => {
+  it('renders the blockedReason under a blocked task card', () => {
+    const bucketed: BucketedExecution = { tasks: [bucket(ID, 'failed')], orphanSignals: [] };
+    const reasonById = new Map([[ID, 'blocked upstream — prerequisite not done: Foundation (blocked)']]);
+    const r = render(<TasksPanel bucketed={bucketed} running={false} blockedReasonById={reasonById} />);
+    const frame = r.lastFrame() ?? '';
+    expect(frame).toContain('blocked upstream');
+    expect(frame).toContain('prerequisite not done');
+    r.unmount();
+  });
+
+  it('shows no reason line when none is supplied', () => {
+    const bucketed: BucketedExecution = { tasks: [bucket(ID, 'failed')], orphanSignals: [] };
+    const r = render(<TasksPanel bucketed={bucketed} running={false} />);
+    const frame = r.lastFrame() ?? '';
+    expect(frame).not.toContain('prerequisite not done');
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/components/tasks-panel-windowing.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-windowing.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Windowing fence for TasksPanel. With 3-4+ tasks the middle column previously mapped the whole
+ * task array and grew unbounded, pushing the Recent-log + footer off-screen. The panel now
+ * renders an anchored window of `maxTasks` cards centred on the active card, with "N more
+ * above / below" cues for the hidden remainder. These tests pin that behaviour.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
+import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+
+// Six tasks: indices 0-3 settled (completed), 4 the active (running) task, 5 still queued.
+// `activeTaskIdx` = first non-completed = 4, which is where the window anchors.
+const buildFixture = (): { bucketed: BucketedExecution; nameById: Map<string, string> } => {
+  const nameById = new Map<string, string>();
+  const tasks: TaskBucket[] = Array.from({ length: 6 }, (_unused, i) => {
+    const id = `01933fbb-0000-7000-8000-${String(i).padStart(12, '0')}`;
+    nameById.set(id, `T${String(i)}X`);
+    return {
+      id,
+      status: i < 4 ? 'completed' : 'running',
+      subSteps: [],
+      evaluations: [],
+      signals: [],
+      genEvalRound: 0,
+    } satisfies TaskBucket;
+  });
+  return { bucketed: { tasks, orphanSignals: [] }, nameById };
+};
+
+describe('TasksPanel windowing', () => {
+  it('renders only the budgeted cards, anchored on the active task, with an "N more above" cue', () => {
+    const { bucketed, nameById } = buildFixture();
+    // maxTasks=3, anchor at active idx 4 → window [3,6): cards T3X, T4X, T5X; T0X-T2X hidden.
+    const r = render(<TasksPanel bucketed={bucketed} running={true} nameById={nameById} maxTasks={3} />);
+    const frame = r.lastFrame() ?? '';
+
+    // The active card and its in-window neighbours are visible.
+    expect(frame).toContain('T3X');
+    expect(frame).toContain('T4X');
+    expect(frame).toContain('T5X');
+    // The settled cards that fell out of the window are hidden behind the cue.
+    expect(frame).not.toContain('T0X');
+    expect(frame).not.toContain('T1X');
+    expect(frame).not.toContain('T2X');
+    // Overflow cue reports the hidden count; nothing is hidden below (window reaches the end).
+    expect(frame).toContain('3 more above');
+    expect(frame).not.toContain('more below');
+
+    r.unmount();
+  });
+
+  it('renders every card with no cues when the budget meets or exceeds the task count', () => {
+    const { bucketed, nameById } = buildFixture();
+    const r = render(<TasksPanel bucketed={bucketed} running={true} nameById={nameById} maxTasks={10} />);
+    const frame = r.lastFrame() ?? '';
+
+    for (let i = 0; i < 6; i++) expect(frame).toContain(`T${String(i)}X`);
+    expect(frame).not.toContain('more above');
+    expect(frame).not.toContain('more below');
+
+    r.unmount();
+  });
+
+  it('is unbounded when no maxTasks is supplied (isolated-render parity)', () => {
+    const { bucketed, nameById } = buildFixture();
+    const r = render(<TasksPanel bucketed={bucketed} running={true} nameById={nameById} />);
+    const frame = r.lastFrame() ?? '';
+
+    for (let i = 0; i < 6; i++) expect(frame).toContain(`T${String(i)}X`);
+    expect(frame).not.toContain('more above');
+    expect(frame).not.toContain('more below');
+
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/prompts/text-area-prompt.test.tsx
+++ b/tests/integration/application/ui/tui/prompts/text-area-prompt.test.tsx
@@ -10,6 +10,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { TextAreaPrompt } from '@src/application/ui/tui/prompts/text-area-prompt.tsx';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import {
   CTRL_A,
   CTRL_E,
@@ -22,10 +23,16 @@ import {
   ESC,
   HOME,
   LEFT,
+  PAGE_DOWN,
+  PAGE_UP,
   RIGHT,
   tick,
   UP,
 } from '@tests/integration/application/ui/tui/_keys.ts';
+
+/** SGR mouse wheel reports (button 65 = wheel-down, 64 = wheel-up) at col/row 10. */
+const MOUSE_WHEEL_DOWN = `${String.fromCharCode(27)}[<65;10;10M`;
+const MOUSE_WHEEL_UP = `${String.fromCharCode(27)}[<64;10;10M`;
 
 describe('TextAreaPrompt', () => {
   it('appends typed characters to the buffer', async () => {
@@ -353,6 +360,103 @@ describe('TextAreaPrompt', () => {
     stdin.write(ENTER);
     await tick();
     expect(onSubmit).toHaveBeenCalledWith('ab\nxc');
+    unmount();
+  });
+
+  it('follows the cursor with a window so a tall buffer keeps the cursor line on screen', async () => {
+    // More lines than any plausible viewport (terminal rows default to 24 in the test harness).
+    const body = Array.from({ length: 16 }, (_, i) => `L${String(i).padStart(2, '0')}`);
+    const { stdin, lastFrame, unmount } = render(
+      <TextAreaPrompt
+        message="Description"
+        initial={body.join('\n')}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    );
+    await tick();
+    // Cursor seeds at the end, so the window has already followed it to the bottom.
+    expect(lastFrame()).toContain('L15');
+    expect(lastFrame()).not.toContain('L00');
+    // Walk the cursor up to the very top; the window follows so the first line shows again.
+    for (let i = 0; i < 15; i++) {
+      stdin.write(UP);
+      await tick();
+    }
+    expect(lastFrame()).toContain('L00');
+    expect(lastFrame()).not.toContain('L15');
+    // Walk back down to the bottom; the window must shift to keep the cursor line visible.
+    for (let i = 0; i < 15; i++) {
+      stdin.write(DOWN);
+      await tick();
+    }
+    expect(lastFrame()).toContain('L15');
+    expect(lastFrame()).not.toContain('L00');
+    unmount();
+  });
+
+  it('PgUp / PgDn scroll the window by a screenful and clamp without wrapping', async () => {
+    const body = Array.from({ length: 30 }, (_, i) => `L${String(i).padStart(2, '0')}`);
+    const { stdin, lastFrame, unmount } = render(
+      <TextAreaPrompt
+        message="Description"
+        initial={body.join('\n')}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    );
+    await tick();
+    // PgUp repeatedly walks to the top and then clamps — pressing past the edge does not wrap.
+    for (let i = 0; i < 6; i++) {
+      stdin.write(PAGE_UP);
+      await tick();
+    }
+    expect(lastFrame()).toContain('L00');
+    expect(lastFrame()).not.toContain('L29');
+    // PgDn repeatedly walks back to the bottom and clamps there.
+    for (let i = 0; i < 6; i++) {
+      stdin.write(PAGE_DOWN);
+      await tick();
+    }
+    expect(lastFrame()).toContain('L29');
+    expect(lastFrame()).not.toContain('L00');
+    unmount();
+  });
+
+  it('renders a short buffer with every line, no scroll cue, and the leading marker', async () => {
+    const { lastFrame, unmount } = render(
+      <TextAreaPrompt
+        message="Description"
+        initial={'alpha\nbravo\ncharlie'}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    );
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('alpha');
+    expect(frame).toContain('bravo');
+    expect(frame).toContain('charlie');
+    // No hidden-content cue and no first-row slicing — identical to the pre-viewport rendering.
+    expect(frame).not.toContain(glyphs.clipEllipsis);
+    expect(frame).toContain(glyphs.arrowRight);
+    unmount();
+  });
+
+  it('ignores mouse SGR wheel reports instead of typing them into the buffer', async () => {
+    const onSubmit = vi.fn();
+    const { stdin, unmount } = render(
+      <TextAreaPrompt message="Description" onSubmit={onSubmit} onCancel={() => undefined} />
+    );
+    stdin.write('hi');
+    await tick();
+    stdin.write(MOUSE_WHEEL_DOWN);
+    await tick();
+    stdin.write(MOUSE_WHEEL_UP);
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onSubmit).toHaveBeenCalledWith('hi');
     unmount();
   });
 });

--- a/tests/integration/application/ui/tui/views/add-ticket-view.review-scroll.test.tsx
+++ b/tests/integration/application/ui/tui/views/add-ticket-view.review-scroll.test.tsx
@@ -11,6 +11,8 @@
  *     output for that content (a single `<Text>` value alongside the Description label)
  *   - PgDn then PgUp: window shifts by a page, then returns
  *   - resize: changing stdout rows triggers a clamp so the offset stays within the new bounds
+ *   - wide terminal + full-size header: the body stays a bounded scroll area (the reserve tracks
+ *     the taller full banner) so the Link row and confirm pills are never pushed off-screen
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -21,7 +23,7 @@ import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { ExternalIssue, IssueFetcher } from '@src/business/scm/issue-fetcher.ts';
 import { makeDraftSprint } from '@tests/fixtures/domain.ts';
-import { DOWN, ENTER, UP } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, ENTER, PAGE_DOWN, UP } from '@tests/integration/application/ui/tui/_keys.ts';
 import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
@@ -190,13 +192,14 @@ describe('AddTicketView — Review step scrollable description', () => {
 
     // ink-testing-library's stdout does not expose `rows` natively; the production terminal-
     // size hook falls back to 24 when rows is undefined. We monkey-patch `rows` onto the
-    // emitter and dispatch 'resize' to drive the production listener. The viewport on the
-    // pre-resize 24-row default is ~10 rows (CHROME=14, MIN=4); after rows=40 the viewport
-    // grows to ~26 — equivalent to a wider terminal that needs less scroll headroom.
+    // emitter and dispatch 'resize' to drive the production listener. The harness reports a
+    // 100-column terminal (full banner), so the pre-resize 24-row viewport floors at MIN=4;
+    // after rows=40 it grows to ~16 — still a bounded window that needs less scroll headroom.
     const stdout = result.stdout as unknown as { rows?: number; emit(event: string): boolean };
 
-    // Scroll near the bottom of the 30-line body on the default 24-row viewport.
-    for (let i = 0; i < 6; i++) {
+    // Scroll to the bottom of the 30-line body. PgDn moves by a viewport-height, which depends
+    // on the chrome reserve, so press enough times to reach the end regardless of viewport size.
+    for (let i = 0; i < 12; i++) {
       result.stdin.write('\x1b[6~'); // PgDn
       await tick(20);
     }
@@ -206,10 +209,10 @@ describe('AddTicketView — Review step scrollable description', () => {
     const beforeStart = Number(beforeMatch?.[1] ?? '0');
     expect(beforeStart).toBeGreaterThan(1);
 
-    // Grow the terminal: rows 24 → 40 ⇒ viewport ≈ 10 → 26 ⇒ maxOffset shrinks. Any offset
-    // that exceeded the new maxOffset must clamp down. The clamp effect runs on the
-    // maxOffset dependency; emitting 'resize' triggers the useTerminalSize listener which
-    // updates the rows state, which re-derives the viewport, which trips the effect.
+    // Grow the terminal: rows 24 → 40 ⇒ viewport grows ⇒ maxOffset shrinks. Any offset that
+    // exceeded the new maxOffset must clamp down. The clamp effect runs on the maxOffset
+    // dependency; emitting 'resize' triggers the useTerminalSize listener which updates the
+    // rows state, which re-derives the viewport, which trips the effect.
     stdout.rows = 40;
     stdout.emit('resize');
     await tick(60);
@@ -225,5 +228,50 @@ describe('AddTicketView — Review step scrollable description', () => {
     expect(afterStart).toBeGreaterThanOrEqual(1);
     expect(afterEnd).toBeLessThanOrEqual(30);
     expect(after).toContain('LAST-LINE-SENTINEL');
+  });
+
+  it('wide terminal with the full-size header: body stays a bounded scroll area so the Link row and confirm pills are never pushed off-screen', async () => {
+    const description = buildDescription(20);
+    const { deps, sprint } = makeDepsWithFetchedDescription(description);
+    const result = await walkToReview(deps, sprint.id);
+
+    // ink-testing-library reports a 100-column terminal — at/above the Banner's full-wordmark
+    // width threshold, so this view already renders the tall full-size header. Capture the body
+    // window at the default 24 rows, then grow the terminal to 40 rows. A reserve that ignored
+    // the full banner would leave room for all 20 lines on a 40-row terminal — expanding the
+    // body and shoving the Link row + confirm pills past the bottom in a real terminal. The
+    // robust layout reserves the taller full banner, so the body stays a bounded scroll window.
+    const preEnd = Number(/lines 1[–-](\d+) of 20/.exec(result.lastFrame() ?? '')?.[1] ?? '0');
+    const stdout = result.stdout as unknown as { rows?: number; emit(event: string): boolean };
+    stdout.rows = 40;
+    stdout.emit('resize');
+
+    // Growing the terminal grows the window — but it stays a bounded window (the indicator is
+    // still present, i.e. fewer than all 20 lines are visible). A banner-blind reserve would fit
+    // every line on 40 rows and drop the indicator entirely, so this is the regression guard.
+    await waitFor(() => {
+      const m = /lines 1[–-](\d+) of 20/.exec(result.lastFrame() ?? '');
+      expect(m).not.toBeNull();
+      const end = Number(m?.[1] ?? '0');
+      expect(end).toBeGreaterThan(preEnd);
+      expect(end).toBeLessThan(20);
+    });
+
+    const top = result.lastFrame() ?? '';
+    expect(top).toContain('FIRST-LINE-SENTINEL');
+    expect(top).toContain('https://github.com/acme/repo/issues/42');
+    expect(top).toContain('Add this ticket?');
+
+    // Scroll to the bottom of the body — the Link row and confirm pills remain on screen at this
+    // scroll position too.
+    for (let i = 0; i < 12; i++) {
+      result.stdin.write(PAGE_DOWN);
+      await tick(20);
+    }
+    await waitFor(() => expect(result.lastFrame()).toContain('LAST-LINE-SENTINEL'));
+    const bottom = result.lastFrame() ?? '';
+    expect(bottom).not.toContain('FIRST-LINE-SENTINEL');
+    expect(bottom).toContain('https://github.com/acme/repo/issues/42');
+    expect(bottom).toContain('Add this ticket?');
   });
 });

--- a/tests/integration/application/ui/tui/views/execute-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view.test.tsx
@@ -14,6 +14,8 @@ import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
 import type { Trace, TraceEntry } from '@src/application/chain/trace.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
@@ -213,22 +215,209 @@ describe('ExecuteView', () => {
     result.unmount();
   });
 
-  it('Enter on a completed session routes to sprint-detail when a sprint is selected', async () => {
+  it('Enter on a completed session routes to sprint-detail when the session has a pinned sprint', async () => {
     const sessions = createSessionManager();
     const runner = fakeRunner('r-3', 'completed');
-    sessions.register({ runner, flowId: 'refine', title: 'Refine — Done' });
+    const pinnedSprintId = 'sprint-fixture' as unknown as SprintId;
+    sessions.register({
+      runner,
+      flowId: 'refine',
+      title: 'Refine — Done',
+      pinnedSprintId,
+      pinnedSprintLabel: 'Demo Sprint',
+    });
 
-    const sprintId = 'sprint-fixture' as unknown as SprintId;
     const { result, routeIds } = renderView(<ExecuteView />, {
       deps: stubDeps(),
       initial: { id: 'execute', props: { sessionId: 'r-3' } },
       sessions,
-      selection: { sprintId, sprintLabel: 'Demo Sprint' },
     });
     await tick(40);
     result.stdin.write(ENTER);
     await tick();
     expect(routeIds()).toContain('sprint-detail');
+    result.unmount();
+  });
+
+  it('routes back to the pinned sprint on Enter even when the global selection drifted to a different sprint', async () => {
+    const sessions = createSessionManager();
+    const runner = fakeRunner('r-pin-nav', 'completed');
+    const sprintA = 'sprint-a-nav' as unknown as SprintId;
+    sessions.register({
+      runner,
+      flowId: 'implement',
+      title: 'Implement — Pinned',
+      pinnedSprintId: sprintA,
+      pinnedSprintLabel: 'Sprint A',
+    });
+
+    const sprintB = 'sprint-b-nav' as unknown as SprintId;
+    const routeEntries: ViewEntry[] = [];
+    const { result } = renderView(<ExecuteView />, {
+      deps: stubDeps(),
+      initial: { id: 'execute', props: { sessionId: 'r-pin-nav' } },
+      sessions,
+      selection: { sprintId: sprintB, sprintLabel: 'Sprint B' },
+      onRoute: (e) => {
+        routeEntries.push(e);
+      },
+    });
+    await tick(40);
+    result.stdin.write(ENTER);
+    await tick();
+    const sprintDetail = routeEntries.find((e) => e.id === 'sprint-detail');
+    expect(sprintDetail?.props?.sprintId).toBe(sprintA);
+    result.unmount();
+  });
+
+  it('two sessions pinned to different sprints each show their own sprint context in the breadcrumb', async () => {
+    const sessions = createSessionManager();
+    const runnerA = fakeRunner('r-ctx-a', 'running');
+    const sprintA = 'sprint-ctx-a' as unknown as SprintId;
+    sessions.register({
+      runner: runnerA,
+      flowId: 'implement',
+      title: 'Implement — A',
+      pinnedSprintId: sprintA,
+      pinnedSprintLabel: 'Sprint Alpha',
+      pinnedProjectLabel: 'Project One',
+    });
+    // Session B is registered but never viewed — A's context should show in the breadcrumb.
+    const runnerB = fakeRunner('r-ctx-b', 'running');
+    const sprintB = 'sprint-ctx-b' as unknown as SprintId;
+    sessions.register({
+      runner: runnerB,
+      flowId: 'implement',
+      title: 'Implement — B',
+      pinnedSprintId: sprintB,
+      pinnedSprintLabel: 'Sprint Beta',
+    });
+
+    const { result } = renderView(<ExecuteView />, {
+      deps: stubDeps(),
+      initial: { id: 'execute', props: { sessionId: 'r-ctx-a' } },
+      sessions,
+      selection: { sprintId: sprintB, sprintLabel: 'Sprint Beta' },
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Sprint Alpha');
+    expect(frame).toContain('Project One');
+    result.unmount();
+  });
+
+  it('cancel-whole-flow calls taskRepo with the pinned sprint id, not the global selection sprint', async () => {
+    const TASK = '01933fbb-1111-7000-8000-000000000099';
+    const taskNames = new Map([[TASK, 'Demo task']]);
+    const traceArray: TraceEntry[] = [{ elementName: `generator-${TASK}`, status: 'completed', durationMs: 100 }];
+    const runner: Runner<unknown> = {
+      id: 'r-cancel-pin',
+      status: 'running' as const,
+      ctx: {},
+      trace: traceArray as Trace,
+      subscribe: () => () => undefined,
+      start: vi.fn(),
+      abort: vi.fn(),
+    } as unknown as Runner<unknown>;
+
+    const sprintA = 'sprint-cancel-a' as unknown as SprintId;
+    const sessions = createSessionManager();
+    sessions.register({
+      runner,
+      flowId: 'implement',
+      title: 'Implement — Cancel',
+      pinnedSprintId: sprintA,
+      taskNames,
+      terminalSubstepName: 'uninstall-skills',
+    });
+
+    const findById = vi.fn().mockResolvedValue({ ok: false });
+    const deps: AppDeps = {
+      eventBus: noopEventBus,
+      taskRepo: { findById, findBySprintId: vi.fn().mockResolvedValue({ ok: true, value: [] }) },
+    } as unknown as AppDeps;
+
+    const sprintB = 'sprint-cancel-b' as unknown as SprintId;
+    const { result } = renderView(<ExecuteView />, {
+      deps,
+      initial: { id: 'execute', props: { sessionId: 'r-cancel-pin' } },
+      sessions,
+      selection: { sprintId: sprintB, sprintLabel: 'Sprint B Cancel' },
+    });
+    await tick(40);
+    result.stdin.write('c');
+    await tick();
+    result.stdin.write('2');
+    await tick(50);
+    expect(findById).toHaveBeenCalledWith(sprintA, TASK as unknown as TaskId);
+    result.unmount();
+  });
+
+  it('shows the stale-sprint fallback and drops baseline-health surfaces when the pinned sprint is done', async () => {
+    const sessions = createSessionManager();
+    const runner = fakeRunner('r-stale-done', 'running');
+    const sprintA = 'sprint-stale-done' as unknown as SprintId;
+    sessions.register({ runner, flowId: 'implement', title: 'Implement — Stale Done', pinnedSprintId: sprintA });
+
+    const mockSprintRepo = { findById: vi.fn().mockResolvedValue({ ok: true, value: { status: 'done' } }) };
+    const deps: AppDeps = { eventBus: noopEventBus, sprintRepo: mockSprintRepo } as unknown as AppDeps;
+
+    const { result } = renderView(<ExecuteView />, {
+      deps,
+      initial: { id: 'execute', props: { sessionId: 'r-stale-done' } },
+      sessions,
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Sprint no longer available');
+    // BaselineHealthChip always renders the word "baseline" — when stale it must be absent.
+    expect(frame).not.toContain('baseline');
+    result.unmount();
+  });
+
+  it('shows the stale-sprint fallback and drops baseline-health when the pinned sprint is removed', async () => {
+    const sessions = createSessionManager();
+    const runner = fakeRunner('r-stale-removed', 'running');
+    const sprintA = 'sprint-stale-removed' as unknown as SprintId;
+    sessions.register({ runner, flowId: 'implement', title: 'Implement — Stale Removed', pinnedSprintId: sprintA });
+
+    const mockSprintRepo = { findById: vi.fn().mockResolvedValue({ ok: false, error: { kind: 'not-found' } }) };
+    const deps: AppDeps = { eventBus: noopEventBus, sprintRepo: mockSprintRepo } as unknown as AppDeps;
+
+    const { result } = renderView(<ExecuteView />, {
+      deps,
+      initial: { id: 'execute', props: { sessionId: 'r-stale-removed' } },
+      sessions,
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Sprint no longer available');
+    expect(frame).not.toContain('baseline');
+    result.unmount();
+  });
+
+  it('focused-run context shows the pinned sprint and project in the breadcrumb while the execute view is mounted', async () => {
+    const sessions = createSessionManager();
+    const runner = fakeRunner('r-focused-ctx', 'running');
+    const sprintA = 'sprint-focused-a' as unknown as SprintId;
+    sessions.register({
+      runner,
+      flowId: 'implement',
+      title: 'Implement — Focused',
+      pinnedSprintId: sprintA,
+      pinnedSprintLabel: 'Sprint Pinned',
+      pinnedProjectLabel: 'Project Alpha',
+    });
+
+    const { result } = renderView(<ExecuteView />, {
+      deps: stubDeps(),
+      initial: { id: 'execute', props: { sessionId: 'r-focused-ctx' } },
+      sessions,
+    });
+    await tick(40);
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Sprint Pinned');
+    expect(frame).toContain('Project Alpha');
     result.unmount();
   });
 });

--- a/tests/integration/io/shell-script-runner.test.ts
+++ b/tests/integration/io/shell-script-runner.test.ts
@@ -196,4 +196,55 @@ describe('createShellScriptRunner', () => {
       }
     });
   });
+
+  describe('pnpm headless defaults (CI / frozen-lockfile)', () => {
+    // Setup/verify scripts spawn with no TTY. pnpm 11 aborts its node_modules purge without a
+    // TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`) and ignores every confirm-modules-purge
+    // form — `CI=true` is the only env lever that suppresses it. `PNPM_CONFIG_FROZEN_LOCKFILE=false`
+    // neutralises CI's frozen-lockfile flip so a bare `pnpm install` keeps its pre-CI (non-frozen)
+    // behaviour. Defaults sit BEFORE process.env so a user can opt out by exporting `CI=`.
+
+    it('defaults CI=true and PNPM_CONFIG_FROZEN_LOCKFILE=false on the spawn env', async () => {
+      const savedCi = process.env['CI'];
+      const savedFrozen = process.env['PNPM_CONFIG_FROZEN_LOCKFILE'];
+      delete process.env['CI'];
+      delete process.env['PNPM_CONFIG_FROZEN_LOCKFILE'];
+      try {
+        const { spawn, calls } = fakeSpawn({ exitCode: 0 });
+        const runner = createShellScriptRunner({ spawn });
+        await runner.run(cwd, 'pnpm install');
+
+        expect(calls[0]?.options.env?.['CI']).toBe('true');
+        expect(calls[0]?.options.env?.['PNPM_CONFIG_FROZEN_LOCKFILE']).toBe('false');
+      } finally {
+        if (savedCi === undefined) delete process.env['CI'];
+        else process.env['CI'] = savedCi;
+        if (savedFrozen === undefined) delete process.env['PNPM_CONFIG_FROZEN_LOCKFILE'];
+        else process.env['PNPM_CONFIG_FROZEN_LOCKFILE'] = savedFrozen;
+      }
+    });
+
+    it('lets a user-exported process.env.CI override the default (opt-out)', async () => {
+      const savedCi = process.env['CI'];
+      process.env['CI'] = '';
+      try {
+        const { spawn, calls } = fakeSpawn({ exitCode: 0 });
+        const runner = createShellScriptRunner({ spawn });
+        await runner.run(cwd, 'true');
+
+        expect(calls[0]?.options.env?.['CI']).toBe('');
+      } finally {
+        if (savedCi === undefined) delete process.env['CI'];
+        else process.env['CI'] = savedCi;
+      }
+    });
+
+    it('lets caller-supplied opts.env override the CI default', async () => {
+      const { spawn, calls } = fakeSpawn({ exitCode: 0 });
+      const runner = createShellScriptRunner({ spawn });
+      await runner.run(cwd, 'true', { env: { CI: 'false' } });
+
+      expect(calls[0]?.options.env?.['CI']).toBe('false');
+    });
+  });
 });

--- a/tests/integration/io/shell-script-runner.test.ts
+++ b/tests/integration/io/shell-script-runner.test.ts
@@ -246,5 +246,22 @@ describe('createShellScriptRunner', () => {
 
       expect(calls[0]?.options.env?.['CI']).toBe('false');
     });
+
+    it('lets a user-exported process.env.PNPM_CONFIG_FROZEN_LOCKFILE override the default', async () => {
+      // Symmetry with the CI opt-out: the frozen-lockfile default also sits before process.env, so a
+      // user who wants the frozen install (e.g. CI parity) can export it and win.
+      const savedFrozen = process.env['PNPM_CONFIG_FROZEN_LOCKFILE'];
+      process.env['PNPM_CONFIG_FROZEN_LOCKFILE'] = 'true';
+      try {
+        const { spawn, calls } = fakeSpawn({ exitCode: 0 });
+        const runner = createShellScriptRunner({ spawn });
+        await runner.run(cwd, 'pnpm install');
+
+        expect(calls[0]?.options.env?.['PNPM_CONFIG_FROZEN_LOCKFILE']).toBe('true');
+      } finally {
+        if (savedFrozen === undefined) delete process.env['PNPM_CONFIG_FROZEN_LOCKFILE'];
+        else process.env['PNPM_CONFIG_FROZEN_LOCKFILE'] = savedFrozen;
+      }
+    });
   });
 });

--- a/tests/integration/persistence/settings/json-settings-repository.test.ts
+++ b/tests/integration/persistence/settings/json-settings-repository.test.ts
@@ -118,6 +118,7 @@ describe('JsonSettingsRepository', () => {
       },
       logging: { level: 'info' },
       concurrency: { maxParallelTasks: 1 },
+      scm: { postRefinementComment: false },
       ui: { notifications: { enabled: true } },
       developer: { showEvaluatorFailureUI: false },
     };
@@ -153,6 +154,7 @@ describe('JsonSettingsRepository', () => {
       },
       logging: { level: 'debug' },
       concurrency: { maxParallelTasks: 4 },
+      scm: { postRefinementComment: true },
       ui: { notifications: { enabled: false } },
       developer: { showEvaluatorFailureUI: true },
     };

--- a/tests/integration/scm/issue-pusher.test.ts
+++ b/tests/integration/scm/issue-pusher.test.ts
@@ -59,33 +59,33 @@ const makeChild = (
   return child;
 };
 
-describe('createIssuePusher — update', () => {
-  it('GitHub: dispatches to `gh issue edit` with body on stdin', async () => {
+describe('createIssuePusher — comment', () => {
+  it('GitHub: dispatches to `gh issue comment` with body on stdin', async () => {
     const { spawn, capture } = scriptedSpawn([
       {
         command: 'gh',
-        args: ['issue', 'edit', '42', '--repo', 'x/y', '--body-file', '-'],
+        args: ['issue', 'comment', '42', '--repo', 'x/y', '--body-file', '-'],
         stdout: '',
         exitCode: 0,
       },
     ]);
     const pusher = createIssuePusher({ spawn });
-    const r = await pusher.update('https://github.com/x/y/issues/42', { body: 'new body' });
+    const r = await pusher.comment('https://github.com/x/y/issues/42', { body: 'new body' });
     expect(r.ok).toBe(true);
     expect(capture.stdinWrites).toEqual(['new body']);
   });
 
-  it('GitLab: dispatches to `glab issue update` with --description flag', async () => {
+  it('GitLab: dispatches to `glab issue comment` with --body flag', async () => {
     const { spawn, capture } = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'update', '7', '--repo', 'foo/bar', '--description', 'new body'],
+        args: ['issue', 'comment', '7', '--repo', 'foo/bar', '--body', 'new body'],
         stdout: '',
         exitCode: 0,
       },
     ]);
     const pusher = createIssuePusher({ spawn });
-    const r = await pusher.update('https://gitlab.com/foo/bar/-/issues/7', { body: 'new body' });
+    const r = await pusher.comment('https://gitlab.com/foo/bar/-/issues/7', { body: 'new body' });
     expect(r.ok).toBe(true);
     // glab takes the body as a flag value, not on stdin.
     expect(capture.stdinWrites).toEqual([]);
@@ -94,7 +94,7 @@ describe('createIssuePusher — update', () => {
   it('rejects unsupported issue URLs with a parse error', async () => {
     const { spawn } = scriptedSpawn([]);
     const pusher = createIssuePusher({ spawn });
-    const r = await pusher.update('https://example.com/not-an-issue', { body: 'x' });
+    const r = await pusher.comment('https://example.com/not-an-issue', { body: 'x' });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error.message).toMatch(/unsupported issue URL/);
   });
@@ -103,63 +103,15 @@ describe('createIssuePusher — update', () => {
     const { spawn } = scriptedSpawn([
       {
         command: 'gh',
-        args: ['issue', 'edit', '42', '--repo', 'x/y', '--body-file', '-'],
+        args: ['issue', 'comment', '42', '--repo', 'x/y', '--body-file', '-'],
         stdout: '',
         stderr: 'gh: not authenticated',
         exitCode: 1,
       },
     ]);
     const pusher = createIssuePusher({ spawn });
-    const r = await pusher.update('https://github.com/x/y/issues/42', { body: 'x' });
+    const r = await pusher.comment('https://github.com/x/y/issues/42', { body: 'x' });
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error.message).toMatch(/gh issue edit failed.*not authenticated/);
-  });
-});
-
-describe('createIssuePusher — create', () => {
-  it('GitHub: dispatches to `gh issue create` and extracts the returned URL from stdout', async () => {
-    const { spawn, capture } = scriptedSpawn([
-      {
-        command: 'gh',
-        args: ['issue', 'create', '--repo', 'x/y', '--title', 'Hello', '--body-file', '-'],
-        stdout: 'https://github.com/x/y/issues/123\n',
-        exitCode: 0,
-      },
-    ]);
-    const pusher = createIssuePusher({ spawn });
-    const r = await pusher.create({ provider: 'github', owner: 'x', repo: 'y' }, { title: 'Hello', body: 'b' });
-    expect(r.ok).toBe(true);
-    if (r.ok) expect(r.value.url).toBe('https://github.com/x/y/issues/123');
-    expect(capture.stdinWrites).toEqual(['b']);
-  });
-
-  it('GitLab: dispatches to `glab issue create`', async () => {
-    const { spawn } = scriptedSpawn([
-      {
-        command: 'glab',
-        args: ['issue', 'create', '--repo', 'foo/bar', '--title', 'Hi', '--description', 'b'],
-        stdout: 'https://gitlab.com/foo/bar/-/issues/9\n',
-        exitCode: 0,
-      },
-    ]);
-    const pusher = createIssuePusher({ spawn });
-    const r = await pusher.create({ provider: 'gitlab', owner: 'foo', repo: 'bar' }, { title: 'Hi', body: 'b' });
-    expect(r.ok).toBe(true);
-    if (r.ok) expect(r.value.url).toBe('https://gitlab.com/foo/bar/-/issues/9');
-  });
-
-  it('surfaces a parse error when stdout has no URL', async () => {
-    const { spawn } = scriptedSpawn([
-      {
-        command: 'gh',
-        args: ['issue', 'create', '--repo', 'x/y', '--title', 'Hello', '--body-file', '-'],
-        stdout: '(nothing useful)\n',
-        exitCode: 0,
-      },
-    ]);
-    const pusher = createIssuePusher({ spawn });
-    const r = await pusher.create({ provider: 'github', owner: 'x', repo: 'y' }, { title: 'Hello', body: 'b' });
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error.message).toMatch(/no URL found in stdout/);
+    if (!r.ok) expect(r.error.message).toMatch(/gh issue comment failed.*not authenticated/);
   });
 });

--- a/tests/unit/application/flows/implement/flow-shape.test.ts
+++ b/tests/unit/application/flows/implement/flow-shape.test.ts
@@ -209,8 +209,13 @@ const reconstructPreRefactorSerialFlow = (
     sequential<ImplementCtx>('implement-tasks', perTaskChains),
     saveTasksLeaf<ImplementCtx>({ taskRepo: deps.taskRepo }),
     guard<ImplementCtx>(
-      'transition-sprint-to-review-when-any-done',
-      (ctx) => ctx.tasks?.some((t) => t.status === 'done') === true,
+      'transition-sprint-to-review-when-settled',
+      (ctx) => {
+        const tasks = ctx.tasks ?? [];
+        const someDone = tasks.some((t) => t.status === 'done');
+        const noneRunnable = !tasks.some((t) => t.status === 'todo' || t.status === 'in_progress');
+        return someDone && noneRunnable;
+      },
       sequential<ImplementCtx>('transition-to-review-and-journal', [
         transitionSprintToReviewLeaf({ sprintRepo: deps.sprintRepo, clock: deps.clock, logger: deps.logger }),
         appendJournalSeparatorLeaf<ImplementCtx>(

--- a/tests/unit/application/flows/implement/leaves/dependency-gate.test.ts
+++ b/tests/unit/application/flows/implement/leaves/dependency-gate.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import type { BlockedTask } from '@src/domain/entity/task.ts';
+import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeDoneTask, makeTodoTask } from '@tests/fixtures/domain.ts';
+import { dependencyGateLeaf, isTaskRunnable } from '@src/application/flows/implement/leaves/dependency-gate.ts';
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+
+const sprintId = ((): ImplementCtx['sprintId'] => {
+  const r = SprintId.parse('0193ed2b-1234-7abc-8def-0123456789ab');
+  if (!r.ok) throw new Error('test setup');
+  return r.value;
+})();
+
+const fakeRepo = (): UpdateTask & { calls: number } => ({
+  calls: 0,
+  async update() {
+    (this as unknown as { calls: number }).calls += 1;
+    return Result.ok(undefined);
+  },
+});
+
+const blockedTask = (name: string): BlockedTask => {
+  const r = markTaskBlocked(makeTodoTask({ name }), 'prior failure');
+  if (!r.ok) throw r.error;
+  return r.value;
+};
+
+describe('dependencyGateLeaf', () => {
+  it('blocks a dependent upstream when a prerequisite is blocked, and the body guard then skips it', async () => {
+    const a = blockedTask('A');
+    const b = makeTodoTask({ name: 'B', dependsOn: [a.id] });
+    const repo = fakeRepo();
+    const ctx: ImplementCtx = { sprintId, tasks: [a, b] };
+
+    const res = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, b.id).execute(ctx);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    const updatedB = res.value.ctx.tasks?.find((t) => t.id === b.id);
+    expect(updatedB?.status).toBe('blocked');
+    expect((updatedB as BlockedTask).blockedReason).toMatch(/blocked upstream/i);
+    expect(repo.calls).toBe(1); // persisted exactly once
+    // The body guard reads this — false means the attempt loop (and its AI spawn) is skipped.
+    expect(isTaskRunnable(res.value.ctx, b.id)).toBe(false);
+  });
+
+  it('cascades transitively: a dependent of an upstream-blocked task is also blocked', async () => {
+    const a = blockedTask('A');
+    const b = makeTodoTask({ name: 'B', dependsOn: [a.id] });
+    const repo = fakeRepo();
+    // First gate B (becomes blocked-upstream)…
+    const afterB = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, b.id).execute({
+      sprintId,
+      tasks: [a, b],
+    });
+    expect(afterB.ok).toBe(true);
+    if (!afterB.ok) return;
+    // …then C (depends on B) sees B blocked and blocks too.
+    const c = makeTodoTask({ name: 'C', dependsOn: [b.id] });
+    const ctxWithBlockedB: ImplementCtx = {
+      sprintId,
+      tasks: [...(afterB.value.ctx.tasks ?? []), c],
+    };
+    const afterC = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, c.id).execute(ctxWithBlockedB);
+    expect(afterC.ok).toBe(true);
+    if (!afterC.ok) return;
+    expect(afterC.value.ctx.tasks?.find((t) => t.id === c.id)?.status).toBe('blocked');
+  });
+
+  it('is a no-op when every prerequisite is done (task stays runnable)', async () => {
+    const a = makeDoneTask({ name: 'A' });
+    const b = makeTodoTask({ name: 'B', dependsOn: [a.id] });
+    const repo = fakeRepo();
+    const ctx: ImplementCtx = { sprintId, tasks: [a, b] };
+
+    const res = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, b.id).execute(ctx);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.value.ctx.tasks?.find((t) => t.id === b.id)?.status).toBe('todo');
+    expect(repo.calls).toBe(0); // no write on the happy path
+    expect(isTaskRunnable(res.value.ctx, b.id)).toBe(true);
+  });
+
+  it('is a no-op for a task with no dependencies', async () => {
+    const b = makeTodoTask({ name: 'B' });
+    const repo = fakeRepo();
+    const res = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, b.id).execute({
+      sprintId,
+      tasks: [b],
+    });
+    expect(res.ok).toBe(true);
+    expect(repo.calls).toBe(0);
+  });
+
+  it('is idempotent on a relaunch re-entering an already-blocked task (no re-write)', async () => {
+    const a = blockedTask('A');
+    const bBlocked = blockedTask('B'); // already blocked from a prior run
+    const repo = fakeRepo();
+    const res = await dependencyGateLeaf({ taskRepo: repo, logger: noopLogger }, bBlocked.id).execute({
+      sprintId,
+      tasks: [a, bBlocked],
+    });
+    expect(res.ok).toBe(true);
+    expect(repo.calls).toBe(0); // already settled → no-op
+  });
+});

--- a/tests/unit/application/flows/implement/leaves/implement-session.test.ts
+++ b/tests/unit/application/flows/implement/leaves/implement-session.test.ts
@@ -48,4 +48,33 @@ describe('implementSession', () => {
     const session = implementSession(SANDBOX, REPO, SPRINT_DIR, PROMPT, 'claude-opus-4-8', SIGNALS, 'evaluator');
     expect(String(session.outputDir)).toBe('/tmp/sandbox/rounds/2/evaluator');
   });
+
+  // Abort wire: without an abortSignal the field is absent (so the field stays optional and
+  // single-shot sessions don't carry a dangling signal).
+  it('omits `abortSignal` when none is supplied', () => {
+    const session = implementSession(SANDBOX, REPO, SPRINT_DIR, PROMPT, 'claude-opus-4-8', SIGNALS, 'generator');
+    expect(session).not.toHaveProperty('abortSignal');
+  });
+
+  // Abort wire (keystone): the leaf framework hands `execute(input, signal)` the chain's abort
+  // signal; the leaf threads it here. The headless provider only arms its SIGTERM→SIGKILL kill
+  // ladder + abort-aware exit classification when `session.abortSignal` is set, so this forward
+  // is what makes a TUI cancel actually kill the in-flight child (instead of letting it run to
+  // natural completion — which previously stranded the repo lock and the progress spinner).
+  it('forwards a supplied `abortSignal` onto the session descriptor', () => {
+    const controller = new AbortController();
+    const session = implementSession(
+      SANDBOX,
+      REPO,
+      SPRINT_DIR,
+      PROMPT,
+      'claude-opus-4-8',
+      SIGNALS,
+      'generator',
+      undefined,
+      undefined,
+      controller.signal
+    );
+    expect(session.abortSignal).toBe(controller.signal);
+  });
 });

--- a/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
+++ b/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
@@ -201,6 +201,7 @@ const scriptedChoicePrompt = <T>(answer: Result<T, StorageError | AbortError>): 
 
 interface FixtureOpts {
   readonly verifyScript?: string;
+  readonly timeoutMs?: number;
   readonly env?: PreTaskVerifyEnvironment;
   readonly interactive?: InteractivePrompt;
   readonly execution?: SprintExecution;
@@ -239,11 +240,49 @@ const fixture = (runner: ShellScriptRunner, opts: FixtureOpts = {}): Fixture => 
       logger: noopLogger,
       environment: opts.env ?? TTY_ENV,
     },
-    { cwd: CWD, ...(opts.verifyScript !== undefined ? { verifyScript: opts.verifyScript } : {}) },
+    {
+      cwd: CWD,
+      ...(opts.verifyScript !== undefined ? { verifyScript: opts.verifyScript } : {}),
+      ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+    },
     task.id
   );
   return { ctx, leaf, repo, execRepo };
 };
+
+// Captures the opts handed to the shell runner so we can assert the verify timeout is threaded.
+const capturingShellRunner = (
+  result: { passed: boolean; exitCode: number | null; output: string },
+  sink: { opts?: { timeoutMs?: number } }
+): ShellScriptRunner => ({
+  async run(_cwd, _script, runOpts) {
+    sink.opts = runOpts;
+    return Result.ok({ ...result, durationMs: 0 });
+  },
+});
+
+describe('preTaskVerifyLeaf — verifyTimeout plumbing', () => {
+  // Regression: Repository.verifyTimeout was dropped between the entity and the chain, so a
+  // user-set timeout silently had no effect and a hung verify burned the full 5-min default on
+  // BOTH the pre- and post-task call. The leaf must forward its `timeoutMs` opt to the runner.
+  it('threads the configured verifyTimeout to the shell runner as timeoutMs', async () => {
+    const sink: { opts?: { timeoutMs?: number } } = {};
+    const runner = capturingShellRunner({ passed: true, exitCode: 0, output: 'ok' }, sink);
+    const { ctx, leaf } = fixture(runner, { verifyScript: 'pnpm test', timeoutMs: 90_000 });
+    const res = await leaf.execute(ctx);
+    expect(res.ok).toBe(true);
+    expect(sink.opts?.timeoutMs).toBe(90_000);
+  });
+
+  it('omits timeoutMs when no verifyTimeout is configured (runner falls back to its default)', async () => {
+    const sink: { opts?: { timeoutMs?: number } } = {};
+    const runner = capturingShellRunner({ passed: true, exitCode: 0, output: 'ok' }, sink);
+    const { ctx, leaf } = fixture(runner, { verifyScript: 'pnpm test' });
+    const res = await leaf.execute(ctx);
+    expect(res.ok).toBe(true);
+    expect(sink.opts?.timeoutMs).toBeUndefined();
+  });
+});
 
 describe('preTaskVerifyLeaf — happy / spawn-error paths', () => {
   it('skipped row when no verifyScript configured — no prompt, lastPreVerifyOutcome="skipped"', async () => {

--- a/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
+++ b/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
@@ -253,7 +253,7 @@ const fixture = (runner: ShellScriptRunner, opts: FixtureOpts = {}): Fixture => 
 // Captures the opts handed to the shell runner so we can assert the verify timeout is threaded.
 const capturingShellRunner = (
   result: { passed: boolean; exitCode: number | null; output: string },
-  sink: { opts?: { timeoutMs?: number } }
+  sink: { opts: unknown }
 ): ShellScriptRunner => ({
   async run(_cwd, _script, runOpts) {
     sink.opts = runOpts;
@@ -266,21 +266,21 @@ describe('preTaskVerifyLeaf — verifyTimeout plumbing', () => {
   // user-set timeout silently had no effect and a hung verify burned the full 5-min default on
   // BOTH the pre- and post-task call. The leaf must forward its `timeoutMs` opt to the runner.
   it('threads the configured verifyTimeout to the shell runner as timeoutMs', async () => {
-    const sink: { opts?: { timeoutMs?: number } } = {};
+    const sink: { opts: unknown } = { opts: undefined };
     const runner = capturingShellRunner({ passed: true, exitCode: 0, output: 'ok' }, sink);
     const { ctx, leaf } = fixture(runner, { verifyScript: 'pnpm test', timeoutMs: 90_000 });
     const res = await leaf.execute(ctx);
     expect(res.ok).toBe(true);
-    expect(sink.opts?.timeoutMs).toBe(90_000);
+    expect((sink.opts as { timeoutMs?: number } | undefined)?.timeoutMs).toBe(90_000);
   });
 
   it('omits timeoutMs when no verifyTimeout is configured (runner falls back to its default)', async () => {
-    const sink: { opts?: { timeoutMs?: number } } = {};
+    const sink: { opts: unknown } = { opts: undefined };
     const runner = capturingShellRunner({ passed: true, exitCode: 0, output: 'ok' }, sink);
     const { ctx, leaf } = fixture(runner, { verifyScript: 'pnpm test' });
     const res = await leaf.execute(ctx);
     expect(res.ok).toBe(true);
-    expect(sink.opts?.timeoutMs).toBeUndefined();
+    expect((sink.opts as { timeoutMs?: number } | undefined)?.timeoutMs).toBeUndefined();
   });
 });
 

--- a/tests/unit/application/flows/implement/leaves/setup-script-runner.test.ts
+++ b/tests/unit/application/flows/implement/leaves/setup-script-runner.test.ts
@@ -193,13 +193,13 @@ describe('setupScriptRunnerLeaf', () => {
     expect(result.error.error.message).toBe('exited 7');
   });
 
-  it('surfaces a project-side hint and persists ONE row when pnpm aborts on missing TTY', async () => {
+  it('surfaces a CI-override hint and persists ONE row when pnpm aborts on missing TTY', async () => {
     // `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` (pnpm refuses to wipe node_modules without
-    // an interactive confirmation, pnpm/pnpm#9966). The leaf does NOT auto-retry with CI=true
-    // because that would flip Maven Surefire, Spring Boot @DisabledIfEnvironmentVariable("CI")
-    // gates, pnpm's frozen-lockfile semantics, and other toolchain heuristics — a "green" retry
-    // could mask drift from the real baseline the post-task verify gate later runs without CI.
-    // Instead the leaf aborts on the single spawn and surfaces an actionable project-side hint.
+    // an interactive confirmation, pnpm/pnpm#9966 / #11562). The shell runner now sets CI=true
+    // on every setup/verify child — the only lever that suppresses this on pnpm 11 — so this
+    // path is reached only when CI is overridden in the operator's env. The leaf still does not
+    // run its own CI retry; it aborts on the single spawn and surfaces an actionable hint that
+    // points at the env override rather than asking the project under development to adapt.
     const repo = savingRepo();
     const bus = createCapturingBus();
     const shell = multiCallShell([
@@ -223,7 +223,8 @@ describe('setupScriptRunnerLeaf', () => {
     if (result.ok) return;
 
     expect(result.error.error).toBeInstanceOf(InvalidStateError);
-    // Exactly one spawn — no auto-retry.
+    // Exactly one spawn — the leaf itself does not do a CI retry (CI=true is injected one layer
+    // down, inside the shell runner, not via the leaf's opts.env).
     expect(shell.calls).toHaveLength(1);
     expect(shell.calls[0]?.env?.CI).toBeUndefined();
     // Exactly one audit row appended (the failed first attempt).
@@ -233,13 +234,13 @@ describe('setupScriptRunnerLeaf', () => {
     expect(finalExec?.setupRanAt[0]?.outcome).toBe('failed');
     // Error message keeps the no-tty pnpm trim form.
     expect(result.error.error.message).toBe('exited 1 (no-tty pnpm)');
-    // Hint surfaces the project-side fixes — no auto-retry / CI=true mention.
+    // Hint points at the env override — the harness sets CI=true, so reaching this path means
+    // CI was cleared in the operator's environment. No longer asks the project to adapt.
     const invalidStateError = result.error.error as InvalidStateError;
     const hint = invalidStateError.hint ?? '';
-    expect(hint).toContain('pin pnpm < 11');
-    expect(hint).toContain('confirm-modules-purge=false');
-    expect(hint).not.toContain('auto-retry');
-    expect(hint).not.toContain('CI=true');
+    expect(hint).toContain('CI');
+    expect(hint).toContain('resync');
+    expect(hint).not.toContain('pin pnpm < 11');
   });
 
   it('does not append the pnpm no-TTY hint to generic script failures', async () => {

--- a/tests/unit/application/flows/implement/leaves/start-attempt.test.ts
+++ b/tests/unit/application/flows/implement/leaves/start-attempt.test.ts
@@ -197,9 +197,12 @@ describe('startAttemptLeaf', () => {
     expect(eventLog.some((e) => e.message.includes('recovering aborted attempt'))).toBe(true);
   });
 
-  it('resume: returns InvalidStateError when settling the prior attempt exhausts the budget', async () => {
-    // Task with maxAttempts=1 and one running attempt → settling it pushes the task to
-    // `blocked`, which the use case surfaces as an InvalidStateError so the chain halts.
+  it('resume: persists the blocked transition AND returns InvalidStateError when the budget is exhausted', async () => {
+    // Task with maxAttempts=1 and one running attempt → settling it pushes the task to `blocked`,
+    // which the use case surfaces as an InvalidStateError so the chain doesn't start an attempt on a
+    // blocked task. Crucially the blocked state is PERSISTED before the error is raised: otherwise
+    // the leftover running attempt stays on disk and every relaunch re-hits this path and re-errors
+    // (a stuck loop), while the task never reports as blocked and the launch queue can't filter it.
     const inProgressMaxed = makeInProgressTaskWithRunningAttempt({ maxAttempts: 1 });
     const { repo, calls } = fakeUpdateTask({
       tasksById: new Map([[String(inProgressMaxed.id), inProgressMaxed]]),
@@ -213,7 +216,10 @@ describe('startAttemptLeaf', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.error.message).toContain('blocked');
-    expect(calls).toHaveLength(0); // nothing persisted — chain bails before the write.
+    // The blocked transition is durably written (regression: it used to be computed but dropped).
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.task.status).toBe('blocked');
+    expect(calls[0]?.task.attempts.at(-1)?.status).toBe('aborted');
   });
 
   it('resume: refuses to overwrite when in-memory diverges from persisted state', async () => {

--- a/tests/unit/application/flows/implement/should-transition-to-review.test.ts
+++ b/tests/unit/application/flows/implement/should-transition-to-review.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { shouldTransitionToReview } from '@src/application/flows/implement/flow.ts';
+import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
+import { makeDoneTask, makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
+
+const blocked = (name: string): BlockedTask => ({
+  ...makeTodoTask({ name }),
+  status: 'blocked',
+  blockedReason: 'unit-test reason',
+});
+
+describe('shouldTransitionToReview', () => {
+  it('does NOT transition while a task is still todo (premature-flip fix)', () => {
+    // The prior `some(done)` predicate flipped here — that is the bug.
+    const tasks: Task[] = [makeDoneTask({ name: 'a' }), makeTodoTask({ name: 'b' })];
+    expect(shouldTransitionToReview(tasks)).toBe(false);
+  });
+
+  it('does NOT transition while a task is still in_progress', () => {
+    const tasks: Task[] = [makeDoneTask({ name: 'a' }), makeInProgressTaskWithRunningAttempt()];
+    expect(shouldTransitionToReview(tasks)).toBe(false);
+  });
+
+  it('transitions when every task has settled and at least one is done (mixed end state)', () => {
+    const tasks: Task[] = [makeDoneTask({ name: 'a' }), blocked('b')];
+    expect(shouldTransitionToReview(tasks)).toBe(true);
+  });
+
+  it('transitions when every task is done', () => {
+    const tasks: Task[] = [makeDoneTask({ name: 'a' }), makeDoneTask({ name: 'b' })];
+    expect(shouldTransitionToReview(tasks)).toBe(true);
+  });
+
+  it('does NOT transition when all tasks are blocked (nothing to review — stay active)', () => {
+    const tasks: Task[] = [blocked('a'), blocked('b')];
+    expect(shouldTransitionToReview(tasks)).toBe(false);
+  });
+
+  it('does NOT transition on an empty / undefined task list', () => {
+    expect(shouldTransitionToReview([])).toBe(false);
+    expect(shouldTransitionToReview(undefined)).toBe(false);
+  });
+});

--- a/tests/unit/application/ui/shared/launch/resolve-implement-queue.test.ts
+++ b/tests/unit/application/ui/shared/launch/resolve-implement-queue.test.ts
@@ -4,8 +4,9 @@
  *  - a cyclic / dangling graph FAILS FAST with the rendered `TaskGraphIssue` (never a silent
  *    deadlock surfacing later as an empty "No tasks to implement" queue);
  *  - a valid graph yields a queue that honours `dependsOn` ordering;
- *  - an in-progress (resumed) task still leads, with dependency order preserved within each
- *    status group.
+ *  - an in-progress (resumed) task leads only among the dependency-independent tasks runnable at
+ *    each step — it is never hoisted ahead of a prerequisite it depends on (the blocked-dependency
+ *    dead-end guard).
  */
 
 import { describe, expect, it } from 'vitest';
@@ -76,10 +77,12 @@ describe('resolveImplementQueue', () => {
     expect(names(result.value)).toEqual(['a', 'b', 'c']);
   });
 
-  it('keeps an in-progress (resumed) task first while preserving dependency order', () => {
-    // a → b → c chain; c is in_progress (a crashed resume). The dependency order is a, b, c,
-    // but the resumed task must LEAD so relaunch resumes it before opening fresh work — and the
-    // remaining todos stay in dependency order behind it.
+  it('does NOT hoist a resumed task ahead of its still-todo prerequisites (dependency order wins)', () => {
+    // a → b → c chain; c is in_progress with a, b still todo (e.g. a crash + manual unblock of a
+    // upstream prerequisite left the dependent in_progress while a prereq is back to todo). The
+    // resumed task must NOT lead here: c depends on b depends on a, so hoisting c first would make
+    // c's dependency-gate fire before a/b ran and dead-end it `blocked upstream`. Dependency order
+    // is the hard constraint — a, then b, then c (which resumes once its prereqs have settled).
     const a = makeTodoTask({ name: 'a', order: 1 });
     const b = makeTodoTask({ name: 'b', order: 2, dependsOn: [a.id] });
     const cTodo = makeTodoTask({ name: 'c', order: 3, dependsOn: [b.id] });
@@ -89,7 +92,35 @@ describe('resolveImplementQueue', () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    // c leads (resume override); a then b preserve dependency order behind it.
+    expect(names(result.value)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('runs a todo prerequisite before its in_progress dependent (blocked-dependency dead-end guard)', () => {
+    // The minimal regression: prerequisite b is todo, dependent c is in_progress and depends on b.
+    // The prerequisite MUST be queued first so c does not gate-block on a not-yet-run prereq.
+    const b = makeTodoTask({ name: 'b', order: 1 });
+    const cTodo = makeTodoTask({ name: 'c', order: 2, dependsOn: [b.id] });
+    const c = inProgressOf(cTodo);
+
+    const result = resolveImplementQueue([c, b]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(names(result.value)).toEqual(['b', 'c']);
+  });
+
+  it('still leads with the resumed task among DEPENDENCY-INDEPENDENT peers', () => {
+    // No edges between a, b, c — all immediately runnable. The in-progress resume override applies
+    // within this frontier (it can violate no dependency order), so c leads, then a, b by order.
+    const a = makeTodoTask({ name: 'a', order: 1 });
+    const b = makeTodoTask({ name: 'b', order: 2 });
+    const cTodo = makeTodoTask({ name: 'c', order: 3 });
+    const c = inProgressOf(cTodo);
+
+    const result = resolveImplementQueue([a, b, c]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
     expect(names(result.value)).toEqual(['c', 'a', 'b']);
     expect(result.value[0]?.status).toBe('in_progress');
   });

--- a/tests/unit/application/ui/tui/components/windowed-anchor.test.ts
+++ b/tests/unit/application/ui/tui/components/windowed-anchor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { computeAnchoredWindow } from '@src/application/ui/tui/components/windowed-anchor.ts';
+
+describe('computeAnchoredWindow', () => {
+  it('returns the full range with nothing hidden when the list fits the budget', () => {
+    expect(computeAnchoredWindow(3, 0, 5)).toEqual({ start: 0, end: 3, hiddenBefore: 0, hiddenAfter: 0 });
+    expect(computeAnchoredWindow(5, 2, 5)).toEqual({ start: 0, end: 5, hiddenBefore: 0, hiddenAfter: 0 });
+  });
+
+  it('treats a non-positive budget as unbounded (no windowing)', () => {
+    expect(computeAnchoredWindow(10, 4, 0)).toEqual({ start: 0, end: 10, hiddenBefore: 0, hiddenAfter: 0 });
+  });
+
+  it('handles an empty list', () => {
+    expect(computeAnchoredWindow(0, 0, 4)).toEqual({ start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 });
+    expect(computeAnchoredWindow(0, -1, 4)).toEqual({ start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 });
+  });
+
+  it('centres the window on the anchor and reports both hidden counts', () => {
+    // 10 items, budget 4, anchor 5 → half=2 → start=3, end=7.
+    expect(computeAnchoredWindow(10, 5, 4)).toEqual({ start: 3, end: 7, hiddenBefore: 3, hiddenAfter: 3 });
+  });
+
+  it('clamps the window to the start edge when the anchor is near the head', () => {
+    // anchor 0 → start clamps to 0, window [0,4).
+    expect(computeAnchoredWindow(10, 0, 4)).toEqual({ start: 0, end: 4, hiddenBefore: 0, hiddenAfter: 6 });
+  });
+
+  it('clamps the window to the end edge (full last page, not a short tail)', () => {
+    // anchor 9 (last) → start clamps to total-cap=6, window [6,10).
+    expect(computeAnchoredWindow(10, 9, 4)).toEqual({ start: 6, end: 10, hiddenBefore: 6, hiddenAfter: 0 });
+  });
+
+  it('always keeps the anchor inside the returned window', () => {
+    const total = 25;
+    const cap = 6;
+    for (let anchor = 0; anchor < total; anchor++) {
+      const w = computeAnchoredWindow(total, anchor, cap);
+      expect(anchor).toBeGreaterThanOrEqual(w.start);
+      expect(anchor).toBeLessThan(w.end);
+      expect(w.end - w.start).toBe(cap);
+      expect(w.hiddenBefore + (w.end - w.start) + w.hiddenAfter).toBe(total);
+    }
+  });
+
+  it('clamps a stale / out-of-range anchor into the list', () => {
+    expect(computeAnchoredWindow(10, 999, 4)).toEqual({ start: 6, end: 10, hiddenBefore: 6, hiddenAfter: 0 });
+    expect(computeAnchoredWindow(10, -5, 4)).toEqual({ start: 0, end: 4, hiddenBefore: 0, hiddenAfter: 6 });
+  });
+});

--- a/tests/unit/application/ui/tui/launch-routing.test.ts
+++ b/tests/unit/application/ui/tui/launch-routing.test.ts
@@ -25,8 +25,8 @@ const SID_LO = sprintId('01900000-0000-7000-8000-0000000000c1');
 const SID_HI = sprintId('01900000-0000-7000-8000-0000000000c9');
 
 /** Minimal draft sprint scoped to a project, with an explicit (lex-sortable) id. */
-const makeSprint = (projectId: ProjectId, id: SprintId): Sprint => {
-  const r = createSprint({ id, name: 'a sprint', projectId });
+const makeSprint = (projectId: ProjectId, id: SprintId, name = 'a sprint'): Sprint => {
+  const r = createSprint({ id, name, projectId });
   if (!r.ok) throw new Error(`fixture sprint failed: ${r.error.message}`);
   return r.value;
 };
@@ -126,6 +126,7 @@ describe('resolveInitialState', () => {
       projectId: a.id,
       projectLabel: 'One',
       sprintId: remembered.id,
+      sprintLabel: 'a sprint',
     });
   });
 
@@ -146,6 +147,7 @@ describe('resolveInitialState', () => {
       projectId: a.id,
       projectLabel: 'One',
       sprintId: newest.id,
+      sprintLabel: 'a sprint',
     });
   });
 
@@ -165,6 +167,7 @@ describe('resolveInitialState', () => {
       projectId: a.id,
       projectLabel: 'One',
       sprintId: newestA.id,
+      sprintLabel: 'a sprint',
     });
   });
 
@@ -185,5 +188,31 @@ describe('resolveInitialState', () => {
     const result = resolveInitialState({ settingsExist: true, projects: [], sprints: [] });
     expect(result.initialView).toEqual({ id: 'create-project' });
     expect(result.initialSelection).toBeUndefined();
+  });
+
+  it('seeds sprintLabel equal to the resolved sprint name', () => {
+    const a = makeProject({ id: ProjectId.generate(), slug: 'alpha', displayName: 'Alpha' });
+    const s = makeSprint(a.id, SID_HI, 'Sprint Alpha');
+    const result = resolveInitialState({
+      settingsExist: true,
+      projects: [a],
+      lastProjectId: a.id,
+      lastSprintId: s.id,
+      sprints: [s],
+    });
+    expect(result.initialSelection?.sprintId).toEqual(s.id);
+    expect(result.initialSelection?.sprintLabel).toBe('Sprint Alpha');
+  });
+
+  it('seeds no sprintLabel when the project has no sprints', () => {
+    const a = makeProject({ id: ProjectId.generate(), slug: 'alpha', displayName: 'Alpha' });
+    const result = resolveInitialState({
+      settingsExist: true,
+      projects: [a],
+      lastProjectId: a.id,
+      sprints: [],
+    });
+    expect(result.initialSelection?.sprintId).toBeUndefined();
+    expect(result.initialSelection?.sprintLabel).toBeUndefined();
   });
 });

--- a/tests/unit/application/ui/tui/runtime/session-manager.test.ts
+++ b/tests/unit/application/ui/tui/runtime/session-manager.test.ts
@@ -16,6 +16,10 @@ import { leaf } from '@src/application/chain/build/leaf.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
 import { createRunner } from '@src/application/chain/run/runner.ts';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
+import { sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 
 interface Ctx {
   readonly _?: never;
@@ -70,6 +74,82 @@ describe('session-manager', () => {
     // Late subscriber replays — manager must already be detached.
     runner.subscribe(() => undefined);
     expect(notifyCount).toBe(countAfterRegister);
+  });
+
+  it('threads pinned project/sprint ids and labels through register', () => {
+    const sessions = createSessionManager();
+    const flow: Element<Ctx> = sequential<Ctx>('flow', [okLeaf('one')]);
+    const runner = createRunner({ id: 'r-pinned', element: flow, initialCtx: {} });
+
+    sessions.register({
+      runner,
+      flowId: 'implement',
+      title: 'Implement',
+      pinnedProjectId: 'proj-1' as ProjectId,
+      pinnedProjectLabel: 'My Project',
+      pinnedSprintId: 'sprint-1' as SprintId,
+      pinnedSprintLabel: 'Sprint Alpha',
+    });
+
+    const record = sessions.get('r-pinned');
+    expect(record?.descriptor.pinnedProjectId).toBe('proj-1');
+    expect(record?.descriptor.pinnedProjectLabel).toBe('My Project');
+    expect(record?.descriptor.pinnedSprintId).toBe('sprint-1');
+    expect(record?.descriptor.pinnedSprintLabel).toBe('Sprint Alpha');
+  });
+
+  it('leaves pinned fields undefined when not supplied to register', () => {
+    const sessions = createSessionManager();
+    const flow: Element<Ctx> = sequential<Ctx>('flow', [okLeaf('one')]);
+    const runner = createRunner({ id: 'r-no-pinned', element: flow, initialCtx: {} });
+
+    sessions.register({ runner, flowId: 'refine', title: 'Refine' });
+
+    const record = sessions.get('r-no-pinned');
+    expect(record?.descriptor.pinnedProjectId).toBeUndefined();
+    expect(record?.descriptor.pinnedProjectLabel).toBeUndefined();
+    expect(record?.descriptor.pinnedSprintId).toBeUndefined();
+    expect(record?.descriptor.pinnedSprintLabel).toBeUndefined();
+  });
+
+  it('sessionHintsFromLaunchResult round-trips pinned project/sprint fields', () => {
+    const flow: Element<Ctx> = sequential<Ctx>('flow', [okLeaf('one')]);
+    const runner = createRunner({ id: 'r-hints', element: flow, initialCtx: {} });
+
+    const result = {
+      ok: true as const,
+      runner: runner as ReturnType<typeof createRunner>,
+      title: 'Implement',
+      pinnedProjectId: 'proj-abc' as ProjectId,
+      pinnedProjectLabel: 'Test Project',
+      pinnedSprintId: 'sprint-xyz' as SprintId,
+      pinnedSprintLabel: 'Test Sprint',
+    } satisfies Extract<LaunchResult, { ok: true }>;
+
+    const hints = sessionHintsFromLaunchResult(result);
+
+    expect(hints.pinnedProjectId).toBe('proj-abc');
+    expect(hints.pinnedProjectLabel).toBe('Test Project');
+    expect(hints.pinnedSprintId).toBe('sprint-xyz');
+    expect(hints.pinnedSprintLabel).toBe('Test Sprint');
+  });
+
+  it('sessionHintsFromLaunchResult omits pinned fields when not set on LaunchResult', () => {
+    const flow: Element<Ctx> = sequential<Ctx>('flow', [okLeaf('one')]);
+    const runner = createRunner({ id: 'r-no-hints', element: flow, initialCtx: {} });
+
+    const result = {
+      ok: true as const,
+      runner: runner as ReturnType<typeof createRunner>,
+      title: 'Refine',
+    } satisfies Extract<LaunchResult, { ok: true }>;
+
+    const hints = sessionHintsFromLaunchResult(result);
+
+    expect(hints.pinnedProjectId).toBeUndefined();
+    expect(hints.pinnedProjectLabel).toBeUndefined();
+    expect(hints.pinnedSprintId).toBeUndefined();
+    expect(hints.pinnedSprintLabel).toBeUndefined();
   });
 
   describe('eviction', () => {

--- a/tests/unit/business/settings/apply-key.test.ts
+++ b/tests/unit/business/settings/apply-key.test.ts
@@ -132,6 +132,29 @@ describe('applySettingsKey', () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error.message).toContain('not a boolean');
   });
+
+  it('defaults scm.postRefinementComment to false', () => {
+    expect(DEFAULT_SETTINGS.scm.postRefinementComment).toBe(false);
+  });
+
+  it('toggles scm.postRefinementComment from common truthy/falsy synonyms', () => {
+    for (const raw of ['true', '1', 'yes', 'on'] as const) {
+      const r = applySettingsKey(DEFAULT_SETTINGS, 'scm.postRefinementComment', raw);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.value.scm.postRefinementComment).toBe(true);
+    }
+    for (const raw of ['false', '0', 'no', 'off'] as const) {
+      const r = applySettingsKey(DEFAULT_SETTINGS, 'scm.postRefinementComment', raw);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.value.scm.postRefinementComment).toBe(false);
+    }
+  });
+
+  it('rejects a non-boolean value for scm.postRefinementComment', () => {
+    const r = applySettingsKey(DEFAULT_SETTINGS, 'scm.postRefinementComment', 'maybe');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toContain('not a boolean');
+  });
 });
 
 describe('parseSettingsKvSyntax', () => {

--- a/tests/unit/business/settings/escalation-map.test.ts
+++ b/tests/unit/business/settings/escalation-map.test.ts
@@ -29,8 +29,8 @@ const baseRecord = {
 };
 
 describe('settings.harness — escalateOnPlateau + escalationMap', () => {
-  it('fresh-install defaults are off / empty', () => {
-    expect(DEFAULT_SETTINGS.harness.escalateOnPlateau).toBe(false);
+  it('fresh-install defaults: escalateOnPlateau on, empty map', () => {
+    expect(DEFAULT_SETTINGS.harness.escalateOnPlateau).toBe(true);
     expect(DEFAULT_SETTINGS.harness.escalationMap).toEqual({});
   });
 
@@ -92,7 +92,7 @@ describe('settings.harness — escalateOnPlateau + escalationMap', () => {
     const parsed = SettingsSchema.safeParse(record);
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
-    expect(parsed.data.harness.escalateOnPlateau).toBe(false);
+    expect(parsed.data.harness.escalateOnPlateau).toBe(true);
     expect(parsed.data.harness.escalationMap).toEqual({});
   });
 });

--- a/tests/unit/business/task/escalation-policy-branches.test.ts
+++ b/tests/unit/business/task/escalation-policy-branches.test.ts
@@ -94,7 +94,7 @@ describe('decideEscalation — user-only and edge cases', () => {
     }
   });
 
-  it('returns no-mapping for a model unknown to both default and user maps', () => {
+  it('returns nudge for a model unknown to both default and user maps (no rung above)', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const decision = decideEscalation({
       task,
@@ -103,8 +103,8 @@ describe('decideEscalation — user-only and edge cases', () => {
       userMap: {},
     });
 
-    expect(decision.kind).toBe('no-mapping');
-    if (decision.kind === 'no-mapping') {
+    expect(decision.kind).toBe('nudge');
+    if (decision.kind === 'nudge') {
       expect(decision.currentModel).toBe('completely-unknown-model');
     }
   });

--- a/tests/unit/business/task/escalation-policy.test.ts
+++ b/tests/unit/business/task/escalation-policy.test.ts
@@ -77,7 +77,7 @@ describe('decideEscalation', () => {
     expect(decision.kind).toBe('already-escalated');
   });
 
-  it('returns no-mapping when the current model has no rung above', () => {
+  it('returns nudge when the current model has no rung above (top of ladder)', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const decision = decideEscalation({
       task,
@@ -85,10 +85,11 @@ describe('decideEscalation', () => {
       flagOn: true,
       userMap: {},
     });
-    expect(decision.kind).toBe('no-mapping');
+    expect(decision.kind).toBe('nudge');
+    if (decision.kind === 'nudge') expect(decision.currentModel).toBe('claude-opus-4-8');
   });
 
-  it('treats self-loop entries (from === to) as no-mapping', () => {
+  it('treats self-loop entries (from === to) as a nudge', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const decision = decideEscalation({
       task,
@@ -96,7 +97,7 @@ describe('decideEscalation', () => {
       flagOn: true,
       userMap: { 'claude-sonnet-4-6': 'claude-sonnet-4-6' },
     });
-    expect(decision.kind).toBe('no-mapping');
+    expect(decision.kind).toBe('nudge');
   });
 
   it('returns budget-exhausted before checking the map when attempts === maxAttempts', () => {
@@ -146,7 +147,30 @@ describe('applyEscalation', () => {
     expect(banner?.id).toBe(escalationBannerId(String(task.id)));
   });
 
-  it('on already-escalated: warn banner + blockedReason, no model-escalated event', () => {
+  it('on nudge: stamps the same model (once-per-task marker), info banner, no blockedReason, no model-escalated event', () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const { bus, events } = captureBus();
+    const applied = applyEscalation({
+      task,
+      decision: { kind: 'nudge', currentModel: 'claude-opus-4-8' },
+      eventBus: bus,
+      logger: noopLogger,
+      clock: fixedClock,
+    });
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    // Stamped from===to so the once-per-task cap fires on a second plateau; the generator reads
+    // escalatedFromModel to arm the change-of-approach directive.
+    expect(applied.value.task.escalatedFromModel).toBe('claude-opus-4-8');
+    expect(applied.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(applied.value.blockedReason).toBeUndefined();
+    expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
+    const banner = events.find((e): e is Extract<AppEvent, { type: 'banner-show' }> => e.type === 'banner-show');
+    expect(banner?.tier).toBe('info');
+    expect(banner?.message).toMatch(/change-of-approach directive/);
+  });
+
+  it('on already-escalated: warn banner, NO blockedReason (preserves work), no model-escalated event', () => {
     const task = withEscalation(
       makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
       'claude-sonnet-4-6',
@@ -162,31 +186,14 @@ describe('applyEscalation', () => {
     });
     expect(applied.ok).toBe(true);
     if (!applied.ok) return;
-    expect(applied.value.blockedReason).toMatch(/plateau persists after escalation/);
+    // A plateau never blocks — after the one retry the work is preserved (done-with-warning).
+    expect(applied.value.blockedReason).toBeUndefined();
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
     const banner = events.find((e): e is Extract<AppEvent, { type: 'banner-show' }> => e.type === 'banner-show');
     expect(banner?.tier).toBe('warn');
   });
 
-  it('on no-mapping: warn banner mentions ladder top, blockedReason set', () => {
-    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
-    const { bus, events } = captureBus();
-    const applied = applyEscalation({
-      task,
-      decision: { kind: 'no-mapping', currentModel: 'claude-opus-4-8' },
-      eventBus: bus,
-      logger: noopLogger,
-      clock: fixedClock,
-    });
-    expect(applied.ok).toBe(true);
-    if (!applied.ok) return;
-    expect(applied.value.blockedReason).toMatch(/top of configured escalation ladder/);
-    const banner = events.find((e): e is Extract<AppEvent, { type: 'banner-show' }> => e.type === 'banner-show');
-    expect(banner?.tier).toBe('warn');
-    expect(banner?.message).toMatch(/claude-opus-4-8/);
-  });
-
-  it('on budget-exhausted: warn banner names budget exhaustion (not missing mapping)', () => {
+  it('on budget-exhausted: warn banner names budget exhaustion, NO blockedReason (preserves work)', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 1 });
     const { bus, events } = captureBus();
     const applied = applyEscalation({
@@ -198,7 +205,7 @@ describe('applyEscalation', () => {
     });
     expect(applied.ok).toBe(true);
     if (!applied.ok) return;
-    expect(applied.value.blockedReason).toMatch(/attempt budget exhausted/);
+    expect(applied.value.blockedReason).toBeUndefined();
     expect(applied.value.task.escalatedToModel).toBeUndefined();
     const banner = events.find((e): e is Extract<AppEvent, { type: 'banner-show' }> => e.type === 'banner-show');
     expect(banner?.tier).toBe('warn');

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -219,7 +219,7 @@ describe('finalizeGenEvalUseCase', () => {
     expect(events.some((e) => e.type === 'model-escalated')).toBe(true);
   });
 
-  it('plateau + already-escalated: no new event, blockedReason set, shouldFailAttempt unset', async () => {
+  it('plateau + already-escalated: no new event, NO blockedReason (preserves work), shouldFailAttempt unset', async () => {
     const initial = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const stamped = recordTaskEscalation(initial, 'claude-sonnet-4-6', 'claude-opus-4-8');
     if (!stamped.ok) throw stamped.error;
@@ -240,12 +240,13 @@ describe('finalizeGenEvalUseCase', () => {
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.blockedReason).toMatch(/plateau persists after escalation/);
+    // After the one plateau-break retry, a second plateau preserves the work (done-with-warning).
+    expect(result.value.blockedReason).toBeUndefined();
     expect(result.value.shouldFailAttempt).toBeFalsy();
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
   });
 
-  it('plateau + flag-on + no-mapping: warn banner, blockedReason set, no escalation stamped', async () => {
+  it('plateau + flag-on + top-of-ladder: nudge stamps the same model + shouldFailAttempt, no blockedReason', async () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const bus = newBus();
     const events: Array<{ type: string }> = [];
@@ -264,11 +265,15 @@ describe('finalizeGenEvalUseCase', () => {
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.task.escalatedToModel).toBeUndefined();
-    expect(result.value.blockedReason).toMatch(/top of configured escalation ladder/);
+    // Nudge: same model stamped (arms the directive + once-per-task cap), one more attempt granted.
+    expect(result.value.task.escalatedFromModel).toBe('claude-opus-4-8');
+    expect(result.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(result.value.shouldFailAttempt).toBe(true);
+    expect(result.value.blockedReason).toBeUndefined();
+    expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
   });
 
-  it('plateau + flag-on + budget edge: warn names budget exhaustion, no escalation stamped', async () => {
+  it('plateau + flag-on + budget edge: warn names budget exhaustion, NO blockedReason (preserves work)', async () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 1 });
     const bus = newBus();
     const events: Array<{ type: string }> = [];
@@ -288,7 +293,8 @@ describe('finalizeGenEvalUseCase', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.task.escalatedToModel).toBeUndefined();
-    expect(result.value.blockedReason).toMatch(/budget exhausted/);
+    expect(result.value.blockedReason).toBeUndefined();
+    expect(result.value.shouldFailAttempt).toBeFalsy();
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
   });
 

--- a/tests/unit/business/task/start-attempt-resume-regression.test.ts
+++ b/tests/unit/business/task/start-attempt-resume-regression.test.ts
@@ -120,6 +120,38 @@ describe('startAttemptUseCase — resume from crashed running attempt', () => {
     expect(writes).toHaveLength(1);
   });
 
+  it('persists the blocked transition when settling the leftover attempt exhausts the budget', async () => {
+    // The task crashed DURING its final allowed attempt (maxAttempts=1, one running attempt). On
+    // resume the leftover attempt settles `aborted`, pushing the task over budget → `blocked`. The
+    // use case must PERSIST that blocked state before surfacing the error — otherwise the running
+    // attempt stays on disk and every relaunch re-hits the same resume path and re-errors (a stuck
+    // loop), while the task never reports as blocked and the operator has nothing to `unblock`.
+    const crashed = makeInProgressTaskWithRunningAttempt();
+    const atBudget: Task = { ...crashed, maxAttempts: 1 };
+    expect(atBudget.attempts).toHaveLength(1);
+
+    const { repo, writes } = fakeTaskRepo(new Map([[String(atBudget.id), atBudget]]));
+
+    const result = await startAttemptUseCase({
+      task: atBudget,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      clock: () => FIXED_LATER,
+      logger: noopLogger,
+    });
+
+    // Surfaced as an error so the chain does not try to start an attempt on a blocked task…
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/is blocked/);
+
+    // …but the blocked transition is durably persisted (the regression: it was computed yet never
+    // written, so the launch queue could never filter it out).
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.status).toBe('blocked');
+    expect(writes[0]?.attempts.at(-1)?.status).toBe('aborted');
+  });
+
   it('baseline: starting from a todo task appends exactly one running attempt and no aborted entries', async () => {
     // Symmetric control: the resume-settlement branch is gated on a prior running attempt.
     // A clean `todo` start must NOT synthesise a phantom aborted attempt — the only output

--- a/tests/unit/business/task/start-attempt-resume-regression.test.ts
+++ b/tests/unit/business/task/start-attempt-resume-regression.test.ts
@@ -85,6 +85,41 @@ describe('startAttemptUseCase — resume from crashed running attempt', () => {
     }
   });
 
+  it('heals a status-corrupt `todo` task whose last attempt is still `running`', async () => {
+    // The wedge state observed in the field: a crash persisted the task as `todo` while its last
+    // attempt was left `running` (n=2). The old recovery branch was gated on `status ===
+    // 'in_progress'`, so it skipped this task and `startNextAttempt` dead-ended every launch with
+    // "already has a running attempt n=2". The fix keys recovery on the running attempt itself.
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const wedged: Task = { ...inProgress, status: 'todo' };
+    expect(wedged.status).toBe('todo');
+    expect(wedged.attempts.at(-1)?.status).toBe('running');
+
+    const priorAttemptCount = wedged.attempts.length;
+    const { repo, writes } = fakeTaskRepo(new Map([[String(wedged.id), wedged]]));
+
+    const result = await startAttemptUseCase({
+      task: wedged,
+      sprintId: SPRINT_ID,
+      taskRepo: repo,
+      clock: () => FIXED_LATER,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const next = result.value;
+
+    // Status repaired to `in_progress`; leftover attempt settled `aborted`; a fresh `running`
+    // attempt appended — exactly the in_progress crash-resume outcome.
+    expect(next.status).toBe('in_progress');
+    expect(next.attempts).toHaveLength(priorAttemptCount + 1);
+    expect(next.attempts.at(-1)?.status).toBe('running');
+    expect(next.attempts.at(-2)?.status).toBe('aborted');
+    expect(next.attempts.at(-1)?.recovering?.fromAttemptN).toBe(priorAttemptCount);
+    expect(writes).toHaveLength(1);
+  });
+
   it('baseline: starting from a todo task appends exactly one running attempt and no aborted entries', async () => {
     // Symmetric control: the resume-settlement branch is gated on a prior running attempt.
     // A clean `todo` start must NOT synthesise a phantom aborted attempt — the only output

--- a/tests/unit/business/task/unblock-task.test.ts
+++ b/tests/unit/business/task/unblock-task.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
-import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import { BLOCKED_UPSTREAM_REASON_PREFIX, markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
 import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
+import type { FindTasksBySprintId } from '@src/domain/repository/task/find-tasks-by-sprint-id.ts';
+import type { SaveAllTasks } from '@src/domain/repository/task/save-all-tasks.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { makeDoneTask, makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
@@ -17,23 +19,41 @@ const makeBlockedTask = (reason = 'flaky pre-task verify'): BlockedTask => {
   return r.value;
 };
 
-interface RepoDouble extends UpdateTask {
-  readonly saved: Task[];
+type Repo = UpdateTask & FindTasksBySprintId & SaveAllTasks;
+interface RepoDouble {
+  readonly repo: Repo;
+  /** Tasks handed to the most recent persistence call (saveAll list, or a single update). */
+  readonly saved: () => readonly Task[];
 }
 
-const repoOk = (): RepoDouble => {
-  const saved: Task[] = [];
-  return {
-    saved,
+// Seeds the sprint's task list for findBySprintId and records whatever the use case persists.
+const repoOk = (seed: readonly Task[] = []): RepoDouble => {
+  let saved: Task[] = [];
+  const repo: Repo = {
     async update(_sprintId, task) {
-      saved.push(task);
+      saved = [task];
+      return Result.ok(undefined);
+    },
+    async findBySprintId() {
+      return Result.ok(seed);
+    },
+    async saveAll(_sprintId, tasks) {
+      saved = [...tasks];
       return Result.ok(undefined);
     },
   };
+  return { repo, saved: () => saved };
 };
 
-const repoFailing = (): UpdateTask => ({
+// Persistence fails on the saveAll path (the cascade write).
+const repoFailing = (seed: readonly Task[] = []): Repo => ({
   async update() {
+    return Result.error(new StorageError({ subCode: 'io', message: 'disk full', path: 'tasks' }));
+  },
+  async findBySprintId() {
+    return Result.ok(seed);
+  },
+  async saveAll() {
     return Result.error(new StorageError({ subCode: 'io', message: 'disk full', path: 'tasks' }));
   },
 });
@@ -41,12 +61,12 @@ const repoFailing = (): UpdateTask => ({
 describe('unblockTaskUseCase', () => {
   it('transitions blocked → todo, strips blockedReason, and persists', async () => {
     const blocked = makeBlockedTask('mvn agent attach failed');
-    const repo = repoOk();
+    const repo = repoOk([blocked]);
 
     const result = await unblockTaskUseCase({
       task: blocked,
       sprintId: SPRINT_ID,
-      taskRepo: repo,
+      taskRepo: repo.repo,
       logger: noopLogger,
     });
 
@@ -54,73 +74,116 @@ describe('unblockTaskUseCase', () => {
     if (!result.ok) return;
     expect(result.value.status).toBe('todo');
     expect((result.value as unknown as { blockedReason?: string }).blockedReason).toBeUndefined();
-    expect(repo.saved).toHaveLength(1);
-    expect(repo.saved[0]?.status).toBe('todo');
+    expect(repo.saved()).toHaveLength(1);
+    expect(repo.saved()[0]?.status).toBe('todo');
   });
 
   it('idempotent — already-todo passes through without re-saving', async () => {
     const todo = makeTodoTask();
-    const repo = repoOk();
+    const repo = repoOk([todo]);
 
     const result = await unblockTaskUseCase({
       task: todo,
       sprintId: SPRINT_ID,
-      taskRepo: repo,
+      taskRepo: repo.repo,
       logger: noopLogger,
     });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.status).toBe('todo');
-    expect(repo.saved).toHaveLength(0);
+    expect(repo.saved()).toHaveLength(0);
   });
 
   it('rejects an in_progress task with InvalidStateError', async () => {
     const inProgress = makeInProgressTaskWithRunningAttempt();
-    const repo = repoOk();
+    const repo = repoOk([inProgress]);
 
     const result = await unblockTaskUseCase({
       task: inProgress,
       sprintId: SPRINT_ID,
-      taskRepo: repo,
+      taskRepo: repo.repo,
       logger: noopLogger,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('invalid-state');
-    expect(repo.saved).toHaveLength(0);
+    expect(repo.saved()).toHaveLength(0);
   });
 
   it('rejects a done task with InvalidStateError', async () => {
     const done = makeDoneTask();
-    const repo = repoOk();
+    const repo = repoOk([done]);
 
     const result = await unblockTaskUseCase({
       task: done,
       sprintId: SPRINT_ID,
-      taskRepo: repo,
+      taskRepo: repo.repo,
       logger: noopLogger,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('invalid-state');
-    expect(repo.saved).toHaveLength(0);
+    expect(repo.saved()).toHaveLength(0);
   });
 
-  it('propagates StorageError when the repository update call fails', async () => {
+  it('propagates StorageError when persistence fails', async () => {
     const blocked = makeBlockedTask();
 
     const result = await unblockTaskUseCase({
       task: blocked,
       sprintId: SPRINT_ID,
-      taskRepo: repoFailing(),
+      taskRepo: repoFailing([blocked]),
       logger: noopLogger,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('storage-error');
+  });
+
+  it('cascade-unblocks upstream-blocked dependents when the root is unblocked', async () => {
+    const root = makeBlockedTask('own failure: eval did not pass'); // own-failure block on the root
+    const depTodo = makeTodoTask({ name: 'dependent', dependsOn: [root.id] });
+    const depUpstream = markTaskBlocked(depTodo, `${BLOCKED_UPSTREAM_REASON_PREFIX} — prerequisite not done: root`);
+    if (!depUpstream.ok) throw depUpstream.error;
+    const repo = repoOk([root, depUpstream.value]);
+
+    const result = await unblockTaskUseCase({
+      task: root,
+      sprintId: SPRINT_ID,
+      taskRepo: repo.repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    const saved = repo.saved();
+    expect(saved.find((t) => t.id === root.id)?.status).toBe('todo');
+    // The dependent the dependency gate parked is re-armed in the same transaction.
+    expect(saved.find((t) => t.id === depUpstream.value.id)?.status).toBe('todo');
+  });
+
+  it('does NOT cascade-unblock a dependent blocked for its own failure', async () => {
+    const root = makeBlockedTask('root own failure');
+    const depTodo = makeTodoTask({ name: 'dependent', dependsOn: [root.id] });
+    const depOwn = markTaskBlocked(depTodo, 'verify failed on the dependent itself'); // NOT an upstream prefix
+    if (!depOwn.ok) throw depOwn.error;
+    const repo = repoOk([root, depOwn.value]);
+
+    const result = await unblockTaskUseCase({
+      task: root,
+      sprintId: SPRINT_ID,
+      taskRepo: repo.repo,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    const saved = repo.saved();
+    expect(saved.find((t) => t.id === root.id)?.status).toBe('todo');
+    // The dependent failed on its own merits — it is NOT in the cascade, so it is left untouched
+    // on disk (only the primary is re-persisted). It stays blocked for the operator to fix.
+    expect(saved.find((t) => t.id === depOwn.value.id)).toBeUndefined();
   });
 });

--- a/tests/unit/domain/entity/task.test.ts
+++ b/tests/unit/domain/entity/task.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { DoneTask, InProgressTask, VerificationCriterion } from '@src/domain/entity/task.ts';
+import type { DoneTask, InProgressTask, Task, VerificationCriterion } from '@src/domain/entity/task.ts';
 import { createTask, updateTask } from '@src/domain/entity/task-factory.ts';
 import {
   recordRunningAttemptCommit,
@@ -122,9 +122,21 @@ describe('failCurrentAttempt', () => {
     expect(r.value.blockedReason).toContain('attempt budget exhausted');
   });
 
-  it('rejects from todo', () => {
+  it('rejects from todo with no running attempt', () => {
     const r = failCurrentAttempt(makeTodoTask(), FIXED_LATER, 'failed');
     expect(r.ok).toBe(false);
+  });
+
+  it('heals a status-corrupt todo task whose last attempt is running', () => {
+    // A crash can persist `status: 'todo'` while the last attempt is still `running`. Settling the
+    // running attempt repairs the status to `in_progress` rather than rejecting — the self-heal the
+    // start-attempt resume path relies on.
+    const corrupt: Task = { ...makeInProgressTaskWithRunningAttempt(), status: 'todo' };
+    const r = failCurrentAttempt(corrupt, FIXED_LATER, 'aborted');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.status).toBe('in_progress');
+    expect(r.value.attempts.at(-1)?.status).toBe('aborted');
   });
 });
 

--- a/tests/unit/domain/entity/upstream-blocked-dependents.test.ts
+++ b/tests/unit/domain/entity/upstream-blocked-dependents.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { BLOCKED_UPSTREAM_REASON_PREFIX, markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import { upstreamBlockedDependents } from '@src/domain/entity/task-graph.ts';
+import { makeTodoTask } from '@tests/fixtures/domain.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+
+const through = <T>(r: { readonly ok: true; readonly value: T } | { readonly ok: false }): T => {
+  if (!r.ok) throw new Error('expected ok');
+  return r.value;
+};
+
+const upstream = (t: Task): Task =>
+  through(markTaskBlocked(t, `${BLOCKED_UPSTREAM_REASON_PREFIX} — prerequisite not done`));
+const ownBlocked = (t: Task): Task => through(markTaskBlocked(t, 'verify failed on its own merits'));
+
+describe('upstreamBlockedDependents', () => {
+  it('returns the transitive upstream-blocked subtree of the root, excluding the root itself', () => {
+    const a = makeTodoTask({ name: 'a' });
+    const b = upstream(makeTodoTask({ name: 'b', dependsOn: [a.id] }));
+    const c = upstream(makeTodoTask({ name: 'c', dependsOn: [b.id] })); // transitive through b
+    const tasks = [a, b, c];
+
+    const ids = new Set(upstreamBlockedDependents(tasks, a.id).map(String));
+    expect(ids.has(String(b.id))).toBe(true);
+    expect(ids.has(String(c.id))).toBe(true);
+    expect(ids.has(String(a.id))).toBe(false);
+  });
+
+  it('excludes own-failure-blocked dependents (they need a real fix, not a cascade)', () => {
+    const a = makeTodoTask({ name: 'a' });
+    const b = ownBlocked(makeTodoTask({ name: 'b', dependsOn: [a.id] }));
+    const ids = upstreamBlockedDependents([a, b], a.id);
+    expect(ids).toHaveLength(0);
+  });
+
+  it('excludes done / todo dependents and unrelated tasks', () => {
+    const a = makeTodoTask({ name: 'a' });
+    const doneDep = makeTodoTask({ name: 'done-dep', dependsOn: [a.id] }); // todo, not blocked
+    const unrelated = upstream(makeTodoTask({ name: 'unrelated' })); // upstream-blocked but no edge to a
+    const ids = upstreamBlockedDependents([a, doneDep, unrelated], a.id);
+    expect(ids).toHaveLength(0);
+  });
+
+  it('does not traverse THROUGH an own-failure-blocked dependent', () => {
+    // a → b(own-blocked) → c(upstream-blocked). c depends on b, not a; since b is not in the
+    // upstream closure, the walk stops at b and never reaches c.
+    const a = makeTodoTask({ name: 'a' });
+    const b = ownBlocked(makeTodoTask({ name: 'b', dependsOn: [a.id] }));
+    const c = upstream(makeTodoTask({ name: 'c', dependsOn: [b.id] }));
+    const ids = upstreamBlockedDependents([a, b, c], a.id);
+    expect(ids).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Bundles two independent streams of work that both branched off the `0.9.0` release. The
lock/abort-hardening branch was rebased on top of the TUI/refine branch so all 14 commits
ship as one PR. Diff: **89 files, +2954 / −848**.

### Stream 1 — Lock / abort / blocked-dependency hardening (8 commits)

Most of these trace to a single real-run post-mortem (manual abort did nothing, the spinner
stuck, the repo lock stranded, resume retried ~100×, and the sprint shipped with blocked tasks):

- **Thread the abort signal to the AI provider** so a manual abort actually kills the spawned
  child. The generator/evaluator leaves were dropping the `AbortSignal` the leaf framework
  passes, leaving the SIGTERM→SIGKILL kill ladder, abort-aware exit classification, and
  cancellable rate-limit sleep all dead. Applied uniformly to every headless AI leaf so the
  gap can't recur silently.
- **Stop the blocked-dependency dead-end and the silent partial ship.** New `dependency-gate`
  leaf at the head of every per-task subchain parks a dependent as `blocked upstream …` when a
  prerequisite isn't `done` (no wasted AI spawn; transitive by construction).
  `shouldTransitionToReview` now requires *every* task settled **and** at least one `done`, so a
  run no longer flips to `review` the instant one task finishes.
- **Codex cold-spawn fallback** when a `--resume` rollout is gone (`no rollout found`,
  `-32600`): retry once with a cold spawn instead of blocking the task. Bounded by a single
  latch; does not consume a rate-limit slot.
- **Honour the configured `verifyTimeout`** — it existed on the entity and on the verify leaves
  but the launcher dropped it, so a hung verify always burned the full 5-min default on both the
  pre- and post-task calls.
- **Cascade-unblock upstream dependents** + surface block reasons in the Execute view. Unblocking
  a root prerequisite re-arms the whole upstream-blocked subtree in one action; own-failure
  blocks are never auto-cleared. Blocked cards now show *why* they blocked.
- **Window the Execute-view Tasks column** (anchored, clamped viewport with `▴ N more` /
  `▾ N more` cues) so the overview survives many in-flight tasks instead of pushing the log and
  footer off-screen.
- **Plateau "change approach" nudge + the model ladder live by default.** A plateau now *never*
  blocks the task — it grants one more attempt or preserves the work. `escalateOnPlateau`
  defaults to `true`; at the top of the ladder the generator keeps the model but gets a
  change-of-approach directive (generator-only; the evaluator rubric is held constant).
- **Docs**: CHANGELOG / CLAUDE.md / REQUIREMENTS.md updated for the above.

### Stream 2 — TUI / refine UX (6 commits)

- **Refine posts refined requirements as an issue comment** instead of overwriting the
  description; the `IssuePusher` port is reduced to a single `comment()` op so no path mutates a
  body or opens an issue. Opt-in via `scm.postRefinementComment` (default `false`). (#133)
- **Cursor-following viewport for the description entry field** — long buffers no longer scroll
  the cursor and hint row off the bottom; PgUp/PgDn paging; rejects leaked SGR mouse reports. (#185)
- **Reserve review-card chrome by banner mode** so the Title / Link / confirm controls never clip
  when the banner auto-switches to its full wordmark frame on wide terminals. (#185)
- **Recover a crashed task left `todo` + `running`** — crash-resume now keys on the leftover
  running attempt rather than the (possibly corrupt) status field, instead of dead-ending
  `start-attempt` on every relaunch.
- **Seed `sprintLabel` into `InitialSelection`** so the status bar shows the sprint name on boot
  instead of a raw UUID. (#186)
- **Pin the focused run's sprint context** to the breadcrumb and progress overlay while an
  Execute view is mounted.

Related issues: #133, #185, #186. (Stream 1 has no single tracking issue — it came out of a
live-run post-mortem.)

## How to test

```bash
pnpm install
pnpm typecheck && pnpm lint && pnpm test
```

Manual smoke (TUI): launch an implement run with a dependency graph, abort mid-spawn (the child
dies, spinner stops, lock releases), block a prerequisite (the dependent parks as
`blocked upstream …`), unblock the root (the subtree cascade-unblocks), and refine a ticket with a
linked issue (a signed comment is posted rather than the description overwritten).

## Checklist

- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (353 files, 2886 tests)
- [x] Added/updated tests if applicable
- [ ] Linked to an issue — partial: #133 / #185 / #186 covered; the lock/abort stream has no single issue
