### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-03
+
 ### Fixed
 
 - **Unblocking a task on a `review` sprint now reopens it so Implement can resume.** A mixed run

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.10.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.10.0]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green