### PR TITLE
fix(tui): coalesce bus→render updates to prevent commit-storm OOM

### DIFF
--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -26,3 +26,5 @@
   inline body-footer hint prose is a duplicate ungated source — remove it when gating a key
 - [project_per_attempt_round_display.md](project_per_attempt_round_display.md) — live round counter folds monotonic global
   round into per-attempt coords via perAttemptRound (render-time, not on bucket); genEvalMaxAttempts cap now fully wired
+- [project_tui_commit_storm_coalescer.md](project_tui_commit_storm_coalescer.md) — consumer-side CoalescedBuffer decouples
+  event-arrival from React-commit rate; fix for DEBUG-floor commit-storm OOM; + status-diff guard on useSessions/useSession

--- a/.claude/agent-memory/implementer/project_tui_commit_storm_coalescer.md
+++ b/.claude/agent-memory/implementer/project_tui_commit_storm_coalescer.md
@@ -1,0 +1,68 @@
+---
+name: tui-commit-storm-coalescer
+description: consumer-side CoalescedBuffer decouples event-arrival rate from React-commit rate in the TUI runtime; the fix for the DEBUG-floor stream-json commit-storm OOM
+metadata:
+  type: project
+---
+
+The TUI OOM under a long DEBUG-floor run is a **React commit storm**, not a retained leak (every
+buffer is already `.slice(-limit)` capped). Mechanism: per stream-json line → many `level:'debug'`
+bus events → `useSinkStream` did `setItems(prev => [...prev, v])` per emit → one React commit per
+line. Ink throttles stdout writes (~30fps) but NOT commits, so per-commit Yoga layout + Output
+allocation ran unthrottled and V8 OOM'd mid-commit.
+
+**Fix shape (all in `src/application/ui/tui/runtime/`, the outermost layer where React + node timers
+are allowed):**
+
+- `coalesced-buffer.ts` — pure factory `createCoalescedBuffer<T>({limit, flushMs?, onFlush, initial?, clearOnFlush?})`.
+  Accumulates pushes; applies `slice(-limit)` ONCE per flush-or-overflow (not `[...prev,v]` spread per
+  push — that O(n)/event spread WAS the heap-churn). One unref'd `setInterval`; `flushNow()`; `discard()`
+  (empties window WITHOUT onFlush, resets dirty); idempotent `stop()`. `flushMs` default 60 (~16fps, under
+  Ink's 30fps write throttle), floored at 16.
+  - **Two flush modes** (the subtle part): default `clearOnFlush:false` = ROLLING-WINDOW REPLACE — window
+    kept across flushes, `onFlush` gets the full trailing window each tick. CORRECT for `setItems`
+    consumers (use-sink-stream/use-event-bus) since setItems replaces. But a forwarder whose onFlush
+    RE-EMITS each value into a downstream sink MUST set `clearOnFlush:true` (DELTA mode: window emptied
+    after each flush → each flush carries only new pushes). A rolling window + re-emit = re-emit prior
+    batches every tick = re-grow the sink = the very OOM. This was bug 1 of the adversarial review.
+- `use-coalesced-buffer.ts` — thin React hook; subscribe seam captured in a ref (fresh arrow each render
+  must NOT churn the sub); deps array caller-owned; seeds initial + `flushNow()` on mount (mount-replay
+  in one frame); cleanup `unsub(); buf.flushNow(); buf.stop()`.
+- `use-sink-stream.ts` and `use-event-bus.ts` reimplemented on the hook — PUBLIC SIGNATURES UNCHANGED so
+  views need no edits. Both gained an optional test-only `flushMs` hatch.
+- `launch.ts` `createLogForwarder` helper: gate-at-ingest (`passesLogLevel` vs live gate) → push admitted
+  → coalescer (`clearOnFlush:true`) `onFlush` re-emits the batch into `logBus` in one synchronous turn
+  (downstream setStates batch into one commit). Heap-watchdog `onCritical` calls `forwarder.discard()`
+  (NOT flushNow — flushing would re-emit the held window into logBus right before clearing it) THEN
+  `harnessBus.clear(); logBus.clear();`. `forwarder.stop()` in `drain()`. (bug 2: flushNow-in-onCritical
+  re-fed the bus; discard fixes it.)
+
+**Why: ** EventBus/BusSink contract MUST stay synchronous fire-and-forget — coalescing is purely
+consumer-side.
+
+**How to apply: ** any future hot TUI subscription (high-frequency bus/sink fan-out) routes through
+`useCoalescedBuffer` instead of per-event `setItems`. The gate at launch.ts's forwarder is the ONLY
+UI-floor chokepoint — providers publish every stream-json line to the EventBus verbatim;
+`createEventBusLogger` is a producer NOT a filter; events.ndjson sink writes verbatim regardless of floor.
+
+**Second, log-floor-INDEPENDENT amplifier:** `session-manager.notify()` fires per leaf `step` into the
+UNGUARDED `useSessions`/`useSession`, consumed by the always-mounted StatusBar. Guarded both with a
+status-diff signature mirroring `views/sprint-detail-internals/use-sprint-bundle.ts` — only `setState`
+when the signature changed; trace-only steps are swallowed. **Signature MUST include pinnedSprintId +
+pinnedSprintLabel, not just `status|hasError`** (bug 3): `setPinnedSprint` (create-sprint, mid-run) changes
+NO status, so a status-only signature drops the notify and the execute view shows a STALE undefined sprint.
+Current sig: `${status}|${error?1:0}|${pinnedSprintId ?? ''}|${pinnedSprintLabel ?? ''}` via shared `sigOf()`.
+Do NOT add `trace` to the signature — the live flow-steps rail stays current via the shared-mutable trace
+array + sibling chainEvents re-render; adding trace re-introduces the per-step storm. See
+[[project_per_attempt_round_display]] for the per-`step` notify cadence context.
+
+**Bug 4 (use-coalesced-buffer mount re-seed):** the useState lazy initializer already holds
+`initial.slice(-limit)`, so the effect's explicit `setItems(seed)` on FIRST mount is a redundant extra
+commit. Gate it behind a `mountedRef` (false→true): skip the explicit re-seed on first effect run
+(initializer covers it), still re-seed on a genuine deps-change re-run (state holds the prior deps' window).
+Replay-paint-in-one-frame invariant preserved because the initializer guarantees it.
+
+**Test conventions reinforced:** pure coalescer test uses `vi.useFakeTimers()` (no React in that layer,
+matches heap-watchdog.test.ts). Rendered TUI hook tests MUST use REAL timers + drain-past-flushMs
+(`flushMs:20`, drain ~60ms) — never `vi.useFakeTimers()` in ink-testing-library renders. Render-count
+probe (`let renders; onRender=()=>renders++`) asserts ~1-2 commits for 50 emits, not 50.

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -5,3 +5,4 @@
 - [project_memory_ledger.md](project_memory_ledger.md) — Theme 6 procedural memory: append-only NDJSON ledger, distill
   sub-chain, attempt outer loop, task-graph validation
 - [project_windowed_list_review.md](project_windowed_list_review.md) — Windowed-list / ScrollRegion review findings: WindowedList dead export, new flaky windowing test, pick-sprint-view not migrated
+- [project_coalesced_buffer_review.md](project_coalesced_buffer_review.md) — CoalescedBuffer onCritical window-not-cleared bug + double-seed nit from 0.10.0 commit-storm fix

--- a/.claude/agent-memory/reviewer/project_coalesced_buffer_review.md
+++ b/.claude/agent-memory/reviewer/project_coalesced_buffer_review.md
@@ -1,0 +1,22 @@
+---
+name: project_coalesced_buffer_review
+description: CoalescedBuffer onCritical window-not-cleared bug and double-seed nit from 0.10.0 commit-storm fix review
+metadata:
+  type: project
+---
+
+The CoalescedBuffer (0.10.0 OOM fix) review found two confirmed correctness bugs and one nit. **STATUS: all RESOLVED** in the amended OOM-fix commit (`fix(tui): coalesce bus→render updates`) — fix option 3 below was taken: added `clearOnFlush` (delta mode) + `discard()` to the primitive, the forwarder uses `clearOnFlush: true`, `onCritical` calls `discard()`, the session signature folds in pinned-sprint, and `useCoalescedBuffer` gained a `mountedRef` guard. Kept as a record of what the review caught and how the suite missed it (one-flush-per-test gap). Original findings below:
+
+**HIGH - Multi-interval duplicate emission (CONFIRMED):** `CoalescedBuffer.window` is never cleared after a flush. `onFlush` receives the full trailing window (all events since creation, capped at `limit`). In the log-forwarder, `onFlush` loops `logBus.emit(event)` for each item — appending to `logBus.entries`. On flush tick 1 it emits [A,B,C]; on tick 2 it emits [A,B,C,D,E] — A/B/C are duplicated. This re-introduces memory pressure on long runs and causes log panel to show repeated entries. Root cause: `CoalescedBuffer` was designed for React's `setItems` (replace semantics) not for append-style sinks. The `onFlush` body in `createLogForwarder` (launch.ts:69) is appending, not replacing.
+
+The test suite only advances the clock **once per test**, so two-interval scenarios with new events between ticks are never exercised.
+
+**HIGH - onCritical window not cleared:** `flushNow()` in `onCritical` sets `dirty=false` but does NOT clear `window`. The next push after the critical sequence sets `dirty=true` and the next interval flush re-emits ALL old window contents — undoing the `clear()`. See above; these are the same root cause.
+
+**NIT - double-seed in useCoalescedBuffer:** The `useState` lazy initializer seeds from `opts.initial` and the effect ALSO calls `setItems(seed.slice(-limit))` on mount. These produce different array references with the same values, triggering an extra render cycle on mount.
+
+**Fix options for log-forwarder:**
+
+1. Track a `forwarded` watermark cursor in the forwarder closure; in `onFlush` emit `window.slice(forwarded)` then set `forwarded = window.length`.
+2. Use a local `pendingBatch: LogEvent[]` array; push admitted events into it; in `onFlush` emit the batch then splice it empty (delta semantics, does not use CoalescedBuffer's window at all).
+3. Add a `clear()` or `discard()` to CoalescedBuffer that resets `window = []` and `dirty = false`, and call it in `onCritical` after `flushNow()`.

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -166,6 +166,33 @@ Resolution uses the `SkillSource.getByName` lookup on the bundled source.
 | `NO_COLOR`                   | unset          | any truthy value | Suppress ANSI colors                                             |
 | `CI`                         | auto-detected  | any truthy value | Suppress implicit interactive prompts inside the implement flow  |
 
+## Diagnosing an OOM (heap snapshot)
+
+The heap watchdog (`startHeapWatchdog`) warns and sheds in-memory buffers as the V8 old-space
+fills, but if the process still aborts (`exit 134`, "JavaScript heap out of memory") the in-memory
+buffers vanish with it. To capture _what_ the heap held at the moment of death, relaunch with V8's
+near-heap-limit snapshot:
+
+```bash
+pnpm dev:heap-snapshot   # = mkdir -p .diagnostics && NODE_OPTIONS='--max-old-space-size=8192
+                         #     --heapsnapshot-near-heap-limit=2 --diagnostic-dir=.diagnostics' tsx src/index.ts
+```
+
+- **Where the dump lands.** `--diagnostic-dir=.diagnostics` writes the snapshot to `<repo>/.diagnostics/`
+  (gitignored). Without `--diagnostic-dir`, V8 writes to the process's **current working directory** — for
+  `pnpm dev` that is the repo root, so the script pins it to `.diagnostics/` to keep the tree clean. The
+  directory is NOT auto-created, hence the `mkdir -p`.
+- **Filename.** `Heap.<YYYYMMDD>.<HHMMSS>.<pid>.<tid>.<seq>.heapsnapshot`.
+- **Size.** The file is roughly the size of the live heap — near an 8 GB limit expect a **multi-GB** file
+  per snapshot (`=2` writes up to two). Delete `.diagnostics/` when done.
+- **Reading it.** Chrome/Edge DevTools → **Memory** → **Load** → pick the `.heapsnapshot` → sort by
+  _Retained Size_ / open the _Dominators_ view. A retained-memory leak shows one structure dominating; a
+  commit/throughput storm (the failure mode the coalescer fixes) shows transient React Fiber + Ink `Output`
+  cell arrays dominating, with every bounded ring buffer small — i.e. nothing is actually _retained_.
+
+For the installed binary instead of `pnpm dev`, set the same flags yourself:
+`NODE_OPTIONS='--heapsnapshot-near-heap-limit=2 --diagnostic-dir=/tmp/ralphctl-diag' ralphctl`.
+
 ## Release procedure
 
 GitHub Actions auto-publishes on tags `v[0-9]+.[0-9]+.[0-9]+`. Tag must match

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -3,7 +3,8 @@
 > On-demand reference (split out of `CLAUDE.md`). Read when working on sprint lifecycle, planning,
 > the implement gen-eval loop, or TUI navigation.
 
-Sprint lifecycle: `draft → planned → active → review → done`.
+Sprint lifecycle: `draft → planned → active → review → done`, plus one recovery edge
+`review → active` (unblocking a task on a review sprint — see below).
 
 | Operation               | Draft | Planned | Active | Review | Done |
 | ----------------------- | :---: | :-----: | :----: | :----: | :--: |
@@ -19,6 +20,16 @@ Implement transitions the sprint to `review` once every task has settled (`done`
 one task settled `done` — an all-blocked run stays `active` so the operator can fix the blocker and
 re-run without backing the sprint out of review. The `sprint close` CLI command and the close-sprint flow
 accept only `review`-status.
+
+**Unblock reopens a review sprint (`review → active`).** A _mixed_ run (some tasks `done`, some `blocked`)
+settles to `review`. Unblocking one of those blocked tasks (TUI `u` single / bulk, or `ralphctl task
+unblock`) revives `todo` work — so `unblockTaskUseCase` reopens a `review` sprint back to `active`
+(`revertSprintToActive` clears `reviewAt`, re-stamps `activatedAt`), re-arming the implement gate
+(`planned` / `active` only) so the unblocked tasks get picked up on the next Implement run. The reopen is
+best-effort and idempotent: a non-`review` sprint passes through untouched, and a reopen that fails to
+persist is logged without failing the unblock (re-running unblock retries it — the already-`todo`
+short-circuit still reopens). Without this, an unblocked task on a review sprint would be stranded:
+Implement is gated out and only Review / Close remain.
 
 **Two-phase planning.** **Refine** (`refine` chain) is implementation-agnostic per-ticket clarification —
 no repo exploration; ticket `requirementStatus` flips `pending → approved`. **Plan** (`plan` chain) requires

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ Thumbs.db
 tmp
 *.tmp
 
+# Heap snapshots from `pnpm dev:heap-snapshot` (--heapsnapshot-near-heap-limit)
+.diagnostics/
+*.heapsnapshot
+
 # Claude Code per-user settings
 .claude/settings.local.json
 .claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unblocking a task on a `review` sprint now reopens it so Implement can resume.** A mixed run
+  (some tasks `done`, some `blocked`) settles the sprint to `review`. Previously, unblocking the
+  blocked tasks left them as `todo` work the Implement gate (`planned` / `active` only) refused to
+  pick up — stranding the sprint with only Review / Close available. `unblockTaskUseCase` now reopens
+  a `review` sprint to `active` (new `revertSprintToActive` domain transition, `review → active`),
+  re-arming Implement so the revived tasks get implemented on the next run. Best-effort and
+  idempotent across the single-unblock, bulk-unblock, and `ralphctl task unblock` paths.
+
 ### Added
 
 - **Skills subsystem — harness-compatibility contract checker.** A new pure scanner

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "tsup && tsx scripts/build-assets.ts",
     "prepublishOnly": "pnpm build",
     "dev": "NODE_OPTIONS=--max-old-space-size=8192 tsx src/index.ts",
+    "dev:heap-snapshot": "mkdir -p .diagnostics && NODE_OPTIONS='--max-old-space-size=8192 --heapsnapshot-near-heap-limit=2 --diagnostic-dir=.diagnostics' tsx src/index.ts",
     "start": "NODE_OPTIONS=--max-old-space-size=8192 tsx src/index.ts",
     "typecheck": "tsc",
     "test": "vitest run",

--- a/src/application/ui/cli/commands/task.ts
+++ b/src/application/ui/cli/commands/task.ts
@@ -104,6 +104,8 @@ export const registerTaskCommand = (program: Command): void => {
         task: loaded.value,
         sprintId: sprintId.value,
         taskRepo: deps.taskRepo,
+        sprintRepo: deps.sprintRepo,
+        clock: deps.clock,
         logger: deps.logger,
       });
       if (!result.ok) {

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -18,9 +18,10 @@ import type { AppSinks } from '@src/application/bootstrap/runtime-sinks.ts';
 import { ensureStorageRoots, resolveStoragePaths } from '@src/application/bootstrap/storage-paths.ts';
 import { detectLegacyLayout, renderLegacyLayoutMessage } from '@src/application/bootstrap/legacy-layout-detector.ts';
 import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
-import { wire } from '@src/application/bootstrap/wire.ts';
+import { type AppDeps, wire } from '@src/application/bootstrap/wire.ts';
 import { broadcastSink } from '@src/integration/observability/sinks/broadcast-sink.ts';
-import { createBusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
+import { type BusSink, createBusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
+import { type CoalescedBuffer, createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
@@ -31,7 +32,7 @@ import type { LaunchExtras } from '@src/application/ui/shared/launcher.ts';
 import { App } from '@src/application/ui/tui/App.tsx';
 import { resolveInitialState } from '@src/application/ui/tui/launch-routing.ts';
 import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
-import { createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
+import { type LogLevelGate, createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
 import { startHeapWatchdog } from '@src/integration/observability/heap-watchdog.ts';
 import { createOsNotificationDispatcher } from '@src/integration/observability/os-notification-dispatcher.ts';
 import { startNotificationSubscriber } from '@src/business/observability/notification-subscriber.ts';
@@ -40,6 +41,44 @@ interface Bootstrapped {
   readonly app: Parameters<typeof App>[0];
   readonly drain: () => void;
 }
+
+/**
+ * Build the EventBus-`log` → logBus forwarder. This forwarder is the UI-floor chokepoint: the
+ * log-level gate is applied HERE, at ingest, against the live gate (`gate.get()` per event) —
+ * providers publish every stream-json line to the EventBus verbatim, so this is the single place
+ * that drops sub-floor events before they reach the UI. (The persistent events.ndjson sink writes
+ * them regardless of floor.)
+ *
+ * Admitted events are pushed through a CoalescedBuffer rather than emitted one-by-one: at a DEBUG
+ * floor a long run fans thousands of lines/sec, and one `logBus.emit` per line drove one React
+ * commit per line in `useSinkStream` → unthrottled Yoga layout → OOM. The buffer delivers a
+ * trailing window at most ~16fps; each flush emits its batch into `logBus` inside one synchronous
+ * turn so the downstream setStates collapse into a single commit.
+ *
+ * Returns the buffer (for `flushNow` on heap-critical + `stop` on drain) and the bus-unsubscribe
+ * (so a re-launched TUI in the same Node process does not stack a second forwarder on the dead one
+ * and double-publish every event).
+ */
+const createLogForwarder = (
+  eventBus: AppDeps['eventBus'],
+  logBus: BusSink<LogEvent>,
+  gate: LogLevelGate
+): { readonly buffer: CoalescedBuffer<LogEvent>; readonly unsubscribe: () => void } => {
+  const buffer = createCoalescedBuffer<LogEvent>({
+    limit: 2000,
+    // Delta semantics: this forwarder re-emits each window value into `logBus`. A rolling window
+    // would re-emit prior-flush events every tick and re-grow the bus (the OOM we are fixing), so
+    // each flush must deliver only the events admitted since the previous flush.
+    clearOnFlush: true,
+    onFlush: (window) => {
+      for (const event of window) logBus.emit(event);
+    },
+  });
+  const unsubscribe = eventBus.subscribe((event) => {
+    if (event.type === 'log' && passesLogLevel(event.level, gate.get())) buffer.push(event);
+  });
+  return { buffer, unsubscribe };
+};
 
 const bootstrap = async (): Promise<Bootstrapped> => {
   const paths = resolveStoragePaths();
@@ -70,19 +109,16 @@ const bootstrap = async (): Promise<Bootstrapped> => {
   const sinks: AppSinks = { harness: harnessSink };
   const deps = wire({ storage: paths.value, sinks, settings: settings.value });
 
-  // Forward EventBus 'log' events into the TUI's log bus so the recent-events-tail panel
-  // keeps rendering. Capture the unsubscribe so the bootstrap's `drain()` (called from
-  // launchTui's finally on Ink shutdown) can release the listener — otherwise a re-launched
-  // TUI in the same Node process would stack a fresh forwarder on top of the dead one and
-  // each 'log' event would publish twice (or N times after N relaunches).
-  //
-  // Log-level gate is a small mutable holder seeded from `settings.logging.level`. The
-  // forwarder reads `gate.get()` on every event so the Settings view can swap the floor at
-  // runtime by calling `gate.set(newLevel)` via the LogLevelContext.
+  // Forward EventBus 'log' events into the TUI's log bus (coalesced, gate-at-ingest). See
+  // createLogForwarder for the full rationale. Log-level gate is a small mutable holder seeded
+  // from `settings.logging.level`; the Settings view swaps the floor at runtime via
+  // `gate.set(newLevel)` through the LogLevelContext, and the forwarder reads it per event.
   const logLevelGate = createLogLevelGate(settings.value.logging.level);
-  const unsubLogForward = deps.eventBus.subscribe((event) => {
-    if (event.type === 'log' && passesLogLevel(event.level, logLevelGate.get())) logBus.emit(event);
-  });
+  const { buffer: logForwarder, unsubscribe: unsubLogForward } = createLogForwarder(
+    deps.eventBus,
+    logBus,
+    logLevelGate
+  );
 
   // Heap watchdog gives the operator a 30-second warning before V8 SIGKILLs the harness on a
   // long-running session. On 'critical' it dumps the TUI's in-memory buffers (which retain the
@@ -90,6 +126,10 @@ const bootstrap = async (): Promise<Bootstrapped> => {
   const heapWatchdog = startHeapWatchdog({
     eventBus: deps.eventBus,
     onCritical: () => {
+      // Drop (do NOT flush) the batch the forwarder is holding, then clear the buses. Flushing
+      // here would re-emit the held window into `logBus` immediately before we empty it — pointless
+      // churn. discard() empties the window without emitting, so the clear below stays final.
+      logForwarder.discard();
       harnessBus.clear();
       logBus.clear();
     },
@@ -154,6 +194,7 @@ const bootstrap = async (): Promise<Bootstrapped> => {
     drain: (): void => {
       queue.drain(new Error('TUI shutting down'));
       unsubLogForward();
+      logForwarder.stop();
       heapWatchdog.stop();
       unsubNotifications();
     },

--- a/src/application/ui/tui/runtime/coalesced-buffer.ts
+++ b/src/application/ui/tui/runtime/coalesced-buffer.ts
@@ -1,0 +1,104 @@
+/**
+ * Consumer-side coalescer — decouples event-arrival rate from downstream flush rate.
+ *
+ * The EventBus / BusSink contract stays synchronous fire-and-forget; this buffer is the seam
+ * that lets a hot subscription (a DEBUG-floor stream-json fan-out, or a per-`step` session
+ * notify) push thousands of values per second while only delivering a trailing window to its
+ * consumer at most once per `flushMs`. In the TUI that consumer is a `setItems`, so each flush
+ * is one React commit instead of one-per-push — the fix for the commit-storm OOM.
+ *
+ * Pure + framework-agnostic: no React, no class, no `this`. Owns a single `setInterval`. The
+ * `slice(-limit)` cap runs once per flush (or on overflow), never the `[...prev, v]` spread per
+ * push that was the actual O(n)/event heap-churn source.
+ */
+
+/** Lower bound on the flush interval. Below this the coalescing buys nothing and just burns CPU. */
+const MIN_FLUSH_MS = 16;
+/** Default flush cadence — ≈16fps, comfortably under Ink's ~30fps stdout-write throttle. */
+const DEFAULT_FLUSH_MS = 60;
+
+/** @public */
+export interface CoalescedBufferOptions<T> {
+  /** Trailing-window cap. The window handed to `onFlush` never exceeds this length. */
+  readonly limit: number;
+  /** Flush cadence in ms. Default {@link DEFAULT_FLUSH_MS}; floored at {@link MIN_FLUSH_MS}. */
+  readonly flushMs?: number;
+  /** Invoked with a copy of the trailing window when (and only when) there are pending pushes. */
+  readonly onFlush: (window: readonly T[]) => void;
+  /** Seed values — trimmed to the trailing `limit` and used as the initial window. */
+  readonly initial?: readonly T[];
+  /**
+   * When `true`, the window is emptied immediately after each `onFlush` so a flush delivers only
+   * the values admitted since the previous flush (a true delta), not a rolling trailing window.
+   * Default `false` (rolling-window REPLACE semantics, for `setItems` consumers).
+   *
+   * Used by forwarders whose `onFlush` re-emits each window value into a downstream sink: a
+   * rolling window would re-emit prior-flush values every tick and re-grow the sink. `limit`
+   * still caps a single pre-flush interval.
+   */
+  readonly clearOnFlush?: boolean;
+}
+
+/** @public */
+export interface CoalescedBuffer<T> {
+  /** Accumulate a value into the trailing window. Does not flush; the timer does. */
+  push(value: T): void;
+  /** Force an immediate flush of the current window (used for replay-seed + unmount). */
+  flushNow(): void;
+  /**
+   * Drop the held window WITHOUT calling `onFlush`, and clear the dirty flag. Use to abandon a
+   * pending batch (e.g. a forwarder on heap-critical that must not re-feed its downstream sink
+   * right before that sink is cleared).
+   */
+  discard(): void;
+  /** Idempotent timer teardown. Safe to call more than once. */
+  stop(): void;
+}
+
+/**
+ * Build a trailing-window coalescer. Accumulates pushes, applies the `limit` cap once per flush
+ * or overflow, and delivers a copy of the window to `onFlush` at most once per `flushMs` — only
+ * when there is something new to deliver.
+ *
+ * @public
+ */
+export const createCoalescedBuffer = <T>(opts: CoalescedBufferOptions<T>): CoalescedBuffer<T> => {
+  const limit = opts.limit;
+  const flushMs = Math.max(MIN_FLUSH_MS, opts.flushMs ?? DEFAULT_FLUSH_MS);
+  const clearOnFlush = opts.clearOnFlush ?? false;
+
+  let window: T[] = opts.initial ? opts.initial.slice(-limit) : [];
+  let dirty = false;
+
+  const flush = (): void => {
+    if (!dirty) return;
+    dirty = false;
+    opts.onFlush(window.slice());
+    // Delta consumers reset the window each flush so the next flush carries only new pushes;
+    // resetting also keeps `window` from ever holding stale indices the overflow trim would shift.
+    if (clearOnFlush) window = [];
+  };
+
+  // One unref'd interval so a pending flush never holds the event loop open on shutdown.
+  const handle = setInterval(flush, flushMs);
+  handle.unref?.();
+
+  return {
+    push(value: T): void {
+      window.push(value);
+      // Cap on overflow so a flood between flushes can't grow `window` past `limit` either.
+      if (window.length > limit) window = window.slice(-limit);
+      dirty = true;
+    },
+    flushNow(): void {
+      flush();
+    },
+    discard(): void {
+      window = [];
+      dirty = false;
+    },
+    stop(): void {
+      clearInterval(handle);
+    },
+  };
+};

--- a/src/application/ui/tui/runtime/sessions-context.tsx
+++ b/src/application/ui/tui/runtime/sessions-context.tsx
@@ -24,20 +24,66 @@ export const useSessionManager = (): SessionManager => {
   return ctx;
 };
 
-/** Re-render the caller whenever the session registry changes. Returns the current snapshot. */
+/**
+ * Build an id→signature map for the registry. The signature folds in status, error presence, and
+ * the pinned-sprint identity. Trace-only `step` notifies mutate the descriptor's `trace` but never
+ * any of these fields, so two snapshots with the same signature are render-equivalent. The pinned
+ * sprint IS included: a `setPinnedSprint` mid-run (create-sprint) changes no status but must
+ * re-render so the execute view drops the stale (undefined) sprint. `trace` is deliberately
+ * EXCLUDED — the live flow-steps rail stays current via the shared-mutable trace array plus the
+ * sibling chainEvents re-render, and adding it here would re-introduce the per-step render storm.
+ */
+const sigOf = (descriptor: SessionRecord['descriptor']): string =>
+  `${descriptor.status}|${descriptor.error ? '1' : '0'}|${descriptor.pinnedSprintId ?? ''}|${descriptor.pinnedSprintLabel ?? ''}`;
+
+const sessionsSignature = (records: readonly SessionRecord[]): Map<string, string> => {
+  const m = new Map<string, string>();
+  for (const rec of records) {
+    m.set(rec.descriptor.id, sigOf(rec.descriptor));
+  }
+  return m;
+};
+
+const sameSignature = (prev: Map<string, string>, next: Map<string, string>): boolean => {
+  if (prev.size !== next.size) return false;
+  for (const [id, sig] of next) {
+    if (prev.get(id) !== sig) return false;
+  }
+  return true;
+};
+
+/**
+ * Re-render the caller whenever the session registry changes in a status-relevant way. Returns
+ * the current snapshot.
+ *
+ * Guarded with a status-diff (mirroring `use-sprint-bundle.ts`): the session manager fires
+ * `notify()` on every chain `step`, but those trace-only updates leave each descriptor's
+ * status/error untouched. We only `setState` when set-membership or a status/error actually
+ * changed — otherwise the always-mounted StatusBar would re-render once per leaf step.
+ */
 export const useSessions = (): readonly SessionRecord[] => {
   const mgr = useSessionManager();
   const [snapshot, setSnapshot] = useState<readonly SessionRecord[]>(() => mgr.list());
   useEffect(() => {
+    let prev = sessionsSignature(mgr.list());
     setSnapshot(mgr.list());
     return mgr.subscribe(() => {
-      setSnapshot(mgr.list());
+      const list = mgr.list();
+      const next = sessionsSignature(list);
+      if (!sameSignature(prev, next)) {
+        prev = next;
+        setSnapshot(list);
+      }
     });
   }, [mgr]);
   return snapshot;
 };
 
-/** Re-render whenever the named session's descriptor changes. Returns `undefined` when unknown. */
+/**
+ * Re-render whenever the named session's status, error presence, or pinned sprint changes.
+ * Returns `undefined` when unknown. Trace-only `step` notifies are ignored — see {@link
+ * useSessions}.
+ */
 export const useSession = (id: string | undefined): SessionRecord | undefined => {
   const mgr = useSessionManager();
   const [record, setRecord] = useState<SessionRecord | undefined>(() => (id ? mgr.get(id) : undefined));
@@ -46,9 +92,16 @@ export const useSession = (id: string | undefined): SessionRecord | undefined =>
       setRecord(undefined);
       return undefined;
     }
+    const sig = (rec: SessionRecord | undefined): string => (rec ? sigOf(rec.descriptor) : 'absent');
+    let prev = sig(mgr.get(id));
     setRecord(mgr.get(id));
     return mgr.subscribe(() => {
-      setRecord(mgr.get(id));
+      const rec = mgr.get(id);
+      const next = sig(rec);
+      if (next !== prev) {
+        prev = next;
+        setRecord(rec);
+      }
     });
   }, [mgr, id]);
   return record;

--- a/src/application/ui/tui/runtime/use-coalesced-buffer.ts
+++ b/src/application/ui/tui/runtime/use-coalesced-buffer.ts
@@ -1,0 +1,78 @@
+/**
+ * Thin React hook over {@link createCoalescedBuffer}. Owns one buffer per mount and routes a
+ * caller-supplied subscribe seam through it, so a hot source re-renders the consumer at most
+ * once per `flushMs` instead of once per emitted value.
+ *
+ * The subscribe seam is captured in a ref so a caller passing a fresh arrow each render does NOT
+ * churn the underlying subscription (which would drop already-buffered values) — same anti-churn
+ * invariant the bus hooks rely on. The effect's dependency array stays caller-owned.
+ *
+ * Mount-replay: state is seeded from `initial` and a `flushNow()` runs on mount, so a panel that
+ * mounts mid-run paints its history in a single frame rather than waiting for the first tick.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { type CoalescedBuffer, createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+
+export interface UseCoalescedBufferOptions<T> {
+  /** Trailing-window cap. Default `100`. */
+  readonly limit?: number;
+  /** Flush cadence in ms. Test-only escape hatch; production callers use the default. */
+  readonly flushMs?: number;
+  /** Seed values for the initial window (mount-replay). */
+  readonly initial?: readonly T[];
+  /**
+   * Attach the source to the buffer's `push`. Returns an unsubscribe. Captured in a ref so a
+   * fresh arrow each render does not churn the subscription — the effect re-runs only on `deps`.
+   */
+  readonly subscribe: (push: (value: T) => void) => () => void;
+  /**
+   * Effect dependency list — owned by the caller so they decide what re-establishes the
+   * subscription (e.g. `[bus, limit]`). The buffer is rebuilt whenever any of these change.
+   */
+  readonly deps: readonly unknown[];
+}
+
+/**
+ * Maintain a coalesced trailing window in component state. Re-renders at most once per `flushMs`
+ * while the source is hot; flushes immediately on mount (so seeded history paints) and on
+ * cleanup (so no final batch is lost).
+ */
+export const useCoalescedBuffer = <T>(opts: UseCoalescedBufferOptions<T>): readonly T[] => {
+  const limit = opts.limit ?? 100;
+  const [items, setItems] = useState<readonly T[]>(() => (opts.initial ? opts.initial.slice(-limit) : []));
+
+  // Capture the subscribe seam in a ref so a fresh arrow each render does not re-run the effect.
+  const subscribeRef = useRef(opts.subscribe);
+  subscribeRef.current = opts.subscribe;
+  // Seed must be read from a ref too — only the explicit `deps` should rebuild the buffer.
+  const initialRef = useRef(opts.initial);
+  initialRef.current = opts.initial;
+  // First effect run only: the useState lazy initializer already holds `initial.slice(-limit)`, so
+  // an explicit re-seed there is a redundant extra commit on mount. A later deps-change re-run
+  // still needs the re-seed (state holds the prior deps' window), so we gate on this flag.
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    const buf: CoalescedBuffer<T> = createCoalescedBuffer<T>({
+      limit,
+      ...(opts.flushMs !== undefined ? { flushMs: opts.flushMs } : {}),
+      ...(initialRef.current !== undefined ? { initial: initialRef.current } : {}),
+      onFlush: setItems,
+    });
+    // Replay: paint seeded history in one frame. Skipped on first mount (the initializer already
+    // holds it); applied on deps-change re-runs so the rebuilt window repaints from the new seed.
+    const seed = initialRef.current;
+    if (mountedRef.current && seed && seed.length > 0) setItems(seed.slice(-limit));
+    mountedRef.current = true;
+    const unsub = subscribeRef.current(buf.push);
+    return () => {
+      unsub();
+      buf.flushNow();
+      buf.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are caller-owned by contract.
+  }, [limit, opts.flushMs, ...opts.deps]);
+
+  return items;
+};

--- a/src/application/ui/tui/runtime/use-event-bus.ts
+++ b/src/application/ui/tui/runtime/use-event-bus.ts
@@ -1,8 +1,8 @@
 // Retention audit: BOUNDED — `useEventBusBuffer` keeps a rolling window of `AppEvent` object refs
-// (default 100, trimmed via `.slice(-limit)` on every push). Memory footprint scales with `limit`
-// not session lifetime — each entry is a single ref to an already-allocated AppEvent (the bus does
-// not deep-clone), so worst-case retention is `limit` × ~one event object. Sound because the FIFO
-// trim runs synchronously inside the setState reducer; no path skips it.
+// (default 100, capped via `.slice(-limit)` once per flush/overflow inside the coalescer). Memory
+// footprint scales with `limit` not session lifetime — each entry is a single ref to an
+// already-allocated AppEvent (the bus does not deep-clone). The window now coalesces, so a burst
+// of matching events yields ONE React commit rather than one-per-publish.
 
 /**
  * Hooks that subscribe React components to the application {@link EventBus}.
@@ -18,38 +18,40 @@
  * a per-runner basis (descriptors carry the full trace at terminal).
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import type { AppEvent } from '@src/business/observability/events.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
+import { useCoalescedBuffer } from '@src/application/ui/tui/runtime/use-coalesced-buffer.ts';
 
 export interface UseEventBufferOptions<T extends AppEvent> {
   readonly filter: (event: AppEvent) => event is T;
   /** Cap on events kept in component state. Default `100`. */
   readonly limit?: number;
+  /** Flush cadence in ms. Test-only escape hatch; production callers use the default. */
+  readonly flushMs?: number;
 }
 
 /**
- * Maintain a rolling buffer of events matching `filter`. Re-renders on each matching publish;
- * drops the oldest entries past `limit` so memory stays bounded for long-running sessions.
+ * Maintain a rolling buffer of events matching `filter`. Re-renders on matching publishes (at
+ * most once per flush window); drops the oldest entries past `limit` so memory stays bounded for
+ * long-running sessions.
  *
  * The filter is captured via a ref so callers can pass a fresh arrow function each render
- * without churning the bus subscription (which would drop already-buffered events).
+ * without churning the bus subscription (which would drop already-buffered events). Only events
+ * that pass `filterRef.current` are pushed into the coalescer.
  */
 export const useEventBusBuffer = <T extends AppEvent>(bus: EventBus, opts: UseEventBufferOptions<T>): readonly T[] => {
   const limit = opts.limit ?? 100;
-  const [items, setItems] = useState<readonly T[]>([]);
   const filterRef = useRef(opts.filter);
   filterRef.current = opts.filter;
 
-  useEffect(() => {
-    return bus.subscribe((event) => {
-      if (!filterRef.current(event)) return;
-      setItems((prev) => {
-        const next = [...prev, event];
-        return next.length > limit ? next.slice(next.length - limit) : next;
-      });
-    });
-  }, [bus, limit]);
-
-  return items;
+  return useCoalescedBuffer<T>({
+    limit,
+    ...(opts.flushMs !== undefined ? { flushMs: opts.flushMs } : {}),
+    subscribe: (push) =>
+      bus.subscribe((event) => {
+        if (filterRef.current(event)) push(event);
+      }),
+    deps: [bus, limit],
+  });
 };

--- a/src/application/ui/tui/runtime/use-sink-stream.ts
+++ b/src/application/ui/tui/runtime/use-sink-stream.ts
@@ -1,16 +1,21 @@
 // Retention audit: BOUNDED — `useSinkStream` keeps a trailing window of `T` refs sourced from the
-// upstream `BusSink` (default 100, trimmed via `.slice(-limit)` on push, and the initial replay is
-// also `.slice(-limit)`). Memory footprint is `limit` × ref-to-T; the sink itself owns the master
-// buffer so the component-side window is incremental, not duplicative. Sound because both the
-// mount-time seed and the per-publish reducer apply the same `limit` ceiling.
+// upstream `BusSink` (default 100, capped via `.slice(-limit)` once per flush/overflow inside the
+// coalescer, and the initial replay is also `.slice(-limit)`). Memory footprint is `limit` ×
+// ref-to-T; the sink itself owns the master buffer so the component-side window is incremental,
+// not duplicative. The window now coalesces — many emits between flushes yield ONE React commit,
+// not one-per-emit, which is what removed the commit-storm OOM.
 
 /**
- * Hooks that subscribe to a {@link BusSink} and re-render on new values. The store-style API
+ * Hook that subscribes to a {@link BusSink} and re-renders on new values. The store-style API
  * keeps the most recent N entries in component state so a panel can show a live tail without
  * the parent retriggering a full snapshot read on every emit.
+ *
+ * Subscription is routed through {@link useCoalescedBuffer}: arrival rate is decoupled from
+ * React-commit rate, so a high-frequency sink (e.g. a DEBUG-floor stream-json fan-out) cannot
+ * drive one Yoga layout + Output allocation per emitted line.
  */
 
-import { useEffect, useState } from 'react';
+import { useCoalescedBuffer } from '@src/application/ui/tui/runtime/use-coalesced-buffer.ts';
 import type { BusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
 
 export interface UseSinkStreamOptions {
@@ -21,6 +26,8 @@ export interface UseSinkStreamOptions {
    * `true` — every panel that mounts mid-run gets the recent history immediately.
    */
   readonly replay?: boolean;
+  /** Flush cadence in ms. Test-only escape hatch; production callers use the default. */
+  readonly flushMs?: number;
 }
 
 /** Subscribe to a bus and keep the trailing window in component state. */
@@ -28,17 +35,11 @@ export const useSinkStream = <T>(bus: BusSink<T>, opts: UseSinkStreamOptions = {
   const limit = opts.limit ?? 100;
   const replay = opts.replay !== false;
 
-  const [items, setItems] = useState<readonly T[]>(() => (replay ? bus.entries.slice(-limit) : []));
-
-  useEffect(() => {
-    if (replay) setItems(bus.entries.slice(-limit));
-    return bus.subscribe((value) => {
-      setItems((prev) => {
-        const next = [...prev, value];
-        return next.length > limit ? next.slice(next.length - limit) : next;
-      });
-    });
-  }, [bus, limit, replay]);
-
-  return items;
+  return useCoalescedBuffer<T>({
+    limit,
+    ...(opts.flushMs !== undefined ? { flushMs: opts.flushMs } : {}),
+    ...(replay ? { initial: bus.entries.slice(-limit) } : {}),
+    subscribe: (push) => bus.subscribe(push),
+    deps: [bus, limit, replay],
+  });
 };

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -152,6 +152,8 @@ export const SprintDetailView = (): React.JSX.Element => {
       task: target,
       sprintId: sprint.id,
       taskRepo: deps.taskRepo,
+      sprintRepo: deps.sprintRepo,
+      clock: deps.clock,
       logger: deps.logger,
     });
     if (!r.ok) {

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -227,6 +227,8 @@ export const SprintsView = (): React.JSX.Element => {
         task,
         sprintId: focusedSprint.id,
         taskRepo: deps.taskRepo,
+        sprintRepo: deps.sprintRepo,
+        clock: deps.clock,
         logger: deps.logger,
       });
       if (r.ok) {

--- a/src/business/task/unblock-task.ts
+++ b/src/business/task/unblock-task.ts
@@ -7,6 +7,10 @@ import type { SaveAllTasks } from '@src/domain/repository/task/save-all-tasks.ts
 import type { Task, TodoTask } from '@src/domain/entity/task.ts';
 import { resetTaskToTodo, unblockTask } from '@src/domain/entity/task-lifecycle.ts';
 import { upstreamBlockedDependents } from '@src/domain/entity/task-graph.ts';
+import { type Sprint, revertSprintToActive } from '@src/domain/entity/sprint.ts';
+import type { FindById } from '@src/domain/repository/_base/find-by-id.ts';
+import type { Save } from '@src/domain/repository/_base/save.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
@@ -28,6 +32,15 @@ import type { StorageError } from '@src/domain/value/error/storage-error.ts';
  * Policy: domain transition + persist + log. Idempotent — an already-`todo` task passes through
  * unchanged (mirrors {@link activateSprintUseCase}'s shape).
  *
+ * **Sprint reopen.** A mixed run (some tasks `done`, some `blocked`) settles the sprint to
+ * `review`. Reviving a `todo` task there means the sprint is no longer review-complete and the
+ * implement gate (`planned` / `active` only) would otherwise leave the revived work stranded. So
+ * after a successful unblock this reopens a `review` sprint to `active` (see
+ * {@link revertSprintToActive}). Best-effort and idempotent: a non-`review` sprint passes through
+ * untouched, and a reopen that fails to persist is logged but does not fail the unblock — the task
+ * is already revived, and re-running unblock retries the reopen (the already-`todo` short-circuit
+ * still reopens).
+ *
  * **TOCTOU precondition.** The cascade path does an UNLOCKED `findBySprintId` read whose result
  * seeds the (now-locked) `saveAll` rewrite — the read that feeds the rewrite happens before any
  * lock is taken. So this use case MUST NOT run while an Implement run is active on the same sprint:
@@ -45,6 +58,10 @@ export interface UnblockTaskProps {
   readonly sprintId: SprintId;
   /** Composite is supplied by callers; the use case needs read + atomic-rewrite for the cascade. */
   readonly taskRepo: UpdateTask & FindTasksBySprintId & SaveAllTasks;
+  /** Used to reopen a `review` sprint to `active` once there is `todo` work again. */
+  readonly sprintRepo: FindById<Sprint, SprintId> & Save<Sprint>;
+  /** Wall-clock for the reopen's `activatedAt` re-stamp. */
+  readonly clock: () => IsoTimestamp;
   readonly logger: Logger;
 }
 
@@ -55,8 +72,43 @@ export const unblockTaskUseCase = async (
 ): Promise<Result<UnblockTaskOutput, InvalidStateError | NotFoundError | StorageError>> => {
   const log = props.logger.named('task.unblock');
 
+  // Reopen a `review` sprint to `active` so the implement gate re-arms now there's `todo` work.
+  // Best-effort: the unblock has already persisted by the time this runs, so a failed reopen is
+  // logged and swallowed rather than failing the operation — re-running unblock retries it.
+  const reopenSprintIfReview = async (): Promise<void> => {
+    const loaded = await props.sprintRepo.findById(props.sprintId);
+    if (!loaded.ok) {
+      log.warn('could not load sprint to reopen after unblock', {
+        sprintId: props.sprintId,
+        error: loaded.error.message,
+      });
+      return;
+    }
+    if (loaded.value.status !== 'review') return;
+    const reopened = revertSprintToActive(loaded.value, props.clock());
+    if (!reopened.ok) {
+      log.warn('could not reopen sprint after unblock', {
+        sprintId: props.sprintId,
+        error: reopened.error.message,
+      });
+      return;
+    }
+    const saved = await props.sprintRepo.save(reopened.value);
+    if (!saved.ok) {
+      log.warn('could not persist reopened sprint after unblock', {
+        sprintId: props.sprintId,
+        error: saved.error.message,
+      });
+      return;
+    }
+    log.info(`sprint '${reopened.value.slug}' reopened review → active to resume unblocked work`, {
+      sprintId: props.sprintId,
+    });
+  };
+
   if (props.task.status === 'todo') {
-    log.debug('already todo, skipping', { taskId: props.task.id, sprintId: props.sprintId });
+    log.debug('already todo, skipping task transition', { taskId: props.task.id, sprintId: props.sprintId });
+    await reopenSprintIfReview();
     return Result.ok(props.task);
   }
 
@@ -90,6 +142,7 @@ export const unblockTaskUseCase = async (
       return Result.error(persisted.error);
     }
     log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
+    await reopenSprintIfReview();
     return Result.ok(primary);
   }
 
@@ -104,6 +157,7 @@ export const unblockTaskUseCase = async (
       return Result.error(persisted.error);
     }
     log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
+    await reopenSprintIfReview();
     return Result.ok(primary);
   }
 
@@ -133,5 +187,6 @@ export const unblockTaskUseCase = async (
       cascaded: cascaded.map((t) => String(t.id)),
     }
   );
+  await reopenSprintIfReview();
   return Result.ok(primary);
 };

--- a/src/domain/entity/sprint.ts
+++ b/src/domain/entity/sprint.ts
@@ -256,6 +256,39 @@ export const transitionSprintToReview = (
 };
 
 /**
+ * Transition `review → active` — the recovery counterpart to {@link transitionSprintToReview}.
+ *
+ * A mixed run (some tasks `done`, some `blocked`) settles the sprint to `review`. When the
+ * operator then unblocks a task, fresh `todo` work re-enters the sprint, so it is no longer
+ * review-complete — the `review` state's invariant ("every task settled") no longer holds.
+ * This reopens it to `active` so the implement gate re-arms and the unblocked tasks get picked
+ * up on the next run. `plannedAt` carries through; `reviewAt` is cleared back to `null`;
+ * `activatedAt` is re-stamped to mark the reopen (the sprint re-enters the active state now).
+ *
+ * Rejects from any non-`review` state — callers unblock between runs and only reopen a sprint
+ * that had actually advanced to review.
+ */
+export const revertSprintToActive = (sprint: Sprint, now: IsoTimestamp): Result<ActiveSprint, InvalidStateError> => {
+  const guard = requireStatus(
+    'sprint',
+    sprint,
+    ['review'] as const,
+    'revert-to-active',
+    'Only review sprints can be reopened to active.'
+  );
+  if (!guard.ok) return Result.error(guard.error);
+  const review = guard.value;
+  return Result.ok({
+    ...sprintBaseFrom(review),
+    status: 'active',
+    plannedAt: review.plannedAt,
+    activatedAt: now,
+    reviewAt: null,
+    doneAt: null,
+  });
+};
+
+/**
  * Transition `review → done`. Called by the review chain's `transition-sprint-to-done` leaf
  * after the user signals "done" via the empty / repeat termination round in `feedback.md`.
  * Terminal state — no further transitions, no further mutations.

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -134,9 +134,11 @@ const previewToolResult = (content: unknown): string | undefined => {
  *  - `type:"system"`, `type:"result"`, unknown / malformed lines: silently skipped — they are
  *    accounted for by other telemetry (system → init logging; result → token-usage event).
  *
- * The `RALPHCTL_LOG_LEVEL=info` filter (applied by the bus → logger consumer at
- * `createEventBusLogger`) drops every event published here under the default verbosity. The
- * events only surface in chain.log when the operator explicitly lifts the floor to `debug`.
+ * These events are published DIRECTLY to the EventBus — there is no producer-side gate here.
+ * `createEventBusLogger` is a producer that *publishes* `log` AppEvents, not a filter, so it does
+ * not drop anything emitted at this site. The only UI-floor gate is the coalescing forwarder in
+ * `launch.ts`, which applies the live log-level floor at ingest before the TUI ever sees a line.
+ * The persistent events.ndjson sink writes every event here verbatim, regardless of the UI floor.
  */
 const publishStreamLineEvents = (eventBus: EventBus, line: ClaudeStreamLine): void => {
   const json = line.json;
@@ -418,10 +420,10 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
 
   const onLine = (line: ClaudeStreamLine): void => {
     parser.ingest(line);
-    // Per-line debug fan-out. The bus → logger consumer (`createEventBusLogger`) honours
-    // `RALPHCTL_LOG_LEVEL`, so these events stay invisible at the default `info` floor and
-    // only land in chain.log when an operator explicitly bumps the floor to `debug`. No
-    // extra gating needed at this site.
+    // Per-line debug fan-out, published DIRECTLY to the EventBus — no gate at this site. The
+    // UI-floor filter lives in launch.ts's coalescing forwarder (applied at ingest against the
+    // live log-level gate); the persistent events.ndjson sink records every event regardless of
+    // that floor. `createEventBusLogger` is a producer, not a filter, and drops nothing here.
     publishStreamLineEvents(deps.eventBus, line);
   };
 

--- a/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
+++ b/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
@@ -27,7 +27,7 @@ import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime
 import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
 import { ProgressOverlay } from '@src/application/ui/tui/components/progress-overlay.tsx';
-import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 
 const SPRINT_ID_STR = '0193ed2b-1234-7abc-8def-0123456789ab';
 
@@ -151,7 +151,9 @@ describe('ProgressOverlay — open / close', () => {
     expect(lastFrame() ?? '').toContain('UNDERLYING_VIEW');
 
     stdin.write('g');
-    await tick(50);
+    // The overlay reads progress.md asynchronously; wait for the content to land rather than a
+    // fixed tick, which races the disk read under load (caught '⠋ Loading…' on a busy box).
+    await waitFor(() => (lastFrame() ?? '').includes('First line of activity.'));
     const opened = lastFrame() ?? '';
     expect(opened).toContain('Progress');
     expect(opened).toContain('demo-sprint');
@@ -190,7 +192,7 @@ describe('ProgressOverlay — open / close', () => {
     await tick(50); // let the focused-run pin effect run
 
     stdin.write('g');
-    await tick(80);
+    await waitFor(() => (lastFrame() ?? '').includes('Pinned run activity.'));
     const opened = lastFrame() ?? '';
     expect(opened).toContain('Progress');
     expect(opened).toContain('pinned-run');
@@ -207,7 +209,7 @@ describe('ProgressOverlay — missing / empty file', () => {
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     await tick(50);
     stdin.write('g');
-    await tick(80); // disk read + state flush
+    await waitFor(() => (lastFrame() ?? '').includes('No progress file yet')); // disk read + state flush
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('No progress file yet');
@@ -221,7 +223,7 @@ describe('ProgressOverlay — missing / empty file', () => {
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     await tick(50);
     stdin.write('g');
-    await tick(80);
+    await waitFor(() => (lastFrame() ?? '').includes('exists but is empty'));
 
     expect(lastFrame() ?? '').toContain('exists but is empty');
     unmount();
@@ -248,7 +250,7 @@ describe('ProgressOverlay — scrolling', () => {
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     await tick(50);
     stdin.write('g');
-    await tick(80);
+    await waitFor(() => (lastFrame() ?? '').includes('HEAD-LINE'));
 
     // Initial: top of file visible, tail not.
     const top = lastFrame() ?? '';

--- a/tests/integration/application/ui/tui/runtime/sessions-context-guard.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/sessions-context-guard.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Status-diff guard on `useSessions` / `useSession`. The session manager fires `notify()` on
+ * every chain `step` (trace-only); the always-mounted StatusBar consumes these hooks, so an
+ * unguarded subscription re-rendered once per leaf step — a log-floor-INDEPENDENT commit
+ * amplifier. The guard must swallow trace-only notifies and only `setState` when a status (or
+ * error presence) actually changed.
+ *
+ * We drive a controllable fake SessionManager so the test can fire N trace-only notifies then ONE
+ * status change with deterministic timing, and count consumer renders via a ref.
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { describe, expect, it } from 'vitest';
+import { SessionsProvider, useSession, useSessions } from '@src/application/ui/tui/runtime/sessions-context.tsx';
+import type {
+  SessionDescriptor,
+  SessionListener,
+  SessionManager,
+  SessionRecord,
+} from '@src/application/ui/tui/runtime/session-manager.ts';
+import type { RunnerStatus } from '@src/application/chain/run/runner.ts';
+import type { Runner } from '@src/application/chain/run/runner.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+
+const drain = (ms: number): Promise<void> => new Promise((res) => setTimeout(res, ms));
+
+/**
+ * Minimal controllable SessionManager: one record, mutable status + trace-version, and a single
+ * listener set. `bumpTrace()` models a `step` (trace changes, status does not); `setStatus` models
+ * a real transition. Both call `notify()`.
+ */
+const createFakeManager = (id: string) => {
+  let status: RunnerStatus = 'running';
+  let traceVersion = 0;
+  let pinnedSprintId: SprintId | undefined;
+  let pinnedSprintLabel: string | undefined;
+  const listeners = new Set<SessionListener>();
+
+  const recordOf = (): SessionRecord => {
+    const descriptor = {
+      id,
+      flowId: 'demo',
+      title: 'Demo',
+      status,
+      startedAt: 0,
+      // `trace` is opaque to the hooks; we only need a fresh ref so a status-blind consumer
+      // would see "something changed".
+      trace: [{ v: traceVersion }] as unknown as SessionDescriptor['trace'],
+      ...(pinnedSprintId !== undefined ? { pinnedSprintId } : {}),
+      ...(pinnedSprintLabel !== undefined ? { pinnedSprintLabel } : {}),
+    } satisfies SessionDescriptor;
+    return { descriptor, runner: {} as Runner<unknown> };
+  };
+
+  const notify = (): void => {
+    for (const fn of [...listeners]) fn();
+  };
+
+  const mgr: SessionManager = {
+    list: () => [recordOf()],
+    get: (lookup) => (lookup === id ? recordOf() : undefined),
+    subscribe: (fn) => {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    register: () => recordOf(),
+    abort: () => undefined,
+    remove: () => undefined,
+    setPinnedSprint: (_runnerId, sprintId, sprintLabel): void => {
+      pinnedSprintId = sprintId;
+      pinnedSprintLabel = sprintLabel;
+      notify();
+    },
+  };
+
+  return {
+    mgr,
+    bumpTrace: (): void => {
+      traceVersion += 1;
+      notify();
+    },
+    setStatus: (next: RunnerStatus): void => {
+      status = next;
+      notify();
+    },
+  };
+};
+
+describe('sessions-context status-diff guard', () => {
+  it('useSessions: ignores trace-only step notifies, re-renders once on a status change', async () => {
+    const fake = createFakeManager('s-1');
+    let renders = 0;
+    const Probe = (): React.JSX.Element => {
+      const sessions = useSessions();
+      renders += 1;
+      return <Text>{sessions[0]?.descriptor.status ?? 'none'}</Text>;
+    };
+    const r = render(
+      <SessionsProvider value={fake.mgr}>
+        <Probe />
+      </SessionsProvider>
+    );
+    await drain(5);
+    const baseline = renders;
+
+    // 20 trace-only notifies → zero consumer renders.
+    for (let i = 0; i < 20; i++) fake.bumpTrace();
+    await drain(10);
+    expect(renders - baseline).toBe(0);
+
+    // One real status change → exactly one render.
+    fake.setStatus('completed');
+    await drain(10);
+    expect(renders - baseline).toBe(1);
+    expect(r.lastFrame()).toBe('completed');
+    r.unmount();
+  });
+
+  it('useSession: ignores trace-only step notifies, re-renders once on a status change', async () => {
+    const fake = createFakeManager('s-2');
+    let renders = 0;
+    const Probe = (): React.JSX.Element => {
+      const rec = useSession('s-2');
+      renders += 1;
+      return <Text>{rec?.descriptor.status ?? 'none'}</Text>;
+    };
+    const r = render(
+      <SessionsProvider value={fake.mgr}>
+        <Probe />
+      </SessionsProvider>
+    );
+    await drain(5);
+    const baseline = renders;
+
+    for (let i = 0; i < 20; i++) fake.bumpTrace();
+    await drain(10);
+    expect(renders - baseline).toBe(0);
+
+    fake.setStatus('failed');
+    await drain(10);
+    expect(renders - baseline).toBe(1);
+    expect(r.lastFrame()).toBe('failed');
+    r.unmount();
+  });
+
+  it('useSession: re-renders on setPinnedSprint (no status change) but still swallows trace-only', async () => {
+    const fake = createFakeManager('s-3');
+    let renders = 0;
+    const Probe = (): React.JSX.Element => {
+      const rec = useSession('s-3');
+      renders += 1;
+      return <Text>{rec?.descriptor.pinnedSprintId ?? 'unpinned'}</Text>;
+    };
+    const r = render(
+      <SessionsProvider value={fake.mgr}>
+        <Probe />
+      </SessionsProvider>
+    );
+    await drain(5);
+    const baseline = renders;
+    expect(r.lastFrame()).toBe('unpinned');
+
+    // Trace-only notifies stay swallowed (the pinned sprint is unchanged) — no re-render.
+    for (let i = 0; i < 20; i++) fake.bumpTrace();
+    await drain(10);
+    expect(renders - baseline).toBe(0);
+
+    // A mid-run setPinnedSprint changes no status but MUST re-render so the execute view drops
+    // the stale (undefined) sprint and shows the now-created one.
+    fake.mgr.setPinnedSprint('s-3', 'sprint-42' as SprintId, 'Sprint 42');
+    await drain(10);
+    expect(renders - baseline).toBe(1);
+    expect(r.lastFrame()).toBe('sprint-42');
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/runtime/use-event-bus.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/use-event-bus.test.tsx
@@ -25,9 +25,11 @@ const Probe = ({
   readonly onSubscribeCount: (count: number) => void;
 }): React.JSX.Element => {
   // Fresh arrow function each render — if the hook re-subscribed on identity churn it would
-  // cycle the bus subscription on every parent re-render.
+  // cycle the bus subscription on every parent re-render. `flushMs: 20` keeps the coalescer's
+  // window short so the drains below stay fast.
   const events = useEventBusBuffer<ChainCompletedEvent>(bus, {
     filter: (e: AppEvent): e is ChainCompletedEvent => e.type === 'chain-completed',
+    flushMs: 20,
   });
   onSubscribeCount(events.length);
   return <Text>count={events.length}</Text>;
@@ -42,15 +44,15 @@ describe('useEventBusBuffer', () => {
 
     bus.publish({ type: 'chain-completed', chainId: 'c1', at: NOW });
     bus.publish({ type: 'chain-completed', chainId: 'c2', at: NOW });
-    // Microtask drain — Ink batches state updates.
-    await new Promise((res) => setTimeout(res, 5));
+    // Drain past the coalescer's 20ms flush window so the batched setState lands.
+    await new Promise((res) => setTimeout(res, 60));
     expect(lastCount).toBe(2);
 
     // Now publish a third event AND a non-matching one. If the hook had unsubscribed-resub'd
     // on the implicit re-render Ink might have caused, the buffer would have been reset.
     bus.publish({ type: 'chain-completed', chainId: 'c3', at: NOW });
     bus.publish({ type: 'log', level: 'info', message: 'noise', at: NOW });
-    await new Promise((res) => setTimeout(res, 5));
+    await new Promise((res) => setTimeout(res, 60));
     expect(lastCount).toBe(3);
     r.unmount();
   });

--- a/tests/integration/application/ui/tui/runtime/use-sink-stream.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/use-sink-stream.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Behavioural proof that `useSinkStream` coalesces. REPO CONVENTION: no `vi.useFakeTimers()` in
+ * rendered TUI tests — Ink's reconciler + the coalescer's real interval must run on the real
+ * event loop. We pass a short `flushMs` via the test-only escape hatch and drain past it.
+ *
+ * 50 synchronous emits must collapse into ~1–2 React commits (not 50), and the rendered output
+ * must show the trailing window. A second test proves mount-replay paints seeded history in a
+ * single frame.
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { describe, expect, it } from 'vitest';
+import { createBusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
+import { useSinkStream } from '@src/application/ui/tui/runtime/use-sink-stream.ts';
+
+const drain = (ms: number): Promise<void> => new Promise((res) => setTimeout(res, ms));
+
+const Probe = ({
+  bus,
+  onRender,
+  flushMs,
+}: {
+  readonly bus: ReturnType<typeof createBusSink<number>>;
+  readonly onRender: () => void;
+  readonly flushMs: number;
+}): React.JSX.Element => {
+  const items = useSinkStream<number>(bus, { limit: 5, flushMs });
+  onRender();
+  return <Text>{items.join(',')}</Text>;
+};
+
+describe('useSinkStream coalescing', () => {
+  it('collapses 50 synchronous emits into a small number of commits and shows the trailing window', async () => {
+    const bus = createBusSink<number>({ maxEntries: 1000 });
+    let renders = 0;
+    const r = render(<Probe bus={bus} onRender={() => (renders += 1)} flushMs={20} />);
+
+    // Let the mount effect attach the subscription before flooding.
+    await drain(5);
+    const rendersBeforeFlood = renders;
+
+    for (let i = 0; i < 50; i++) bus.emit(i);
+
+    // Drain well past one flush window so the single coalesced commit lands.
+    await drain(60);
+
+    const commitsFromFlood = renders - rendersBeforeFlood;
+    expect(commitsFromFlood).toBeGreaterThanOrEqual(1);
+    expect(commitsFromFlood).toBeLessThanOrEqual(2);
+    // Trailing window of the last 5 values.
+    expect(r.lastFrame()).toBe('45,46,47,48,49');
+    r.unmount();
+  });
+
+  it('seeds mount-replay from the bus buffer and paints it in one frame', async () => {
+    const bus = createBusSink<number>({ maxEntries: 1000 });
+    for (let i = 0; i < 10; i++) bus.emit(i);
+
+    const r = render(<Probe bus={bus} onRender={() => undefined} flushMs={20} />);
+    await drain(5);
+
+    // replay default true → trailing 5 of the pre-existing buffer.
+    expect(r.lastFrame()).toBe('5,6,7,8,9');
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/sprints-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprints-view.test.tsx
@@ -26,6 +26,13 @@ const fakeSprintRepo = (sprints: readonly Sprint[]): SprintRepository =>
     async list() {
       return Result.ok([...sprints]);
     },
+    async findById(id: Sprint['id']) {
+      const found = sprints.find((s) => s.id === id);
+      return found ? Result.ok(found) : Result.ok(sprints[0] as Sprint);
+    },
+    async save() {
+      return Result.ok(undefined);
+    },
     async remove() {
       return Result.ok(undefined);
     },
@@ -46,6 +53,7 @@ const stubDeps = (sprints: readonly Sprint[]): AppDeps =>
     sprintExecutionRepo: {} as never,
     taskRepo: emptyTaskRepo(),
     settingsRepo: {} as never,
+    clock: () => IsoTimestamp.now(),
     logger: noopLogger,
   }) as unknown as AppDeps;
 

--- a/tests/unit/application/ui/tui/runtime/coalesced-buffer.test.ts
+++ b/tests/unit/application/ui/tui/runtime/coalesced-buffer.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Pure unit coverage for the consumer-side coalescer. Fake timers are fine here — this layer has
+ * no React (mirrors heap-watchdog.test.ts). The core guarantees: flush rate is O(elapsed/flushMs)
+ * not O(pushes), the trailing window never exceeds `limit`, `flushNow` delivers the final batch,
+ * `stop()` leaks no timer, and an idle buffer never flushes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createCoalescedBuffer', () => {
+  it('coalesces a flood into O(elapsed/flushMs) flushes, not one-per-push', () => {
+    const windows: number[][] = [];
+    const buf = createCoalescedBuffer<number>({
+      limit: 1000,
+      flushMs: 100,
+      onFlush: (w) => windows.push([...w]),
+    });
+
+    // Push 10_000 values, advancing the clock by one flush interval every 1000 pushes.
+    for (let i = 0; i < 10_000; i++) {
+      buf.push(i);
+      if (i % 1000 === 999) vi.advanceTimersByTime(100);
+    }
+
+    // 10 advances → at most ~10 flushes, NOT 10_000.
+    expect(windows.length).toBeLessThanOrEqual(11);
+    expect(windows.length).toBeGreaterThan(0);
+    buf.stop();
+  });
+
+  it('never lets the trailing window exceed limit (cap on overflow between flushes)', () => {
+    let maxLen = 0;
+    const buf = createCoalescedBuffer<number>({
+      limit: 50,
+      flushMs: 100,
+      onFlush: (w) => {
+        maxLen = Math.max(maxLen, w.length);
+      },
+    });
+
+    // 5000 pushes with NO timer advance between them — the overflow cap must still bound the
+    // window so a flush (or the final flushNow) never hands out more than `limit`.
+    for (let i = 0; i < 5000; i++) buf.push(i);
+    buf.flushNow();
+
+    expect(maxLen).toBe(50);
+    buf.stop();
+  });
+
+  it('flushNow delivers the final batch synchronously with the trailing window', () => {
+    const windows: number[][] = [];
+    const buf = createCoalescedBuffer<number>({
+      limit: 3,
+      flushMs: 1000,
+      onFlush: (w) => windows.push([...w]),
+    });
+
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.push(4);
+    buf.flushNow();
+
+    expect(windows).toEqual([[2, 3, 4]]);
+    buf.stop();
+  });
+
+  it('seeds the window from initial (trimmed to limit) and includes it in the first flush', () => {
+    const windows: number[][] = [];
+    const buf = createCoalescedBuffer<number>({
+      limit: 3,
+      flushMs: 1000,
+      initial: [10, 20, 30, 40],
+      onFlush: (w) => windows.push([...w]),
+    });
+
+    buf.push(50);
+    buf.flushNow();
+
+    // initial trimmed to last 3 → [20,30,40], then push 50 overflows → [30,40,50].
+    expect(windows).toEqual([[30, 40, 50]]);
+    buf.stop();
+  });
+
+  it('does not flush when idle (no pushes between ticks)', () => {
+    const onFlush = vi.fn();
+    const buf = createCoalescedBuffer<number>({ limit: 10, flushMs: 100, onFlush });
+
+    vi.advanceTimersByTime(1000); // 10 ticks, zero pushes
+    buf.flushNow(); // explicit flush with nothing dirty
+
+    expect(onFlush).not.toHaveBeenCalled();
+    buf.stop();
+  });
+
+  it('leaks no timer after stop()', () => {
+    const buf = createCoalescedBuffer<number>({ limit: 10, flushMs: 100, onFlush: () => undefined });
+    buf.push(1);
+    buf.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('stop() is idempotent', () => {
+    const buf = createCoalescedBuffer<number>({ limit: 10, onFlush: () => undefined });
+    buf.stop();
+    expect(() => buf.stop()).not.toThrow();
+  });
+
+  it('clearOnFlush:true empties the window after each flush — a flush carries only new pushes', () => {
+    const windows: number[][] = [];
+    const buf = createCoalescedBuffer<number>({
+      limit: 1000,
+      flushMs: 100,
+      clearOnFlush: true,
+      onFlush: (w) => windows.push([...w]),
+    });
+
+    buf.push(1);
+    buf.push(2);
+    vi.advanceTimersByTime(100); // first flush → [1, 2], window then cleared
+    buf.push(3);
+    vi.advanceTimersByTime(100); // second flush → only [3], not [1, 2, 3]
+
+    expect(windows).toEqual([[1, 2], [3]]);
+    buf.stop();
+  });
+
+  it('discard() empties the window without calling onFlush and resets dirty', () => {
+    const onFlush = vi.fn();
+    const buf = createCoalescedBuffer<number>({ limit: 10, flushMs: 100, onFlush });
+
+    buf.push(1);
+    buf.push(2);
+    buf.discard(); // drop the held batch — no onFlush
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // dirty was reset: a flush tick with nothing new must not fire onFlush either.
+    vi.advanceTimersByTime(100);
+    buf.flushNow();
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // The window is genuinely empty: a fresh push then flush delivers ONLY the new value.
+    buf.push(3);
+    buf.flushNow();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith([3]);
+    buf.stop();
+  });
+
+  it('floors flushMs at 16ms when a shorter interval is requested', () => {
+    const onFlush = vi.fn();
+    const buf = createCoalescedBuffer<number>({ limit: 10, flushMs: 1, onFlush });
+    buf.push(1);
+
+    vi.advanceTimersByTime(15); // below the 16ms floor — must not have fired yet
+    expect(onFlush).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1); // now at 16ms
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    buf.stop();
+  });
+});

--- a/tests/unit/application/ui/tui/runtime/log-forwarder-coalescing.test.ts
+++ b/tests/unit/application/ui/tui/runtime/log-forwarder-coalescing.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage for the launch.ts log-forwarder wiring in isolation. `createLogForwarder` is a
+ * module-private helper in launch.ts (a full `launchTui` bootstrap mounts Ink + real storage, so
+ * it is not a feasible unit), but its behaviour is the composition of three exported pieces:
+ * gate-at-ingest (`passesLogLevel`) + CoalescedBuffer + BusSink. We reconstruct that exact wiring
+ * and assert the two properties the fix depends on:
+ *
+ *   1. Admitted events flush as ONE batch into the bus, not one emit per push (the OOM fix).
+ *   2. Delta semantics (`clearOnFlush:true`): consecutive flushes with new pushes between them
+ *      never re-emit prior-flush events — the bus holds each admitted event exactly once.
+ *   3. `onCritical`-style teardown: `discard()` drops the held window WITHOUT re-emitting it, then
+ *      `clear()` empties the bus, so the post-critical bus only contains events pushed afterwards.
+ *
+ * Fake timers are fine — no React in this layer (mirrors heap-watchdog.test.ts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+import { createBusSink } from '@src/application/ui/tui/runtime/sinks-bus.ts';
+import { createLogLevelGate, passesLogLevel } from '@src/business/observability/log-level-filter.ts';
+import type { LogEvent } from '@src/business/observability/events.ts';
+import { isoTimestamp } from '@tests/fixtures/domain.ts';
+
+const NOW = isoTimestamp('2026-06-05T10:00:00.000Z');
+
+const logEvent = (level: LogEvent['level'], message: string): LogEvent => ({
+  type: 'log',
+  level,
+  message,
+  at: NOW,
+});
+
+/**
+ * Reconstruct the launch.ts forwarder: gate-at-ingest → coalescer → logBus. Mirrors the real
+ * wiring's `clearOnFlush:true` (delta re-emit, no duplicates) and exposes a `critical()` that
+ * models `onCritical`: `discard()` the held batch THEN `clear()` the bus.
+ */
+const wireForwarder = (floor: LogEvent['level']) => {
+  const logBus = createBusSink<LogEvent>({ maxEntries: 2000 });
+  const gate = createLogLevelGate(floor);
+  const buffer = createCoalescedBuffer<LogEvent>({
+    limit: 2000,
+    flushMs: 100,
+    clearOnFlush: true,
+    onFlush: (window) => {
+      for (const event of window) logBus.emit(event);
+    },
+  });
+  const ingest = (event: LogEvent): void => {
+    if (passesLogLevel(event.level, gate.get())) buffer.push(event);
+  };
+  const critical = (): void => {
+    buffer.discard();
+    logBus.clear();
+  };
+  return { logBus, gate, buffer, ingest, critical };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('launch log-forwarder coalescing', () => {
+  it('drops sub-floor events at ingest and coalesces admitted ones into one flush window', () => {
+    const f = wireForwarder('info');
+    let emits = 0;
+    f.logBus.subscribe(() => (emits += 1));
+
+    // 100 debug lines (below the info floor) → dropped at ingest, never buffered.
+    for (let i = 0; i < 100; i++) f.ingest(logEvent('debug', `noise-${i}`));
+    // 50 info lines → admitted, accumulate in one window.
+    for (let i = 0; i < 50; i++) f.ingest(logEvent('info', `keep-${i}`));
+
+    expect(emits).toBe(0); // nothing emitted before a flush tick
+    vi.advanceTimersByTime(100); // one flush
+    expect(emits).toBe(50); // all 50 admitted, in a single coalesced flush
+    expect(f.logBus.entries.map((e) => e.message)).toContain('keep-49');
+    f.buffer.stop();
+  });
+
+  it('two consecutive flushes with new pushes between them never duplicate (delta re-emit)', () => {
+    const f = wireForwarder('debug');
+
+    for (let i = 0; i < 5; i++) f.ingest(logEvent('debug', `a-${i}`));
+    vi.advanceTimersByTime(100); // flush 1 → emits a-0..a-4, window cleared
+    for (let i = 0; i < 3; i++) f.ingest(logEvent('debug', `b-${i}`));
+    vi.advanceTimersByTime(100); // flush 2 → emits ONLY b-0..b-2, not a-* again
+
+    const messages = f.logBus.entries.map((e) => e.message);
+    expect(messages).toEqual(['a-0', 'a-1', 'a-2', 'a-3', 'a-4', 'b-0', 'b-1', 'b-2']);
+    // No duplicates: every admitted event appears exactly once.
+    expect(messages).toHaveLength(new Set(messages).size);
+    f.buffer.stop();
+  });
+
+  it('after onCritical (discard + clear), a later push lands ONLY the new event — no repopulate', () => {
+    const f = wireForwarder('debug');
+    for (let i = 0; i < 10; i++) f.ingest(logEvent('debug', `held-${i}`));
+
+    // onCritical: discard() drops the held batch WITHOUT emitting it, then clear() empties the bus.
+    f.critical();
+    expect(f.logBus.entries).toHaveLength(0);
+
+    // A fresh push + one interval: the bus must contain only the post-critical event — the
+    // pre-critical batch was dropped, not re-fed.
+    f.ingest(logEvent('debug', 'after-critical'));
+    vi.advanceTimersByTime(100);
+    expect(f.logBus.entries.map((e) => e.message)).toEqual(['after-critical']);
+    f.buffer.stop();
+  });
+
+  it('honours a live floor change (gate read per event at ingest)', () => {
+    const f = wireForwarder('info');
+    f.ingest(logEvent('debug', 'before')); // dropped at info floor
+    f.gate.set('debug'); // operator lifts the floor at runtime
+    f.ingest(logEvent('debug', 'after')); // now admitted
+
+    vi.advanceTimersByTime(100);
+    expect(f.logBus.entries.map((e) => e.message)).toEqual(['after']);
+    f.buffer.stop();
+  });
+});

--- a/tests/unit/business/task/unblock-task.test.ts
+++ b/tests/unit/business/task/unblock-task.test.ts
@@ -3,15 +3,51 @@ import { Result } from '@src/domain/result.ts';
 import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
 import { BLOCKED_UPSTREAM_REASON_PREFIX, markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
 import type { FindTasksBySprintId } from '@src/domain/repository/task/find-tasks-by-sprint-id.ts';
 import type { SaveAllTasks } from '@src/domain/repository/task/save-all-tasks.ts';
+import type { FindById } from '@src/domain/repository/_base/find-by-id.ts';
+import type { Save } from '@src/domain/repository/_base/save.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
-import { makeDoneTask, makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
+import {
+  FIXED_LATEST,
+  makeActiveSprint,
+  makeDoneTask,
+  makeInProgressTaskWithRunningAttempt,
+  makeReviewSprint,
+  makeTodoTask,
+} from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const SPRINT_ID = '01900000-0000-7000-8000-0000000000aa' as unknown as SprintId;
+
+const FIXED_CLOCK = (): IsoTimestamp => FIXED_LATEST;
+
+type SprintRepo = FindById<Sprint, SprintId> & Save<Sprint>;
+interface SprintRepoDouble {
+  readonly repo: SprintRepo;
+  /** The sprint handed to `save()`, or undefined if reopen never persisted. */
+  readonly saved: () => Sprint | undefined;
+}
+
+// Sprint repo double: `findById` returns the seeded sprint, `save` records it. Default seed is an
+// ACTIVE sprint, so the reopen-on-unblock path is a no-op unless a test seeds a `review` sprint.
+const sprintRepoWith = (sprint: Sprint = makeActiveSprint()): SprintRepoDouble => {
+  let saved: Sprint | undefined;
+  const repo: SprintRepo = {
+    async findById() {
+      return Result.ok(sprint);
+    },
+    async save(s) {
+      saved = s;
+      return Result.ok(undefined);
+    },
+  };
+  return { repo, saved: () => saved };
+};
 
 const makeBlockedTask = (reason = 'flaky pre-task verify'): BlockedTask => {
   const r = markTaskBlocked(makeTodoTask(), reason, 'own');
@@ -67,6 +103,8 @@ describe('unblockTaskUseCase', () => {
       task: blocked,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -86,6 +124,8 @@ describe('unblockTaskUseCase', () => {
       task: todo,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -103,6 +143,8 @@ describe('unblockTaskUseCase', () => {
       task: inProgress,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -120,6 +162,8 @@ describe('unblockTaskUseCase', () => {
       task: done,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -136,6 +180,8 @@ describe('unblockTaskUseCase', () => {
       task: blocked,
       sprintId: SPRINT_ID,
       taskRepo: repoFailing([blocked]),
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -159,6 +205,8 @@ describe('unblockTaskUseCase', () => {
       task: root,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -180,6 +228,8 @@ describe('unblockTaskUseCase', () => {
       task: root,
       sprintId: SPRINT_ID,
       taskRepo: repo.repo,
+      sprintRepo: sprintRepoWith().repo,
+      clock: FIXED_CLOCK,
       logger: noopLogger,
     });
 
@@ -189,5 +239,115 @@ describe('unblockTaskUseCase', () => {
     // The dependent failed on its own merits — it is NOT in the cascade, so it is left untouched
     // on disk (only the primary is re-persisted). It stays blocked for the operator to fix.
     expect(saved.find((t) => t.id === depOwn.value.id)).toBeUndefined();
+  });
+
+  it('reopens a review sprint to active so the implement gate re-arms', async () => {
+    const blocked = makeBlockedTask();
+    const taskRepo = repoOk([blocked]);
+    const sprintRepo = sprintRepoWith(makeReviewSprint());
+
+    const result = await unblockTaskUseCase({
+      task: blocked,
+      sprintId: SPRINT_ID,
+      taskRepo: taskRepo.repo,
+      sprintRepo: sprintRepo.repo,
+      clock: FIXED_CLOCK,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    const saved = sprintRepo.saved();
+    expect(saved?.status).toBe('active');
+    expect(saved?.reviewAt).toBeNull();
+  });
+
+  it('leaves a non-review sprint untouched (active passes through, no save)', async () => {
+    const blocked = makeBlockedTask();
+    const taskRepo = repoOk([blocked]);
+    const sprintRepo = sprintRepoWith(makeActiveSprint());
+
+    const result = await unblockTaskUseCase({
+      task: blocked,
+      sprintId: SPRINT_ID,
+      taskRepo: taskRepo.repo,
+      sprintRepo: sprintRepo.repo,
+      clock: FIXED_CLOCK,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sprintRepo.saved()).toBeUndefined();
+  });
+
+  it('reopens the review sprint on the cascade path too', async () => {
+    const root = makeBlockedTask('own failure: eval did not pass');
+    const depTodo = makeTodoTask({ name: 'dependent', dependsOn: [root.id] });
+    const depUpstream = markTaskBlocked(
+      depTodo,
+      `${BLOCKED_UPSTREAM_REASON_PREFIX} — prerequisite not done: root`,
+      'upstream'
+    );
+    if (!depUpstream.ok) throw depUpstream.error;
+    const taskRepo = repoOk([root, depUpstream.value]);
+    const sprintRepo = sprintRepoWith(makeReviewSprint());
+
+    const result = await unblockTaskUseCase({
+      task: root,
+      sprintId: SPRINT_ID,
+      taskRepo: taskRepo.repo,
+      sprintRepo: sprintRepo.repo,
+      clock: FIXED_CLOCK,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sprintRepo.saved()?.status).toBe('active');
+  });
+
+  it('reopens a review sprint even when the task is already todo (recovery retry)', async () => {
+    const todo = makeTodoTask();
+    const taskRepo = repoOk([todo]);
+    const sprintRepo = sprintRepoWith(makeReviewSprint());
+
+    const result = await unblockTaskUseCase({
+      task: todo,
+      sprintId: SPRINT_ID,
+      taskRepo: taskRepo.repo,
+      sprintRepo: sprintRepo.repo,
+      clock: FIXED_CLOCK,
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sprintRepo.saved()?.status).toBe('active');
+  });
+
+  it('best-effort reopen — unblock still succeeds when the sprint save fails', async () => {
+    const blocked = makeBlockedTask();
+    const taskRepo = repoOk([blocked]);
+    const reviewSprint = makeReviewSprint();
+    const sprintRepo: SprintRepo = {
+      async findById() {
+        return Result.ok(reviewSprint);
+      },
+      async save() {
+        return Result.error(new StorageError({ subCode: 'io', message: 'disk full', path: 'sprint' }));
+      },
+    };
+
+    const result = await unblockTaskUseCase({
+      task: blocked,
+      sprintId: SPRINT_ID,
+      taskRepo: taskRepo.repo,
+      sprintRepo,
+      clock: FIXED_CLOCK,
+      logger: noopLogger,
+    });
+
+    // The task was already revived to todo before the reopen ran — a failed reopen must not roll
+    // that back or surface as an error. The operator can re-run unblock to retry the reopen.
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('todo');
   });
 });

--- a/tests/unit/domain/entity/sprint.test.ts
+++ b/tests/unit/domain/entity/sprint.test.ts
@@ -5,6 +5,7 @@ import {
   createSprintWithExecution,
   planSprint,
   renameSprint,
+  revertSprintToActive,
   setSprintSlug,
   type Sprint,
   transitionSprintToDone,
@@ -107,6 +108,26 @@ describe('transitionSprintToReview', () => {
   });
 });
 
+describe('revertSprintToActive', () => {
+  it('reopens review → active, clears reviewAt, and re-stamps activatedAt', () => {
+    const r = revertSprintToActive(makeReviewSprint(), FIXED_LATEST);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.status).toBe('active');
+    expect(r.value.reviewAt).toBeNull();
+    expect(r.value.doneAt).toBeNull();
+    expect(r.value.activatedAt).toBe(FIXED_LATEST);
+    expect(r.value.plannedAt).not.toBeNull();
+  });
+
+  it('rejects from any non-review state', () => {
+    expect(revertSprintToActive(makeDraftSprint(), FIXED_LATEST).ok).toBe(false);
+    expect(revertSprintToActive(makePlannedSprint(), FIXED_LATEST).ok).toBe(false);
+    expect(revertSprintToActive(makeActiveSprint(), FIXED_LATEST).ok).toBe(false);
+    expect(revertSprintToActive(makeDoneSprint(), FIXED_LATEST).ok).toBe(false);
+  });
+});
+
 describe('transitionSprintToDone', () => {
   it('transitions review → done and stamps doneAt', () => {
     const r = transitionSprintToDone(makeReviewSprint(), FIXED_LATEST);
@@ -147,7 +168,7 @@ describe('Sprint state-machine matrix', () => {
     },
     { from: 'planned', sprint: () => makePlannedSprint(), allowed: ['activate', 'rename'] },
     { from: 'active', sprint: () => makeActiveSprint(), allowed: ['transition-to-review', 'rename'] },
-    { from: 'review', sprint: () => makeReviewSprint(), allowed: ['transition-to-done', 'rename'] },
+    { from: 'review', sprint: () => makeReviewSprint(), allowed: ['transition-to-done', 'revert-to-active', 'rename'] },
     { from: 'done', sprint: () => makeDoneSprint(), allowed: [] },
   ];
 
@@ -167,6 +188,10 @@ describe('Sprint state-machine matrix', () => {
     it(`from ${c.from}: transition-to-done ${c.allowed.includes('transition-to-done') ? '✓' : '✗'}`, () => {
       const r = transitionSprintToDone(c.sprint(), FIXED_LATEST);
       expect(r.ok).toBe(c.allowed.includes('transition-to-done'));
+    });
+    it(`from ${c.from}: revert-to-active ${c.allowed.includes('revert-to-active') ? '✓' : '✗'}`, () => {
+      const r = revertSprintToActive(c.sprint(), FIXED_LATEST);
+      expect(r.ok).toBe(c.allowed.includes('revert-to-active'));
     });
     it(`from ${c.from}: rename ${c.allowed.includes('rename') ? '✓' : '✗'}`, () => {
       const r = renameSprint(c.sprint(), 'new-name');


### PR DESCRIPTION
## What

Fixes a TUI **out-of-memory crash** (V8 `exit 134`) that hit a ~25-min Opus `implement` run at a DEBUG log floor. Root cause was a **React commit storm**, not a retained leak — every in-memory buffer is already capped. At DEBUG, each Claude `stream-json` line fans out into many debug log events, each driving a per-event `setState` on the live-tail hooks. Ink throttles stdout *writes* (~30 fps) but **not** React commits, so per-commit Yoga layout + `Output` allocation ran unthrottled and outpaced GC.

The fix decouples event-arrival rate from React-commit rate with a consumer-side coalescer that flushes batched events to state at ~16 fps:

- `createCoalescedBuffer` + `useCoalescedBuffer` — one `unref`'d timer, O(1) push, `slice(-limit)` at flush (not the per-event `[...prev, v]` spread)
- `useSinkStream` / `useEventBusBuffer` reimplemented on it — **public signatures unchanged**, mount-replay preserved
- the `launch.ts` logBus forwarder coalesces with **delta semantics** (`clearOnFlush`) so it never re-emits prior batches; gate at ingest against the live floor; `onCritical` drops the held batch (`discard`), `drain()` stops the timer
- `useSessions`/`useSession` guarded with a status+pinned-sprint diff so per-leaf trace `step` notifies stop re-rendering — the **log-floor-independent** amplifier

Also adds `pnpm dev:heap-snapshot` (auto heap dump to gitignored `.diagnostics/` on the next near-OOM) so a recurrence is provable, not guessed.

This caps render *frequency*, which holds at **any** log floor and under parallel waves.

## Process note

The change was adversarially reviewed (multi-lens) — the review caught 3 real bugs the green suite missed (forwarder duplicate-emission re-growing memory, `onCritical` not freeing its batch, a stale pinned-sprint from the new guard). All fixed and folded in before this PR.

## Branch note

`fix/misc` was based off the `release/0.10.0` tip, so this PR also carries two pre-existing 0.10.0 commits — `bf3161a8` (ProgressOverlay test de-flake) and `bd7147b2` (sprint reopen-on-unblock fix). They're already destined for `main`; keeping them here keeps CI stable. When `release/0.10.0` is rebased onto `main` after merge, only the version-bump commit replays (these two are already present by SHA).

## Test plan

- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm deadcode` ✅
- `pnpm test` ✅ — **3120 passed** (incl. new coalescer / forwarder-delta / session-guard / onCritical coverage)