### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-07
+
+### Changed
+
+- **Dependency refresh.** Bumped `react` to 19.2.7 (runtime) plus dev-tooling patch/minor updates
+  (`@types/react`, `@types/node`, `vitest` / `@vitest/coverage-v8`, `typescript-eslint`, `knip`).
+
 ## [0.10.0] - 2026-06-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.10.1
- Promote `## [Unreleased]` CHANGELOG section to `## [0.10.1]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green