### PR TITLE
feat(scm): target self-hosted GitLab hosts via glab --repo host prefix

### DIFF
--- a/src/integration/scm/issue-fetcher.ts
+++ b/src/integration/scm/issue-fetcher.ts
@@ -24,6 +24,8 @@ const MAX_COMMENTS = 20;
 
 interface ParsedUrl {
   readonly host: 'github' | 'gitlab';
+  /** The URL hostname (e.g. `gitlab.com`, `gitlab.example.internal`). Used to target self-hosted instances. */
+  readonly hostname: string;
   readonly owner: string;
   readonly repo: string;
   readonly number: number;
@@ -123,25 +125,35 @@ export const parseIssueUrl = (url: string): ParsedUrl | null => {
       const repo = segments[1];
       const num = Number(segments[3]);
       if (owner && repo && Number.isInteger(num) && num > 0) {
-        return { host: 'github', owner, repo, number: num };
+        return { host: 'github', hostname: parsed.hostname, owner, repo, number: num };
       }
     }
     return null;
   }
 
-  // GitLab: /<group...>/<project>/-/issues/<number>
+  // GitLab: /<group...>/<project>/-/issues/<number> — also accept the `work_items` path.
+  // Since GitLab 16 issues are work items sharing one iid namespace, so a `/-/work_items/N`
+  // URL resolves to the same issue as `/-/issues/N` and `glab issue view N` fetches both.
   const dashIdx = segments.indexOf('-');
-  if (dashIdx >= 2 && segments[dashIdx + 1] === 'issues') {
+  const kind = dashIdx >= 0 ? segments[dashIdx + 1] : undefined;
+  if (dashIdx >= 2 && (kind === 'issues' || kind === 'work_items')) {
     const num = Number(segments[dashIdx + 2]);
     const repo = segments[dashIdx - 1];
     if (repo && Number.isInteger(num) && num > 0) {
       const owner = segments.slice(0, dashIdx - 1).join('/');
-      return { host: 'gitlab', owner, repo, number: num };
+      return { host: 'gitlab', hostname: parsed.hostname, owner, repo, number: num };
     }
   }
 
   return null;
 };
+
+/**
+ * The `--repo` argument for `glab`. Fully-qualified as `HOST/OWNER/REPO` so the CLI targets the
+ * right instance — without the host, `glab` silently defaults to `gitlab.com` and an issue on a
+ * self-hosted host (e.g. `gitlab.example.internal`) 401s / 404s against the wrong server.
+ */
+const glabRepoArg = (parsed: ParsedUrl): string => `${parsed.hostname}/${parsed.owner}/${parsed.repo}`;
 
 const looksLikeNotFound = (stderr: string): boolean => {
   const s = stderr.toLowerCase();
@@ -227,7 +239,7 @@ const fetchGitLabNotes = async (
   const result = await runCli(
     spawn,
     'glab',
-    ['issue', 'note', 'list', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--output', 'json'],
+    ['issue', 'note', 'list', String(parsed.number), '--repo', glabRepoArg(parsed), '--output', 'json'],
     { timeoutMs: CLI_TIMEOUT_MS }
   );
   if (!result.ok) return { comments: [], failure: result.error.message };
@@ -268,7 +280,7 @@ const fetchGitLab = async (
   const result = await runCli(
     spawn,
     'glab',
-    ['issue', 'view', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--output', 'json'],
+    ['issue', 'view', String(parsed.number), '--repo', glabRepoArg(parsed), '--output', 'json'],
     { timeoutMs: CLI_TIMEOUT_MS }
   );
   if (!result.ok) return Result.error(result.error);

--- a/src/integration/scm/issue-pusher.ts
+++ b/src/integration/scm/issue-pusher.ts
@@ -52,15 +52,24 @@ const commentGitLab = async (
   spawn: Spawn,
   url: string,
   body: string,
-  parsed: { owner: string; repo: string; number: number }
+  parsed: { hostname: string; owner: string; repo: string; number: number }
 ): Promise<Result<void, StorageError>> => {
-  // `glab issue comment <number> --repo <owner>/<repo> --body <body>` — glab doesn't accept
+  // `glab issue comment <number> --repo <host>/<owner>/<repo> --body <body>` — glab doesn't accept
   // the body via stdin, so we pass it as a flag value. Markdown / newlines survive because
-  // spawn marshals each argv element as a separate exec arg (no shell parsing).
+  // spawn marshals each argv element as a separate exec arg (no shell parsing). The host MUST be
+  // prefixed — without it glab defaults to gitlab.com and a self-hosted issue 401s / 404s.
   const r = await runCli(
     spawn,
     'glab',
-    ['issue', 'comment', String(parsed.number), '--repo', `${parsed.owner}/${parsed.repo}`, '--body', body],
+    [
+      'issue',
+      'comment',
+      String(parsed.number),
+      '--repo',
+      `${parsed.hostname}/${parsed.owner}/${parsed.repo}`,
+      '--body',
+      body,
+    ],
     { timeoutMs: CLI_TIMEOUT_MS }
   );
   if (!r.ok) return Result.error(r.error);

--- a/tests/integration/scm/issue-fetcher.test.ts
+++ b/tests/integration/scm/issue-fetcher.test.ts
@@ -67,6 +67,7 @@ describe('parseIssueUrl', () => {
   it('parses GitHub issue URLs', () => {
     expect(parseIssueUrl('https://github.com/x/y/issues/42')).toEqual({
       host: 'github',
+      hostname: 'github.com',
       owner: 'x',
       repo: 'y',
       number: 42,
@@ -76,9 +77,20 @@ describe('parseIssueUrl', () => {
   it('parses GitLab issue URLs (group/project/-/issues/N)', () => {
     expect(parseIssueUrl('https://gitlab.com/foo/bar/-/issues/7')).toEqual({
       host: 'gitlab',
+      hostname: 'gitlab.com',
       owner: 'foo',
       repo: 'bar',
       number: 7,
+    });
+  });
+
+  it('parses GitLab work-item URLs (group/project/-/work_items/N) on self-hosted hosts', () => {
+    expect(parseIssueUrl('https://gitlab.example.internal/team/project/-/work_items/55')).toEqual({
+      host: 'gitlab',
+      hostname: 'gitlab.example.internal',
+      owner: 'team',
+      repo: 'project',
+      number: 55,
     });
   });
 
@@ -191,7 +203,7 @@ describe('createIssueFetcher', () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({
           title: 'GLab issue',
           description: 'desc body',
@@ -202,7 +214,7 @@ describe('createIssueFetcher', () => {
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: '[]',
         exitCode: 0,
       },
@@ -217,11 +229,34 @@ describe('createIssueFetcher', () => {
     expect(out.value.comments).toEqual([]);
   });
 
+  it('self-hosted GitLab — threads the URL host into glab --repo (not gitlab.com)', async () => {
+    const spawn = scriptedSpawn([
+      {
+        command: 'glab',
+        // The host MUST be prefixed — otherwise glab defaults to gitlab.com and 401s.
+        args: ['issue', 'view', '55', '--repo', 'gitlab.example.internal/team/project', '--output', 'json'],
+        stdout: JSON.stringify({ title: 'WI', description: 'body', state: 'opened' }),
+        exitCode: 0,
+      },
+      {
+        command: 'glab',
+        args: ['issue', 'note', 'list', '55', '--repo', 'gitlab.example.internal/team/project', '--output', 'json'],
+        stdout: '[]',
+        exitCode: 0,
+      },
+    ]);
+    const fetcher = createIssueFetcher({ spawn });
+    const out = await fetcher('https://gitlab.example.internal/team/project/-/work_items/55');
+    expect(out.ok).toBe(true);
+    if (!out.ok || out.value === null) return;
+    expect(out.value.title).toBe('WI');
+  });
+
   it('GitLab notes — filters system notes, maps username + body', async () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({
           title: 'T',
           description: 'D',
@@ -232,7 +267,7 @@ describe('createIssueFetcher', () => {
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify([
           { body: 'first reply', author: { username: 'alice' }, system: false, created_at: '2026-01-01T00:00:00Z' },
           {
@@ -260,13 +295,13 @@ describe('createIssueFetcher', () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({ title: 'T', description: 'D', state: 'opened' }),
         exitCode: 0,
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify([
           { body: 'closed', author: { username: 'bot' }, system: true, created_at: '2026-01-01T00:00:00Z' },
           { body: 'reopened', author: { username: 'bot' }, system: true, created_at: '2026-01-02T00:00:00Z' },
@@ -296,13 +331,13 @@ describe('createIssueFetcher', () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({ title: 'T', description: 'D', state: 'opened' }),
         exitCode: 0,
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify(raw),
         exitCode: 0,
       },
@@ -321,7 +356,7 @@ describe('createIssueFetcher', () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({
           title: 'T',
           description: 'D',
@@ -332,7 +367,7 @@ describe('createIssueFetcher', () => {
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: '',
         stderr: 'permission denied',
         exitCode: 1,
@@ -357,7 +392,7 @@ describe('createIssueFetcher', () => {
     const spawn = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'view', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'view', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: JSON.stringify({
           title: 'T',
           description: 'D',
@@ -368,7 +403,7 @@ describe('createIssueFetcher', () => {
       },
       {
         command: 'glab',
-        args: ['issue', 'note', 'list', '5', '--repo', 'foo/bar', '--output', 'json'],
+        args: ['issue', 'note', 'list', '5', '--repo', 'gitlab.com/foo/bar', '--output', 'json'],
         stdout: 'not json',
         exitCode: 0,
       },

--- a/tests/integration/scm/issue-pusher.test.ts
+++ b/tests/integration/scm/issue-pusher.test.ts
@@ -79,7 +79,7 @@ describe('createIssuePusher — comment', () => {
     const { spawn, capture } = scriptedSpawn([
       {
         command: 'glab',
-        args: ['issue', 'comment', '7', '--repo', 'foo/bar', '--body', 'new body'],
+        args: ['issue', 'comment', '7', '--repo', 'gitlab.com/foo/bar', '--body', 'new body'],
         stdout: '',
         exitCode: 0,
       },
@@ -89,6 +89,20 @@ describe('createIssuePusher — comment', () => {
     expect(r.ok).toBe(true);
     // glab takes the body as a flag value, not on stdin.
     expect(capture.stdinWrites).toEqual([]);
+  });
+
+  it('self-hosted GitLab: prefixes the URL host onto glab --repo', async () => {
+    const { spawn } = scriptedSpawn([
+      {
+        command: 'glab',
+        args: ['issue', 'comment', '55', '--repo', 'gitlab.example.internal/team/project', '--body', 'done'],
+        stdout: '',
+        exitCode: 0,
+      },
+    ]);
+    const pusher = createIssuePusher({ spawn });
+    const r = await pusher.comment('https://gitlab.example.internal/team/project/-/work_items/55', { body: 'done' });
+    expect(r.ok).toBe(true);
   });
 
   it('rejects unsupported issue URLs with a parse error', async () => {


### PR DESCRIPTION
## Summary

Issues on self-hosted GitLab instances were resolving against `gitlab.com` instead of the actual server. `glab --repo OWNER/REPO` silently defaults to `gitlab.com`, so a self-hosted issue (e.g. on `gitlab.example.internal`) would 401/404 against the wrong host.

This threads the URL hostname through `parseIssueUrl` into the `glab --repo` argument as a fully-qualified `HOST/OWNER/REPO`, so fetches and comments target the correct instance.

## Changes

- **`issue-fetcher.ts`** — `ParsedUrl` now carries the URL `hostname`; new `glabRepoArg()` builds the `HOST/OWNER/REPO` `--repo` value used by `glab issue view` and `glab issue note list`.
- Also accept the `/-/work_items/N` path. Since GitLab 16 issues are work items sharing one iid namespace, so `/-/work_items/N` resolves to the same issue as `/-/issues/N`.
- **`issue-pusher.ts`** — `glab issue comment` now passes the host-prefixed `--repo` value too.

## Testing

- `tests/integration/scm/issue-fetcher.test.ts` + `issue-pusher.test.ts` extended for self-hosted hosts and the `work_items` path.
- Full suite green: 399 files, 3346 tests.