### PR TITLE
fix(io): silence DEP0190 on POSIX PATH probe

### DIFF
--- a/src/integration/io/command-exists.ts
+++ b/src/integration/io/command-exists.ts
@@ -10,8 +10,11 @@ import { spawn } from 'node:child_process';
  *     `.bat` — which is what npm / winget shims install (`claude.cmd`, `gh.cmd`, …). A bare
  *     `spawn(name)` cannot launch a `.cmd` shim, and the POSIX `command -v` builtin does not
  *     exist in `cmd.exe`, so neither is safe here.
- *   - POSIX: spawn `command -v <name>` under a shell. `command` is a POSIX shell builtin
- *     (hence `shell: true`) mandated to report PATH presence without executing the target.
+ *   - POSIX: spawn `sh -c 'command -v "$0"' <name>`. `command` is a POSIX shell builtin
+ *     (hence the explicit `sh`) mandated to report PATH presence without executing the target.
+ *     `<name>` is bound to the shell's `$0` positional rather than interpolated into the script,
+ *     so it is never re-parsed as shell syntax — this closes the command-injection seam AND
+ *     avoids the Node `DEP0190` warning that fires when an args array is paired with `shell: true`.
  *
  * Resolution policy (identical on both platforms):
  *
@@ -26,7 +29,7 @@ export const commandExists = (name: string): Promise<boolean> =>
     const child =
       process.platform === 'win32'
         ? spawn('where', [name], { stdio: 'ignore' })
-        : spawn('command', ['-v', name], { stdio: 'ignore', shell: true });
+        : spawn('sh', ['-c', 'command -v "$0"', name], { stdio: 'ignore' });
     let settled = false;
     const settle = (value: boolean): void => {
       if (settled) return;


### PR DESCRIPTION
## Problem

Starting the TUI printed a Node 24 deprecation warning:

```
(node:NNNNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

Source: the launch-time fail-fast PATH check (`commandExists`). Its POSIX branch combined an args array with `shell: true`:

```ts
spawn('command', ['-v', name], { stdio: 'ignore', shell: true });
```

That args+`shell:true` combination is exactly what DEP0190 flags — args are concatenated into the shell line unescaped, which is also a latent injection seam.

## Fix

Spawn `sh` explicitly and bind `<name>` to the shell's `$0` positional rather than letting the shell re-parse it:

```ts
spawn('sh', ['-c', 'command -v "$0"', name], { stdio: 'ignore' });
```

- Drops `shell: true` → no DEP0190.
- Keeps the POSIX `command` builtin (the presence check semantics are unchanged).
- `<name>` is never interpreted as shell syntax → injection seam closed.
- Windows `where` branch untouched (already clean).

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors
- `tests/unit/integration/io/command-exists.test.ts` — 3/3 pass (real end-to-end probe, no spawn-shape mocking)
- Standalone repro confirms the warning no longer prints and presence resolution is unchanged.