### PR TITLE
Selection coherence across flows, CLI pinned-sprint defaults, TUI affordances, editable escalation map

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -67,7 +67,10 @@ or add a custom rung via `settings.harness.escalationMap`:
 
 `claude-fable-5` and its 1M-context variant `claude-fable-5[1m]` are in the Claude catalog as
 **opt-in only** — no preset, default, or built-in escalation rung references them. Select per row via
-the TUI picker or `settings set`, or add an escalationMap rung as shown above.
+the TUI picker or `settings set`, or add an escalationMap rung as shown above. Escalation-map rungs
+can also be added and removed from the TUI's **Harness** settings section: the `map-add` row walks a
+two-step from/to model picker; each existing override appears as a `map-entry` row that can be
+retargeted or removed without leaving the TUI.
 
 **`settings.harness` keys** (full list — see `PERFORMANCE.md § Iteration budget` for the gen-eval tuning knobs):
 

--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -297,8 +297,9 @@ only and are suspended while a prompt or overlay is mounted.
 | Key | Action                                             |
 | --- | -------------------------------------------------- |
 | `t` | Toggle scope — all projects ↔ current project only |
+| `f` | Toggle hide-done — hide / show `done` sprints      |
 
-The picker is opened globally via `S`; `t` is its one view-local key and is registered in `keyboard-map.ts`
+The picker is opened globally via `S`; `t` and `f` are its view-local keys and are registered in `keyboard-map.ts`
 alongside the other `pickerKeys`. Any new picker keys follow the same pattern.
 
 ### 6.3 View-local keys — published via `useViewHints`
@@ -415,7 +416,7 @@ pushes a dedicated `*-detail-view.tsx`).
 
 - `FieldList` for metadata.
 - `StatusChip` for lifecycle state.
-- No action verbs — detail views are read-only.
+- Detail views are primarily read-only browse surfaces. An explicit `m` chord is allowed to make the viewed entity current when opening the detail must not implicitly switch the selection (e.g. `ProjectsView` and `ProjectDetailView` — browsing must not clear the sprint cursor as a side effect).
 
 ### 7.4 Phase views (refine / plan / implement / review)
 
@@ -444,9 +445,11 @@ keypress-counting exercise. Three candidate fixes:
   budget), and the `←/→` idiom matches the canonical "prev/next page" vocabulary in
   [§6.3](#63-view-local-keys--published-via-useviewhints).
 
-Per-section row counts (all ≤ ~8): `Presets 4`, `Global 1`, `Refine 3`, `Plan 3`, `Implement 6`
-(generator triple + evaluator triple), `Readiness 3`, `Ideate 3`, `Create-PR 3`, `Harness 4`, `Other 2`,
-`Storage 0` (read-only). Implement is the largest and is the right stress-test for the cap.
+Per-section row counts (all ≤ ~8 static rows): `Presets 4`, `Global 1`, `Refine 3`, `Plan 3`,
+`Implement 6` (generator triple + evaluator triple), `Readiness 3`, `Ideate 3`, `Create-PR 3`,
+`Harness 7` (six scalar/select rows + one `map-add` action row; grows by one `map-entry` row per
+user-defined escalation-map override), `Other 2`, `Storage 0` (read-only). Implement is the
+largest among the fixed-size sections.
 
 **Responsive fallback.** The section strip uses `flexWrap="wrap"`, so on terminals narrower
 than the strip's natural width (the default 11 labels) the strip wraps onto a

--- a/.claude/docs/MANUAL-TEST-PLAYBOOK.md
+++ b/.claude/docs/MANUAL-TEST-PLAYBOOK.md
@@ -249,11 +249,16 @@ leaves whose `name` contains an absolute repo path).
 3. Press `t` inside the picker
 4. **Expected:** scope toggles — if the picker was showing current-project sprints, it now shows all
    sprints across every project; pressing `t` again returns to project scope.
-5. Navigate the list with `↑`/`↓`, select a sprint from a different project with `Enter`
-6. **Expected:** both the active project and active sprint update atomically — the breadcrumb reflects the
-   new project/sprint combination, and no partial state is visible mid-transition.
-7. Press `S` again from Home with NO project loaded
-8. **Expected:** picker opens in all-projects scope; `t` still toggles without crashing.
+5. Press `f` inside the picker
+6. **Expected:** done sprints are hidden (the counter and visible rows reflect only non-done sprints);
+   pressing `f` again restores them. When `f` hides everything, a "All sprints here are done (hidden)"
+   message with a "Press f to show them" hint renders in place of the list.
+7. Navigate the list with `↑`/`↓`, select a sprint from a different project with `Enter`
+8. **Expected:** both the active project and active sprint update atomically — the breadcrumb reflects the
+   new project/sprint combination (including a `[S]` affordance next to the sprint name), and no partial
+   state is visible mid-transition.
+9. Press `S` again from Home with NO project loaded
+10. **Expected:** picker opens in all-projects scope; `t` and `f` still toggle without crashing.
 
 **Negative tests:**
 
@@ -263,7 +268,32 @@ leaves whose `name` contains an absolute repo path).
 
 ---
 
-## Scenario 13 — cross-process advisory lock
+## Scenario 13 — Home digit shortcuts and Projects browse-only behaviour
+
+**Setup:** at least two sprints exist under the current project (so the "switch sprint" section of the
+Home action menu shows multiple recent-sprint rows).
+
+1. From Home, note the recent-sprint rows in the "switch sprint" section — up to five are listed
+2. Press `1`, then `2` (digit keys)
+3. **Expected:** pressing `1` selects the first recent sprint; a `✓ now on <name>` toast flashes above
+   the menu. Pressing `2` switches to the second. The breadcrumb `[S]` label updates to reflect each switch.
+4. Navigate to Projects (`p` from Home)
+5. Move the cursor over a project that is NOT the current one
+6. Press `Enter` to open its detail view
+7. **Expected:** the breadcrumb right-side still shows the original project and sprint — opening a
+   project detail is a browse and must NOT switch the current project or clear the sprint cursor.
+8. Press `m` while in the project detail view
+9. **Expected:** the project switches to the viewed one; feedback line `✓ now on <project-name>` appears;
+   the breadcrumb right-side updates.
+10. Press `Esc` back to the Projects list; press `m` on a different focused row without drilling in
+11. **Expected:** the project switches directly from the list view; same feedback and breadcrumb update.
+
+**Negative test:** press `Enter` on any project in the list (without `m`) and navigate away — the
+original project selection must be unchanged on the breadcrumb.
+
+---
+
+## Scenario 14 — cross-process advisory lock
 
 **Setup:** a sprint with at least one task remaining (`todo`). Two separate terminal tabs.
 
@@ -306,7 +336,7 @@ can't reach. Things still NOT covered:
 - Concurrency under load — the implement flow runs strictly sequential (or parallel when
   `maxParallelTasks > 1`), but cross-process lock contention (the `<stateRoot>/locks/repo-<hash>.lock/`
   directory) and the heartbeat crash-reclaim path are best tested with two real ralphctl processes
-  (see Scenario 13).
+  (see Scenario 14).
 
 If you find a class of bug that recurs, add a scenario for it here rather than fixing it once and waiting
 for the next regression.

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -273,8 +273,9 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
       fit the rail column budget.
 - [x] **TUI hotkeys** — `b` banner compact ↔ full toggle; `g` progress overlay (reads `progress.md` on
       demand); `y` yank active-task summary to clipboard; `P` cross-project project picker; `S`
-      cross-project sprint picker (with `t` toggle-scope inside the picker); `j`/`k` task-card navigation;
-      `e` expand done-criteria for active card; `c` cancel-scope picker (attempt vs whole flow).
+      cross-project sprint picker (with `t` toggle-scope and `f` hide-done inside the picker); `j`/`k`
+      task-card navigation; `e` expand done-criteria for active card; `c` cancel-scope picker (attempt vs
+      whole flow).
 - [x] **Baseline-health card + chip** — `BaselineHealthCard` and `BaselineHealthChip` surface
       `SprintExecution.setupRanAt` history in the context column.
 - [x] **Token-budget card** — `TokenBudgetCard` subscribes to `TokenUsageEvent`; renders

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -122,5 +122,5 @@ Budget exhaustion still transitions to `blocked` and the commit guard independen
 reason, so red work never lands regardless of budget.
 
 **Branch management.** `resolveBranchLeaf` prompts on first run; persists on `SprintExecution.branch`;
-per-task preflight verifies the right branch. `ralphctl create-pr --sprint <id>` opens PR / MR via `gh` /
-`glab` and persists `SprintExecution.pullRequestUrl`.
+per-task preflight verifies the right branch. `ralphctl create-pr [--sprint <id>]` opens PR / MR via `gh` /
+`glab` and persists `SprintExecution.pullRequestUrl`. `--sprint` defaults to the pinned current sprint (same as `sprint show` / `sprint progress`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,28 @@ command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins
   "Keep default (xhigh — saved row)" / "(high — global)"), so keeping a setting is an informed choice
   rather than an invisible carryover.
 
-- **TUI settings harness section gains two new toggles and a read-only `escalationMap` display.**
+- **TUI settings harness section gains two new toggles and a fully editable `escalationMap`.**
   `escalateOnPlateau` and `skipPreVerifyOnFreshSetup` are now editable from the settings view (with
-  one-line caveats in the hints); `escalationMap` renders read-only with the CLI edit hint — every harness
-  key the CLI supports is now visible in the TUI.
+  one-line caveats in the hints). The escalation map is a first-class editable group: an add-rung row
+  walks a two-step picker (FROM model, then TO model — targets scoped to the catalogs that know the
+  from-model, self-loops excluded), each user override is a row of its own with in-place retarget or
+  `(remove this override)`, and the card renders the EFFECTIVE ladder (overrides merged over the
+  built-in map) as dim chains with customised ones marked. Every route persists through the same
+  `harness.escalationMap.<fromModel>` grammar the CLI's `settings set` speaks.
+
+- **CLI commands default to the pinned current sprint.** `ralphctl sprint set-current` (and every TUI
+  sprint pick) already persisted the selection; now the CLI reads it back: `sprint show`/`sprint progress`
+  and `project show` take an optional `[id]`, and `task list/show/unblock`, `ticket list/show/add/remove`,
+  `create-pr`, `export-context`, and `export-requirements` make `--sprint` optional — all falling back to
+  the pin with a one-line stderr notice naming the substituted sprint. Missing both exits 1 with
+  `set-current` guidance; `sprint remove` / `project remove` clear a matching dangling pin; ticket
+  add/remove success lines name the resolved sprint.
+
+- **TUI affordances: breadcrumb `[S]`, Home digit quick-switch, picker hide-done, create-PR retry.**
+  The breadcrumb sprint label now carries the `[S]` picker affordance (mirroring `[P]`); Home's
+  recent-sprint rows take digit hotkeys 1–5; the sprint picker's `f` hides done sprints (default off —
+  closed sprints stay reachable); the create-PR view's error card offers `r` to retry via the confirm
+  card instead of dead-ending.
 
 - **Model picker filtered to account-available models.** A per-provider `ModelAvailabilityProbe` (new port
   in `providers/_engine`) narrows the picker and settings-view catalogs to the models the operator's
@@ -84,6 +102,26 @@ command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins
   `gpt-5.2-codex`, `gpt-4.1`, `claude-sonnet-4`, and `gemini-3-pro-preview`. The static catalog is now the
   official set rather than retaining superseded entries; the per-session availability probe is the mechanism
   for hiding models a given account can't use.
+
+- **Opening a project to browse no longer switches the selection.** The Projects list and project detail
+  are browse-only: opening a different project's detail no longer silently switches the current project
+  (which cleared the sprint cursor as a side effect). A new `m — make current` chord on both views is the
+  explicit switch, mirroring the sprint-detail opt-in.
+
+### Fixed
+
+- **The project/sprint combo now stays coherent as you move between flows.** The mutable global selection
+  (what launches use) and the per-run pinned context (what the execute view shows) had no path back to
+  convergence once they diverged — you could watch sprint B while `n → Flows` silently launched against
+  sprint A. Now: focusing an execute view converges the selection onto the run's pinned project/sprint;
+  `create-sprint` launched from Flows reseats onto the new sprint and never pins the previous sprint onto
+  its run; `close-sprint` refreshes the status chip to `done` without yanking a user who switched away
+  mid-run; sprint-detail's `n` makes the viewed sprint current before opening Flows (as its hint always
+  promised); the breadcrumb status chip refreshes from every fresh snapshot load and on boot, and a fresh
+  pick can no longer be clobbered by the in-flight boot probe.
+
+- **Home's "✓ now on …" switch toast expires again.** The expiry timer forced a repaint through an
+  identity state-updater, which React bails out of — on an idle Home the toast stayed painted forever.
 
 ## [0.11.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins
   promised); the breadcrumb status chip refreshes from every fresh snapshot load and on boot, and a fresh
   pick can no longer be clobbered by the in-flight boot probe.
 
+- **Project detail's `r — sprints` key works now.** The hint (and header doc) advertised it since the
+  view shipped, but no handler existed — the key was a silent no-op. It opens the Sprints list scoped
+  to the current selection; `m` then `r` reaches the viewed project's sprints.
+
 - **Home's "✓ now on …" switch toast expires again.** The expiry timer forced a repaint through an
   identity state-updater, which React bails out of — on an idle Home the toast stayed painted forever.
 

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,6 @@
   "entry": ["tests/**/*.test.{ts,tsx}", "scripts/**/*.ts"],
   "project": ["src/**/*.{ts,tsx}"],
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": ["ralphctl"],
+  "ignoreBinaries": ["ralphctl", "where"],
   "tags": ["-public"]
 }

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -212,8 +212,10 @@ export interface AppDeps {
    */
   readonly skillsAdapter: SkillsAdapter;
   /**
-   * Source of canonical {@link Skill}s for a flow. Bundled-only in this PR; the same port
-   * will host a user-skill source in a follow-up.
+   * Source of canonical {@link Skill}s for a flow. `wire()` binds the static BUNDLED source
+   * only; the launcher composes it per launch with the project-scoped source (setup / verify
+   * skills authored via detect-skills) and the operator drop-in source — see
+   * `composeSkillSources` in `ui/shared/launcher.ts`.
    */
   readonly skillSource: SkillSource;
   /**

--- a/src/application/ui/cli/commands/create-pr.ts
+++ b/src/application/ui/cli/commands/create-pr.ts
@@ -1,14 +1,14 @@
 import { join } from 'node:path';
 import type { Command } from 'commander';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 
 interface Opts {
-  readonly sprint: string;
+  readonly sprint?: string;
   readonly cwd?: string;
   readonly base: string;
   readonly draft: boolean;
@@ -20,12 +20,13 @@ interface Opts {
 /**
  * Register the `create-pr` CLI command.
  *
- *   ralphctl create-pr --sprint <id> [--cwd <path>] [--base main]
+ *   ralphctl create-pr [--sprint <id>] [--cwd <path>] [--base main]
  *                      [--draft] [--title T] [--body B] [--no-ai]
  *
  * Opens a PR via `gh` / `glab` for the sprint's branch and persists the
- * URL on the sprint execution. `--cwd` defaults to the current working
- * directory; the PR creator runs the platform CLI from there.
+ * URL on the sprint execution. `--sprint` defaults to the pinned current
+ * sprint; `--cwd` defaults to the current working directory; the PR
+ * creator runs the platform CLI from there.
  *
  * `--no-ai` skips the optional AI authoring step (default-on) and falls back to the
  * template-derived title + body. The AI step is best-effort — any failure also falls back
@@ -35,7 +36,7 @@ export const registerCreatePrCommand = (program: Command): void => {
   program
     .command('create-pr')
     .description("open a PR for the sprint's branch and persist the URL")
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .option('--cwd <path>', 'repository root (defaults to process.cwd())')
     .option('-b, --base <branch>', 'target branch', 'main')
     .option('--draft', 'open as draft', false)
@@ -51,7 +52,16 @@ export const registerCreatePrCommand = (program: Command): void => {
       }
 
       const { deps, storage } = await bootstrapCli();
-      const sprintDir = AbsolutePath.parse(join(String(storage.dataRoot), 'sprints', opts.sprint));
+      const resolved = await resolveSprintId(opts.sprint, storage.stateRoot);
+      if (!resolved.ok) {
+        process.stderr.write(`error: ${resolved.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      // Opening a PR is a write to the upstream — always disambiguate a pin-derived target.
+      if (resolved.value.fromPin) process.stderr.write(pinFallbackNotice(resolved.value.sprintId));
+      const sprintId = resolved.value.sprintId;
+      const sprintDir = AbsolutePath.parse(join(String(storage.dataRoot), 'sprints', String(sprintId)));
       if (!sprintDir.ok) {
         process.stderr.write(`error: sprint dir: ${sprintDir.error.message}\n`);
         process.exit(1);
@@ -93,7 +103,7 @@ export const registerCreatePrCommand = (program: Command): void => {
       );
       const result = await flow.execute({
         input: {
-          sprintId: opts.sprint as SprintId,
+          sprintId,
           cwd: cwd.value,
           sprintDir: sprintDir.value,
           base: opts.base,

--- a/src/application/ui/cli/commands/export-context.ts
+++ b/src/application/ui/cli/commands/export-context.ts
@@ -1,12 +1,12 @@
 import type { Command } from 'commander';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
-import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { createExportContextFlow } from '@src/application/flows/export-context/flow.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 
 interface Opts {
-  readonly sprint: string;
+  readonly sprint?: string;
   readonly project: string;
   readonly output: string;
 }
@@ -14,17 +14,18 @@ interface Opts {
 /**
  * Register the `export-context` CLI command.
  *
- *   ralphctl export-context --sprint <id> --project <id> --output <path>
+ *   ralphctl export-context [--sprint <id>] --project <id> --output <path>
  *
  * Renders the harness-context markdown (sprint + project + tasks) to the
- * supplied path. Exits 0 with a one-line confirmation, or 1 with a stderr
- * message on validation / NotFound / IO error.
+ * supplied path. `--sprint` defaults to the pinned current sprint. Exits 0
+ * with a one-line confirmation, or 1 with a stderr message on validation /
+ * NotFound / IO error.
  */
 export const registerExportContextCommand = (program: Command): void => {
   program
     .command('export-context')
     .description('render the harness-context markdown for a sprint')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .requiredOption('-p, --project <id>', 'project id')
     .requiredOption('-o, --output <path>', 'output markdown path')
     .action(async (opts: Opts) => {
@@ -35,7 +36,14 @@ export const registerExportContextCommand = (program: Command): void => {
         return;
       }
 
-      const { deps } = await bootstrapCli();
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
+      if (!sprintId.ok) {
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
       const flow = createExportContextFlow({
         sprintRepo: deps.sprintRepo,
         projectRepo: deps.projectRepo,
@@ -44,7 +52,7 @@ export const registerExportContextCommand = (program: Command): void => {
       });
       const result = await flow.execute({
         input: {
-          sprintId: opts.sprint as SprintId,
+          sprintId: sprintId.value.sprintId,
           projectId: opts.project as ProjectId,
           outputPath: outputPath.value,
         },

--- a/src/application/ui/cli/commands/export-requirements.ts
+++ b/src/application/ui/cli/commands/export-requirements.ts
@@ -1,28 +1,29 @@
 import type { Command } from 'commander';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { createExportRequirementsFlow } from '@src/application/flows/export-requirements/flow.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 
 interface Opts {
-  readonly sprint: string;
+  readonly sprint?: string;
   readonly output: string;
 }
 
 /**
  * Register the `export-requirements` CLI command.
  *
- *   ralphctl export-requirements --sprint <id> --output <path>
+ *   ralphctl export-requirements [--sprint <id>] --output <path>
  *
  * Writes the sprint's approved-ticket requirements to the supplied
- * markdown path. Exits 0 with a one-line confirmation, or 1 with a
- * stderr message on validation / NotFound / IO error.
+ * markdown path. `--sprint` defaults to the pinned current sprint.
+ * Exits 0 with a one-line confirmation, or 1 with a stderr message on
+ * validation / NotFound / IO error.
  */
 export const registerExportRequirementsCommand = (program: Command): void => {
   program
     .command('export-requirements')
     .description("write the sprint's approved-ticket requirements to a markdown file")
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .requiredOption('-o, --output <path>', 'output markdown path')
     .action(async (opts: Opts) => {
       const outputPath = AbsolutePath.parse(opts.output);
@@ -32,13 +33,20 @@ export const registerExportRequirementsCommand = (program: Command): void => {
         return;
       }
 
-      const { deps } = await bootstrapCli();
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
+      if (!sprintId.ok) {
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
+        process.exit(1);
+        return;
+      }
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
       const flow = createExportRequirementsFlow({
         sprintRepo: deps.sprintRepo,
         writeFile: deps.writeFile,
       });
       const result = await flow.execute({
-        input: { sprintId: opts.sprint as SprintId, outputPath: outputPath.value },
+        input: { sprintId: sprintId.value.sprintId, outputPath: outputPath.value },
       });
 
       if (!result.ok) {

--- a/src/application/ui/cli/commands/project.ts
+++ b/src/application/ui/cli/commands/project.ts
@@ -2,17 +2,19 @@ import type { Command } from 'commander';
 import type { Project } from '@src/domain/entity/project.ts';
 import { ProjectId } from '@src/domain/value/id/project-id.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
 
 /**
  * Register the `project` command group.
  *
  *   ralphctl project list
- *   ralphctl project show <id>
+ *   ralphctl project show [id]
  *   ralphctl project remove <id>
  *
- * Read-side ops dispatch directly to `deps.projectRepo` — there's no surrounding logic to
- * encapsulate, so a use-case wrapper would just be ceremony. Project creation lives in the
- * TUI (interactive multi-input flow).
+ * `show` defaults its `[id]` to the pinned current project (written by the TUI and
+ * `sprint set-current`). Read-side ops dispatch directly to `deps.projectRepo` — there's no
+ * surrounding logic to encapsulate, so a use-case wrapper would just be ceremony. Project
+ * creation lives in the TUI (interactive multi-input flow).
  */
 export const registerProjectCommand = (program: Command): void => {
   const project = program.command('project').description('inspect and manage projects');
@@ -38,16 +40,29 @@ export const registerProjectCommand = (program: Command): void => {
     });
 
   project
-    .command('show <id>')
-    .description('print a single project as JSON')
-    .action(async (raw: string) => {
-      const id = ProjectId.parse(raw);
+    .command('show [id]')
+    .description('print a single project as JSON (defaults to the current project)')
+    .action(async (raw?: string) => {
+      const { deps, storage } = await bootstrapCli();
+      // Fall back to the pinned selection when no id is given. The pinned id still funnels
+      // through ProjectId.parse — the store's read is silent on corruption, so a stale or
+      // hand-edited file must fail with the same message an invalid explicit argument gets.
+      let effectiveRaw = raw;
+      if (effectiveRaw === undefined) {
+        const pinned = await createLastSelectionStore(storage.stateRoot).read();
+        if (pinned?.projectId === undefined) {
+          process.stderr.write('error: no current project — pick one in the TUI or pass an id\n');
+          process.exit(1);
+          return;
+        }
+        effectiveRaw = String(pinned.projectId);
+      }
+      const id = ProjectId.parse(effectiveRaw);
       if (!id.ok) {
         process.stderr.write(`error: invalid project id: ${id.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
       const result = await deps.projectRepo.findById(id.value);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
@@ -67,13 +82,19 @@ export const registerProjectCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
+      const { deps, storage } = await bootstrapCli();
       const result = await deps.projectRepo.remove(id.value);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
         process.exit(1);
         return;
       }
+      // Clear a dangling pin: a removed project would otherwise keep resolving as the default
+      // for `project show` and re-seed the TUI on next launch. The sprint pin lives under the
+      // project, so the whole file goes (write(undefined) deletes it).
+      const store = createLastSelectionStore(storage.stateRoot);
+      const cur = await store.read();
+      if (cur?.projectId === id.value) await store.write(undefined);
       process.stdout.write(`removed project ${String(id.value)}\n`);
     });
 };

--- a/src/application/ui/cli/commands/sprint.ts
+++ b/src/application/ui/cli/commands/sprint.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 import { activateSprintUseCase } from '@src/business/sprint/activate-sprint.ts';
 import { transitionSprintToDoneUseCase } from '@src/business/sprint/transition-sprint-to-done.ts';
 import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
@@ -10,16 +11,18 @@ import { createLastSelectionStore } from '@src/integration/persistence/selection
  * Register the `sprint` command group.
  *
  *   ralphctl sprint list
- *   ralphctl sprint show <id>
+ *   ralphctl sprint show [id]
  *   ralphctl sprint remove <id>
  *   ralphctl sprint activate <id>
  *   ralphctl sprint close <id>
  *   ralphctl sprint set-current <id>
  *   ralphctl sprint progress [id]
  *
- * Read-side ops dispatch directly to `deps.sprintRepo`. Sprint creation is an interactive
- * chain flow (`flows/create-sprint`) that lives in the TUI; surfacing it via CLI would lose
- * the interactive prompts that drive its inputs.
+ * `show` and `progress` default their `[id]` to the pinned current sprint (written by
+ * `sprint set-current` and the TUI) so inspection doesn't repeat the UUID the user already
+ * pinned. Read-side ops dispatch directly to `deps.sprintRepo`. Sprint creation is an
+ * interactive chain flow (`flows/create-sprint`) that lives in the TUI; surfacing it via CLI
+ * would lose the interactive prompts that drive its inputs.
  */
 export const registerSprintCommand = (program: Command): void => {
   const sprintCmd = program.command('sprint').description('inspect and manage sprints');
@@ -45,17 +48,19 @@ export const registerSprintCommand = (program: Command): void => {
     });
 
   sprintCmd
-    .command('show <id>')
-    .description('print a single sprint as JSON')
-    .action(async (raw: string) => {
-      const id = SprintId.parse(raw);
+    .command('show [id]')
+    .description('print a single sprint as JSON (defaults to the current sprint)')
+    .action(async (raw?: string) => {
+      const { deps, storage } = await bootstrapCli();
+      const id = await resolveSprintId(raw, storage.stateRoot, {
+        missingMessage: 'no current sprint pinned — run `ralphctl sprint set-current <id>` or pass an id',
+      });
       if (!id.ok) {
-        process.stderr.write(`error: invalid sprint id: ${id.error.message}\n`);
+        process.stderr.write(`error: ${id.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const result = await deps.sprintRepo.findById(id.value);
+      const result = await deps.sprintRepo.findById(id.value.sprintId);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
         process.exit(1);
@@ -74,12 +79,23 @@ export const registerSprintCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
+      const { deps, storage } = await bootstrapCli();
       const result = await deps.sprintRepo.remove(id.value);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
         process.exit(1);
         return;
+      }
+      // Clear a dangling pin: leaving the removed sprint in last-selection.json would make
+      // every defaulting command (and the next TUI boot) resolve to a ghost. The project pin
+      // survives — only the sprint slot is dropped (rest-destructure keeps
+      // exactOptionalPropertyTypes happy by omitting the key instead of assigning undefined).
+      const store = createLastSelectionStore(storage.stateRoot);
+      const cur = await store.read();
+      if (cur?.sprintId === id.value) {
+        const { sprintId: _drop, ...rest } = cur;
+        void _drop;
+        await store.write(rest);
       }
       process.stdout.write(`removed sprint ${String(id.value)}\n`);
     });
@@ -154,7 +170,9 @@ export const registerSprintCommand = (program: Command): void => {
 
   sprintCmd
     .command('set-current <id>')
-    .description("pin a sprint as the user's current selection (read by the TUI on launch)")
+    .description(
+      "pin a sprint as the user's current selection (read by the TUI on launch and used as the default sprint for CLI commands)"
+    )
     .action(async (raw: string) => {
       const id = SprintId.parse(raw);
       if (!id.ok) {
@@ -188,29 +206,32 @@ export const registerSprintCommand = (program: Command): void => {
     });
 
   sprintCmd
-    .command('progress <id>')
-    .description('print task counts, blockers, and the sprint branch for one sprint')
-    .action(async (raw: string) => {
-      const id = SprintId.parse(raw);
-      if (!id.ok) {
-        process.stderr.write(`error: invalid sprint id: ${id.error.message}\n`);
+    .command('progress [id]')
+    .description('print task counts, blockers, and the sprint branch (defaults to the current sprint)')
+    .action(async (raw?: string) => {
+      const { deps, storage } = await bootstrapCli();
+      const resolved = await resolveSprintId(raw, storage.stateRoot, {
+        missingMessage: 'no current sprint pinned — run `ralphctl sprint set-current <id>` or pass an id',
+      });
+      if (!resolved.ok) {
+        process.stderr.write(`error: ${resolved.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const sprint = await deps.sprintRepo.findById(id.value);
+      const sprintId = resolved.value.sprintId;
+      const sprint = await deps.sprintRepo.findById(sprintId);
       if (!sprint.ok) {
         process.stderr.write(`error: ${sprint.error.message}\n`);
         process.exit(1);
         return;
       }
-      const tasks = await deps.taskRepo.findBySprintId(id.value);
+      const tasks = await deps.taskRepo.findBySprintId(sprintId);
       if (!tasks.ok) {
         process.stderr.write(`error: ${tasks.error.message}\n`);
         process.exit(1);
         return;
       }
-      const execution = await deps.sprintExecutionRepo.findById(id.value);
+      const execution = await deps.sprintExecutionRepo.findById(sprintId);
       const branchLine = execution.ok
         ? execution.value.branch !== null
           ? execution.value.branch

--- a/src/application/ui/cli/commands/task.ts
+++ b/src/application/ui/cli/commands/task.ts
@@ -1,12 +1,12 @@
 import type { Command } from 'commander';
 import type { Task } from '@src/domain/entity/task.ts';
 import { TaskId } from '@src/domain/value/id/task-id.ts';
-import { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 
 interface SprintOpt {
-  readonly sprint: string;
+  readonly sprint?: string;
 }
 
 /**
@@ -15,9 +15,13 @@ interface SprintOpt {
  * tickets); manual `task add` / `task edit` are deferred until there's a concrete UX for
  * tweaking AI-generated plans.
  *
- *   ralphctl task list --sprint <id>
- *   ralphctl task show --sprint <id> <task-id>
- *   ralphctl task unblock --sprint <id> <task-id>
+ *   ralphctl task list [--sprint <id>]
+ *   ralphctl task show [--sprint <id>] <task-id>
+ *   ralphctl task unblock [--sprint <id>] <task-id>
+ *
+ * `--sprint` defaults to the pinned current sprint (`ralphctl sprint set-current <id>` or any
+ * TUI sprint pick); the fallback path prints a one-line stderr notice naming the substituted
+ * sprint so a stale pin never silently targets the wrong one.
  */
 export const registerTaskCommand = (program: Command): void => {
   const task = program.command('task').description('inspect tasks for a sprint (planning generates them)');
@@ -25,16 +29,17 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('list')
     .description('list every task on the sprint, in order')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const result = await deps.taskRepo.findBySprintId(sprintId.value);
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
+      const result = await deps.taskRepo.findBySprintId(sprintId.value.sprintId);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
         process.exit(1);
@@ -52,11 +57,12 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('show <taskId>')
     .description('print a single task as JSON')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (rawTaskId: string, opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
@@ -66,8 +72,8 @@ export const registerTaskCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const result = await deps.taskRepo.findById(sprintId.value, taskId.value);
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
+      const result = await deps.taskRepo.findById(sprintId.value.sprintId, taskId.value);
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.message}\n`);
         process.exit(1);
@@ -79,11 +85,12 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('unblock <taskId>')
     .description('flip a blocked task back to todo so the implement loop picks it up again')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (rawTaskId: string, opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
@@ -93,8 +100,8 @@ export const registerTaskCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const loaded = await deps.taskRepo.findById(sprintId.value, taskId.value);
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
+      const loaded = await deps.taskRepo.findById(sprintId.value.sprintId, taskId.value);
       if (!loaded.ok) {
         process.stderr.write(`error: ${loaded.error.message}\n`);
         process.exit(1);
@@ -102,7 +109,7 @@ export const registerTaskCommand = (program: Command): void => {
       }
       const result = await unblockTaskUseCase({
         task: loaded.value,
-        sprintId: sprintId.value,
+        sprintId: sprintId.value.sprintId,
         taskRepo: deps.taskRepo,
         sprintRepo: deps.sprintRepo,
         clock: deps.clock,

--- a/src/application/ui/cli/commands/ticket.ts
+++ b/src/application/ui/cli/commands/ticket.ts
@@ -1,13 +1,13 @@
 import type { Command } from 'commander';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
 import { TicketId } from '@src/domain/value/id/ticket-id.ts';
-import { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { createTicketAddFlow } from '@src/application/flows/add-ticket/flow.ts';
 import { createTicketRemoveFlow } from '@src/application/flows/remove-ticket/flow.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
 
 interface SprintOpt {
-  readonly sprint: string;
+  readonly sprint?: string;
 }
 
 interface AddOpts extends SprintOpt {
@@ -21,10 +21,16 @@ interface AddOpts extends SprintOpt {
  * repo), so list/show route through `sprintRepo.findById` directly; add/remove dispatch to
  * use-cases because they carry domain invariants (only-when-draft, conflict on duplicate id).
  *
- *   ralphctl ticket list   --sprint <id>
- *   ralphctl ticket show   --sprint <id> <ticket-id>
- *   ralphctl ticket add    --sprint <id> --title <title> [--description <text>] [--link <url>]
- *   ralphctl ticket remove --sprint <id> <ticket-id>
+ *   ralphctl ticket list   [--sprint <id>]
+ *   ralphctl ticket show   [--sprint <id>] <ticket-id>
+ *   ralphctl ticket add    [--sprint <id>] --title <title> [--description <text>] [--link <url>]
+ *   ralphctl ticket remove [--sprint <id>] <ticket-id>
+ *
+ * `--sprint` defaults to the pinned current sprint (`ralphctl sprint set-current <id>` or any
+ * TUI sprint pick); the fallback path prints a one-line stderr notice naming the substituted
+ * sprint, and the add/remove success lines always name the resolved sprint so the mutation
+ * target is never ambiguous. A stale pin fails naturally downstream (`findById` not-found /
+ * the only-when-draft invariant).
  */
 export const registerTicketCommand = (program: Command): void => {
   const ticketCmd = program.command('ticket').description('inspect and manage tickets within a sprint');
@@ -32,16 +38,17 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('list')
     .description('list every ticket on the sprint')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const sprint = await deps.sprintRepo.findById(sprintId.value);
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
+      const sprint = await deps.sprintRepo.findById(sprintId.value.sprintId);
       if (!sprint.ok) {
         process.stderr.write(`error: ${sprint.error.message}\n`);
         process.exit(1);
@@ -59,11 +66,12 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('show <ticketId>')
     .description('print a single ticket as JSON')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (rawTicketId: string, opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
@@ -73,8 +81,8 @@ export const registerTicketCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
-      const sprint = await deps.sprintRepo.findById(sprintId.value);
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
+      const sprint = await deps.sprintRepo.findById(sprintId.value.sprintId);
       if (!sprint.ok) {
         process.stderr.write(`error: ${sprint.error.message}\n`);
         process.exit(1);
@@ -82,7 +90,7 @@ export const registerTicketCommand = (program: Command): void => {
       }
       const found = sprint.value.tickets.find((t) => t.id === ticketId.value);
       if (!found) {
-        process.stderr.write(`error: ticket ${rawTicketId} not found on sprint ${opts.sprint}\n`);
+        process.stderr.write(`error: ticket ${rawTicketId} not found on sprint ${String(sprintId.value.sprintId)}\n`);
         process.exit(1);
         return;
       }
@@ -92,22 +100,23 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('add')
     .description('append a pending ticket to a draft sprint')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .requiredOption('-t, --title <title>', 'ticket title')
     .option('-d, --description <text>', 'optional description')
     .option('-l, --link <url>', 'optional issue link (http/https)')
     .action(async (opts: AddOpts) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
       const flow = createTicketAddFlow({ sprintRepo: deps.sprintRepo });
       const result = await flow.execute({
         input: {
-          sprintId: sprintId.value,
+          sprintId: sprintId.value.sprintId,
           title: opts.title,
           ...(opts.description !== undefined ? { description: opts.description } : {}),
           ...(opts.link !== undefined ? { link: opts.link } : {}),
@@ -119,17 +128,20 @@ export const registerTicketCommand = (program: Command): void => {
         return;
       }
       const ticket = result.value.ctx.output!;
-      process.stdout.write(`added ticket ${String(ticket.id)} — ${ticket.title}\n`);
+      process.stdout.write(
+        `added ticket ${String(ticket.id)} to sprint ${String(sprintId.value.sprintId)} — ${ticket.title}\n`
+      );
     });
 
   ticketCmd
     .command('remove <ticketId>')
     .description('drop a ticket from a draft sprint')
-    .requiredOption('-s, --sprint <id>', 'sprint id')
+    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
     .action(async (rawTicketId: string, opts: SprintOpt) => {
-      const sprintId = SprintId.parse(opts.sprint);
+      const { deps, storage } = await bootstrapCli();
+      const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
       if (!sprintId.ok) {
-        process.stderr.write(`error: invalid sprint id: ${sprintId.error.message}\n`);
+        process.stderr.write(`error: ${sprintId.error.message}\n`);
         process.exit(1);
         return;
       }
@@ -139,10 +151,10 @@ export const registerTicketCommand = (program: Command): void => {
         process.exit(1);
         return;
       }
-      const { deps } = await bootstrapCli();
+      if (sprintId.value.fromPin) process.stderr.write(pinFallbackNotice(sprintId.value.sprintId));
       const flow = createTicketRemoveFlow({ sprintRepo: deps.sprintRepo });
       const result = await flow.execute({
-        input: { sprintId: sprintId.value, ticketId: ticketId.value },
+        input: { sprintId: sprintId.value.sprintId, ticketId: ticketId.value },
       });
       if (!result.ok) {
         process.stderr.write(`error: ${result.error.error.message}\n`);
@@ -151,12 +163,12 @@ export const registerTicketCommand = (program: Command): void => {
       }
       const out = result.value.ctx.output!;
       if (!out.removed) {
-        process.stderr.write(`error: ticket ${rawTicketId} not found on sprint ${opts.sprint}\n`);
+        process.stderr.write(`error: ticket ${rawTicketId} not found on sprint ${String(sprintId.value.sprintId)}\n`);
         process.exit(1);
         return;
       }
       process.stdout.write(
-        `removed ticket ${rawTicketId} (${String(out.remainingTickets)} ticket${out.remainingTickets === 1 ? '' : 's'} remain)\n`
+        `removed ticket ${rawTicketId} from sprint ${String(sprintId.value.sprintId)} (${String(out.remainingTickets)} ticket${out.remainingTickets === 1 ? '' : 's'} remain)\n`
       );
     });
 };

--- a/src/application/ui/cli/resolve-sprint-selection.ts
+++ b/src/application/ui/cli/resolve-sprint-selection.ts
@@ -1,0 +1,77 @@
+/**
+ * Sprint-id resolution for CLI commands — explicit argument first, pinned selection second.
+ *
+ * `ralphctl sprint set-current <id>` (and every TUI sprint pick) persists the user's current
+ * sprint in `<stateRoot>/last-selection.json`; commands that take a sprint fall back to that
+ * pin when the argument is omitted, so day-to-day invocations don't repeat the UUID the user
+ * already pinned. The explicit argument always wins.
+ *
+ * The pinned id is re-parsed through `SprintId.parse` before use: the store's read is silent
+ * on corruption (it's a UX optimisation, not a contract), so a stale or hand-edited file must
+ * fail with the same actionable message an invalid explicit argument gets.
+ *
+ * When the fallback path is taken, the calling action prints {@link pinFallbackNotice} to
+ * stderr — write paths (`unblock`, `ticket add`/`remove`) especially must disambiguate a
+ * possibly-stale pin from a deliberate target.
+ */
+
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { Result } from '@src/domain/result.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
+
+export interface ResolvedSprintId {
+  readonly sprintId: SprintId;
+  /** True when the id came from the pinned selection rather than an explicit argument. */
+  readonly fromPin: boolean;
+}
+
+const DEFAULT_MISSING_MESSAGE =
+  'no sprint specified — pass --sprint <id> or pin one with `ralphctl sprint set-current <id>`';
+
+export interface ResolveSprintIdOptions {
+  /**
+   * Guidance emitted when neither an explicit id nor a pin exists. Defaults to the
+   * `--sprint <id>` phrasing; commands with a positional `[id]` pass their own wording.
+   */
+  readonly missingMessage?: string;
+}
+
+const invalidId = (value: unknown, detail: string): ValidationError =>
+  // Keep the long-established `invalid sprint id: …` stderr phrasing every command printed
+  // before this helper existed — scripts (and the e2e suite) match on it.
+  new ValidationError({ field: 'sprint-id', value, message: `invalid sprint id: ${detail}` });
+
+export const resolveSprintId = async (
+  raw: string | undefined,
+  stateRoot: AbsolutePath,
+  opts: ResolveSprintIdOptions = {}
+): Promise<Result<ResolvedSprintId, DomainError>> => {
+  if (raw !== undefined) {
+    const parsed = SprintId.parse(raw);
+    if (!parsed.ok) return Result.error(invalidId(raw, parsed.error.message));
+    return Result.ok({ sprintId: parsed.value, fromPin: false });
+  }
+  const pinned = (await createLastSelectionStore(stateRoot).read())?.sprintId;
+  if (pinned === undefined) {
+    return Result.error(
+      new ValidationError({
+        field: 'sprint',
+        value: undefined,
+        message: opts.missingMessage ?? DEFAULT_MISSING_MESSAGE,
+      })
+    );
+  }
+  const parsed = SprintId.parse(String(pinned));
+  if (!parsed.ok) return Result.error(invalidId(pinned, `${parsed.error.message} (from the pinned selection)`));
+  return Result.ok({ sprintId: parsed.value, fromPin: true });
+};
+
+/**
+ * One-line stderr notice for the fallback path — tells the user which sprint was substituted
+ * and how to override it, so a stale pin never silently targets the wrong sprint.
+ */
+export const pinFallbackNotice = (id: SprintId): string =>
+  `using current sprint ${String(id)} (from sprint set-current; pass --sprint to override)\n`;

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -438,7 +438,11 @@ export const launchFlow = async (
     ...(snapshot.project !== undefined
       ? { pinnedProjectId: snapshot.project.id, pinnedProjectLabel: snapshot.project.displayName }
       : {}),
-    ...(snapshot.sprint !== undefined
+    // create-sprint never pins the snapshot sprint: the run's sprint does not exist at launch
+    // time, so a sprint on the snapshot is by definition the PREVIOUS selection — pinning it
+    // would mislabel the run's execute view / breadcrumb. The sprint-bound launch wrapper pins
+    // the real one via `setPinnedSprint` once the chain resolves it.
+    ...(snapshot.sprint !== undefined && flowId !== 'create-sprint'
       ? { pinnedSprintId: snapshot.sprint.id, pinnedSprintLabel: snapshot.sprint.name }
       : {}),
   };

--- a/src/application/ui/tui/components/async-rows.tsx
+++ b/src/application/ui/tui/components/async-rows.tsx
@@ -1,0 +1,44 @@
+/**
+ * `LoadingRow` / `LoadErrorRow` — the indented one-line gates that every data-backed list /
+ * detail view renders while a {@link useAsyncLoad} fetch is pending or has failed. Each view had
+ * its own `<Box paddingX={spacing.indent}><Spinner label="…" /></Box>` and
+ * `<Box paddingX={spacing.indent}><Text>Failed to load …</Text></Box>`; these centralise the
+ * wrapper + spacing.
+ *
+ * `LoadingRow` takes the spinner `label` (views differ: "Loading sprints…", "Loading…", …).
+ * `LoadErrorRow` takes the failure `message` and an optional `color` — the sprint picker tints
+ * its failure line with `inkColors.error` while the other views leave it default-weight, so the
+ * colour is passed through to keep each call site byte-identical.
+ *
+ * @public
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
+
+export interface LoadingRowProps {
+  /** Spinner label — imperative present-continuous, e.g. `Loading sprints…`. */
+  readonly label: string;
+}
+
+export const LoadingRow = ({ label }: LoadingRowProps): React.JSX.Element => (
+  <Box paddingX={spacing.indent}>
+    <Spinner label={label} />
+  </Box>
+);
+
+export interface LoadErrorRowProps {
+  /** One-line failure copy, e.g. `Failed to load sprints.`. */
+  readonly message: string;
+  /** Optional text colour. Omit for default weight (matches most views); the sprint picker
+   *  passes `inkColors.error`. */
+  readonly color?: string;
+}
+
+export const LoadErrorRow = ({ message, color }: LoadErrorRowProps): React.JSX.Element => (
+  <Box paddingX={spacing.indent}>
+    <Text {...(color !== undefined ? { color } : {})}>{message}</Text>
+  </Box>
+);

--- a/src/application/ui/tui/components/baseline-health-card.tsx
+++ b/src/application/ui/tui/components/baseline-health-card.tsx
@@ -19,10 +19,10 @@
  *  - Fluid width at `xxl`: caller passes `width` (default `CONTEXT_WIDTH`); the card never
  *    hardcodes its own width.
  *
- * The card aggregates data from the sources rather than depending on the (not-yet-wired)
- * `SprintState` projection. Once P1c wires `projectSprintState` into the TUI we can swap to
- * reading directly off that — for now we derive in-place from the entities the dashboard
- * already has access to.
+ * The card derives in-place from `SprintExecution` + `Task[]` — the entities the dashboard
+ * already has access to. The wider `SprintState` projection this once anticipated was deleted
+ * in Wave 7 (see the `tasks-projection.ts` header); there is no sprint-level verify
+ * projection, by design.
  *
  * The chip variant in {@link BaselineHealthChip} is the single-line companion that
  * sits next to the breadcrumb.

--- a/src/application/ui/tui/components/breadcrumb.tsx
+++ b/src/application/ui/tui/components/breadcrumb.tsx
@@ -122,6 +122,10 @@ export const Breadcrumb = (): React.JSX.Element => {
               <Text color={inkColors.primary} bold>
                 {right[1]}
               </Text>
+              <Text dimColor> </Text>
+              <Text color={inkColors.highlight} bold>
+                [S]
+              </Text>
               {atLeast('md') && effectiveSprintStatus !== undefined && (
                 <Box marginLeft={1}>
                   <StatusChip label={effectiveSprintStatus} kind={sprintStatusKind(effectiveSprintStatus)} />

--- a/src/application/ui/tui/components/confirm-card.tsx
+++ b/src/application/ui/tui/components/confirm-card.tsx
@@ -1,0 +1,48 @@
+/**
+ * `ConfirmCard` — the destructive-confirm body shared by the list / detail views (projects,
+ * project-detail, sprints, sprint-detail). Each rendered its own `Box` + message lines +
+ * `ConfirmPrompt`, plus a per-view `useEffect(() => x !== undefined ? claimPrompt() : undefined)`
+ * to mute the global keys while the prompt is up.
+ *
+ * The card is only mounted while its host view's "pending removal" state is set, so it claims
+ * the prompt on mount and releases on unmount — one effect here replaces the four per-view
+ * conditional-claim effects. Callers pass the exact message JSX (`title`, optional `body`) so
+ * wording stays byte-identical per call site; the card owns the layout, the claim, and the
+ * `defaultYes={false}` destructive-confirm prompt.
+ *
+ * @public
+ */
+
+import React, { useEffect } from 'react';
+import { Box } from 'ink';
+import { spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+
+export interface ConfirmCardProps {
+  /** Primary prompt line(s) — supplied as JSX so the host keeps its exact bold/dim wording. */
+  readonly title: React.ReactNode;
+  /** Optional secondary line(s) rendered directly under the title (e.g. a dim caveat). */
+  readonly body?: React.ReactNode;
+  /** Label shown inside the yes/no {@link ConfirmPrompt} (e.g. `Delete?` / `Remove?`). */
+  readonly message: string;
+  readonly onSubmit: (value: boolean) => void;
+  readonly onCancel: () => void;
+}
+
+export const ConfirmCard = ({ title, body, message, onSubmit, onCancel }: ConfirmCardProps): React.JSX.Element => {
+  // Mute the global keys for as long as this card is mounted; the host only mounts it while a
+  // removal is pending, so mount/unmount maps 1:1 onto the old per-view conditional claim.
+  const claimPrompt = useUiState().claimPrompt;
+  useEffect(() => claimPrompt(), [claimPrompt]);
+
+  return (
+    <Box flexDirection="column" paddingX={spacing.indent}>
+      {title}
+      {body}
+      <Box marginTop={1}>
+        <ConfirmPrompt message={message} defaultYes={false} onSubmit={onSubmit} onCancel={onCancel} />
+      </Box>
+    </Box>
+  );
+};

--- a/src/application/ui/tui/components/feedback-line.tsx
+++ b/src/application/ui/tui/components/feedback-line.tsx
@@ -1,0 +1,31 @@
+/**
+ * `FeedbackLine` — the transient inline result line shared by the list / detail views (sprints,
+ * projects, project-detail). Each rendered the same indented `<Box>` with a colour ternary:
+ * error tone when the message starts with the cross glyph, primary tone otherwise.
+ *
+ * Centralising it also retires an inline-glyph violation — the views compared against a literal
+ * `'✗'`; the canonical token is `glyphs.cross`, used here for the prefix test.
+ *
+ * Renders nothing when `text` is `undefined`, so callers drop the previous
+ * `text !== undefined && (<Box>…</Box>)` guard.
+ *
+ * @public
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+
+export interface FeedbackLineProps {
+  /** Resolved feedback text. A leading {@link glyphs.cross} tints the line error-red. */
+  readonly text: string | undefined;
+}
+
+export const FeedbackLine = ({ text }: FeedbackLineProps): React.JSX.Element | null => {
+  if (text === undefined) return null;
+  return (
+    <Box paddingX={spacing.indent} marginTop={1}>
+      <Text color={text.startsWith(glyphs.cross) ? inkColors.error : inkColors.primary}>{text}</Text>
+    </Box>
+  );
+};

--- a/src/application/ui/tui/runtime/keyboard-map.ts
+++ b/src/application/ui/tui/runtime/keyboard-map.ts
@@ -44,7 +44,10 @@ export const globalKeys = {
   progressOverlay: { keys: ['g'], label: 'show progress.md' },
   yankTask: { keys: ['y'], label: 'copy active task summary' },
   pickProject: { keys: ['P'], label: 'pick project', showInFooter: true },
-  pickSprint: { keys: ['S'], label: 'pick sprint', showInFooter: true },
+  // NOT showInFooter: with `pick sprint` added the strip overflows a 100-col terminal and the
+  // whole footer wraps. The breadcrumb's `[S]` affordance (right next to the sprint name)
+  // carries the discoverability instead.
+  pickSprint: { keys: ['S'], label: 'pick sprint' },
   help: { keys: ['?'], label: 'help', showInFooter: true },
   quit: { keys: ['q', 'ctrl+c'], label: 'quit', showInFooter: true },
 } as const satisfies Record<string, KeyBinding>;

--- a/src/application/ui/tui/runtime/keyboard-map.ts
+++ b/src/application/ui/tui/runtime/keyboard-map.ts
@@ -44,7 +44,7 @@ export const globalKeys = {
   progressOverlay: { keys: ['g'], label: 'show progress.md' },
   yankTask: { keys: ['y'], label: 'copy active task summary' },
   pickProject: { keys: ['P'], label: 'pick project', showInFooter: true },
-  pickSprint: { keys: ['S'], label: 'pick sprint' },
+  pickSprint: { keys: ['S'], label: 'pick sprint', showInFooter: true },
   help: { keys: ['?'], label: 'help', showInFooter: true },
   quit: { keys: ['q', 'ctrl+c'], label: 'quit', showInFooter: true },
 } as const satisfies Record<string, KeyBinding>;
@@ -72,6 +72,10 @@ export const footerGlobalHints: ReadonlyArray<{ readonly keys: string; readonly 
  */
 export const pickerKeys = {
   toggleScope: { keys: ['t'], label: 'toggle project scope' },
+  // `f` (filter), NOT `d`: `d` double-fires with the StatusBanner dismiss mounted inside the
+  // picker's ViewShell and means delete-with-confirm in every sibling list view. Plain `f` is
+  // unused TUI-wide.
+  hideDone: { keys: ['f'], label: 'hide done sprints' },
 } as const satisfies Record<string, KeyBinding>;
 
 /**
@@ -89,6 +93,8 @@ export const pickerKeys = {
  *
  * `+` on Home opens create-sprint (requires a project). `m` on the sprint-detail view marks the
  * opened sprint as the current selection — replaces the prior silent auto-sync on detail mount.
+ * The same chord on the projects list / project detail marks the focused (or viewed) project
+ * current — opening a project detail is a browse and never switches the selection.
  */
 export const contextualKeys = {
   editField: { keys: ['e'], label: 'edit focused field' },
@@ -96,6 +102,7 @@ export const contextualKeys = {
   bulkUnblockSprintTasks: { keys: ['u'], label: 'unblock all stuck tasks in focused sprint' },
   createSprint: { keys: ['+'], label: 'create a new sprint' },
   makeSprintCurrent: { keys: ['m'], label: 'make focused sprint current' },
+  makeProjectCurrent: { keys: ['m'], label: 'make focused project current' },
 } as const satisfies Record<string, KeyBinding>;
 
 /**

--- a/src/application/ui/tui/runtime/open-flow-session.ts
+++ b/src/application/ui/tui/runtime/open-flow-session.ts
@@ -1,0 +1,56 @@
+/**
+ * `openFlowSession` — the register + start + route tail shared by every TUI call site that
+ * launches a flow runner. Given a successful {@link LaunchResult}, it:
+ *
+ *   1. Registers the runner with the {@link SessionManager}, projecting the launch result's
+ *      optional UI hints via {@link sessionHintsFromLaunchResult}.
+ *   2. Fires `runner.start()` (fire-and-forget — events flow into the session manager via the
+ *      manager's own subscription, established during `register`).
+ *   3. Routes to the Execute view for the new runner's session id — pushing a new frame by
+ *      default, or replacing the current frame when `opts.mode === 'replace'`.
+ *
+ * Centralised so the launch call sites (flows / home / pick-sprint / project-detail / sprints,
+ * plus the create-sprint copies folded into {@link useLaunchCreateSprint}) don't each re-stamp
+ * the same three-statement tail. Flows-view passes `mode: 'replace'` and runs its own
+ * `reload()` afterwards; the reload stays at the call site because it is flows-view-specific.
+ *
+ * @public
+ */
+
+import type { RouterApi } from '@src/application/ui/tui/runtime/router.tsx';
+import type { SessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
+import { type LaunchResult, sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+
+export interface OpenFlowSessionDeps {
+  readonly sessions: SessionManager;
+  readonly router: RouterApi;
+}
+
+export interface OpenFlowSessionOpts {
+  /**
+   * How to route to the Execute view. `push` (default) stacks a new frame so `Esc` returns to
+   * the launching view; `replace` swaps the current frame (flows-view uses this so the menu
+   * isn't left on the stack behind the run).
+   */
+  readonly mode?: 'push' | 'replace';
+}
+
+export const openFlowSession = (
+  deps: OpenFlowSessionDeps,
+  result: Extract<LaunchResult, { readonly ok: true }>,
+  flowId: string,
+  opts: OpenFlowSessionOpts = {}
+): void => {
+  deps.sessions.register({
+    runner: result.runner,
+    flowId,
+    title: result.title,
+    ...sessionHintsFromLaunchResult(result),
+  });
+  // Fire-and-forget — the session manager already subscribed during register(), so progress
+  // events land there without further wiring here.
+  void result.runner.start();
+  const entry = { id: 'execute', props: { sessionId: result.runner.id } };
+  if (opts.mode === 'replace') deps.router.replace(entry);
+  else deps.router.push(entry);
+};

--- a/src/application/ui/tui/runtime/selection-context.tsx
+++ b/src/application/ui/tui/runtime/selection-context.tsx
@@ -53,6 +53,16 @@ interface SelectionApi {
   setProject(id: ProjectId | undefined, label?: string): void;
   setSprint(id: SprintId | undefined, label?: string, status?: SprintStatus): void;
   /**
+   * Toast-free status refresh for the CURRENTLY selected sprint. Flow chains transition the
+   * sprint's status on disk (plan → planned, implement → review, close-sprint → done) but the
+   * cached `sprintStatus` is only written on manual picks — so the breadcrumb chip goes stale
+   * the moment a flow completes. Views that load a fresh snapshot call this with the loaded
+   * status; the update is a no-op unless `id` still matches the selected sprint (checked
+   * against a live ref, so a stale closure can never clobber a newer pick) and deliberately
+   * does NOT touch `lastSwitch` — refreshing a chip must not replay the "✓ now on …" toast.
+   */
+  syncSprintStatus(id: SprintId, status: SprintStatus): void;
+  /**
    * Atomic project + sprint switch — used by the cross-project sprint picker so picking a
    * sprint from a different project updates both ids in a single state batch. Going through
    * `setProject` then `setSprint` would clear the sprint mid-flight (setProject zeroes the
@@ -124,6 +134,10 @@ export const SelectionProvider = ({
   // and force every memoised consumer to re-evaluate).
   const projectIdRef = useRef(projectId);
   projectIdRef.current = projectId;
+  // Same mirror for the sprint cursor — lets `syncSprintStatus` and the done-on-boot probe
+  // check "is this still the selected sprint?" at resolution time instead of capture time.
+  const sprintIdRef = useRef(sprintId);
+  sprintIdRef.current = sprintId;
 
   // Persist whenever the canonical selection changes — but skip the initial render. The launch
   // router may seed an auto-default project/sprint (first project + most-recent sprint) when
@@ -171,6 +185,15 @@ export const SelectionProvider = ({
     }
   }, []);
 
+  const syncSprintStatus = useCallback((id: SprintId, status: SprintStatus) => {
+    // Ref check (not a dep) keeps the setter identity stable AND makes the guard live: a
+    // snapshot loaded for sprint A must never restamp the chip after the user picked sprint B.
+    if (sprintIdRef.current !== id) return;
+    // Functional update so an unchanged status bails out without a re-render — callers fire
+    // this on every snapshot load.
+    setSprintStatus((prev) => (prev === status ? prev : status));
+  }, []);
+
   // Done-on-boot clear. Runs once per seeded sprint id: if `sprintRepo.findById` resolves to
   // a sprint with status `done`, drop both ids so the first paint of Home shows the empty-
   // sprint card. The hook is single-shot per (provider lifetime + seeded id) — re-running on
@@ -188,11 +211,21 @@ export const SelectionProvider = ({
       .findById(seedSprintId)
       .then((r) => {
         if (cancelled) return;
-        if (r.ok && r.value.status === 'done') {
+        // The probe races user input: if a pick landed on a different sprint while findById
+        // was in flight, the seed is no longer what's selected — clearing (or restamping)
+        // now would clobber the fresh pick AND persist the clobber. Bail via the live ref.
+        if (sprintIdRef.current !== seedSprintId) return;
+        if (!r.ok) return;
+        if (r.value.status === 'done') {
           setSprintId(undefined);
           setSprintLabel(undefined);
           setSprintStatus(undefined);
+          return;
         }
+        // Live sprint: the seed carries only ids + labels (status is never persisted), so
+        // without this the breadcrumb chip is missing after every restart until a manual
+        // re-pick. The probe already fetched the entity — keep its status.
+        setSprintStatus(r.value.status);
       })
       .catch(() => {
         // Swallow — a probe failure must never break the TUI boot. The seeded sprint stays in
@@ -227,6 +260,7 @@ export const SelectionProvider = ({
       lastSwitch,
       setProject,
       setSprint,
+      syncSprintStatus,
       setProjectAndSprint,
     }),
     [
@@ -238,6 +272,7 @@ export const SelectionProvider = ({
       lastSwitch,
       setProject,
       setSprint,
+      syncSprintStatus,
       setProjectAndSprint,
     ]
   );

--- a/src/application/ui/tui/runtime/use-app-state-snapshot.ts
+++ b/src/application/ui/tui/runtime/use-app-state-snapshot.ts
@@ -1,0 +1,34 @@
+/**
+ * `useAppStateSnapshot` — loads the {@link AppStateSnapshot} for the current selection and keeps
+ * it fresh as the selection changes. Wraps the `useAsyncLoad(() => loadAppStateSnapshot(deps,
+ * selection), [selection.projectId, selection.sprintId])` boilerplate that both flows-view and
+ * home-view carried verbatim.
+ *
+ * `AppDeps` structurally satisfies {@link LoadSnapshotDeps}, so the repo trio is passed straight
+ * through — no `{ projectRepo, sprintRepo, taskRepo }` wrapper. The selection ids are forwarded
+ * with the same `exactOptionalPropertyTypes`-safe conditional spread (omit the key when the id
+ * is `undefined`) the call sites used.
+ *
+ * Returns the same `{ state, reload }` shape as {@link useAsyncLoad} so callers narrow on
+ * `state.kind` exactly as before.
+ *
+ * @public
+ */
+
+import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { useAsyncLoad, type UseAsyncLoadResult } from '@src/application/ui/tui/runtime/use-async-load.ts';
+import { type AppStateSnapshot, loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+
+export const useAppStateSnapshot = (): UseAsyncLoadResult<AppStateSnapshot, unknown> => {
+  const deps = useDeps();
+  const selection = useSelection();
+  return useAsyncLoad<AppStateSnapshot>(
+    () =>
+      loadAppStateSnapshot(deps, {
+        ...(selection.projectId !== undefined ? { projectId: selection.projectId } : {}),
+        ...(selection.sprintId !== undefined ? { sprintId: selection.sprintId } : {}),
+      }),
+    [selection.projectId, selection.sprintId]
+  );
+};

--- a/src/application/ui/tui/runtime/use-launch-create-sprint.ts
+++ b/src/application/ui/tui/runtime/use-launch-create-sprint.ts
@@ -1,0 +1,83 @@
+/**
+ * `useLaunchCreateSprint` — the create-sprint launch sequence shared by the three views that
+ * offer a "create sprint" affordance (home `+` hotkey, pick-sprint synthetic row,
+ * sprints `c` chord). Each had a near-verbatim copy of:
+ *
+ *   load snapshot → createInkInteractivePrompt → launchSprintBoundFlow('create-sprint', …,
+ *     { onReseat: selection.setSprint, onSprintResolved: sessions.setPinnedSprint }) →
+ *     register + start + push execute
+ *
+ * The reseat / pinned-sprint wiring is identical across all three; only the feedback channel and
+ * the no-project gating wording differ, so both are injected. The register + start + route tail
+ * is composed via {@link openFlowSession} (mode defaults to `push`, matching every call site).
+ *
+ * The returned function is `useCallback`-stable so home-view can list it in a `useMemo`
+ * dependency array (the menu builder closes over it) without re-running the memo every render.
+ *
+ * @public
+ */
+
+import { useCallback } from 'react';
+import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
+import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
+import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
+import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
+import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
+import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
+import { openFlowSession } from '@src/application/ui/tui/runtime/open-flow-session.ts';
+import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
+import { loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+
+export interface UseLaunchCreateSprintOpts {
+  /**
+   * Sink for both gating and launch-failure messages. Each view feeds its own feedback / flash
+   * mechanism (home's `flashErr`, the picker / sprints `setFeedback`), so the strings are passed
+   * through verbatim — the hook never renders.
+   */
+  readonly onError: (text: string) => void;
+  /**
+   * Message shown when there is no current project to create the sprint against. Differs per
+   * call site (home / sprints say "pick a project first …"; the picker says "select a project
+   * first"), so it is supplied by the caller to keep wording byte-identical.
+   */
+  readonly noProjectMessage: string;
+}
+
+export const useLaunchCreateSprint = (opts: UseLaunchCreateSprintOpts): (() => Promise<void>) => {
+  const deps = useDeps();
+  const router = useRouter();
+  const selection = useSelection();
+  const sessions = useSessionManager();
+  const storage = useStorage();
+  const queue = usePromptQueue();
+  const { onError, noProjectMessage } = opts;
+
+  return useCallback(async (): Promise<void> => {
+    if (selection.projectId === undefined) {
+      onError(noProjectMessage);
+      return;
+    }
+    const snapshot = await loadAppStateSnapshot(deps, { projectId: selection.projectId });
+    const interactive = createInkInteractivePrompt(queue);
+    const result = await launchSprintBoundFlow(
+      { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
+      'create-sprint',
+      snapshot,
+      {
+        onReseat: ({ id, name, status }) => {
+          selection.setSprint(id, name, status);
+        },
+        onSprintResolved: (runnerId, { id, name }) => {
+          sessions.setPinnedSprint(runnerId, id, name);
+        },
+      }
+    );
+    if (!result.ok) {
+      onError(`✗ ${result.reason}`);
+      return;
+    }
+    openFlowSession({ sessions, router }, result, 'create-sprint');
+  }, [deps, router, selection, sessions, storage, queue, onError, noProjectMessage]);
+};

--- a/src/application/ui/tui/views/create-pr-view.tsx
+++ b/src/application/ui/tui/views/create-pr-view.tsx
@@ -50,6 +50,7 @@ export const CreatePrView = (): React.JSX.Element => {
   useViewHints([
     { keys: '↵', label: 'open PR' },
     { keys: 'a', label: 'toggle AI' },
+    { keys: 'r', label: 'retry', enabledWhen: run.kind === 'error' },
     { keys: 'esc', label: 'back' },
   ]);
 
@@ -161,6 +162,12 @@ export const CreatePrView = (): React.JSX.Element => {
     }
     if (input === 'a' && run.kind === 'idle') {
       setUseAi((prev) => !prev);
+      return;
+    }
+    if (input === 'r' && run.kind === 'error') {
+      // Back to the confirm card (re-enabling the `a` toggle) rather than re-firing directly —
+      // this view creates an upstream PR, so every attempt goes through the explicit Enter.
+      setRun({ kind: 'idle' });
     }
   });
 
@@ -209,6 +216,7 @@ export const CreatePrView = (): React.JSX.Element => {
               <Text color={inkColors.error}>
                 {glyphs.bullet} {run.message}
               </Text>
+              <Text dimColor>press r to retry</Text>
             </Card>
           )}
         </Box>

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -47,6 +47,7 @@ import { useEventBusBuffer } from '@src/application/ui/tui/runtime/use-event-bus
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 import type { AppEvent } from '@src/business/observability/events.ts';
 import { useUiState, type FocusedRunCtx } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
 
@@ -187,6 +188,25 @@ export const ExecuteView = (): React.JSX.Element => {
       setFocusedRunContext(undefined);
     };
   }, [pinnedProjectLabel, pinnedSprintId, pinnedSprintLabel, setFocusedRunContext]);
+
+  // Converge the mutable global selection onto the focused run's pinned context. Tab /
+  // Ctrl+1..9 / Sessions-open land the user on a run whose sprint may differ from the
+  // selection; without this, every panel shows sprint B while `n → Flows` silently launches
+  // against sprint A. Atomic setter so the project can't flicker out from under the sprint.
+  // Status is unknown here — the Home/Flows snapshot-sync effect backfills the chip.
+  const selection = useSelection();
+  const setProjectAndSprint = selection.setProjectAndSprint;
+  const sessionDescriptor = session?.descriptor;
+  React.useEffect(() => {
+    if (sessionDescriptor?.pinnedProjectId === undefined || sessionDescriptor.pinnedSprintId === undefined) return;
+    if (sessionDescriptor.pinnedSprintId === selection.sprintId) return; // already converged
+    setProjectAndSprint(
+      sessionDescriptor.pinnedProjectId,
+      sessionDescriptor.pinnedProjectLabel ?? String(sessionDescriptor.pinnedProjectId),
+      sessionDescriptor.pinnedSprintId,
+      sessionDescriptor.pinnedSprintLabel ?? String(sessionDescriptor.pinnedSprintId)
+    );
+  }, [sessionDescriptor, selection.sprintId, setProjectAndSprint]);
 
   const baselineSprintId: SprintId | undefined = pinnedSprintId;
   const { executionState, taskState } = useBaselineHealthData({

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -7,7 +7,7 @@
  * the session manager, and pushes the execute view with the new session id.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
@@ -29,6 +29,7 @@ import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { launchFlow, sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
 import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customize-picker.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
@@ -252,17 +253,51 @@ export const FlowsView = (): React.JSX.Element => {
                 ? getImplementRoleOverrides()
                 : undefined;
           const override = picker.kind === 'single' ? picker.override : undefined;
-          const result = await launchFlow(
-            { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
-            entry.manifest.id,
-            snapshot,
-            {
-              ...(ui.sessionRepositoryId !== undefined ? { repositoryId: ui.sessionRepositoryId } : {}),
-              ...(override !== undefined ? { override } : {}),
-              ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
-              settingsSnapshot: settings,
-            }
-          );
+          const launcherDeps = { app: deps, interactive, storage, runInTerminal: getRunInTerminal() };
+          const launchExtras = {
+            ...(ui.sessionRepositoryId !== undefined ? { repositoryId: ui.sessionRepositoryId } : {}),
+            ...(override !== undefined ? { override } : {}),
+            ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
+            settingsSnapshot: settings,
+          };
+          // create-sprint and close-sprint change which sprint (or status) the user is "on" —
+          // route them through the sprint-bound wrapper so the post-completion selection reseat
+          // happens in one place instead of leaving the global selection stale. create-sprint
+          // additionally strips the launch-time sprint from the snapshot: the new sprint doesn't
+          // exist yet, so pinning the PREVIOUS sprint onto the run's descriptor would mislabel
+          // every panel; onSprintResolved pins the real one once known.
+          const sprintBound = entry.manifest.id === 'create-sprint' || entry.manifest.id === 'close-sprint';
+          let result;
+          if (sprintBound) {
+            const { sprint: _staleSprint, ...snapshotWithoutSprint } = snapshot;
+            void _staleSprint;
+            result = await launchSprintBoundFlow(
+              launcherDeps,
+              entry.manifest.id,
+              entry.manifest.id === 'create-sprint' ? snapshotWithoutSprint : snapshot,
+              {
+                ...launchExtras,
+                onReseat: ({ id, name, status }) => {
+                  if (entry.manifest.id === 'create-sprint') {
+                    // A brand-new sprint can't collide with a mid-run switch — always reseat
+                    // (and let the "✓ now on …" toast fire via lastSwitch).
+                    selection.setSprint(id, name, status);
+                    return;
+                  }
+                  // close-sprint: the sprint stays selected but its status flipped to done on
+                  // disk — refresh the chip without replaying the switch toast. syncSprintStatus
+                  // no-ops when the user moved to a different sprint mid-run, so a late
+                  // completion never yanks them back.
+                  if (status !== undefined) selection.syncSprintStatus(id, status);
+                },
+                onSprintResolved: (runnerId, { id, name }) => {
+                  sessions.setPinnedSprint(runnerId, id, name);
+                },
+              }
+            );
+          } else {
+            result = await launchFlow(launcherDeps, entry.manifest.id, snapshot, launchExtras);
+          }
           if (!result.ok) {
             setLaunchError(`${entry.manifest.title}: ${result.reason}`);
             return;
@@ -301,7 +336,18 @@ export const FlowsView = (): React.JSX.Element => {
     // Sort by section so the action menu's section headers stay sticky (items in the same
     // category render consecutively even when registry order interleaves them).
     return [...built].sort((a, b) => sectionRank(a.section ?? 'other') - sectionRank(b.section ?? 'other'));
-  }, [state, deps, queue, storage, sessions, router, reload, showAll, ui]);
+  }, [state, deps, queue, storage, sessions, router, reload, showAll, ui, selection]);
+
+  // Refresh the cached breadcrumb status chip from every fresh snapshot load — flow chains
+  // transition the sprint's status on disk (plan → planned, implement → review, close-sprint →
+  // done) and the chip would otherwise wave the stale status until the next manual pick.
+  // syncSprintStatus no-ops unless the loaded sprint is still the selected one.
+  const syncSprintStatus = selection.syncSprintStatus;
+  useEffect(() => {
+    if (state.kind !== 'ok') return;
+    const s = state.value.sprint;
+    if (s !== undefined) syncSprintStatus(s.id, s.status);
+  }, [state, syncSprintStatus]);
 
   // `r` re-fetches the snapshot so the menu's enabled/disabled state reflects the latest
   // storage read — useful after mutating something in a detail view and coming back. `v`

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -12,7 +12,7 @@ import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { ActionMenu, type MenuItem } from '@src/application/ui/tui/components/action-menu.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
+import { LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
 import { StatusChip, sprintStatusKind } from '@src/application/ui/tui/components/status-chip.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { flowRegistry } from '@src/application/registry.ts';
@@ -20,15 +20,16 @@ import { evaluateTriggers } from '@src/application/registry-triggers.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
-import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
-import { type AppStateSnapshot, loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import { useAppStateSnapshot } from '@src/application/ui/tui/runtime/use-app-state-snapshot.ts';
+import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
 import { useRouter, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
-import { launchFlow, sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+import { openFlowSession } from '@src/application/ui/tui/runtime/open-flow-session.ts';
+import { launchFlow } from '@src/application/ui/shared/launcher.ts';
 import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
 import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customize-picker.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
@@ -171,17 +172,7 @@ export const FlowsView = (): React.JSX.Element => {
     { keys: 'v', label: showAll ? 'hide inapplicable' : 'show all' },
   ]);
 
-  const { state, reload } = useAsyncLoad<AppStateSnapshot>(
-    () =>
-      loadAppStateSnapshot(
-        { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-        {
-          ...(selection.projectId !== undefined ? { projectId: selection.projectId } : {}),
-          ...(selection.sprintId !== undefined ? { sprintId: selection.sprintId } : {}),
-        }
-      ),
-    [selection.projectId, selection.sprintId]
-  );
+  const { state, reload } = useAppStateSnapshot();
 
   const items = useMemo<readonly MenuItem[]>(() => {
     if (state.kind !== 'ok') return [];
@@ -318,15 +309,10 @@ export const FlowsView = (): React.JSX.Element => {
             if (ctx.repository !== undefined) ui.setSessionRepositoryId(ctx.repository.id);
             unsubRepoCapture();
           });
-          sessions.register({
-            runner: result.runner,
-            flowId: entry.manifest.id,
-            title: result.title,
-            ...sessionHintsFromLaunchResult(result),
-          });
-          // Fire-and-forget — events flow into the session manager via subscribe.
-          void result.runner.start();
-          router.replace({ id: 'execute', props: { sessionId: result.runner.id } });
+          // Register + start + route via the shared tail. `replace` (not push) so the flow menu
+          // isn't left on the stack behind the run; the trailing reload refreshes this menu's
+          // enabled/disabled state for when the user pops back.
+          openFlowSession({ sessions, router }, result, entry.manifest.id, { mode: 'replace' });
           reload();
         },
       };
@@ -364,9 +350,7 @@ export const FlowsView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind !== 'ok' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading state…" />
-        </Box>
+        <LoadingRow label="Loading state…" />
       ) : (
         <Box flexDirection="column">
           <SprintPipeline snapshot={state.value} />

--- a/src/application/ui/tui/views/harness-row.tsx
+++ b/src/application/ui/tui/views/harness-row.tsx
@@ -1,9 +1,13 @@
 /**
  * Harness section body — renders iteration budget knobs (maxTurns / maxAttempts /
  * rateLimitRetries / plateauThreshold), boolean toggles (escalateOnPlateau /
- * skipPreVerifyOnFreshSetup), and the read-only escalationMap display, with per-field
- * one-line hints sourced from `HARNESS_HINTS`. Edits route through the orchestrator's
- * prompt-mounting machinery; the escalationMap field is read-only with a CLI edit hint.
+ * skipPreVerifyOnFreshSetup), and the editable escalation-map group (an add-rung action row
+ * plus one row per user override), with per-field one-line hints sourced from `HARNESS_HINTS`.
+ * Edits route through the orchestrator's prompt-mounting machinery.
+ *
+ * Below the field list the EFFECTIVE escalation ladder (user overrides merged over the
+ * built-in map) renders as dim chains so "defaults apply" is never a mystery — customised
+ * chains carry a marker.
  */
 
 import React from 'react';
@@ -11,10 +15,12 @@ import { Box, Text } from 'ink';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { FieldList } from '@src/application/ui/tui/components/field-list.tsx';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
-import { type EditableField, HARNESS_HINTS } from '@src/application/ui/tui/views/settings-view-model.ts';
-
-const ESCALATION_MAP_CLI_HINT =
-  'Read-only here — edit via: ralphctl settings set harness.escalationMap.<fromModel> <toModel>';
+import {
+  type EditableField,
+  effectiveEscalationChains,
+  ESCALATION_ENTRY_HINT,
+  HARNESS_HINTS,
+} from '@src/application/ui/tui/views/settings-view-model.ts';
 
 export interface HarnessRowProps {
   readonly title: string;
@@ -22,33 +28,34 @@ export interface HarnessRowProps {
   readonly valueFor: (key: string) => React.ReactNode;
 }
 
-export const HarnessRow = ({ title, fields, valueFor }: HarnessRowProps): React.JSX.Element => (
-  <Card title={title} tone="primary">
-    <FieldList
-      fields={fields.map((f) => {
-        if (f.kind === 'readonly-map') {
-          const hint = ESCALATION_MAP_CLI_HINT;
-          const value: React.ReactNode =
-            f.entries.length === 0 ? (
-              <Text dimColor>none {glyphs.emDash} defaults apply</Text>
-            ) : (
-              <Box flexDirection="column">
-                {f.entries.map(({ from, to }) => (
-                  <Text key={from} dimColor>
-                    {from} {glyphs.arrowRight} {to}
-                  </Text>
-                ))}
-              </Box>
-            );
-          return { label: f.label, value, hint };
-        }
-        const hint = HARNESS_HINTS[f.key];
-        return {
-          label: f.label,
-          value: valueFor(f.key),
-          ...(hint !== undefined ? { hint } : {}),
-        };
-      })}
-    />
-  </Card>
-);
+export const HarnessRow = ({ title, fields, valueFor }: HarnessRowProps): React.JSX.Element => {
+  // The map-entry fields ARE the persisted overrides — derive instead of threading a prop.
+  const overrides = Object.fromEntries(
+    fields.flatMap((f) => (f.kind === 'map-entry' ? [[f.from, f.to] as const] : []))
+  );
+  const chains = effectiveEscalationChains(overrides);
+  return (
+    <Card title={title} tone="primary">
+      <FieldList
+        fields={fields.map((f) => {
+          const hint = f.kind === 'map-entry' ? ESCALATION_ENTRY_HINT : HARNESS_HINTS[f.key];
+          return {
+            label: f.label,
+            value: valueFor(f.key),
+            ...(hint !== undefined ? { hint } : {}),
+          };
+        })}
+      />
+      <Box flexDirection="column" marginTop={1}>
+        <Text dimColor>Effective ladder (built-in {glyphs.bullet} overrides win):</Text>
+        {chains.map((chain) => (
+          <Text key={chain.models[0]} dimColor>
+            {'  '}
+            {chain.models.join(` ${glyphs.arrowRight} `)}
+            {chain.customised ? ' (customised)' : ''}
+          </Text>
+        ))}
+      </Box>
+    </Card>
+  );
+};

--- a/src/application/ui/tui/views/home-internals/menu-items.ts
+++ b/src/application/ui/tui/views/home-internals/menu-items.ts
@@ -52,7 +52,7 @@ export const buildMenuItems = (input: BuildMenuItemsInput): readonly MenuItem[] 
     });
   }
 
-  for (const s of input.recentSprints) {
+  for (const [idx, s] of input.recentSprints.entries()) {
     const ticketsSuffix = `${String(s.tickets.length)} ticket${s.tickets.length === 1 ? '' : 's'}`;
     const description =
       s.id === input.currentSprint?.id
@@ -63,6 +63,10 @@ export const buildMenuItems = (input: BuildMenuItemsInput): readonly MenuItem[] 
       section: 'switch sprint',
       label: s.name,
       description,
+      // Digit quick-switch — recentSprints is capped at 5 (RECENT_SPRINTS_LIMIT), so 1–5
+      // always suffice. Deliberately NOT a globalHotkey: ActionMenu owns the binding, so the
+      // digits work on Home only and never collide with other views' keys.
+      hotkey: String(idx + 1),
       onSelect: (): void => {
         if (s.id === input.selectionSprintId) return;
         // setSprint updates `selection.lastSwitch`, which drives the transient toast line

--- a/src/application/ui/tui/views/home-view.tsx
+++ b/src/application/ui/tui/views/home-view.tsx
@@ -22,18 +22,10 @@ import { ActionMenu } from '@src/application/ui/tui/components/action-menu.tsx';
 import { inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
-import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
-import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
-import { type AppStateSnapshot, loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import { useAppStateSnapshot } from '@src/application/ui/tui/runtime/use-app-state-snapshot.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
-import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
-import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
-import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
-import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
-import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
-import { sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
-import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
+import { useLaunchCreateSprint } from '@src/application/ui/tui/runtime/use-launch-create-sprint.ts';
 import { StateCard } from '@src/application/ui/tui/views/home-internals/state-card.tsx';
 import { buildMenuItems } from '@src/application/ui/tui/views/home-internals/menu-items.ts';
 
@@ -47,24 +39,10 @@ const SWITCH_FEEDBACK_MS = 3000;
 
 export const HomeView = (): React.JSX.Element => {
   const router = useRouter();
-  const deps = useDeps();
   const ui = useUiState();
   const selection = useSelection();
-  const sessions = useSessionManager();
-  const queue = usePromptQueue();
-  const storage = useStorage();
 
-  const { state } = useAsyncLoad<AppStateSnapshot>(
-    () =>
-      loadAppStateSnapshot(
-        { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-        {
-          ...(selection.projectId !== undefined ? { projectId: selection.projectId } : {}),
-          ...(selection.sprintId !== undefined ? { sprintId: selection.sprintId } : {}),
-        }
-      ),
-    [selection.projectId, selection.sprintId]
-  );
+  const { state } = useAppStateSnapshot();
 
   const snapshot = state.kind === 'ok' ? state.value : undefined;
   const hasProject = snapshot?.project !== undefined;
@@ -139,42 +117,10 @@ export const HomeView = (): React.JSX.Element => {
   // Launch create-sprint via the shared sprint-bound launcher. Reseat-on-completion fires
   // `selection.setSprint` — which writes to `lastSwitch` and feeds the toast line. Failures
   // (no project) flash a local error instead.
-  const launchCreateSprint = useCallback(async (): Promise<void> => {
-    if (selection.projectId === undefined) {
-      flashErr('✗ pick a project first (Projects → open one)');
-      return;
-    }
-    const snap = await loadAppStateSnapshot(
-      { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-      { projectId: selection.projectId }
-    );
-    const interactive = createInkInteractivePrompt(queue);
-    const result = await launchSprintBoundFlow(
-      { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
-      'create-sprint',
-      snap,
-      {
-        onReseat: ({ id, name, status }) => {
-          selection.setSprint(id, name, status);
-        },
-        onSprintResolved: (runnerId, { id, name }) => {
-          sessions.setPinnedSprint(runnerId, id, name);
-        },
-      }
-    );
-    if (!result.ok) {
-      flashErr(`✗ ${result.reason}`);
-      return;
-    }
-    sessions.register({
-      runner: result.runner,
-      flowId: 'create-sprint',
-      title: result.title,
-      ...sessionHintsFromLaunchResult(result),
-    });
-    void result.runner.start();
-    router.push({ id: 'execute', props: { sessionId: result.runner.id } });
-  }, [deps, queue, storage, sessions, router, selection, flashErr]);
+  const launchCreateSprint = useLaunchCreateSprint({
+    onError: flashErr,
+    noProjectMessage: '✗ pick a project first (Projects → open one)',
+  });
 
   // Inline-shortcut + `+` hotkey. We watch for `+` outside the ActionMenu's hotkey machinery
   // because `+` is shift-bound on many keyboards (not portable as a registered MenuItem hotkey

--- a/src/application/ui/tui/views/home-view.tsx
+++ b/src/application/ui/tui/views/home-view.tsx
@@ -15,7 +15,7 @@
  * orchestrates state + effects + key handling.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { ActionMenu } from '@src/application/ui/tui/components/action-menu.tsx';
@@ -69,6 +69,15 @@ export const HomeView = (): React.JSX.Element => {
   const snapshot = state.kind === 'ok' ? state.value : undefined;
   const hasProject = snapshot?.project !== undefined;
   const currentSprint = snapshot?.sprint;
+
+  // Refresh the cached breadcrumb status chip from every fresh snapshot load — flows route
+  // back to Home after a run settles, so this is where a plan/implement/close transition
+  // first becomes visible. syncSprintStatus no-ops unless the loaded sprint is still the
+  // selected one, so firing on every load is safe.
+  const syncSprintStatus = selection.syncSprintStatus;
+  useEffect(() => {
+    if (currentSprint !== undefined) syncSprintStatus(currentSprint.id, currentSprint.status);
+  }, [currentSprint, syncSprintStatus]);
   // Stabilise the empty-array fallback so downstream `useMemo`s keyed on `recentSprints` don't
   // re-run whenever this render's `??` would allocate a fresh `[]`.
   const recentSprints = useMemo(() => snapshot?.recentSprints ?? [], [snapshot?.recentSprints]);
@@ -104,7 +113,10 @@ export const HomeView = (): React.JSX.Element => {
 
   // Re-render once when the switch window expires so the toast disappears without waiting for
   // an external trigger. `+ 50ms` slack avoids edge cases where the timer fires fractionally
-  // before the freshness check resolves to "stale".
+  // before the freshness check resolves to "stale". A real reducer bump is required: an
+  // identity updater like `setLocalError((curr) => curr)` bails out of the re-render under
+  // React's Object.is check, leaving the toast painted forever on an otherwise idle Home.
+  const [, forceRender] = useReducer((n: number) => n + 1, 0);
   const lastSwitch = selection.lastSwitch;
   useEffect(() => {
     if (lastSwitch === undefined) return undefined;
@@ -112,9 +124,9 @@ export const HomeView = (): React.JSX.Element => {
     const remaining = SWITCH_FEEDBACK_MS - elapsed;
     if (remaining <= 0) return undefined;
     const id = setTimeout(() => {
-      // Re-render via a no-op state churn. The render itself reads the freshness window —
-      // there's nothing to flip on this side beyond forcing a paint.
-      setLocalError((curr) => curr);
+      // The render itself reads the freshness window — there's nothing to flip on this side
+      // beyond forcing a paint.
+      forceRender();
     }, remaining + 50);
     return (): void => clearTimeout(id);
   }, [lastSwitch]);

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -18,7 +18,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
@@ -26,15 +26,8 @@ import { useSelection } from '@src/application/ui/tui/runtime/selection-context.
 import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
-import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
-import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
-import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
-import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
-import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
-import { sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
-import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
-import { loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import { useLaunchCreateSprint } from '@src/application/ui/tui/runtime/use-launch-create-sprint.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
@@ -68,9 +61,6 @@ export const PickSprintView = (): React.JSX.Element => {
   const router = useRouter();
   const selection = useSelection();
   const ui = useUiState();
-  const sessions = useSessionManager();
-  const queue = usePromptQueue();
-  const storage = useStorage();
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
   const [scopeAll, setScopeAll] = useState<boolean>(true);
   // Default OFF — closed sprints stay reachable here by contract (the Home shortcut list
@@ -192,42 +182,10 @@ export const PickSprintView = (): React.JSX.Element => {
   // Route create-sprint through the shared sprint-bound launcher so the post-completion
   // selection reseat lives in one place (see launch/sprint-bound.ts). Failures surface inline;
   // success pushes the execute view.
-  const launchCreateSprint = async (): Promise<void> => {
-    if (selection.projectId === undefined) {
-      setFeedback('✗ select a project first');
-      return;
-    }
-    const snapshot = await loadAppStateSnapshot(
-      { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-      { projectId: selection.projectId }
-    );
-    const interactive = createInkInteractivePrompt(queue);
-    const result = await launchSprintBoundFlow(
-      { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
-      'create-sprint',
-      snapshot,
-      {
-        onReseat: ({ id, name, status }) => {
-          selection.setSprint(id, name, status);
-        },
-        onSprintResolved: (runnerId, { id, name }) => {
-          sessions.setPinnedSprint(runnerId, id, name);
-        },
-      }
-    );
-    if (!result.ok) {
-      setFeedback(`✗ ${result.reason}`);
-      return;
-    }
-    sessions.register({
-      runner: result.runner,
-      flowId: 'create-sprint',
-      title: result.title,
-      ...sessionHintsFromLaunchResult(result),
-    });
-    void result.runner.start();
-    router.push({ id: 'execute', props: { sessionId: result.runner.id } });
-  };
+  const launchCreateSprint = useLaunchCreateSprint({
+    onError: setFeedback,
+    noProjectMessage: '✗ select a project first',
+  });
 
   const toggleScope = (): void => {
     const next = !scopeAll;
@@ -299,13 +257,9 @@ export const PickSprintView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading sprints…" />
-        </Box>
+        <LoadingRow label="Loading sprints…" />
       ) : state.kind === 'error' ? (
-        <Box paddingX={spacing.indent}>
-          <Text color={inkColors.error}>Failed to load sprints.</Text>
-        </Box>
+        <LoadErrorRow message="Failed to load sprints." color={inkColors.error} />
       ) : sprintCount === 0 ? (
         <Box flexDirection="column" paddingX={spacing.indent}>
           {hiddenByDoneFilter ? (

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -3,7 +3,8 @@
  * can switch project + sprint in one keystroke. Loads both repositories in parallel; orders
  * groups with the current project first, then alphabetical by project label; newest sprint
  * first within each group (UUIDv7 sort, reversed). `t` toggles between "all projects" (the
- * default) and "current project only".
+ * default) and "current project only"; `f` hides done sprints (default off — closed sprints
+ * stay reachable here by contract).
  *
  * Picking a sprint that belongs to a different project than the current selection calls
  * `selection.setProjectAndSprint` so both ids switch in a single state batch — chaining
@@ -72,9 +73,13 @@ export const PickSprintView = (): React.JSX.Element => {
   const storage = useStorage();
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
   const [scopeAll, setScopeAll] = useState<boolean>(true);
+  // Default OFF — closed sprints stay reachable here by contract (the Home shortcut list
+  // already filters them; this picker is the documented way back to a done sprint).
+  const [hideDone, setHideDone] = useState<boolean>(false);
   useViewHints([
     { keys: '↵', label: 'use sprint' },
     { keys: 't', label: 'toggle scope' },
+    { keys: 'f', label: hideDone ? 'show done' : 'hide done' },
     { keys: '+', label: 'create new' },
     { keys: 'r', label: 'reload' },
   ]);
@@ -102,13 +107,33 @@ export const PickSprintView = (): React.JSX.Element => {
     [state]
   );
 
-  const groups = useMemo(() => buildGroups(data, selection.projectId, scopeAll), [data, selection.projectId, scopeAll]);
+  // Shared filtered view — BOTH the group build below and the `t`-toggle cursor reseat must
+  // derive from the same list, or toggling scope would reseat the cursor against unfiltered
+  // rows while the screen renders filtered ones.
+  const visibleData: PickerData = useMemo(
+    () => (hideDone ? { ...data, sprints: data.sprints.filter((s) => s.status !== 'done') } : data),
+    [data, hideDone]
+  );
+
+  const groups = useMemo(
+    () => buildGroups(visibleData, selection.projectId, scopeAll),
+    [visibleData, selection.projectId, scopeAll]
+  );
   // Only inject the `+ Create new sprint` action row when a project is selected — without one
   // there's nothing to create the sprint against, so the synthetic row would just surface a
   // "select a project first" error on Enter. Skipping it keeps the picker honest.
   const includeCreate = selection.projectId !== undefined;
   const rows = useMemo(() => flatten(groups, includeCreate), [groups, includeCreate]);
   const sprintCount = useMemo(() => rows.reduce((acc, r) => (r.kind === 'sprint' ? acc + 1 : acc), 0), [rows]);
+
+  // Distinguish "the f filter hid everything in scope" from a genuinely empty scope so the
+  // empty state names the right escape hatch (press f vs press +). Checked against the
+  // UNfiltered data under the same project scope — `data.sprints` alone would miscount when
+  // another project's sprints exist outside the current scope.
+  const hiddenByDoneFilter = useMemo(() => {
+    if (!hideDone || sprintCount > 0) return false;
+    return flatten(buildGroups(data, selection.projectId, scopeAll), false).some((r) => r.kind === 'sprint');
+  }, [hideDone, sprintCount, data, selection.projectId, scopeAll]);
 
   // Window the rendered slice so a user with hundreds of sprints across many projects doesn't
   // pay an Ink reconciliation cost proportional to the full row list. Capacity tracks terminal
@@ -209,7 +234,7 @@ export const PickSprintView = (): React.JSX.Element => {
     setScopeAll(next);
     // Recompute the cursor: prefer the already-selected sprint, then the first sprint row,
     // then the create row (only relevant on a totally empty picker).
-    const nextRows = flatten(buildGroups(data, selection.projectId, next), includeCreate);
+    const nextRows = flatten(buildGroups(visibleData, selection.projectId, next), includeCreate);
     let idx = -1;
     if (selection.sprintId !== undefined) {
       idx = nextRows.findIndex((r) => r.kind === 'sprint' && r.sprint.id === selection.sprintId);
@@ -258,6 +283,10 @@ export const PickSprintView = (): React.JSX.Element => {
       toggleScope();
       return;
     }
+    if (input === 'f') {
+      setHideDone((v) => !v);
+      return;
+    }
     if (input === '+' || input === 'c') {
       void launchCreateSprint();
       return;
@@ -279,10 +308,19 @@ export const PickSprintView = (): React.JSX.Element => {
         </Box>
       ) : sprintCount === 0 ? (
         <Box flexDirection="column" paddingX={spacing.indent}>
-          <Text>No sprints yet.</Text>
-          <Text dimColor>
-            {scopeAll ? 'Press + to create one.' : 'Press t to show all projects, or + to create one.'}
-          </Text>
+          {hiddenByDoneFilter ? (
+            <>
+              <Text>All sprints here are done (hidden).</Text>
+              <Text dimColor>Press f to show them, or + to create a new one.</Text>
+            </>
+          ) : (
+            <>
+              <Text>No sprints yet.</Text>
+              <Text dimColor>
+                {scopeAll ? 'Press + to create one.' : 'Press t to show all projects, or + to create one.'}
+              </Text>
+            </>
+          )}
         </Box>
       ) : (
         <Box flexDirection="column">
@@ -305,8 +343,8 @@ export const PickSprintView = (): React.JSX.Element => {
           <RowWindowView rows={rows} cursor={cursor} visibleRows={visibleRows} currentSprintId={selection.sprintId} />
           <Box marginTop={spacing.section} paddingX={spacing.indent}>
             <Text dimColor>
-              {glyphs.bullet} ↵ use the highlighted sprint {glyphs.bullet} t toggle scope {glyphs.bullet} + create a new
-              one
+              {glyphs.bullet} ↵ use the highlighted sprint {glyphs.bullet} t toggle scope {glyphs.bullet} f{' '}
+              {hideDone ? 'show' : 'hide'} done {glyphs.bullet} + create a new one
             </Text>
           </Box>
           {feedback !== undefined && (

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -1,6 +1,10 @@
 /**
  * Project detail — info card + repository roster + per-repo health (paths + scripts). Pressing
  * `r` jumps to this project's sprints; `n` opens the flow launcher with this project current.
+ *
+ * Opening the detail is a BROWSE — it never switches the current selection (a project switch
+ * clears the sprint cursor as a side effect). Press `m` to make the viewed project current,
+ * mirroring the sprint-detail view's explicit opt-in.
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
@@ -62,14 +66,21 @@ export const ProjectDetailView = (): React.JSX.Element => {
     return r.value;
   }, [projectId]);
 
-  // Once the project loads, stamp its display name into the selection cache so the status bar
-  // can show "proj: <name>" without re-loading the aggregate. Direct routes (deep links from
-  // suggestions) may not have stamped a label yet.
+  // Once the project loads, refresh the display-name label in the selection cache so the
+  // status bar can show "proj: <name>" without re-loading the aggregate — but ONLY for the
+  // project that is already current. Re-stamping a *different* project here would switch the
+  // selection (and clear the sprint cursor) as a side effect of merely browsing its detail;
+  // the explicit `m` chord below is the only path that switches.
   const selection = useSelection();
   const setProjectRef = React.useRef(selection.setProject);
   setProjectRef.current = selection.setProject;
+  const selectionProjectIdRef = React.useRef(selection.projectId);
+  selectionProjectIdRef.current = selection.projectId;
   React.useEffect(() => {
-    if (state.kind === 'ok') setProjectRef.current(state.value.id, state.value.displayName);
+    if (state.kind !== 'ok') return;
+    if (selectionProjectIdRef.current === state.value.id) {
+      setProjectRef.current(state.value.id, state.value.displayName);
+    }
   }, [state]);
 
   const [cursorIdx, setCursorIdx] = useState(0);
@@ -105,6 +116,9 @@ export const ProjectDetailView = (): React.JSX.Element => {
   useViewHints([
     { keys: '↑/↓', label: 'navigate' },
     { keys: '↵', label: 'confirm/select' },
+    // Surface the `m` chord only while the viewed project is not already current — once they
+    // match the action is a no-op and the hint adds noise (mirrors sprint-detail).
+    { keys: 'm', label: 'current', enabledWhen: project !== undefined && selection.projectId !== project.id },
     { keys: 'e', label: 'edit field', enabledWhen: focused !== undefined },
     { keys: 'a', label: 'add repo' },
     { keys: 'd', label: 'remove repo', enabledWhen: focusedRepo },
@@ -217,6 +231,15 @@ export const ProjectDetailView = (): React.JSX.Element => {
     if (ui.helpOpen || ui.promptActive || confirmRemove !== undefined || project === undefined) return;
     if (input === 'a') {
       router.push({ id: 'add-repository', props: { projectId: project.id } });
+      return;
+    }
+    if (input === 'm') {
+      // Explicit "make this project current" — the deliberate counterpart to the browse-only
+      // open. No-op if already current so re-pressing doesn't churn feedback.
+      if (selection.projectId !== project.id) {
+        selection.setProject(project.id, project.displayName);
+        setFeedback(`✓ now on ${project.displayName}`);
+      }
       return;
     }
     if (input === 'e' || key.return) {

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -13,8 +13,9 @@ import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { FieldList } from '@src/application/ui/tui/components/field-list.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
-import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
+import { FeedbackLine } from '@src/application/ui/tui/components/feedback-line.tsx';
+import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { type Project, removeRepository, setProjectDisplayName, updateRepository } from '@src/domain/entity/project.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
@@ -34,7 +35,8 @@ import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.t
 import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
 import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
-import { launchFlow, sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
+import { openFlowSession } from '@src/application/ui/tui/runtime/open-flow-session.ts';
+import { launchFlow } from '@src/application/ui/shared/launcher.ts';
 import { loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 
@@ -140,10 +142,7 @@ export const ProjectDetailView = (): React.JSX.Element => {
   const launchPerRepoFlow = async (flowId: 'detect-scripts' | 'detect-skills', target: Repository): Promise<void> => {
     if (project === undefined) return;
     setFeedback(undefined);
-    const snapshot = await loadAppStateSnapshot(
-      { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-      { projectId: project.id }
-    );
+    const snapshot = await loadAppStateSnapshot(deps, { projectId: project.id });
     const interactive = createInkInteractivePrompt(queue);
     const result = await launchFlow(
       { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
@@ -155,14 +154,7 @@ export const ProjectDetailView = (): React.JSX.Element => {
       setFeedback(`✗ ${result.reason}`);
       return;
     }
-    sessions.register({
-      runner: result.runner,
-      flowId,
-      title: result.title,
-      ...sessionHintsFromLaunchResult(result),
-    });
-    void result.runner.start();
-    router.push({ id: 'execute', props: { sessionId: result.runner.id } });
+    openFlowSession({ sessions, router }, result, flowId);
   };
 
   const renderEditPrompt = (target: EditTarget): OpenEditPromptInput | undefined => {
@@ -275,10 +267,6 @@ export const ProjectDetailView = (): React.JSX.Element => {
     }
   });
 
-  // Claim the global-key mute while the confirm prompt is mounted.
-  const claimPrompt = ui.claimPrompt;
-  useEffect(() => (confirmRemove !== undefined ? claimPrompt() : undefined), [confirmRemove, claimPrompt]);
-
   const handleRemoveConfirmed = async (target: Repository, confirmed: boolean): Promise<void> => {
     setConfirmRemove(undefined);
     if (!confirmed || project === undefined) return;
@@ -296,28 +284,21 @@ export const ProjectDetailView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading…" />
-        </Box>
+        <LoadingRow label="Loading…" />
       ) : state.kind === 'error' ? (
-        <Box paddingX={spacing.indent}>
-          <Text>Failed to load project.</Text>
-        </Box>
+        <LoadErrorRow message="Failed to load project." />
       ) : confirmRemove !== undefined ? (
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          <Text>
-            Remove repository <Text bold>{confirmRemove.name}</Text> from this project?
-          </Text>
-          <Text dimColor>Files on disk are not touched.</Text>
-          <Box marginTop={1}>
-            <ConfirmPrompt
-              message="Remove?"
-              defaultYes={false}
-              onSubmit={(value) => void handleRemoveConfirmed(confirmRemove, value)}
-              onCancel={() => setConfirmRemove(undefined)}
-            />
-          </Box>
-        </Box>
+        <ConfirmCard
+          title={
+            <Text>
+              Remove repository <Text bold>{confirmRemove.name}</Text> from this project?
+            </Text>
+          }
+          body={<Text dimColor>Files on disk are not touched.</Text>}
+          message="Remove?"
+          onSubmit={(value) => void handleRemoveConfirmed(confirmRemove, value)}
+          onCancel={() => setConfirmRemove(undefined)}
+        />
       ) : (
         <Body project={state.value} focused={focused} feedback={feedback ?? edit.feedback} />
       )}
@@ -417,11 +398,7 @@ const Body = ({ project, focused, feedback }: BodyProps): React.JSX.Element => {
         {/* Key affordances are published through the router's hint strip (`useViewHints`), the
             single source of truth that gates the repo-only `d`/`c`/`S` chords on the focused row.
             An inline duplicate would re-advertise them ungated and contradict the gate. */}
-        {feedback !== undefined && (
-          <Box paddingX={spacing.indent} marginTop={1}>
-            <Text color={feedback.startsWith('✗') ? inkColors.error : inkColors.primary}>{feedback}</Text>
-          </Box>
-        )}
+        <FeedbackLine text={feedback} />
       </Box>
     </Box>
   );

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -1,10 +1,11 @@
 /**
  * Project detail — info card + repository roster + per-repo health (paths + scripts). Pressing
- * `r` jumps to this project's sprints; `n` opens the flow launcher with this project current.
+ * `r` opens the Sprints list (scoped to the current selection); `n` opens the flow launcher.
  *
  * Opening the detail is a BROWSE — it never switches the current selection (a project switch
  * clears the sprint cursor as a side effect). Press `m` to make the viewed project current,
- * mirroring the sprint-detail view's explicit opt-in.
+ * mirroring the sprint-detail view's explicit opt-in — `m` then `r` reaches the viewed
+ * project's sprints.
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
@@ -264,6 +265,13 @@ export const ProjectDetailView = (): React.JSX.Element => {
     }
     if (input === 'S' && focused?.kind === 'repo') {
       void launchPerRepoFlow('detect-skills', focused.repo);
+      return;
+    }
+    if (input === 'r') {
+      // The hint has advertised `r — sprints` since this view shipped, but no handler ever
+      // existed. Plain navigation: the Sprints list scopes to the current selection (press
+      // `m` first to scope it to the viewed project).
+      router.push({ id: 'sprints' });
     }
   });
 

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -1,7 +1,9 @@
 /**
  * Projects list — read-only enumeration of every project in storage. Selecting a row pushes
- * the project detail view and stamps the selection cursor on the row's id, so subsequent
- * sprint-related navigation stays scoped to the right project.
+ * the project detail view to BROWSE it; browsing never switches the current selection (a
+ * project switch clears the sprint cursor as a side effect, so a passive look-around must not
+ * cost the user their working sprint). Press `m` on a focused row to make it current —
+ * mirroring the sprint-detail view's explicit opt-in.
  */
 
 import React, { useEffect, useState } from 'react';
@@ -33,6 +35,7 @@ export const ProjectsView = (): React.JSX.Element => {
   useViewHints([
     { keys: '↑/↓', label: 'move' },
     { keys: '↵', label: 'open' },
+    { keys: 'm', label: 'make current' },
     { keys: 'c', label: 'create' },
     { keys: 'e', label: 'rename' },
     { keys: 'd', label: 'delete' },
@@ -62,7 +65,8 @@ export const ProjectsView = (): React.JSX.Element => {
     visibleRows,
     active: listActive,
     onSubmit: (p) => {
-      selection.setProject(p.id, p.displayName);
+      // Browse only — opening a detail view must not switch the selection (and wipe the
+      // sprint cursor). `m` below is the explicit make-current action.
       router.push({ id: 'project-detail', props: { projectId: p.id } });
     },
   });
@@ -90,6 +94,16 @@ export const ProjectsView = (): React.JSX.Element => {
     if (ui.helpOpen || ui.promptActive || confirmDelete !== undefined) return;
     if (input === 'c') {
       router.push({ id: 'create-project' });
+      return;
+    }
+    if (input === 'm') {
+      // Explicit make-current — switching projects clears the sprint cursor by design, so
+      // this is the deliberate action, not a side effect of browsing.
+      const target = focusedItem ?? items[0];
+      if (target !== undefined && selection.projectId !== target.id) {
+        selection.setProject(target.id, target.displayName);
+        setFeedback(`✓ now on ${target.displayName}`);
+      }
       return;
     }
     if (input === 'e') {
@@ -126,7 +140,7 @@ export const ProjectsView = (): React.JSX.Element => {
   };
 
   return (
-    <ViewShell title="Projects" subtitle="Pick a project to make it the current selection" suppressScrollArrows>
+    <ViewShell title="Projects" subtitle="Browse projects — press m to make one current" suppressScrollArrows>
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
@@ -205,7 +219,8 @@ export const ProjectsView = (): React.JSX.Element => {
           <Box paddingX={spacing.indent} marginTop={spacing.section}>
             <Text dimColor>
               {glyphs.bullet} {state.value.length} project(s) {glyphs.bullet} ↑/↓ move {glyphs.bullet} ↵ open{' '}
-              {glyphs.bullet} c create {glyphs.bullet} e rename {glyphs.bullet} d delete {glyphs.bullet} r reload
+              {glyphs.bullet} m make current {glyphs.bullet} c create {glyphs.bullet} e rename {glyphs.bullet} d delete{' '}
+              {glyphs.bullet} r reload
             </Text>
           </Box>
           {(feedback ?? edit.feedback) !== undefined && (

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -6,13 +6,14 @@
  * mirroring the sprint-detail view's explicit opt-in.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
 import { EmptyState } from '@src/application/ui/tui/components/empty-state.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
-import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
+import { FeedbackLine } from '@src/application/ui/tui/components/feedback-line.tsx';
+import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { type Project, setProjectDisplayName } from '@src/domain/entity/project.ts';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { Result } from '@src/domain/result.ts';
@@ -122,10 +123,6 @@ export const ProjectsView = (): React.JSX.Element => {
     }
   });
 
-  // Claim the global-key mute while the confirm prompt is mounted.
-  const claimPrompt = ui.claimPrompt;
-  useEffect(() => (confirmDelete !== undefined ? claimPrompt() : undefined), [confirmDelete, claimPrompt]);
-
   const handleDeleteConfirmed = async (target: Project, confirmed: boolean): Promise<void> => {
     setConfirmDelete(undefined);
     if (!confirmed) return;
@@ -144,28 +141,21 @@ export const ProjectsView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading projects…" />
-        </Box>
+        <LoadingRow label="Loading projects…" />
       ) : state.kind === 'error' ? (
-        <Box paddingX={spacing.indent}>
-          <Text>Failed to load projects.</Text>
-        </Box>
+        <LoadErrorRow message="Failed to load projects." />
       ) : confirmDelete !== undefined ? (
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          <Text>
-            Remove project <Text bold>{confirmDelete.displayName}</Text>?
-          </Text>
-          <Text dimColor>Sprints and repository contents are not touched.</Text>
-          <Box marginTop={1}>
-            <ConfirmPrompt
-              message="Delete?"
-              defaultYes={false}
-              onSubmit={(value) => void handleDeleteConfirmed(confirmDelete, value)}
-              onCancel={() => setConfirmDelete(undefined)}
-            />
-          </Box>
-        </Box>
+        <ConfirmCard
+          title={
+            <Text>
+              Remove project <Text bold>{confirmDelete.displayName}</Text>?
+            </Text>
+          }
+          body={<Text dimColor>Sprints and repository contents are not touched.</Text>}
+          message="Delete?"
+          onSubmit={(value) => void handleDeleteConfirmed(confirmDelete, value)}
+          onCancel={() => setConfirmDelete(undefined)}
+        />
       ) : state.value.length === 0 ? (
         <EmptyState
           title="No projects yet"
@@ -223,13 +213,7 @@ export const ProjectsView = (): React.JSX.Element => {
               {glyphs.bullet} r reload
             </Text>
           </Box>
-          {(feedback ?? edit.feedback) !== undefined && (
-            <Box paddingX={spacing.indent} marginTop={1}>
-              <Text color={(feedback ?? edit.feedback)?.startsWith('✗') ? inkColors.error : inkColors.primary}>
-                {feedback ?? edit.feedback}
-              </Text>
-            </Box>
-          )}
+          <FeedbackLine text={feedback ?? edit.feedback} />
         </Box>
       )}
     </ViewShell>

--- a/src/application/ui/tui/views/settings-editor.tsx
+++ b/src/application/ui/tui/views/settings-editor.tsx
@@ -3,14 +3,27 @@
  * with the provider-picker availability gate layered on top of the bare `SelectPrompt`.
  * Provider rows surface dimmed `(not installed)` options + an install-command footer; every
  * other select stays plain.
+ *
+ * Escalation-map fields get dedicated treatment:
+ *  - `map-entry` mounts a target picker scoped to catalogs containing the rung's from-model,
+ *    plus a `(remove this override)` choice that submits the empty string (the apply-key
+ *    grammar's delete semantic).
+ *  - `map-add` walks a two-step picker — FROM model, then TO model — and submits the pair as
+ *    `from=to`. Esc on the second step returns to the first instead of abandoning the add.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { SelectPrompt } from '@src/application/ui/tui/prompts/select-prompt.tsx';
 import { TextPrompt } from '@src/application/ui/tui/prompts/text-prompt.tsx';
 import { primaryInstallCommand } from '@src/integration/system/detect-cli.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
-import { type EditableField, isProviderField } from '@src/application/ui/tui/views/settings-view-model.ts';
+import {
+  type EditableField,
+  escalationModelOptions,
+  escalationTargetsFor,
+  isProviderField,
+} from '@src/application/ui/tui/views/settings-view-model.ts';
 
 interface ProviderChoice {
   readonly label: string;
@@ -55,12 +68,62 @@ export interface SettingsEditorProps {
   readonly onCancel: () => void;
 }
 
+/**
+ * Two-step from/to picker for a new escalation rung. Local state holds the chosen FROM model
+ * while the TO picker is mounted; the component is remounted per edit (the orchestrator keys
+ * the editor on the active field) so the state never leaks across edits.
+ */
+const EscalationAddEditor = ({
+  onSubmit,
+  onCancel,
+}: {
+  readonly onSubmit: (value: string) => void;
+  readonly onCancel: () => void;
+}): React.JSX.Element => {
+  const [fromModel, setFromModel] = useState<string | undefined>(undefined);
+  if (fromModel === undefined) {
+    return (
+      <SelectPrompt
+        message="Escalate FROM which model? (step 1/2)"
+        options={escalationModelOptions().map((value) => ({ label: value, value }))}
+        onSubmit={(value) => setFromModel(String(value))}
+        onCancel={onCancel}
+      />
+    );
+  }
+  return (
+    <SelectPrompt
+      message={`${fromModel} ${glyphs.arrowRight} which model? (step 2/2)`}
+      options={escalationTargetsFor(fromModel).map((value) => ({ label: value, value }))}
+      footer="esc goes back to the from-model pick"
+      onSubmit={(value) => onSubmit(`${fromModel}=${String(value)}`)}
+      onCancel={() => setFromModel(undefined)}
+    />
+  );
+};
+
 export const SettingsEditor = ({
   field,
   installedProviders,
   onSubmit,
   onCancel,
 }: SettingsEditorProps): React.JSX.Element => {
+  if (field.kind === 'map-add') {
+    return <EscalationAddEditor onSubmit={onSubmit} onCancel={onCancel} />;
+  }
+  if (field.kind === 'map-entry') {
+    return (
+      <SelectPrompt
+        message={`${field.from} escalates to (current: ${field.to})`}
+        options={[
+          ...escalationTargetsFor(field.from).map((value) => ({ label: value, value })),
+          { label: '(remove this override)', value: '' },
+        ]}
+        onSubmit={(value) => onSubmit(String(value))}
+        onCancel={onCancel}
+      />
+    );
+  }
   if (field.kind === 'select') {
     if (isProviderField(field)) {
       const { choices, footer } = buildProviderOptions(field.options, installedProviders);

--- a/src/application/ui/tui/views/settings-mutations.ts
+++ b/src/application/ui/tui/views/settings-mutations.ts
@@ -12,11 +12,12 @@ import { createSettingsApplyPresetFlow } from '@src/application/flows/settings-a
 import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.ts';
 import { createSettingsSetProviderFlow } from '@src/application/flows/settings-set-provider/flow.ts';
 import type { PresetWarning } from '@src/application/flows/settings-apply-preset/ctx.ts';
-import { applySettingsKey } from '@src/business/settings/apply-key.ts';
+import { applySettingsKey, parseSettingsKvSyntax } from '@src/business/settings/apply-key.ts';
 import type { PresetName } from '@src/business/settings/presets.ts';
 import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { capitalize, DEFAULT_TOKEN, type EditableField } from '@src/application/ui/tui/views/settings-view-model.ts';
 
 export type MutationOutcome =
@@ -57,13 +58,44 @@ export const submitField = async (
     const label = role !== undefined ? `Implement (${role})` : capitalize(flow);
     return { kind: 'ok', text: `${label} provider = ${raw} · model reset to default` };
   }
+  // Escalation-map fields: the add-row submits a `from=to` pair (built by the two-step
+  // picker); per-entry rows submit a bare target — empty string deletes (the apply-key
+  // grammar's clear semantic). Both reuse the same `harness.escalationMap.<from>` key the
+  // CLI's `settings set` speaks, so the mutation grammar stays one truth.
+  if (field.kind === 'map-add') {
+    const pair = parseSettingsKvSyntax(raw);
+    if (pair === undefined || pair.value.length === 0) {
+      return { kind: 'error', text: `malformed escalation pair '${raw}' — expected <fromModel>=<toModel>` };
+    }
+    return persistKey(settings, `harness.escalationMap.${pair.key}`, pair.value, settingsRepo, {
+      okText: `escalation rung added: ${pair.key} ${glyphs.arrowRight} ${pair.value}`,
+    });
+  }
+  if (field.kind === 'map-entry') {
+    const okText =
+      raw.trim().length === 0
+        ? `removed escalation override for ${field.from}`
+        : `escalation rung updated: ${field.from} ${glyphs.arrowRight} ${raw}`;
+    return persistKey(settings, field.key, raw, settingsRepo, { okText });
+  }
   const normalised = raw === DEFAULT_TOKEN ? '' : raw;
-  const next = applySettingsKey(settings, field.key, normalised);
+  return persistKey(settings, field.key, normalised, settingsRepo, { okText: `${field.label} = ${raw}` });
+};
+
+/** Shared applySettingsKey → settings-set tail used by every non-provider route above. */
+const persistKey = async (
+  settings: Settings,
+  key: string,
+  value: string,
+  settingsRepo: SettingsRepository,
+  opts: { readonly okText: string }
+): Promise<MutationOutcome> => {
+  const next = applySettingsKey(settings, key, value);
   if (!next.ok) return { kind: 'error', text: next.error.message };
   const setFlow = createSettingsSetFlow({ settingsRepo });
   const saved = await setFlow.execute({ input: { next: next.value } });
   if (!saved.ok) return { kind: 'error', text: saved.error.error.message };
-  return { kind: 'ok', text: `${field.label} = ${raw}`, next: next.value };
+  return { kind: 'ok', text: opts.okText, next: next.value };
 };
 
 /**

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -6,6 +6,8 @@
  */
 
 import { PRESET_NAMES, type PresetName } from '@src/business/settings/presets.ts';
+import { mergeEscalationMap } from '@src/business/task/escalation-map.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { AiFlowSettings, AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
@@ -38,17 +40,29 @@ export type EditableField =
     }
   | {
       /**
-       * Read-only map display — renders `<from> → <to>` entries or a dimmed empty-state message.
-       * Activating this field (↵/e) is a no-op. The cursor still navigates through it so the
-       * hint line stays visible; `settings-view.tsx` guards against editing it via `field.kind`.
+       * Escalation-map "add a rung" action row. Activating it (↵/e) walks a two-step picker —
+       * choose the FROM model, then the model it escalates TO — and submits the pair as
+       * `from=to`; `submitField` translates that to the `harness.escalationMap.<from>` key the
+       * CLI grammar already speaks.
        */
-      readonly kind: 'readonly-map';
+      readonly kind: 'map-add';
       readonly key: string;
       readonly label: string;
-      /** Serialised representation shown as the "current value" — rendered by the row component. */
       readonly current: string;
-      /** The raw entries to render; empty map shows the empty-state message. */
-      readonly entries: ReadonlyArray<{ readonly from: string; readonly to: string }>;
+    }
+  | {
+      /**
+       * One editable escalation-map override (`harness.escalationMap.<from>`). Activating it
+       * opens a target picker pre-scoped to catalogs containing `from`, plus a
+       * `(remove this override)` choice that submits the empty string — the apply-key grammar's
+       * delete semantic.
+       */
+      readonly kind: 'map-entry';
+      readonly key: string;
+      readonly label: string;
+      readonly current: string;
+      readonly from: string;
+      readonly to: string;
     };
 
 /**
@@ -105,6 +119,70 @@ export const HARNESS_HINTS: Readonly<Record<string, string>> = {
     'Gates ALL failure-driven escalation — plateau AND budget-exhausted exits climb the model ladder; disable to always stay on the configured model.',
   'harness.skipPreVerifyOnFreshSetup':
     'Asserts your setup script verifies the tree (builds + tests); enable only when setup is a full verify gate, not just a dependency install.',
+  'harness.escalationMap':
+    'Override or extend the built-in weaker → stronger ladder — pick the from-model, then the model it escalates to.',
+};
+
+/** Hint rendered under every escalation-map override row (keys are dynamic, so not in the map above). */
+export const ESCALATION_ENTRY_HINT = 'Change the escalation target — pick (remove this override) to drop the rung.';
+
+/**
+ * Union of every provider's model catalog — the FROM options for a new escalation rung. Order:
+ * Claude, Copilot, Codex; duplicates (ids shared across catalogs) collapse to their first
+ * occurrence.
+ */
+export const escalationModelOptions = (): readonly string[] => [
+  ...new Set<string>([...CLAUDE_MODELS, ...COPILOT_MODELS, ...CODEX_MODELS]),
+];
+
+/**
+ * Target options for an escalation rung starting at `from` — the union of the catalogs that
+ * list `from`, minus `from` itself (a self-loop has no runtime effect and the schema-load path
+ * only warns). Scoping targets to the same catalog family keeps the picker from inviting
+ * cross-provider ids the generator's CLI could never spawn. A `from` no catalog knows (a
+ * custom id set via the CLI) falls back to the full union.
+ */
+export const escalationTargetsFor = (from: string): readonly string[] => {
+  const catalogs: ReadonlyArray<readonly string[]> = [CLAUDE_MODELS, COPILOT_MODELS, CODEX_MODELS];
+  const owning = catalogs.filter((c) => c.includes(from));
+  const pool = owning.length > 0 ? owning.flat() : catalogs.flat();
+  return [...new Set(pool)].filter((m) => m !== from);
+};
+
+export interface EscalationChain {
+  /** Model ids in climb order, e.g. `['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8']`. */
+  readonly models: readonly string[];
+  /** True when any rung on the chain comes from the user's overrides (not the built-in map). */
+  readonly customised: boolean;
+}
+
+/**
+ * The EFFECTIVE escalation ladder — user overrides merged over the built-in map — flattened
+ * into display chains. A chain starts at every model that is not itself an escalation target
+ * (a root) and follows the map until it ends or would revisit a model (user-authored cycles
+ * are cut rather than walked forever; the runtime treats cyclic rungs as top-of-ladder too).
+ */
+export const effectiveEscalationChains = (user: Readonly<Record<string, string>>): readonly EscalationChain[] => {
+  const merged = mergeEscalationMap(user);
+  const targets = new Set(Object.values(merged));
+  const chains: EscalationChain[] = [];
+  for (const root of Object.keys(merged)) {
+    if (targets.has(root)) continue;
+    const models: string[] = [root];
+    const seen = new Set<string>([root]);
+    let customised = root in user;
+    let cur = merged[root];
+    let prev = root;
+    while (cur !== undefined && !seen.has(cur)) {
+      if (user[prev] !== undefined) customised = true;
+      models.push(cur);
+      seen.add(cur);
+      prev = cur;
+      cur = merged[cur];
+    }
+    chains.push({ models, customised });
+  }
+  return chains;
 };
 
 export const modelOptionsFor = (provider: AiProvider): readonly string[] => {
@@ -189,7 +267,7 @@ export const buildSections = (
     readonly: false,
   });
 
-  const escalationMapEntries = Object.entries(s.harness.escalationMap).map(([from, to]) => ({ from, to }));
+  const escalationOverrides = Object.entries(s.harness.escalationMap);
   const harnessFields: readonly EditableField[] = [
     { kind: 'text', key: 'harness.maxTurns', label: 'Max turns', current: String(s.harness.maxTurns) },
     { kind: 'text', key: 'harness.maxAttempts', label: 'Max attempts', current: String(s.harness.maxAttempts) },
@@ -220,12 +298,27 @@ export const buildSections = (
       current: String(s.harness.skipPreVerifyOnFreshSetup),
     },
     {
-      kind: 'readonly-map',
+      kind: 'map-add',
       key: 'harness.escalationMap',
       label: 'Escalation map',
-      current: escalationMapEntries.length === 0 ? 'defaults apply' : `${String(escalationMapEntries.length)} entries`,
-      entries: escalationMapEntries,
+      current:
+        escalationOverrides.length === 0
+          ? `defaults apply ${glyphs.bullet} ↵ add rung`
+          : `${String(escalationOverrides.length)} override${escalationOverrides.length === 1 ? '' : 's'} ${glyphs.bullet} ↵ add rung`,
     },
+    // One editable row per user override, directly under the add-row so the group reads as one
+    // unit. Keys reuse the CLI grammar (`harness.escalationMap.<from>`) — submit routes through
+    // the same applySettingsKey path `settings set` uses.
+    ...escalationOverrides.map(
+      ([from, to]): EditableField => ({
+        kind: 'map-entry',
+        key: `harness.escalationMap.${from}`,
+        label: `  ${from}`,
+        current: `${glyphs.arrowRight} ${to}`,
+        from,
+        to,
+      })
+    ),
   ];
 
   const otherFields: readonly EditableField[] = [

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -189,9 +189,6 @@ export const SettingsView = (): React.JSX.Element => {
         setPendingPreset(field.preset);
         return;
       }
-      // Read-only map fields are not editable in the TUI — activating them is a no-op.
-      // The hint line already guides the user to the CLI syntax for editing.
-      if (field.kind === 'readonly-map') return;
       setPresetWarnings([]);
       setEditingField(field);
     }

--- a/src/application/ui/tui/views/sprint-detail-internals/shortcuts.ts
+++ b/src/application/ui/tui/views/sprint-detail-internals/shortcuts.ts
@@ -62,6 +62,17 @@ export const useSprintDetailShortcuts = (args: SprintDetailShortcutArgs): void =
       }
       return;
     }
+    if (input === 'n') {
+      // The view advertises `n — flows` as "scoped to this sprint", so honour it: reseat the
+      // selection onto the viewed sprint before the navigation lands. The actual route push is
+      // owned by the GLOBAL `n` handler (use-global-keys), which processes the same keystroke
+      // — this hook only fixes up the selection, so the two handlers compose instead of
+      // double-pushing the Flows view.
+      if (!args.isCurrent) {
+        args.markCurrent(sprint);
+      }
+      return;
+    }
     if ((key.downArrow || input === 'j') && args.focusList.length > 0) {
       args.moveCursor(1);
       return;

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -34,13 +34,12 @@ import { Box, Text } from 'ink';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
-import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
+import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
-import { spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
@@ -198,13 +197,10 @@ export const SprintDetailView = (): React.JSX.Element => {
     },
   });
 
-  // Mute global keys while the confirm prompt is mounted.
-  const claimPrompt = ui.claimPrompt;
-  const claimEscape = ui.claimEscape;
-  useEffect(() => (confirmRemove !== undefined ? claimPrompt() : undefined), [confirmRemove, claimPrompt]);
-
   // Claim `esc` while the detail card is open so the local handler can close the card without
-  // the global `router.pop()` racing it and dumping the user back to the Sprints list.
+  // the global `router.pop()` racing it and dumping the user back to the Sprints list. (The
+  // confirm-remove prompt mute is owned by `ConfirmCard`, which claims on mount.)
+  const claimEscape = ui.claimEscape;
   useEffect(() => (inDetail ? claimEscape() : undefined), [inDetail, claimEscape]);
 
   const handleRemoveConfirmed = async (target: Ticket, confirmed: boolean): Promise<void> => {
@@ -233,27 +229,20 @@ export const SprintDetailView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading…" />
-        </Box>
+        <LoadingRow label="Loading…" />
       ) : state.kind === 'error' ? (
-        <Box paddingX={spacing.indent}>
-          <Text>Failed to load sprint.</Text>
-        </Box>
+        <LoadErrorRow message="Failed to load sprint." />
       ) : confirmRemove !== undefined ? (
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          <Text>
-            Remove ticket <Text bold>{confirmRemove.title}</Text> from this sprint?
-          </Text>
-          <Box marginTop={1}>
-            <ConfirmPrompt
-              message="Remove?"
-              defaultYes={false}
-              onSubmit={(value) => void handleRemoveConfirmed(confirmRemove, value)}
-              onCancel={() => setConfirmRemove(undefined)}
-            />
-          </Box>
-        </Box>
+        <ConfirmCard
+          title={
+            <Text>
+              Remove ticket <Text bold>{confirmRemove.title}</Text> from this sprint?
+            </Text>
+          }
+          message="Remove?"
+          onSubmit={(value) => void handleRemoveConfirmed(confirmRemove, value)}
+          onCancel={() => setConfirmRemove(undefined)}
+        />
       ) : (
         <Body
           bundle={state.value}

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -13,9 +13,10 @@ import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { OverflowRow, useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
 import { EmptyState } from '@src/application/ui/tui/components/empty-state.tsx';
-import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
+import { FeedbackLine } from '@src/application/ui/tui/components/feedback-line.tsx';
 import { sprintStatusKind, StatusChip } from '@src/application/ui/tui/components/status-chip.tsx';
-import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
+import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { renameSprint, type Sprint } from '@src/domain/entity/sprint.ts';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { Result } from '@src/domain/result.ts';
@@ -26,14 +27,7 @@ import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
-import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
-import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
-import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
-import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
-import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
-import { sessionHintsFromLaunchResult } from '@src/application/ui/shared/launcher.ts';
-import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
-import { loadAppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import { useLaunchCreateSprint } from '@src/application/ui/tui/runtime/use-launch-create-sprint.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
@@ -45,9 +39,6 @@ export const SprintsView = (): React.JSX.Element => {
   const selection = useSelection();
   const ui = useUiState();
   const { rows } = useBreakpoint();
-  const sessions = useSessionManager();
-  const queue = usePromptQueue();
-  const storage = useStorage();
   const edit = useEditField();
 
   const { state, reload } = useAsyncLoad<readonly Sprint[]>(async () => {
@@ -122,48 +113,12 @@ export const SprintsView = (): React.JSX.Element => {
     { keys: 'u', label: `unblock (${String(stuckCount)})`, enabledWhen: stuckCount > 0 },
   ]);
 
-  // Claim the global-key mute while the confirm prompt is mounted.
-  const claimPrompt = ui.claimPrompt;
-  useEffect(() => (confirmDelete !== undefined ? claimPrompt() : undefined), [confirmDelete, claimPrompt]);
-
-  const launchCreateSprint = async (): Promise<void> => {
-    if (selection.projectId === undefined) {
-      setFeedback('✗ pick a project first (Projects → open one)');
-      return;
-    }
-    const snapshot = await loadAppStateSnapshot(
-      { projectRepo: deps.projectRepo, sprintRepo: deps.sprintRepo, taskRepo: deps.taskRepo },
-      { projectId: selection.projectId }
-    );
-    const interactive = createInkInteractivePrompt(queue);
-    // The shared sprint-bound launcher owns the post-completion `selection.setSprint` reseat
-    // — wiring it inline here would duplicate the subscriber across every sprint-bound view.
-    const result = await launchSprintBoundFlow(
-      { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
-      'create-sprint',
-      snapshot,
-      {
-        onReseat: ({ id, name, status }) => {
-          selection.setSprint(id, name, status);
-        },
-        onSprintResolved: (runnerId, { id, name }) => {
-          sessions.setPinnedSprint(runnerId, id, name);
-        },
-      }
-    );
-    if (!result.ok) {
-      setFeedback(`✗ ${result.reason}`);
-      return;
-    }
-    sessions.register({
-      runner: result.runner,
-      flowId: 'create-sprint',
-      title: result.title,
-      ...sessionHintsFromLaunchResult(result),
-    });
-    void result.runner.start();
-    router.push({ id: 'execute', props: { sessionId: result.runner.id } });
-  };
+  // The shared sprint-bound launcher owns the post-completion `selection.setSprint` reseat —
+  // wiring it inline here would duplicate the subscriber across every sprint-bound view.
+  const launchCreateSprint = useLaunchCreateSprint({
+    onError: setFeedback,
+    noProjectMessage: '✗ pick a project first (Projects → open one)',
+  });
 
   const handleRename = (target: Sprint): void => {
     setFeedback(undefined);
@@ -274,30 +229,25 @@ export const SprintsView = (): React.JSX.Element => {
       {ui.helpOpen ? (
         <HelpOverlay />
       ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading sprints…" />
-        </Box>
+        <LoadingRow label="Loading sprints…" />
       ) : state.kind === 'error' ? (
-        <Box paddingX={spacing.indent}>
-          <Text>Failed to load sprints.</Text>
-        </Box>
+        <LoadErrorRow message="Failed to load sprints." />
       ) : confirmDelete !== undefined ? (
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          <Text>
-            Remove sprint <Text bold>{confirmDelete.name}</Text>?
-          </Text>
-          <Text dimColor>
-            Cascades to its execution record + tasks. Tickets stay in the sprint history if you re-create.
-          </Text>
-          <Box marginTop={1}>
-            <ConfirmPrompt
-              message="Delete?"
-              defaultYes={false}
-              onSubmit={(value) => void handleDeleteConfirmed(confirmDelete, value)}
-              onCancel={() => setConfirmDelete(undefined)}
-            />
-          </Box>
-        </Box>
+        <ConfirmCard
+          title={
+            <Text>
+              Remove sprint <Text bold>{confirmDelete.name}</Text>?
+            </Text>
+          }
+          body={
+            <Text dimColor>
+              Cascades to its execution record + tasks. Tickets stay in the sprint history if you re-create.
+            </Text>
+          }
+          message="Delete?"
+          onSubmit={(value) => void handleDeleteConfirmed(confirmDelete, value)}
+          onCancel={() => setConfirmDelete(undefined)}
+        />
       ) : state.value.length === 0 ? (
         <EmptyState
           title="No sprints yet"
@@ -368,13 +318,7 @@ export const SprintsView = (): React.JSX.Element => {
               {glyphs.bullet} {state.value.length} sprint(s)
             </Text>
           </Box>
-          {(feedback ?? edit.feedback) !== undefined && (
-            <Box paddingX={spacing.indent} marginTop={1}>
-              <Text color={(feedback ?? edit.feedback)?.startsWith('✗') ? inkColors.error : inkColors.primary}>
-                {feedback ?? edit.feedback}
-              </Text>
-            </Box>
-          )}
+          <FeedbackLine text={feedback ?? edit.feedback} />
         </Box>
       )}
     </ViewShell>

--- a/tests/e2e/cli/sprint.test.ts
+++ b/tests/e2e/cli/sprint.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFsSprintRepository } from '@src/integration/persistence/sprint/repository.ts';
-import { makeActiveSprint, makeDraftSprint, makeReviewSprint } from '@tests/fixtures/domain.ts';
+import { createFsProjectRepository } from '@src/integration/persistence/project/repository.ts';
+import { makeActiveSprint, makeDraftSprint, makeProject, makeReviewSprint } from '@tests/fixtures/domain.ts';
 import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
 
 describe('ralphctl sprint', () => {
@@ -64,6 +65,72 @@ describe('ralphctl sprint', () => {
 
       const listAfterRemove = await runCliCaptured(cli, ['sprint', 'list']);
       expect(listAfterRemove.stdout).toContain('no sprints yet');
+    });
+  });
+
+  describe('pinned-selection defaults', () => {
+    it('set-current pins the sprint; a bare `progress` resolves it', async () => {
+      // set-current re-loads the project to keep the persisted selection coherent, so both
+      // aggregates must exist (the fixture sprint's projectId matches the fixture project's id).
+      const projectRepo = createFsProjectRepository({ root: cli.paths.dataRoot });
+      const sprintRepo = createFsSprintRepository({ root: cli.paths.dataRoot });
+      const project = makeProject();
+      const sprint = makeDraftSprint();
+      await projectRepo.save(project);
+      await sprintRepo.save(sprint);
+
+      const pin = await runCliCaptured(cli, ['sprint', 'set-current', String(sprint.id)]);
+      expect(pin.exitCode).toBe(0);
+      expect(pin.stdout).toContain('pinned current sprint');
+
+      const progress = await runCliCaptured(cli, ['sprint', 'progress']);
+      expect(progress.exitCode).toBe(0);
+      expect(progress.stdout).toContain(sprint.name);
+      expect(progress.stdout).toContain(String(sprint.id));
+    });
+
+    it('bare `progress` with no pin exits 1 with guidance', async () => {
+      const result = await runCliCaptured(cli, ['sprint', 'progress']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no current sprint pinned');
+      expect(result.stderr).toContain('sprint set-current');
+    });
+
+    it('bare `show` resolves the pin', async () => {
+      const projectRepo = createFsProjectRepository({ root: cli.paths.dataRoot });
+      const sprintRepo = createFsSprintRepository({ root: cli.paths.dataRoot });
+      await projectRepo.save(makeProject());
+      const sprint = makeDraftSprint();
+      await sprintRepo.save(sprint);
+      await runCliCaptured(cli, ['sprint', 'set-current', String(sprint.id)]);
+
+      const result = await runCliCaptured(cli, ['sprint', 'show']);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as { readonly id: string };
+      expect(parsed.id).toBe(String(sprint.id));
+    });
+
+    it('bare `show` with no pin exits 1 with guidance', async () => {
+      const result = await runCliCaptured(cli, ['sprint', 'show']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no current sprint pinned');
+    });
+
+    it('`remove` clears a dangling sprint pin (subsequent bare command exits 1)', async () => {
+      const projectRepo = createFsProjectRepository({ root: cli.paths.dataRoot });
+      const sprintRepo = createFsSprintRepository({ root: cli.paths.dataRoot });
+      await projectRepo.save(makeProject());
+      const sprint = makeDraftSprint();
+      await sprintRepo.save(sprint);
+      await runCliCaptured(cli, ['sprint', 'set-current', String(sprint.id)]);
+
+      const removed = await runCliCaptured(cli, ['sprint', 'remove', String(sprint.id)]);
+      expect(removed.exitCode).toBe(0);
+
+      // The pin no longer resolves — the default must fail with guidance, not a ghost lookup.
+      const progress = await runCliCaptured(cli, ['sprint', 'progress']);
+      expect(progress.exitCode).toBe(1);
+      expect(progress.stderr).toContain('no current sprint pinned');
     });
   });
 

--- a/tests/e2e/cli/task.test.ts
+++ b/tests/e2e/cli/task.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFsTaskRepository } from '@src/integration/persistence/task/repository.ts';
+import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
 import { markTaskBlocked } from '@src/domain/entity/task-lifecycle.ts';
 import { makeDoneTask, makeDraftSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
 import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
@@ -39,6 +40,31 @@ describe('ralphctl task', () => {
       const result = await runCliCaptured(cli, ['task', 'list', '--sprint', 'nope']);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('invalid sprint id');
+    });
+
+    it('defaults --sprint to the pinned current sprint (with a stderr notice)', async () => {
+      const sprint = makeDraftSprint();
+      const repo = createFsTaskRepository({ root: cli.paths.dataRoot });
+      await repo.saveAll(sprint.id, [makeTodoTask({ name: 'pinned task', order: 1 })]);
+      await createLastSelectionStore(cli.paths.stateRoot).write({
+        projectId: sprint.projectId,
+        sprintId: sprint.id,
+      });
+
+      const result = await runCliCaptured(cli, ['task', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('pinned task');
+      // The fallback path must announce the substituted sprint so a stale pin never
+      // silently targets the wrong one.
+      expect(result.stderr).toContain(`using current sprint ${String(sprint.id)}`);
+    });
+
+    it('exits 1 with guidance when --sprint is omitted and nothing is pinned', async () => {
+      const result = await runCliCaptured(cli, ['task', 'list']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no sprint specified');
+      expect(result.stderr).toContain('--sprint');
+      expect(result.stderr).toContain('sprint set-current');
     });
   });
 

--- a/tests/e2e/cli/ticket.test.ts
+++ b/tests/e2e/cli/ticket.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFsSprintRepository } from '@src/integration/persistence/sprint/repository.ts';
+import { createLastSelectionStore } from '@src/integration/persistence/selection/last-selection-store.ts';
 import { addTicket } from '@src/domain/entity/sprint.ts';
 import { makeApprovedTicket, makeDraftSprint, makePendingTicket, makePlannedSprint } from '@tests/fixtures/domain.ts';
 import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
@@ -47,6 +48,29 @@ describe('ralphctl ticket', () => {
       const result = await runCliCaptured(cli, ['ticket', 'list', '--sprint', 'not-a-uuid']);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('invalid sprint id');
+    });
+
+    it('defaults --sprint to the pinned current sprint (with a stderr notice)', async () => {
+      const repo = createFsSprintRepository({ root: cli.paths.dataRoot });
+      const withTicket = addTicket(makeDraftSprint(), makePendingTicket({ title: 'pinned ticket' }));
+      if (!withTicket.ok) throw new Error('fixture: addTicket failed');
+      await repo.save(withTicket.value);
+      await createLastSelectionStore(cli.paths.stateRoot).write({
+        projectId: withTicket.value.projectId,
+        sprintId: withTicket.value.id,
+      });
+
+      const result = await runCliCaptured(cli, ['ticket', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('pinned ticket');
+      expect(result.stderr).toContain(`using current sprint ${String(withTicket.value.id)}`);
+    });
+
+    it('exits 1 with guidance when --sprint is omitted and nothing is pinned', async () => {
+      const result = await runCliCaptured(cli, ['ticket', 'list']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no sprint specified');
+      expect(result.stderr).toContain('sprint set-current');
     });
   });
 
@@ -104,6 +128,23 @@ describe('ralphctl ticket', () => {
       if (!reloaded.ok) return;
       expect(reloaded.value.tickets).toHaveLength(1);
       expect(reloaded.value.tickets[0]?.title).toBe('add metrics dashboard');
+    });
+
+    it('names the resolved sprint in the success line when falling back to the pin', async () => {
+      // Draft-sprint mutations from a pin must be unambiguous about their target — the
+      // success line carries the resolved sprint id, not just the ticket.
+      const repo = createFsSprintRepository({ root: cli.paths.dataRoot });
+      const sprint = makeDraftSprint();
+      await repo.save(sprint);
+      await createLastSelectionStore(cli.paths.stateRoot).write({
+        projectId: sprint.projectId,
+        sprintId: sprint.id,
+      });
+
+      const result = await runCliCaptured(cli, ['ticket', 'add', '--title', 'pin-target ticket']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`to sprint ${String(sprint.id)}`);
+      expect(result.stderr).toContain(`using current sprint ${String(sprint.id)}`);
     });
 
     it('exits 1 when the sprint is not in draft status (invariant violated)', async () => {

--- a/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
+++ b/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
@@ -24,7 +24,7 @@ import { Breadcrumb } from '@src/application/ui/tui/components/breadcrumb.tsx';
 import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { UiStateProvider, useUiState, type FocusedRunCtx } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 
 // Hoisted size control — vi.hoisted so the variable exists when the mock factory is hoisted.
 const sizeRef = vi.hoisted(() => ({ columns: 100, rows: 24 }));
@@ -105,7 +105,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="stale-sprint" focusedRun={focusedRun} />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('run-project'));
 
     const frame = lastFrame() ?? '';
     // Project resolves from the focused run.
@@ -129,7 +129,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="stale-sprint" focusedRun={focusedRun} />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('run-sprint'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('run-project');
@@ -145,7 +145,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="global-sprint" />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('global-sprint'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('global-project');
@@ -161,7 +161,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="global-sprint" />
     );
-    await tick(30);
+    await waitFor(() => (lastFrame() ?? '').includes('[S]'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('[P]');
     expect(frame).toContain('[S]');
@@ -173,7 +173,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="my-project" globalSprintLabel="my-sprint" globalSprintStatus="active" />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('[ACTIVE]'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('my-sprint');
     // StatusChip wraps the label in brackets and uppercases it.
@@ -186,7 +186,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="my-project" globalSprintLabel="my-sprint" globalSprintStatus="active" />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('my-sprint'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('my-sprint');
     // No chip at narrow width — avoids overflow on small terminals.
@@ -209,7 +209,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
         focusedRun={focusedRun}
       />
     );
-    await tick(50);
+    await waitFor(() => (lastFrame() ?? '').includes('run-sprint'));
     const frame = lastFrame() ?? '';
     // The focused run's sprint label shows but the global status chip must not leak through.
     expect(frame).toContain('run-sprint');
@@ -228,7 +228,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
       const { lastFrame, unmount } = render(
         <Harness globalProjectLabel="p" globalSprintLabel="s" globalSprintStatus={status as SprintStatus} />
       );
-      await tick(50);
+      await waitFor(() => (lastFrame() ?? '').includes(expected));
 
       expect(lastFrame() ?? '').toContain(expected);
       unmount();

--- a/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
+++ b/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
@@ -156,6 +156,18 @@ describe('Breadcrumb — right-side label coalescing', () => {
 });
 
 describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
+  it('renders the [S] picker affordance next to the sprint label (mirroring [P])', async () => {
+    sizeRef.columns = 100;
+    const { lastFrame, unmount } = render(
+      <Harness globalProjectLabel="global-project" globalSprintLabel="global-sprint" />
+    );
+    await tick(30);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[P]');
+    expect(frame).toContain('[S]');
+    unmount();
+  });
+
   it('renders the sprint status chip at ≥md (100 cols)', async () => {
     sizeRef.columns = 100;
     const { lastFrame, unmount } = render(

--- a/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
+++ b/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
@@ -161,7 +161,7 @@ describe('ProgressOverlay — open / close', () => {
     expect(opened).not.toContain('UNDERLYING_VIEW');
 
     stdin.write(ESC);
-    await tick(80);
+    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     expect(lastFrame() ?? '').toContain('UNDERLYING_VIEW');
 
     unmount();
@@ -170,7 +170,7 @@ describe('ProgressOverlay — open / close', () => {
   it('`g` is a no-op on Home (no sprint loaded)', async () => {
     const dataRoot = await makeTmpRoot();
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={false} />);
-    await tick(30);
+    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('g');
     await tick(30);
     // No overlay — underlying view still showing, no "Progress" title.
@@ -207,7 +207,7 @@ describe('ProgressOverlay — missing / empty file', () => {
     const dataRoot = await makeTmpRoot();
     // No file written — overlay should NOT crash.
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
-    await tick(50);
+    await tick(50); // let the selection seed effect run
     stdin.write('g');
     await waitFor(() => (lastFrame() ?? '').includes('No progress file yet')); // disk read + state flush
 
@@ -221,7 +221,7 @@ describe('ProgressOverlay — missing / empty file', () => {
     const dataRoot = await makeTmpRoot();
     await writeProgressFile(dataRoot, '');
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
-    await tick(50);
+    await tick(50); // let the selection seed effect run
     stdin.write('g');
     await waitFor(() => (lastFrame() ?? '').includes('exists but is empty'));
 
@@ -248,7 +248,7 @@ describe('ProgressOverlay — scrolling', () => {
     const dataRoot = await makeTmpRoot();
     await writeProgressFile(dataRoot, buildLongFile());
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
-    await tick(50);
+    await tick(50); // let the selection seed effect run
     stdin.write('g');
     await waitFor(() => (lastFrame() ?? '').includes('HEAD-LINE'));
 

--- a/tests/integration/application/ui/tui/views/add-repository-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/add-repository-view.test.tsx
@@ -14,7 +14,7 @@ import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import { makeProject } from '@tests/fixtures/domain.ts';
 import { CTRL_U, ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 describe('AddRepositoryView — wizard e2e', () => {
   let root: string;
@@ -44,7 +44,7 @@ describe('AddRepositoryView — wizard e2e', () => {
       deps,
       initial: { id: 'add-repository', props: { projectId: project.id } },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Repository path'));
 
     // Step 1: path picker — use `t` typing overlay for determinism.
     result.stdin.write('t');

--- a/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
@@ -21,7 +21,7 @@ import { createSprintExecution, setExecutionBranch } from '@src/domain/entity/sp
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import { DEFAULT_SETTINGS, defaultAiSettingsForProvider } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
-import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { absolutePath, makeReviewSprint } from '@tests/fixtures/domain.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
@@ -173,7 +173,7 @@ describe('CreatePrView — provider rebuild + PATH gate', () => {
     await waitForViewReady(result, (f) => f.includes('Confirm'));
 
     result.stdin.write(ENTER);
-    await tick(120);
+    await waitFor(() => factoryRef.calls.map((c) => c.flow).includes('createPr'));
 
     expect(factoryRef.calls.map((c) => c.flow)).toContain('createPr');
   });
@@ -193,7 +193,7 @@ describe('CreatePrView — provider rebuild + PATH gate', () => {
     await waitForViewReady(result, (f) => f.includes('Confirm'));
 
     result.stdin.write(ENTER);
-    await tick(120);
+    await waitFor(() => (result.lastFrame() ?? '').includes('copilot'));
 
     const frame = result.lastFrame() ?? '';
     // The gate's actionable message names the binary + the settings key — surfaced as the

--- a/tests/integration/application/ui/tui/views/create-project-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/create-project-view.test.tsx
@@ -16,7 +16,7 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import { CTRL_U, ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 describe('CreateProjectView — wizard e2e', () => {
   let root: string;
@@ -37,7 +37,7 @@ describe('CreateProjectView — wizard e2e', () => {
     const deps: AppDeps = { projectRepo } as unknown as AppDeps;
 
     const { result } = renderView(<CreateProjectView />, { deps, initial: { id: 'create-project' } });
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Display name'));
 
     // Step 1: display name.
     result.stdin.write('Mainline');

--- a/tests/integration/application/ui/tui/views/doctor-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/doctor-view.test.tsx
@@ -20,7 +20,7 @@ import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sp
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const deps: AppDeps = {
@@ -56,8 +56,10 @@ const deps: AppDeps = {
 describe('DoctorView', () => {
   it('renders the grouped probe report with a summary header', async () => {
     const { result } = renderView(<DoctorView />, { deps, initial: { id: 'doctor' } });
-    // Probes shell out to git / gh / glab; give them time to settle.
-    await tick(6000);
+    // Probes shell out to git / gh / glab; poll until they settle rather than a fixed budget.
+    await waitFor(() => /passed/.test(result.lastFrame() ?? '') && (result.lastFrame() ?? '').includes('Storage'), {
+      timeoutMs: 10000,
+    });
     const frame = result.lastFrame() ?? '';
     // Summary header is one of "passed / warnings / failures".
     expect(frame).toMatch(/passed/);
@@ -70,7 +72,7 @@ describe('DoctorView', () => {
 
   it('publishes the r reload hint', async () => {
     const { result } = renderView(<DoctorView />, { deps, initial: { id: 'doctor' } });
-    await tick(6000);
+    await waitFor(() => (result.lastFrame() ?? '').includes('reload'), { timeoutMs: 10000 });
     expect(result.lastFrame() ?? '').toContain('reload');
     result.unmount();
   });

--- a/tests/integration/application/ui/tui/views/execute-view-width-regimes.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view-width-regimes.test.tsx
@@ -17,8 +17,7 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 // Hoisted controls — the mock factory reads from this state holder so each test can set its
 // own columns/rows before rendering. `vi.hoisted` ensures the variable exists when the mock
@@ -70,7 +69,7 @@ describe('ExecuteView width regimes', () => {
       initial: { id: 'execute', props: { sessionId: 'rw-1' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Implement — Width'));
     return { frame: result.lastFrame() ?? '', unmount: () => result.unmount() };
   };
 

--- a/tests/integration/application/ui/tui/views/execute-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view.test.tsx
@@ -17,8 +17,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
-import { ENTER, ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { ENTER, ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopEventBus: EventBus = {
   publish: vi.fn(),
@@ -52,7 +52,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-1' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Refine — Demo'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Refine — Demo');
     expect(frame).toMatch(/running/i);
@@ -75,7 +75,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-2' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Refine — Done'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Refine — Done');
     expect(frame).toMatch(/completed/i);
@@ -91,7 +91,7 @@ describe('ExecuteView', () => {
       deps: stubDeps(),
       initial: { id: 'execute', props: { sessionId: 'r-ghost' } },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('not found in the registry'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('not found in the registry');
     result.unmount();
@@ -141,7 +141,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-rounds' } },
       sessions,
     });
-    await tick(60);
+    await waitForViewReady(result, (f) => /round 5/.test(f));
     const frame1 = result.lastFrame() ?? '';
     expect(frame1).toMatch(/round 5/);
 
@@ -156,7 +156,7 @@ describe('ExecuteView', () => {
     // fake runner. Re-render by re-registering a new sessions object isn't right either.
     // Instead: poke the view via tick — execute-view runs a setInterval(setNow, 1000) while
     // the session is running. Advance some time so the view re-renders.
-    await tick(120);
+    await waitFor(() => /round 5/.test(result.lastFrame() ?? ''));
     const frame2 = result.lastFrame() ?? '';
     // The monotonic ref must hold the count at 5 even though only 2 generator entries remain
     // in the trace.
@@ -180,7 +180,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-models' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('claude-opus-4-8'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('claude-opus-4-8');
     expect(frame).toContain('gpt-5.5');
@@ -205,7 +205,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-models-same' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('claude-opus-4-8'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('claude-opus-4-8');
     // The arrow / (eval) tag stay hidden when the two models match — single-provider runs
@@ -232,9 +232,9 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-3' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Refine — Done'));
     result.stdin.write(ENTER);
-    await tick();
+    await waitFor(() => routeIds().includes('sprint-detail'));
     expect(routeIds()).toContain('sprint-detail');
     result.unmount();
   });
@@ -262,9 +262,9 @@ describe('ExecuteView', () => {
         routeEntries.push(e);
       },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Implement — Pinned'));
     result.stdin.write(ENTER);
-    await tick();
+    await waitFor(() => routeEntries.some((e) => e.id === 'sprint-detail'));
     const sprintDetail = routeEntries.find((e) => e.id === 'sprint-detail');
     expect(sprintDetail?.props?.sprintId).toBe(sprintA);
     result.unmount();
@@ -299,7 +299,7 @@ describe('ExecuteView', () => {
       sessions,
       selection: { sprintId: sprintB, sprintLabel: 'Sprint Beta' },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Sprint Alpha'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Sprint Alpha');
     expect(frame).toContain('Project One');
@@ -344,11 +344,11 @@ describe('ExecuteView', () => {
       sessions,
       selection: { sprintId: sprintB, sprintLabel: 'Sprint B Cancel' },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Implement — Cancel'));
     result.stdin.write('c');
-    await tick();
+    await waitFor(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
     result.stdin.write('2');
-    await tick(50);
+    await waitFor(() => findById.mock.calls.length > 0);
     expect(findById).toHaveBeenCalledWith(sprintA, TASK as unknown as TaskId);
     result.unmount();
   });
@@ -406,14 +406,14 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-cancel-mute' } },
       sessions,
     });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('Implement — Mute'));
     // `›` (selectMarker) sits on the first task at rest.
     const cursorOnSecond = (frame: string): boolean => /›[^\n]*Second task/.test(frame);
     expect(cursorOnSecond(result.lastFrame() ?? '')).toBe(false);
 
     // Open the overlay, then press `j` — the panel is muted, so the cursor stays put.
     result.stdin.write('c');
-    await tick();
+    await waitFor(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
     expect(result.lastFrame() ?? '').toContain('Cancel — pick a scope');
     result.stdin.write('j');
     await tick();
@@ -424,7 +424,7 @@ describe('ExecuteView', () => {
     await tick();
     expect(result.lastFrame() ?? '').not.toContain('Cancel — pick a scope');
     result.stdin.write('j');
-    await tick();
+    await waitFor(() => cursorOnSecond(result.lastFrame() ?? ''));
     expect(cursorOnSecond(result.lastFrame() ?? '')).toBe(true);
     result.unmount();
   });
@@ -443,7 +443,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-stale-done' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Sprint no longer available'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Sprint no longer available');
     // BaselineHealthChip always renders the word "baseline" — when stale it must be absent.
@@ -485,7 +485,7 @@ describe('ExecuteView', () => {
         sessions,
       });
 
-      await tick(40);
+      await waitForViewReady(result, (f) => f.includes(expectedTitle));
       const frame = result.lastFrame() ?? '';
       expect(frame, `flowId="${flowId}" should show "${expectedTitle}"`).toContain(expectedTitle);
       // The old hardcoded title must not appear for non-implement flows.
@@ -509,7 +509,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-stale-removed' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Sprint no longer available'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Sprint no longer available');
     expect(frame).not.toContain('baseline');
@@ -534,7 +534,7 @@ describe('ExecuteView', () => {
       initial: { id: 'execute', props: { sessionId: 'r-focused-ctx' } },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Sprint Pinned'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Sprint Pinned');
     expect(frame).toContain('Project Alpha');

--- a/tests/integration/application/ui/tui/views/flows-view.sprint-bound-launch.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.sprint-bound-launch.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Flows view — sprint-bound launch wiring.
+ *
+ * Launching `create-sprint` from the Flows menu must not pin the PREVIOUS selection's sprint
+ * onto the new run's session descriptor: the run's sprint does not exist at launch time, and a
+ * stale pin would mislabel the execute view / breadcrumb for the whole run. The project still
+ * pins (the new sprint will belong to it). The real sprint is pinned later via the sprint-bound
+ * wrapper's `onSprintResolved` — chain completion is not driven here (the create-sprint chain
+ * parks on an interactive name prompt), so this test fences the launch-time descriptor only.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { FlowsView } from '@src/application/ui/tui/views/flows-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
+import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
+import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sprint-execution-repository.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
+import { ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+
+const PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
+const STALE_SPRINT_ID = 'stale-sprint-id' as unknown as SprintId;
+
+const project = {
+  id: PROJECT_ID,
+  slug: 'fixture-project',
+  displayName: 'Fixture Project',
+  repositories: [],
+} as unknown as Project;
+
+const staleSprint = {
+  id: STALE_SPRINT_ID,
+  projectId: PROJECT_ID,
+  slug: 'stale-sprint',
+  name: 'Stale Sprint',
+  status: 'draft',
+  tickets: [],
+} as unknown as Sprint;
+
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const makeDeps = (): AppDeps =>
+  ({
+    projectRepo: {
+      async list() {
+        return Result.ok([project]);
+      },
+      async findById() {
+        return Result.ok(project);
+      },
+    } as unknown as ProjectRepository,
+    sprintRepo: {
+      async list() {
+        return Result.ok([staleSprint]);
+      },
+      async findById() {
+        return Result.ok(staleSprint);
+      },
+    } as unknown as SprintRepository,
+    sprintExecutionRepo: {} as unknown as SprintExecutionRepository,
+    taskRepo: {
+      async findBySprintId() {
+        return Result.ok([]);
+      },
+    } as unknown as TaskRepository,
+    settingsRepo: {
+      async load() {
+        return Result.ok(DEFAULT_SETTINGS);
+      },
+    } as unknown as SettingsRepository,
+    settings: DEFAULT_SETTINGS,
+    eventBus: createInMemoryEventBus(),
+    clock: () => Date.now(),
+    logger: noopLogger,
+    appendFile: async () => Result.ok(undefined),
+    skillSource: { skillsFor: () => [] },
+  }) as unknown as AppDeps;
+
+describe('FlowsView — create-sprint launch does not pin the stale sprint', () => {
+  it('registers the session with pinnedProjectId set and pinnedSprintId unset', async () => {
+    const sessions = createSessionManager();
+    const routedIds: string[] = [];
+
+    const { result } = renderView(<FlowsView />, {
+      deps: makeDeps(),
+      initial: { id: 'flows' },
+      sessions,
+      selection: {
+        projectId: PROJECT_ID,
+        projectLabel: 'Fixture Project',
+        sprintId: STALE_SPRINT_ID,
+        sprintLabel: 'Stale Sprint',
+      },
+      onRoute: (entry) => {
+        routedIds.push(entry.id);
+      },
+    });
+
+    await waitForViewReady(result, (frame) => frame.includes('Create sprint'));
+
+    // Walk the cursor down until the "Create sprint" row is focused, then launch it. The
+    // bounded walk keeps the test robust against trigger-gating changes upstream in the menu.
+    const focusedOnCreate = (): boolean => {
+      const frame = result.lastFrame() ?? '';
+      return new RegExp(`\\${glyphs.actionCursor}\\s+Create sprint`).test(frame);
+    };
+    for (let i = 0; i < 15 && !focusedOnCreate(); i += 1) {
+      result.stdin.write('j');
+      await tick(20);
+    }
+    expect(focusedOnCreate()).toBe(true);
+
+    result.stdin.write(ENTER);
+    await waitFor(() => sessions.list().some((s) => s.descriptor.flowId === 'create-sprint'), { timeoutMs: 3000 });
+
+    const record = sessions.list().find((s) => s.descriptor.flowId === 'create-sprint');
+    expect(record).toBeDefined();
+    // Project pins; the stale sprint must NOT.
+    expect(record?.descriptor.pinnedProjectId).toBe(PROJECT_ID);
+    expect(record?.descriptor.pinnedSprintId).toBeUndefined();
+    expect(record?.descriptor.pinnedSprintLabel).toBeUndefined();
+
+    // The launch routed into the execute view.
+    await waitFor(() => routedIds.includes('execute'));
+    expect(routedIds).toContain('execute');
+  });
+});

--- a/tests/integration/application/ui/tui/views/home-create-hotkey.test.tsx
+++ b/tests/integration/application/ui/tui/views/home-create-hotkey.test.tsx
@@ -19,8 +19,8 @@ import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sp
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { makeProject } from '@tests/fixtures/domain.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopVersionChecker = async (): Promise<null> => null;
 
@@ -94,11 +94,12 @@ describe('HomeView — + hotkey', () => {
       },
     });
 
-    await tick(500);
+    // Wait for HomeView's async load to settle before sending input.
+    await waitForViewReady(result, (f) => f.includes('Hotkey Project'));
 
     // Press '+' — should launch create-sprint.
     result.stdin.write('+');
-    await tick(100);
+    await waitFor(() => routedIds.length > 0 && routedIds[routedIds.length - 1] !== 'home');
 
     // The router should have been asked to push the create-sprint execute view.
     // The implementer may route via 'execute' (after launching the runner) or navigate to
@@ -121,7 +122,8 @@ describe('HomeView — + hotkey', () => {
       },
     });
 
-    await tick(500);
+    // Wait for HomeView's async load to settle before sending input.
+    await waitForViewReady(result, (f) => f.includes('Start by creating a project'));
 
     // Before pressing + — record current route count.
     const countBefore = routedIds.length;

--- a/tests/integration/application/ui/tui/views/home-switch-feedback.test.tsx
+++ b/tests/integration/application/ui/tui/views/home-switch-feedback.test.tsx
@@ -30,7 +30,7 @@ import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { makeDraftSprint, makeProject } from '@tests/fixtures/domain.ts';
 import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopVersionChecker = async (): Promise<null> => null;
 
@@ -129,7 +129,7 @@ describe('HomeView — switch feedback line', () => {
     );
 
     // Wait for async load and state updates.
-    await tick(80);
+    await waitForViewReady(result, (f) => /✓ now on Beta Sprint|now on Beta|switched to Beta/i.test(f));
 
     const frame = result.lastFrame() ?? '';
     // After switching to Beta Sprint, the feedback line must appear.
@@ -166,7 +166,7 @@ describe('HomeView — switch feedback line', () => {
       }
     );
 
-    await tick(80);
+    await waitForViewReady(result, (f) => /now on Vanish Sprint|✓.*Vanish/i.test(f));
 
     // Verify toast is visible.
     const frameBefore = result.lastFrame() ?? '';
@@ -217,7 +217,7 @@ describe('HomeView — switch feedback line', () => {
     );
 
     // Wait for async load and state updates. lastSwitch.at = BASE_TIME.
-    await tick(80);
+    await waitForViewReady(result, (f) => /now on Timer Sprint|✓.*Timer/i.test(f));
 
     // Confirm feedback is visible (Date.now() - lastSwitch.at = 0 < 3000).
     const frameBefore = result.lastFrame() ?? '';

--- a/tests/integration/application/ui/tui/views/home-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/home-view.test.tsx
@@ -20,8 +20,7 @@ import type { VersionChecker } from '@src/business/version/version-checker.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { makeProject } from '@tests/fixtures/domain.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopVersionChecker: VersionChecker = async () => null;
 
@@ -68,8 +67,8 @@ const baseDeps = (overrides: Partial<AppDeps>): AppDeps =>
 describe('HomeView', () => {
   it('shows the create-project CTA when no projects exist', async () => {
     const { result } = renderView(<HomeView />, { deps: baseDeps({}), initial: { id: 'home' } });
-    // Doctor probes shell out, so allow time before reading the frame.
-    await tick(2500);
+    // Doctor probes shell out; waitForViewReady + waitFor handles variable durations.
+    await waitForViewReady(result, (f) => f.includes('Start by creating a project'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toMatch(/Start by creating a project/);
     expect(frame).toMatch(/create your first project/);
@@ -91,7 +90,7 @@ describe('HomeView', () => {
       initial: { id: 'home' },
       selection: { projectId: project.id, projectLabel: project.displayName },
     });
-    await tick(2500);
+    await waitForViewReady(result, (f) => f.includes('Mainline'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Mainline');
     expect(frame).toMatch(/sprint/i);

--- a/tests/integration/application/ui/tui/views/pick-sprint-create-row.test.tsx
+++ b/tests/integration/application/ui/tui/views/pick-sprint-create-row.test.tsx
@@ -21,7 +21,7 @@ import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { makeProject, makeRepository } from '@tests/fixtures/domain.ts';
 import { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { RepositoryId } from '@src/domain/value/id/repository-id.ts';
@@ -111,7 +111,7 @@ describe('PickSprintView — + Create row', () => {
       selection: { projectId: PID_A.id, projectLabel: 'Alpha Project' },
     });
 
-    await tick(60);
+    await waitForViewReady(result, (f) => /Create new sprint|create.*sprint|\+ Create/i.test(f));
     const frame = result.lastFrame() ?? '';
 
     // The synthetic create row must appear.
@@ -175,7 +175,7 @@ describe('PickSprintView — + Create row', () => {
       },
     });
 
-    await tick(60);
+    await waitForViewReady(result, (f) => /Create new sprint|create.*sprint|\+ Create/i.test(f));
 
     // The create row is expected to be first or reachable via keyboard. Press 'k' to move
     // to the top of the list where the create row should be, then Enter.

--- a/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
@@ -165,6 +165,44 @@ describe('PickSprintView', () => {
     expect(after).toContain('1 sprint');
   });
 
+  it('f key hides done sprints and shows them again on re-press', async () => {
+    const sprints = [
+      makeSprint({ id: SID_A1, projectId: PID_A, name: 'live sprint' }),
+      makeSprint({ id: SID_A2, projectId: PID_A, name: 'closed sprint', status: 'done' }),
+    ];
+    const { result } = renderView(<PickSprintView />, {
+      deps: stubDeps(sprints, [projectAlpha]),
+      initial: { id: 'pick-sprint' },
+      selection: { projectId: PID_A, projectLabel: 'Alpha Project' },
+    });
+    // Default OFF — done sprints are listed (closed sprints stay reachable here by contract).
+    await waitFor(() => expect(result.lastFrame() ?? '').toContain('closed sprint'));
+    expect(result.lastFrame() ?? '').toContain('live sprint');
+
+    result.stdin.write('f');
+    await waitFor(() => expect(result.lastFrame() ?? '').not.toContain('closed sprint'));
+    expect(result.lastFrame() ?? '').toContain('live sprint');
+    expect(result.lastFrame() ?? '').toContain('1 sprint');
+
+    result.stdin.write('f');
+    await waitFor(() => expect(result.lastFrame() ?? '').toContain('closed sprint'));
+    expect(result.lastFrame() ?? '').toContain('live sprint');
+  });
+
+  it('empty state names the f escape hatch when the filter hid every sprint in scope', async () => {
+    const sprints = [makeSprint({ id: SID_A2, projectId: PID_A, name: 'closed sprint', status: 'done' })];
+    const { result } = renderView(<PickSprintView />, {
+      deps: stubDeps(sprints, [projectAlpha]),
+      initial: { id: 'pick-sprint' },
+      selection: { projectId: PID_A, projectLabel: 'Alpha Project' },
+    });
+    await waitFor(() => expect(result.lastFrame() ?? '').toContain('closed sprint'));
+
+    result.stdin.write('f');
+    await waitFor(() => expect(result.lastFrame() ?? '').toContain('done (hidden)'));
+    expect(result.lastFrame() ?? '').toContain('Press f to show them');
+  });
+
   it('cursor j/k skips group header sentinel rows', async () => {
     const sprints = [
       makeSprint({ id: SID_A1, projectId: PID_A, name: 'alpha sprint' }),

--- a/tests/integration/application/ui/tui/views/projects-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/projects-view.test.tsx
@@ -10,8 +10,8 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import { makeProject, makeRepository } from '@tests/fixtures/domain.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { ProjectId } from '@src/domain/value/id/project-id.ts';
 import { RepositoryId } from '@src/domain/value/id/repository-id.ts';
@@ -39,7 +39,7 @@ const stubDeps = (projects: readonly Project[]): AppDeps =>
 describe('ProjectsView', () => {
   it('shows the empty state when no projects exist', async () => {
     const { result } = renderView(<ProjectsView />, { deps: stubDeps([]), initial: { id: 'projects' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('No projects yet'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('No projects yet');
     expect(frame).toContain('Press c to create');
@@ -49,7 +49,7 @@ describe('ProjectsView', () => {
   it('renders one row per project with name + slug + repo count', async () => {
     const project = makeProject({ displayName: 'Demo Project', slug: 'demo-proj' });
     const { result } = renderView(<ProjectsView />, { deps: stubDeps([project]), initial: { id: 'projects' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Demo Project'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Demo Project');
     expect(frame).toContain('demo-proj');
@@ -62,7 +62,7 @@ describe('ProjectsView', () => {
       makeProject({ id: ProjectId.generate(), displayName: `Project ${String(i)}`, slug: `proj-${String(i)}` })
     );
     const { result } = renderView(<ProjectsView />, { deps: stubDeps(projects), initial: { id: 'projects' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('6 project(s)'));
     const frame = result.lastFrame() ?? '';
     // visibleRows = 4, so two projects spill past the window and the below-overflow cue appears.
     expect(frame).toContain(glyphs.moreBelow);
@@ -88,7 +88,7 @@ describe('ProjectsView', () => {
       deps: stubDeps([projectWithRepos(3)]),
       initial: { id: 'projects' },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('+1 more repository'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('+1 more repository');
     expect(frame).not.toContain('repositoryies');
@@ -102,7 +102,7 @@ describe('ProjectsView', () => {
       deps: stubDeps([projectWithRepos(4)]),
       initial: { id: 'projects' },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('+2 more repositories'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('+2 more repositories');
     expect(frame).not.toContain('repositoryies');
@@ -111,9 +111,9 @@ describe('ProjectsView', () => {
 
   it('c pushes the create-project route', async () => {
     const { result, routeIds } = renderView(<ProjectsView />, { deps: stubDeps([]), initial: { id: 'projects' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('No projects yet'));
     result.stdin.write('c');
-    await tick();
+    await waitFor(() => routeIds().includes('create-project'));
     expect(routeIds()).toContain('create-project');
     result.unmount();
   });
@@ -137,15 +137,15 @@ describe('ProjectsView', () => {
     const deps = stubDeps([project]);
     (deps as unknown as { projectRepo: ProjectRepository }).projectRepo = repo;
     const { result } = renderView(<ProjectsView />, { deps, initial: { id: 'projects' }, queue });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Old Label'));
     result.stdin.write('e');
-    await tick(40);
+    await waitFor(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Old Label');
     }
     queue.resolveHead('New Label');
-    await tick(40);
+    await waitFor(() => save.mock.calls.length > 0);
     expect(save).toHaveBeenCalledTimes(1);
     expect(save.mock.calls[0]?.[0]?.displayName).toBe('New Label');
     result.unmount();

--- a/tests/integration/application/ui/tui/views/sessions-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sessions-view.test.tsx
@@ -19,8 +19,8 @@ import {
 } from '@src/application/ui/tui/runtime/session-manager.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
-import { DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { DOWN, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const emptyDeps: AppDeps = {} as unknown as AppDeps;
 
@@ -87,7 +87,7 @@ describe('SessionsView', () => {
       initial: { id: 'sessions' },
       sessions: createSessionManager(),
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('No sessions yet'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('No sessions yet');
     result.unmount();
@@ -105,7 +105,7 @@ describe('SessionsView', () => {
       initial: { id: 'sessions' },
       sessions,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Refine — Demo'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Refine — Demo');
     expect(frame).toContain('refine');
@@ -125,17 +125,17 @@ describe('SessionsView', () => {
       initial: { id: 'sessions' },
       sessions: manager,
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Alpha'));
 
     // Move the cursor onto the middle session (Bravo, id s-b).
     result.stdin.write(DOWN);
-    await tick(40);
+    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     // Reorder so the index that used to hold Bravo now holds a different session. The cursor
     // must follow the id (Bravo), not the old index-1 slot.
     setList([c, a, b]);
-    await tick(40);
+    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     result.unmount();
@@ -156,11 +156,11 @@ describe('SessionsView', () => {
         if (entry.id === 'execute') routed.push((entry.props as { sessionId: string }).sessionId);
       },
     });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Alpha'));
 
     // Focus Bravo, then evict Bravo. The cursor snaps to a survivor (by prior index, clamped).
     result.stdin.write(DOWN);
-    await tick(40);
+    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     setList([a, c]);
@@ -172,7 +172,7 @@ describe('SessionsView', () => {
     // Enter must open the execute view for the session the cursor now sits on — not the evicted
     // one. The cursor landed on Charlie (prior index 1, clamped into the 2-item list).
     result.stdin.write('\r');
-    await tick(40);
+    await waitFor(() => routed.length > 0);
     expect(routed.at(-1)).toBe('s-c');
 
     result.unmount();

--- a/tests/integration/application/ui/tui/views/settings-view.escalation-map.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.escalation-map.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * SettingsView — escalation-map editing end-to-end.
+ *
+ * Drives the harness section's map group through the real prompt machinery: the add-rung row
+ * walks a two-step from/to picker and persists `harness.escalationMap.<from>`; the per-entry
+ * row re-renders after the refresh; the effective-ladder summary marks the customised chain.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type * as DetectCliModule from '@src/integration/system/detect-cli.ts';
+import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
+import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { ENTER, RIGHT, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+
+vi.mock('@src/integration/system/detect-cli.ts', async () => {
+  const actual = await vi.importActual<typeof DetectCliModule>('@src/integration/system/detect-cli.ts');
+  return {
+    ...actual,
+    detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> =>
+      new Set<AiProvider>(['claude-code', 'github-copilot', 'openai-codex']),
+  };
+});
+
+const stubRepo = (): { readonly repo: SettingsRepository; readonly saved: () => Settings | undefined } => {
+  const state = { saved: undefined as Settings | undefined, current: DEFAULT_SETTINGS };
+  return {
+    saved: () => state.saved,
+    repo: {
+      path: '/tmp/test-settings.json',
+      async exists() {
+        return Result.ok(true);
+      },
+      async load() {
+        return Result.ok(state.current);
+      },
+      async save(next: Settings) {
+        state.saved = next;
+        state.current = next;
+        return Result.ok(undefined);
+      },
+    } as unknown as SettingsRepository,
+  };
+};
+
+/** Section order mirrors buildSections — harness is 8 `→` presses from the initial presets. */
+const goToHarness = async (stdin: { write: (s: string) => void }): Promise<void> => {
+  for (let i = 0; i < 8; i += 1) {
+    stdin.write(RIGHT);
+    await tick(20);
+  }
+};
+
+describe('SettingsView — escalation map editor', () => {
+  it('adds a rung via the two-step picker and renders the new override row', async () => {
+    const { repo, saved } = stubRepo();
+    const deps = { settingsRepo: repo } as unknown as AppDeps;
+    const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
+
+    await waitFor(() => (result.lastFrame() ?? '').includes('Presets'));
+    await goToHarness(result.stdin);
+    await waitFor(() => (result.lastFrame() ?? '').includes('Escalation map'));
+
+    // The defaults summary is visible before any override exists.
+    expect(result.lastFrame() ?? '').toContain('Effective ladder');
+    expect(result.lastFrame() ?? '').toContain('defaults apply');
+
+    // Cursor: 6 knob rows precede the map-add row.
+    for (let i = 0; i < 6; i += 1) {
+      result.stdin.write('j');
+      await tick(15);
+    }
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+
+    // Step 1 — first catalog entry is claude-haiku-4-5.
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('step 2/2'));
+    expect(result.lastFrame() ?? '').toContain('claude-haiku-4-5');
+
+    // Step 2 — first compatible target is claude-sonnet-4-6.
+    result.stdin.write(ENTER);
+    await waitFor(() => saved() !== undefined);
+
+    expect(saved()?.harness.escalationMap).toEqual({ 'claude-haiku-4-5': 'claude-sonnet-4-6' });
+
+    // Back on the section: the override row + customised ladder render after the refresh.
+    await waitFor(() => (result.lastFrame() ?? '').includes('1 override'));
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('claude-haiku-4-5');
+    expect(frame).toContain('(customised)');
+    expect(frame).toContain('escalation rung added');
+  });
+
+  it('esc on step 2 returns to the from-model pick instead of abandoning the add', async () => {
+    const { repo, saved } = stubRepo();
+    const deps = { settingsRepo: repo } as unknown as AppDeps;
+    const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
+
+    await waitFor(() => (result.lastFrame() ?? '').includes('Presets'));
+    await goToHarness(result.stdin);
+    await waitFor(() => (result.lastFrame() ?? '').includes('Escalation map'));
+    for (let i = 0; i < 6; i += 1) {
+      result.stdin.write('j');
+      await tick(15);
+    }
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('step 2/2'));
+
+    result.stdin.write(String.fromCharCode(27)); // esc
+    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+
+    expect(saved()).toBeUndefined();
+  });
+});

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -11,8 +11,8 @@ import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { ENTER, RIGHT, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { ENTER, RIGHT, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 // Hoisted state holder — each test mutates this before rendering so the mocked
 // `detectInstalledProviders` returns the desired set. The mock targets the integration
@@ -96,7 +96,7 @@ const goToSection = async (stdin: { write: (s: string) => void }, target: (typeo
 describe('SettingsView', () => {
   it('renders the section strip and the active section after the load completes', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
     const frame = result.lastFrame() ?? '';
     // Every section label is in the strip.
     for (const label of [
@@ -131,7 +131,7 @@ describe('SettingsView', () => {
 
   it('shows the storage paths card when the storage section is active', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
     await goToSection(result.stdin, 'storage');
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Storage paths');
@@ -141,7 +141,7 @@ describe('SettingsView', () => {
 
   it('exposes ←/→ section, ↑/↓ navigate, ↵/e edit hints', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('section'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('section');
     expect(frame).toContain('navigate');
@@ -151,7 +151,7 @@ describe('SettingsView', () => {
 
   it('renders Implement as a parent card with indented generator and evaluator sub-rows', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
     await goToSection(result.stdin, 'implement');
     const frame = result.lastFrame() ?? '';
     // The parent card carries the non-editable Implement label exactly once; the two role
@@ -203,7 +203,7 @@ describe('SettingsView', () => {
     // evaluator triple) and is the right stress-test for the ≤ ~8-row cap.
     it('caps ↓ at the Implement section last row no matter how many presses arrive', async () => {
       const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-      await tick(40);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
       await goToSection(result.stdin, 'implement');
       // The Implement section has six fields (generator.{provider,model,effort} +
       // evaluator.{provider,model,effort}). Ten ↓ presses pin the cursor at the last row.
@@ -230,7 +230,7 @@ describe('SettingsView', () => {
 
     it('caps ↑ at the first row inside a section', async () => {
       const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-      await tick(40);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
       await goToSection(result.stdin, 'harness');
       // Park the cursor on the last row first, then hammer ↑.
       for (let i = 0; i < 5; i += 1) {
@@ -252,14 +252,14 @@ describe('SettingsView', () => {
   describe('model field is catalog-only', () => {
     it('does not mount a TextPrompt on a model row (no free-text input affordance)', async () => {
       const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
-      await tick(40);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
       await goToSection(result.stdin, 'refine');
       // Refine section field order: 0 provider, 1 model, 2 effort. One ↓ lands on the model
       // row; ↵ opens the picker.
       result.stdin.write('j');
       await tick(20);
       result.stdin.write(ENTER);
-      await tick(40);
+      await waitForViewReady(result, (f) => f.includes('↑/↓ navigate · ↵ submit · esc cancel'));
       const frame = result.lastFrame() ?? '';
       // SelectPrompt always renders the navigation legend below its option list.
       expect(frame).toContain('↑/↓ navigate · ↵ submit · esc cancel');
@@ -288,7 +288,7 @@ describe('SettingsView', () => {
     const stub = stubRepoWith(initial);
     const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
     const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
     await goToSection(result.stdin, 'refine');
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain(offCatalogModel);
@@ -299,10 +299,13 @@ describe('SettingsView', () => {
     // Section ordering puts Refine third (presets → global → refine), so two RIGHT presses
     // step from the initial Presets section to Refine; ENTER on the first row (provider)
     // opens the picker.
-    const openRefineProviderPicker = async (stdin: { write: (s: string) => void }): Promise<void> => {
+    const openRefineProviderPicker = async (
+      stdin: { write: (s: string) => void },
+      lastFrame: () => string | undefined
+    ): Promise<void> => {
       await goToSection(stdin, 'refine');
       stdin.write(ENTER);
-      await tick(40);
+      await waitFor(() => (lastFrame() ?? '').includes('↑/↓ navigate · ↵ submit · esc cancel'));
     };
 
     it("labels unavailable providers as '(not installed)' in the provider picker", async () => {
@@ -310,8 +313,8 @@ describe('SettingsView', () => {
       const stub = stubRepoWith(DEFAULT_SETTINGS);
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
-      await tick(80);
-      await openRefineProviderPicker(result.stdin);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
+      await openRefineProviderPicker(result.stdin, result.lastFrame);
       const frame = result.lastFrame() ?? '';
       expect(frame).toContain('github-copilot (not installed)');
       expect(frame).toContain('openai-codex (not installed)');
@@ -325,8 +328,8 @@ describe('SettingsView', () => {
       const stub = stubRepoWith(DEFAULT_SETTINGS);
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
-      await tick(80);
-      await openRefineProviderPicker(result.stdin);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
+      await openRefineProviderPicker(result.stdin, result.lastFrame);
       // Strip the rendered frame's word-wrap whitespace before asserting — ink may break the
       // footer across multiple lines depending on terminal width, but the install command must
       // still be present as a contiguous token sequence.
@@ -346,8 +349,8 @@ describe('SettingsView', () => {
       const stub = stubRepoWith(DEFAULT_SETTINGS);
       const stubDeps: AppDeps = { settingsRepo: stub.repo } as unknown as AppDeps;
       const { result } = renderView(<SettingsView />, { deps: stubDeps, initial: { id: 'settings' } });
-      await tick(80);
-      await openRefineProviderPicker(result.stdin);
+      await waitForViewReady(result, (f) => f.includes('Apply: Mixed'));
+      await openRefineProviderPicker(result.stdin, result.lastFrame);
       const frame = result.lastFrame() ?? '';
       expect(frame).toContain('No AI provider CLI is installed.');
       expect(frame).toContain('claude-code (not installed)');

--- a/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
@@ -18,8 +18,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const SPRINT_ID = 'sprint-make-current-id' as unknown as SprintId;
 
@@ -86,10 +86,10 @@ describe('SprintDetailView — m key makes current', () => {
       { deps: stubDeps(sprint), initial }
     );
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Make Current Sprint'));
 
     result.stdin.write('m');
-    await tick(40);
+    await waitFor(() => setSprint.mock.calls.length === 1);
 
     expect(setSprint).toHaveBeenCalledTimes(1);
     const [calledId, calledLabel] = setSprint.mock.calls[0] as [SprintId | undefined, string | undefined];
@@ -110,7 +110,7 @@ describe('SprintDetailView — m key makes current', () => {
       { deps: stubDeps(sprint), initial }
     );
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Other Key Sprint'));
 
     result.stdin.write('z'); // inert key — neither make-current (m) nor open-flows (n)
     await tick(40);
@@ -135,10 +135,10 @@ describe('SprintDetailView — m key makes current', () => {
       { deps: stubDeps(sprint), initial }
     );
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Scoped Sprint'));
 
     result.stdin.write('n');
-    await tick(40);
+    await waitFor(() => setSprint.mock.calls.length === 1);
 
     expect(setSprint).toHaveBeenCalledTimes(1);
     const [calledId, calledLabel] = setSprint.mock.calls[0] as [SprintId | undefined, string | undefined];
@@ -160,7 +160,7 @@ describe('SprintDetailView — m key makes current', () => {
       selection: { sprintId: SPRINT_ID, sprintLabel: 'Already Current Sprint' },
     });
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Already Current Sprint'));
 
     result.stdin.write('n');
     await tick(40);
@@ -180,7 +180,7 @@ describe('SprintDetailView — m key makes current', () => {
       selection: { sprintId: SPRINT_ID, sprintLabel: 'Selected Sprint' },
     });
 
-    await tick(80);
+    await waitForViewReady(result, (f) => /·\s*current|\(current\)|current sprint/i.test(f));
     const frame = result.lastFrame() ?? '';
 
     // The current badge must appear in the header area.
@@ -201,7 +201,7 @@ describe('SprintDetailView — m key makes current', () => {
       selection: { sprintId: OTHER_SPRINT_ID, sprintLabel: 'Other Sprint' },
     });
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Not Current Sprint'));
     const frame = result.lastFrame() ?? '';
 
     // The current badge must NOT appear when a different sprint is selected.
@@ -222,7 +222,7 @@ describe('SprintDetailView — m key makes current', () => {
       },
     });
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Local Key Sprint'));
     result.stdin.write('m');
     await tick(40);
 

--- a/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
@@ -99,7 +99,7 @@ describe('SprintDetailView — m key makes current', () => {
     result.unmount();
   });
 
-  it('does NOT call setSprint when a key other than m is pressed', async () => {
+  it('does NOT call setSprint when a key other than m/n is pressed', async () => {
     const sprint = makeSprint({ name: 'Other Key Sprint' });
     const setSprint = vi.fn<(id: SprintId | undefined, label?: string) => void>();
 
@@ -112,10 +112,60 @@ describe('SprintDetailView — m key makes current', () => {
 
     await tick(80);
 
-    result.stdin.write('n'); // 'n' opens Flows, not make-current
+    result.stdin.write('z'); // inert key — neither make-current (m) nor open-flows (n)
     await tick(40);
 
     expect(setSprint).not.toHaveBeenCalled();
+
+    result.unmount();
+  });
+
+  it('n reseats the selection onto the viewed sprint before opening Flows', async () => {
+    // The view advertises `n — flows` as "scoped to this sprint": pressing it while a
+    // DIFFERENT sprint is current must make the viewed sprint current so the Flows launch
+    // targets what the user is looking at. The route push itself is owned by the global `n`
+    // handler (not mounted in this harness), so only the reseat is asserted here.
+    const sprint = makeSprint({ name: 'Scoped Sprint' });
+    const setSprint = vi.fn<(id: SprintId | undefined, label?: string) => void>();
+
+    const { result } = renderView(
+      <MakeSpy spy={setSprint}>
+        <SprintDetailView />
+      </MakeSpy>,
+      { deps: stubDeps(sprint), initial }
+    );
+
+    await tick(80);
+
+    result.stdin.write('n');
+    await tick(40);
+
+    expect(setSprint).toHaveBeenCalledTimes(1);
+    const [calledId, calledLabel] = setSprint.mock.calls[0] as [SprintId | undefined, string | undefined];
+    expect(calledId).toBe(SPRINT_ID);
+    expect(calledLabel).toBe('Scoped Sprint');
+
+    result.unmount();
+  });
+
+  it('n does NOT reseat when the viewed sprint is already current', async () => {
+    // Seeding the selection re-memoizes the api object, which would silently drop a MakeSpy
+    // patch — so assert via the view's own "✓ now on …" feedback line instead: it renders on
+    // every reseat and must stay absent when `n` is pressed on the already-current sprint.
+    const sprint = makeSprint({ name: 'Already Current Sprint' });
+
+    const { result } = renderView(<SprintDetailView />, {
+      deps: stubDeps(sprint),
+      initial,
+      selection: { sprintId: SPRINT_ID, sprintLabel: 'Already Current Sprint' },
+    });
+
+    await tick(80);
+
+    result.stdin.write('n');
+    await tick(40);
+
+    expect(result.lastFrame() ?? '').not.toContain('✓ now on');
 
     result.unmount();
   });

--- a/tests/integration/application/ui/tui/views/sprint-detail-no-auto-sync.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-no-auto-sync.test.tsx
@@ -24,7 +24,7 @@ import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repo
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { makeDraftSprint } from '@tests/fixtures/domain.ts';
 
 const FIXED_SPRINT_ID = 'sprint-no-autosync' as unknown as SprintId;
@@ -145,7 +145,7 @@ describe('SprintDetailView — no auto-sync', () => {
     const sprint = makeSprint({ status: 'draft', name: 'Visible Sprint' });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint), initial });
 
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Visible Sprint'));
     const frame = result.lastFrame() ?? '';
 
     // The view should still render correctly (sprint name appears).
@@ -179,7 +179,7 @@ describe('SprintDetailView — setSprint is reachable via m key after redesign',
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial: initialWithId });
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Renderable Sprint'));
 
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Renderable Sprint');

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
@@ -28,8 +28,7 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const sizeRef = vi.hoisted(() => ({ columns: 120, rows: 40 }));
@@ -128,7 +127,7 @@ describe('SprintDetailView — ticket / task card harmony', () => {
       } as never,
     ];
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('bravo-card-marker') && f.includes('alpha-task-marker'));
 
     const frame = stripAnsi(result.lastFrame() ?? '');
     const lines = frame.split('\n');
@@ -192,7 +191,7 @@ describe('SprintDetailView — task metadata row wrap policy', () => {
     const sprint = makeSprint([{ id: 'ticket-a' as never, title: longTicketTitle, status: 'approved' } as never]);
     const tasks: readonly Task[] = [buildMetadataHeavyTask('task-meta-wide')];
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('· ticket:'));
 
     const frame = stripAnsi(result.lastFrame() ?? '');
     const lines = frame.split('\n');
@@ -217,7 +216,7 @@ describe('SprintDetailView — task metadata row wrap policy', () => {
     const sprint = makeSprint([{ id: 'ticket-a' as never, title: longTicketTitle, status: 'approved' } as never]);
     const tasks: readonly Task[] = [buildMetadataHeavyTask('task-meta-narrow')];
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('ticket:'));
 
     const frame = stripAnsi(result.lastFrame() ?? '');
     const lines = frame.split('\n');

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -21,20 +21,10 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeApprovedTicket, makeDraftSprint } from '@tests/fixtures/domain.ts';
-
-type Renderable = { readonly lastFrame: () => string | undefined };
-
-const waitForFrame = async (rendered: Renderable, predicate: (frame: string) => boolean): Promise<void> => {
-  for (let i = 0; i < 50; i++) {
-    const frame = rendered.lastFrame() ?? '';
-    if (predicate(frame)) return;
-    await tick(40);
-  }
-};
 
 const FIXED_SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
 
@@ -83,16 +73,16 @@ describe('SprintDetailView — per-card expand/collapse', () => {
       makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
     ]);
     const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
-    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+    await waitForViewReady(result, (f) => f.includes('alpha card'));
 
     // Expand the first ticket (cursor starts at idx 0).
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to the second ticket and expand it without collapsing the first.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
     const frame = result.lastFrame() ?? '';
     // Both expanded views render their per-ticket Requirements heading; if either card
@@ -107,21 +97,21 @@ describe('SprintDetailView — per-card expand/collapse', () => {
       makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
     ]);
     const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
-    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+    await waitForViewReady(result, (f) => f.includes('alpha card'));
 
     // Open card 0.
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to card 1 and open it.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
     // Move back to card 0 and toggle it closed.
     result.stdin.write('k');
     await tick(40);
     result.stdin.write('o');
-    await waitForFrame(result, (f) => !f.includes('requirements for alpha card'));
+    await tick(40);
 
     const frame = result.lastFrame() ?? '';
     // Card 0's requirements heading should be gone; card 1's must remain.
@@ -135,15 +125,15 @@ describe('SprintDetailView — per-card expand/collapse', () => {
       makeTicket('ticket-b', 'bravo card', 'bravo-only-marker-line-in-description'),
     ]);
     const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
-    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+    await waitForViewReady(result, (f) => f.includes('alpha card'));
 
     // Expand both cards.
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for bravo card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
     // Confirm pre-condition: both cards expanded.
     let frame = result.lastFrame() ?? '';
@@ -152,7 +142,7 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // One Esc must clear the entire openIds set.
     result.stdin.write(ESC);
-    await waitForFrame(result, (f) => !f.includes('requirements for alpha card'));
+    await tick(40);
 
     frame = result.lastFrame() ?? '';
     expect(frame).not.toContain('requirements for alpha card');
@@ -166,11 +156,11 @@ describe('SprintDetailView — per-card expand/collapse', () => {
       makeTicket('ticket-c', 'charlie card', 'charlie-only-marker-line-in-description'),
     ]);
     const { result } = renderView(<SprintDetailView />, { deps: stubReadOnlyDeps(sprint, []), initial });
-    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+    await waitForViewReady(result, (f) => f.includes('alpha card'));
 
     // Expand only the first card.
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
 
     // Navigate cursor up and down across all three cards.
     result.stdin.write('j');
@@ -233,18 +223,18 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     const initialWithRealId = { id: 'sprint-detail', props: { sprintId: storedSprint.id } };
     const { result } = renderView(<SprintDetailView />, { deps, initial: initialWithRealId });
-    await waitForFrame(result, (f) => f.includes('alpha card') && !f.includes('Loading'));
+    await waitForViewReady(result, (f) => f.includes('alpha card'));
 
     // Open card 0 (alpha).
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for alpha card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move down twice to card 2 (charlie) and open it.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitForFrame(result, (f) => f.includes('requirements for charlie card'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for charlie card'));
 
     // Pre-condition: alpha and charlie expanded; bravo collapsed.
     let frame = result.lastFrame() ?? '';
@@ -260,13 +250,12 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     result.stdin.write('k');
     await tick(40);
     result.stdin.write('d');
-    await waitForFrame(result, (f) => f.includes('Remove ticket'));
+    await waitFor(() => (result.lastFrame() ?? '').includes('Remove ticket'));
     result.stdin.write('y');
-    await waitForFrame(
-      result,
-      (f) =>
-        f.includes('alpha card') && f.includes('charlie card') && !f.includes('bravo card') && !f.includes('Loading')
-    );
+    await waitFor(() => {
+      const f = result.lastFrame() ?? '';
+      return f.includes('alpha card') && f.includes('charlie card') && !f.includes('Loading');
+    });
 
     frame = result.lastFrame() ?? '';
     // The two surviving cards (alpha + charlie) keep their expansion; bravo is gone from the

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
@@ -12,8 +12,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { makeDraftSprint, makePendingTicket, makeTodoTask } from '@tests/fixtures/domain.ts';
@@ -57,7 +57,7 @@ describe('SprintDetailView — phase workspace', () => {
   it('draft sprint with no tickets suggests "Add tickets"', async () => {
     const sprint = makeSprint({ status: 'draft', tickets: [] });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Add tickets'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Next phase');
     expect(frame).toContain('Add tickets');
@@ -73,7 +73,7 @@ describe('SprintDetailView — phase workspace', () => {
       ],
     });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Refine 2 pending ticket(s)'));
     expect(result.lastFrame() ?? '').toContain('Refine 2 pending ticket(s)');
     result.unmount();
   });
@@ -104,7 +104,7 @@ describe('SprintDetailView — phase workspace', () => {
       } as never,
     ];
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Implement 2 resumable task(s)'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Implement 2 resumable task(s)');
     const tasksHeader = frame.indexOf('▣ Tasks');
@@ -122,7 +122,7 @@ describe('SprintDetailView — phase workspace', () => {
       tickets: [{ id: 't1' as never, title: 'first', status: 'approved' } as never],
     });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Open a pull request'));
     expect(result.lastFrame() ?? '').toContain('Open a pull request');
     result.unmount();
   });
@@ -175,13 +175,13 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('wedged'));
     // Cursor starts at idx 0 (the ticket). Press 'j' once to land on the (one) task below.
     result.stdin.write('j');
-    await tick(40);
+    await waitFor(() => (result.lastFrame() ?? '').includes('unbl'));
     result.stdin.write('u');
     // Give the async use case + reload a chance to settle.
-    await tick(80);
+    await waitFor(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
@@ -218,20 +218,20 @@ describe('SprintDetailView — phase workspace', () => {
     const queue = createPromptQueue();
     const initialWithId = { id: 'sprint-detail', props: { sprintId: sprintWithTicket.id } };
     const { result } = renderView(<SprintDetailView />, { deps, initial: initialWithId, queue });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Typo iin Title'));
     // Cursor starts on the ticket. Press 'e' → opens the field-picker choice.
     result.stdin.write('e');
-    await tick(40);
+    await waitFor(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('choice');
     // Pick "title" (the first option for a pending ticket).
     queue.resolveHead('title');
-    await tick(40);
+    await waitFor(() => queue.head?.kind === 'text');
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Typo iin Title');
     }
     queue.resolveHead('Typo in Title');
-    await tick(40);
+    await waitFor(() => save.mock.calls.length === 1);
     expect(save).toHaveBeenCalledTimes(1);
     const saved = save.mock.calls[0]?.[0];
     expect(saved?.tickets?.[0]?.title).toBe('Typo in Title');
@@ -275,10 +275,10 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('stuck-task'));
     // Cursor starts on the ticket; press 'j' to land on the blocked task.
     result.stdin.write('j');
-    await tick(40);
+    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     // The 'u unblock' hint must appear in the status bar footer area. The terminal width used
     // by ink-testing-library may wrap the label across lines — match a prefix that survives
@@ -323,7 +323,7 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('not-stuck'));
     // Cursor starts on the ticket; press 'j' to land on the todo task.
     result.stdin.write('j');
     await tick(40);
@@ -373,10 +373,10 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('in-progress-stuck'));
     // Cursor starts on the ticket; press 'j' to land on the in_progress task.
     result.stdin.write('j');
-    await tick(40);
+    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('in-progress-stuck');
     // The 'u unblock' hint must appear for in_progress tasks, same as for blocked.
@@ -431,12 +431,12 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('crashed-task'));
     // Cursor starts on the ticket; press 'j' to land on the in_progress task.
     result.stdin.write('j');
-    await tick(40);
+    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
     result.stdin.write('u');
-    await tick(80);
+    await waitFor(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
@@ -451,7 +451,7 @@ describe('SprintDetailView — phase workspace', () => {
       tickets: [{ id: 't1' as never, title: 'first', status: 'pending' } as never],
     });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('add ticket'));
     const frame = result.lastFrame() ?? '';
     // The hint strip advertises the ticket add/remove chords only while they are wired up.
     expect(frame).toContain('add ticket');
@@ -465,7 +465,7 @@ describe('SprintDetailView — phase workspace', () => {
       tickets: [{ id: 't1' as never, title: 'first', status: 'approved' } as never],
     });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('first'));
     const frame = result.lastFrame() ?? '';
     // Ticket CRUD is draft-only; on an active sprint the chords do nothing, so the footer must
     // not advertise them — the hint shares one source of truth with the gated handler.
@@ -515,7 +515,7 @@ describe('SprintDetailView — phase workspace', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintDetailView />, { deps, initial });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('fine'));
     result.stdin.write('j');
     await tick(20);
     result.stdin.write('u');

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.windowing.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.windowing.test.tsx
@@ -21,8 +21,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const sizeRef = vi.hoisted(() => ({ columns: 120, rows: 24 }));
@@ -96,7 +96,7 @@ describe('SprintDetailView — task-list windowing (M4 guard)', () => {
     });
     const tasks = Array.from({ length: TOTAL }, (_, i) => makeTask(i + 1));
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('task-marker-1'));
 
     // Before moving, the last task is well past the rows=24 / 8-card window — it must NOT render.
     const initialFrame = result.lastFrame() ?? '';
@@ -110,7 +110,7 @@ describe('SprintDetailView — task-list windowing (M4 guard)', () => {
 
       await tick(8);
     }
-    await tick(40);
+    await waitFor(() => (result.lastFrame() ?? '').includes('task-marker-19'));
 
     const frame = result.lastFrame() ?? '';
     // The focused task (#19) must be inside the rendered window — the M4 regression would have it
@@ -127,7 +127,7 @@ describe('SprintDetailView — task-list windowing (M4 guard)', () => {
     const sprint = makeSprint({ status: 'active', tickets: [] });
     const tasks = Array.from({ length: TOTAL }, (_, i) => makeTask(i + 1));
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('task-marker-1'));
 
     const frame = result.lastFrame() ?? '';
     // Cursor parked at the head → the tail is hidden, so a "below" cue must show the remainder.
@@ -143,7 +143,7 @@ describe('SprintDetailView — task-list windowing (M4 guard)', () => {
     });
     const tasks = [makeTask(1), makeTask(2), makeTask(3)];
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, tasks), initial });
-    await tick(60);
+    await waitForViewReady(result, (f) => f.includes('task-marker-1'));
 
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('task-marker-1');

--- a/tests/integration/application/ui/tui/views/sprints-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprints-view.test.tsx
@@ -1,5 +1,9 @@
 /**
  * Smoke tests for SprintsView. Empty state, populated row, `c` advice when no project picked.
+ *
+ * Load-settling uses `waitForViewReady` / `waitFor` (not fixed ticks): under the full parallel
+ * suite a 40–120ms tick races the async repo load, leaving assertions staring at the boot
+ * banner frame — the exact flake the harness helper exists to prevent.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -12,8 +16,8 @@ import type { TaskRepository } from '@src/domain/repository/task/task-repository
 import type { Task } from '@src/domain/entity/task.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
-import { END, tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { END, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { makeDraftSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
@@ -71,7 +75,7 @@ const makeSprint = (overrides: Record<string, unknown> = {}): Sprint =>
 describe('SprintsView', () => {
   it('shows the empty state when no sprints exist (no project picked)', async () => {
     const { result } = renderView(<SprintsView />, { deps: stubDeps([]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('No sprints yet'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('No sprints yet');
     expect(frame).toContain('Pick a project first');
@@ -81,7 +85,7 @@ describe('SprintsView', () => {
   it('renders one row per sprint with name, status, ticket count', async () => {
     const sprint = makeSprint({ name: 'Spring Sprint', slug: 'spring' });
     const { result } = renderView(<SprintsView />, { deps: stubDeps([sprint]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Spring Sprint'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Spring Sprint');
     expect(frame).toContain('spring');
@@ -93,7 +97,7 @@ describe('SprintsView', () => {
   it('publishes c / d / r hints to the status bar', async () => {
     const sprint = makeSprint({});
     const { result } = renderView(<SprintsView />, { deps: stubDeps([sprint]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('c create'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('c create');
     expect(frame).toContain('d delete');
@@ -104,7 +108,7 @@ describe('SprintsView', () => {
   it('hides the e rename hint when the focused sprint is done (rename guards status !== done)', async () => {
     const done = makeSprint({ name: 'Shipped Sprint', status: 'done' });
     const { result } = renderView(<SprintsView />, { deps: stubDeps([done]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Shipped Sprint'));
     const frame = result.lastFrame() ?? '';
     // The rename handler is a no-op on a done sprint, so the hint must hide rather than advertise
     // a dead key — hint and handler share one source of truth.
@@ -116,9 +120,9 @@ describe('SprintsView', () => {
   it("pressing 'e' on a done sprint flashes a reason instead of a silent no-op", async () => {
     const done = makeSprint({ name: 'Shipped Sprint', status: 'done' });
     const { result } = renderView(<SprintsView />, { deps: stubDeps([done]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Shipped Sprint'));
     result.stdin.write('e');
-    await tick(40);
+    await waitFor(() => (result.lastFrame() ?? '').includes("done sprints can't be renamed"));
     const frame = result.lastFrame() ?? '';
     // Someone who found `e` via `?` should learn why it's inert, not be left guessing.
     expect(frame).toContain("done sprints can't be renamed");
@@ -144,9 +148,9 @@ describe('SprintsView', () => {
     const deps = stubDeps([sprint]);
     (deps as unknown as { sprintRepo: SprintRepository }).sprintRepo = repo;
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' }, queue });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Mispeld Sprint'));
     result.stdin.write('e');
-    await tick(40);
+    await waitFor(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Mispeld Sprint');
@@ -190,8 +194,9 @@ describe('SprintsView', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' } });
-    // Extra ticks: one for sprint list render, one for task fetch effect.
-    await tick(80);
+    // Two async waves settle here: the sprint list render, then the task-fetch effect that
+    // feeds the unblock hint count.
+    await waitForViewReady(result, (f) => f.includes('Broken Sprint') && f.includes('(1)'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Broken Sprint');
     // 'u unblock (1)' should appear somewhere in the status bar hints. The terminal used by
@@ -240,11 +245,11 @@ describe('SprintsView', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' } });
-    // Wait for sprint list + task fetch to settle.
-    await tick(80);
+    // Sprint list + task fetch must both settle before `u` has a stuck task to act on.
+    await waitForViewReady(result, (f) => f.includes('Recovery Sprint') && f.includes('unblock'));
     result.stdin.write('u');
-    // Let the sequential unblock loop + feedback + task refresh complete.
-    await tick(120);
+    // The sequential unblock loop + feedback + task refresh complete when the toast lands.
+    await waitFor(() => /unblocked 1 task/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
@@ -290,9 +295,9 @@ describe('SprintsView', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' } });
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Crash Sprint') && f.includes('unblock'));
     result.stdin.write('u');
-    await tick(120);
+    await waitFor(() => updateCalls.length === 1);
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
     result.unmount();
@@ -305,7 +310,7 @@ describe('SprintsView', () => {
     const newer = makeSprint({ id: 'sprint-02', name: 'Newer Sprint', slug: 'newer' });
     // Pass them oldest-first, mimicking sprintRepo.list()'s ascending order.
     const { result } = renderView(<SprintsView />, { deps: stubDeps([older, newer]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Newer Sprint') && f.includes('Older Sprint'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Newer Sprint');
     expect(frame).toContain('Older Sprint');
@@ -322,7 +327,7 @@ describe('SprintsView', () => {
       initial: { id: 'sprints' },
       selection: { projectId: scopedProject },
     });
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('Newer Scoped') && f.includes('Older Scoped'));
     const frame = result.lastFrame() ?? '';
     expect(frame.indexOf('Newer Scoped')).toBeLessThan(frame.indexOf('Older Scoped'));
     result.unmount();
@@ -331,7 +336,7 @@ describe('SprintsView', () => {
   it('renders a single sprint without error', async () => {
     const sprint = makeSprint({ id: 'sprint-01', name: 'Solo Sprint', slug: 'solo' });
     const { result } = renderView(<SprintsView />, { deps: stubDeps([sprint]), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Solo Sprint'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Solo Sprint');
     expect(frame).toContain('1 sprint(s)');
@@ -347,14 +352,14 @@ describe('SprintsView', () => {
       return makeSprint({ id: `sprint-${n}`, name: `Sprint ${n}`, slug: `s-${n}` });
     });
     const { result } = renderView(<SprintsView />, { deps: stubDeps(sprints), initial: { id: 'sprints' } });
-    await tick(40);
+    await waitForViewReady(result, (f) => f.includes('Sprint 08'));
     const before = result.lastFrame() ?? '';
     // Newest (sprint-08) is at the top of the window; the oldest (sprint-01) is below the fold.
     expect(before).toContain('Sprint 08');
     expect(before).not.toContain('Sprint 01');
 
     result.stdin.write(END);
-    await tick(40);
+    await waitFor(() => (result.lastFrame() ?? '').includes('Sprint 01'));
     const after = result.lastFrame() ?? '';
     // After End the window has scrolled to the bottom: the previously-hidden oldest sprint shows,
     // and the newest has scrolled off the top.
@@ -370,7 +375,7 @@ describe('SprintsView', () => {
       initial: { id: 'sprints' },
       selection: { projectId: scopedProject },
     });
-    await tick(80);
+    await waitForViewReady(result, (f) => f.includes('No sprints yet'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('No sprints yet');
     result.unmount();

--- a/tests/integration/application/ui/tui/views/welcome-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/welcome-view.test.tsx
@@ -13,8 +13,8 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
-import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
-import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { makeProject } from '@tests/fixtures/domain.ts';
 import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 
@@ -65,7 +65,7 @@ describe('WelcomeView — first-run UX', () => {
       initial: { id: 'welcome' },
       onRoute: (e) => routes.push(e),
     });
-    await tick(120);
+    await waitForViewReady(result, (f) => f.includes('claude-only'));
 
     expect(saved).toHaveLength(1);
     for (const flow of ['refine', 'plan', 'readiness', 'ideate'] as const) {
@@ -94,7 +94,7 @@ describe('WelcomeView — first-run UX', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<WelcomeView />, { deps, initial: { id: 'welcome' } });
-    await tick(120);
+    await waitForViewReady(result, (f) => f.includes('No AI CLIs detected'));
 
     expect(saved).toHaveLength(1);
     // The mixed preset routes refine → codex, implement → claude — a clean fingerprint.
@@ -121,7 +121,7 @@ describe('WelcomeView — first-run UX', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<WelcomeView />, { deps, initial: { id: 'welcome' } });
-    await tick(120);
+    await waitForViewReady(result, (f) => f.includes('mixed'));
 
     expect(saved).toHaveLength(1);
     expect(saved[0]?.ai.refine.provider).toBe('openai-codex');
@@ -137,14 +137,15 @@ describe('WelcomeView — first-run UX', () => {
     } as unknown as AppDeps;
 
     const routes: ViewEntry[] = [];
-    renderView(<WelcomeView />, {
+    const { result: welcomeResult } = renderView(<WelcomeView />, {
       deps,
       initial: { id: 'welcome' },
       onRoute: (e) => routes.push(e),
     });
-    await tick(120);
+    await waitFor(() => routes.at(-1)?.id === 'home');
 
     expect(routes.at(-1)?.id).toBe('home');
+    welcomeResult.unmount();
   });
 
   it('surfaces a "Failed to save settings" message when persistence fails', async () => {
@@ -158,7 +159,7 @@ describe('WelcomeView — first-run UX', () => {
     } as unknown as AppDeps;
 
     const { result } = renderView(<WelcomeView />, { deps, initial: { id: 'welcome' } });
-    await tick(120);
+    await waitForViewReady(result, (f) => f.includes('Failed to save settings'));
 
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('Failed to save settings');

--- a/tests/unit/application/ui/cli/commands/create-pr.test.ts
+++ b/tests/unit/application/ui/cli/commands/create-pr.test.ts
@@ -37,7 +37,9 @@ describe('ralphctl create-pr — PATH gate for the createPr provider', () => {
   afterEach(async () => cli.cleanup());
 
   it('exits non-zero naming the missing binary and the ai.createPr.provider key when AI is on', async () => {
-    const result = await runCliCaptured(cli, ['create-pr', '--sprint', 'does-not-matter']);
+    // Well-formed (but nonexistent) sprint id: argument validation runs before the gate, so a
+    // malformed id would short-circuit with `invalid sprint id` instead of exercising the probe.
+    const result = await runCliCaptured(cli, ['create-pr', '--sprint', '01900000-0000-7000-8000-00000000aaaa']);
     // The gate fires before any sprint I/O — a missing claude CLI is surfaced first.
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('CLI claude not on PATH');
@@ -48,7 +50,12 @@ describe('ralphctl create-pr — PATH gate for the createPr provider', () => {
 
   it('does NOT fire the PATH gate under --no-ai (template path spawns no provider)', async () => {
     detectRef.installed = new Set(); // nothing installed at all
-    const result = await runCliCaptured(cli, ['create-pr', '--sprint', 'no-such-sprint', '--no-ai']);
+    const result = await runCliCaptured(cli, [
+      'create-pr',
+      '--sprint',
+      '01900000-0000-7000-8000-00000000bbbb',
+      '--no-ai',
+    ]);
     // The gate is skipped; the run instead fails downstream on the missing sprint — never with
     // the PATH-gate message. That proves --no-ai bypasses the probe.
     expect(result.stderr).not.toContain('not on PATH');

--- a/tests/unit/application/ui/shared/launcher-pin.test.ts
+++ b/tests/unit/application/ui/shared/launcher-pin.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Launch-time sprint pinning — `launchFlow` stamps the snapshot's project + sprint onto the
+ * LaunchResult so the session descriptor can identify the run independently of the mutable
+ * global selection.
+ *
+ * The one exception is `create-sprint`: its sprint does not exist at launch time, so any
+ * sprint on the snapshot is by definition the PREVIOUS selection. Pinning that would
+ * mislabel the run's execute view / breadcrumb; the sprint-bound launch wrapper pins the
+ * real one via `setPinnedSprint` once the chain resolves it. These tests fence the guard.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { launchFlow, type LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
+import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+
+const PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
+const SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
+
+const absPath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+const storage = (): StoragePaths => {
+  const cwd = process.cwd();
+  return {
+    appRoot: absPath(cwd),
+    dataRoot: absPath(cwd),
+    configRoot: absPath(cwd),
+    stateRoot: absPath(cwd),
+    locksRoot: absPath(cwd),
+    runsRoot: absPath(cwd),
+    memoryRoot: absPath(cwd),
+    operatorSkillsRoot: absPath(cwd),
+  };
+};
+
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * Minimal AppDeps for chain CONSTRUCTION only — the runner is never started, so the stubs
+ * exist purely to satisfy the flow factories' dependency shapes.
+ */
+const makeAppDeps = (): AppDeps =>
+  ({
+    settings: DEFAULT_SETTINGS,
+    settingsRepo: {
+      async load() {
+        return Result.ok(DEFAULT_SETTINGS);
+      },
+    },
+    eventBus: createInMemoryEventBus(),
+    clock: () => Date.now(),
+    logger: noopLogger,
+    projectRepo: {},
+    sprintRepo: {},
+    sprintExecutionRepo: {},
+    taskRepo: {},
+    appendFile: async () => Result.ok(undefined),
+    skillSource: { skillsFor: () => [] },
+  }) as unknown as AppDeps;
+
+const makeDeps = (): LauncherDeps => ({
+  app: makeAppDeps(),
+  interactive: {} as InteractivePrompt,
+  storage: storage(),
+  runInTerminal: passthroughRunInTerminal,
+});
+
+const project = {
+  id: PROJECT_ID,
+  slug: 'fixture-project',
+  displayName: 'Fixture Project',
+  repositories: [],
+} as unknown as Project;
+
+const sprint = {
+  id: SPRINT_ID,
+  projectId: PROJECT_ID,
+  slug: 'fixture-sprint',
+  name: 'Fixture Sprint',
+  status: 'draft',
+  tickets: [],
+} as unknown as Sprint;
+
+const snapshot: AppStateSnapshot = {
+  project,
+  sprint,
+  tasks: [],
+  triggerInputs: {
+    hasProject: true,
+    currentSprintStatus: 'draft',
+    pendingTicketCount: 0,
+    approvedTicketCount: 0,
+    resumableTaskCount: 0,
+  },
+  projectCount: 1,
+  sprintCount: 1,
+  recentSprints: [sprint],
+};
+
+describe('launchFlow — pinned project/sprint stamping', () => {
+  it('pins the snapshot sprint for a regular sprint-scoped flow (add-tickets)', async () => {
+    const result = await launchFlow(makeDeps(), 'add-tickets', snapshot);
+    if (!result.ok) throw new Error(`launch failed: ${result.reason}`);
+
+    expect(result.pinnedProjectId).toBe(PROJECT_ID);
+    expect(result.pinnedProjectLabel).toBe('Fixture Project');
+    expect(result.pinnedSprintId).toBe(SPRINT_ID);
+    expect(result.pinnedSprintLabel).toBe('Fixture Sprint');
+  });
+
+  it('does NOT pin the (stale) snapshot sprint for create-sprint', async () => {
+    const result = await launchFlow(makeDeps(), 'create-sprint', snapshot);
+    if (!result.ok) throw new Error(`launch failed: ${result.reason}`);
+
+    // Project still pins — the new sprint will belong to it.
+    expect(result.pinnedProjectId).toBe(PROJECT_ID);
+    // The previous selection's sprint must NOT be pinned onto the new run.
+    expect(result.pinnedSprintId).toBeUndefined();
+    expect(result.pinnedSprintLabel).toBeUndefined();
+  });
+});

--- a/tests/unit/application/ui/tui/runtime/keyboard-map.test.ts
+++ b/tests/unit/application/ui/tui/runtime/keyboard-map.test.ts
@@ -46,6 +46,7 @@ describe('footerGlobalHints', () => {
       'sessions',
       'settings',
       'pick project',
+      'pick sprint',
       'help',
       'quit',
     ]);

--- a/tests/unit/application/ui/tui/runtime/keyboard-map.test.ts
+++ b/tests/unit/application/ui/tui/runtime/keyboard-map.test.ts
@@ -46,10 +46,13 @@ describe('footerGlobalHints', () => {
       'sessions',
       'settings',
       'pick project',
-      'pick sprint',
       'help',
       'quit',
     ]);
+  });
+
+  it('keeps pick sprint out of the footer (breadcrumb [S] owns discoverability; the strip overflows 100 cols otherwise)', () => {
+    expect((globalKeys.pickSprint as KeyBinding).showInFooter).toBeUndefined();
   });
 });
 

--- a/tests/unit/application/ui/tui/runtime/selection-done-on-boot.test.tsx
+++ b/tests/unit/application/ui/tui/runtime/selection-done-on-boot.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { render } from 'ink-testing-library';
-import { Text } from 'ink';
+import { Text, useInput } from 'ink';
 import { describe, expect, it, vi } from 'vitest';
 import {
   SelectionProvider,
@@ -122,6 +122,87 @@ describe('SelectionProvider — done-on-boot clear', () => {
 
     // Draft sprint must survive rehydration.
     expect(r.lastFrame()).toContain(`s=${String(DRAFT_SPRINT_ID)}`);
+
+    r.unmount();
+  });
+
+  it('populates sprintStatus from the probe for a live (non-done) seeded sprint', async () => {
+    // The persisted seed carries only ids + labels — status is never written to disk. The
+    // boot probe already fetched the entity to answer "is it done?", so a live sprint must
+    // keep its status for the breadcrumb chip instead of leaving it blank until a re-pick.
+    const draftSprint = { ...makeDraftSprint(), id: DRAFT_SPRINT_ID } as unknown as Sprint;
+    const repo = makeSprintRepo(draftSprint);
+
+    const Probe = (): React.JSX.Element => {
+      const api = useSelection();
+      return <Text>status={String(api.sprintStatus)}</Text>;
+    };
+
+    const r = render(
+      <SelectionProvider
+        seed={{ sprintId: DRAFT_SPRINT_ID, sprintLabel: 'Active Sprint' }}
+        sprintRepo={repo}
+        onChange={vi.fn()}
+      >
+        <Probe />
+      </SelectionProvider>
+    );
+    await new Promise((res) => setTimeout(res, 50));
+
+    expect(r.lastFrame()).toContain('status=draft');
+
+    r.unmount();
+  });
+
+  it('does NOT clobber a fresh user pick made while the probe is still in flight', async () => {
+    // The probe races user input: seed points at a done sprint, but the user picks a
+    // different sprint before findById resolves. The late resolution must bail (live ref
+    // check) instead of clearing the fresh pick.
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((res) => {
+      release = res;
+    });
+    const doneSprint = { ...makeDoneSprint(), id: DONE_SPRINT_ID } as unknown as Sprint;
+    const repo = {
+      async findById() {
+        await gate;
+        return Result.ok(doneSprint);
+      },
+    } as unknown as SprintRepository;
+
+    const Probe = (): React.JSX.Element => {
+      const api = useSelection();
+      useInput((input) => {
+        if (input === 'p') api.setSprint(DRAFT_SPRINT_ID, 'Fresh Pick', 'draft');
+      });
+      return (
+        <Text>
+          s={String(api.sprintId)} status={String(api.sprintStatus)}
+        </Text>
+      );
+    };
+
+    const r = render(
+      <SelectionProvider
+        seed={{ sprintId: DONE_SPRINT_ID, sprintLabel: 'Closed Sprint' }}
+        sprintRepo={repo}
+        onChange={vi.fn()}
+      >
+        <Probe />
+      </SelectionProvider>
+    );
+    await new Promise((res) => setTimeout(res, 20));
+
+    // User picks another sprint while the probe is pending…
+    r.stdin.write('p');
+    await new Promise((res) => setTimeout(res, 20));
+    // …then the probe resolves with "seed sprint is done".
+    release?.();
+    await new Promise((res) => setTimeout(res, 50));
+
+    // The fresh pick (id AND status) must survive the late probe.
+    expect(r.lastFrame()).toContain(`s=${String(DRAFT_SPRINT_ID)}`);
+    expect(r.lastFrame()).toContain('status=draft');
 
     r.unmount();
   });

--- a/tests/unit/application/ui/tui/runtime/selection-sync-sprint-status.test.tsx
+++ b/tests/unit/application/ui/tui/runtime/selection-sync-sprint-status.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * `syncSprintStatus` — toast-free status refresh for the currently-selected sprint.
+ *
+ * Contract:
+ *  - Updates `sprintStatus` when the given id matches the live selection (views fire this on
+ *    every snapshot load, so flow-driven transitions reach the breadcrumb chip).
+ *  - No-op when the id does NOT match — a snapshot loaded for sprint A must never restamp
+ *    the chip after the user picked sprint B.
+ *  - Never writes `lastSwitch` — refreshing a chip must not replay the "✓ now on …" toast.
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text, useInput } from 'ink';
+import { describe, expect, it, vi } from 'vitest';
+import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+
+const sid = (s: string): SprintId => {
+  const r = SprintId.parse(s);
+  if (!r.ok) throw new Error(`bad sprint id: ${r.error.message}`);
+  return r.value;
+};
+
+const SPRINT_A = sid('01900000-0000-7000-8000-0000000000a1');
+const SPRINT_B = sid('01900000-0000-7000-8000-0000000000b1');
+
+/**
+ * Probe drives the api through Ink input so updates flow through React's normal scheduling:
+ *   a — syncSprintStatus(SPRINT_A, 'active')
+ *   b — syncSprintStatus(SPRINT_B, 'done')   (a non-selected sprint)
+ */
+const Probe = (): React.JSX.Element => {
+  const api = useSelection();
+  useInput((input) => {
+    if (input === 'a') api.syncSprintStatus(SPRINT_A, 'active');
+    if (input === 'b') api.syncSprintStatus(SPRINT_B, 'done');
+  });
+  return (
+    <Text>
+      status={String(api.sprintStatus)} switch={String(api.lastSwitch?.sprintId)}
+    </Text>
+  );
+};
+
+const mount = (): ReturnType<typeof render> =>
+  render(
+    <SelectionProvider seed={{ sprintId: SPRINT_A, sprintLabel: 'Alpha Sprint' }} onChange={vi.fn()}>
+      <Probe />
+    </SelectionProvider>
+  );
+
+describe('SelectionProvider — syncSprintStatus', () => {
+  it('updates sprintStatus when the id matches the selected sprint', async () => {
+    const r = mount();
+    await new Promise((res) => setTimeout(res, 20));
+
+    expect(r.lastFrame()).toContain('status=undefined');
+    r.stdin.write('a');
+    await new Promise((res) => setTimeout(res, 20));
+
+    expect(r.lastFrame()).toContain('status=active');
+    r.unmount();
+  });
+
+  it('is a no-op when the id does not match the selected sprint', async () => {
+    const r = mount();
+    await new Promise((res) => setTimeout(res, 20));
+
+    r.stdin.write('b');
+    await new Promise((res) => setTimeout(res, 20));
+
+    expect(r.lastFrame()).toContain('status=undefined');
+    r.unmount();
+  });
+
+  it('never records a lastSwitch (no toast replay on chip refresh)', async () => {
+    const r = mount();
+    await new Promise((res) => setTimeout(res, 20));
+
+    r.stdin.write('a');
+    await new Promise((res) => setTimeout(res, 20));
+
+    expect(r.lastFrame()).toContain('status=active');
+    expect(r.lastFrame()).toContain('switch=undefined');
+    r.unmount();
+  });
+});

--- a/tests/unit/application/ui/tui/views/home-internals/menu-items.test.ts
+++ b/tests/unit/application/ui/tui/views/home-internals/menu-items.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Home menu builder — digit quick-switch hotkeys on the recent-sprint rows.
+ *
+ * Each "switch sprint" row carries `hotkey: '1'..'N'` (recentSprints is capped at 5 upstream,
+ * so digits always suffice) and must NOT be flagged `globalHotkey` — ActionMenu owns the
+ * binding so the digits work on Home only.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { buildMenuItems } from '@src/application/ui/tui/views/home-internals/menu-items.ts';
+
+const makeSprint = (n: number): Sprint =>
+  ({
+    id: `sprint-${String(n)}` as unknown as SprintId,
+    name: `Sprint ${String(n)}`,
+    status: 'draft',
+    tickets: [],
+  }) as unknown as Sprint;
+
+const buildWith = (recentSprints: readonly Sprint[]): ReturnType<typeof buildMenuItems> =>
+  buildMenuItems({
+    hasProject: true,
+    stateLoaded: true,
+    currentSprint: undefined,
+    recentSprints,
+    selectionSprintId: undefined,
+    switchSprintDisabled: undefined,
+    addTicketDisabled: undefined,
+    onPushHome: vi.fn(),
+    onPushAddTicket: vi.fn(),
+    onSwitchSprint: vi.fn(),
+    onLaunchCreateSprint: vi.fn(),
+  });
+
+describe('buildMenuItems — recent-sprint digit hotkeys', () => {
+  it('assigns 1..N to the sprint rows in order', () => {
+    const items = buildWith([makeSprint(1), makeSprint(2), makeSprint(3)]);
+    const sprintRows = items.filter((i) => i.id.startsWith('sprint-sprint-'));
+    expect(sprintRows.map((i) => i.hotkey)).toEqual(['1', '2', '3']);
+  });
+
+  it('keeps the digit binding local to the menu (no globalHotkey)', () => {
+    const items = buildWith([makeSprint(1), makeSprint(2)]);
+    for (const row of items.filter((i) => i.id.startsWith('sprint-sprint-'))) {
+      expect(row.globalHotkey).not.toBe(true);
+    }
+  });
+
+  it('selecting a row via its callback switches to that sprint', () => {
+    const onSwitchSprint = vi.fn();
+    const sprints = [makeSprint(1), makeSprint(2)];
+    const items = buildMenuItems({
+      hasProject: true,
+      stateLoaded: true,
+      currentSprint: undefined,
+      recentSprints: sprints,
+      selectionSprintId: undefined,
+      switchSprintDisabled: undefined,
+      addTicketDisabled: undefined,
+      onPushHome: vi.fn(),
+      onPushAddTicket: vi.fn(),
+      onSwitchSprint,
+      onLaunchCreateSprint: vi.fn(),
+    });
+    const second = items.find((i) => i.hotkey === '2');
+    expect(second).toBeDefined();
+    second?.onSelect();
+    expect(onSwitchSprint).toHaveBeenCalledWith(sprints[1]);
+  });
+});

--- a/tests/unit/application/ui/tui/views/settings-mutations.escalation.test.ts
+++ b/tests/unit/application/ui/tui/views/settings-mutations.escalation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * submitField — escalation-map routing.
+ *
+ * `map-add` submits a `from=to` pair from the two-step picker; `map-entry` submits a bare
+ * target where the empty string deletes the override. Both must persist through the same
+ * `harness.escalationMap.<from>` apply-key grammar the CLI's `settings set` uses.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { submitField } from '@src/application/ui/tui/views/settings-mutations.ts';
+import type { EditableField } from '@src/application/ui/tui/views/settings-view-model.ts';
+
+const recordingRepo = (): { readonly repo: SettingsRepository; readonly saved: () => Settings | undefined } => {
+  let saved: Settings | undefined;
+  return {
+    saved: () => saved,
+    repo: {
+      path: '/tmp/test-settings.json',
+      async exists() {
+        return Result.ok(true);
+      },
+      async load() {
+        return Result.ok(saved ?? DEFAULT_SETTINGS);
+      },
+      async save(next: Settings) {
+        saved = next;
+        return Result.ok(undefined);
+      },
+    } as unknown as SettingsRepository,
+  };
+};
+
+const mapAddField: EditableField = {
+  kind: 'map-add',
+  key: 'harness.escalationMap',
+  label: 'Escalation map',
+  current: 'defaults apply',
+};
+
+const mapEntryField = (from: string, to: string): EditableField => ({
+  kind: 'map-entry',
+  key: `harness.escalationMap.${from}`,
+  label: `  ${from}`,
+  current: to,
+  from,
+  to,
+});
+
+describe('submitField — escalation map', () => {
+  it('map-add persists the from=to pair as a new override', async () => {
+    const { repo, saved } = recordingRepo();
+    const outcome = await submitField(DEFAULT_SETTINGS, mapAddField, 'claude-opus-4-8=claude-fable-5', repo);
+
+    expect(outcome.kind).toBe('ok');
+    if (outcome.kind === 'ok') expect(outcome.text).toContain('claude-opus-4-8');
+    expect(saved()?.harness.escalationMap).toEqual({ 'claude-opus-4-8': 'claude-fable-5' });
+  });
+
+  it('map-add rejects a malformed pair without persisting', async () => {
+    const { repo, saved } = recordingRepo();
+    const outcome = await submitField(DEFAULT_SETTINGS, mapAddField, 'not-a-pair', repo);
+
+    expect(outcome.kind).toBe('error');
+    expect(saved()).toBeUndefined();
+  });
+
+  it('map-entry with a new target updates the override in place', async () => {
+    const settings: Settings = {
+      ...DEFAULT_SETTINGS,
+      harness: { ...DEFAULT_SETTINGS.harness, escalationMap: { 'claude-opus-4-8': 'claude-fable-5' } },
+    };
+    const { repo, saved } = recordingRepo();
+    const outcome = await submitField(
+      settings,
+      mapEntryField('claude-opus-4-8', 'claude-fable-5'),
+      'claude-fable-5[1m]',
+      repo
+    );
+
+    expect(outcome.kind).toBe('ok');
+    expect(saved()?.harness.escalationMap).toEqual({ 'claude-opus-4-8': 'claude-fable-5[1m]' });
+  });
+
+  it('map-entry with the empty string removes the override', async () => {
+    const settings: Settings = {
+      ...DEFAULT_SETTINGS,
+      harness: { ...DEFAULT_SETTINGS.harness, escalationMap: { 'claude-opus-4-8': 'claude-fable-5' } },
+    };
+    const { repo, saved } = recordingRepo();
+    const outcome = await submitField(settings, mapEntryField('claude-opus-4-8', 'claude-fable-5'), '', repo);
+
+    expect(outcome.kind).toBe('ok');
+    if (outcome.kind === 'ok') expect(outcome.text).toContain('removed');
+    expect(saved()?.harness.escalationMap).toEqual({});
+  });
+});

--- a/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
+++ b/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Settings view-model — escalation-map field group + pure helpers.
+ *
+ * The harness section exposes the map as an editable group: one `map-add` action row plus one
+ * `map-entry` row per user override. Target options are scoped to the catalogs that know the
+ * from-model so the picker never invites cross-provider ids; the effective-ladder summary
+ * merges user overrides over the built-in map and marks customised chains.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import {
+  buildSections,
+  effectiveEscalationChains,
+  escalationModelOptions,
+  escalationTargetsFor,
+} from '@src/application/ui/tui/views/settings-view-model.ts';
+
+const withOverrides = (escalationMap: Readonly<Record<string, string>>): Settings => ({
+  ...DEFAULT_SETTINGS,
+  harness: { ...DEFAULT_SETTINGS.harness, escalationMap },
+});
+
+const harnessFields = (s: Settings): ReturnType<typeof buildSections>[number]['fields'] => {
+  const section = buildSections(s).find((sec) => sec.id === 'harness');
+  if (section === undefined) throw new Error('harness section missing');
+  return section.fields;
+};
+
+describe('buildSections — escalation-map group', () => {
+  it('exposes a single map-add row (and no entries) when no overrides exist', () => {
+    const fields = harnessFields(DEFAULT_SETTINGS);
+    const add = fields.filter((f) => f.kind === 'map-add');
+    expect(add).toHaveLength(1);
+    expect(add[0]?.key).toBe('harness.escalationMap');
+    expect(add[0]?.current).toContain('defaults apply');
+    expect(fields.some((f) => f.kind === 'map-entry')).toBe(false);
+  });
+
+  it('exposes one editable map-entry row per override, keyed on the CLI grammar', () => {
+    const fields = harnessFields(withOverrides({ 'claude-opus-4-8': 'claude-fable-5' }));
+    const entries = fields.filter((f) => f.kind === 'map-entry');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.key).toBe('harness.escalationMap.claude-opus-4-8');
+    expect(entries[0]?.from).toBe('claude-opus-4-8');
+    expect(entries[0]?.to).toBe('claude-fable-5');
+    const add = fields.find((f) => f.kind === 'map-add');
+    expect(add?.current).toContain('1 override');
+  });
+});
+
+describe('escalation model helpers', () => {
+  it('escalationModelOptions unions the three catalogs without duplicates', () => {
+    const options = escalationModelOptions();
+    expect(options).toContain('claude-opus-4-8');
+    expect(new Set(options).size).toBe(options.length);
+  });
+
+  it('escalationTargetsFor scopes targets to catalogs owning the from-model and excludes self', () => {
+    const targets = escalationTargetsFor('claude-haiku-4-5');
+    expect(targets).toContain('claude-sonnet-4-6');
+    expect(targets).toContain('claude-opus-4-8');
+    expect(targets).not.toContain('claude-haiku-4-5');
+    // Dash-form Claude ids live in the Claude-Code catalog only — no GPT ids offered.
+    expect(targets.some((t) => t.startsWith('gpt-'))).toBe(false);
+  });
+
+  it('escalationTargetsFor falls back to the full union for a custom (uncatalogued) id', () => {
+    const targets = escalationTargetsFor('my-private-model');
+    expect(targets).toContain('claude-opus-4-8');
+    expect(targets.some((t) => t.startsWith('gpt-'))).toBe(true);
+  });
+});
+
+describe('effectiveEscalationChains', () => {
+  it('renders the built-in haiku→sonnet→opus chain uncustomised with no overrides', () => {
+    const chains = effectiveEscalationChains({});
+    const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8']);
+    expect(claude?.customised).toBe(false);
+  });
+
+  it('extends a chain through a user rung and marks it customised', () => {
+    const chains = effectiveEscalationChains({ 'claude-opus-4-8': 'claude-fable-5' });
+    const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-fable-5']);
+    expect(claude?.customised).toBe(true);
+  });
+
+  it('cuts user-authored cycles instead of walking forever', () => {
+    const chains = effectiveEscalationChains({ 'model-a': 'model-b', 'model-b': 'model-a' });
+    // Both rungs are targets of each other, so neither is a root — the cycle simply never
+    // surfaces as a chain. The default chains still render.
+    expect(chains.some((c) => c.models[0] === 'claude-haiku-4-5')).toBe(true);
+    expect(chains.every((c) => new Set(c.models).size === c.models.length)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Four independent workstreams, each its own commit, all driven by the selection-coherence audit handoff plus two follow-up asks (editable escalation map, plateau-escalation default).

### 1. Selection coherence — the project/sprint combo now follows you (`fix(tui)`)

The TUI keeps two project/sprint stores — the mutable global selection (what flow launches use) and the per-run pinned context (what the execute view shows) — and nothing re-converged them once they diverged: you could watch sprint B while `n → Flows` silently launched against sprint A.

- Focusing an execute view (Tab / Ctrl+1..9 / Sessions) converges the global selection onto the run's pinned project/sprint.
- `create-sprint` / `close-sprint` launched from Flows route through the sprint-bound reseat wrapper: create-sprint reseats onto the new sprint and **never pins the stale previous sprint onto its descriptor** (launcher-side guard + snapshot strip); close-sprint refreshes the status chip to `done` via the new toast-free `syncSprintStatus` — which no-ops if you switched sprints mid-run.
- The breadcrumb status chip refreshes from every fresh Home/Flows snapshot load and on boot; a fresh pick can no longer be clobbered by the in-flight done-on-boot probe.
- Sprint-detail's `n` makes the viewed sprint current before the global handler opens Flows — as its "scoped to this sprint" hint always promised.
- Projects list / project detail are **browse-only**: opening a detail no longer switches the project (which wiped the sprint cursor); an explicit `m — make current` chord on both views is the deliberate switch.
- Fixed Home's "✓ now on …" toast that never expired (identity-updater bailout).

### 2. CLI defaults to the pinned current sprint (`feat(cli)`)

`sprint set-current` (and every TUI pick) persisted the selection, but no command read it back. Now: `sprint show/progress [id]`, `project show [id]` take optional ids, and `task list/show/unblock`, `ticket list/show/add/remove`, `create-pr`, `export-context`, `export-requirements` make `--sprint` optional — all falling back to the pin with a one-line stderr notice naming the substituted sprint. Missing both exits 1 with `set-current` guidance; removals clear matching dangling pins; ticket mutations name the resolved sprint in their success lines.

### 3. TUI affordances (`feat(tui)`)

Breadcrumb `[S]` next to the sprint label (mirroring `[P]`); Home digit hotkeys `1–5` on the recent-sprint quick-switch rows; sprint picker `f` hides done sprints (default off — closed sprints stay reachable by contract); create-PR error card gains `r` retry. The optional "pick sprint" footer hint was tried and reverted — it overflows a 100-col terminal and wraps the whole strip.

### 4. Editable escalation map in Settings (`feat(tui)`)

The Harness section's read-only escalation map is now a first-class editable group: an add-rung row walks a two-step FROM→TO picker (targets scoped to the catalogs that know the from-model; self-loops excluded; esc on step 2 returns to step 1), each override is a row you can retarget or `(remove)`, and the card renders the **effective** ladder (overrides merged over the built-in map) with customised chains marked. Both routes persist through the same `harness.escalationMap.<from>` grammar as `settings set`. `escalateOnPlateau` was verified to already default to `true` — no change needed.

Plus: stale doc comments settled (wire() `skillSource`, baseline-health-card), `pnpm deadcode` green on Linux (knip ignores the Windows-only `where` binary), `sprints-view` test deflaked (fixed ticks → `waitForViewReady`), CHANGELOG and `.claude/docs` refreshed.

## Test plan

- `pnpm typecheck` ✓ · `pnpm lint` ✓ (0 errors) · `pnpm test` ✓ **3522/3522** · `pnpm deadcode` ✓
- New coverage: selection sync/probe-race unit tests, launcher pin-guard unit test, flows-view sprint-bound launch integration test, sprint-detail `n` reseat tests, CLI pin-fallback e2e (sprint/task/ticket), escalation-map view-model + mutation unit tests, and an integration drive of the two-step picker.
