### PR TITLE
Guard the suspended claude-fable-5 family gracefully

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -46,7 +46,10 @@ in one transaction; subsequent per-key edits via `ralphctl settings set ai.<flow
   long-context syntax, passed through verbatim — on large repos the 1M window avoids mid-session
   compaction during deep implement runs) as **opt-in only** — no preset, default, or built-in
   escalation rung references them; pick per row or add an `'claude-opus-4-8': 'claude-fable-5'` rung
-  via `settings.harness.escalationMap`.
+  via `settings.harness.escalationMap`. **Temporarily suspended (2026-06-12 Anthropic export-control
+  directive):** the `claude-fable-5` family stays in the catalog but is currently rejected at launch
+  with a clear message and flagged `(suspended)` in the pickers; it will be restored when access
+  returns (single-list revert in `settings-models/suspended-models.ts`).
 - GitHub Copilot — adds `gpt-5.5`, `claude-opus-4.7`, `claude-opus-4.8`, Gemini 3.x family
   (`gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`),
   plus `mai-code-1-flash`, `raptor-mini-preview` (verified against Copilot CLI v1.0.60).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins
 
 ### Changed
 
+- **`claude-fable-5` family guarded as temporarily suspended (2026-06-12 Anthropic export-control
+  directive).** Fable 5 / Mythos 5 went down server-side. The catalog entries (`claude-fable-5`,
+  `claude-fable-5[1m]`, plus the Anthropic-served Copilot `claude-fable-5`) stay in place so persisted
+  configs remain valid — but the Claude / Copilot adapters now reject these models fast at launch with a
+  clear message, and the model pickers flag them `(suspended)`. Gated on one reversible list
+  (`settings-models/suspended-models.ts`); re-enabling is a one-line revert.
+
 - **Verification division of labor — each gate runs exactly once.** The prompt templates now assign each role
   its own verify gate so the repo-wide script is never executed more than once per round: the generator runs
   each auto verification criterion once (never the full `verifyScript` — the harness post-verify is named as

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -24,6 +24,7 @@ import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
 import { PROVIDER_EFFORT_LEVELS } from '@src/domain/value/settings-models/effort.ts';
+import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
 import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { LaunchExtras } from '@src/application/ui/shared/launcher.ts';
@@ -57,6 +58,17 @@ const resolveModelCatalog = async (
 
 /** Sentinel value returned for the `Keep default` option — never collides with a real id. */
 const KEEP = '__keep__';
+
+/**
+ * Map a model id to a picker choice — flagging temporarily-suspended models in the LABEL only.
+ * The `value` stays the bare id so a pre-pinned choice still round-trips; if the user picks it
+ * anyway, the adapter guard rejects it at launch with a clear message. Applies to both the static
+ * and account-narrowed catalogs, since both flow through `modelCatalog.map`.
+ */
+const modelChoice = (m: string): Choice<string> => ({
+  label: isSuspendedModel(m) ? `${m} (${SUSPENSION_NOTE})` : m,
+  value: m,
+});
 
 /**
  * Outcome of one picker session. `kind` discriminates:
@@ -145,11 +157,8 @@ const customizeRow = async (
   // incompatible model. Otherwise show `Keep default` first.
   const modelCatalog = await resolveModelCatalog(effectiveProvider, availableModelsFor);
   const modelOptions: ReadonlyArray<Choice<string>> = providerChanged
-    ? modelCatalog.map((m) => ({ label: m, value: m }))
-    : [
-        { label: labelKeepDefault(defaultRow.model), value: KEEP },
-        ...modelCatalog.map((m) => ({ label: m, value: m })),
-      ];
+    ? modelCatalog.map(modelChoice)
+    : [{ label: labelKeepDefault(defaultRow.model), value: KEEP }, ...modelCatalog.map(modelChoice)];
   const modelAns = await interactive.askChoice<string>(`${header}\nModel:`, modelOptions);
   if (!modelAns.ok) return undefined;
 

--- a/src/application/ui/tui/views/settings-editor.tsx
+++ b/src/application/ui/tui/views/settings-editor.tsx
@@ -22,8 +22,10 @@ import {
   type EditableField,
   escalationModelOptions,
   escalationTargetsFor,
+  isModelField,
   isProviderField,
 } from '@src/application/ui/tui/views/settings-view-model.ts';
+import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
 
 interface ProviderChoice {
   readonly label: string;
@@ -137,10 +139,17 @@ export const SettingsEditor = ({
         />
       );
     }
+    // Model selects flag temporarily-suspended ids in the LABEL only; the value stays the bare id
+    // so a pre-pinned choice round-trips (the adapter guard rejects it at launch). Every other
+    // select (log level, booleans, …) renders plain.
+    const annotate = isModelField(field);
     return (
       <SelectPrompt
         message={`${field.label} (current: ${field.current})`}
-        options={field.options.map((value) => ({ label: value, value }))}
+        options={field.options.map((value) => ({
+          label: annotate && isSuspendedModel(value) ? `${value} (${SUSPENSION_NOTE})` : value,
+          value,
+        }))}
         onSubmit={(value) => onSubmit(String(value))}
         onCancel={onCancel}
       />

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -361,3 +361,10 @@ export const buildSections = (
  */
 export const isProviderField = (field: EditableField): boolean =>
   field.kind === 'select' && (field.key.endsWith('.provider') || field.key === 'ai.provider');
+
+/**
+ * `true` when `field` is a per-flow / per-role model picker — its options are model ids, so the
+ * editor flags temporarily-suspended entries. The escalation FROM/TO pickers are separate field
+ * kinds (`map-add` / `map-entry`), not `select`, so they are unaffected here.
+ */
+export const isModelField = (field: EditableField): boolean => field.kind === 'select' && field.key.endsWith('.model');

--- a/src/domain/value/settings-models/suspended-models.ts
+++ b/src/domain/value/settings-models/suspended-models.ts
@@ -1,0 +1,46 @@
+/**
+ * Single reversible kill-switch for models that are temporarily unusable server-side while still
+ * carried in the provider catalogs. As of 2026-06-12 the `claude-fable-5` family (Fable 5 /
+ * Mythos 5) is suspended by an Anthropic export-control directive; the bare `claude-fable-5`
+ * string also matches the Copilot catalog entry (Anthropic-served via Copilot, so it is down too).
+ *
+ * The catalog entries deliberately STAY in place: the suspension is described as temporary, and the
+ * `settings` model fields accept any catalog id OR a custom string (`z.union([z.enum(...),
+ * CustomModelStringSchema])`), so already-persisted configs that name a suspended model remain
+ * schema-valid. Rather than churn the catalog, the adapters fail fast with a clear message and the
+ * model pickers flag the entry — all gated on this one list.
+ *
+ * To fully restore a model: empty {@link SUSPENDED_MODELS} (or delete this module and its four
+ * consumers — the two adapter guards in `claude/headless.ts` + `copilot/headless.ts`, and the two
+ * picker annotations in `flows-customize-picker.ts` + `settings-editor.tsx`). Re-enabling is a
+ * one-line revert.
+ *
+ * Domain layer — pure, no I/O.
+ *
+ * @public
+ */
+export const SUSPENDED_MODELS: readonly string[] = ['claude-fable-5', 'claude-fable-5[1m]'] as const;
+
+/**
+ * `true` when `s` names a temporarily-suspended model (see {@link SUSPENDED_MODELS}).
+ *
+ * @public
+ */
+export const isSuspendedModel = (s: string): boolean => SUSPENDED_MODELS.includes(s);
+
+/**
+ * Short suffix tag appended to a suspended model's label in the pickers (the value stays the bare
+ * id so a pre-pinned choice still round-trips).
+ *
+ * @public
+ */
+export const SUSPENSION_NOTE = 'suspended';
+
+/**
+ * The launch-time rejection message for a suspended model — surfaced via `InvalidStateError` at the
+ * adapter boundary so the user gets actionable context rather than an opaque CLI failure.
+ *
+ * @public
+ */
+export const suspendedModelMessage = (model: string): string =>
+  `'${model}' is temporarily suspended by Anthropic (2026-06-12 export-control directive on Fable 5 / Mythos 5) — pick another model until access is restored`;

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -10,6 +10,7 @@ import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
+import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/settings-models/suspended-models.ts';
 import { createClaudeStreamParser } from '@src/integration/ai/providers/claude/parse-stream.ts';
 import type { ClaudeStreamLine } from '@src/integration/ai/providers/_engine/claude-stream.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
@@ -284,6 +285,18 @@ export const buildClaudeArgs = (session: AiSession): Result<readonly string[], I
         currentState: 'model-validation',
         attemptedAction: 'build argv',
         message: `claude-provider: '${session.model}' is not a known Claude model`,
+      })
+    );
+  }
+  // Catalog-valid but temporarily suspended server-side (see suspended-models.ts) — fail fast
+  // with a clear message rather than dispatching a --model the provider will reject opaquely.
+  if (isSuspendedModel(session.model)) {
+    return Result.error(
+      new InvalidStateError({
+        entity: 'claude-provider',
+        currentState: 'model-suspended',
+        attemptedAction: 'build argv',
+        message: suspendedModelMessage(session.model),
       })
     );
   }

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -10,6 +10,7 @@ import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
+import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/settings-models/suspended-models.ts';
 import { createCopilotStreamParser } from '@src/integration/ai/providers/copilot/parse-stream.ts';
 import type { CopilotStreamLine, CopilotUsage } from '@src/integration/ai/providers/_engine/copilot-stream.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
@@ -112,6 +113,18 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
         currentState: 'model-validation',
         attemptedAction: 'build argv',
         message: `copilot-provider: '${session.model}' is not a known Copilot model`,
+      })
+    );
+  }
+  // Catalog-valid but temporarily suspended server-side (see suspended-models.ts). For Copilot
+  // this hits the Anthropic-served claude-fable-5 entry — fail fast with a clear message.
+  if (isSuspendedModel(session.model)) {
+    return Result.error(
+      new InvalidStateError({
+        entity: 'copilot-provider',
+        currentState: 'model-suspended',
+        attemptedAction: 'build argv',
+        message: suspendedModelMessage(session.model),
       })
     );
   }

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -11,6 +11,7 @@ import { FULL_AUTO, READ_ONLY } from '@src/integration/ai/providers/_engine/sess
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
+import { isSuspendedModel } from '@src/domain/value/settings-models/suspended-models.ts';
 import { buildClaudeArgs, createClaudeProvider } from '@src/integration/ai/providers/claude/headless.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import type { TokenUsageEvent } from '@src/business/observability/events.ts';
@@ -578,7 +579,7 @@ describe('createClaudeProvider — TokenUsageEvent emission', () => {
 });
 
 describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
-  it.each(CLAUDE_MODELS.map((m) => [m]))('passes through --model %s', (model) => {
+  it.each(CLAUDE_MODELS.filter((m) => !isSuspendedModel(m)).map((m) => [m]))('passes through --model %s', (model) => {
     const args = unwrapArgs(session({ model }));
     const idx = args.indexOf('--model');
     expect(idx).toBeGreaterThanOrEqual(0);
@@ -591,6 +592,24 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
     if (r.ok) return;
     expect(r.error.code).toBe('invalid-state');
     expect(r.error.message).toContain("'gpt-5.4'");
+  });
+
+  it.each([['claude-fable-5'], ['claude-fable-5[1m]']])(
+    'rejects the suspended model %s with InvalidStateError(model-suspended)',
+    (model) => {
+      const r = buildClaudeArgs(session({ model }));
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('invalid-state');
+      expect(r.error.currentState).toBe('model-suspended');
+      expect(r.error.message).toContain('suspended');
+      expect(r.error.message).toContain(`'${model}'`);
+    }
+  );
+
+  it('still builds args for a non-suspended model (claude-opus-4-8)', () => {
+    const args = unwrapArgs(session({ model: 'claude-opus-4-8' }));
+    expect(args[args.indexOf('--model') + 1]).toBe('claude-opus-4-8');
   });
 
   it('always includes -p so claude runs in print/headless mode', () => {

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -11,6 +11,7 @@ import { FULL_AUTO, READ_ONLY } from '@src/integration/ai/providers/_engine/sess
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+import { isSuspendedModel } from '@src/domain/value/settings-models/suspended-models.ts';
 import { buildCopilotArgs, createCopilotProvider } from '@src/integration/ai/providers/copilot/headless.ts';
 import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import type { TokenUsageEvent } from '@src/business/observability/events.ts';
@@ -605,7 +606,7 @@ describe('createCopilotProvider — TokenUsageEvent emission', () => {
 });
 
 describe('buildCopilotArgs — AiSession → CLI flag translation', () => {
-  it.each(COPILOT_MODELS.map((m) => [m]))('passes through --model=%s', (model) => {
+  it.each(COPILOT_MODELS.filter((m) => !isSuspendedModel(m)).map((m) => [m]))('passes through --model=%s', (model) => {
     const args = unwrapArgs(session({ model }));
     expect(args).toContain(`--model=${model}`);
     expect(args).not.toContain('--model');
@@ -617,6 +618,21 @@ describe('buildCopilotArgs — AiSession → CLI flag translation', () => {
     if (r.ok) return;
     expect(r.error.code).toBe('invalid-state');
     expect(r.error.message).toContain("'claude-haiku-4-5'");
+  });
+
+  it('rejects the suspended claude-fable-5 with InvalidStateError(model-suspended)', () => {
+    const r = buildCopilotArgs(session({ model: 'claude-fable-5' }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('invalid-state');
+    expect(r.error.currentState).toBe('model-suspended');
+    expect(r.error.message).toContain('suspended');
+    expect(r.error.message).toContain("'claude-fable-5'");
+  });
+
+  it('still builds args for a non-suspended copilot model (claude-opus-4.8)', () => {
+    const args = unwrapArgs(session({ model: 'claude-opus-4.8' }));
+    expect(args).toContain('--model=claude-opus-4.8');
   });
 
   it('always emits --output-format=json --autopilot --silent --no-ask-user', () => {

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -28,6 +28,7 @@ import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
+import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
 import {
   type CustomizePickerResult,
   modelCatalogFor,
@@ -427,10 +428,56 @@ describe('runCustomizePicker — catalog source parity with settings', () => {
       settings: DEFAULT_SETTINGS,
     });
     // The first label is `Keep default (<saved model>)`; the rest must match the
-    // CLAUDE_MODELS catalog in order so a model bump or rename is caught immediately.
+    // CLAUDE_MODELS catalog in order so a model bump or rename is caught immediately. Suspended
+    // models carry a ` (suspended)` suffix on the LABEL (value stays the bare id).
     expect(modelStepOptions).toBeDefined();
     const catalogLabels = modelStepOptions!.slice(1);
-    expect(catalogLabels).toEqual([...CLAUDE_MODELS]);
+    expect(catalogLabels).toEqual(CLAUDE_MODELS.map((m) => (isSuspendedModel(m) ? `${m} (${SUSPENSION_NOTE})` : m)));
+  });
+
+  it('flags a suspended model on the LABEL only — value stays the bare id', async () => {
+    let modelStepChoices: ReadonlyArray<Choice<unknown>> | undefined;
+    const interactive: InteractivePrompt = {
+      async askText() {
+        throw new Error('not used');
+      },
+      async askTextArea() {
+        throw new Error('not used');
+      },
+      async askConfirm() {
+        throw new Error('not used');
+      },
+      async askMultiChoice() {
+        throw new Error('not used');
+      },
+      async askChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
+        if (message.includes('What would you like to do?')) {
+          const c = options.find((o) => o.label === 'Customize for this run…');
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        if (message.includes('Provider:')) {
+          const c = options.find((o) => o.label.startsWith('Keep default'));
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        if (message.includes('Model:')) {
+          modelStepChoices = options;
+          return Result.error(new AbortError({ elementName: 'test', reason: 'snapshot' })) as unknown as Result<
+            T,
+            DomainError
+          >;
+        }
+        throw new Error(`unexpected prompt: ${message}`);
+      },
+    };
+    await runCustomizePicker({ interactive, flowId: 'refine', flowTitle: 'Refine', settings: DEFAULT_SETTINGS });
+    expect(modelStepChoices).toBeDefined();
+    const fable = modelStepChoices!.find((c) => c.value === 'claude-fable-5');
+    expect(fable).toBeDefined();
+    expect(fable!.label).toBe(`claude-fable-5 (${SUSPENSION_NOTE})`);
+    expect(fable!.value).toBe('claude-fable-5');
+    // A live model is unannotated.
+    const opus = modelStepChoices!.find((c) => c.value === 'claude-opus-4-8');
+    expect(opus!.label).toBe('claude-opus-4-8');
   });
 });
 
@@ -793,8 +840,12 @@ describe('runCustomizePicker — availableModelsFor gates the model step', () =>
     ]);
     await runCustomizePicker({ interactive, flowId: 'refine', flowTitle: 'refine', settings: DEFAULT_SETTINGS });
     const modelOptions = modelOptionsFromCapture(captured);
-    // Keep-default is the first option; the rest are the full catalog.
-    for (const model of fullCatalog) expect(modelOptions).toContain(model);
+    // Keep-default is the first option; the rest are the full catalog. Suspended models render
+    // with a ` (suspended)` LABEL suffix (the value stays the bare id).
+    for (const model of fullCatalog) {
+      const expectedLabel = isSuspendedModel(model) ? `${model} (${SUSPENSION_NOTE})` : model;
+      expect(modelOptions).toContain(expectedLabel);
+    }
   });
 
   it('availableModelsFor returning a subset → model step shows only the subset', async () => {

--- a/tests/unit/application/ui/tui/views/settings-view-model.suspended.test.ts
+++ b/tests/unit/application/ui/tui/views/settings-view-model.suspended.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The Settings editor flags temporarily-suspended models in the model-select LABEL only; the
+ * underlying option VALUE stays the bare catalog id so a pre-pinned choice round-trips and the
+ * adapter guard is the single rejection point. `buildSections` therefore keeps the bare ids in
+ * `field.options` — the suffix is applied at render time in `settings-editor.tsx`, gated on
+ * `isModelField`. These tests pin that seam: model fields are detected, non-model selects are not,
+ * and the suspended fable id is present (bare) in the model options.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { buildSections, isModelField } from '@src/application/ui/tui/views/settings-view-model.ts';
+
+const fieldByKey = (sections: ReturnType<typeof buildSections>, key: string) => {
+  for (const section of sections) {
+    const field = section.fields.find((f) => f.key === key);
+    if (field !== undefined) return field;
+  }
+  throw new Error(`no field with key ${key}`);
+};
+
+describe('isModelField', () => {
+  const sections = buildSections(DEFAULT_SETTINGS);
+
+  it('is true for per-flow / per-role model selects', () => {
+    expect(isModelField(fieldByKey(sections, 'ai.refine.model'))).toBe(true);
+    expect(isModelField(fieldByKey(sections, 'ai.implement.generator.model'))).toBe(true);
+    expect(isModelField(fieldByKey(sections, 'ai.implement.evaluator.model'))).toBe(true);
+  });
+
+  it('is false for provider, effort, and non-AI selects', () => {
+    expect(isModelField(fieldByKey(sections, 'ai.refine.provider'))).toBe(false);
+    expect(isModelField(fieldByKey(sections, 'ai.refine.effort'))).toBe(false);
+    expect(isModelField(fieldByKey(sections, 'logging.level'))).toBe(false);
+  });
+
+  it('keeps the suspended fable id BARE in the model options (suffix is render-time only)', () => {
+    const field = fieldByKey(sections, 'ai.refine.model');
+    if (field.kind !== 'select') throw new Error('expected a select field');
+    expect(field.options).toContain('claude-fable-5');
+    expect(field.options).not.toContain('claude-fable-5 (suspended)');
+  });
+});

--- a/tests/unit/domain/value/settings-models/suspended-models.test.ts
+++ b/tests/unit/domain/value/settings-models/suspended-models.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSuspendedModel,
+  SUSPENDED_MODELS,
+  SUSPENSION_NOTE,
+  suspendedModelMessage,
+} from '@src/domain/value/settings-models/suspended-models.ts';
+
+describe('suspended-models', () => {
+  it('flags both fable ids as suspended', () => {
+    expect(isSuspendedModel('claude-fable-5')).toBe(true);
+    expect(isSuspendedModel('claude-fable-5[1m]')).toBe(true);
+  });
+
+  it('does not flag a live catalog model, a custom string, or empty', () => {
+    expect(isSuspendedModel('claude-opus-4-8')).toBe(false);
+    expect(isSuspendedModel('my-custom-model')).toBe(false);
+    expect(isSuspendedModel('')).toBe(false);
+  });
+
+  it('SUSPENDED_MODELS contains exactly the two fable ids', () => {
+    expect([...SUSPENDED_MODELS].sort()).toEqual(['claude-fable-5', 'claude-fable-5[1m]']);
+  });
+
+  it('message names the model and carries the suspension note tag', () => {
+    const msg = suspendedModelMessage('claude-fable-5');
+    expect(msg).toContain("'claude-fable-5'");
+    expect(msg).toContain(SUSPENSION_NOTE);
+    expect(SUSPENSION_NOTE).toBe('suspended');
+  });
+});


### PR DESCRIPTION
Anthropic suspended **Fable 5 / Mythos 5** server-side on 2026-06-12 (export-control directive). ralphctl recently shipped `claude-fable-5` (+ the `[1m]` variant) as opt-in catalog models, so any user who pinned one now hits an opaque CLI failure at launch.

This is a **graceful, reversible** treatment — not a removal. The suspension is described as temporary, and the model fields accept any catalog id *or* a custom string, so the catalog entries deliberately stay put (persisted configs remain valid). Instead of churning the catalog, we fail fast with a clear message and flag the entry in the pickers.

## What changed
- **One reversible source of truth** — `src/domain/value/settings-models/suspended-models.ts` lists the suspended ids. To restore the model when access returns, empty `SUSPENDED_MODELS` (one-line revert; the module documents it).
- **Fail-fast at both adapters** — `buildClaudeArgs` / `buildCopilotArgs` reject a suspended model with: *"'claude-fable-5' is temporarily suspended by Anthropic (2026-06-12 export-control directive on Fable 5 / Mythos 5) — pick another model until access is restored"* instead of dispatching a `--model` the provider opaquely rejects.
- **Pickers flag it** — the per-run customize picker and the settings editor render suspended entries with a `(suspended)` suffix; the option *value* stays the bare id so a pre-pinned config still round-trips (and then surfaces the clear adapter message if launched).

## Blast radius
Tiny by design: Fable is opt-in only — not in any preset, default, or the built-in escalation ladder (the existing opt-in fence test is untouched). Default users are unaffected; only those who explicitly pinned Fable hit the guard, and they now get an actionable message.

## Verification
`pnpm typecheck` ✓ · `pnpm lint` 0 errors ✓ · 3,633 tests ✓ · `pnpm deadcode` ✓
New tests cover the suspended-models module, both adapter rejections (+ a non-suspended model still builds), and the picker label/value split.