### PR TITLE
feat(settings): expand presets to 20 across five families

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -24,16 +24,19 @@ floored from the global value; `minimal` is reachable only via an explicit per-f
 at a different one; the launcher rebuilds the provider / interactive-AI / skills-adapter trio per launch
 keyed on the dispatched flow's row, so mixed and uniform configs traverse the same code path.
 
-**Eight presets** stamp the entire `ai` section in one shot — four standard and four economic, all equally
-first-class (none is marked default). Standard presets: `mixed` (best-fit provider per flow),
-`claude-only`, `copilot-only`, `codex-only`. Economic presets (ADDITIONAL — they do not replace the
-standard ones): `mixed-economic`, `claude-economic`, `copilot-economic`, `codex-economic`. The economic
-strategy is: start `implement` one tier below the provider's flagship at `high` effort, so most tasks
-finish on the cheaper tier; the graduated escalation ladder climbs to the flagship only when a task
-plateaus — quality is preserved, token spend is reduced on easy tasks. The effort matrix keeps the
+**Nine presets** stamp the entire `ai` section in one shot — four standard, four economic, and one
+strong-gate, all equally first-class (none is marked default). Standard presets: `mixed` (best-fit
+provider per flow), `claude-only`, `copilot-only`, `codex-only`. Economic presets (ADDITIONAL — they do
+not replace the standard ones): `mixed-economic`, `claude-economic`, `copilot-economic`, `codex-economic`.
+The economic strategy is: start `implement` one tier below the provider's flagship at `high` effort, so
+most tasks finish on the cheaper tier; the graduated escalation ladder climbs to the flagship only when a
+task plateaus — quality is preserved, token spend is reduced on easy tasks. The effort matrix keeps the
 standard presets' shape (`plan`/`implement` heavy, `readiness` `medium`, `refine`/`ideate` inherit global
 `high`) but runs `plan`/`implement` at `high` — one tier below the standard presets' `xhigh` (Codex
-already floors `xhigh` to `high`, so its economic and standard rows match there).
+already floors `xhigh` to `high`, so its economic and standard rows match there). `claude-strong-gate`
+(all `claude-code`) pairs a cheap sonnet implement generator with a permanently-opus evaluator gate — the
+only preset that splits generator and evaluator onto different models; it relies on plateau escalation to
+climb the sonnet generator to opus on hard tasks.
 Apply via `ralphctl settings apply-preset <name>` or from the TUI settings view; the apply surface is
 unchanged — eight names are accepted, same command and same TUI flow. Re-applying overwrites every row
 in one transaction; subsequent per-key edits via `ralphctl settings set ai.<flow>.<field> <value>` stick.

--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -24,22 +24,44 @@ floored from the global value; `minimal` is reachable only via an explicit per-f
 at a different one; the launcher rebuilds the provider / interactive-AI / skills-adapter trio per launch
 keyed on the dispatched flow's row, so mixed and uniform configs traverse the same code path.
 
-**Nine presets** stamp the entire `ai` section in one shot — four standard, four economic, and one
-strong-gate, all equally first-class (none is marked default). Standard presets: `mixed` (best-fit
-provider per flow), `claude-only`, `copilot-only`, `codex-only`. Economic presets (ADDITIONAL — they do
-not replace the standard ones): `mixed-economic`, `claude-economic`, `copilot-economic`, `codex-economic`.
-The economic strategy is: start `implement` one tier below the provider's flagship at `high` effort, so
-most tasks finish on the cheaper tier; the graduated escalation ladder climbs to the flagship only when a
-task plateaus — quality is preserved, token spend is reduced on easy tasks. The effort matrix keeps the
-standard presets' shape (`plan`/`implement` heavy, `readiness` `medium`, `refine`/`ideate` inherit global
-`high`) but runs `plan`/`implement` at `high` — one tier below the standard presets' `xhigh` (Codex
-already floors `xhigh` to `high`, so its economic and standard rows match there). `claude-strong-gate`
-(all `claude-code`) pairs a cheap sonnet implement generator with a permanently-opus evaluator gate — the
-only preset that splits generator and evaluator onto different models; it relies on plateau escalation to
-climb the sonnet generator to opus on hard tasks.
-Apply via `ralphctl settings apply-preset <name>` or from the TUI settings view; the apply surface is
-unchanged — eight names are accepted, same command and same TUI flow. Re-applying overwrites every row
-in one transaction; subsequent per-key edits via `ralphctl settings set ai.<flow>.<field> <value>` stick.
+**Twenty presets across five families** stamp the entire `ai` section plus `harness.escalateOnPlateau`
+in one shot — all equally first-class (none is marked default). Each family carries four variants:
+`mixed` (best-fit provider per flow), `claude-only`, `copilot-only`, `codex-only`. The families:
+
+- **standard** (`mixed`, `claude-only`, `copilot-only`, `codex-only`) — flagship model per flow at
+  `xhigh` effort for `implement`/`plan`; `readiness` at `medium`; `refine`/`ideate` inherit global `high`.
+- **economic** (`mixed-economic`, `claude-economic`, `copilot-economic`, `codex-economic`) — same routing
+  as standard but `implement` starts one tier below the flagship at `high` effort; the escalation ladder
+  climbs to the flagship only when a task plateaus — cheaper tokens on easy tasks, same quality gate on
+  hard ones.
+- **strong-gate** (`mixed-strong-gate`, `claude-strong-gate`, `copilot-strong-gate`, `codex-strong-gate`)
+  — cheap generate tier paired with a permanently-flagship evaluator gate — the only family that
+  intentionally splits `implement.generator` and `implement.evaluator` onto different models. The generator
+  climbs to the flagship on plateau via the escalation ladder (`escalateOnPlateau` stamped `true`). The
+  Codex variant (`gpt-5.4` gen → `gpt-5.5` gate) has the narrowest gap of the family.
+- **fast** (`mixed-fast`, `claude-fast`, `copilot-fast`, `codex-fast`) — cheapest viable tier at `low`
+  effort across the board. Implement uses sonnet/mini (not haiku — too weak to author code reliably); light
+  flows drop further. This is the only family with `escalateOnPlateau` stamped **`false`** — a plateau
+  settles (done-with-warning) rather than climbing the ladder, which is what keeps the family genuinely
+  cheap and predictable. `codex-fast` uses `minimal` effort for the lightest Codex rows.
+- **frontier** (`mixed-frontier`, `claude-frontier`, `copilot-frontier`, `codex-frontier`) — flagship
+  everywhere at `max` effort. Codex is floored to `high` (its effort ceiling). Tops out at opus;
+  `claude-fable-5` is intentionally not referenced — it is export-control-suspended and would be rejected
+  at launch. Restoring fable is a one-line model swap when the suspension lifts.
+
+**`applyPreset` stamps `harness.escalateOnPlateau`** alongside the AI section. Standard / economic /
+strong-gate / frontier all stamp it `true`; fast stamps it `false`. The rest of `harness` (`maxTurns`,
+`escalationMap`, `plateauThreshold`, …) plus all other top-level settings keys are preserved verbatim.
+
+**Model-tier ordering.** The ladders each family relies on are grounded in SWE-bench rankings (June
+2026 data): Claude haiku < sonnet < opus < fable; GPT mini < 5.4 < 5.5. These orderings explain why
+the cheap-to-strong tier progressions are wired the way they are — not as guaranteed scores (OpenAI
+stopped publishing SWE-bench Verified after contamination concerns, and results swing significantly with
+scaffolding). Treat this as relative-ordering rationale, not a performance promise.
+
+Apply via `ralphctl settings apply-preset <name>` or from the TUI settings view. Re-applying overwrites
+every `ai` row plus `harness.escalateOnPlateau` in one transaction; subsequent per-key edits via
+`ralphctl settings set ai.<flow>.<field> <value>` stick.
 
 **Model catalog versions used by the presets** (as of the 0.10.x catalogs):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`claude-strong-gate` preset.** A ninth settings preset (all `claude-code`): cheap sonnet implement
+  generator behind a permanently-opus evaluator gate. The only preset that intentionally splits
+  implement generator and evaluator onto different models — the sonnet author climbs to opus on plateau
+  via the default escalation ladder, so it relies on `harness.escalateOnPlateau` (default on).
+
 - **Structured per-module verify gates (`Repository.verifyGates`).** A `VerifyGate[]` — `{ pathPrefix,
 command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins when present and non-empty.
   Pre-task verify runs ALL gates (complete attribution baseline); post-task verify runs only the gates whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,27 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **`claude-strong-gate` preset.** A ninth settings preset (all `claude-code`): cheap sonnet implement
-  generator behind a permanently-opus evaluator gate. The only preset that intentionally splits
-  implement generator and evaluator onto different models — the sonnet author climbs to opus on plateau
-  via the default escalation ladder, so it relies on `harness.escalateOnPlateau` (default on).
+- **Expanded preset matrix — 20 presets across five families.** Two new families (`fast`, `frontier`)
+  and three new strong-gate variants (`mixed-strong-gate`, `copilot-strong-gate`, `codex-strong-gate`)
+  join the nine presets from prior releases, for 20 total. Each family ships in `mixed` / `claude-only`
+  / `copilot-only` / `codex-only` variants:
+  - `fast` — cheapest viable tier at `low` effort; implement uses sonnet/mini (not haiku); `codex-fast`
+    uses `minimal` effort for light flows.
+  - `frontier` — flagship everywhere at `max` effort (Codex floored to `high`); tops out at opus —
+    `claude-fable-5` is excluded while export-control-suspended (one-line swap to restore).
+  - `mixed-strong-gate`, `copilot-strong-gate`, `codex-strong-gate` — cheap generator + permanently-
+    flagship evaluator gate; mirrors the existing `claude-strong-gate` pattern for the other providers.
+    Codex variant is the narrowest gap of the family (`gpt-5.4` gen → `gpt-5.5` gate).
+
+- **`applyPreset` now stamps `harness.escalateOnPlateau`.** Standard / economic / strong-gate / frontier
+  presets stamp it `true`; `fast` stamps it `false` — a plateau settles (done-with-warning) rather than
+  climbing the escalation ladder, which is what makes the fast family genuinely cheap and predictable.
+  The rest of `harness` is preserved verbatim. This also eliminates the old `claude-strong-gate` caveat
+  about assuming `escalateOnPlateau` was on — it now guarantees it.
+
+- **`claude-strong-gate` preset.** (Added in this release cycle; documented here for completeness.) All
+  `claude-code`: cheap sonnet implement generator behind a permanently-opus evaluator gate — the only
+  preset that intentionally splits implement generator and evaluator onto different models.
 
 - **Structured per-module verify gates (`Repository.verifyGates`).** A `VerifyGate[]` — `{ pathPrefix,
 command, timeoutMs? }` — supplements the legacy `verifyScript` string and wins when present and non-empty.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ provider each implement role is configured to use, under the same per-provider c
 preview provider, please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
 One-shot configuration for any provider: `ralphctl settings apply-preset <name>` where `<name>` is one of
-the eight presets — `mixed`, `claude-only`, `copilot-only`, `codex-only`, or a `*-economic` variant.
+the nine presets — `mixed`, `claude-only`, `copilot-only`, `codex-only`, a `*-economic` variant, or
+`claude-strong-gate` (cheap sonnet implement generation behind an opus evaluator gate).
 
 ---
 
@@ -204,6 +205,7 @@ ralphctl settings apply-preset mixed-economic      # best-fit + cheaper implemen
 ralphctl settings apply-preset claude-economic     # Claude Code + cheaper implement tier
 ralphctl settings apply-preset copilot-economic    # GitHub Copilot + cheaper implement tier
 ralphctl settings apply-preset codex-economic      # OpenAI Codex + cheaper implement tier
+ralphctl settings apply-preset claude-strong-gate  # cheap sonnet generation, opus evaluator gate; climbs via plateau escalation
 ```
 
 Eight presets ship, all equally first-class — none is marked default. The four `*-economic` variants mirror
@@ -305,14 +307,14 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 
 ### Getting Started
 
-| Command                                 | Description                                                                                                                    |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `ralphctl`                              | Interactive TUI (primary surface)                                                                                              |
-| `ralphctl doctor`                       | Check environment health                                                                                                       |
-| `ralphctl settings show`                | Print current settings                                                                                                         |
-| `ralphctl settings set <key> <value>`   | Set a single settings key                                                                                                      |
-| `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section — eight presets: `mixed` / `claude-only` / `copilot-only` / `codex-only` / `*-economic` variants |
-| `ralphctl completion <shell>`           | Print shell tab-completion script                                                                                              |
+| Command                                 | Description                                                                                                                                          |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ralphctl`                              | Interactive TUI (primary surface)                                                                                                                    |
+| `ralphctl doctor`                       | Check environment health                                                                                                                             |
+| `ralphctl settings show`                | Print current settings                                                                                                                               |
+| `ralphctl settings set <key> <value>`   | Set a single settings key                                                                                                                            |
+| `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section — nine presets: `mixed` / `claude-only` / `copilot-only` / `codex-only` / `*-economic` variants / `claude-strong-gate` |
+| `ralphctl completion <shell>`           | Print shell tab-completion script                                                                                                                    |
 
 ### Project & Sprint Inspection
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ with [GitHub Copilot](https://docs.github.com/en/copilot/github-copilot-in-the-c
 > _"I'm helping!"_ — Ralph Wiggum
 
 > [!NOTE]
-> **Active development.** New features and polish ship regularly. **0.11.0** adds four budget-conscious
-> presets (`mixed-economic`, `claude-economic`, `copilot-economic`, `codex-economic`), a binding attempt
-> cap, and refreshed model catalogs.
+> **Active development.** New features and polish ship regularly. The upcoming release expands the preset
+> matrix to 20 presets across five families (`standard`, `economic`, `strong-gate`, `fast`, `frontier`),
+> each in `mixed` / `claude-only` / `copilot-only` / `codex-only` variants.
 > Upgrades are best-effort: install the latest version, redo your config, proceed.
 > See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
 
@@ -95,7 +95,7 @@ ralphctl export-context --sprint <id> --project <id> --output <path>
 
 # Settings
 ralphctl settings show
-ralphctl settings apply-preset claude-only     # or mixed / copilot-only / codex-only / *-economic
+ralphctl settings apply-preset claude-only     # or mixed / copilot-only / codex-only / *-economic / *-strong-gate / *-fast / *-frontier
 ralphctl settings set ai.implement.generator.provider claude-code
 ralphctl settings set ai.implement.generator.model    <model-id>
 ralphctl settings set ai.implement.generator.effort   high
@@ -164,8 +164,8 @@ provider each implement role is configured to use, under the same per-provider c
 preview provider, please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
 One-shot configuration for any provider: `ralphctl settings apply-preset <name>` where `<name>` is one of
-the nine presets — `mixed`, `claude-only`, `copilot-only`, `codex-only`, a `*-economic` variant, or
-`claude-strong-gate` (cheap sonnet implement generation behind an opus evaluator gate).
+20 presets across five families — `standard`, `economic`, `strong-gate`, `fast`, and `frontier`, each in
+`mixed` / `claude-only` / `copilot-only` / `codex-only` variants.
 
 ---
 
@@ -197,22 +197,41 @@ Configure via the TUI `Settings` view or one-shot CLI commands.
 **Quickest path — apply a preset:**
 
 ```bash
+# Standard — flagship model per flow
 ralphctl settings apply-preset mixed               # best-fit provider per flow
 ralphctl settings apply-preset claude-only         # every flow on Claude Code
 ralphctl settings apply-preset copilot-only        # every flow on GitHub Copilot
 ralphctl settings apply-preset codex-only          # every flow on OpenAI Codex
-ralphctl settings apply-preset mixed-economic      # best-fit + cheaper implement tier
-ralphctl settings apply-preset claude-economic     # Claude Code + cheaper implement tier
-ralphctl settings apply-preset copilot-economic    # GitHub Copilot + cheaper implement tier
-ralphctl settings apply-preset codex-economic      # OpenAI Codex + cheaper implement tier
-ralphctl settings apply-preset claude-strong-gate  # cheap sonnet generation, opus evaluator gate; climbs via plateau escalation
+
+# Economic — implement starts one tier below flagship; escalation ladder climbs only on plateau
+ralphctl settings apply-preset mixed-economic
+ralphctl settings apply-preset claude-economic
+ralphctl settings apply-preset copilot-economic
+ralphctl settings apply-preset codex-economic
+
+# Strong-gate — cheap generator, permanently-flagship evaluator gate
+ralphctl settings apply-preset mixed-strong-gate
+ralphctl settings apply-preset claude-strong-gate
+ralphctl settings apply-preset copilot-strong-gate
+ralphctl settings apply-preset codex-strong-gate
+
+# Fast — cheapest viable tier at low effort; plateau settles rather than escalating (escalateOnPlateau=false)
+ralphctl settings apply-preset mixed-fast
+ralphctl settings apply-preset claude-fast
+ralphctl settings apply-preset copilot-fast
+ralphctl settings apply-preset codex-fast
+
+# Frontier — flagship everywhere at max effort
+ralphctl settings apply-preset mixed-frontier
+ralphctl settings apply-preset claude-frontier
+ralphctl settings apply-preset copilot-frontier
+ralphctl settings apply-preset codex-frontier
 ```
 
-Eight presets ship, all equally first-class — none is marked default. The four `*-economic` variants mirror
-the standard routings but start `implement` one model tier below the flagship; the escalation ladder climbs
-to the flagship only when a task plateaus — cheaper tokens on easy tasks, same quality gate on hard ones.
-A preset stamps the entire `ai` section in one shot. On a fresh install the welcome view silently auto-seeds
-a preset based on which provider CLIs it detects on `PATH`.
+Twenty presets across five families ship, all equally first-class — none is marked default. Applying a
+preset stamps the entire `ai` section plus `harness.escalateOnPlateau` in one transaction (`fast` stamps it
+`false` so a plateau settles; all others stamp it `true`). On a fresh install the welcome view silently
+auto-seeds a preset based on which provider CLIs it detects on `PATH`.
 
 **Per-flow settings.** Each flow carries its own `{provider, model, effort?}` row: `refine`, `plan`, `readiness`,
 `ideate`, and `createPr`. The `implement` flow instead splits into a nested `generator` / `evaluator` pair
@@ -307,14 +326,14 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 
 ### Getting Started
 
-| Command                                 | Description                                                                                                                                          |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ralphctl`                              | Interactive TUI (primary surface)                                                                                                                    |
-| `ralphctl doctor`                       | Check environment health                                                                                                                             |
-| `ralphctl settings show`                | Print current settings                                                                                                                               |
-| `ralphctl settings set <key> <value>`   | Set a single settings key                                                                                                                            |
-| `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section — nine presets: `mixed` / `claude-only` / `copilot-only` / `codex-only` / `*-economic` variants / `claude-strong-gate` |
-| `ralphctl completion <shell>`           | Print shell tab-completion script                                                                                                                    |
+| Command                                 | Description                                                                                                                                                                                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ralphctl`                              | Interactive TUI (primary surface)                                                                                                                                                                                              |
+| `ralphctl doctor`                       | Check environment health                                                                                                                                                                                                       |
+| `ralphctl settings show`                | Print current settings                                                                                                                                                                                                         |
+| `ralphctl settings set <key> <value>`   | Set a single settings key                                                                                                                                                                                                      |
+| `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section — 20 presets across five families: `standard` / `economic` / `strong-gate` / `fast` / `frontier`, each in `mixed` / `*-only` / `*-economic` / `*-strong-gate` / `*-fast` / `*-frontier` variants |
+| `ralphctl completion <shell>`           | Print shell tab-completion script                                                                                                                                                                                              |
 
 ### Project & Sprint Inspection
 

--- a/src/application/ui/tui/views/preset-bar.tsx
+++ b/src/application/ui/tui/views/preset-bar.tsx
@@ -1,18 +1,27 @@
 /**
- * Preset bar — four equal preset buttons (mixed / claude-only / copilot-only / codex-only).
+ * Preset bar — twenty preset buttons across five families (Standard / Economic / Strong-gate /
+ * Fast / Frontier). Each family renders under a dim bold sub-header so 20 rows stay scannable.
  * Activating a row opens a confirmation prompt in the parent view; this component is purely
  * the read-side render of the preset section card. Warnings from the most recent apply-preset
  * fan out as dimmed rows underneath so the operator sees missing-CLI guidance in-line.
+ *
+ * Keyboard navigation is unchanged — the sub-headers are visual-only; the cursor still walks
+ * only the preset `EditableField` rows (the parent's `activeFields` array carries no headers).
  */
 
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { FieldList } from '@src/application/ui/tui/components/field-list.tsx';
-import { glyphs, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { PRESET_NAMES } from '@src/business/settings/presets.ts';
 import type { PresetWarning } from '@src/application/flows/settings-apply-preset/ctx.ts';
-import { PRESET_LABEL } from '@src/application/ui/tui/views/settings-view-model.ts';
+import {
+  PRESET_FAMILY,
+  PRESET_FAMILY_LABEL,
+  PRESET_LABEL,
+  type PresetFamily,
+} from '@src/application/ui/tui/views/settings-view-model.ts';
 
 export interface PresetBarProps {
   readonly title: string;
@@ -20,14 +29,31 @@ export interface PresetBarProps {
   readonly warnings: readonly PresetWarning[];
 }
 
+/** Ordered families — drives the rendering order of sub-headers. */
+const FAMILY_ORDER: readonly PresetFamily[] = ['standard', 'economic', 'strong-gate', 'fast', 'frontier'];
+
 export const PresetBar = ({ title, valueFor, warnings }: PresetBarProps): React.JSX.Element => (
   <Card title={title} tone="primary">
-    <FieldList
-      fields={PRESET_NAMES.map((preset) => ({
-        label: PRESET_LABEL[preset],
-        value: valueFor(`presets.${preset}`),
-      }))}
-    />
+    <Box flexDirection="column">
+      {FAMILY_ORDER.map((family, familyIdx) => {
+        const presets = PRESET_NAMES.filter((p) => PRESET_FAMILY[p] === family);
+        return (
+          <Box key={family} flexDirection="column" marginTop={familyIdx === 0 ? 0 : spacing.section}>
+            <Box paddingX={spacing.indent}>
+              <Text bold color={inkColors.muted}>
+                {PRESET_FAMILY_LABEL[family]}
+              </Text>
+            </Box>
+            <FieldList
+              fields={presets.map((preset) => ({
+                label: PRESET_LABEL[preset],
+                value: valueFor(`presets.${preset}`),
+              }))}
+            />
+          </Box>
+        );
+      })}
+    </Box>
     {warnings.length > 0 && (
       <Box flexDirection="column" paddingX={spacing.indent} marginTop={spacing.section}>
         {warnings.map((w) => (

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -101,6 +101,7 @@ export const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
   'claude-economic': 'Apply: Claude (economic)',
   'copilot-economic': 'Apply: Copilot (economic)',
   'codex-economic': 'Apply: Codex (economic)',
+  'claude-strong-gate': 'Apply: Claude strong-gate',
 };
 
 export const LOG_LEVELS = ['silent', 'debug', 'info', 'warn', 'error'] as const;

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -101,7 +101,53 @@ export const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
   'claude-economic': 'Apply: Claude (economic)',
   'copilot-economic': 'Apply: Copilot (economic)',
   'codex-economic': 'Apply: Codex (economic)',
+  'mixed-strong-gate': 'Apply: Mixed strong-gate',
   'claude-strong-gate': 'Apply: Claude strong-gate',
+  'copilot-strong-gate': 'Apply: Copilot strong-gate',
+  'codex-strong-gate': 'Apply: Codex strong-gate',
+  'mixed-fast': 'Apply: Mixed (fast)',
+  'claude-fast': 'Apply: Claude (fast)',
+  'copilot-fast': 'Apply: Copilot (fast)',
+  'codex-fast': 'Apply: Codex (fast)',
+  'mixed-frontier': 'Apply: Mixed (frontier)',
+  'claude-frontier': 'Apply: Claude (frontier)',
+  'copilot-frontier': 'Apply: Copilot (frontier)',
+  'codex-frontier': 'Apply: Codex (frontier)',
+};
+
+/** Display names for the five preset families — used by the grouped preset bar. */
+export type PresetFamily = 'standard' | 'economic' | 'strong-gate' | 'fast' | 'frontier';
+
+export const PRESET_FAMILY_LABEL: Readonly<Record<PresetFamily, string>> = {
+  standard: 'Standard',
+  economic: 'Economic',
+  'strong-gate': 'Strong-gate',
+  fast: 'Fast',
+  frontier: 'Frontier',
+};
+
+/** Maps each preset to its family — single source so preset-bar and any future caller stay in sync. */
+export const PRESET_FAMILY: Readonly<Record<PresetName, PresetFamily>> = {
+  mixed: 'standard',
+  'claude-only': 'standard',
+  'copilot-only': 'standard',
+  'codex-only': 'standard',
+  'mixed-economic': 'economic',
+  'claude-economic': 'economic',
+  'copilot-economic': 'economic',
+  'codex-economic': 'economic',
+  'mixed-strong-gate': 'strong-gate',
+  'claude-strong-gate': 'strong-gate',
+  'copilot-strong-gate': 'strong-gate',
+  'codex-strong-gate': 'strong-gate',
+  'mixed-fast': 'fast',
+  'claude-fast': 'fast',
+  'copilot-fast': 'fast',
+  'codex-fast': 'fast',
+  'mixed-frontier': 'frontier',
+  'claude-frontier': 'frontier',
+  'copilot-frontier': 'frontier',
+  'codex-frontier': 'frontier',
 };
 
 export const LOG_LEVELS = ['silent', 'debug', 'info', 'warn', 'error'] as const;

--- a/src/application/ui/tui/views/welcome-view.tsx
+++ b/src/application/ui/tui/views/welcome-view.tsx
@@ -43,6 +43,7 @@ const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
   'claude-economic': 'claude-economic',
   'copilot-economic': 'copilot-economic',
   'codex-economic': 'codex-economic',
+  'claude-strong-gate': 'claude-strong-gate',
 };
 
 const pickPresetForDetected = (installed: ReadonlySet<AiProvider>): PresetName => {

--- a/src/application/ui/tui/views/welcome-view.tsx
+++ b/src/application/ui/tui/views/welcome-view.tsx
@@ -34,18 +34,6 @@ const PRESET_FOR_PROVIDER: Readonly<Record<AiProvider, PresetName>> = {
   'openai-codex': 'codex-only',
 };
 
-const PRESET_LABEL: Readonly<Record<PresetName, string>> = {
-  mixed: 'mixed',
-  'claude-only': 'claude-only',
-  'copilot-only': 'copilot-only',
-  'codex-only': 'codex-only',
-  'mixed-economic': 'mixed-economic',
-  'claude-economic': 'claude-economic',
-  'copilot-economic': 'copilot-economic',
-  'codex-economic': 'codex-economic',
-  'claude-strong-gate': 'claude-strong-gate',
-};
-
 const pickPresetForDetected = (installed: ReadonlySet<AiProvider>): PresetName => {
   if (installed.size === 1) {
     const [only] = [...installed];
@@ -106,10 +94,10 @@ export const WelcomeView = (): React.JSX.Element => {
                   <Text color={inkColors.warning}>
                     {glyphs.warningGlyph} No AI CLIs detected — install one (claude / copilot / codex) and run doctor.
                   </Text>
-                  <Text dimColor>Seeded the {PRESET_LABEL[chosenPreset]} preset as a placeholder.</Text>
+                  <Text dimColor>Seeded the {chosenPreset} preset as a placeholder.</Text>
                 </Box>
               ) : (
-                <Text>Seeded with {PRESET_LABEL[chosenPreset]} preset based on detected CLIs.</Text>
+                <Text>Seeded with {chosenPreset} preset based on detected CLIs.</Text>
               ))}
             {step === 'error' && (
               <Box flexDirection="column">

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -5,12 +5,14 @@ import type { AiSettings, Settings } from '@src/domain/entity/settings.ts';
  * applying it stamps `ai.effort` plus all five per-flow rows. Preset identity is NOT
  * persisted; the next per-row edit sticks and nothing remembers which preset was applied.
  *
- * Eight shipped presets, all equally first-class — no preset is marked "recommended" or
+ * Nine shipped presets, all equally first-class — no preset is marked "recommended" or
  * "default". The four standard presets: `mixed` routes each flow to the best provider for that
  * flow's purpose; `<provider>-only` routes every flow to that one provider (the fully-supported
  * single-provider configuration). The four `*-economic` variants mirror those routings but
  * start `implement` one tier below the flagship to save tokens, leaning on the escalation
- * ladder to climb to the flagship only when a task plateaus.
+ * ladder to climb to the flagship only when a task plateaus. `claude-strong-gate` pairs a cheap
+ * sonnet implement generator with a permanently-opus evaluator — the only preset that splits
+ * generator and evaluator onto different models.
  */
 export type PresetName =
   | 'mixed'
@@ -20,7 +22,8 @@ export type PresetName =
   | 'mixed-economic'
   | 'claude-economic'
   | 'copilot-economic'
-  | 'codex-economic';
+  | 'codex-economic'
+  | 'claude-strong-gate';
 
 export const PRESET_NAMES: readonly PresetName[] = [
   'mixed',
@@ -31,6 +34,7 @@ export const PRESET_NAMES: readonly PresetName[] = [
   'claude-economic',
   'copilot-economic',
   'codex-economic',
+  'claude-strong-gate',
 ] as const;
 
 export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as readonly string[]).includes(raw);
@@ -180,6 +184,34 @@ const CODEX_ECONOMIC: AiSettings = {
   createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
 };
 
+/**
+ * `claude-strong-gate` — "strong gate, cheap generation." Mirrors `claude-economic`'s cheap
+ * generation tiers but bumps `plan` and the implement EVALUATOR to the opus flagship: a cheap
+ * sonnet author paired with a permanently-opus critic. It is the only preset that intentionally
+ * SPLITS implement.generator and implement.evaluator onto different models (same `claude-code`
+ * provider) — every other preset stamps one shared implement row.
+ *
+ * The generator starts on sonnet and climbs sonnet→opus on plateau via the default escalation
+ * ladder, so this preset ASSUMES `settings.harness.escalateOnPlateau` (default true) is on —
+ * without it a genuinely hard task can plateau-loop on the sonnet generator while the opus gate
+ * keeps rejecting it, never escalating the author. The evaluator stays opus regardless: the gate
+ * is strong from the first round, generation is cheap until a task proves it needs more.
+ */
+const CLAUDE_STRONG_GATE: AiSettings = {
+  effort: 'high',
+  refine: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
+  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  implement: {
+    // Cheap author: sonnet at high effort, climbs to opus on plateau via the default ladder.
+    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+    // Strong gate: opus from the first round, never cheapened.
+    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  },
+  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'medium' },
+  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
+  createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+};
+
 const PRESETS: Readonly<Record<PresetName, AiSettings>> = {
   mixed: MIXED,
   'claude-only': CLAUDE_ONLY,
@@ -189,6 +221,7 @@ const PRESETS: Readonly<Record<PresetName, AiSettings>> = {
   'claude-economic': CLAUDE_ECONOMIC,
   'copilot-economic': COPILOT_ECONOMIC,
   'codex-economic': CODEX_ECONOMIC,
+  'claude-strong-gate': CLAUDE_STRONG_GATE,
 };
 
 /**

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -5,14 +5,22 @@ import type { AiSettings, Settings } from '@src/domain/entity/settings.ts';
  * applying it stamps `ai.effort` plus all five per-flow rows. Preset identity is NOT
  * persisted; the next per-row edit sticks and nothing remembers which preset was applied.
  *
- * Nine shipped presets, all equally first-class — no preset is marked "recommended" or
- * "default". The four standard presets: `mixed` routes each flow to the best provider for that
- * flow's purpose; `<provider>-only` routes every flow to that one provider (the fully-supported
- * single-provider configuration). The four `*-economic` variants mirror those routings but
- * start `implement` one tier below the flagship to save tokens, leaning on the escalation
- * ladder to climb to the flagship only when a task plateaus. `claude-strong-gate` pairs a cheap
- * sonnet implement generator with a permanently-opus evaluator — the only preset that splits
- * generator and evaluator onto different models.
+ * Twenty shipped presets across five families (four each), all equally first-class — no preset
+ * is marked "recommended" or "default". Each family carries a `mixed` variant plus one per
+ * single provider, in that order. The families:
+ *   standard      — `mixed` routes each flow to the best provider for that flow's purpose;
+ *                   `<provider>-only` routes every flow to that one provider.
+ *   economic      — mirror the standard routings but start `implement` one tier below the
+ *                   flagship to save tokens, leaning on the escalation ladder to climb only when
+ *                   a task plateaus.
+ *   strong-gate   — cheap implement generator paired with a permanently-strong evaluator — the
+ *                   only family that splits generator and evaluator onto different models.
+ *   fast          — cheapest viable tier at `low` effort, optimising speed/cost over quality;
+ *                   the only family with `escalateOnPlateau` stamped OFF so a plateau settles.
+ *   frontier      — flagship everywhere at `max` effort (codex floored to `high`).
+ *
+ * Applying a preset stamps the AI section AND `harness.escalateOnPlateau`. Preset identity is
+ * NOT persisted; the next per-row edit sticks and nothing remembers which preset was applied.
  */
 export type PresetName =
   | 'mixed'
@@ -23,7 +31,18 @@ export type PresetName =
   | 'claude-economic'
   | 'copilot-economic'
   | 'codex-economic'
-  | 'claude-strong-gate';
+  | 'mixed-strong-gate'
+  | 'claude-strong-gate'
+  | 'copilot-strong-gate'
+  | 'codex-strong-gate'
+  | 'mixed-fast'
+  | 'claude-fast'
+  | 'copilot-fast'
+  | 'codex-fast'
+  | 'mixed-frontier'
+  | 'claude-frontier'
+  | 'copilot-frontier'
+  | 'codex-frontier';
 
 export const PRESET_NAMES: readonly PresetName[] = [
   'mixed',
@@ -34,7 +53,18 @@ export const PRESET_NAMES: readonly PresetName[] = [
   'claude-economic',
   'copilot-economic',
   'codex-economic',
+  'mixed-strong-gate',
   'claude-strong-gate',
+  'copilot-strong-gate',
+  'codex-strong-gate',
+  'mixed-fast',
+  'claude-fast',
+  'copilot-fast',
+  'codex-fast',
+  'mixed-frontier',
+  'claude-frontier',
+  'copilot-frontier',
+  'codex-frontier',
 ] as const;
 
 export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as readonly string[]).includes(raw);
@@ -212,27 +242,231 @@ const CLAUDE_STRONG_GATE: AiSettings = {
   createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
 };
 
-const PRESETS: Readonly<Record<PresetName, AiSettings>> = {
-  mixed: MIXED,
-  'claude-only': CLAUDE_ONLY,
-  'copilot-only': COPILOT_ONLY,
-  'codex-only': CODEX_ONLY,
-  'mixed-economic': MIXED_ECONOMIC,
-  'claude-economic': CLAUDE_ECONOMIC,
-  'copilot-economic': COPILOT_ECONOMIC,
-  'codex-economic': CODEX_ECONOMIC,
-  'claude-strong-gate': CLAUDE_STRONG_GATE,
+/**
+ * Strong-gate family — "strong gate, cheap generation." Mirrors the economic generation tiers
+ * but bumps `plan` and the implement EVALUATOR to the provider flagship: a cheap author paired
+ * with a permanently-strong critic. This is the only family that intentionally SPLITS
+ * implement.generator and implement.evaluator onto different models (same provider) — every
+ * other preset stamps one shared implement row.
+ *
+ * The generator starts a tier below flagship and climbs to it on plateau via the default
+ * escalation ladder, so this family ASSUMES `escalateOnPlateau` (stamped true): without it a
+ * genuinely hard task can plateau-loop on the cheap generator while the strong gate keeps
+ * rejecting it, never escalating the author. The evaluator stays flagship regardless: the gate
+ * is strong from the first round, generation is cheap until a task proves it needs more.
+ *
+ * Codex's `gpt-5.4`→`gpt-5.5` gate is the NARROWEST of the family — the two Codex tiers sit one
+ * rung apart with a small capability gap, so the cheap author is already close to the gate.
+ */
+const MIXED_STRONG_GATE: AiSettings = {
+  effort: 'high',
+  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  implement: {
+    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  },
+  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
+  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+};
+
+const COPILOT_STRONG_GATE: AiSettings = {
+  effort: 'high',
+  refine: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
+  plan: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+  implement: {
+    generator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
+    evaluator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+  },
+  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
+  ideate: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
+  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+};
+
+const CODEX_STRONG_GATE: AiSettings = {
+  effort: 'high',
+  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  plan: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  implement: {
+    // Narrowest gate of the family: gpt-5.4 author climbs the single rung to the gpt-5.5 gate.
+    generator: { provider: 'openai-codex', model: 'gpt-5.4', effort: 'high' },
+    evaluator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  },
+  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'medium' },
+  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
 };
 
 /**
- * Stamp a preset onto `current`. The AI section is replaced wholesale with the preset's
- * matrix; `harness`, `logging`, `concurrency`, `ui`, `developer`, and `schemaVersion` are
- * preserved verbatim. Pure — does not touch persistence.
+ * Fast family — cheapest viable tier at LOW effort across the board: speed and cost over
+ * quality. This is the only family with `escalateOnPlateau` stamped OFF — a plateau here settles
+ * (done-with-warning) rather than climbing the ladder, because the whole point is to stay cheap.
+ *
+ * Implement deliberately uses sonnet / gpt-mini, NOT haiku: haiku (and the codex nano tier) is
+ * too weak to author code reliably, so the cheapest model that can still complete a task gates
+ * the implement rows even in the fast family. Light flows (refine / readiness / ideate / createPr)
+ * drop further — `codex-fast` leans on `minimal` effort for those light flows where Codex offers
+ * a cheaper-than-low rung.
+ */
+const MIXED_FAST: AiSettings = {
+  effort: 'low',
+  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+  implement: {
+    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+  },
+  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'low' },
+  ideate: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+};
+
+const CLAUDE_FAST: AiSettings = {
+  effort: 'low',
+  refine: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  plan: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+  implement: {
+    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+  },
+  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'low' },
+  ideate: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+};
+
+const COPILOT_FAST: AiSettings = {
+  effort: 'low',
+  refine: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+  implement: {
+    generator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+    evaluator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+  },
+  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'low' },
+  ideate: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+};
+
+const CODEX_FAST: AiSettings = {
+  effort: 'low',
+  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+  plan: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+  implement: {
+    generator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+    evaluator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+  },
+  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+  ideate: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+};
+
+/**
+ * Frontier family — flagship everywhere at MAX effort: quality over cost, every flow on the
+ * strongest model. Codex is floored to `high` (its effort ceiling — global `ai.effort` stays
+ * `high` on `codex-frontier` so nothing implies a `max` codex row, which the schema would reject).
+ *
+ * The family tops out at opus. `claude-fable-5` is intentionally NOT referenced even though it
+ * is the catalog tier above opus: it is export-control-suspended and would be rejected at launch,
+ * so the flagship-everywhere story stops at opus. Restoring fable when the suspension lifts is a
+ * one-line model swap on the implement / plan rows here.
+ */
+const MIXED_FRONTIER: AiSettings = {
+  effort: 'max',
+  refine: { provider: 'openai-codex', model: 'gpt-5.5' },
+  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  implement: {
+    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  },
+  readiness: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'high' },
+  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.5' },
+};
+
+const CLAUDE_FRONTIER: AiSettings = {
+  effort: 'max',
+  refine: { provider: 'claude-code', model: 'claude-opus-4-8' },
+  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  implement: {
+    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  },
+  readiness: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'high' },
+  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
+  createPr: { provider: 'claude-code', model: 'claude-opus-4-8' },
+};
+
+const COPILOT_FRONTIER: AiSettings = {
+  effort: 'max',
+  refine: { provider: 'github-copilot', model: 'claude-opus-4.8' },
+  plan: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
+  implement: {
+    generator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
+    evaluator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
+  },
+  readiness: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'high' },
+  ideate: { provider: 'github-copilot', model: 'claude-opus-4.8' },
+  createPr: { provider: 'github-copilot', model: 'claude-opus-4.8' },
+};
+
+const CODEX_FRONTIER: AiSettings = {
+  // Codex ceiling — global stays `high` so nothing implies a `max` codex row.
+  effort: 'high',
+  refine: { provider: 'openai-codex', model: 'gpt-5.5' },
+  plan: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  implement: {
+    generator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+    evaluator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  },
+  readiness: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
+  createPr: { provider: 'openai-codex', model: 'gpt-5.5' },
+};
+
+/**
+ * Each preset carries its AI matrix plus the `escalateOnPlateau` flag {@link applyPreset} stamps
+ * onto `harness`. Standard / economic / strong-gate / frontier families want the escalation
+ * ladder on; the fast family stamps it OFF so a plateau settles instead of climbing.
+ */
+const PRESETS: Readonly<Record<PresetName, { ai: AiSettings; escalateOnPlateau: boolean }>> = {
+  mixed: { ai: MIXED, escalateOnPlateau: true },
+  'claude-only': { ai: CLAUDE_ONLY, escalateOnPlateau: true },
+  'copilot-only': { ai: COPILOT_ONLY, escalateOnPlateau: true },
+  'codex-only': { ai: CODEX_ONLY, escalateOnPlateau: true },
+  'mixed-economic': { ai: MIXED_ECONOMIC, escalateOnPlateau: true },
+  'claude-economic': { ai: CLAUDE_ECONOMIC, escalateOnPlateau: true },
+  'copilot-economic': { ai: COPILOT_ECONOMIC, escalateOnPlateau: true },
+  'codex-economic': { ai: CODEX_ECONOMIC, escalateOnPlateau: true },
+  'mixed-strong-gate': { ai: MIXED_STRONG_GATE, escalateOnPlateau: true },
+  'claude-strong-gate': { ai: CLAUDE_STRONG_GATE, escalateOnPlateau: true },
+  'copilot-strong-gate': { ai: COPILOT_STRONG_GATE, escalateOnPlateau: true },
+  'codex-strong-gate': { ai: CODEX_STRONG_GATE, escalateOnPlateau: true },
+  'mixed-fast': { ai: MIXED_FAST, escalateOnPlateau: false },
+  'claude-fast': { ai: CLAUDE_FAST, escalateOnPlateau: false },
+  'copilot-fast': { ai: COPILOT_FAST, escalateOnPlateau: false },
+  'codex-fast': { ai: CODEX_FAST, escalateOnPlateau: false },
+  'mixed-frontier': { ai: MIXED_FRONTIER, escalateOnPlateau: true },
+  'claude-frontier': { ai: CLAUDE_FRONTIER, escalateOnPlateau: true },
+  'copilot-frontier': { ai: COPILOT_FRONTIER, escalateOnPlateau: true },
+  'codex-frontier': { ai: CODEX_FRONTIER, escalateOnPlateau: true },
+};
+
+/**
+ * Stamp a preset onto `current`. The AI section is replaced wholesale with the preset's matrix,
+ * and `harness.escalateOnPlateau` is overwritten with the preset's flag (fast family OFF, all
+ * others ON). The REST of `harness` (maxTurns, escalationMap, plateauThreshold, …) plus
+ * `logging`, `concurrency`, `ui`, `developer`, and `schemaVersion` are preserved verbatim. Pure
+ * — does not touch persistence.
  *
  * Re-applying a preset clobbers any per-row customizations. No stored preset identity is
  * created, so a subsequent edit to any individual row sticks across reloads.
  */
-export const applyPreset = (name: PresetName, current: Settings): Settings => ({
-  ...current,
-  ai: PRESETS[name],
-});
+export const applyPreset = (name: PresetName, current: Settings): Settings => {
+  const preset = PRESETS[name];
+  return {
+    ...current,
+    ai: preset.ai,
+    harness: { ...current.harness, escalateOnPlateau: preset.escalateOnPlateau },
+  };
+};

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -49,7 +49,7 @@ const modelGuardFor = (provider: AiProvider): ((s: string) => boolean) => {
 };
 
 describe('presets', () => {
-  it('exposes all eight equal preset names', () => {
+  it('exposes all nine equal preset names', () => {
     expect([...PRESET_NAMES]).toEqual([
       'mixed',
       'claude-only',
@@ -59,6 +59,7 @@ describe('presets', () => {
       'claude-economic',
       'copilot-economic',
       'codex-economic',
+      'claude-strong-gate',
     ]);
   });
 
@@ -202,7 +203,13 @@ describe('presets', () => {
       it(`'${preset}' stamps both implement.generator and implement.evaluator with the same provider`, () => {
         const out = applyPreset(preset, DEFAULT_SETTINGS);
         expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
-        expect(out.ai.implement.generator.model).toBe(out.ai.implement.evaluator.model);
+        // Every preset keeps generator + evaluator on the SAME provider. Sharing the same MODEL
+        // is the norm too — EXCEPT `claude-strong-gate`, which intentionally pairs a cheap sonnet
+        // generator with a permanently-opus evaluator (asserted explicitly in its own matrix
+        // block below). Excluding it here keeps the same-model invariant true for the other eight.
+        if (preset !== 'claude-strong-gate') {
+          expect(out.ai.implement.generator.model).toBe(out.ai.implement.evaluator.model);
+        }
       });
     }
 
@@ -225,6 +232,53 @@ describe('presets', () => {
         expect(out.ai.readiness.effort).toBe('medium');
         expect(out.ai.refine.effort).toBeUndefined();
         expect(out.ai.ideate.effort).toBeUndefined();
+      });
+    });
+
+    describe("'claude-strong-gate' preset matrix", () => {
+      const out = applyPreset('claude-strong-gate', DEFAULT_SETTINGS);
+
+      it('routes every flow to claude-code', () => {
+        for (const flow of FLOW_IDS) {
+          if (flow === 'implement') {
+            expect(out.ai.implement.generator.provider).toBe('claude-code');
+            expect(out.ai.implement.evaluator.provider).toBe('claude-code');
+            continue;
+          }
+          expect(out.ai[flow].provider).toBe('claude-code');
+        }
+      });
+
+      it('stamps the exact model + effort matrix', () => {
+        expect(out.ai.effort).toBe('high');
+        expect(out.ai.refine.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.refine.effort).toBeUndefined();
+        expect(out.ai.plan.model).toBe('claude-opus-4-8');
+        expect(out.ai.plan.effort).toBe('xhigh');
+        expect(out.ai.readiness.model).toBe('claude-haiku-4-5');
+        expect(out.ai.readiness.effort).toBe('medium');
+        expect(out.ai.ideate.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.ideate.effort).toBeUndefined();
+        expect(out.ai.createPr.model).toBe('claude-haiku-4-5');
+      });
+
+      it('splits a cheap sonnet generator against a strong opus evaluator (same provider, different model)', () => {
+        // The novel property no other preset has: generator weaker than evaluator.
+        expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
+        expect(out.ai.implement.generator.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.implement.evaluator.model).toBe('claude-opus-4-8');
+        expect(out.ai.implement.generator.model).not.toBe(out.ai.implement.evaluator.model);
+        expect(out.ai.implement.generator.effort).toBe('high');
+        expect(out.ai.implement.evaluator.effort).toBe('xhigh');
+      });
+
+      it('generator climbs the default ladder to the evaluator model on plateau', () => {
+        // The whole preset assumes escalateOnPlateau: the cheap sonnet author must have a real
+        // default-ladder rung up to the opus evaluator model, otherwise a hard task plateau-loops
+        // on sonnet while the opus gate keeps rejecting it.
+        const ladder = mergeEscalationMap({});
+        const path = climbToLadderTop(ladder, out.ai.implement.generator.model);
+        expect(path).toContain(out.ai.implement.evaluator.model);
       });
     });
 

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -9,11 +9,46 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
 import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
 import { mergeEscalationMap } from '@src/business/task/escalation-map.ts';
 
+/** The exact 20-preset order — 5 families × 4 (mixed-first within each family). */
+const EXPECTED_PRESET_ORDER: readonly PresetName[] = [
+  'mixed',
+  'claude-only',
+  'copilot-only',
+  'codex-only',
+  'mixed-economic',
+  'claude-economic',
+  'copilot-economic',
+  'codex-economic',
+  'mixed-strong-gate',
+  'claude-strong-gate',
+  'copilot-strong-gate',
+  'codex-strong-gate',
+  'mixed-fast',
+  'claude-fast',
+  'copilot-fast',
+  'codex-fast',
+  'mixed-frontier',
+  'claude-frontier',
+  'copilot-frontier',
+  'codex-frontier',
+];
+
 const ECONOMIC_PRESETS: readonly PresetName[] = [
   'mixed-economic',
   'claude-economic',
   'copilot-economic',
   'codex-economic',
+];
+
+/** The four fast presets — the only family with escalateOnPlateau stamped OFF. */
+const FAST_PRESETS: readonly PresetName[] = ['mixed-fast', 'claude-fast', 'copilot-fast', 'codex-fast'];
+
+/** Strong-gate presets intentionally split generator and evaluator onto different models. */
+const STRONG_GATE_PRESETS: readonly PresetName[] = [
+  'mixed-strong-gate',
+  'claude-strong-gate',
+  'copilot-strong-gate',
+  'codex-strong-gate',
 ];
 
 /** Each economic preset and the standard preset whose implement flagship it should climb to. */
@@ -49,18 +84,9 @@ const modelGuardFor = (provider: AiProvider): ((s: string) => boolean) => {
 };
 
 describe('presets', () => {
-  it('exposes all nine equal preset names', () => {
-    expect([...PRESET_NAMES]).toEqual([
-      'mixed',
-      'claude-only',
-      'copilot-only',
-      'codex-only',
-      'mixed-economic',
-      'claude-economic',
-      'copilot-economic',
-      'codex-economic',
-      'claude-strong-gate',
-    ]);
+  it('exposes all twenty preset names in the canonical five-family order', () => {
+    expect([...PRESET_NAMES]).toEqual([...EXPECTED_PRESET_ORDER]);
+    expect(PRESET_NAMES).toHaveLength(20);
   });
 
   it('includes each economic preset in PRESET_NAMES', () => {
@@ -105,6 +131,21 @@ describe('presets', () => {
     }
   });
 
+  it('every strong-gate generator climbs the default ladder to its own evaluator model', () => {
+    // The whole strong-gate story assumes escalateOnPlateau: the cheap author must have a real
+    // default-ladder rung up to the strong evaluator model, otherwise a hard task plateau-loops
+    // on the cheap generator while the strong gate keeps rejecting it.
+    const ladder = mergeEscalationMap({});
+    for (const preset of STRONG_GATE_PRESETS) {
+      const out = applyPreset(preset, DEFAULT_SETTINGS);
+      const path = climbToLadderTop(ladder, out.ai.implement.generator.model);
+      expect(
+        path,
+        `${preset}: ${out.ai.implement.generator.model} must climb to ${out.ai.implement.evaluator.model}`
+      ).toContain(out.ai.implement.evaluator.model);
+    }
+  });
+
   it('claude-fable-5 (base + 1M variant) is in catalog but stays opt-in only — no preset row and no default ladder rung references it', () => {
     // Catalog membership is what lets a per-row pick pass the adapter boundary…
     expect(isClaudeModel('claude-fable-5')).toBe(true);
@@ -113,6 +154,7 @@ describe('presets', () => {
     // …while presets and the built-in escalation ladder deliberately do NOT reference it: the
     // catalog-top = ladder-top = preset-flagship invariant intentionally excludes the fable tier
     // until a deliberate flagship swap. Promoting it later means deleting this fence on purpose.
+    // The frontier family tops out at opus for exactly this reason (fable is export-suspended).
     for (const preset of PRESET_NAMES) {
       const out = applyPreset(preset, DEFAULT_SETTINGS);
       for (const flow of FLOW_IDS) {
@@ -146,16 +188,20 @@ describe('presets', () => {
     expect(out.ai.implement.evaluator.effort).toBe('high');
   });
 
-  it('isPresetName guards string input', () => {
-    expect(isPresetName('mixed')).toBe(true);
-    expect(isPresetName('codex-only')).toBe(true);
+  it('isPresetName accepts all twenty preset names and rejects garbage', () => {
+    for (const preset of EXPECTED_PRESET_ORDER) {
+      expect(isPresetName(preset), preset).toBe(true);
+    }
     expect(isPresetName('not-a-preset')).toBe(false);
+    expect(isPresetName('')).toBe(false);
+    expect(isPresetName('mixed-turbo')).toBe(false);
+    expect(isPresetName('claude')).toBe(false);
   });
 
   describe('applyPreset', () => {
     const sentinel: Settings = {
       ...DEFAULT_SETTINGS,
-      harness: { ...DEFAULT_SETTINGS.harness, maxTurns: 9, maxAttempts: 7 },
+      harness: { ...DEFAULT_SETTINGS.harness, maxTurns: 9, maxAttempts: 7, escalationMap: { 'foo-1': 'foo-2' } },
       logging: { level: 'debug' },
       concurrency: { maxParallelTasks: 3 },
       ui: { notifications: { enabled: false } },
@@ -163,25 +209,41 @@ describe('presets', () => {
     };
 
     for (const preset of PRESET_NAMES) {
-      it(`'${preset}' stamps a record that round-trips through SettingsSchema`, () => {
+      it(`'${preset}' stamps an ai section that round-trips through SettingsSchema`, () => {
         const out = applyPreset(preset, DEFAULT_SETTINGS);
         const parsed = SettingsSchema.safeParse(out);
-        expect(parsed.success).toBe(true);
+        // A clean parse catches any invalid per-row effort (e.g. xhigh/max on a codex row) or
+        // off-catalog model id the matrix might smuggle in.
+        expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.issues)).toBe(true);
       });
 
-      it(`'${preset}' preserves harness / logging / concurrency / ui / developer from current`, () => {
+      it(`'${preset}' preserves logging / concurrency / ui / developer / schemaVersion and the rest of harness from current`, () => {
         const out = applyPreset(preset, sentinel);
-        expect(out.harness).toEqual(sentinel.harness);
         expect(out.logging).toEqual(sentinel.logging);
         expect(out.concurrency).toEqual(sentinel.concurrency);
         expect(out.ui).toEqual(sentinel.ui);
         expect(out.developer).toEqual(sentinel.developer);
         expect(out.schemaVersion).toEqual(sentinel.schemaVersion);
+        // Every harness key EXCEPT escalateOnPlateau is preserved verbatim.
+        expect(out.harness.maxTurns).toBe(sentinel.harness.maxTurns);
+        expect(out.harness.maxAttempts).toBe(sentinel.harness.maxAttempts);
+        expect(out.harness.escalationMap).toEqual(sentinel.harness.escalationMap);
+        expect(out.harness.plateauThreshold).toBe(sentinel.harness.plateauThreshold);
+        expect(out.harness.rateLimitRetries).toBe(sentinel.harness.rateLimitRetries);
+        expect(out.harness.idleWatchdogMs).toBe(sentinel.harness.idleWatchdogMs);
+        expect(out.harness.skipPreVerifyOnFreshSetup).toBe(sentinel.harness.skipPreVerifyOnFreshSetup);
       });
 
-      it(`'${preset}' sets global ai.effort to 'high'`, () => {
-        const out = applyPreset(preset, DEFAULT_SETTINGS);
-        expect(out.ai.effort).toBe('high');
+      it(`'${preset}' stamps harness.escalateOnPlateau (off for fast, on otherwise)`, () => {
+        const expected = !FAST_PRESETS.includes(preset);
+        // Flip the sentinel's flag to the opposite of expected so we prove applyPreset wrote it,
+        // not that it merely inherited a matching value from current.
+        const current: Settings = {
+          ...sentinel,
+          harness: { ...sentinel.harness, escalateOnPlateau: !expected },
+        };
+        const out = applyPreset(preset, current);
+        expect(out.harness.escalateOnPlateau, preset).toBe(expected);
       });
 
       it(`'${preset}' stamps a row for every flow id`, () => {
@@ -204,14 +266,43 @@ describe('presets', () => {
         const out = applyPreset(preset, DEFAULT_SETTINGS);
         expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
         // Every preset keeps generator + evaluator on the SAME provider. Sharing the same MODEL
-        // is the norm too — EXCEPT `claude-strong-gate`, which intentionally pairs a cheap sonnet
-        // generator with a permanently-opus evaluator (asserted explicitly in its own matrix
-        // block below). Excluding it here keeps the same-model invariant true for the other eight.
-        if (preset !== 'claude-strong-gate') {
+        // is the norm too — EXCEPT the strong-gate family, which intentionally pairs a cheap
+        // generator with a permanently-strong evaluator (asserted explicitly in its own block).
+        if (!STRONG_GATE_PRESETS.includes(preset)) {
           expect(out.ai.implement.generator.model).toBe(out.ai.implement.evaluator.model);
         }
       });
     }
+
+    it('the four fast presets stamp global ai.effort to low', () => {
+      for (const preset of FAST_PRESETS) {
+        const out = applyPreset(preset, DEFAULT_SETTINGS);
+        expect(out.ai.effort, preset).toBe('low');
+      }
+    });
+
+    it('the standard, economic and strong-gate presets stamp global ai.effort to high', () => {
+      const highEffort: readonly PresetName[] = [
+        'mixed',
+        'claude-only',
+        'copilot-only',
+        'codex-only',
+        ...ECONOMIC_PRESETS,
+        ...STRONG_GATE_PRESETS,
+      ];
+      for (const preset of highEffort) {
+        const out = applyPreset(preset, DEFAULT_SETTINGS);
+        expect(out.ai.effort, preset).toBe('high');
+      }
+    });
+
+    it('frontier presets stamp global ai.effort to max — except codex-frontier which floors to high', () => {
+      expect(applyPreset('mixed-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
+      expect(applyPreset('claude-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
+      expect(applyPreset('copilot-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
+      // Codex has no max/xhigh effort rung, so the global stays high to avoid implying a max row.
+      expect(applyPreset('codex-frontier', DEFAULT_SETTINGS).ai.effort).toBe('high');
+    });
 
     describe("'mixed' preset matrix", () => {
       const out = applyPreset('mixed', DEFAULT_SETTINGS);
@@ -263,7 +354,7 @@ describe('presets', () => {
       });
 
       it('splits a cheap sonnet generator against a strong opus evaluator (same provider, different model)', () => {
-        // The novel property no other preset has: generator weaker than evaluator.
+        // The novel property no other family has: generator weaker than evaluator.
         expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
         expect(out.ai.implement.generator.model).toBe('claude-sonnet-4-6');
         expect(out.ai.implement.evaluator.model).toBe('claude-opus-4-8');
@@ -271,14 +362,65 @@ describe('presets', () => {
         expect(out.ai.implement.generator.effort).toBe('high');
         expect(out.ai.implement.evaluator.effort).toBe('xhigh');
       });
+    });
 
-      it('generator climbs the default ladder to the evaluator model on plateau', () => {
-        // The whole preset assumes escalateOnPlateau: the cheap sonnet author must have a real
-        // default-ladder rung up to the opus evaluator model, otherwise a hard task plateau-loops
-        // on sonnet while the opus gate keeps rejecting it.
-        const ladder = mergeEscalationMap({});
-        const path = climbToLadderTop(ladder, out.ai.implement.generator.model);
-        expect(path).toContain(out.ai.implement.evaluator.model);
+    describe("'codex-strong-gate' preset matrix — the narrowest gate", () => {
+      const out = applyPreset('codex-strong-gate', DEFAULT_SETTINGS);
+
+      it('pairs a gpt-5.4 author with a gpt-5.5 evaluator one rung apart', () => {
+        expect(out.ai.implement.generator.provider).toBe('openai-codex');
+        expect(out.ai.implement.evaluator.provider).toBe('openai-codex');
+        expect(out.ai.implement.generator.model).toBe('gpt-5.4');
+        expect(out.ai.implement.evaluator.model).toBe('gpt-5.5');
+        // Codex never carries xhigh/max — both rows floor at high.
+        expect(out.ai.implement.generator.effort).toBe('high');
+        expect(out.ai.implement.evaluator.effort).toBe('high');
+      });
+    });
+
+    describe("'codex-fast' preset matrix", () => {
+      const out = applyPreset('codex-fast', DEFAULT_SETTINGS);
+
+      it('leans on minimal effort for light flows and low effort for implement', () => {
+        expect(out.ai.refine.effort).toBe('minimal');
+        expect(out.ai.readiness.effort).toBe('minimal');
+        expect(out.ai.createPr.effort).toBe('minimal');
+        expect(out.ai.implement.generator.effort).toBe('low');
+        expect(out.ai.implement.evaluator.effort).toBe('low');
+      });
+
+      it('uses the mini tier for implement rather than a coding-grade frontier model', () => {
+        expect(out.ai.implement.generator.model).toBe('gpt-5.4-mini');
+      });
+    });
+
+    describe('fast family does not use haiku / nano for implement', () => {
+      it('keeps every fast implement row on a code-capable tier (no haiku, no nano)', () => {
+        for (const preset of FAST_PRESETS) {
+          const out = applyPreset(preset, DEFAULT_SETTINGS);
+          for (const role of ['generator', 'evaluator'] as const) {
+            const model = out.ai.implement[role].model;
+            expect(model.includes('haiku'), `${preset}/${role}: ${model}`).toBe(false);
+            expect(model.includes('nano'), `${preset}/${role}: ${model}`).toBe(false);
+          }
+        }
+      });
+    });
+
+    describe('frontier family tops out at opus / gpt-5.5 (never fable)', () => {
+      it('routes implement to the provider flagship at max effort (codex floored to high)', () => {
+        const cases: ReadonlyArray<[PresetName, string, 'max' | 'high']> = [
+          ['mixed-frontier', 'claude-opus-4-8', 'max'],
+          ['claude-frontier', 'claude-opus-4-8', 'max'],
+          ['copilot-frontier', 'claude-opus-4.8', 'max'],
+          ['codex-frontier', 'gpt-5.5', 'high'],
+        ];
+        for (const [preset, model, effort] of cases) {
+          const out = applyPreset(preset, DEFAULT_SETTINGS);
+          expect(out.ai.implement.generator.model, preset).toBe(model);
+          expect(out.ai.implement.evaluator.model, preset).toBe(model);
+          expect(out.ai.implement.generator.effort, preset).toBe(effort);
+        }
       });
     });
 


### PR DESCRIPTION
## Summary

Grows the settings-preset matrix from **9 → 20 presets**, organised into **five families × four provider variants** (mixed / claude / copilot / codex):

| Family | Strategy |
|---|---|
| **standard** | Flagship implement @ `xhigh`, best model per flow *(unchanged)* |
| **economic** | One tier below flagship @ `high`, climbs the escalation ladder on plateau *(unchanged)* |
| **strong-gate** | Cheap generator + permanently-strong evaluator (the only gen/eval split). Rounded out: **+copilot, +codex, +mixed** |
| **fast** *(new)* | Cheapest viable tier @ `low` effort — speed/cost over quality |
| **frontier** *(new)* | Flagship everywhere @ `max` effort — cost no object |

## Key behavioural change

`applyPreset` now also stamps **`harness.escalateOnPlateau`** (rest of `harness` still preserved verbatim):
- `fast` → **`false`** — a plateau settles instead of climbing, keeping it genuinely cheap/predictable.
- all other families → **`true`** — which also closes the old `claude-strong-gate` "assumes escalateOnPlateau is on" gap (now guaranteed, not assumed).

## Model-tier rationale (SWE-bench)

The cheap→strong ladders each family relies on are grounded in SWE-bench (June 2026) relative ordering — Claude `haiku < sonnet < opus`; GPT `mini < 5.4 < 5.5`. Framed as *ordering rationale only*, never hard scores (OpenAI stopped reporting Verified over contamination; scores swing with scaffolding). Notable calls:
- `fast` implement uses sonnet/mini, **not haiku** (too weak to author code reliably).
- `frontier` tops out at **opus**, not `fable-5` — Fable is export-control-suspended and would be rejected at launch; wired for a one-line swap when it returns.
- codex strong-gate's `5.4→5.5` gate is the narrowest gap (documented as least-differentiated).

## UI / docs

- Preset picker now **grouped by family** sub-headers in the TUI; `welcome-view` label duplicate removed in favour of the canonical map.
- `AI-SETTINGS.md` rewritten (fixes the stale "nine/eight" count), `README.md` + `CHANGELOG.md` updated.

## Verification

`pnpm typecheck && pnpm lint && pnpm test` → green (0 lint errors, **3741 tests passed** / 431 files). Effort vocabularies re-verified consistent across schema / UI / resolve-effort floor / adapter flags for all three providers.