### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-13
+
 ### Added
 
 - **Expanded preset matrix — 20 presets across five families.** Two new families (`fast`, `frontier`)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with [GitHub Copilot](https://docs.github.com/en/copilot/github-copilot-in-the-c
 > _"I'm helping!"_ — Ralph Wiggum
 
 > [!NOTE]
-> **Active development.** New features and polish ship regularly. The upcoming release expands the preset
+> **Active development.** New features and polish ship regularly. The latest release expands the preset
 > matrix to 20 presets across five families (`standard`, `economic`, `strong-gate`, `fast`, `frontier`),
 > each in `mixed` / `claude-only` / `copilot-only` / `codex-only` variants.
 > Upgrades are best-effort: install the latest version, redo your config, proceed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.12.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.12.0] - 2026-06-13`

Headline of this release: the **20-preset / five-family** settings matrix (standard · economic · strong-gate · fast · frontier) with `applyPreset` now stamping `harness.escalateOnPlateau`. The Unreleased backlog (structured verify gates, diff-scoped post-verify, model-availability probe, TUI sprint-pin/escalation-map editing, fable suspension guard, and more) also ships here.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (3741 tests)
- [ ] CI green

> ⚠️ HOLD: do not merge/tag/publish yet — awaiting maintainer's final review before release.