### PR TITLE
chore(release): 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-14
+
+### Changed
+
+- **Dependency bump.** `ink` 7.0.5 → 7.0.6 — fixes stale frames on Windows when output exactly fills
+  the terminal. Dev-tooling bumps (`@types/node`, `eslint`, `prettier`, `typescript-eslint`) ride along.
+
 ## [0.12.0] - 2026-06-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.12.1
- Promote `## [Unreleased]` CHANGELOG section to `## [0.12.1]` (dependency bump: `ink` 7.0.6 Windows stale-frame fix + dev-tooling)

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green