### PR TITLE
feat(tui): show provider in implement header + actionable model-unavailable error

### DIFF
--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -425,6 +425,8 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   // settings read.
   const generatorModel = implementPair.generator.model;
   const evaluatorModel = implementPair.evaluator.model;
+  const generatorProviderId = implementPair.generator.provider;
+  const evaluatorProviderId = implementPair.evaluator.provider;
   return {
     ok: true,
     runner: bridge(runner) as Runner<unknown>,
@@ -438,6 +440,8 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     ...(taskRecovering.size > 0 ? { taskRecovering } : {}),
     generatorModel,
     evaluatorModel,
+    generatorProvider: generatorProviderId,
+    evaluatorProvider: evaluatorProviderId,
     ...(generatorEffort !== undefined ? { generatorEffort } : {}),
     ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
   };

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -95,6 +95,14 @@ export type LaunchResult =
       readonly generatorModel?: string;
       readonly evaluatorModel?: string;
       /**
+       * Provider id backing each implement role (`claude-code` / `github-copilot` / `openai-codex`),
+       * rendered dim before the model name in the HeaderCard so the operator can see which backend
+       * each role runs on. Only the implement launcher sets these; every other flow leaves them
+       * undefined and the HeaderCard omits the provider segment.
+       */
+      readonly generatorProvider?: AiProvider;
+      readonly evaluatorProvider?: AiProvider;
+      /**
        * Resolved effort strings for each implement role (`low|medium|high|xhigh|max`). Displayed
        * alongside the model name in the HeaderCard so the operator can see the effort at a glance.
        * Only the implement launcher sets these; every other flow leaves them undefined.
@@ -197,6 +205,8 @@ export const sessionHintsFromLaunchResult = (
   readonly taskRecovering?: ReadonlyMap<string, RecoveryContext>;
   readonly generatorModel?: string;
   readonly evaluatorModel?: string;
+  readonly generatorProvider?: AiProvider;
+  readonly evaluatorProvider?: AiProvider;
   readonly generatorEffort?: string;
   readonly evaluatorEffort?: string;
   readonly pinnedProjectId?: ProjectId;
@@ -213,6 +223,8 @@ export const sessionHintsFromLaunchResult = (
   ...(result.taskRecovering !== undefined ? { taskRecovering: result.taskRecovering } : {}),
   ...(result.generatorModel !== undefined ? { generatorModel: result.generatorModel } : {}),
   ...(result.evaluatorModel !== undefined ? { evaluatorModel: result.evaluatorModel } : {}),
+  ...(result.generatorProvider !== undefined ? { generatorProvider: result.generatorProvider } : {}),
+  ...(result.evaluatorProvider !== undefined ? { evaluatorProvider: result.evaluatorProvider } : {}),
   ...(result.generatorEffort !== undefined ? { generatorEffort: result.generatorEffort } : {}),
   ...(result.evaluatorEffort !== undefined ? { evaluatorEffort: result.evaluatorEffort } : {}),
   ...(result.pinnedProjectId !== undefined ? { pinnedProjectId: result.pinnedProjectId } : {}),

--- a/src/application/ui/tui/runtime/session-manager.ts
+++ b/src/application/ui/tui/runtime/session-manager.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { AiProvider } from '@src/domain/entity/settings.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -131,6 +132,13 @@ export interface SessionDescriptor {
   readonly generatorModel?: string;
   readonly evaluatorModel?: string;
   /**
+   * Provider id backing each implement role (`claude-code` / `github-copilot` / `openai-codex`).
+   * The HeaderCard renders it dim before the model name so the operator sees which backend each
+   * role runs on. Only set for the implement flow; every other flow leaves these undefined.
+   */
+  readonly generatorProvider?: AiProvider;
+  readonly evaluatorProvider?: AiProvider;
+  /**
    * Resolved effort strings for each implement role (`low|medium|high|xhigh|max`). Displayed
    * alongside the model name in the HeaderCard so the operator can see the effort at a glance.
    * Only set for the implement flow; every other flow leaves these undefined.
@@ -179,6 +187,8 @@ export interface SessionManager {
     readonly taskRecovering?: ReadonlyMap<string, RecoveryContext>;
     readonly generatorModel?: string;
     readonly evaluatorModel?: string;
+    readonly generatorProvider?: AiProvider;
+    readonly evaluatorProvider?: AiProvider;
     readonly generatorEffort?: string;
     readonly evaluatorEffort?: string;
     readonly pinnedProjectId?: ProjectId;
@@ -330,6 +340,8 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
       taskRecovering,
       generatorModel,
       evaluatorModel,
+      generatorProvider,
+      evaluatorProvider,
       generatorEffort,
       evaluatorEffort,
       pinnedProjectId,
@@ -354,6 +366,8 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
         ...(taskRecovering !== undefined ? { taskRecovering } : {}),
         ...(generatorModel !== undefined ? { generatorModel } : {}),
         ...(evaluatorModel !== undefined ? { evaluatorModel } : {}),
+        ...(generatorProvider !== undefined ? { generatorProvider } : {}),
+        ...(evaluatorProvider !== undefined ? { evaluatorProvider } : {}),
         ...(generatorEffort !== undefined ? { generatorEffort } : {}),
         ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
         ...(pinnedProjectId !== undefined ? { pinnedProjectId } : {}),

--- a/src/application/ui/tui/views/execute-view-internals/header-card.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/header-card.tsx
@@ -43,22 +43,58 @@ interface HeaderCardProps {
  * Renders the model + effort lines inside the HeaderCard.
  *
  * Implement runs (both `generatorModel` and `evaluatorModel` set): two explicit lines so the
- * operator can clearly see each role, even when generator === evaluator.
+ * operator can clearly see each role, even when generator === evaluator. When the role's provider
+ * id is known it renders dim before the model (secondary context) — model stays highlighted.
  *
- *   ↳ generator  claude-opus-4-8 · high
- *   ↳ evaluator  gpt-5.5 · medium
+ *   ↳ generator  github-copilot · claude-opus-4-8 · high
+ *   ↳ evaluator  openai-codex · gpt-5.5 · medium
  *
- * Non-implement flows (at most one model set): single `model <name>` line.
- * When neither model is set: nothing rendered.
+ * Non-implement flows (at most one model set): single `model <name>` line, optionally prefixed
+ * with the provider when one is available. When neither model is set: nothing rendered.
  */
+const RoleLine = ({
+  role,
+  provider,
+  model,
+  effort,
+}: {
+  readonly role: string;
+  readonly provider: string | undefined;
+  readonly model: string;
+  readonly effort: string | undefined;
+}): React.JSX.Element => (
+  <Box>
+    <Text dimColor>
+      {glyphs.activityArrow} {role}{' '}
+    </Text>
+    {provider !== undefined && (
+      <>
+        <Text dimColor>{provider}</Text>
+        <Text dimColor> {glyphs.bullet} </Text>
+      </>
+    )}
+    <Text color={inkColors.highlight}>{model}</Text>
+    {effort !== undefined && (
+      <>
+        <Text dimColor> {glyphs.bullet} </Text>
+        <Text dimColor>{effort}</Text>
+      </>
+    )}
+  </Box>
+);
+
 const ModelLines = ({
   generatorModel,
   evaluatorModel,
+  generatorProvider,
+  evaluatorProvider,
   generatorEffort,
   evaluatorEffort,
 }: {
   readonly generatorModel: string | undefined;
   readonly evaluatorModel: string | undefined;
+  readonly generatorProvider: string | undefined;
+  readonly evaluatorProvider: string | undefined;
   readonly generatorEffort: string | undefined;
   readonly evaluatorEffort: string | undefined;
 }): React.JSX.Element | null => {
@@ -66,36 +102,25 @@ const ModelLines = ({
   if (generatorModel !== undefined && evaluatorModel !== undefined) {
     return (
       <Box flexDirection="column">
-        <Box>
-          <Text dimColor>{glyphs.activityArrow} generator </Text>
-          <Text color={inkColors.highlight}>{generatorModel}</Text>
-          {generatorEffort !== undefined && (
-            <>
-              <Text dimColor> {glyphs.bullet} </Text>
-              <Text dimColor>{generatorEffort}</Text>
-            </>
-          )}
-        </Box>
-        <Box>
-          <Text dimColor>{glyphs.activityArrow} evaluator </Text>
-          <Text color={inkColors.highlight}>{evaluatorModel}</Text>
-          {evaluatorEffort !== undefined && (
-            <>
-              <Text dimColor> {glyphs.bullet} </Text>
-              <Text dimColor>{evaluatorEffort}</Text>
-            </>
-          )}
-        </Box>
+        <RoleLine role="generator" provider={generatorProvider} model={generatorModel} effort={generatorEffort} />
+        <RoleLine role="evaluator" provider={evaluatorProvider} model={evaluatorModel} effort={evaluatorEffort} />
       </Box>
     );
   }
 
-  // Non-implement flows: single model line (whichever is set).
+  // Non-implement flows: single model line (whichever is set), with its provider when available.
   const model = generatorModel ?? evaluatorModel;
+  const provider = generatorProvider ?? evaluatorProvider;
   if (model !== undefined) {
     return (
       <Box>
         <Text dimColor>{glyphs.activityArrow} model </Text>
+        {provider !== undefined && (
+          <>
+            <Text dimColor>{provider}</Text>
+            <Text dimColor> {glyphs.bullet} </Text>
+          </>
+        )}
         <Text color={inkColors.highlight}>{model}</Text>
       </Box>
     );
@@ -146,6 +171,8 @@ export const HeaderCard = ({
         <ModelLines
           generatorModel={descriptor.generatorModel}
           evaluatorModel={descriptor.evaluatorModel}
+          generatorProvider={descriptor.generatorProvider}
+          evaluatorProvider={descriptor.evaluatorProvider}
           generatorEffort={descriptor.generatorEffort}
           evaluatorEffort={descriptor.evaluatorEffort}
         />

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -50,6 +50,20 @@ import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attem
  */
 export type ProviderName = 'claude-provider' | 'codex-provider' | 'copilot-provider';
 
+/**
+ * Matches the provider-CLI "the selected model isn't available" failure across the three
+ * backends. Real-world wordings observed:
+ *  - copilot: `Error: Model "gpt-5.4-nano" from --model flag is not available.`
+ *  - codex:   `model not found`
+ *  - claude:  `unknown model`
+ * Broad enough to catch phrasing drift (`model ... is not available`, `model not found`,
+ * `unknown model`, `unsupported model`) yet anchored on the word `model` so it can't trip on
+ * unrelated "not available" lines. Abort is classified first, so this regex never sees an
+ * abort message even though it couldn't match one anyway.
+ */
+const MODEL_UNAVAILABLE_RE =
+  /\bmodel\b[^\n]*\b(?:is\s+not\s+available|not\s+available|not\s+found)|\b(?:unknown|unsupported|invalid)\s+model\b/i;
+
 export interface ClassifySpawnExitInput {
   readonly session: AiSession;
   readonly exit: {
@@ -162,7 +176,34 @@ export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<
     };
   }
 
-  // 5. Recovery — audit-[09]: signals.json is authoritative. Existence-check only; the
+  // 5. Model unavailable — a configuration failure, not recoverable work. It wins over
+  // signals-recovery because a model-not-available exit means the run never produced valid work
+  // for this model; a stale signals.json must not mask the real cause. The actionable hint is
+  // folded into `.message` (not just the separate `.hint` field) so it survives unchanged through
+  // `run-generator-turn`'s blockedReason string and into the TUI without touching the render layer.
+  //
+  // **stderr ONLY (unlike rate-limit).** All three provider CLIs report model-availability errors
+  // on stderr. Scanning `stdoutTail` here would be a false-positive hazard: stdoutTail carries
+  // assistant-generated task output (Claude envelope body / Copilot event text / Codex agent
+  // message), where benign phrases like "the model is not available in TensorFlow" or "the model
+  // checkpoint was not found" appear in NORMAL responses and would be misclassified as a config
+  // failure. The rate-limit branch above legitimately needs stdoutTail (claude reports quota in
+  // its stream-json result envelope); model-availability has no such stdout-only case.
+  if (MODEL_UNAVAILABLE_RE.test(stderr)) {
+    const hint = 'model not available — it may not be on your plan or CLI version; pick another model in settings';
+    return {
+      kind: 'error',
+      error: new InvalidStateError({
+        entity: providerName,
+        currentState: `exit-${String(exit.code ?? 'null')}`,
+        attemptedAction: 'complete generation',
+        message: `${providerName}: process exited with code ${String(exit.code)}${exit.signal !== null ? ` (signal=${exit.signal})` : ''}: ${stderr.trim() || '<empty stderr>'} — ${hint}`,
+        hint,
+      }),
+    };
+  }
+
+  // 6. Recovery — audit-[09]: signals.json is authoritative. Existence-check only; the
   // downstream validator catches malformed content.
   const exists = await pathExists(String(session.signalsFile));
   if (exists.ok && exists.value) {
@@ -191,7 +232,7 @@ export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<
     return outcome;
   }
 
-  // 6. Hard fail. Mirrors the historical per-adapter exit-N error shape.
+  // 7. Hard fail. Mirrors the historical per-adapter exit-N error shape.
   return {
     kind: 'error',
     error: new InvalidStateError({

--- a/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
+++ b/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
@@ -287,6 +287,119 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     }
   });
 
+  // Representative model-unavailable stderr strings observed across the three real CLIs.
+  const MODEL_UNAVAILABLE_STDERR: readonly string[] = [
+    'Error: Model "gpt-5.4-nano" from --model flag is not available.',
+    'model claude-opus-9 not found',
+    'unknown model: o5-mega',
+    'unsupported model requested',
+  ];
+
+  it.each(MODEL_UNAVAILABLE_STDERR)(
+    'model-unavailable stderr maps to InvalidStateError with actionable hint (%s)',
+    async (stderr) => {
+      const session = baseSession();
+      // No signals.json — and even if there were one, the model branch wins over recovery.
+      let invoked = 0;
+      const outcome = await classifySpawnExit({
+        session,
+        exit: { code: 1, signal: null },
+        stderr,
+        rateLimitRe: RATE_RE,
+        providerName,
+        eventBus: createCapturingBus().bus,
+        watchdogBannerId: 'unused',
+        onSuccess: () => {
+          invoked += 1;
+          return okSuccess(session);
+        },
+      });
+      expect(invoked).toBe(0);
+      expect(outcome.kind).toBe('error');
+      if (outcome.kind === 'error') {
+        expect(outcome.error).toBeInstanceOf(InvalidStateError);
+        // Raw stderr detail is preserved …
+        expect(outcome.error.message).toContain(stderr);
+        // … alongside the actionable hint, folded into `.message` so it survives to the UI.
+        expect(outcome.error.message).toContain('model not available');
+        expect(outcome.error.message).toContain('pick another model in settings');
+        // Separate `.hint` field is also populated.
+        expect((outcome.error as InvalidStateError).hint).toContain('pick another model in settings');
+      }
+    }
+  );
+
+  it('model-unavailable wins over signals-present recovery (config error, not recoverable work)', async () => {
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: 'Error: Model "gpt-5.4-nano" from --model flag is not available.',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(0);
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error.message).toContain('model not available');
+    }
+  });
+
+  it('model-unavailable wording ONLY in stdoutTail does NOT classify as model-unavailable (false-positive guard)', async () => {
+    // stdoutTail carries assistant-generated task output, where benign phrases like "the model is
+    // not available in TensorFlow" appear in NORMAL responses. The model-unavailable branch scans
+    // stderr ONLY — a model-availability phrase that lands solely in stdoutTail (with a generic
+    // non-zero exit and unrelated stderr) must fall through to the generic hard-fail branch, NOT be
+    // misclassified as a config failure. All three CLIs report real model errors on stderr.
+    const session = baseSession();
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: '',
+      stdoutTail: '{"type":"result","result":"the model is not available in TensorFlow yet"}',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      // Falls through to generic hard-fail — the model hint must NOT appear.
+      expect(outcome.error.message).not.toContain('pick another model in settings');
+      expect(outcome.error.message).toContain('process exited with code 1');
+    }
+  });
+
+  it('generic non-zero failure (not model-related) does NOT trip the model hint', async () => {
+    const session = baseSession();
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 2, signal: null },
+      stderr: 'TypeError: cannot read property of undefined',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error.message).not.toContain('pick another model in settings');
+    }
+  });
+
   it('rate-limit in stderr wins over signals-present recovery', async () => {
     const session = baseSession();
     await writeSignalsFile(String(session.signalsFile));


### PR DESCRIPTION
## Summary

Surfaces the AI provider in the implement-flow TUI header and turns an opaque "model not available" CLI exit into an actionable, provider-aware error.

- Thread generator/evaluator provider id through `launch → SessionDescriptor → header-card`.
- Header now renders `provider · model · effort` per role, so cross-provider (generator vs evaluator) rows are visible at a glance.
- `classify-spawn-exit`: detect "model not available" across Claude / Copilot / Codex, fold an actionable hint into the surfaced error.

## Files

- `src/application/ui/shared/launch/implement.ts`
- `src/application/ui/shared/launcher.ts`
- `src/application/ui/tui/runtime/session-manager.ts`
- `src/application/ui/tui/views/execute-view-internals/header-card.tsx`
- `src/integration/ai/providers/_engine/classify-spawn-exit.ts`
- `tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts`

## Verification

`pnpm typecheck && pnpm lint && pnpm test` — green (0 type errors, 0 lint errors, 3985 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
