### PR TITLE
chore(release): 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-06-23
+
+### Changed
+
+- **Dependency maintenance.** Bumped the all-dependencies group — dev tooling and lockfile
+  resolutions, including `@types/node` 25 → 26 and a within-range `ink` 7.0.x → 7.1.0 update. No
+  runtime API or behavior changes.
+
 ## [0.13.0] - 2026-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.13.1
- Promote `## [Unreleased]` CHANGELOG section to `## [0.13.1]`

Maintenance release: only change since v0.13.0 is the all-dependencies group bump (dev tooling + lockfile resolutions, incl. `@types/node` 25→26, within-range `ink` 7.0.x→7.1.0). No runtime API or behavior changes; the published runtime dependency ranges are unchanged.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (0 errors, 3985 tests pass)
- [ ] CI green