### PR TITLE
audit: critical, high, medium, and research improvements (10 commits)

### DIFF
--- a/src/application/chain/build/leaf.ts
+++ b/src/application/chain/build/leaf.ts
@@ -56,6 +56,11 @@ export const leaf = <TCtx, UInput, UOutput>(
       } catch (cause) {
         if (!isDomainError(cause)) throw cause;
         const durationMs = performance.now() - start;
+        if (cause instanceof AbortError) {
+          const entry: TraceEntry = { elementName: name, ...labelExt, status: 'aborted', durationMs, error: cause };
+          onTrace?.(entry);
+          return Result.error({ error: cause, trace: [entry] });
+        }
         const entry: TraceEntry = { elementName: name, ...labelExt, status: 'failed', durationMs, error: cause };
         onTrace?.(entry);
         return Result.error({ error: cause, trace: [entry] });

--- a/src/application/flows/add-ticket/manifest.ts
+++ b/src/application/flows/add-ticket/manifest.ts
@@ -1,0 +1,9 @@
+import type { FlowManifest } from '@src/application/registry.ts';
+
+export const ticketAddManifest: FlowManifest = {
+  id: 'add-ticket',
+  title: 'Add ticket',
+  description: 'Append a pending ticket to the current sprint.',
+  canBackground: false,
+  triggers: { currentSprintStatus: ['draft'] },
+};

--- a/src/application/flows/implement/leaves/gen-eval-loop.ts
+++ b/src/application/flows/implement/leaves/gen-eval-loop.ts
@@ -1,3 +1,4 @@
+import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { HarnessSignalSink } from '@src/business/observability/harness-signal-sink.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -10,8 +11,12 @@ import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { guard } from '@src/application/chain/build/guard.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
 import { loop } from '@src/application/chain/build/loop.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
+import { detectRepetitiveLoop } from '@src/business/task/escalation-policy.ts';
+import { failedDimensions } from '@src/business/task/plateau-detection.ts';
+import type { PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { evaluatorLeaf } from '@src/application/flows/implement/leaves/evaluator.ts';
 import { generatorLeaf } from '@src/application/flows/implement/leaves/generator.ts';
@@ -123,6 +128,111 @@ export const createGenEvalLoop = (
     ...(opts.evaluator.effort !== undefined ? { effort: opts.evaluator.effort } : {}),
   };
 
+  // ---------------------------------------------------------------------------
+  // Loop-diversity guard (TIDE arXiv 2602.02196)
+  //
+  // Tracks a rolling fingerprint of each evaluator turn's failed-dimension set.
+  // When the last DIVERSITY_WINDOW_SIZE fingerprints are all identical the loop is
+  // repeating the same approach without progress — exit via a plateau exit so the
+  // escalation policy can climb the model ladder or apply a change-of-approach nudge.
+  //
+  // State is closure-scoped to this element instance; `lastAttemptCount` resets the
+  // history at each new attempt boundary so fingerprints don't leak across attempts.
+  // ---------------------------------------------------------------------------
+  const DIVERSITY_WINDOW_SIZE = 3;
+  let lastAttemptCount = -1;
+  const diversityHistory: string[] = [];
+
+  interface DiversityCheckInput {
+    readonly latestRecord: PlateauTurnRecord | undefined;
+    readonly alreadyExiting: boolean;
+    readonly attemptCount: number;
+    /** Turn just completed (`ctx.genEvalTurn`) — compared against the budget so the guard never pre-empts the final turn. */
+    readonly turnsUsed: number;
+  }
+
+  interface DiversityCheckOutput {
+    readonly shouldExit: boolean;
+    readonly dimensions?: readonly string[];
+  }
+
+  const loopDiversityCheckLeaf = leaf<ImplementCtx, DiversityCheckInput, DiversityCheckOutput>(
+    `loop-diversity-check-${String(taskId)}`,
+    {
+      useCase: {
+        execute: async (input) => {
+          // Reset per attempt so history from a prior attempt doesn't carry over.
+          if (input.attemptCount !== lastAttemptCount) {
+            lastAttemptCount = input.attemptCount;
+            diversityHistory.length = 0;
+          }
+
+          // Skip when the evaluator already set a terminal exit this turn, or when the
+          // evaluator did not run (generator self-blocked — latestRecord is undefined).
+          if (input.alreadyExiting || input.latestRecord === undefined) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Fingerprint = sorted set of currently-failed dimension names joined by '|'.
+          // A passing evaluation (all dimensions green) has no failed dimensions → no
+          // fingerprint → no diversity record (the loop would exit via 'passed' anyway).
+          const failed = failedDimensions(input.latestRecord.evaluation);
+          if (failed.size === 0) return Result.ok({ shouldExit: false });
+
+          const fingerprint = [...failed].sort().join('|');
+          diversityHistory.push(fingerprint);
+          if (diversityHistory.length > DIVERSITY_WINDOW_SIZE * 2) {
+            diversityHistory.splice(0, diversityHistory.length - DIVERSITY_WINDOW_SIZE * 2);
+          }
+
+          if (!detectRepetitiveLoop(diversityHistory, DIVERSITY_WINDOW_SIZE)) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Budget exhaustion takes precedence. When this was the final turn the loop would run
+          // anyway (turnsUsed === budget), there is no remaining budget for an early escalation
+          // to reclaim — the truthful terminal state is `budget-exhausted`, so let `finalize`
+          // synthesise it instead of pre-empting it with a `plateau`. This preserves the
+          // invariant that a run where every turn fails from the very start (never any progress)
+          // always exits as `budget-exhausted`. Read the same `readConfig` budget the loop's
+          // `shouldContinue` uses so a runtime config change can't diverge the two.
+          const { maxTurns } = await deps.readConfig();
+          if (input.turnsUsed >= Math.max(1, maxTurns)) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Diversity collapsed — the generator has repeated the exact same failure pattern
+          // for the last DIVERSITY_WINDOW_SIZE turns without any approach change. Surface a
+          // warn banner and exit the loop so the escalation ladder can intervene.
+          deps.eventBus.publish({
+            type: 'banner-show',
+            id: `loop-diversity-${String(taskId)}`,
+            tier: 'warn',
+            message: 'Generator is repeating the same approach — escalating',
+            cause: 'loop-diversity-exhausted',
+            at: deps.clock(),
+          });
+
+          return Result.ok({ shouldExit: true, dimensions: [...failed] });
+        },
+      },
+      input: (ctx) => {
+        const history = ctx.plateauHistory;
+        const latestRecord = history !== undefined && history.length > 0 ? history[history.length - 1] : undefined;
+        return {
+          latestRecord,
+          alreadyExiting: ctx.lastExit !== undefined,
+          attemptCount: ctx.currentTask?.attempts.length ?? 0,
+          turnsUsed: ctx.genEvalTurn ?? 0,
+        };
+      },
+      output: (ctx, out) => {
+        if (!out.shouldExit || out.dimensions === undefined) return ctx;
+        return { ...ctx, lastExit: { kind: 'plateau', dimensions: out.dimensions } };
+      },
+    }
+  );
+
   return loop<ImplementCtx>(
     `gen-eval-${String(taskId)}`,
     sequential<ImplementCtx>(`gen-eval-turn-${String(taskId)}`, [
@@ -169,6 +279,7 @@ export const createGenEvalLoop = (
             taskId
           ),
           evaluatorLeaf(evaluatorLeafDeps, taskId),
+          loopDiversityCheckLeaf,
         ])
       ),
     ]),

--- a/src/application/flows/readiness/flow.ts
+++ b/src/application/flows/readiness/flow.ts
@@ -7,6 +7,9 @@ import {
   primaryFlowRow,
   uniqueProvidersFromAi,
 } from '@src/domain/entity/settings.ts';
+import { Result } from '@src/domain/result.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
 import { loadProjectLeaf } from '@src/application/flows/_shared/project/load.ts';
@@ -90,6 +93,59 @@ const resolveEffortForRow = (ai: AiSettings, flow: FlowId): string | undefined =
   if (row.provider === 'openai-codex' && (globalEffort === 'xhigh' || globalEffort === 'max')) return 'high';
   return globalEffort;
 };
+
+/**
+ * Error codes that represent a PROVIDER-SPECIFIC infrastructure failure — the kind it is safe to
+ * skip past so the remaining providers still get set up. A filesystem failure inside this
+ * provider's readiness probe (`probe-error`), or this provider's CLI being throttled after the
+ * adapter exhausted its 429 retries (`rate-limit`), says nothing about the other providers.
+ *
+ * Everything NOT in this set propagates and fails the run:
+ *  - Domain contract errors — the AI omitted a required signal (`invalid-state`), wrote malformed
+ *    `signals.json` (`parse-error`), or a value failed validation (`invalid-value`). These are
+ *    real defects the operator must see, not a provider to silently skip.
+ *  - Spawn failures (provider CLI not on PATH, non-zero exit, model unavailable) also surface as
+ *    `invalid-state`, so they propagate too — failing loudly on a misconfiguration beats hiding
+ *    it. The code cannot be told apart from a contract violation, and surfacing both is correct.
+ *  - Global infrastructure — a lock / I/O `storage-error` affects every provider, so it aborts the
+ *    whole run rather than being swallowed per-provider.
+ *  - `AbortError` (`aborted`) — operator cancellation; always propagates transparently.
+ */
+const PROVIDER_INFRASTRUCTURE_ERROR_CODES: ReadonlySet<ErrorCode> = new Set([ErrorCode.Probe, ErrorCode.RateLimit]);
+
+/**
+ * Wraps a per-provider subchain so that a provider-specific infrastructure failure emits a warn
+ * banner and lets execution continue to the remaining providers. Only the codes in
+ * {@link PROVIDER_INFRASTRUCTURE_ERROR_CODES} are tolerated — domain contract errors, global I/O
+ * failures and operator AbortError all propagate so the run fails loudly or cancels.
+ */
+const wrapProviderContinue = (
+  eventBus: SetupReadinessDeps['eventBus'],
+  provider: AiProvider,
+  inner: Element<ReadinessCtx>
+): Element<ReadinessCtx> => ({
+  name: `continue-on-error(${inner.name})`,
+  // Expose children so flattenLeaves walks the full per-provider step list for the TUI plan.
+  children: [inner],
+  async execute(ctx, signal, onTrace) {
+    const result = await inner.execute(ctx, signal, onTrace);
+    if (result.ok) return result;
+    // Only a provider-specific infrastructure failure is tolerated — skip this provider and let
+    // the fan-out continue. Everything else (contract errors, global I/O, abort) propagates.
+    if (!PROVIDER_INFRASTRUCTURE_ERROR_CODES.has(result.error.error.code)) return result;
+    // Provider-level infra failure (probe filesystem error, CLI throttle): surface as a warn
+    // banner and continue to the next provider. The inner trace already recorded the failure.
+    eventBus.publish({
+      type: 'banner-show',
+      id: `readiness-provider-error-${provider}`,
+      tier: 'warn',
+      message: `Provider '${provider}' readiness setup failed — skipping, other providers continue`,
+      cause: result.error.error.message,
+      at: IsoTimestamp.now(),
+    });
+    return Result.ok({ ctx, trace: result.error.trace });
+  },
+});
 
 const buildPerToolSubchain = (
   deps: SetupReadinessDeps,
@@ -177,12 +233,14 @@ const buildPerToolSubchain = (
  *   sequential('readiness', [
  *     load-project,
  *     pick-repository,                       // interactive (auto-selects single-repo projects)
- *     // one per-tool sub-chain per unique provider in settings.ai (order follows FLOW_IDS):
- *     sequential('tool-claude-code', [ probe → install-skills → propose → uninstall-skills →
- *                                       confirm → write → offer-skill-suggestions →
- *                                       install-readiness-skills ]),
- *     sequential('tool-copilot',    [ … ]),
- *     sequential('tool-codex',      [ … ]),
+ *     // one per-tool sub-chain per unique provider in settings.ai (order follows FLOW_IDS), each
+ *     // wrapped in a continue-on-error guard so a provider-specific infra failure skips that
+ *     // provider while the fan-out carries on:
+ *     continue-on-error(sequential('tool-claude-code', [ probe → install-skills → propose →
+ *                                       uninstall-skills → confirm → write →
+ *                                       offer-skill-suggestions → install-readiness-skills ])),
+ *     continue-on-error(sequential('tool-copilot',    [ … ])),
+ *     continue-on-error(sequential('tool-codex',      [ … ])),
  *     persist-suggested-skills,             // one save: union of every tool's suggestions
  *   ])
  *
@@ -196,7 +254,7 @@ export const createReadinessFlow = (deps: SetupReadinessDeps, opts: CreateReadin
   // still reads the full `opts.ai`, so any provider in the list resolves correctly.
   const providers = opts.providers ?? uniqueProvidersFromAi(opts.ai);
   const perToolSubchains = providers.map((provider) =>
-    buildPerToolSubchain(deps, opts, provider, toolForProvider(provider))
+    wrapProviderContinue(deps.eventBus, provider, buildPerToolSubchain(deps, opts, provider, toolForProvider(provider)))
   );
   return sequential<ReadinessCtx>('readiness', [
     loadProjectLeaf<ReadinessCtx>({ projectRepo: deps.projectRepo }),

--- a/src/application/flows/review/flow.ts
+++ b/src/application/flows/review/flow.ts
@@ -1,5 +1,6 @@
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { guard } from '@src/application/chain/build/guard.ts';
 import { loop } from '@src/application/chain/build/loop.ts';
@@ -75,9 +76,10 @@ export interface CreateReviewFlowOpts {
  * The loop can also exit via its `shouldContinue` round cap (`i <= maxRounds`) — a fail-safe for a
  * UI bug that would otherwise re-enter the round forever. On THAT exit `lastReviewExit` is still
  * undefined (no human terminal decision was reached), so the guard skips both settle steps and the
- * sprint stays in `review` with a visible `skipped` trace entry. The human end-of-sprint decision
- * stays the only path to `done`, and re-running review resumes cleanly because the status never
- * moved.
+ * sprint stays in `review` with a visible `skipped` trace entry. The cap exit also publishes a warn
+ * banner from inside `shouldContinue` (off-trace, so the happy path stays clean) explaining WHY the
+ * sprint stayed in `review`. The human end-of-sprint decision stays the only path to `done`, and
+ * re-running review resumes cleanly because the status never moved.
  */
 export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): Element<ReviewCtx> => {
   const maxRounds = opts.maxRounds ?? DEFAULT_MAX_ROUNDS;
@@ -108,12 +110,32 @@ export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): 
     loadAndAssertSprintSubChain<ReviewCtx>({ sprintRepo: deps.sprintRepo }, ['review']),
     ensureFeedbackFileLeaf(opts.feedbackFile),
     loop<ReviewCtx>('review-loop', reviewRound, {
-      shouldContinue: (_ctx, i) => i <= maxRounds,
+      // Pre-iteration round cap. `i > maxRounds` exits the loop without running another round.
+      // When the cap is the reason we stop — no human terminal decision reached, `lastReviewExit`
+      // still undefined — publish a warn banner from HERE so the operator knows WHY the sprint
+      // stayed in 'review'. Emitting from `shouldContinue` keeps the banner OFF the trace: a
+      // normal terminal exit makes `shouldStop` fire first, so this branch is never reached on
+      // the happy path and the trace stays clean. Re-running review resumes cleanly (status never
+      // moved).
+      shouldContinue: (ctx, i) => {
+        if (i <= maxRounds) return true;
+        if (ctx.lastReviewExit === undefined) {
+          deps.eventBus.publish({
+            type: 'banner-show',
+            id: 'review-cap-exhausted',
+            tier: 'warn',
+            message: `Review round cap (${maxRounds}) reached — sprint remains in 'review'. Re-run the review flow to continue.`,
+            at: IsoTimestamp.now(),
+          });
+        }
+        return false;
+      },
       shouldStop: (ctx) => ctx.lastReviewExit !== undefined,
     }),
     // Only settle the sprint to `done` when the review loop reached a human terminal decision
     // (`lastReviewExit` set). A round-cap exit leaves it undefined → guard skips both settle steps
-    // so a UI-bug-driven cap exhaustion never silently closes the sprint.
+    // (a visible `skipped` trace entry) so a UI-bug-driven cap exhaustion never silently closes the
+    // sprint. The human end-of-sprint decision stays the only path to `done`.
     guard<ReviewCtx>(
       'review-settled',
       (ctx) => ctx.lastReviewExit !== undefined,

--- a/src/application/registry.ts
+++ b/src/application/registry.ts
@@ -14,6 +14,7 @@ import { exportRequirementsManifest } from '@src/application/flows/export-requir
 import { createPrManifest } from '@src/application/flows/create-pr/manifest.ts';
 import { doctorManifest } from '@src/application/flows/doctor/manifest.ts';
 import { settingsManifest } from '@src/application/flows/settings/manifest.ts';
+import { ticketAddManifest } from '@src/application/flows/add-ticket/manifest.ts';
 import { ticketRemoveManifest } from '@src/application/flows/remove-ticket/manifest.ts';
 
 /**
@@ -100,5 +101,6 @@ export const flowRegistry: readonly FlowEntry[] = [
   { manifest: createPrManifest },
   { manifest: doctorManifest },
   { manifest: settingsManifest },
+  { manifest: ticketAddManifest },
   { manifest: ticketRemoveManifest },
 ];

--- a/src/application/ui/tui/prompts/path-picker-prompt.tsx
+++ b/src/application/ui/tui/prompts/path-picker-prompt.tsx
@@ -75,9 +75,11 @@ export const PathPickerPrompt = ({
   const [typing, setTyping] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     const load = async (): Promise<void> => {
       try {
         const items = await fs.readdir(cwd, { withFileTypes: true });
+        if (cancelled) return;
         const filtered = items
           .filter((d) => showHidden || !d.name.startsWith('.'))
           .filter((d) => d.isDirectory())
@@ -86,11 +88,15 @@ export const PathPickerPrompt = ({
         setEntries(filtered);
         setError(undefined);
       } catch (err) {
+        if (cancelled) return;
         setEntries([]);
         setError(err instanceof Error ? err.message : String(err));
       }
     };
     void load();
+    return () => {
+      cancelled = true;
+    };
   }, [cwd, showHidden]);
 
   // Synthetic rows: parent (..) → [Select this directory] → directory entries.

--- a/src/application/ui/tui/views/home-internals/menu-items.ts
+++ b/src/application/ui/tui/views/home-internals/menu-items.ts
@@ -11,6 +11,7 @@ import type { MenuItem } from '@src/application/ui/tui/components/action-menu.ts
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { ticketAddManifest } from '@src/application/flows/add-ticket/manifest.ts';
 
 export interface BuildMenuItemsInput {
   readonly hasProject: boolean;
@@ -120,10 +121,10 @@ export const buildMenuItems = (input: BuildMenuItemsInput): readonly MenuItem[] 
       onSelect: (): void => input.onPushHome('pick-sprint'),
     },
     {
-      id: 'add-ticket',
+      id: ticketAddManifest.id,
       section: 'work',
-      label: 'Add ticket',
-      description: 'Append a pending ticket to the current sprint.',
+      label: ticketAddManifest.title,
+      description: ticketAddManifest.description,
       hotkey: 'a',
       ...(input.addTicketDisabled !== undefined ? { disabledReason: input.addTicketDisabled } : {}),
       onSelect: (): void => {

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -67,7 +67,7 @@ export const PickSprintView = (): React.JSX.Element => {
   // already filters them; this picker is the documented way back to a done sprint).
   const [hideDone, setHideDone] = useState<boolean>(false);
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'use sprint' },
     { keys: 't', label: 'toggle scope' },
     { keys: 'f', label: hideDone ? 'show done' : 'hide done' },

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -8,7 +8,7 @@
  * project's sprints.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
@@ -89,6 +89,18 @@ export const ProjectDetailView = (): React.JSX.Element => {
   const [cursorIdx, setCursorIdx] = useState(0);
   const [confirmRemove, setConfirmRemove] = useState<Repository | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  // Mounted-ref guard for the async remove-repo handler: dismissing the confirm overlay unblocks the
+  // router, so the operator can navigate away (unmounting this view) before the awaited save resolves.
+  // The guard skips the post-await view-local writes (setFeedback / reload) so they never fire into an
+  // unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
 
   const project = state.kind === 'ok' ? state.value : undefined;
 
@@ -272,9 +284,10 @@ export const ProjectDetailView = (): React.JSX.Element => {
     if (!confirmed || project === undefined) return;
     const removeResult = await removeRepoFromProject(project, target.id, deps.projectRepo);
     if (!removeResult.ok) {
-      setFeedback(`✗ ${removeResult.error}`);
+      if (mountedRef.current) setFeedback(`✗ ${removeResult.error}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`✓ removed ${target.name}`);
     reload();
   };

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -6,7 +6,7 @@
  * mirroring the sprint-detail view's explicit opt-in.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -46,6 +46,18 @@ export const ProjectsView = (): React.JSX.Element => {
 
   const [confirmDelete, setConfirmDelete] = useState<Project | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  // Mounted-ref guard for the async delete handler: dismissing the confirm overlay unblocks the
+  // router, so the operator can navigate away (unmounting this view) before `projectRepo.remove`
+  // resolves. The guard skips the post-await view-local writes (setFeedback / reload) so they never
+  // fire into an unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
 
   const { state, reload } = useAsyncLoad<readonly Project[]>(async () => {
     const r = await deps.projectRepo.list();
@@ -128,10 +140,13 @@ export const ProjectsView = (): React.JSX.Element => {
     if (!confirmed) return;
     const r = await deps.projectRepo.remove(target.id);
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    // Clearing the deleted project's selection targets the always-mounted SelectionProvider, so it
+    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
     if (selection.projectId === target.id) selection.setProject(undefined);
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed ${target.displayName}`);
     reload();
   };

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -34,7 +34,7 @@ export const ProjectsView = (): React.JSX.Element => {
   const ui = useUiState();
   const { rows } = useBreakpoint();
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'm', label: 'make current' },
     { keys: 'c', label: 'create' },

--- a/src/application/ui/tui/views/sessions-view.tsx
+++ b/src/application/ui/tui/views/sessions-view.tsx
@@ -28,8 +28,10 @@ import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import type { SessionRecord } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
+import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 
-const VISIBLE_ROWS = 10;
+/** Non-list rows consumed by ViewShell chrome + column header + overflow rows + summary + feedback. */
+const CHROME_ROWS = 9;
 const FLOW_COL_WIDTH = 16;
 const STATUS_COL_WIDTH = 14;
 const ELAPSED_COL_WIDTH = 10;
@@ -41,8 +43,10 @@ export const SessionsView = (): React.JSX.Element => {
   const sessions = useSessions();
   const manager = useSessionManager();
   const ui = useUiState();
+  const { rows } = useBreakpoint();
+  const VISIBLE_ROWS = Math.max(5, Math.min(15, rows - CHROME_ROWS));
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'c', label: 'cancel run' },
   ]);

--- a/src/application/ui/tui/views/sprint-detail-internals/field-editors.ts
+++ b/src/application/ui/tui/views/sprint-detail-internals/field-editors.ts
@@ -10,6 +10,7 @@
  */
 
 import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import { replaceTicket } from '@src/domain/entity/sprint.ts';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
@@ -141,7 +142,10 @@ export const runEdit = (args: RunEditArgs): void => {
         const cfg = buildTicketEdit({ sprint, ticket: focusedTicket, field, sprintRepo, reload });
         if (cfg !== undefined) void openEditPrompt(cfg);
       })
-      .catch(() => undefined);
+      .catch((cause: unknown) => {
+        if (cause instanceof AbortError) throw cause;
+        return undefined;
+      });
     return;
   }
   if (focusedTodoTask !== undefined) {
@@ -156,6 +160,9 @@ export const runEdit = (args: RunEditArgs): void => {
         const cfg = buildTaskEdit({ sprint, task: focusedTodoTask, field, taskRepo, reload });
         if (cfg !== undefined) void openEditPrompt(cfg);
       })
-      .catch(() => undefined);
+      .catch((cause: unknown) => {
+        if (cause instanceof AbortError) throw cause;
+        return undefined;
+      });
   }
 };

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -29,7 +29,7 @@
  * helpers, footer hints, keymap) live in `sprint-detail-internals/`.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
@@ -121,6 +121,18 @@ export const SprintDetailView = (): React.JSX.Element => {
   const [confirmRemove, setConfirmRemove] = useState<Ticket | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
+  // Mounted-ref guard for the async unblock / remove-ticket handlers: dismissing the confirm overlay
+  // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
+  // before the awaited use-case / flow resolves. The guard skips the post-await view-local writes
+  // (setFeedback / reload) so they never fire into an unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';
   const inDetail = openIds.size > 0;
@@ -192,9 +204,10 @@ export const SprintDetailView = (): React.JSX.Element => {
       logger: deps.logger,
     });
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} unblocked "${target.name}"`);
     reload();
   };
@@ -242,9 +255,10 @@ export const SprintDetailView = (): React.JSX.Element => {
     const flow = createTicketRemoveFlow({ sprintRepo: deps.sprintRepo });
     const r = await flow.execute({ input: { sprintId: sprint.id, ticketId: target.id } });
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.error.message}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed "${target.title}"`);
     reload();
   };

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -118,7 +118,7 @@ export const SprintsView = (): React.JSX.Element => {
   // rather than advertise a no-op. `u` follows the same declarative gate on the stuck-task count.
   const focusedDone = focusedSprint?.status === 'done';
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'c', label: 'create' },
     { keys: 'e', label: 'rename', enabledWhen: !focusedDone },

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -8,7 +8,7 @@
  *   ↵   open the sprint's detail view.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { OverflowRow, useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -56,6 +56,19 @@ export const SprintsView = (): React.JSX.Element => {
 
   const [confirmDelete, setConfirmDelete] = useState<Sprint | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  // Mounted-ref guard for the async bulk-unblock / delete handlers: dismissing the confirm overlay
+  // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
+  // before the awaited repo writes resolve. The guard skips the post-await view-local writes
+  // (setFeedback / reload / setFocusedSprintTasks) so they never fire into an unmounted tree.
+  // Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
 
   // Windowed cursor — owns ↑/↓ + j/k + PgUp/PgDn + Home/End + Enter; the cursor is the sprint id,
   // so a reload/reorder keeps focus on the same sprint. Enter selects (sets current + drills in).
@@ -194,6 +207,7 @@ export const SprintsView = (): React.JSX.Element => {
       }
     }
     const total = stuckTasks.length;
+    if (!mountedRef.current) return;
     if (succeeded === total) {
       setFeedback(
         `${glyphs.check} unblocked ${String(succeeded)} task${succeeded === 1 ? '' : 's'} in "${focusedSprint.name}"`
@@ -205,7 +219,7 @@ export const SprintsView = (): React.JSX.Element => {
     }
     // Refresh task list so the hint and count update immediately.
     const refreshed = await deps.taskRepo.findBySprintId(focusedSprint.id);
-    if (refreshed.ok) setFocusedSprintTasks(refreshed.value);
+    if (mountedRef.current && refreshed.ok) setFocusedSprintTasks(refreshed.value);
   };
 
   const handleDeleteConfirmed = async (target: Sprint, confirmed: boolean): Promise<void> => {
@@ -213,10 +227,13 @@ export const SprintsView = (): React.JSX.Element => {
     if (!confirmed) return;
     const r = await deps.sprintRepo.remove(target.id);
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    // Clearing the deleted sprint's selection targets the always-mounted SelectionProvider, so it
+    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
     if (selection.sprintId === target.id) selection.setSprint(undefined);
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed ${target.name}`);
     reload();
   };

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -143,6 +143,27 @@ export const decideEscalation = (props: DecideEscalationProps): EscalationDecisi
  */
 export const escalationBannerId = (taskId: string): string => `model-escalation-${taskId}`;
 
+/**
+ * Pure predicate — returns `true` when the last `windowSize` entries in `history` are all
+ * identical (the gen-eval loop is repeating the same failure fingerprint without progress).
+ * Returns `false` when `history` has fewer than `windowSize` entries (insufficient data) or
+ * when the tail is diverse.
+ *
+ * Implements the TIDE diversity break condition (arXiv 2602.02196): plateaus stem from
+ * recursive looping on the same error repeated, not reasoning incapacity. Detecting low
+ * action diversity is the reliable exit signal.
+ *
+ * `windowSize` is clamped to ≥ 2 defensively — a window of 1 would fire after every single
+ * turn, which is not useful.
+ */
+export const detectRepetitiveLoop = (history: readonly string[], windowSize: number): boolean => {
+  const effective = Math.max(2, Math.trunc(windowSize));
+  if (history.length < effective) return false;
+  const tail = history.slice(-effective);
+  const first = tail[0];
+  return tail.every((f) => f === first);
+};
+
 export interface ApplyEscalationProps {
   readonly task: InProgressTask;
   readonly decision: EscalationDecision;

--- a/src/business/task/loop-diversity.ts
+++ b/src/business/task/loop-diversity.ts
@@ -1,0 +1,50 @@
+/**
+ * Loop-diversity guard — detects when the gen-eval inner loop is repeating the same failure
+ * fingerprint across consecutive turns (low action diversity), a leading indicator of
+ * algorithmic stasis. Based on TIDE (arXiv 2602.02196): plateaus stem from recursive looping
+ * on the same error repeated, not reasoning incapacity; low action diversity is the reliable
+ * break condition.
+ *
+ * Pure. No I/O, no side effects.
+ */
+
+export interface LoopDiversityTracker {
+  /** Record a fingerprint for the current iteration. */
+  record(fingerprint: string): void;
+  /**
+   * Returns `false` when the last `windowSize` fingerprints are all identical — the loop is
+   * repeating the exact same failure pattern and diversity has collapsed.
+   * Returns `true` when there is insufficient history or the tail is diverse.
+   */
+  isDiverse(): boolean;
+}
+
+/**
+ * Create a loop-diversity tracker backed by a bounded rolling buffer.
+ *
+ * Maintains the last `windowSize * 2` fingerprints at most, capped on every `record` call so
+ * the buffer never grows unboundedly across a long run.
+ *
+ * @param windowSize - Number of consecutive identical fingerprints that constitute a non-diverse
+ *   loop. Clamped to ≥ 2 defensively.
+ */
+export const createLoopDiversityTracker = (windowSize = 3): LoopDiversityTracker => {
+  const effective = Math.max(2, Math.trunc(windowSize));
+  const history: string[] = [];
+
+  return {
+    record(fingerprint: string): void {
+      history.push(fingerprint);
+      // Bound the buffer to windowSize * 2 to prevent unbounded growth.
+      if (history.length > effective * 2) {
+        history.splice(0, history.length - effective * 2);
+      }
+    },
+    isDiverse(): boolean {
+      if (history.length < effective) return true;
+      const tail = history.slice(-effective);
+      const first = tail[0];
+      return !tail.every((f) => f === first);
+    },
+  };
+};

--- a/src/integration/ai/prompts/detect-skills/template.md
+++ b/src/integration/ai/prompts/detect-skills/template.md
@@ -25,7 +25,7 @@ covers that responsibility for this repo.
 
 <inputs>
 <repository_path>{{REPOSITORY_PATH}}</repository_path>
-<skills_convention>{{SKILLS_CONVENTION}}</skills_convention>
+<skills_convention>See the full skills convention in the constraints section below.</skills_convention>
 </inputs>
 
 {{HARNESS_CONTEXT}}

--- a/src/integration/ai/prompts/distill-learnings/definition.ts
+++ b/src/integration/ai/prompts/distill-learnings/definition.ts
@@ -1,7 +1,9 @@
 /**
  * `distill-learnings` prompt: one-shot documentation edit that folds a curated set of
- * machine-collected learnings into an existing project context file's own idempotent
- * `## Learnings (ralphctl)` section.
+ * machine-collected learnings into an existing project context file's own idempotent learnings
+ * section. The section heading is a parameter ({@link DistillLearningsPromptParams.learningsSectionHeading})
+ * so the generic template never hardcodes a brand — it runs on downstream user projects, not just
+ * this one.
  *
  * The AI is an editor, not a researcher — every learning was produced and reviewed by an earlier
  * session and confirmed by the operator before this call. The prompt instructs the AI to write
@@ -21,11 +23,19 @@ import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 
+/**
+ * Default H2 heading text for the section this prompt owns (without the leading `## `). Generic and
+ * brand-free so the template stays portable across downstream user projects. Callers that want a
+ * project-specific heading pass {@link DistillLearningsPromptParams.learningsSectionHeading}.
+ */
+const DEFAULT_LEARNINGS_SECTION_HEADING = 'Learnings (AI sessions)';
+
 export interface DistillLearningsPromptParams {
   /**
    * Existing context-file body wrapped for prompting, or an explicit "no existing file" line. The
-   * AI reconciles the candidate learnings against this file's current `## Learnings (ralphctl)`
-   * section and writes the full updated file back.
+   * AI reconciles the candidate learnings against this file's current learnings section (the one
+   * headed by {@link DistillLearningsPromptParams.learningsSectionHeading}) and writes the full
+   * updated file back.
    */
   readonly existingContextFile: string;
   /**
@@ -45,6 +55,13 @@ export interface DistillLearningsPromptParams {
    * this section so the prompt copy never hardcodes a specific ecosystem's commands.
    */
   readonly projectTooling: string;
+  /**
+   * H2 heading text for the section this prompt owns (without the leading `## `). Optional — omit it
+   * to fall back to a generic, brand-free default ({@link DEFAULT_LEARNINGS_SECTION_HEADING}). The
+   * template is generic and runs on downstream user projects, so the heading must never hardcode a
+   * brand; callers that want a project-specific heading pass it here.
+   */
+  readonly learningsSectionHeading?: string;
 }
 
 const requireNonEmpty =
@@ -55,7 +72,7 @@ const requireNonEmpty =
 export const distillLearningsPromptDef: PromptDefinition<DistillLearningsPromptParams> = {
   templateName: 'distill-learnings',
   description:
-    'One-shot documentation edit that folds curated learnings into an existing project context file’s own idempotent `## Learnings (ralphctl)` section.',
+    'One-shot documentation edit that folds curated learnings into an existing project context file’s own idempotent learnings section (heading configurable, brand-free by default).',
   parameters: {
     existingContextFile: {
       placeholder: 'EXISTING_CONTEXT_FILE',
@@ -77,6 +94,12 @@ export const distillLearningsPromptDef: PromptDefinition<DistillLearningsPromptP
       description:
         'Detected build/test/task tooling, or "(none detected)". The only place package-manager commands may appear.',
     },
+    learningsSectionHeading: {
+      placeholder: 'LEARNINGS_SECTION_HEADING',
+      description:
+        'H2 heading text for the owned learnings section (without the leading `## `). Brand-free generic default applied by the builder when the caller omits it.',
+      optional: true,
+    },
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
@@ -90,6 +113,8 @@ export interface BuildDistillLearningsPromptInput {
   readonly candidateLearnings: string;
   readonly targetFilename: string;
   readonly projectTooling: string;
+  /** Optional H2 heading for the owned section; falls back to the brand-free default when omitted. */
+  readonly learningsSectionHeading?: string;
 }
 
 /**
@@ -107,4 +132,5 @@ export const buildDistillLearningsPrompt = async (
     candidateLearnings: input.candidateLearnings,
     targetFilename: input.targetFilename,
     projectTooling: input.projectTooling,
+    learningsSectionHeading: input.learningsSectionHeading ?? DEFAULT_LEARNINGS_SECTION_HEADING,
   });

--- a/src/integration/ai/prompts/distill-learnings/template.md
+++ b/src/integration/ai/prompts/distill-learnings/template.md
@@ -7,7 +7,7 @@ Your job is to integrate them cleanly, not to invent new ones.
 </role>
 
 <goal>
-Update `{{TARGET_FILENAME}}` so that it carries an up-to-date `## Learnings (ralphctl)` section containing
+Update `{{TARGET_FILENAME}}` so that it carries an up-to-date `## {{LEARNINGS_SECTION_HEADING}}` section containing
 the candidate learnings below — folded in idempotently, preserving everything else in the file verbatim.
 </goal>
 
@@ -26,15 +26,15 @@ the candidate learnings below — folded in idempotently, preserving everything 
 {{HARNESS_CONTEXT}}
 
 <owned_section>
-You own exactly one section of `{{TARGET_FILENAME}}` — the one headed `## Learnings (ralphctl)`. This is
+You own exactly one section of `{{TARGET_FILENAME}}` — the one headed `## {{LEARNINGS_SECTION_HEADING}}`. This is
 the only part of the file you may add, reorder, or rewrite. Everything outside that section is
 hand-authored or owned by another tool — preserve it byte-for-byte.
 
-- When the file already contains a `## Learnings (ralphctl)` section, treat its current bullets as the
+- When the file already contains a `## {{LEARNINGS_SECTION_HEADING}}` section, treat its current bullets as the
   prior state and reconcile the candidates against them (see the idempotency rule below).
 - When the file has no such section yet, append one at the end of the file — after the last existing
   section, separated by a single blank line.
-- Never create a second `## Learnings (ralphctl)` section — there must be exactly one.
+- Never create a second `## {{LEARNINGS_SECTION_HEADING}}` section — there must be exactly one.
   </owned_section>
 
 <idempotency_rule>
@@ -87,7 +87,7 @@ as "when present"; many repositories do not have one, and a learning must not as
 
 <output_contract>
 
-1. Read the existing context file body above and locate the `## Learnings (ralphctl)` section, if any.
+1. Read the existing context file body above and locate the `## {{LEARNINGS_SECTION_HEADING}}` section, if any.
 2. Reconcile the candidate learnings against the owned section per the idempotency rule.
 3. Write the COMPLETE, updated `{{TARGET_FILENAME}}` back to disk at its original path — the full file, not
    a diff and not only the section. Everything outside the owned section must be unchanged.

--- a/src/integration/ai/prompts/evaluate-continuation/template.md
+++ b/src/integration/ai/prompts/evaluate-continuation/template.md
@@ -66,13 +66,32 @@ For the complete history — older than the excerpt above — read `{{PROGRESS_F
 <protocol>
 **Checkpoint write — do this first, before re-grading**
 
-If you have not already written a checkpoint `signals.json` for this round, write one now before
-continuing. Use `status: "failed"`, all four floor dimensions present, each set to
-`passed: false` with `finding: "assessment in progress"`. Use the path named in the output
+If you have not already written a checkpoint `signals.json` for this round, write an `evaluation`
+signal now before continuing. Use `status: "failed"`, all four floor dimensions present, each set
+to `passed: false` with `finding: "assessment in progress"`. Use the path named in the output
 contract section at the bottom of this prompt. This placeholder is valid against the schema the
 harness validates — it ensures a recoverable file exists on disk if this session exhausts its
 token budget before you reach your final verdict. You will overwrite it after completing all steps
 below.
+
+```json
+{
+  "schemaVersion": 1,
+  "signals": [
+    {
+      "type": "evaluation",
+      "status": "failed",
+      "dimensions": [
+        { "dimension": "correctness", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "completeness", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "safety", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" }
+      ],
+      "timestamp": "<ISO-8601 timestamp>"
+    }
+  ]
+}
+```
 
 Re-grade this round the same way you graded the first:
 

--- a/src/integration/ai/prompts/evaluate/definition.ts
+++ b/src/integration/ai/prompts/evaluate/definition.ts
@@ -193,6 +193,12 @@ export interface BuildEvaluatePromptInput {
  * Top-level builder — accepts domain types, renders the param strings, calls `buildPrompt`.
  * The chain leaf consumes this via function injection. `task.extraDimensions` is threaded into
  * the rubric automatically; the rendered section is empty when the field is unset.
+ *
+ * The template includes a `<reasoning_protocol>` section instructing the evaluator to write its
+ * step-by-step assessment inside `<evaluation_thinking>` tags before emitting the verdict signal.
+ * This approximates the think-tool effect via prompt engineering — research (TIDE/τ-Bench) shows
+ * a 57% improvement on sequential decision chains when models externalise intermediate reasoning
+ * before committing to output.
  */
 export const buildEvaluatePrompt = async (
   deps: TemplateLoader,

--- a/src/integration/ai/prompts/evaluate/template.md
+++ b/src/integration/ai/prompts/evaluate/template.md
@@ -92,6 +92,17 @@ The block below mirrors that file for in-context reference.
 
 </task_specification>
 
+<reasoning_protocol>
+Before emitting your evaluation signal, write your step-by-step assessment inside
+<evaluation_thinking>…</evaluation_thinking> tags. The harness ignores these tags — they are
+for your reasoning only. Structure the block as:
+
+- Review each acceptance criterion against the evidence collected in Phases 1–2.
+- Identify what specifically changed vs. what the specification required.
+- Decide the verdict for each floor dimension with explicit reasoning.
+- THEN write the final `signals.json` with your concluded verdict.
+  </reasoning_protocol>
+
 <inputs>
   <project_path>{{PROJECT_PATH}}</project_path>
   <verify_script>{{VERIFY_SCRIPT_SECTION}}</verify_script>

--- a/src/integration/ai/prompts/implement-continuation/definition.ts
+++ b/src/integration/ai/prompts/implement-continuation/definition.ts
@@ -142,6 +142,7 @@ export const implementContinuationPromptDef: PromptDefinition<ImplementContinuat
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
+    DECISIONS_GUIDANCE: 'decisions',
   },
   // Same accepted signal union as the full implement prompt — a continuation turn is still a
   // generator turn and may emit the full narrative + lifecycle set.

--- a/src/integration/ai/prompts/implement-continuation/template.md
+++ b/src/integration/ai/prompts/implement-continuation/template.md
@@ -42,6 +42,8 @@ context to apply.
 For the complete history — older than the excerpt above — read `{{PROGRESS_FILE}}` on disk.
 </prior_progress>
 
+{{DECISIONS_GUIDANCE}}
+
 <goal>
 Address every dimension the evaluator flagged in `<prior_critique>`, then run each `auto`
 criterion's command once. Do NOT run the verify script — the harness runs it after your turn as
@@ -51,7 +53,8 @@ script once yourself. Emit `task-verified` with the verbatim command output, pro
 dimension is resolved and every criterion command passes. Removing or disabling a test to make
 verify pass counts as task failure — fix the implementation, not the test. When a flagged item is
 genuinely blocked (missing dependency, contradictory input, unresolvable ambiguity), emit
-`task-blocked` with the concrete reason instead of guessing.
+`task-blocked` with the concrete reason instead of guessing. Emit `change`, `learning`, and
+`note` signals as applicable — the harness records them in the sprint journal.
 </goal>
 
 {{OUTPUT_CONTRACT_SECTION}}

--- a/src/integration/ai/prompts/plan/template.md
+++ b/src/integration/ai/prompts/plan/template.md
@@ -140,7 +140,7 @@ implemented in a single session, and verified end-to-end against its criteria.
 
 **Do not split when:**
 
-- A utility and its first caller would be separated — create-and-use is always one task.
+- A utility and its first caller would be separated — create-and-use is always one task, unless the utility already exists in the codebase or a prior task in this plan produces it.
 - A feature and its tests would be separated.
 - The same pattern applies across N call sites — it is one refactor, not N tasks.
 

--- a/src/integration/ai/prompts/readiness/template.md
+++ b/src/integration/ai/prompts/readiness/template.md
@@ -33,8 +33,9 @@ warranted. Write all signals to the `signals.json` path described in `<output_co
 <target_file_conventions>
 {{TARGET_FILE_CONVENTIONS}}
 </target_file_conventions>
-{{HARNESS_CONTEXT}}
 </inputs>
+
+{{HARNESS_CONTEXT}}
 
 <constraints>
 

--- a/src/integration/ai/providers/_engine/bounded-tail.ts
+++ b/src/integration/ai/providers/_engine/bounded-tail.ts
@@ -29,6 +29,29 @@ export const STDERR_TAIL_CAP = 16_384;
  */
 export const RATE_LIMIT_SCAN_TAIL_CAP = 8192;
 
+/**
+ * Hard ceiling on the in-flight NDJSON line-parse accumulator in the stdout stream parsers
+ * (`claude/parse-stream.ts`, `copilot/parse-stream.ts`). Those parsers grow `buffer += chunk`
+ * until a newline terminates the current line; a single record embedding a large file-read or
+ * bash tool result can inflate one line to tens of MB before the newline clears it, which is an
+ * OOM-class accumulation (same root cause as the TUI render-path leak). When the unterminated
+ * line crosses this cap the parser drops the OLDEST bytes back to the cap and keeps draining —
+ * 512 KiB leaves ample room for any legitimate JSONL record while pinning the worst-case
+ * per-line footprint regardless of how large a tool result the child streams.
+ */
+export const STDOUT_LINE_PARSE_CAP = 524_288;
+
+/**
+ * Retained-tail size for the Copilot forensic body mirror (`body.txt` when `session.bodyFile` is
+ * set). The adapter formerly retained EVERY stdout line for the whole spawn in an unbounded
+ * `events[]` array — an OOM-class accumulation on a multi-hour, chatty session. A bounded tail
+ * caps that footprint while keeping the most recent ~256 KiB, which is the diagnostic window an
+ * operator actually inspects when a proposal comes back empty (older lines rarely matter for that
+ * post-mortem). Larger than {@link RATE_LIMIT_SCAN_TAIL_CAP} because forensic capture wants more
+ * context than the narrow rate-limit marker scan.
+ */
+export const FORENSIC_BODY_TAIL_CAP = 262_144;
+
 /** @public */
 export interface BoundedTail {
   /** Append a chunk, trimming the retained window back to the cap when it overflows. */

--- a/src/integration/ai/providers/_engine/headless-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/headless-ai-provider.ts
@@ -2,10 +2,35 @@ import type { Result } from '@src/domain/result.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
+
+/**
+ * Per-call input to {@link HeadlessAiProvider.generate}. Extends {@link AiSession} with
+ * adapter-level hooks that do not belong on the session descriptor itself.
+ *
+ * `promptTransform` — optional per-provider prompt rewrite hook applied at the
+ * {@link HeadlessAiProvider} boundary, before the prompt reaches the spawn layer.
+ * Lets each adapter tune its preamble (e.g. system-message injection, model-specific
+ * prefixes) without breaking the port contract. Callers that do not need a transform
+ * simply omit the field; implementations apply it as:
+ *
+ *   const effectivePrompt = input.promptTransform
+ *     ? input.promptTransform(input.prompt as Prompt)
+ *     : input.prompt;
+ */
+export interface HeadlessAiProviderInput extends AiSession {
+  /**
+   * Optional prompt rewrite applied before the session is spawned. Receives the
+   * fully-rendered {@link Prompt} and must return a valid {@link Prompt}. Absent →
+   * the original prompt is used unchanged. No per-provider transforms are wired yet;
+   * the field is reserved for future cross-harness provider tuning (AgencyBench R7).
+   */
+  readonly promptTransform?: (prompt: Prompt) => Prompt;
+}
 
 /**
  * AI provider port — runs one headless coding-assistant session against the caller's
- * {@link AiSession} descriptor and returns a structured-output handle:
+ * {@link HeadlessAiProviderInput} descriptor and returns a structured-output handle:
  *
  *   { signalsFile, sessionId?, exitCode }
  *
@@ -20,7 +45,7 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
  * codex's JSONL meta event, copilot's stream meta line. Absence is never an error.
  */
 export interface HeadlessAiProvider {
-  generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>>;
+  generate(input: HeadlessAiProviderInput): Promise<Result<ProviderOutput, DomainError>>;
 }
 
 export interface ProviderOutput {

--- a/src/integration/ai/providers/_engine/interactive-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/interactive-ai-provider.ts
@@ -46,6 +46,14 @@ export interface InteractiveAiProviderInput {
    * of `AiSession.effort` on the headless port.
    */
   readonly effort?: string;
+  /**
+   * Caller-controlled abort (Ctrl-C / TUI cancel). When it fires, the adapter tears the child
+   * down with a SIGTERM → grace → SIGKILL kill ladder — without it a `stdio: 'inherit'` child
+   * is unreachable once spawned (the harness holds no reference past `run`) and keeps running
+   * indefinitely after a cancel. A signal already aborted when `run` is called kills the child
+   * immediately. Sibling of `AiSession.abortSignal` on the headless port.
+   */
+  readonly abortSignal?: AbortSignal;
 }
 
 export interface InteractiveAiProviderOutput {

--- a/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
+++ b/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
@@ -156,11 +156,11 @@ export const runWithRateLimitRetry = async (
             cause: `attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
             at: IsoTimestamp.now(),
           });
-          await sleepCancellable(delayMs, opts.session.abortSignal);
+          await sleepCancellable(delayMs, session.abortSignal);
           // Clear once the wait completes (either elapsed or abort fired); the next attempt
           // re-publishes if it also hits the rate-limit.
           eventBus.publish({ type: 'banner-clear', id: bannerId, at: IsoTimestamp.now() });
-          if (opts.session.abortSignal?.aborted === true) {
+          if (session.abortSignal?.aborted === true) {
             // User cancel during the backoff sleep must surface as AbortError — the one error
             // chains propagate transparently (CLAUDE.md §AbortError). InvalidStateError is
             // classified as a recoverable turn error and would wrongly self-block the task.

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -12,6 +12,7 @@ import {
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
+import { DEFAULT_GRACE_MS } from '@src/integration/ai/providers/_engine/idle-watchdog.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -155,10 +156,17 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',
@@ -197,3 +205,36 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
 };
 
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/**
+ * Wire a caller {@link AbortSignal} to a SIGTERM → grace → SIGKILL kill ladder for a
+ * `stdio: 'inherit'` child (mirrors `installIdleWatchdog`'s abort path, minus idle detection).
+ * Returns a cleanup fn the caller MUST invoke once the child has exited — it cancels the pending
+ * SIGKILL escalation and drops the abort listener so a reused AbortController never fires kill
+ * against the now-dead pid. A signal already aborted when called kills the child immediately.
+ */
+const attachAbortKill = (child: ChildProcess, abortSignal: AbortSignal | undefined): (() => void) => {
+  let graceTimer: NodeJS.Timeout | null = null;
+  const kill = (): void => {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // Child may already be dead (ESRCH) — best-effort.
+    }
+    graceTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already dead — best-effort.
+      }
+    }, DEFAULT_GRACE_MS);
+  };
+  const cleanup = (): void => {
+    if (graceTimer !== null) clearTimeout(graceTimer);
+    abortSignal?.removeEventListener('abort', kill);
+  };
+  if (abortSignal === undefined) return cleanup;
+  if (abortSignal.aborted) kill();
+  else abortSignal.addEventListener('abort', kill, { once: true });
+  return cleanup;
+};

--- a/src/integration/ai/providers/claude/parse-stream.ts
+++ b/src/integration/ai/providers/claude/parse-stream.ts
@@ -29,10 +29,33 @@ import type {
   ClaudeStreamParser,
   ClaudeUsage,
 } from '@src/integration/ai/providers/_engine/claude-stream.ts';
+import { STDOUT_LINE_PARSE_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 
 export const createClaudeStreamParser = (): ClaudeStreamParser => {
   let buffer = '';
+  // One-shot latch: warn exactly once per parser so a child that streams a pathologically long
+  // unterminated line does not itself spam the console with one warning per chunk.
+  let overflowWarned = false;
+  // Cap the in-flight line accumulator. A single NDJSON record embedding a large file-read /
+  // bash tool result can grow `buffer` to tens of MB before its newline clears it — an OOM-class
+  // accumulation. `feed` is the SOLE append site, so capping here keeps the invariant for `flush`
+  // too (it only drains an already-bounded buffer). Drop the OLDEST bytes (keep the tail) so the
+  // record's terminating `}`/newline, when it finally arrives, still lands inside the window.
+  const appendCapped = (chunk: string): void => {
+    buffer += chunk;
+    if (buffer.length > STDOUT_LINE_PARSE_CAP) {
+      buffer = buffer.slice(-STDOUT_LINE_PARSE_CAP);
+      if (!overflowWarned) {
+        overflowWarned = true;
+        console.warn(
+          `[claude-stream] in-flight NDJSON line exceeded ${String(STDOUT_LINE_PARSE_CAP)} bytes — ` +
+            'truncating the parse buffer to its tail and continuing. A single record is streaming an ' +
+            'oversized tool result; the affected line may parse as plain text.'
+        );
+      }
+    }
+  };
   // `body` is reassigned from the latest `result` event's `.result` field in `ingest` (one
   // O(1) write), never built by per-line concatenation. Keep it that way — see the analogous
   // `bodyLines.push` + `.join('\n')` pattern in copilot/headless.ts for why.
@@ -120,7 +143,7 @@ export const createClaudeStreamParser = (): ClaudeStreamParser => {
 
   return {
     feed(chunk, onLine) {
-      buffer += chunk;
+      appendCapped(chunk);
       let nl = buffer.indexOf('\n');
       while (nl !== -1) {
         const line = buffer.slice(0, nl);

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -459,40 +459,40 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   let model: string | undefined;
   let inputTokens: number | undefined;
   let outputTokens: number | undefined;
+
+  const onMeta = (update: CodexMetaUpdate): void => {
+    if (update.sessionId !== undefined && sessionId === undefined) {
+      sessionId = update.sessionId;
+      deps.eventBus.publish({
+        type: 'log',
+        level: 'debug',
+        message: 'codex-provider: session id captured',
+        meta: { sessionId: update.sessionId },
+        at: IsoTimestamp.now(),
+      });
+    }
+    if (update.model !== undefined && model === undefined) {
+      model = update.model;
+    }
+    // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+    // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
+    if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
+    if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
+  };
+  const onLine = (obj: Record<string, unknown>): void => {
+    publishCodexStreamLineEvents(deps.eventBus, obj);
+    const text = agentMessageText(obj);
+    if (text !== undefined) {
+      agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
+        -RATE_LIMIT_SCAN_TAIL_CAP
+      );
+    }
+  };
+
   const { code, signal } = await runHeadlessSpawn({
     child,
     onStdout: (chunk) => {
-      stdoutLineBuf = consumeMetaLines(
-        stdoutLineBuf + chunk,
-        (update) => {
-          if (update.sessionId !== undefined && sessionId === undefined) {
-            sessionId = update.sessionId;
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'debug',
-              message: 'codex-provider: session id captured',
-              meta: { sessionId: update.sessionId },
-              at: IsoTimestamp.now(),
-            });
-          }
-          if (update.model !== undefined && model === undefined) {
-            model = update.model;
-          }
-          // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
-          // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
-          if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
-          if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
-        },
-        (obj) => {
-          publishCodexStreamLineEvents(deps.eventBus, obj);
-          const text = agentMessageText(obj);
-          if (text !== undefined) {
-            agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
-              -RATE_LIMIT_SCAN_TAIL_CAP
-            );
-          }
-        }
-      );
+      stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
     },
     onStderr: (chunk) => {
       stderrTail.append(chunk);
@@ -519,6 +519,13 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
     },
   });
+
+  // Flush any partial line remaining in the line buffer — codex may terminate without a
+  // trailing newline. Appending a synthetic '\n' forces the partial through the parser,
+  // matching the parser.flush(onLine) convention used in the claude and copilot adapters.
+  if (stdoutLineBuf.length > 0) {
+    consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
+  }
 
   const onSuccess = async (): Promise<AttemptOutcome> => {
     let body: string;

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -11,6 +11,7 @@ import {
   defaultInteractiveSpawn,
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+import { DEFAULT_GRACE_MS } from '@src/integration/ai/providers/_engine/idle-watchdog.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -141,10 +142,17 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',
@@ -175,3 +183,36 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
 };
 
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/**
+ * Wire a caller {@link AbortSignal} to a SIGTERM → grace → SIGKILL kill ladder for a
+ * `stdio: 'inherit'` child (mirrors `installIdleWatchdog`'s abort path, minus idle detection).
+ * Returns a cleanup fn the caller MUST invoke once the child has exited — it cancels the pending
+ * SIGKILL escalation and drops the abort listener so a reused AbortController never fires kill
+ * against the now-dead pid. A signal already aborted when called kills the child immediately.
+ */
+const attachAbortKill = (child: ChildProcess, abortSignal: AbortSignal | undefined): (() => void) => {
+  let graceTimer: NodeJS.Timeout | null = null;
+  const kill = (): void => {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // Child may already be dead (ESRCH) — best-effort.
+    }
+    graceTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already dead — best-effort.
+      }
+    }, DEFAULT_GRACE_MS);
+  };
+  const cleanup = (): void => {
+    if (graceTimer !== null) clearTimeout(graceTimer);
+    abortSignal?.removeEventListener('abort', kill);
+  };
+  if (abortSignal === undefined) return cleanup;
+  if (abortSignal.aborted) kill();
+  else abortSignal.addEventListener('abort', kill, { once: true });
+  return cleanup;
+};

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,6 +1,7 @@
 import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import {
+  FORENSIC_BODY_TAIL_CAP,
   RATE_LIMIT_SCAN_TAIL_CAP,
   STDERR_TAIL_CAP,
   createBoundedTail,
@@ -218,13 +219,21 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   // auto-discover their context file from cwd."
   const child = spawnFn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] as const, cwd: String(session.cwd) });
   const parser = createCopilotStreamParser();
-  // Two buffers, one tagged event log: assistant body text feeds signal parsing; the
-  // forensic body.txt mirrors every assistant + unrecognised-event line in stream order.
-  // Splitting matters because Copilot echoes the prompt as a `user.message` event whose raw
-  // JSONL would otherwise be matched by the harness signal regexes (literal `<task-blocked>`
-  // inside the prompt → fake signal). Order preservation: derive both views from one tagged
-  // event list rather than two parallel arrays.
-  const events: Array<{ readonly assistant: boolean; readonly text: string }> = [];
+  // Two BOUNDED tails fed in stream order — replaces a formerly-unbounded `events[]` that
+  // retained every stdout line for the whole spawn (an OOM-class accumulation on a chatty
+  // multi-hour session — same root cause as the PR #229 TUI render-path leak). `forensicTail`
+  // backs `body.txt`; `rateLimitTail` is the classifier's scan haystack. Both drop their oldest
+  // bytes once full, so the per-spawn stdout footprint is pinned regardless of child verbosity.
+  // The prior per-line `assistant` tag is gone: neither consumer ever filtered on it (signals
+  // land in `signals.json` via the file-based audit-[09] contract, not by re-parsing the body),
+  // and the prompt-echo leak it once guarded is moot since both views were already derived from
+  // every recorded line.
+  const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
+  const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
+  const recordLine = (text: string): void => {
+    forensicTail.append(`${text}\n`);
+    rateLimitTail.append(`${text}\n`);
+  };
   let sessionId: string | undefined;
   let model: string | undefined;
   let usage: CopilotUsage = {};
@@ -254,7 +263,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         usage = line.usage;
       }
       if (line.bodyText !== undefined && line.bodyText.length > 0) {
-        events.push({ assistant: true, text: line.bodyText });
+        recordLine(line.bodyText);
         // Per-line assistant debug event. The bus → logger consumer drops debug events at
         // the default `info` floor; only `RALPHCTL_LOG_LEVEL=debug` operators see them.
         const text = truncateField(line.bodyText);
@@ -271,7 +280,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
         // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
         // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
-        events.push({ assistant: false, text: line.raw });
+        recordLine(line.raw);
       }
       // Truncate the raw line like every other stream-originated debug field (see truncateField):
       // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
@@ -287,7 +296,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       return;
     }
     // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
-    events.push({ assistant: false, text: line.raw });
+    recordLine(line.raw);
   };
 
   // Copilot reads the prompt from -p argv (no stdin payload). Tokens stream to stdout via the
@@ -326,9 +335,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     // `session.outputDir`; the harness validates it post-spawn. The provider never writes
     // signals.json itself. The forensic body buffer below stays — operators inspect it when
     // a proposal comes back empty to decide whether the prompt, the AI, or the validator is
-    // at fault. On SIGTERM-recovery `events[]` may be partial; the join still produces a
-    // useful snapshot of what the model emitted before the watchdog stepped in.
-    const forensicBody = events.map((e) => e.text).join('\n');
+    // at fault. On SIGTERM-recovery the tail may be partial; it still produces a useful snapshot
+    // of what the model emitted before the watchdog stepped in (bounded to its most recent window).
+    const forensicBody = forensicTail.value();
     // Mirror raw body for diagnostic capture. Best-effort: a write failure here is logged but
     // does not fail the session. Critically, the body is captured even when the AI emits no
     // signals, so operators can see what the model actually produced.
@@ -389,12 +398,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   };
 
   // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota throttle in
-  // its result-record text (captured as a raw `events[]` line), not on stderr. Capped so a long
-  // session doesn't build a multi-MB scan string.
-  const stdoutTail = events
-    .map((e) => e.text)
-    .join('\n')
-    .slice(-RATE_LIMIT_SCAN_TAIL_CAP);
+  // its result-record text (recorded as a stream line), not on stderr. `rateLimitTail` is already
+  // bounded to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
+  const stdoutTail = rateLimitTail.value();
 
   return classifySpawnExit({
     session,

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -12,6 +12,7 @@ import {
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
+import { DEFAULT_GRACE_MS } from '@src/integration/ai/providers/_engine/idle-watchdog.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -135,10 +136,17 @@ export const createInteractiveCopilotProvider = (deps: InteractiveCopilotDeps): 
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',
@@ -174,3 +182,36 @@ export const createInteractiveCopilotProvider = (deps: InteractiveCopilotDeps): 
 };
 
 const stringifyError = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause));
+
+/**
+ * Wire a caller {@link AbortSignal} to a SIGTERM → grace → SIGKILL kill ladder for a
+ * `stdio: 'inherit'` child (mirrors `installIdleWatchdog`'s abort path, minus idle detection).
+ * Returns a cleanup fn the caller MUST invoke once the child has exited — it cancels the pending
+ * SIGKILL escalation and drops the abort listener so a reused AbortController never fires kill
+ * against the now-dead pid. A signal already aborted when called kills the child immediately.
+ */
+const attachAbortKill = (child: ChildProcess, abortSignal: AbortSignal | undefined): (() => void) => {
+  let graceTimer: NodeJS.Timeout | null = null;
+  const kill = (): void => {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // Child may already be dead (ESRCH) — best-effort.
+    }
+    graceTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already dead — best-effort.
+      }
+    }, DEFAULT_GRACE_MS);
+  };
+  const cleanup = (): void => {
+    if (graceTimer !== null) clearTimeout(graceTimer);
+    abortSignal?.removeEventListener('abort', kill);
+  };
+  if (abortSignal === undefined) return cleanup;
+  if (abortSignal.aborted) kill();
+  else abortSignal.addEventListener('abort', kill, { once: true });
+  return cleanup;
+};

--- a/src/integration/ai/providers/copilot/parse-stream.ts
+++ b/src/integration/ai/providers/copilot/parse-stream.ts
@@ -15,6 +15,7 @@ import type {
   CopilotStreamParser,
   CopilotUsage,
 } from '@src/integration/ai/providers/_engine/copilot-stream.ts';
+import { STDOUT_LINE_PARSE_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 
 const extractUsage = (json: Record<string, unknown>): CopilotUsage | undefined => {
@@ -91,6 +92,28 @@ const extractBodyText = (json: Record<string, unknown>): string | undefined => {
 
 export const createCopilotStreamParser = (): CopilotStreamParser => {
   let buffer = '';
+  // One-shot latch: warn exactly once per parser so a child that streams a pathologically long
+  // unterminated line does not itself spam the console with one warning per chunk.
+  let overflowWarned = false;
+  // Cap the in-flight line accumulator. A single NDJSON record embedding a large file-read /
+  // bash tool result can grow `buffer` to tens of MB before its newline clears it — an OOM-class
+  // accumulation. `feed` is the SOLE append site, so capping here keeps the invariant for `flush`
+  // too (it only drains an already-bounded buffer). Drop the OLDEST bytes (keep the tail) so the
+  // record's terminating `}`/newline, when it finally arrives, still lands inside the window.
+  const appendCapped = (chunk: string): void => {
+    buffer += chunk;
+    if (buffer.length > STDOUT_LINE_PARSE_CAP) {
+      buffer = buffer.slice(-STDOUT_LINE_PARSE_CAP);
+      if (!overflowWarned) {
+        overflowWarned = true;
+        console.warn(
+          `[copilot-stream] in-flight NDJSON line exceeded ${String(STDOUT_LINE_PARSE_CAP)} bytes — ` +
+            'truncating the parse buffer to its tail and continuing. A single record is streaming an ' +
+            'oversized tool result; the affected line may parse as plain text.'
+        );
+      }
+    }
+  };
   const emit = (raw: string, onLine: (line: CopilotStreamLine) => void): void => {
     if (raw.length === 0) return;
     if (raw.startsWith('{') && raw.endsWith('}')) {
@@ -121,7 +144,7 @@ export const createCopilotStreamParser = (): CopilotStreamParser => {
   };
   return {
     feed(chunk, onLine) {
-      buffer += chunk;
+      appendCapped(chunk);
       let nl = buffer.indexOf('\n');
       while (nl !== -1) {
         const line = buffer.slice(0, nl);

--- a/tests/integration/ai/prompts/distill-learnings/definition.test.ts
+++ b/tests/integration/ai/prompts/distill-learnings/definition.test.ts
@@ -31,13 +31,31 @@ describe('distillLearningsPromptDef — completeness', () => {
     expect(report.unreferenced).toEqual([]);
   });
 
-  it('declares exactly the four spec placeholders', async () => {
+  it('declares exactly the five spec placeholders', async () => {
     const rawTemplate = await readTemplate();
     const partials = await loadPartialMap(distillLearningsPromptDef, loader);
     const report = computePlaceholderParity({ def: distillLearningsPromptDef, rawTemplate, partials });
     expect(report.declaredParameters).toEqual(
-      ['CANDIDATE_LEARNINGS', 'EXISTING_CONTEXT_FILE', 'PROJECT_TOOLING', 'TARGET_FILENAME'].sort()
+      [
+        'CANDIDATE_LEARNINGS',
+        'EXISTING_CONTEXT_FILE',
+        'LEARNINGS_SECTION_HEADING',
+        'PROJECT_TOOLING',
+        'TARGET_FILENAME',
+      ].sort()
     );
+  });
+
+  it('templates the owned-section heading instead of hardcoding the ralphctl brand', async () => {
+    const rawTemplate = await readTemplate();
+    // The template runs on downstream user projects — the owned-section heading must be a
+    // placeholder, never a literal brand, so each project gets its own (or the generic default).
+    expect(rawTemplate).toContain('{{LEARNINGS_SECTION_HEADING}}');
+    expect(rawTemplate).not.toMatch(/Learnings \(ralphctl\)/);
+    // …and that placeholder is backed by a declared parameter spec.
+    const partials = await loadPartialMap(distillLearningsPromptDef, loader);
+    const report = computePlaceholderParity({ def: distillLearningsPromptDef, rawTemplate, partials });
+    expect(report.declaredParameters).toContain('LEARNINGS_SECTION_HEADING');
   });
 
   it('the template hardcodes no package-manager commands outside PROJECT_TOOLING', async () => {
@@ -54,9 +72,22 @@ describe('buildDistillLearningsPrompt — end-to-end', () => {
     if (!result.ok) return;
     expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
     expect(result.value).toContain('CLAUDE.md');
-    expect(result.value).toContain('## Learnings (ralphctl)');
+    // No learningsSectionHeading supplied → the builder applies the brand-free default.
+    expect(result.value).toContain('## Learnings (AI sessions)');
+    expect(result.value).not.toContain('## Learnings (ralphctl)');
     expect(result.value).toContain('The build emits ESM only.');
     expect(result.value).toContain('Detected: pnpm + vitest.');
+  });
+
+  it('substitutes a caller-supplied learnings-section heading', async () => {
+    const result = await buildDistillLearningsPrompt(loader, {
+      ...VALID_INPUT,
+      learningsSectionHeading: 'Learnings (my-project)',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain('## Learnings (my-project)');
+    expect(result.value).not.toContain('## Learnings (AI sessions)');
   });
 
   it('rejects empty candidateLearnings', async () => {

--- a/tests/integration/ai/prompts/template-signal-coverage.test.ts
+++ b/tests/integration/ai/prompts/template-signal-coverage.test.ts
@@ -7,8 +7,10 @@ import { applyFeedbackPromptDef } from '@src/integration/ai/prompts/apply-feedba
 import { createPrPromptDef } from '@src/integration/ai/prompts/create-pr/definition.ts';
 import { detectScriptsPromptDef } from '@src/integration/ai/prompts/detect-scripts/definition.ts';
 import { detectSkillsPromptDef } from '@src/integration/ai/prompts/detect-skills/definition.ts';
+import { evaluateContinuationPromptDef } from '@src/integration/ai/prompts/evaluate-continuation/definition.ts';
 import { evaluatePromptDef } from '@src/integration/ai/prompts/evaluate/definition.ts';
 import { ideatePromptDef } from '@src/integration/ai/prompts/ideate/definition.ts';
+import { implementContinuationPromptDef } from '@src/integration/ai/prompts/implement-continuation/definition.ts';
 import { implementPromptDef } from '@src/integration/ai/prompts/implement/definition.ts';
 import { planPromptDef } from '@src/integration/ai/prompts/plan/definition.ts';
 import { readinessPromptDef } from '@src/integration/ai/prompts/readiness/definition.ts';
@@ -40,7 +42,9 @@ const FLOWS: ReadonlyArray<{ readonly name: string; readonly def: PromptDefiniti
   { name: 'plan', def: planPromptDef as PromptDefinition<never> },
   { name: 'ideate', def: ideatePromptDef as PromptDefinition<never> },
   { name: 'implement', def: implementPromptDef as PromptDefinition<never> },
+  { name: 'implement-continuation', def: implementContinuationPromptDef as PromptDefinition<never> },
   { name: 'evaluate', def: evaluatePromptDef as PromptDefinition<never> },
+  { name: 'evaluate-continuation', def: evaluateContinuationPromptDef as PromptDefinition<never> },
   { name: 'readiness', def: readinessPromptDef as PromptDefinition<never> },
   { name: 'detect-scripts', def: detectScriptsPromptDef as PromptDefinition<never> },
   { name: 'detect-skills', def: detectSkillsPromptDef as PromptDefinition<never> },

--- a/tests/integration/application/flows/detect-scripts/leaves/detect-scripts-contract.test.ts
+++ b/tests/integration/application/flows/detect-scripts/leaves/detect-scripts-contract.test.ts
@@ -1,0 +1,283 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { HarnessSignal, SetupScriptSignal, VerifyScriptSignal } from '@src/domain/signal.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import type { AiSignalEvent, AppEvent } from '@src/business/observability/events.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
+import { absolutePath, makeProject, makeRepository } from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import {
+  proposeDetectScriptsLeaf,
+  type ProposeDetectScriptsLeafDeps,
+} from '@src/application/flows/detect-scripts/leaves/propose.ts';
+import type { DetectScriptsCtx } from '@src/application/flows/detect-scripts/ctx.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Audit-[10] contract grid for `proposeDetectScriptsLeaf` — audit-[09] detect-scripts contract.
+ *
+ * A `FakeProvider` writes the test payload directly to `session.signalsFile`, bypassing the
+ * real AI CLI. The propose leaf then calls `validateSignalsFile` against `detectScriptsOutputContract`
+ * and projects the result onto `ctx.proposal`. This exercises the full integration path from
+ * provider → validate → project, under a real tmpdir, without spawning a CLI process.
+ *
+ * Contract rules:
+ *  - All signal kinds (`setup-script`, `verify-script`, `verify-gates`, `note`) are optional.
+ *  - At most one of each kind per spawn.
+ *  - Empty signals array is a valid "no answer" response.
+ *  - `migrations[0]` lifts the legacy bare-array shape into the v1 `{ schemaVersion, signals }` wrapper.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+type EmitPayload =
+  | { readonly kind: 'signals'; readonly signals: readonly HarnessSignal[] }
+  | { readonly kind: 'raw'; readonly body: string }
+  | { readonly kind: 'omit' }
+  | { readonly kind: 'spawn-error'; readonly error: DomainError }
+  | { readonly kind: 'abort' };
+
+const fakeProvider = (payload: EmitPayload): HeadlessAiProvider => ({
+  async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+    if (payload.kind === 'spawn-error') return Result.error(payload.error);
+    if (payload.kind === 'abort')
+      throw new AbortError({ elementName: 'fake-detect-scripts-provider', reason: 'abort in test' });
+    if (payload.kind === 'signals') {
+      // Write the v1 wrapper so `validateSignalsFile` skips the legacy migration.
+      const wrote = await writeJsonAtomic(String(session.signalsFile), {
+        schemaVersion: 1,
+        signals: payload.signals,
+      });
+      if (!wrote.ok) return Result.error(wrote.error);
+    } else if (payload.kind === 'raw') {
+      await fs.writeFile(String(session.signalsFile), payload.body, 'utf8');
+    }
+    // `omit` → never touch signalsFile → `validateSignalsFile` returns InvalidStateError.
+    return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 });
+  },
+});
+
+const captureBus = (eventBus = createInMemoryEventBus()): { events: AppEvent[]; eventBus: typeof eventBus } => {
+  const events: AppEvent[] = [];
+  eventBus.subscribe((e) => {
+    events.push(e);
+  });
+  return { events, eventBus };
+};
+
+describe('proposeDetectScriptsLeaf — audit-[09] contract', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+  let runsRoot: ReturnType<typeof absolutePath>;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+    runsRoot = absolutePath(join(String(root.root), 'runs'));
+    repoPath = join(String(root.root), 'repo-a');
+    await fs.mkdir(repoPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const buildDeps = (payload: EmitPayload, eventBus = createInMemoryEventBus()): ProposeDetectScriptsLeafDeps => ({
+    provider: fakeProvider(payload),
+    templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+    signals: createInMemorySink<HarnessSignal>(),
+    eventBus,
+    logger: noopLogger,
+    model: 'claude-sonnet-4-6',
+    runsRoot,
+  });
+
+  const buildCtx = (): DetectScriptsCtx => {
+    const project = makeProject();
+    const repository = makeRepository({ path: repoPath, name: 'repo-a' });
+    return {
+      projectId: project.id,
+      repository,
+    };
+  };
+
+  const setupScriptSignal = (): SetupScriptSignal => ({
+    type: 'setup-script',
+    command: 'pnpm install',
+    timestamp: TS,
+  });
+
+  const verifyScriptSignal = (): VerifyScriptSignal => ({
+    type: 'verify-script',
+    command: 'pnpm typecheck && pnpm lint && pnpm test',
+    timestamp: TS,
+  });
+
+  // ── 1. Happy path — all valid signals present ────────────────────────────────
+
+  it('ok: setup-script + verify-script → parsed, projected onto ctx, fanned to bus', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupScriptSignal(), verifyScriptSignal()] }, eventBus);
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    // Bus fan-out: every validated signal as a typed `ai-signal` event with source 'detect-scripts'.
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-script', 'verify-script']);
+    for (const ev of aiSignals) expect(ev.source).toBe('detect-scripts');
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBe('pnpm install');
+    expect(result.value.ctx.proposal?.proposedVerifyScript).toBe('pnpm typecheck && pnpm lint && pnpm test');
+  });
+
+  // ── 2. Empty signals — valid "no answer" ────────────────────────────────────
+
+  it('ok: empty signals array — "no answer" is valid, proposal has no scripts', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [] });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBeUndefined();
+    expect(result.value.ctx.proposal?.proposedVerifyScript).toBeUndefined();
+    // runDir is always set on success.
+    expect(result.value.ctx.proposal?.runDir).toBeDefined();
+  });
+
+  // ── 3. Duplicate signal kind — at-most-one refine fails ─────────────────────
+
+  it('duplicate setup-script → ParseError (at-most-one violated)', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [setupScriptSignal(), setupScriptSignal()] });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 4. Invalid / unknown signal kind ─────────────────────────────────────────
+
+  it('unknown signal kind (commit-message) → ParseError(schema-mismatch)', async () => {
+    const unknown = [
+      { type: 'commit-message', subject: 'feat: not a detect-scripts signal', timestamp: TS },
+    ] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: unknown });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 5. Missing required field on a valid type ─────────────────────────────────
+
+  it('setup-script missing required command field → ParseError(schema-mismatch)', async () => {
+    const malformed = [{ type: 'setup-script', timestamp: TS }] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: malformed });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 6. Malformed JSON ──────────────────────────────────────────────────────────
+
+  it('malformed JSON in signals.json → ParseError(invalid-json)', async () => {
+    const deps = buildDeps({ kind: 'raw', body: '{ this is not valid json' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('malformed JSON');
+  });
+
+  // ── 7. signals.json not written ───────────────────────────────────────────────
+
+  it('signals-missing: provider omits signals.json → InvalidStateError', async () => {
+    const deps = buildDeps({ kind: 'omit' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.error.message).toContain('signals-missing');
+  });
+
+  // ── 8. Legacy bare-array migration ────────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    const { events, eventBus } = captureBus();
+    // Write legacy shape: a bare JSON array without the `{ schemaVersion, signals }` wrapper.
+    const legacyPayload = JSON.stringify([setupScriptSignal()]);
+    const deps = buildDeps({ kind: 'raw', body: legacyPayload }, eventBus);
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-script']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBe('pnpm install');
+  });
+
+  // ── 9. Spawn error ────────────────────────────────────────────────────────────
+
+  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+    const spawnError = new InvalidStateError({
+      entity: 'provider',
+      currentState: 'broken',
+      attemptedAction: 'detect-scripts',
+      message: 'simulated spawn failure',
+    });
+    const deps = buildDeps({ kind: 'spawn-error', error: spawnError });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBe(spawnError);
+  });
+
+  // ── 10. AbortError propagation ────────────────────────────────────────────────
+
+  it('abort: AbortError surfaces as an aborted Result out of the leaf (chain framework design)', async () => {
+    // The provider throws AbortError mid-spawn (a TUI cancel). The `leaf` chain primitive
+    // catches it and returns `Result.error({ error, trace })` with the trace entry marked
+    // `aborted` — it does NOT re-throw. The runner's status machine routes that aborted Result
+    // to the interrupted exit path, so cancellation stays a first-class Result, not an exception.
+    const deps = buildDeps({ kind: 'abort' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(result.error.trace.at(-1)?.status).toBe('aborted');
+  });
+});

--- a/tests/integration/application/flows/detect-skills/leaves/detect-skills-contract.test.ts
+++ b/tests/integration/application/flows/detect-skills/leaves/detect-skills-contract.test.ts
@@ -1,0 +1,321 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { HarnessSignal, SetupSkillProposalSignal, VerifySkillProposalSignal } from '@src/domain/signal.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import type { AiSignalEvent, AppEvent } from '@src/business/observability/events.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
+import { absolutePath, makeProject, makeRepository } from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import {
+  proposeDetectSkillsLeaf,
+  type ProposeDetectSkillsLeafDeps,
+} from '@src/application/flows/detect-skills/leaves/propose.ts';
+import type { DetectSkillsCtx } from '@src/application/flows/detect-skills/ctx.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Audit-[10] contract grid for `proposeDetectSkillsLeaf` — audit-[09] detect-skills contract.
+ *
+ * A `FakeProvider` writes the test payload directly to `session.signalsFile`, bypassing the
+ * real AI CLI. The propose leaf then calls `validateSignalsFile` against `detectSkillsOutputContract`,
+ * renders sidecars for the two optional `*-proposal` kinds, and projects the result onto
+ * `ctx.proposal`. This exercises the full integration path from provider → validate → sidecar →
+ * project, under a real tmpdir, without spawning a CLI process.
+ *
+ * Contract rules:
+ *  - `setup-skill-proposal`, `verify-skill-proposal`, and `note` are all optional.
+ *  - At most one of each kind per spawn.
+ *  - Empty signals array is a valid "no skill needed" response.
+ *  - `migrations[0]` lifts the legacy bare-array shape into the v1 `{ schemaVersion, signals }` wrapper.
+ *  - Sidecars (`setup-skill.md`, `verify-skill.md`) are rendered from the accepted proposals.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+type EmitPayload =
+  | { readonly kind: 'signals'; readonly signals: readonly HarnessSignal[] }
+  | { readonly kind: 'raw'; readonly body: string }
+  | { readonly kind: 'omit' }
+  | { readonly kind: 'spawn-error'; readonly error: DomainError }
+  | { readonly kind: 'abort' };
+
+const fakeProvider = (payload: EmitPayload): HeadlessAiProvider => ({
+  async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+    if (payload.kind === 'spawn-error') return Result.error(payload.error);
+    if (payload.kind === 'abort')
+      throw new AbortError({ elementName: 'fake-detect-skills-provider', reason: 'abort in test' });
+    if (payload.kind === 'signals') {
+      const wrote = await writeJsonAtomic(String(session.signalsFile), {
+        schemaVersion: 1,
+        signals: payload.signals,
+      });
+      if (!wrote.ok) return Result.error(wrote.error);
+    } else if (payload.kind === 'raw') {
+      await fs.writeFile(String(session.signalsFile), payload.body, 'utf8');
+    }
+    // `omit` → never touch signalsFile → `validateSignalsFile` returns InvalidStateError.
+    return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 });
+  },
+});
+
+/**
+ * Real-disk WriteFile impl. The sidecar render path calls this for `setup-skill.md` and
+ * `verify-skill.md`; errors are surfaced as `StorageError` matching production behaviour.
+ */
+const makeWriteFile = (): WriteFile => async (path, content) => {
+  try {
+    await fs.mkdir(join(String(path), '..'), { recursive: true });
+    await fs.writeFile(String(path), content, 'utf8');
+    return Result.ok(undefined);
+  } catch (cause) {
+    return Result.error(new StorageError({ subCode: 'io', message: 'writeFile failed', path: String(path), cause }));
+  }
+};
+
+const captureBus = (eventBus = createInMemoryEventBus()): { events: AppEvent[]; eventBus: typeof eventBus } => {
+  const events: AppEvent[] = [];
+  eventBus.subscribe((e) => {
+    events.push(e);
+  });
+  return { events, eventBus };
+};
+
+describe('proposeDetectSkillsLeaf — audit-[09] contract', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+  let runsRoot: ReturnType<typeof absolutePath>;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+    runsRoot = absolutePath(join(String(root.root), 'runs'));
+    repoPath = join(String(root.root), 'repo-a');
+    await fs.mkdir(repoPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const buildDeps = (payload: EmitPayload, eventBus = createInMemoryEventBus()): ProposeDetectSkillsLeafDeps => ({
+    provider: fakeProvider(payload),
+    templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+    signals: createInMemorySink<HarnessSignal>(),
+    eventBus,
+    writeFile: makeWriteFile(),
+    logger: noopLogger,
+    skillsAdapter: noopSkillsAdapter,
+    model: 'claude-sonnet-4-6',
+    runsRoot,
+  });
+
+  const buildCtx = (): DetectSkillsCtx => {
+    const project = makeProject();
+    const repository = makeRepository({ path: repoPath, name: 'repo-a' });
+    return {
+      projectId: project.id,
+      repository,
+    };
+  };
+
+  const setupSkillSignal = (): SetupSkillProposalSignal => ({
+    type: 'setup-skill-proposal',
+    content: 'Run `mise install` then `pnpm install` before editing.',
+    timestamp: TS,
+  });
+
+  const verifySkillSignal = (): VerifySkillProposalSignal => ({
+    type: 'verify-skill-proposal',
+    content: 'Run `pnpm typecheck && pnpm lint && pnpm test` in sequence.',
+    timestamp: TS,
+  });
+
+  // ── 1. Happy path — both proposals present ──────────────────────────────────
+
+  it('ok: setup-skill + verify-skill → parsed, projected onto ctx, fanned to bus', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal(), verifySkillSignal()] }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    // Bus fan-out: every validated signal as a typed `ai-signal` event with source 'detect-skills'.
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal', 'verify-skill-proposal']);
+    for (const ev of aiSignals) expect(ev.source).toBe('detect-skills');
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toContain('pnpm typecheck');
+  });
+
+  // ── 2. Only one proposal — the other is absent ────────────────────────────────
+
+  it('ok: only setup-skill-proposal → verify-skill absent from ctx', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal()] }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toBeUndefined();
+  });
+
+  // ── 3. Empty signals — valid "no skill needed" ─────────────────────────────────
+
+  it('ok: empty signals array — "no skill needed" is a valid response', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [] });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toBeUndefined();
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toBeUndefined();
+    expect(result.value.ctx.proposal?.runDir).toBeDefined();
+  });
+
+  // ── 4. Duplicate signal kind — at-most-one refine fails ──────────────────────
+
+  it('duplicate setup-skill-proposal → ParseError (at-most-one violated)', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal(), setupSkillSignal()] });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 5. Invalid / unknown signal kind ────────────────────────────────────────────
+
+  it('unknown signal kind (refined-ticket) → ParseError(schema-mismatch)', async () => {
+    const unknown = [
+      { type: 'refined-ticket', body: 'not a skills signal', timestamp: TS },
+    ] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: unknown });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 6. Missing required field on a valid type ────────────────────────────────────
+
+  it('setup-skill-proposal missing required content field → ParseError(schema-mismatch)', async () => {
+    // `content` is required by setupSkillProposalSignalSchema but omitted here.
+    const malformed = [{ type: 'setup-skill-proposal', timestamp: TS }] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: malformed });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 7. Malformed JSON ────────────────────────────────────────────────────────────
+
+  it('malformed JSON in signals.json → ParseError(invalid-json)', async () => {
+    const deps = buildDeps({ kind: 'raw', body: '{ this is not valid json either' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('malformed JSON');
+  });
+
+  // ── 8. signals.json not written ──────────────────────────────────────────────────
+
+  it('signals-missing: provider omits signals.json → InvalidStateError', async () => {
+    const deps = buildDeps({ kind: 'omit' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.error.message).toContain('signals-missing');
+  });
+
+  // ── 9. Legacy bare-array migration ───────────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    const { events, eventBus } = captureBus();
+    // Write legacy shape: a bare JSON array without the `{ schemaVersion, signals }` wrapper.
+    const legacyPayload = JSON.stringify([setupSkillSignal()]);
+    const deps = buildDeps({ kind: 'raw', body: legacyPayload }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+  });
+
+  // ── 10. Spawn error ──────────────────────────────────────────────────────────────
+
+  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+    const spawnError = new InvalidStateError({
+      entity: 'provider',
+      currentState: 'broken',
+      attemptedAction: 'detect-skills',
+      message: 'simulated spawn failure',
+    });
+    const deps = buildDeps({ kind: 'spawn-error', error: spawnError });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBe(spawnError);
+  });
+
+  // ── 11. AbortError propagation ───────────────────────────────────────────────────
+
+  it('abort: AbortError surfaces as an aborted Result out of the leaf (chain framework design)', async () => {
+    // The provider throws AbortError mid-spawn (a TUI cancel). The `leaf` chain primitive
+    // catches it and returns `Result.error({ error, trace })` with the trace entry marked
+    // `aborted` — it does NOT re-throw. The runner's status machine routes that aborted Result
+    // to the interrupted exit path, so cancellation stays a first-class Result, not an exception.
+    const deps = buildDeps({ kind: 'abort' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(result.error.trace.at(-1)?.status).toBe('aborted');
+  });
+});

--- a/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
+++ b/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
@@ -198,7 +198,7 @@ describe('createGenEvalLoop — gen-eval-turn child order (step-order fence)', (
     ]);
   });
 
-  it('evaluator-guard body is [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf] in that order', () => {
+  it('evaluator-guard body is [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf, loop-diversity-check] in that order', () => {
     const { loop, task } = buildLoopShape();
     const id = String(task.id);
 
@@ -214,7 +214,12 @@ describe('createGenEvalLoop — gen-eval-turn child order (step-order fence)', (
     const evalChildren = evalStep?.children ?? [];
     const names = evalChildren.map((c) => c.name);
 
-    expect(names).toStrictEqual([`stamp-meta-evaluator-${id}`, `stamp-role-meta-evaluator-${id}`, `evaluator-${id}`]);
+    expect(names).toStrictEqual([
+      `stamp-meta-evaluator-${id}`,
+      `stamp-role-meta-evaluator-${id}`,
+      `evaluator-${id}`,
+      `loop-diversity-check-${id}`,
+    ]);
   });
 });
 

--- a/tests/integration/application/flows/readiness/fan-out.test.ts
+++ b/tests/integration/application/flows/readiness/fan-out.test.ts
@@ -710,8 +710,9 @@ describe('readiness fan-out across unique providers', () => {
 /**
  * Provider-scoping fan-out: the `providers` opt scopes the per-tool sub-chains the chain builds.
  * These tests inspect the static element tree (`flow.children`) rather than running the chain —
- * the per-tool sub-chains are the top-level `sequential('readiness', …)` children named
- * `tool-<tool>`, so the set of those names is exactly the scoped fan-out.
+ * each per-tool sub-chain (`sequential('tool-<tool>', …)`) is wrapped in a continue-on-error
+ * guard and sits among the top-level `sequential('readiness', …)` children, so unwrapping the
+ * guards and collecting the `tool-<tool>` names yields exactly the scoped fan-out.
  */
 describe('readiness fan-out provider scoping', () => {
   const buildFlow = (ai: AiSettings, opts: { readonly providers?: readonly AiProvider[] }) => {
@@ -743,9 +744,15 @@ describe('readiness fan-out provider scoping', () => {
     );
   };
 
-  /** Names of the per-tool sub-chain children of the top-level `sequential('readiness', …)`. */
+  /**
+   * Names of the per-tool sub-chains, unwrapping the per-provider continue-on-error guard each
+   * one is nested under (`continue-on-error(tool-<tool>)` → child `tool-<tool>`).
+   */
   const toolSubchainNames = (flow: ReturnType<typeof buildFlow>): readonly string[] =>
-    (flow.children ?? []).map((c) => c.name).filter((n) => n.startsWith('tool-'));
+    (flow.children ?? [])
+      .flatMap((c) => [c, ...(c.children ?? [])])
+      .map((c) => c.name)
+      .filter((n) => n.startsWith('tool-'));
 
   it('providers scoped to one provider → exactly that provider tool sub-chain is built', () => {
     // Settings reference three providers; scope to github-copilot only.

--- a/tests/integration/application/flows/review/leaves/ensure-feedback-file.test.ts
+++ b/tests/integration/application/flows/review/leaves/ensure-feedback-file.test.ts
@@ -1,0 +1,96 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ensureFeedbackFileLeaf } from '@src/application/flows/review/leaves/ensure-feedback-file.ts';
+import type { ReviewCtx } from '@src/application/flows/review/ctx.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Integration tests for `ensureFeedbackFileLeaf`.
+ *
+ * The leaf materialises `feedback.md` at a given path if the file is absent, threads the
+ * path forward on `ctx.feedbackFile`, and is idempotent (a pre-existing file is left
+ * untouched). These tests exercise the I/O contract against a real tmpdir.
+ */
+
+const makeCtx = (): ReviewCtx => ({
+  sprintId: makeDraftSprint().id,
+  distillRequested: false,
+});
+
+const parsePath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`invalid path: ${p}`);
+  return r.value;
+};
+
+describe('ensureFeedbackFileLeaf', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const feedbackPath = (): string => join(String(root.root), 'feedback.md');
+
+  it('creates file with template when absent', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    const result = await leaf.execute(makeCtx());
+
+    expect(result.ok).toBe(true);
+    const content = await fs.readFile(feedbackPath(), 'utf8');
+    expect(content).toContain('# Feedback');
+    expect(content).toContain('Round 1');
+    // The template includes the marker comment the round parser relies on.
+    expect(content).toContain('write your feedback below');
+  });
+
+  it('reuses existing file without overwriting its content', async () => {
+    const existingContent = '# My custom feedback\n\n- existing round instructions\n';
+    await fs.writeFile(feedbackPath(), existingContent, 'utf8');
+
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    const result = await leaf.execute(makeCtx());
+
+    expect(result.ok).toBe(true);
+    const content = await fs.readFile(feedbackPath(), 'utf8');
+    expect(content).toBe(existingContent);
+  });
+
+  it('threads feedbackFile path onto ctx', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+    const ctx = makeCtx();
+
+    const result = await leaf.execute(ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.feedbackFile).toBeDefined();
+    expect(String(result.value.ctx.feedbackFile)).toBe(feedbackPath());
+  });
+
+  it('is idempotent — second run succeeds and leaves file unchanged', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    await leaf.execute(makeCtx());
+    const contentAfterFirst = await fs.readFile(feedbackPath(), 'utf8');
+
+    const result2 = await leaf.execute(makeCtx());
+    expect(result2.ok).toBe(true);
+    const contentAfterSecond = await fs.readFile(feedbackPath(), 'utf8');
+
+    expect(contentAfterFirst).toBe(contentAfterSecond);
+  });
+});

--- a/tests/integration/application/flows/review/leaves/review-round-contract.test.ts
+++ b/tests/integration/application/flows/review/leaves/review-round-contract.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import { validateSignalsFile } from '@src/integration/ai/contract/_engine/validate-signals-file.ts';
+import { reviewRoundOutputContract } from '@src/application/flows/review/leaves/review-round.contract.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Signal schema validation tests for `reviewRoundOutputContract` — audit-[09].
+ *
+ * The review-round leaf uses `validateSignalsFile` internally after each AI spawn. These
+ * tests exercise the contract rules directly (without going through the full leaf, which
+ * requires interactive, git, shell, and append-file ports) so regressions in the Zod
+ * schema surface quickly.
+ *
+ * Contract rules:
+ *  - Exactly one of `task-complete` or `task-blocked` must be present.
+ *  - No other signal kinds are permitted.
+ *  - `task-blocked` requires a `reason` string.
+ *  - `migrations[0]` lifts a legacy bare array into the `{ schemaVersion, signals }` wrapper.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+describe('reviewRoundOutputContract — signal schema validation', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  /**
+   * Allocate a fresh subdir under the tmproot, write `signals.json` with the supplied payload,
+   * and return the dir as an `AbsolutePath` for `validateSignalsFile`.
+   */
+  const arrange = async (payload: unknown, subdir = 'round'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    await fs.writeFile(join(dirStr, 'signals.json'), JSON.stringify(payload), 'utf8');
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  const arrangeRaw = async (body: string, subdir = 'round-raw'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    await fs.writeFile(join(dirStr, 'signals.json'), body, 'utf8');
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  const emptyDir = async (subdir = 'empty'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  // ── 1. Happy paths ──────────────────────────────────────────────────────────
+
+  it('ok: task-complete → validates and returns signal', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'task-complete', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-complete');
+  });
+
+  it('ok: task-blocked with reason → validates and returns signal', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'task-blocked', reason: 'CI is red — dependency build failed', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-blocked');
+    // @ts-expect-error narrow to TaskBlockedSignal for the assertion
+    expect(result.value[0]?.reason).toBe('CI is red — dependency build failed');
+  });
+
+  // ── 2. Missing required terminal → refine rejects ──────────────────────────
+
+  it('empty signals array → ParseError (zero terminals)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('exactly one');
+  });
+
+  // ── 3. Both terminals → refine rejects ─────────────────────────────────────
+
+  it('both task-complete and task-blocked → ParseError (two terminals)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [
+        { type: 'task-complete', timestamp: TS },
+        { type: 'task-blocked', reason: 'contradicts complete', timestamp: TS },
+      ],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('exactly one');
+  });
+
+  // ── 4. Invalid / unknown signal kind ──────────────────────────────────────
+
+  it('unknown signal kind (commit-message) → ParseError(schema-mismatch)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'commit-message', subject: 'feat: irrelevant', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('schema');
+  });
+
+  // ── 5. Missing required field on a valid type ──────────────────────────────
+
+  it('task-blocked missing required reason field → ParseError(schema-mismatch)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      // `reason` is required by taskBlockedSignalSchema but omitted here.
+      signals: [{ type: 'task-blocked', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('schema');
+  });
+
+  // ── 6. Malformed JSON ──────────────────────────────────────────────────────
+
+  it('malformed JSON → ParseError(invalid-json)', async () => {
+    const outputDir = await arrangeRaw('{ this is not valid json at all');
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('malformed JSON');
+  });
+
+  // ── 7. Missing signals.json ─────────────────────────────────────────────────
+
+  it('signals-missing: no file → InvalidStateError', async () => {
+    const outputDir = await emptyDir();
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.message).toContain('signals-missing');
+  });
+
+  // ── 8. Legacy bare-array migration ─────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    // The legacy shape written by the headless adapter's stdout parser (pre-Wave-6). The
+    // contract's `migrations[0]` lifts it into `{ schemaVersion: 1, signals: [...] }`.
+    const outputDir = await arrange([{ type: 'task-complete', timestamp: TS }], 'round-legacy');
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-complete');
+  });
+
+  // ── 9. Example signals from the contract round-trip ───────────────────────
+
+  it('example signals in the contract round-trip through the schema', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: reviewRoundOutputContract.exampleSignals,
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(reviewRoundOutputContract.exampleSignals.length);
+  });
+});

--- a/tests/unit/application/chain/build/guard.test.ts
+++ b/tests/unit/application/chain/build/guard.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import type { TraceEntry } from '@src/application/chain/trace.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import { guard } from '@src/application/chain/build/guard.ts';
+
+interface Ctx {
+  readonly trail: readonly string[];
+}
+
+/** A leaf that appends its name to the ctx trail — proves the body actually ran and threaded ctx. */
+const tag = (name: string): Element<Ctx> =>
+  leaf<Ctx, Ctx, Ctx>(name, {
+    useCase: {
+      async execute(input) {
+        return Result.ok({ trail: [...input.trail, name] });
+      },
+    },
+    input: (c) => c,
+    output: (_c, o) => o,
+  });
+
+/** A leaf that always fails — proves a body error propagates through the guard. */
+const fail = (name: string): Element<Ctx> =>
+  leaf<Ctx, unknown, unknown>(name, {
+    useCase: {
+      async execute() {
+        return Result.error(new ValidationError({ field: name, value: 0, message: `${name} failed` }));
+      },
+    },
+    input: () => undefined,
+    output: (c) => c,
+  });
+
+describe('guard', () => {
+  it('skips the body and emits a skipped trace entry when the predicate returns false', async () => {
+    let bodyRan = false;
+    const body = leaf<Ctx, Ctx, Ctx>('body', {
+      useCase: {
+        async execute(input) {
+          bodyRan = true;
+          return Result.ok(input);
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const result = await guard<Ctx>('only-when', () => false, body).execute({ trail: ['start'] });
+
+    expect(bodyRan).toBe(false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // ctx is threaded through unchanged when the body is skipped.
+      expect(result.value.ctx).toEqual({ trail: ['start'] });
+      // The single trace entry names the BODY (not the guard) with `skipped` status.
+      expect(result.value.trace.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:skipped']);
+    }
+  });
+
+  it('forwards the skipped entry through onTrace so the live stream matches the final trace', async () => {
+    const emitted: TraceEntry[] = [];
+    await guard<Ctx>('only-when', () => false, tag('body')).execute({ trail: [] }, undefined, (e) => emitted.push(e));
+
+    expect(emitted.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:skipped']);
+  });
+
+  it('runs the body and returns its result when the predicate returns true', async () => {
+    const result = await guard<Ctx>('only-when', () => true, tag('body')).execute({ trail: ['start'] });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.ctx).toEqual({ trail: ['start', 'body'] });
+      expect(result.value.trace.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:completed']);
+    }
+  });
+
+  it('propagates the body failure verbatim when the predicate returns true and the body fails', async () => {
+    const result = await guard<Ctx>('only-when', () => true, fail('body')).execute({ trail: [] });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBeInstanceOf(ValidationError);
+      expect(result.error.trace.at(-1)?.elementName).toBe('body');
+      expect(result.error.trace.at(-1)?.status).toBe('failed');
+    }
+  });
+
+  it('short-circuits to aborted — evaluating neither predicate nor body — when the signal is already tripped', async () => {
+    let predicateRan = false;
+    let bodyRan = false;
+    const body = leaf<Ctx, Ctx, Ctx>('body', {
+      useCase: {
+        async execute(input) {
+          bodyRan = true;
+          return Result.ok(input);
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const ac = new AbortController();
+    ac.abort();
+    const result = await guard<Ctx>(
+      'only-when',
+      () => {
+        predicateRan = true;
+        return true;
+      },
+      body
+    ).execute({ trail: [] }, ac.signal);
+
+    expect(predicateRan).toBe(false);
+    expect(bodyRan).toBe(false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBeInstanceOf(AbortError);
+      // The pre-execution abort entry carries the GUARD name (built by `checkAborted`), not the body's.
+      expect(result.error.trace[0]?.elementName).toBe('only-when');
+      expect(result.error.trace[0]?.status).toBe('aborted');
+    }
+  });
+});

--- a/tests/unit/application/flows/create-pr/flow-shape.test.ts
+++ b/tests/unit/application/flows/create-pr/flow-shape.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
+import type { CreatePrDeps } from '@src/application/flows/create-pr/deps.ts';
+
+/**
+ * Topology fence for the create-pr chain. Construction-only: every leaf factory captures its deps in
+ * a closure read lazily inside `execute`, never called here, so the deps cast is sound (same
+ * rationale as the implement flow-shape fence). The AI sub-chain is a construction-time toggle
+ * (`useAi`), not a runtime branch — so each shape is fenced independently. Fails deterministically if
+ * a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): CreatePrDeps => ({}) as unknown as CreatePrDeps;
+
+describe('createCreatePrFlow — chain-shape fence', () => {
+  it('splices the AI authoring sub-chain ahead of the create-pr leaf when useAi is true (default)', () => {
+    expect(names(createCreatePrFlow(stubDeps()))).toStrictEqual([
+      'create-pr',
+      'push-branch',
+      'load-create-pr-context',
+      'build-create-pr-unit',
+      'render-prompt-to-file',
+      'generate-pr-content',
+      'create-pr',
+    ]);
+  });
+
+  it('omits the AI authoring sub-chain when useAi is false', () => {
+    expect(names(createCreatePrFlow(stubDeps(), { useAi: false }))).toStrictEqual([
+      'create-pr',
+      'push-branch',
+      'create-pr',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/ideate/flow-shape.test.ts
+++ b/tests/unit/application/flows/ideate/flow-shape.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createIdeateFlow, type CreateIdeateFlowOpts } from '@src/application/flows/ideate/flow.ts';
+import type { IdeateDeps } from '@src/application/flows/ideate/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID, makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the ideate chain. Construction-only: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, never called here, so the deps cast is sound (same rationale
+ * as the implement flow-shape fence). Fails deterministically if a leaf is dropped, added, or
+ * reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): IdeateDeps => ({}) as unknown as IdeateDeps;
+
+const makeOpts = (): CreateIdeateFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  projectId: FIXED_PROJECT_ID,
+  ideaTitle: 'an idea',
+  ideaText: 'flesh it out',
+  cwd: absolutePath('/repos/main'),
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  maxAttempts: 3,
+  ideateRoot: absolutePath('/sprints/s1/ideate'),
+});
+
+describe('createIdeateFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order', () => {
+    expect(names(createIdeateFlow(stubDeps(), makeOpts()))).toStrictEqual([
+      'ideate',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'load-project',
+      'load-tasks',
+      'build-ideate-unit',
+      'render-prompt-to-file',
+      'install-skills',
+      'stamp-meta-ideate',
+      'ideate-and-plan',
+      'uninstall-skills',
+      'transition-to-planned',
+      'save-tasks',
+      'save-sprint',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/plan/flow-shape.test.ts
+++ b/tests/unit/application/flows/plan/flow-shape.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createPlanFlow, type CreatePlanFlowOpts } from '@src/application/flows/plan/flow.ts';
+import type { PlanDeps } from '@src/application/flows/plan/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID, makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the plan chain. Construction-only: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, never called here, so the deps cast is sound (same rationale
+ * as the implement flow-shape fence). Fails deterministically if a leaf is dropped, added, or
+ * reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): PlanDeps => ({}) as unknown as PlanDeps;
+
+const makeOpts = (): CreatePlanFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  projectId: FIXED_PROJECT_ID,
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  maxAttempts: 3,
+  planRoot: absolutePath('/sprints/s1/plan'),
+});
+
+describe('createPlanFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order', () => {
+    expect(names(createPlanFlow(stubDeps(), makeOpts()))).toStrictEqual([
+      'plan',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'load-project',
+      'load-sprint-execution',
+      'load-tasks',
+      'build-plan-unit',
+      'render-prompt-to-file',
+      'install-skills',
+      'stamp-meta-plan',
+      'call-planner-interactive',
+      'uninstall-skills',
+      'save-tasks',
+      'save-sprint',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/readiness/flow-shape.test.ts
+++ b/tests/unit/application/flows/readiness/flow-shape.test.ts
@@ -50,6 +50,9 @@ describe('createReadinessFlow — chain-shape fence', () => {
       'readiness',
       'load-project',
       'pick-repository',
+      // Each per-provider sub-chain is wrapped in a continue-on-error guard (skips the provider
+      // on a provider-specific infra failure); the guard exposes the sub-chain as its child.
+      'continue-on-error(tool-claude-code)',
       'tool-claude-code',
       'probe-claude-code',
       'install-skills-claude-code',
@@ -70,7 +73,8 @@ describe('createReadinessFlow — chain-shape fence', () => {
     expect((top.children ?? []).map((c) => c.name)).toStrictEqual([
       'load-project',
       'pick-repository',
-      'tool-claude-code',
+      // The per-provider sub-chain is wrapped in a continue-on-error guard at the top level.
+      'continue-on-error(tool-claude-code)',
       'persist-suggested-skills',
     ]);
   });

--- a/tests/unit/application/flows/readiness/flow-shape.test.ts
+++ b/tests/unit/application/flows/readiness/flow-shape.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AiProvider, AiSettings } from '@src/domain/entity/settings.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { createReadinessFlow, type CreateReadinessFlowOpts } from '@src/application/flows/readiness/flow.ts';
+import type { SetupReadinessDeps } from '@src/application/flows/readiness/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID } from '@tests/fixtures/domain.ts';
+import { noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+
+/**
+ * Topology fence for the readiness chain. Construction-only — no leaf executes — so most deps are an
+ * inert cast. The two exceptions are `providerFor` / `skillsAdapterFor`, which the flow CALLS at
+ * construction to bake the per-provider adapters into each tool sub-chain; they must therefore be
+ * real callables (their return values are only stored, never invoked here). `opts.ai` is also read
+ * eagerly (to pick a model + effort per provider), so it carries real per-flow rows. Fails
+ * deterministically if a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): SetupReadinessDeps =>
+  ({
+    providerFor: () => undefined,
+    skillsAdapterFor: () => noopSkillsAdapter,
+    runsRoot: absolutePath('/data/runs'),
+  }) as unknown as SetupReadinessDeps;
+
+// All six per-flow rows on claude-code → `uniqueProvidersFromAi` resolves to a single provider, so
+// the fan-out builds exactly one `tool-claude-code` sub-chain.
+const row = { provider: 'claude-code', model: 'claude-opus-4-8' } as const;
+const ai: AiSettings = {
+  refine: row,
+  plan: row,
+  implement: { generator: row, evaluator: row },
+  readiness: row,
+  ideate: row,
+  createPr: row,
+};
+
+const makeOpts = (providers?: readonly AiProvider[]): CreateReadinessFlowOpts => ({
+  projectId: FIXED_PROJECT_ID,
+  cwd: absolutePath('/repos/main'),
+  ai,
+  ...(providers !== undefined ? { providers } : {}),
+});
+
+describe('createReadinessFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order, for a single-provider fan-out', () => {
+    expect(names(createReadinessFlow(stubDeps(), makeOpts(['claude-code'])))).toStrictEqual([
+      'readiness',
+      'load-project',
+      'pick-repository',
+      'tool-claude-code',
+      'probe-claude-code',
+      'install-skills-claude-code',
+      'allocate-run-dir-claude-code',
+      'stamp-meta-claude-code',
+      'propose-claude-code',
+      'uninstall-skills-claude-code',
+      'confirm-claude-code',
+      'write-claude-code',
+      'offer-skill-suggestions-claude-code',
+      'install-readiness-skills-claude-code',
+      'persist-suggested-skills',
+    ]);
+  });
+
+  it('fans out one tool-<tool> sub-chain per scoped provider, framed by load/pick and the terminal persist leaf', () => {
+    const top = createReadinessFlow(stubDeps(), makeOpts(['claude-code']));
+    expect((top.children ?? []).map((c) => c.name)).toStrictEqual([
+      'load-project',
+      'pick-repository',
+      'tool-claude-code',
+      'persist-suggested-skills',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/refine/flow-shape.test.ts
+++ b/tests/unit/application/flows/refine/flow-shape.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PendingTicket } from '@src/domain/entity/ticket.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { createRefineFlow, type CreateRefineFlowOpts } from '@src/application/flows/refine/flow.ts';
+import type { RefineDeps } from '@src/application/flows/refine/deps.ts';
+
+import { absolutePath, makeDraftSprint, makePendingTicket } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the refine chain. `createRefineFlow` only CONSTRUCTS the element tree here —
+ * no leaf executes — so the deps can be an inert cast: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, which these tests never call (same rationale as the
+ * implement flow-shape fence). This asserts the OBSERVABLE chain shape (the thing the TUI walks to
+ * render the upfront plan) deterministically fails if a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): RefineDeps => ({}) as unknown as RefineDeps;
+
+const makeOpts = (pendingTickets: readonly PendingTicket[]): CreateRefineFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  pendingTickets,
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  refinementRoot: absolutePath('/sprints/s1/refinement'),
+});
+
+describe('createRefineFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order, for a single ticket', () => {
+    const ticket = makePendingTicket({ title: 'do-work' });
+    const id = String(ticket.id);
+
+    expect(names(createRefineFlow(stubDeps(), makeOpts([ticket])))).toStrictEqual([
+      'refine',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'refine-tickets',
+      `refine-${id}`,
+      `fetch-issue-context-${id}`,
+      `build-refine-unit-${id}`,
+      `render-prompt-to-file-${id}`,
+      `install-skills-${id}`,
+      `stamp-meta-refine-${id}`,
+      `refine-ticket-${id}`,
+      `uninstall-skills-${id}`,
+      `save-after-${id}`,
+    ]);
+  });
+
+  it('fans out one refine-<id> sub-chain per pending ticket, in order', () => {
+    const t1 = makePendingTicket({ title: 't1' });
+    const t2 = makePendingTicket({ title: 't2' });
+
+    const top = createRefineFlow(stubDeps(), makeOpts([t1, t2]));
+    const ticketsNode = (top.children ?? []).find((c) => c.name === 'refine-tickets');
+
+    expect((ticketsNode?.children ?? []).map((c) => c.name)).toStrictEqual([
+      `refine-${String(t1.id)}`,
+      `refine-${String(t2.id)}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Multi-session ultracode audit of the full codebase, landing all Critical, High, Medium, Small, and selected Research findings in one branch. 465 test files / 4071 tests green.

### Critical / High (commits 1–4) — already reviewed last session

| ID | What | Where |
|----|------|--------|
| C1 | Cap stdout NDJSON parse buffer at 512 KiB (one-shot warn latch) | `providers/{claude,copilot}/parse-stream.ts` |
| C2 | Replace unbounded Copilot events array with two `BoundedTail` instances | `providers/copilot/headless.ts` |
| H1 | `mountedRef` guard on all async confirm handlers (stale-setState) | 5 TUI views |
| H2 | `attachAbortKill` SIGTERM→SIGKILL path in all interactive adapters | `providers/{claude,copilot,codex}/interactive.ts` |
| H3–H5 | `guard` unit tests, flow-shape DFS fences, distill-learnings de-branding | tests/ + prompt |

### Research

| ID | What |
|----|------|
| R1 | **Loop-diversity guard** in gen-eval loop — detects when the same failure fingerprint repeats 3× consecutive turns and escalates early; budget-exhausted always wins over diversity exit. Research: TIDE arXiv 2602.02196. |
| R5 | **Think-protocol** in evaluate template — `<reasoning_protocol>` block instructs the evaluator to write `<evaluation_thinking>` before emitting a verdict. Research: TIDE/τ-Bench 57% improvement on sequential decision chains. |
| R7 | **`promptTransform` hook** on `HeadlessAiProviderInput` — optional per-provider prompt transform at the port boundary. Research: AgencyBench 48% success gap between native and cross-harness adapters. |

### Medium structural

| ID | What |
|----|------|
| M9 | Readiness fan-out **continue-on-error per provider** — only swallows `probe`/`rate-limit` codes; contract and spawn failures still propagate and fail the run. |
| M10 | Review **cap-exhaustion banner** emitted inside `shouldContinue` (avoids spurious trace entries on normal exit). |
| M11 | Integration tests for **review leaves** — `ensure-feedback-file` (4 cases) and `review-round-contract` (9 cases). |
| M12 | Integration tests for **detect-scripts** (10 cases) and **detect-skills** (11 cases) contracts. |
| M13 | **add-ticket** wired into flow registry and TUI menu via a proper `FlowManifest`. |

### Small fixes

| ID | What |
|----|------|
| M1 | `field-editors.ts` — re-throw `AbortError` in promise `.catch()` handlers |
| M2 | `readiness/template.md` — move `{{HARNESS_CONTEXT}}` outside `<inputs>` |
| M3 | `detect-skills/template.md` — remove duplicate `{{SKILLS_CONVENTION}}` |
| M4 | `plan/template.md` — name the exception to the always-one-task rule |
| M5 | `evaluate-continuation/template.md` — add checkpoint JSON example |
| M6 | `template-signal-coverage.test.ts` — add evaluate-continuation and implement-continuation |
| M7 | `sessions-view.tsx` — adaptive `VISIBLE_ROWS` via `useBreakpoint` instead of hardcoded 10 |
| M8 | j/k nav hints in sessions, projects, sprints, pick-sprint views |
| M14 | `implement-continuation` — wire `DECISIONS_GUIDANCE` partial |
| L1 | `leaf.ts` — `AbortError` caught → `Result.error` with trace status `aborted` |
| L4 | `path-picker-prompt.tsx` — cancellation guard in `readdir` `useEffect` |
| L8 | `codex/headless.ts` — flush partial `stdoutLineBuf` after spawn closes |
| L9 | `run-with-rate-limit-retry.ts` — use loop-var `session.abortSignal` not `opts.session` |

### Deferred (separate sprint)

R2 (formal plateau policy), R3 (multi-checkpoint eval), R4 (episodic memory), R6 (ACON prompt compression) — scoped for the next sprint.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 465 files / 4071 tests passed

https://claude.ai/code/session_01TPmwCSX8HGWTQm7wmq9aAE