### PR TITLE
Harness improvements: gen-eval plateau detection, episodic memory, provider/TUI hardening

### DIFF
--- a/.claude/agent-memory/docs-keeper/project_high_drift_areas.md
+++ b/.claude/agent-memory/docs-keeper/project_high_drift_areas.md
@@ -61,10 +61,26 @@ Based on the P0–P4 harness overhaul audit (2026-05-21), sections that had the 
 **Why:** These areas cluster around the observability/TUI surface, the chain framework primitives,
 and the implement-flow — all of which evolve in every sprint. Items 14–18 specifically from the
 `feat/parallelism-wiring-memory` drop (2026-05-30); items 19–23 from the `ui-ux-stabilization` drop
-(2026-06-03).
+(2026-06-03); items 24–28 from `feature/audit-research-xl` (2026-06-27).
+
+24. **KERNEL-DESIGN.md § implementFlow — gen-eval inner loop body** — each sprint that touches
+    gen-eval-loop.ts will change the evaluator-step sequential. The fence test at
+    `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` is authoritative;
+    always read it before updating the doc.
+25. **WORKFLOWS.md § Per-task generator-evaluator** — prose description of the loop body lags the
+    code. Re-read whenever gen-eval-loop.ts or the evaluator guard changes.
+26. **PERFORMANCE.md § Escalation on plateau** — the plateau signals list grew from 1 to 3 this
+    sprint (count-based + loop-diversity + entropy). Will grow again if new guards are added.
+27. **ARCHITECTURE.md § Flows-and-their-nature table** — `add-ticket` was marked "(no registry)"
+    until the manifest landed. Flow registry rows change when a new flow adds a manifest or an
+    existing flow's triggers change; always diff `registry.ts` before closing.
+28. **ARCHITECTURE.md § business/task layout** — new business-task modules (escalation-policy,
+    loop-diversity, episode composition) added without doc update. Grep `src/business/task/` after
+    any implement-flow or plateau feature.
 
 **How to apply:** On the next feature drop, check these sections first before reading git log. In
 particular, always grep `events.ts` for the AppEvent union (compare to every doc that lists it),
 diff `element.ts` + `trace.ts` against KERNEL-DESIGN.md, re-read CLAUDE.md § Performance &
 Limits after any implement-flow structural change, and grep `StoragePaths` type for new fields after
-any storage-paths change.
+any storage-paths change. Also read the step-order fence test in gen-eval-loop.test.ts before
+updating any gen-eval step-trace description.

--- a/.claude/agent-memory/docs-keeper/reference_step_trace_locations.md
+++ b/.claude/agent-memory/docs-keeper/reference_step_trace_locations.md
@@ -17,3 +17,11 @@ for `onboard` and `create-pr` flows (by name/reference, not full trace), so chec
 
 The canonical source of truth is always `tests/e2e/flows/<flow>.test.ts` — its `describe(...)` / `it(...)` titles and
 asserted trace contain the exact step list.
+
+**Gen-eval inner loop specifically** has its own step-order fence at
+`tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` (not a full e2e test). Two fences there:
+
+- **gen-eval-turn children** (outer sequential): `[resolve-round-num, stamp-meta-generator, stamp-role-meta-generator, generator-<id>, evaluator-guard-<id>]`
+- **evaluator-guard body** (inner sequential `evaluator-step-<id>`): `[stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-<id>, loop-diversity-check-<id>, entropy-check-<id>]`
+
+All three doc locations must reflect this exact order. As of 2026-06-27: KERNEL-DESIGN.md code example and WORKFLOWS.md prose are updated; REQUIREMENTS.md plateau-predicate checkbox names the two new guard leaves.

--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -1,5 +1,8 @@
 # Implementer Memory
 
+- [project_prompt_queue_cancel_vs_abort.md](project_prompt_queue_cancel_vs_abort.md) — TUI prompt-queue esc-cancel
+  & shutdown reject with PLAIN Error (never AbortError), so a blanket `.catch` around prompt promises can safely
+  re-throw AbortError; edit text-prompt seam (use-edit-field) vs field-picker seam (field-editors) are independent
 - [project_slugged_data_layout_resolver.md](project_slugged_data_layout_resolver.md) — human-readable `<id>--<slug>`
   data/ layout: one tolerant id-prefix resolver in storage.ts; direct-build (entity-in-hand) vs resolver (id-only);
   reconcile-on-save (project write-then-delete, sprint rename-then-write); projectSlug threaded for memory ledger;
@@ -63,3 +66,9 @@
 - [project_flows_view_soft_repo_default.md](project_flows_view_soft_repo_default.md) — flows-view launch handler runs a
   dedicated repo-selection step (flows-repository-picker.ts) BEFORE the customize picker; sessionRepositoryId is a
   re-pickable soft default not a hard lock; gate on explicit 3-flow allowlist (detect-scripts/detect-skills/readiness)
+- [project_loop_diversity_budget_precedence.md](project_loop_diversity_budget_precedence.md) — gen-eval loop-diversity
+  guard must not pre-empt the final budgeted turn; budget-exhausted wins over plateau when turnsUsed >= maxTurns (reads
+  readConfig budget, not a captured const)
+- [project_plateau_predicate_count_based.md](project_plateau_predicate_count_based.md) — plateau predicate is
+  failed-dim-COUNT based (not identical-set); critique-shift (Jaccard<0.5) is the lever to keep a multi-turn loop test
+  running; R2 entropy guard reads ctx.lastTurnActionCounts (signal-kind proxy) stamped by generator every turn

--- a/.claude/agent-memory/implementer/project_loop_diversity_budget_precedence.md
+++ b/.claude/agent-memory/implementer/project_loop_diversity_budget_precedence.md
@@ -1,0 +1,29 @@
+---
+name: loop-diversity-budget-precedence
+description: gen-eval loop-diversity guard must NOT pre-empt the final budgeted turn — budget-exhausted wins over plateau when no turns remain
+metadata:
+  type: project
+---
+
+The loop-diversity guard in `src/application/flows/implement/leaves/gen-eval-loop.ts`
+(`loop-diversity-check-<taskId>` leaf, last child of the `evaluator-step-<id>` sequential)
+fingerprints each evaluator turn's failed-dimension set and exits the gen-eval loop via a
+`plateau` exit when the last `DIVERSITY_WINDOW_SIZE` (3) fingerprints are identical.
+
+**Invariant:** a run where every turn fails from the very start (never any progress) must always
+exit as `budget-exhausted`, never `plateau`. The guard reads `ctx.genEvalTurn` (turnsUsed) and
+`deps.readConfig().maxTurns`; when `turnsUsed >= Math.max(1, maxTurns)` it returns
+`shouldExit: false` so `finalize-gen-eval` synthesises the `budget-exhausted` exit instead.
+
+**Why:** when maxTurns == windowSize (e.g. e2e "exhausted budget: every turn fails", maxTurns=3,
+window=3), the diversity collapse fingerprint fills on the final budgeted turn — both budget and
+diversity would fire, but the diversity leaf runs inside the turn body BEFORE the loop's
+`shouldContinue` re-checks budget, so it would set `lastExit: plateau` first and steal the exit.
+The fix: diversity only fires while turns still remain to reclaim via early escalation.
+
+**How to apply:** read the budget from the same `readConfig()` the loop's `shouldContinue` uses
+(not a captured constant) so a runtime config change can't diverge the two. If you ever change the
+diversity-exit kind or add another in-turn terminal guard, preserve this budget-precedence ordering.
+
+Related: [[project_escalation_gate_broadened.md]] (finalize escalation on plateau/budget/malformed),
+[[project_recoverable_turn_error_policy.md]].

--- a/.claude/agent-memory/implementer/project_plateau_predicate_count_based.md
+++ b/.claude/agent-memory/implementer/project_plateau_predicate_count_based.md
@@ -1,0 +1,33 @@
+---
+name: plateau-predicate-count-based
+description: The gen-eval plateau predicate is FAILED-DIMENSION-COUNT based (not identical-set); driving a multi-turn loop test past it needs dissimilar critiques
+metadata:
+  type: project
+---
+
+`computePlateauVerdict` in `business/task/plateau-detection.ts` flags a stall when the failed-dimension
+COUNT never DECREASES across the window AND the current turn still has failures — NOT when the failed SET is
+identical (that was the legacy check). So rotating WHICH single dimension fails each turn does NOT keep the
+evaluator's own plateau quiet: count stays constant (1,1,1) → stall → plateau exit at `threshold` turns.
+
+**Two exemptions, checked in order (only consulted once a stall is detected):**
+
+1. **critique-shift** — current critique's max trigram-Jaccard vs every prior in the window `< 0.5` → returns
+   `{kind:'progress'}`, loop continues. This is the reliable lever to keep a loop running for a test.
+2. **work-product-changed** — `changedFilesHash` differs from every prior in the window → `{kind:'warning'}`,
+   capped at `WARNING_SOFTEN_CAP=2` consecutive softenings, then fires anyway.
+
+**How to apply (test design — `gen-eval-loop.test.ts` R2 entropy tests):** to drive the gen-eval loop across
+N turns WITHOUT any plateau exit firing so a LATER guard (entropy-check) can be exercised in isolation, the
+scripted evaluator must satisfy BOTH:
+
+- ROTATE the single failing floor dim each turn (correctness→completeness→safety→…) so the R1
+  loop-diversity-check fingerprint stays diverse (it joins sorted failed-dim names), AND
+- give a genuinely DISSIMILAR critique each turn (pairwise Jaccard < 0.5 — distinct full sentences, the e2e
+  "exhausted budget" test's technique) so the count-based evaluator plateau is exempted via critique-shift.
+  Empty/stub gitRunner ⇒ identical `changedFilesHash` every turn ⇒ work-product exemption never helps; rely on
+  critique-shift. The R2 entropy guard then fires at turn == `DIVERSITY_WINDOW_SIZE` (3) when generator action
+  entropy is collapsed (single signal kind) and budget remains (`turnsUsed < maxTurns`). See
+  [[project_loop_diversity_budget_precedence]] for the budget-precedence guard that suppresses both diversity
+  guards on the final turn. The entropy guard reads `ctx.lastTurnActionCounts` (signal-kind distribution proxy —
+  the harness never sees raw tool-use), stamped by the generator leaf's output projection every turn.

--- a/.claude/agent-memory/implementer/project_prompt_queue_cancel_vs_abort.md
+++ b/.claude/agent-memory/implementer/project_prompt_queue_cancel_vs_abort.md
@@ -1,0 +1,28 @@
+---
+name: prompt-queue-cancel-vs-abort
+description: TUI prompt-queue esc-cancel/shutdown reject with PLAIN Error, never AbortError — so a blanket .catch around prompt promises can safely re-throw AbortError
+metadata:
+  type: project
+---
+
+The TUI prompt-queue distinguishes user-cancel from chain-abort by error CLASS, and this is what
+makes "re-throw AbortError, swallow the rest" safe in any `.catch` wrapping a prompt promise.
+
+- esc-cancel of a single prompt → `prompt-host.tsx` `rejectHead(new Error('cancelled by user'))` —
+  a PLAIN `Error`, NOT an `AbortError`.
+- TUI shutdown → `launch.ts` `queue.drain(new Error('TUI shutting down'))` — also a plain `Error`.
+- `AbortError` (`src/domain/value/error/abort-error.ts`, code `aborted`) is ONLY the chain-runtime
+  cancellation error; nothing in the prompt path produces it.
+
+**Why:** The project rule "a blanket promise `.catch` MUST re-throw AbortError" (CLAUDE.md) looks
+like it would break the silent esc-cancel-swallow in `use-edit-field.ts`'s blanket catch. It does
+NOT — because esc rejects with a plain Error, `if (cause instanceof AbortError) throw cause; else
+swallow` keeps esc silent while letting a real abort propagate.
+
+**How to apply:** When adding/reviewing a `.catch` around any `queue.enqueue(...)` promise or
+`openEditPrompt(...)` (single-option fast path AND multi-option field-picker in
+`field-editors.ts`), gate the swallow on `instanceof AbortError`. The two seams are independent:
+`use-edit-field.ts` guards the edit TEXT prompt; `field-editors.ts`'s `.catch` guards the field-
+PICKER choice prompt — the latter is NOT made redundant by fixing the former. See
+[[recoverable-turn-error-policy]] for the analogous "Aborted always propagates, recoverable errors
+get handled" split one layer down.

--- a/.claude/agent-memory/implementer/project_provider_stream_parse_oom_caps.md
+++ b/.claude/agent-memory/implementer/project_provider_stream_parse_oom_caps.md
@@ -1,0 +1,39 @@
+---
+name: provider-stream-parse-oom-caps
+description: OOM-hardening of provider stdout stream parsing — STDOUT_LINE_PARSE_CAP on the NDJSON line accumulator in both parsers + bounded forensic/rate-limit tails replacing copilot headless events[]; pure-parser warnings use console.warn one-shot latch (no bus available).
+metadata:
+  type: project
+---
+
+Provider stdout stream parsing had two uncapped accumulators in the same OOM class as the
+PR #229 TUI render-path leak (commit 821f7bff). Both fixed by bounding in `_engine/bounded-tail.ts`.
+
+**The cap constants now living in `_engine/bounded-tail.ts`** (one home so siblings can't drift):
+`STDERR_TAIL_CAP` (16 KiB), `RATE_LIMIT_SCAN_TAIL_CAP` (8 KiB), `STDOUT_LINE_PARSE_CAP` (512 KiB),
+`FORENSIC_BODY_TAIL_CAP` (256 KiB).
+
+**C1 — NDJSON line accumulator (`claude/parse-stream.ts` + `copilot/parse-stream.ts`).** Both grow
+`buffer += chunk` until a newline ends the current line; a single record embedding a large
+file-read / bash result inflated one line to tens of MB. Fix: an `appendCapped(chunk)` closure (the
+SOLE append site — `feed` calls it; `flush` only drains, so the invariant holds there too) that
+trims `buffer` to the tail at `STDOUT_LINE_PARSE_CAP`. Tail-trim (keep last N) so the record's
+terminating `}`/newline still lands in-window when it arrives.
+
+**C2 — copilot `headless.ts` `events[]`.** A `let events: Array<{assistant, text}>` retained every
+stdout line for the whole spawn. The `assistant` boolean tag was VESTIGIAL — neither consumer ever
+filtered on it (signals come from signals.json via the file-based audit-[09] contract, not by
+re-parsing the body). Replaced with two `createBoundedTail`s fed via a `recordLine(text)` helper:
+`forensicTail` (FORENSIC_BODY_TAIL_CAP → body.txt) and `rateLimitTail` (RATE_LIMIT_SCAN_TAIL_CAP →
+classifier haystack). Consumers became `forensicTail.value()` / `rateLimitTail.value()`. Trailing
+`\n` per recorded line differs harmlessly from the old `.join('\n')`.
+
+**Non-obvious: surfacing warnings from a pure-factory parser with no EventBus.** The parsers are
+pure factories (no deps, no bus). Use `console.warn` guarded by a one-shot latch
+(`let overflowWarned = false`) — this is the established project pattern, mirroring
+`integration/observability/in-memory-event-bus.ts` (warn once per instance so a sustained
+condition doesn't itself spam the console). `heap-watchdog.ts` / `broadcast-sink.ts` do the same.
+Do NOT change the parser factory signature to inject a logger — `claude/headless.ts` (a non-owned
+caller) constructs `createClaudeStreamParser()` with no args.
+
+Related OOM-cluster memories: [[project_eventbus_branch_listener_leak]],
+[[project_tui_commit_storm_coalescer]], [[project_ledger_compaction_dedup_asymmetry]].

--- a/.claude/agent-memory/implementer/project_run_scoped_ctx_marker_fences.md
+++ b/.claude/agent-memory/implementer/project_run_scoped_ctx_marker_fences.md
@@ -20,6 +20,16 @@ fails. There are THREE coupled sites:
 silently skip the merge/fork projection. Miss site 2 or 3 and the field is silently dropped in parallel mode
 even though typecheck passed (the guard only forces classification, not correct carry).
 
+**Classification decides how many sites you touch.** Only `SPRINT` (run-scoped) fields need all THREE sites
+(the merge/fork bodies must explicitly carry/spread them). A `PER_TASK` or `SIGNAL_ACCUM` field needs ONLY
+site 1 (the `_exhaustive` map entry) — `mergeImplementWave` and `forkCtx` intentionally OMIT those classes
+(reset to undefined between waves / cleared on fork), so adding the map entry is the whole edit. Example
+(feature/audit-research-xl R2): `lastTurnActionCounts?: ReadonlyMap<string,number>` (per-turn generator
+signal-kind distribution, stamped every generator turn, read by the entropy-plateau guard) → `PER_TASK` → one
+line in the `_exhaustive` map and done. Heads-up: this still forces a touch of `merge-wave.ts` even when your
+task's owned-file list excludes it — adding ANY ctx field breaks the `satisfies` check, so flag it to the
+integrator.
+
 **How to apply:** T13 (feat/gen-eval-speed) added `setupVerifiedRepoIdsThisRun` (run-scoped set of repo ids
 whose setup ran green THIS launch). Set by `setup-script-runner` output projection (only on the fresh green-run
 path — NOT resume-skip, NOT no-script-skip; those successes belong to a prior launch / validate nothing). Read

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -162,7 +162,9 @@ business/
 ├── sprint/            ← createSprint, planSprint, transitionToReview, transitionToDone, …
 ├── sprint/views/      ← read-only views: sprint progress, requirements export, context export
 ├── ticket/            ← addTicket, refineTicket, removeTicket, …
-├── task/              ← createTasks, updateTask, markBlocked, recordEvaluation, …
+├── task/              ← createTasks, updateTask, markBlocked, recordEvaluation,
+│                       escalation-policy (decideEscalation / applyEscalation / computeActionEntropy / detectLowEntropy),
+│                       loop-diversity (createLoopDiversityTracker), composeTaskEpisodes, summariseEpisodes, …
 ├── feedback/          ← applyFeedback (review flow body)
 ├── settings/          ← loadSettings, updateSettings
 ├── version/           ← cli-metadata, version-check, version-checker (npm poll)
@@ -191,6 +193,22 @@ in `domain/repository/<aggregate>/`.
 | `WriteFile` (port) + `FileLocker` (adapter)           | `business/io/` / `integration/io/`  | atomic write helper / `createFileLocker`                                                                                                                                    |
 | `IssueFetcher` / `IssuePusher` / `PullRequestCreator` | `business/scm/`                     | `gh` / `glab` shell wrappers under `integration/scm/`                                                                                                                       |
 | `VersionChecker`                                      | `business/version/`                 | `createNpmVersionChecker` (`integration/version/`)                                                                                                                          |
+
+Shared engine-level helpers (not ports — no interface boundary, but architecturally significant):
+
+- **`attachAbortKill`** (`providers/_engine/abort-kill.ts`) — wires a caller `AbortSignal` to a
+  SIGTERM → grace → SIGKILL kill ladder for `stdio: 'inherit'` (interactive) child processes. Shared
+  by all three interactive adapters so a TUI cancel consistently terminates the AI child regardless of
+  provider.
+- **`BoundedTail` / `createBoundedTail`** (`providers/_engine/bounded-tail.ts`) — rolling tail
+  accumulator with a configurable byte cap. Used by all headless adapters for stderr
+  (`STDERR_TAIL_CAP` = 16 KiB), rate-limit scan windows (`RATE_LIMIT_SCAN_TAIL_CAP` = 8 KiB), and
+  forensic body mirrors (`FORENSIC_BODY_TAIL_CAP` = 256 KiB). The NDJSON line-parse accumulator in
+  the Claude / Copilot stream parsers is also bounded (`STDOUT_LINE_PARSE_CAP` = 512 KiB) — a
+  single large tool-result line can otherwise inflate to tens of MB before a newline clears it.
+- **`compressSection`** (`prompts/_engine/compress-section.ts`) — tail-compresses oversized prompt
+  sections (`PRIOR_PROGRESS` / `PRIOR_LEARNINGS` / `PRIOR_EPISODES`) to at most `SECTION_CHAR_CAP`
+  (4,000) characters, keeping the most-recent tail and prepending a truncation notice.
 
 ## Repository interfaces (`src/domain/repository/`)
 
@@ -300,26 +318,26 @@ are imported by the launcher (`application/ui/shared/launch/<flow>.ts`) or the C
 
 ### Flows and their nature
 
-| Flow id                    | Shape    | CLI command                   | Notes                                                                                        |
-| -------------------------- | -------- | ----------------------------- | -------------------------------------------------------------------------------------------- |
-| `create-sprint`            | chain    | no                            | Interactive prompts; TUI only                                                                |
-| `refine`                   | chain    | no                            | Hands the terminal to the AI CLI; TUI only                                                   |
-| `plan`                     | chain    | no                            | Interactive AI handoff; TUI only                                                             |
-| `ideate`                   | chain    | no                            | Interactive AI handoff; TUI only                                                             |
-| `readiness`                | chain    | no                            | Multi-step with confirm gates; TUI only                                                      |
-| `detect-scripts`           | chain    | no                            | Setup/verify script discovery; TUI only                                                      |
-| `detect-skills`            | chain    | no                            | Skill discovery; TUI only                                                                    |
-| `implement`                | chain    | no                            | Genuinely needs the chain (gen-eval + retry)                                                 |
-| `review`                   | chain    | no                            | Apply-feedback loop; TUI only                                                                |
-| `close-sprint`             | use-case | yes (`sprint close`)          | review → done transition                                                                     |
-| `export-context`           | use-case | yes                           | Render harness-context markdown                                                              |
-| `export-requirements`      | use-case | yes                           | Render approved-ticket requirements markdown                                                 |
-| `create-pr`                | use-case | yes                           | Open PR via `gh` / `glab`, persist URL on execution                                          |
-| `doctor`                   | use-case | yes                           | Environment health check                                                                     |
-| `settings`                 | use-case | yes (`settings show` / `set`) | Per-key read/write                                                                           |
-| `remove-ticket`            | use-case | yes (`ticket remove`)         | Routes via `sprint-detail` view when launched from Flows                                     |
-| `add-ticket` (no registry) | use-case | yes (`ticket add`)            | Sole add-tickets path: CLI + `a` shortcut → `add-ticket` looping wizard; no Flows menu entry |
-| —                          | CLI-only | `runs list` / `runs prune`    | Inspect and prune per-run forensic artifacts                                                 |
+| Flow id               | Shape    | CLI command                   | Notes                                                                                             |
+| --------------------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `create-sprint`       | chain    | no                            | Interactive prompts; TUI only                                                                     |
+| `refine`              | chain    | no                            | Hands the terminal to the AI CLI; TUI only                                                        |
+| `plan`                | chain    | no                            | Interactive AI handoff; TUI only                                                                  |
+| `ideate`              | chain    | no                            | Interactive AI handoff; TUI only                                                                  |
+| `readiness`           | chain    | no                            | Multi-step with confirm gates; TUI only                                                           |
+| `detect-scripts`      | chain    | no                            | Setup/verify script discovery; TUI only                                                           |
+| `detect-skills`       | chain    | no                            | Skill discovery; TUI only                                                                         |
+| `implement`           | chain    | no                            | Genuinely needs the chain (gen-eval + retry)                                                      |
+| `review`              | chain    | no                            | Apply-feedback loop; TUI only                                                                     |
+| `close-sprint`        | use-case | yes (`sprint close`)          | review → done transition                                                                          |
+| `export-context`      | use-case | yes                           | Render harness-context markdown                                                                   |
+| `export-requirements` | use-case | yes                           | Render approved-ticket requirements markdown                                                      |
+| `create-pr`           | use-case | yes                           | Open PR via `gh` / `glab`, persist URL on execution                                               |
+| `doctor`              | use-case | yes                           | Environment health check                                                                          |
+| `settings`            | use-case | yes (`settings show` / `set`) | Per-key read/write                                                                                |
+| `remove-ticket`       | use-case | yes (`ticket remove`)         | Routes via `sprint-detail` view when launched from Flows                                          |
+| `add-ticket`          | use-case | yes (`ticket add`)            | TUI Flows menu (draft sprints) + `a` shortcut (Home / sprint detail); backs `ralphctl ticket add` |
+| —                     | CLI-only | `runs list` / `runs prune`    | Inspect and prune per-run forensic artifacts                                                      |
 
 CLI surface is deliberately smaller than v0.6.x — the interactive chains stay TUI-only by design. Run
 `ralphctl <command> --help` for flag-level detail on the CLI commands.
@@ -445,6 +463,13 @@ and the non-obvious mutators.
   planner's per-task grading rubric beyond the four floor dimensions (Correctness / Completeness / Safety /
   Consistency). Optional `maxAttempts` overrides the global cap. Optional `escalatedFromModel` /
   `escalatedToModel` are stamped on first plateau-escalation.
+- **`TaskEpisode`** (`src/domain/repository/episode/episode-types.ts`) — an in-memory value type (no
+  on-disk persistence in this release) capturing the outcome of one settled task: `taskId`, `sprintId`,
+  `goal`, `outcome` (`success | partial | blocked | abandoned`), `keyLearnings`, `timestamp`. Derived
+  in-memory from settled siblings by `composeTaskEpisodes` (`business/task/`) and rendered to a compact
+  markdown bullet list by `summariseEpisodes`; the result populates `{{PRIOR_EPISODES}}` in the
+  implement prompt so a later task can orient on what an earlier sprint task solved or got blocked on.
+  Cross-sprint persistence is explicitly future work.
 - **`Settings`** — declared by `SettingsSchema` in `domain/entity/settings.ts`. Top-level fields:
   `schemaVersion` (currently `2`), `ai`,
   `harness: { maxTurns, maxAttempts, rateLimitRetries, plateauThreshold, escalateOnPlateau, escalationMap, skipPreVerifyOnFreshSetup }`,

--- a/.claude/docs/KERNEL-DESIGN.md
+++ b/.claude/docs/KERNEL-DESIGN.md
@@ -138,10 +138,14 @@ Semantics:
 - Body failure (`Result.isErr`) ends the loop with the failure wrapped.
 
 `loop` is used twice in the implement flow. The inner `loop('gen-eval-<id>')` body is a `sequential` of
-`generator-leaf → guarded evaluator-leaf`; it continues until the generator/evaluator sets a terminal exit on
-ctx (`ctx.lastExit`) or the `maxTurns` budget is reached. An outer `loop('task-attempts-<id>')` re-runs the
-whole attempt segment (`start-attempt → … → settle-attempt → progress-journal`) until the task settles
-`done`/`blocked` or `task.maxAttempts` fires.
+`generator-leaf → guarded evaluator-step`; the evaluator step is itself a `sequential` of
+`evaluatorLeaf → loopDiversityCheckLeaf → entropyCheckLeaf`. The two check leaves each emit a `plateau`
+exit on ctx when they detect stagnation — `loop-diversity-check` when the failed-dimension fingerprint
+repeats for `DIVERSITY_WINDOW_SIZE` (3) consecutive turns, `entropy-check` when the normalised Shannon
+entropy over the generator's per-turn signal-kind distribution collapses below a threshold (secondary,
+softer signal). The loop exits when any leaf sets `ctx.lastExit` or the `maxTurns` budget is reached.
+An outer `loop('task-attempts-<id>')` re-runs the whole attempt segment (`start-attempt → … →
+settle-attempt → progress-journal`) until the task settles `done`/`blocked` or `task.maxAttempts` fires.
 
 ## guard — predicate-skipped body
 
@@ -278,10 +282,18 @@ const perTask = sequential('task-<id>', [
         'gen-eval-<id>',
         sequential('gen-eval-turn-<id>', [
           generatorLeaf, // writes rounds/<N>/generator/prompt.md before spawn
-          guard('evaluator-guard-<id>', (ctx) => ctx.lastExit === undefined, evaluatorLeaf),
-        ]), // evaluator writes rounds/<N>/evaluator/prompt.md before spawn
+          guard(
+            'evaluator-guard-<id>',
+            (ctx) => ctx.lastExit === undefined,
+            sequential('evaluator-step-<id>', [
+              evaluatorLeaf, // writes rounds/<N>/evaluator/prompt.md before spawn
+              loopDiversityCheckLeaf, // exits 'plateau' when failed-dimension fingerprint repeats
+              entropyCheckLeaf, // exits 'plateau' when signal-kind entropy collapses (secondary)
+            ])
+          ),
+        ]),
         {
-          shouldContinue: (ctx, i) => i <= settings.harness.maxTurns, // re-read each turn so a mid-run edit applies
+          shouldContinue: (ctx, i) => ctx.lastExit === undefined && i <= settings.harness.maxTurns,
           shouldStop: (ctx) => ctx.lastExit !== undefined,
         }
       ),

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -78,6 +78,25 @@ required. The only path that resets a task to `todo` is `task unblock`.
   `maxTurns` 1–2 was valid before the invariant, and a parse failure would brick the TUI and the
   `settings set` repair command on upgrade.
 
+Two additional plateau signals fire _inside_ each gen-eval turn via dedicated guard leaves, without
+waiting for the `plateauThreshold` count:
+
+- **`loop-diversity-check`** (`src/business/task/loop-diversity.ts`) — tracks a rolling window of
+  failed-dimension fingerprints (sorted set of failing dimension names joined by `|`). When the last
+  `DIVERSITY_WINDOW_SIZE` (3) fingerprints are identical the loop exits with `plateau`, letting the
+  escalation ladder intervene earlier than the count-based predicate would. Tracker state resets at
+  each new attempt so fingerprints do not leak across attempts.
+- **`entropy-check`** — computes normalised Shannon entropy (`H = -Σ(p·log₂p)/log₂K`) over the
+  generator's per-turn signal-kind distribution (decision / change / learning / note counts stamped
+  on `ctx.lastTurnActionCounts` by the generator leaf). When `H < 0.25` (the agent concentrated
+  its actions on one kind), the loop exits with `plateau`. **Honesty:** this is a
+  _signal-kind-distribution proxy_ for action diversity — the harness never sees raw tool-use, so
+  the spread of reported signal kinds stands in for "action variety." It is a secondary, softer signal
+  to the fingerprint guard and does not fire on the first `DIVERSITY_WINDOW_SIZE` turns or when
+  another exit is already pending. Both guards respect the budget-precedence invariant: when the
+  current turn is the final budgeted turn, `finalize` synthesises the terminal state rather than an
+  early plateau pre-empting it.
+
 Mirrored on `IterationConfig` (`src/application/chain/run/iteration-config.ts`); the chain `loop` predicates
 and the headless provider adapter read it.
 
@@ -175,6 +194,15 @@ and the next attempt's append heals the file.
 
 **Per-round artifacts.** Generator and evaluator prompts land at `rounds/<N>/{generator,evaluator}/prompt.md`
 before each spawn; `settle-attempt-leaf` writes `rounds/<N>/outcome.md` after settlement.
+
+**Oversized prior-context section compression.** `PRIOR_PROGRESS`, `PRIOR_LEARNINGS`, and `PRIOR_EPISODES`
+are tail-compressed to at most `SECTION_CHAR_CAP` (4,000) characters each before prompt substitution
+(`src/integration/ai/prompts/_engine/compress-section.ts`). When a section overflows, the oldest bytes are
+dropped and a one-line notice is prepended at the truncation boundary so the model sees where content was
+omitted. Keeping the _most-recent_ tail follows the "Lost in the Middle" finding (Liu et al.,
+arXiv 2307.03172): LLMs attend poorly to content placed in the middle of long contexts, so
+pushing task-critical sections (goal, success-criteria, output contract) toward the middle is the
+failure mode being avoided. The harness already applies the same principle to stderr via `BoundedTail`.
 
 **AI signal routing.** `<change>` / `<decision>` / `<learning>` / `<note>` signals accumulate per-attempt on the
 implement ctx (`ctx.currentAttempt{Changes,Decisions,Learnings,Notes}`) as the generator / evaluator leaves parse them;

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -161,6 +161,13 @@ Status flow: `draft → planned → active → review → done`.
       loop with a plateau warning after `settings.harness.plateauThreshold` (2–5, default 3) rounds.
       A critique-Jaccard shift or a genuine work-product (changed-files-hash) change exempts a round; a
       commit-subject-only reword of an unchanged work-product no longer softens the plateau.
+      Two additional plateau signals fire inside each gen-eval turn without waiting for the threshold count:
+      (a) `loop-diversity-check` exits with `plateau` when the failed-dimension fingerprint repeats for
+      `DIVERSITY_WINDOW_SIZE` (3) consecutive turns (`business/task/loop-diversity.ts`); (b) `entropy-check`
+      exits with `plateau` when the normalised Shannon entropy over the generator's per-turn signal-kind
+      distribution (decision / change / learning / note counts) falls below 0.25 — a signal-kind-distribution
+      proxy for approach stagnation, not raw tool-use entropy. Both guards respect the turn-budget-precedence
+      invariant and only fire when no other exit is already pending.
 - [x] **Token-usage event** — `TokenUsageEvent` emitted once per spawn (model, context window,
       input/output, cache tokens). TUI `TokenBudgetCard` subscribes.
 - [x] **Per-round artifacts** — generator and evaluator prompts written to
@@ -169,6 +176,10 @@ Status flow: `draft → planned → active → review → done`.
 - [x] **Decision capture** — AI-emitted `<decision>` tags accumulate per-attempt on the implement ctx and
       render as the `### Decisions` subsection of each `progress.md` journal entry (audit-[07] retired the
       standalone `decisions.log` sink).
+- [x] **Episodic task memory** — earlier settled siblings (done / blocked) within the same sprint populate
+      `{{PRIOR_EPISODES}}` in the generator prompt via `composeTaskEpisodes` (derives in-memory from
+      `tasks.json`, no new persistence) and `summariseEpisodes` (compact markdown bullet list, up to 5 most
+      recent). In-sprint only in this release; cross-sprint persistence is future work.
 - [x] **Notifications** — terminal bell + macOS `osascript` fire on attention events when
       `settings.ui.notifications.enabled` is `true` (default).
 

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -37,12 +37,20 @@ every ticket `approved`; repo selection runs inside the chain and persists on `S
 (absolute paths); AI generates `tasks.json` atomically and the sprint transitions `draft → planned`.
 **Ideate** combines both in a single AI session for low-stakes work.
 
-**Per-task generator-evaluator** inside `implement` uses the `loop` primitive. The gen-eval loop body is
-`generator-leaf → evaluator-leaf` (looped up to `maxTurns` per attempt, stopping when the evaluator sets
-`ctx.lastExit`). Each attempt then runs `settle-attempt` (which records the verdict) plus `append-learnings`
-and `progress-journal`; the outer attempt loop re-enters up to `maxAttempts` times per task and transitions
-the task to `blocked` once that budget is exhausted. A single launch now runs the outer attempt loop up to
-`maxAttempts` times per task — `maxAttempts === 1` is byte-for-byte the prior single-attempt behaviour.
+**Per-task generator-evaluator** inside `implement` uses the `loop` primitive. Each gen-eval turn runs
+`generator-leaf` then — if the generator did not already set `ctx.lastExit` — the guarded
+`evaluator-step`, a `sequential` of `evaluatorLeaf → loop-diversity-check → entropy-check`. The two
+plateau-check leaves each emit a `plateau` exit on ctx without waiting for the full `plateauThreshold`
+count: `loop-diversity-check` fires when the failed-dimension fingerprint repeats for 3 consecutive
+turns; `entropy-check` fires when the normalised Shannon entropy over the generator's per-turn signal-kind
+distribution (decision / change / learning / note) falls below 0.25 — a heuristic proxy for approach
+stagnation, not raw tool-use entropy. Both respect the turn-budget-precedence guard so neither
+pre-empts the final budgeted turn. The loop exits when any leaf sets `ctx.lastExit` or the `maxTurns`
+budget is reached. Each attempt then runs `settle-attempt` (which records the verdict) plus
+`append-learnings` and `progress-journal`; the outer attempt loop re-enters up to `maxAttempts` times
+per task and transitions the task to `blocked` once that budget is exhausted. A single launch runs the
+outer attempt loop up to `maxAttempts` times per task — `maxAttempts === 1` is byte-for-byte the prior
+single-attempt behaviour.
 `settings.ai.implement` is a nested
 `{ generator, evaluator }` pair — each role carries its own `{ provider, model, effort? }` row, so
 the two sessions can run on different providers / models / effort levels (effort resolution rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,65 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Two earlier-exit plateau signals in the gen-eval loop.** The inner generator-evaluator loop now
+  has two additional plateau guard leaves that fire without waiting for the full `plateauThreshold`
+  count. `loop-diversity-check` exits with `plateau` when the failed-dimension fingerprint repeats
+  for 3 consecutive turns — a more reliable break signal than the turn budget alone. `entropy-check`
+  exits when the normalised Shannon entropy over the generator's per-turn signal-kind distribution
+  (decision / change / learning / note) collapses below 0.25 — a heuristic proxy for approach
+  stagnation. Both guards respect the turn-budget-precedence invariant (they never pre-empt the
+  final budgeted turn) and route through the same escalation ladder as the existing plateau signal.
+
+- **Episodic task memory in the implement prompt.** Earlier settled tasks within the same sprint now
+  populate `{{PRIOR_EPISODES}}` in the generator prompt. The harness derives these in-memory from
+  the settled siblings already in `tasks.json` — no new persistence — and renders them as a compact
+  bullet list (up to 5 most recent) so a later task can orient on what an earlier task already
+  solved or got blocked on. In-sprint only in this release; cross-sprint persistence is future work.
+
+- **`add-ticket` flow registered in the flow registry.** The add-ticket wizard is now a first-class
+  `FlowManifest` entry wired into `flowRegistry`, so it appears in the TUI Flows menu for draft
+  sprints. The `a` shortcut (Home / sprint detail) and `ralphctl ticket add` CLI command are
+  unchanged.
+
+- **Oversized prior-context section compression.** `PRIOR_PROGRESS`, `PRIOR_LEARNINGS`, and
+  `PRIOR_EPISODES` are tail-compressed to at most 4,000 characters each before prompt substitution,
+  keeping the most-recent content. A one-line truncation notice is prepended at the boundary so
+  the model sees where content was omitted.
+
+- **Evaluator reasoning phase and per-criterion checkpoint protocol.** The evaluate prompt now
+  opens with a structured reasoning phase and steps the model through each criterion with an
+  explicit checkpoint before producing its verdict, improving grading consistency and reducing
+  ungrounded pass/fail decisions.
+
 ### Fixed
+
+- **Provider stdout parse-buffer OOM caps.** A single large tool-result line embedded in the AI's
+  NDJSON output stream could inflate the in-flight line-parse accumulator to tens of MB before
+  a newline cleared it — an OOM-class accumulation on long-running sessions. The Claude and Copilot
+  stream parsers now trim the oldest bytes back to 512 KiB when the unterminated line crosses that
+  cap. Forensic body mirrors (Copilot's `body.txt`) are bounded to 256 KiB per spawn.
+
+- **AbortSignal kill path wired to all interactive AI sessions.** The three interactive adapters
+  (claude / copilot / codex) now share `attachAbortKill`, which hooks the caller's `AbortSignal` to
+  a SIGTERM → grace → SIGKILL ladder for `stdio: 'inherit'` children. Previously a TUI cancel had
+  no lever against an interactive session once `run()` returned — the child continued until natural
+  completion, stranding the repo lock.
+
+- **`AbortError` surfaces as `'aborted'` trace status in the chain leaf.** A thrown `AbortError`
+  from inside a leaf's `useCase.execute()` now produces a `TraceEntry` with `status: 'aborted'`
+  (and propagates as a chain error) rather than `'failed'`, so the TUI and trace consumers can
+  distinguish user-initiated cancellation from genuine failures.
+
+- **Readiness continue-on-error for provider-specific failures.** A readiness probe filesystem
+  error or a CLI rate-limit exhaustion for one provider now emits a warn banner and lets the
+  remaining providers complete their setup. Domain contract errors, global I/O failures, and
+  operator `AbortError` still propagate and fail the run.
+
+- **Review round-cap banner.** When the review loop exhausts its `maxRounds` (50) failsafe without
+  a human terminal decision, it now publishes a warn banner explaining why the sprint stayed in
+  `review` and how to resume, rather than stopping silently.
 
 - **TUI out-of-memory on long implement runs.** Long sprints (80+ min) could exhaust the V8 heap
   and crash the TUI. A second round of the commit-storm fix coalesces the remaining hot event-bus

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -186,7 +186,7 @@ const BUSINESS_SIBLINGS = [
   'version',
 ] as const;
 
-const REPOSITORY_SIBLINGS = ['project', 'settings', 'sprint', 'task'] as const;
+const REPOSITORY_SIBLINGS = ['episode', 'project', 'settings', 'sprint', 'task'] as const;
 
 const PROVIDERS = ['claude', 'codex', 'copilot'] as const;
 

--- a/src/application/chain/build/leaf.ts
+++ b/src/application/chain/build/leaf.ts
@@ -56,6 +56,11 @@ export const leaf = <TCtx, UInput, UOutput>(
       } catch (cause) {
         if (!isDomainError(cause)) throw cause;
         const durationMs = performance.now() - start;
+        if (cause instanceof AbortError) {
+          const entry: TraceEntry = { elementName: name, ...labelExt, status: 'aborted', durationMs, error: cause };
+          onTrace?.(entry);
+          return Result.error({ error: cause, trace: [entry] });
+        }
         const entry: TraceEntry = { elementName: name, ...labelExt, status: 'failed', durationMs, error: cause };
         onTrace?.(entry);
         return Result.error({ error: cause, trace: [entry] });

--- a/src/application/flows/add-ticket/manifest.ts
+++ b/src/application/flows/add-ticket/manifest.ts
@@ -1,0 +1,9 @@
+import type { FlowManifest } from '@src/application/registry.ts';
+
+export const ticketAddManifest: FlowManifest = {
+  id: 'add-ticket',
+  title: 'Add ticket',
+  description: 'Append a pending ticket to the current sprint.',
+  canBackground: false,
+  triggers: { currentSprintStatus: ['draft'] },
+};

--- a/src/application/flows/implement/ctx.ts
+++ b/src/application/flows/implement/ctx.ts
@@ -72,6 +72,16 @@ export interface ImplementCtx {
    * Reset implicitly per task: a fresh `currentTask` starts with an empty array.
    */
   readonly plateauHistory?: readonly PlateauTurnRecord[] | undefined;
+  /**
+   * Per-turn distribution of generator-emitted signal kinds (`decision` / `change` / `learning` /
+   * `note`) for the turn just completed — only kinds with a non-zero count are present. Stamped by
+   * the generator leaf on every turn and consumed by the entropy-plateau heuristic in the
+   * gen-eval loop (`entropy-check-<id>`) as a SIGNAL-KIND-DISTRIBUTION proxy for action entropy:
+   * the harness never sees the AI's raw tool-use, so the spread of reported signal kinds stands in
+   * for "action diversity". Run-scoped to the CURRENT turn (overwritten every generator turn), so it
+   * never accumulates across turns. A secondary/softer signal to the fingerprint-repetition guard.
+   */
+  readonly lastTurnActionCounts?: ReadonlyMap<string, number> | undefined;
   readonly lastExit?: GenEvalExit | undefined;
   readonly lastVerdict?: RunTaskVerdict | undefined;
   readonly lastBlockReason?: string | undefined;

--- a/src/application/flows/implement/leaves/gen-eval-loop.ts
+++ b/src/application/flows/implement/leaves/gen-eval-loop.ts
@@ -1,3 +1,4 @@
+import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { HarnessSignalSink } from '@src/business/observability/harness-signal-sink.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -10,8 +11,13 @@ import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { guard } from '@src/application/chain/build/guard.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
 import { loop } from '@src/application/chain/build/loop.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
+import { computeActionEntropy, detectLowEntropy } from '@src/business/task/escalation-policy.ts';
+import { createLoopDiversityTracker } from '@src/business/task/loop-diversity.ts';
+import { failedDimensions } from '@src/business/task/plateau-detection.ts';
+import type { PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { evaluatorLeaf } from '@src/application/flows/implement/leaves/evaluator.ts';
 import { generatorLeaf } from '@src/application/flows/implement/leaves/generator.ts';
@@ -123,6 +129,186 @@ export const createGenEvalLoop = (
     ...(opts.evaluator.effort !== undefined ? { effort: opts.evaluator.effort } : {}),
   };
 
+  // ---------------------------------------------------------------------------
+  // Loop-diversity guard
+  //
+  // Tracks a rolling fingerprint of each evaluator turn's failed-dimension set via the
+  // canonical `createLoopDiversityTracker`. A gen-eval loop that re-emits the identical
+  // failed-dimension fingerprint round after round has plateaued — detecting that
+  // repetition is a more reliable break signal than waiting out the turn budget — so on
+  // collapse we exit via a plateau exit and let the escalation policy climb the model
+  // ladder or apply a change-of-approach nudge.
+  //
+  // State is closure-scoped to this element instance; `lastAttemptCount` re-creates the
+  // tracker at each new attempt boundary so fingerprints don't leak across attempts.
+  // ---------------------------------------------------------------------------
+  const DIVERSITY_WINDOW_SIZE = 3;
+  let lastAttemptCount = -1;
+  let diversityTracker = createLoopDiversityTracker(DIVERSITY_WINDOW_SIZE);
+
+  interface DiversityCheckInput {
+    readonly latestRecord: PlateauTurnRecord | undefined;
+    readonly alreadyExiting: boolean;
+    readonly attemptCount: number;
+    /** Turn just completed (`ctx.genEvalTurn`) — compared against the budget so the guard never pre-empts the final turn. */
+    readonly turnsUsed: number;
+  }
+
+  interface DiversityCheckOutput {
+    readonly shouldExit: boolean;
+    readonly dimensions?: readonly string[];
+  }
+
+  const loopDiversityCheckLeaf = leaf<ImplementCtx, DiversityCheckInput, DiversityCheckOutput>(
+    `loop-diversity-check-${String(taskId)}`,
+    {
+      useCase: {
+        execute: async (input) => {
+          // Reset per attempt so history from a prior attempt doesn't carry over — a fresh
+          // tracker is the per-attempt reset (the old buffer is dropped with the prior tracker).
+          if (input.attemptCount !== lastAttemptCount) {
+            lastAttemptCount = input.attemptCount;
+            diversityTracker = createLoopDiversityTracker(DIVERSITY_WINDOW_SIZE);
+          }
+
+          // Skip when the evaluator already set a terminal exit this turn, or when the
+          // evaluator did not run (generator self-blocked — latestRecord is undefined).
+          if (input.alreadyExiting || input.latestRecord === undefined) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Fingerprint = sorted set of currently-failed dimension names joined by '|'.
+          // A passing evaluation (all dimensions green) has no failed dimensions → no
+          // fingerprint → no diversity record (the loop would exit via 'passed' anyway).
+          const failed = failedDimensions(input.latestRecord.evaluation);
+          if (failed.size === 0) return Result.ok({ shouldExit: false });
+
+          const fingerprint = [...failed].sort().join('|');
+          diversityTracker.record(fingerprint);
+          if (diversityTracker.isDiverse()) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Budget exhaustion takes precedence. When this was the final turn the loop would run
+          // anyway (turnsUsed === budget), there is no remaining budget for an early escalation
+          // to reclaim — the truthful terminal state is `budget-exhausted`, so let `finalize`
+          // synthesise it instead of pre-empting it with a `plateau`. This preserves the
+          // invariant that a run where every turn fails from the very start (never any progress)
+          // always exits as `budget-exhausted`. Read the same `readConfig` budget the loop's
+          // `shouldContinue` uses so a runtime config change can't diverge the two.
+          const { maxTurns } = await deps.readConfig();
+          if (input.turnsUsed >= Math.max(1, maxTurns)) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          // Diversity collapsed — the generator has repeated the exact same failure pattern
+          // for the last DIVERSITY_WINDOW_SIZE turns without any approach change. Surface a
+          // warn banner and exit the loop so the escalation ladder can intervene.
+          deps.eventBus.publish({
+            type: 'banner-show',
+            id: `loop-diversity-${String(taskId)}`,
+            tier: 'warn',
+            message: 'Generator is repeating the same approach — escalating',
+            cause: 'loop-diversity-exhausted',
+            at: deps.clock(),
+          });
+
+          return Result.ok({ shouldExit: true, dimensions: [...failed] });
+        },
+      },
+      input: (ctx) => {
+        const history = ctx.plateauHistory;
+        const latestRecord = history !== undefined && history.length > 0 ? history[history.length - 1] : undefined;
+        return {
+          latestRecord,
+          alreadyExiting: ctx.lastExit !== undefined,
+          attemptCount: ctx.currentTask?.attempts.length ?? 0,
+          turnsUsed: ctx.genEvalTurn ?? 0,
+        };
+      },
+      output: (ctx, out) => {
+        if (!out.shouldExit || out.dimensions === undefined) return ctx;
+        return { ...ctx, lastExit: { kind: 'plateau', dimensions: out.dimensions } };
+      },
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Entropy-check guard (R2)
+  //
+  // Computes normalised Shannon entropy over the distribution of the generator's
+  // emitted signal KINDS this turn (decision / change / learning / note), read from
+  // `ctx.lastTurnActionCounts` (stamped by the generator leaf). Low entropy (< 0.25 by
+  // default) means the generator concentrated its reported actions on a single kind —
+  // a leading indicator of a plateau.
+  //
+  // HONESTY: this is a SIGNAL-KIND-DISTRIBUTION PROXY for action entropy — the harness
+  // never sees the AI's raw tool-use, so the spread of reported signal kinds stands in
+  // for "action diversity". It is a SECONDARY / softer signal to the R1 fingerprint-
+  // repetition guard (loop-diversity-check) above, and the budget-precedence guard keeps
+  // it from ever pre-empting the final budgeted turn.
+  // ---------------------------------------------------------------------------
+  interface EntropyCheckInput {
+    /** Per-kind action counts for the current turn. Undefined when the generator stamped none. */
+    readonly actionCounts: Map<string, number> | undefined;
+    readonly alreadyExiting: boolean;
+    readonly turnsUsed: number;
+  }
+
+  interface EntropyCheckOutput {
+    readonly shouldExit: boolean;
+  }
+
+  const entropyCheckLeaf = leaf<ImplementCtx, EntropyCheckInput, EntropyCheckOutput>(
+    `entropy-check-${String(taskId)}`,
+    {
+      useCase: {
+        execute: async (input) => {
+          // No signal-kind distribution stamped this turn (round 1 before any generator turn, or a
+          // turn that emitted zero narrative signals) — no evidence of low entropy, so no-op.
+          if (input.actionCounts === undefined) return Result.ok({ shouldExit: false });
+          // Skip when another exit is already pending or insufficient turns have elapsed.
+          if (input.alreadyExiting || input.turnsUsed < DIVERSITY_WINDOW_SIZE) {
+            return Result.ok({ shouldExit: false });
+          }
+          // Budget-precedence guard: if this was the final allowed turn, let finalize
+          // synthesise the budget-exhausted exit rather than pre-empting it with a plateau.
+          const { maxTurns } = await deps.readConfig();
+          if (input.turnsUsed >= Math.max(1, maxTurns)) {
+            return Result.ok({ shouldExit: false });
+          }
+
+          const entropy = computeActionEntropy(input.actionCounts);
+          if (!detectLowEntropy(entropy)) return Result.ok({ shouldExit: false });
+
+          deps.eventBus.publish({
+            type: 'banner-show',
+            id: `entropy-plateau-${String(taskId)}`,
+            tier: 'warn',
+            message: `Generator action entropy collapsed (H=${entropy.toFixed(2)}) — escalating`,
+            cause: 'low-action-entropy',
+            at: deps.clock(),
+          });
+
+          return Result.ok({ shouldExit: true });
+        },
+      },
+      input: (ctx): EntropyCheckInput => ({
+        // SIGNAL-KIND-DISTRIBUTION proxy for action entropy: read the generator leaf's per-turn
+        // `lastTurnActionCounts` (decision/change/learning/note spread for the turn just completed).
+        // Copy into a mutable `Map` for `computeActionEntropy`; undefined when nothing was stamped.
+        actionCounts: ctx.lastTurnActionCounts !== undefined ? new Map(ctx.lastTurnActionCounts) : undefined,
+        alreadyExiting: ctx.lastExit !== undefined,
+        turnsUsed: ctx.genEvalTurn ?? 0,
+      }),
+      output: (ctx, out) => {
+        if (!out.shouldExit) return ctx;
+        // Re-use the plateau exit kind so the escalation ladder applies the same remedy.
+        return { ...ctx, lastExit: { kind: 'plateau', dimensions: [] } };
+      },
+    }
+  );
+
   return loop<ImplementCtx>(
     `gen-eval-${String(taskId)}`,
     sequential<ImplementCtx>(`gen-eval-turn-${String(taskId)}`, [
@@ -169,6 +355,8 @@ export const createGenEvalLoop = (
             taskId
           ),
           evaluatorLeaf(evaluatorLeafDeps, taskId),
+          loopDiversityCheckLeaf,
+          entropyCheckLeaf,
         ])
       ),
     ]),

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -34,6 +34,8 @@ import { implementSession } from '@src/application/flows/implement/leaves/implem
 import { generatorOutputContract } from '@src/application/flows/implement/leaves/generator.contract.ts';
 import { escalationBannerId } from '@src/business/task/escalation-policy.ts';
 import { composeDimensionTrajectory } from '@src/business/task/dimension-trajectory.ts';
+import { composeTaskEpisodes } from '@src/business/task/compose-task-episodes.ts';
+import { summariseEpisodes } from '@src/business/task/episode-summary.ts';
 import { composePriorLearnings } from '@src/application/flows/_shared/memory/compose-prior-learnings.ts';
 import {
   readRoundSessionId,
@@ -168,6 +170,14 @@ interface GeneratorInput {
    * already carries it in-conversation, so threading it again would be redundant context.
    */
   readonly priorLearnings?: string;
+  /**
+   * Pre-composed `<prior_task_episodes>` block (R4, read side) — a compact summary of this sprint's
+   * already-settled sibling tasks (done / blocked), built in the input projection from `ctx.tasks`
+   * via `composeTaskEpisodes` + `summariseEpisodes`. Mirrors {@link priorLearnings}: rides ONLY the
+   * FULL implement prompt (round 1 of a session thread); a resumed continuation already carries it
+   * in-conversation. Empty when no sibling task has settled yet → the prompt slot collapses cleanly.
+   */
+  readonly priorEpisodes?: string;
 }
 
 interface GeneratorOutput {
@@ -209,6 +219,21 @@ interface GeneratorOutput {
    */
   readonly notesEmitted: readonly string[];
 }
+
+/**
+ * Per-turn signal-kind distribution (R2) for the entropy-plateau heuristic — only kinds the
+ * generator actually emitted this turn (count > 0). Built fresh from the turn's accumulators so the
+ * stamped map reflects ONLY the current turn, never an accumulation across turns. The harness never
+ * sees the AI's raw tool-use, so this signal-kind spread is the proxy the entropy guard reads.
+ */
+const countTurnActionKinds = (out: GeneratorOutput): Map<string, number> => {
+  const counts = new Map<string, number>();
+  if (out.decisionsEmitted.length > 0) counts.set('decision', out.decisionsEmitted.length);
+  if (out.changesEmitted.length > 0) counts.set('change', out.changesEmitted.length);
+  if (out.learningsEmitted.length > 0) counts.set('learning', out.learningsEmitted.length);
+  if (out.notesEmitted.length > 0) counts.set('note', out.notesEmitted.length);
+  return counts;
+};
 
 /**
  * Read the current `progress.md` body to inline into the prompt, CAPPED to the sprint header,
@@ -287,6 +312,12 @@ const buildGeneratorPrompt = async (
      */
     readonly priorLearnings: string;
     /**
+     * Pre-composed prior-episodes block (R4) — threaded into the FULL implement prompt's
+     * `priorEpisodes` slot only when non-empty. Ignored on the continuation branch (the resumed
+     * thread already carries it), exactly like `priorLearnings`.
+     */
+    readonly priorEpisodes: string;
+    /**
      * Pre-rendered `<pre_verify_results>` body — the current attempt's harness pre-verify run +
      * log tail (T4). Empty string when no pre-verify ran. Passed through to the builder's
      * `preVerifyOutput` slot only when non-empty so the placeholder collapses cleanly otherwise.
@@ -313,6 +344,8 @@ const buildGeneratorPrompt = async (
   const trajectoryCarry = args.dimensionTrajectory.length > 0 ? { dimensionTrajectory: args.dimensionTrajectory } : {};
   // Prior-learnings rides ONLY the full prompt (continuation already carries it in-conversation).
   const priorLearningsCarry = args.priorLearnings.length > 0 ? { priorLearnings: args.priorLearnings } : {};
+  // Prior-episodes (R4) rides ONLY the full prompt — same rule as prior-learnings.
+  const priorEpisodesCarry = args.priorEpisodes.length > 0 ? { priorEpisodes: args.priorEpisodes } : {};
 
   if (args.priorGeneratorSessionId === undefined) {
     return buildImplementPrompt(deps.templateLoader, {
@@ -327,6 +360,7 @@ const buildGeneratorPrompt = async (
       ...(plateauBreak ? { plateauBreak: true } : {}),
       ...trajectoryCarry,
       ...priorLearningsCarry,
+      ...priorEpisodesCarry,
       ...preVerifyCarry,
       ...retryFeedbackCarry,
     });
@@ -479,6 +513,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
             priorGeneratorSessionId: input.priorGeneratorSessionId,
             dimensionTrajectory: input.dimensionTrajectory ?? '',
             priorLearnings: input.priorLearnings ?? '',
+            priorEpisodes: input.priorEpisodes ?? '',
             preVerifyOutput,
             retryFeedback,
           });
@@ -663,6 +698,9 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
       // Cross-sprint procedural memory (principle 3) loaded once by the prologue's `load-learnings`.
       // Pure ctx read; '' when the ledger was absent/empty so the prompt placeholder collapses.
       const priorLearnings = composePriorLearnings(ctx.priorLearnings ?? []);
+      // Episodic memory (R4) derived from this sprint's already-settled sibling tasks. Pure ctx
+      // read; '' until a sibling has settled (done/blocked) so the prompt placeholder collapses.
+      const priorEpisodes = summariseEpisodes(composeTaskEpisodes(ctx.tasks ?? [], taskId, ctx.sprintId));
       return {
         task: ctx.currentTask,
         turn: (ctx.genEvalTurn ?? 0) + 1,
@@ -671,6 +709,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
         ...(ctx.priorGeneratorSessionId !== undefined ? { priorGeneratorSessionId: ctx.priorGeneratorSessionId } : {}),
         ...(dimensionTrajectory.length > 0 ? { dimensionTrajectory } : {}),
         ...(priorLearnings.length > 0 ? { priorLearnings } : {}),
+        ...(priorEpisodes.length > 0 ? { priorEpisodes } : {}),
       };
     },
     output: (ctx, out) => {
@@ -702,6 +741,10 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
         out.notesEmitted.length > 0
           ? { currentAttemptNotes: [...(ctx.currentAttemptNotes ?? []), ...out.notesEmitted] }
           : {};
+      // Per-turn signal-kind distribution (R2) — stamped fresh every turn (overwrites the prior
+      // turn's map) so the entropy-plateau heuristic in the gen-eval loop sees the current turn's
+      // action diversity, never an accumulation across turns.
+      const actionCountsCarry = { lastTurnActionCounts: countTurnActionKinds(out) };
       if (out.exit !== undefined) {
         return {
           ...ctx,
@@ -717,6 +760,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
           ...changesCarry,
           ...learningsCarry,
           ...notesCarry,
+          ...actionCountsCarry,
         };
       }
       return {
@@ -731,6 +775,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
         ...changesCarry,
         ...learningsCarry,
         ...notesCarry,
+        ...actionCountsCarry,
       };
     },
   });

--- a/src/application/flows/implement/merge-wave.ts
+++ b/src/application/flows/implement/merge-wave.ts
@@ -55,6 +55,9 @@ const _exhaustive = {
   currentRoundNum: PER_TASK,
   lastEvaluation: PER_TASK,
   plateauHistory: PER_TASK,
+  // Per-turn signal-kind distribution for the in-flight task's current gen-eval turn — meaningless
+  // between waves (each branch carries its own), reset to undefined in the merged ctx.
+  lastTurnActionCounts: PER_TASK,
   lastExit: PER_TASK,
   lastVerdict: PER_TASK,
   lastBlockReason: PER_TASK,

--- a/src/application/flows/readiness/flow.ts
+++ b/src/application/flows/readiness/flow.ts
@@ -7,6 +7,9 @@ import {
   primaryFlowRow,
   uniqueProvidersFromAi,
 } from '@src/domain/entity/settings.ts';
+import { Result } from '@src/domain/result.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
 import { loadProjectLeaf } from '@src/application/flows/_shared/project/load.ts';
@@ -90,6 +93,62 @@ const resolveEffortForRow = (ai: AiSettings, flow: FlowId): string | undefined =
   if (row.provider === 'openai-codex' && (globalEffort === 'xhigh' || globalEffort === 'max')) return 'high';
   return globalEffort;
 };
+
+/**
+ * Error codes that represent a PROVIDER-SPECIFIC infrastructure failure — the kind it is safe to
+ * skip past so the remaining providers still get set up. A filesystem failure inside this
+ * provider's readiness probe (`probe-error`), or this provider's CLI being throttled after the
+ * adapter exhausted its 429 retries (`rate-limit`), says nothing about the other providers.
+ *
+ * Everything NOT in this set propagates and fails the run:
+ *  - Domain contract errors — the AI omitted a required signal (`invalid-state`), wrote malformed
+ *    `signals.json` (`parse-error`), or a value failed validation (`invalid-value`). These are
+ *    real defects the operator must see, not a provider to silently skip.
+ *  - Spawn failures (provider CLI not on PATH, non-zero exit, model unavailable) also surface as
+ *    `invalid-state`, so they propagate too — failing loudly on a misconfiguration beats hiding
+ *    it. The code cannot be told apart from a contract violation, and surfacing both is correct.
+ *  - Global infrastructure — a lock / I/O `storage-error` affects every provider, so it aborts the
+ *    whole run rather than being swallowed per-provider.
+ *  - `AbortError` (`aborted`) — operator cancellation; always propagates transparently.
+ */
+const PROVIDER_INFRASTRUCTURE_ERROR_CODES: ReadonlySet<ErrorCode> = new Set([ErrorCode.Probe, ErrorCode.RateLimit]);
+
+/**
+ * Wraps a per-provider subchain so that a provider-specific infrastructure failure emits a warn
+ * banner and lets execution continue to the remaining providers. Only the codes in
+ * {@link PROVIDER_INFRASTRUCTURE_ERROR_CODES} are tolerated — domain contract errors, global I/O
+ * failures and operator AbortError all propagate so the run fails loudly or cancels.
+ *
+ * Exported so the continue-vs-propagate decision can be tested against a raw `Element` stub
+ * without standing up the full fan-out.
+ */
+export const wrapProviderContinue = (
+  eventBus: SetupReadinessDeps['eventBus'],
+  provider: AiProvider,
+  inner: Element<ReadinessCtx>
+): Element<ReadinessCtx> => ({
+  name: `continue-on-error(${inner.name})`,
+  // Expose children so flattenLeaves walks the full per-provider step list for the TUI plan.
+  children: [inner],
+  async execute(ctx, signal, onTrace) {
+    const result = await inner.execute(ctx, signal, onTrace);
+    if (result.ok) return result;
+    // Only a provider-specific infrastructure failure is tolerated — skip this provider and let
+    // the fan-out continue. Everything else (contract errors, global I/O, abort) propagates.
+    if (!PROVIDER_INFRASTRUCTURE_ERROR_CODES.has(result.error.error.code)) return result;
+    // Provider-level infra failure (probe filesystem error, CLI throttle): surface as a warn
+    // banner and continue to the next provider. The inner trace already recorded the failure.
+    eventBus.publish({
+      type: 'banner-show',
+      id: `readiness-provider-error-${provider}`,
+      tier: 'warn',
+      message: `Provider '${provider}' readiness setup failed — skipping, other providers continue`,
+      cause: result.error.error.message,
+      at: IsoTimestamp.now(),
+    });
+    return Result.ok({ ctx, trace: result.error.trace });
+  },
+});
 
 const buildPerToolSubchain = (
   deps: SetupReadinessDeps,
@@ -177,12 +236,14 @@ const buildPerToolSubchain = (
  *   sequential('readiness', [
  *     load-project,
  *     pick-repository,                       // interactive (auto-selects single-repo projects)
- *     // one per-tool sub-chain per unique provider in settings.ai (order follows FLOW_IDS):
- *     sequential('tool-claude-code', [ probe → install-skills → propose → uninstall-skills →
- *                                       confirm → write → offer-skill-suggestions →
- *                                       install-readiness-skills ]),
- *     sequential('tool-copilot',    [ … ]),
- *     sequential('tool-codex',      [ … ]),
+ *     // one per-tool sub-chain per unique provider in settings.ai (order follows FLOW_IDS), each
+ *     // wrapped in a continue-on-error guard so a provider-specific infra failure skips that
+ *     // provider while the fan-out carries on:
+ *     continue-on-error(sequential('tool-claude-code', [ probe → install-skills → propose →
+ *                                       uninstall-skills → confirm → write →
+ *                                       offer-skill-suggestions → install-readiness-skills ])),
+ *     continue-on-error(sequential('tool-copilot',    [ … ])),
+ *     continue-on-error(sequential('tool-codex',      [ … ])),
  *     persist-suggested-skills,             // one save: union of every tool's suggestions
  *   ])
  *
@@ -196,7 +257,7 @@ export const createReadinessFlow = (deps: SetupReadinessDeps, opts: CreateReadin
   // still reads the full `opts.ai`, so any provider in the list resolves correctly.
   const providers = opts.providers ?? uniqueProvidersFromAi(opts.ai);
   const perToolSubchains = providers.map((provider) =>
-    buildPerToolSubchain(deps, opts, provider, toolForProvider(provider))
+    wrapProviderContinue(deps.eventBus, provider, buildPerToolSubchain(deps, opts, provider, toolForProvider(provider)))
   );
   return sequential<ReadinessCtx>('readiness', [
     loadProjectLeaf<ReadinessCtx>({ projectRepo: deps.projectRepo }),

--- a/src/application/flows/review/flow.ts
+++ b/src/application/flows/review/flow.ts
@@ -1,5 +1,6 @@
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { guard } from '@src/application/chain/build/guard.ts';
 import { loop } from '@src/application/chain/build/loop.ts';
@@ -75,9 +76,10 @@ export interface CreateReviewFlowOpts {
  * The loop can also exit via its `shouldContinue` round cap (`i <= maxRounds`) — a fail-safe for a
  * UI bug that would otherwise re-enter the round forever. On THAT exit `lastReviewExit` is still
  * undefined (no human terminal decision was reached), so the guard skips both settle steps and the
- * sprint stays in `review` with a visible `skipped` trace entry. The human end-of-sprint decision
- * stays the only path to `done`, and re-running review resumes cleanly because the status never
- * moved.
+ * sprint stays in `review` with a visible `skipped` trace entry. The cap exit also publishes a warn
+ * banner from inside `shouldContinue` (off-trace, so the happy path stays clean) explaining WHY the
+ * sprint stayed in `review`. The human end-of-sprint decision stays the only path to `done`, and
+ * re-running review resumes cleanly because the status never moved.
  */
 export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): Element<ReviewCtx> => {
   const maxRounds = opts.maxRounds ?? DEFAULT_MAX_ROUNDS;
@@ -108,12 +110,32 @@ export const createReviewFlow = (deps: ReviewDeps, opts: CreateReviewFlowOpts): 
     loadAndAssertSprintSubChain<ReviewCtx>({ sprintRepo: deps.sprintRepo }, ['review']),
     ensureFeedbackFileLeaf(opts.feedbackFile),
     loop<ReviewCtx>('review-loop', reviewRound, {
-      shouldContinue: (_ctx, i) => i <= maxRounds,
+      // Pre-iteration round cap. `i > maxRounds` exits the loop without running another round.
+      // When the cap is the reason we stop — no human terminal decision reached, `lastReviewExit`
+      // still undefined — publish a warn banner from HERE so the operator knows WHY the sprint
+      // stayed in 'review'. Emitting from `shouldContinue` keeps the banner OFF the trace: a
+      // normal terminal exit makes `shouldStop` fire first, so this branch is never reached on
+      // the happy path and the trace stays clean. Re-running review resumes cleanly (status never
+      // moved).
+      shouldContinue: (ctx, i) => {
+        if (i <= maxRounds) return true;
+        if (ctx.lastReviewExit === undefined) {
+          deps.eventBus.publish({
+            type: 'banner-show',
+            id: 'review-cap-exhausted',
+            tier: 'warn',
+            message: `Review round cap (${maxRounds}) reached — sprint remains in 'review'. Re-run the review flow to continue.`,
+            at: IsoTimestamp.now(),
+          });
+        }
+        return false;
+      },
       shouldStop: (ctx) => ctx.lastReviewExit !== undefined,
     }),
     // Only settle the sprint to `done` when the review loop reached a human terminal decision
     // (`lastReviewExit` set). A round-cap exit leaves it undefined → guard skips both settle steps
-    // so a UI-bug-driven cap exhaustion never silently closes the sprint.
+    // (a visible `skipped` trace entry) so a UI-bug-driven cap exhaustion never silently closes the
+    // sprint. The human end-of-sprint decision stays the only path to `done`.
     guard<ReviewCtx>(
       'review-settled',
       (ctx) => ctx.lastReviewExit !== undefined,

--- a/src/application/registry.ts
+++ b/src/application/registry.ts
@@ -14,6 +14,7 @@ import { exportRequirementsManifest } from '@src/application/flows/export-requir
 import { createPrManifest } from '@src/application/flows/create-pr/manifest.ts';
 import { doctorManifest } from '@src/application/flows/doctor/manifest.ts';
 import { settingsManifest } from '@src/application/flows/settings/manifest.ts';
+import { ticketAddManifest } from '@src/application/flows/add-ticket/manifest.ts';
 import { ticketRemoveManifest } from '@src/application/flows/remove-ticket/manifest.ts';
 
 /**
@@ -100,5 +101,6 @@ export const flowRegistry: readonly FlowEntry[] = [
   { manifest: createPrManifest },
   { manifest: doctorManifest },
   { manifest: settingsManifest },
+  { manifest: ticketAddManifest },
   { manifest: ticketRemoveManifest },
 ];

--- a/src/application/ui/tui/prompts/path-picker-prompt.tsx
+++ b/src/application/ui/tui/prompts/path-picker-prompt.tsx
@@ -75,9 +75,11 @@ export const PathPickerPrompt = ({
   const [typing, setTyping] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     const load = async (): Promise<void> => {
       try {
         const items = await fs.readdir(cwd, { withFileTypes: true });
+        if (cancelled) return;
         const filtered = items
           .filter((d) => showHidden || !d.name.startsWith('.'))
           .filter((d) => d.isDirectory())
@@ -86,11 +88,15 @@ export const PathPickerPrompt = ({
         setEntries(filtered);
         setError(undefined);
       } catch (err) {
+        if (cancelled) return;
         setEntries([]);
         setError(err instanceof Error ? err.message : String(err));
       }
     };
     void load();
+    return () => {
+      cancelled = true;
+    };
   }, [cwd, showHidden]);
 
   // Synthetic rows: parent (..) → [Select this directory] → directory entries.

--- a/src/application/ui/tui/runtime/use-edit-field.ts
+++ b/src/application/ui/tui/runtime/use-edit-field.ts
@@ -18,6 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { PendingPromptInput, PromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
@@ -108,11 +109,18 @@ export const useEditField = (): UseEditFieldState => {
           return;
         }
         setFeedback(input.successLabel ?? '✓ saved');
-      } catch {
-        // Promise rejection from the queue means the user cancelled (esc). No feedback —
-        // cancellation is its own UI signal (the prompt disappears) and adding a "cancelled"
-        // chip on every esc is noisy. Pre-existing feedback (from a previous edit) is cleared
-        // so the view doesn't carry stale state.
+      } catch (cause) {
+        // AbortError is operator cancellation propagating up through the chain runtime — it must
+        // pass through transparently (the run-abort path depends on it surfacing). This blanket
+        // catch is the only seam between the prompt queue and the void'd callers in
+        // `field-editors.ts`, so swallowing it here would strand the abort. `release()` in the
+        // `finally` still runs before the re-throw.
+        if (cause instanceof AbortError) throw cause;
+        // Any other rejection means the user cancelled THIS prompt (esc — the queue rejects with a
+        // plain `Error('cancelled by user')`, never an AbortError). No feedback: cancellation is
+        // its own UI signal (the prompt disappears) and a "cancelled" chip on every esc is noisy.
+        // Pre-existing feedback (from a previous edit) is cleared so the view doesn't carry stale
+        // state.
         setFeedback(undefined);
       } finally {
         release();

--- a/src/application/ui/tui/views/home-internals/menu-items.ts
+++ b/src/application/ui/tui/views/home-internals/menu-items.ts
@@ -11,6 +11,7 @@ import type { MenuItem } from '@src/application/ui/tui/components/action-menu.ts
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { ticketAddManifest } from '@src/application/flows/add-ticket/manifest.ts';
 
 export interface BuildMenuItemsInput {
   readonly hasProject: boolean;
@@ -120,10 +121,10 @@ export const buildMenuItems = (input: BuildMenuItemsInput): readonly MenuItem[] 
       onSelect: (): void => input.onPushHome('pick-sprint'),
     },
     {
-      id: 'add-ticket',
+      id: ticketAddManifest.id,
       section: 'work',
-      label: 'Add ticket',
-      description: 'Append a pending ticket to the current sprint.',
+      label: ticketAddManifest.title,
+      description: ticketAddManifest.description,
       hotkey: 'a',
       ...(input.addTicketDisabled !== undefined ? { disabledReason: input.addTicketDisabled } : {}),
       onSelect: (): void => {

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -67,7 +67,7 @@ export const PickSprintView = (): React.JSX.Element => {
   // already filters them; this picker is the documented way back to a done sprint).
   const [hideDone, setHideDone] = useState<boolean>(false);
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'use sprint' },
     { keys: 't', label: 'toggle scope' },
     { keys: 'f', label: hideDone ? 'show done' : 'hide done' },

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -8,7 +8,7 @@
  * project's sprints.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
@@ -90,6 +90,18 @@ export const ProjectDetailView = (): React.JSX.Element => {
   const [confirmRemove, setConfirmRemove] = useState<Repository | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
+  // Mounted-ref guard for the async remove-repo handler: dismissing the confirm overlay unblocks the
+  // router, so the operator can navigate away (unmounting this view) before the awaited save resolves.
+  // The guard skips the post-await view-local writes (setFeedback / reload) so they never fire into an
+  // unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   const project = state.kind === 'ok' ? state.value : undefined;
 
   // Flat field cursor — every editable row gets one stable index. Top-to-bottom order matches
@@ -112,12 +124,12 @@ export const ProjectDetailView = (): React.JSX.Element => {
   const focused = fields[Math.min(cursorIdx, Math.max(0, fields.length - 1))];
 
   // Hints share one source of truth with their handlers. The view drives a flat field cursor
-  // (`↑/↓`) and edits the focused row (`e` / `↵`), plus the per-repo CRUD chords. `e edit field`
-  // gates on there being an editable focused row, so the footer never advertises a no-op edit on
-  // an empty field list. `d`/`c`/`S` act on the focused row only when it is a repo.
+  // (`↑/↓` / `j/k`) and edits the focused row (`e` / `↵`), plus the per-repo CRUD chords. `e edit
+  // field` gates on there being an editable focused row, so the footer never advertises a no-op
+  // edit on an empty field list. `d`/`c`/`S` act on the focused row only when it is a repo.
   const focusedRepo = focused?.kind === 'repo';
   useViewHints([
-    { keys: '↑/↓', label: 'navigate' },
+    { keys: '↑/↓/j/k', label: 'navigate' },
     { keys: '↵', label: 'confirm/select' },
     // Surface the `m` chord only while the viewed project is not already current — once they
     // match the action is a no-op and the hint adds noise (mirrors sprint-detail).
@@ -150,6 +162,11 @@ export const ProjectDetailView = (): React.JSX.Element => {
       snapshot,
       { repositoryId: target.id }
     );
+    // `c`/`S` don't claim the global key-mute, so the operator can navigate away (unmounting this
+    // view) while the launcher resolves. Skip consuming the result once unmounted — both the
+    // view-local `setFeedback` and the session/router open — so neither fires into an unmounted
+    // tree. Mirrors `handleRemoveConfirmed`.
+    if (!mountedRef.current) return;
     if (!result.ok) {
       setFeedback(`✗ ${result.reason}`);
       return;
@@ -272,9 +289,10 @@ export const ProjectDetailView = (): React.JSX.Element => {
     if (!confirmed || project === undefined) return;
     const removeResult = await removeRepoFromProject(project, target.id, deps.projectRepo);
     if (!removeResult.ok) {
-      setFeedback(`✗ ${removeResult.error}`);
+      if (mountedRef.current) setFeedback(`✗ ${removeResult.error}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`✓ removed ${target.name}`);
     reload();
   };

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -6,7 +6,7 @@
  * mirroring the sprint-detail view's explicit opt-in.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -34,7 +34,7 @@ export const ProjectsView = (): React.JSX.Element => {
   const ui = useUiState();
   const { rows } = useBreakpoint();
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'm', label: 'make current' },
     { keys: 'c', label: 'create' },
@@ -46,6 +46,18 @@ export const ProjectsView = (): React.JSX.Element => {
 
   const [confirmDelete, setConfirmDelete] = useState<Project | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  // Mounted-ref guard for the async delete handler: dismissing the confirm overlay unblocks the
+  // router, so the operator can navigate away (unmounting this view) before `projectRepo.remove`
+  // resolves. The guard skips the post-await view-local writes (setFeedback / reload) so they never
+  // fire into an unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
 
   const { state, reload } = useAsyncLoad<readonly Project[]>(async () => {
     const r = await deps.projectRepo.list();
@@ -128,10 +140,13 @@ export const ProjectsView = (): React.JSX.Element => {
     if (!confirmed) return;
     const r = await deps.projectRepo.remove(target.id);
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    // Clearing the deleted project's selection targets the always-mounted SelectionProvider, so it
+    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
     if (selection.projectId === target.id) selection.setProject(undefined);
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed ${target.displayName}`);
     reload();
   };

--- a/src/application/ui/tui/views/sessions-view.tsx
+++ b/src/application/ui/tui/views/sessions-view.tsx
@@ -28,8 +28,10 @@ import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import type { SessionRecord } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
+import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 
-const VISIBLE_ROWS = 10;
+/** Non-list rows consumed by ViewShell chrome + column header + overflow rows + summary + feedback. */
+const CHROME_ROWS = 9;
 const FLOW_COL_WIDTH = 16;
 const STATUS_COL_WIDTH = 14;
 const ELAPSED_COL_WIDTH = 10;
@@ -41,8 +43,10 @@ export const SessionsView = (): React.JSX.Element => {
   const sessions = useSessions();
   const manager = useSessionManager();
   const ui = useUiState();
+  const { rows } = useBreakpoint();
+  const VISIBLE_ROWS = Math.max(5, Math.min(15, rows - CHROME_ROWS));
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'c', label: 'cancel run' },
   ]);

--- a/src/application/ui/tui/views/sprint-detail-internals/field-editors.ts
+++ b/src/application/ui/tui/views/sprint-detail-internals/field-editors.ts
@@ -10,6 +10,7 @@
  */
 
 import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import { replaceTicket } from '@src/domain/entity/sprint.ts';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
@@ -141,7 +142,10 @@ export const runEdit = (args: RunEditArgs): void => {
         const cfg = buildTicketEdit({ sprint, ticket: focusedTicket, field, sprintRepo, reload });
         if (cfg !== undefined) void openEditPrompt(cfg);
       })
-      .catch(() => undefined);
+      .catch((cause: unknown) => {
+        if (cause instanceof AbortError) throw cause;
+        return undefined;
+      });
     return;
   }
   if (focusedTodoTask !== undefined) {
@@ -156,6 +160,9 @@ export const runEdit = (args: RunEditArgs): void => {
         const cfg = buildTaskEdit({ sprint, task: focusedTodoTask, field, taskRepo, reload });
         if (cfg !== undefined) void openEditPrompt(cfg);
       })
-      .catch(() => undefined);
+      .catch((cause: unknown) => {
+        if (cause instanceof AbortError) throw cause;
+        return undefined;
+      });
   }
 };

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -29,7 +29,7 @@
  * helpers, footer hints, keymap) live in `sprint-detail-internals/`.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
@@ -121,6 +121,18 @@ export const SprintDetailView = (): React.JSX.Element => {
   const [confirmRemove, setConfirmRemove] = useState<Ticket | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
+  // Mounted-ref guard for the async unblock / remove-ticket handlers: dismissing the confirm overlay
+  // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
+  // before the awaited use-case / flow resolves. The guard skips the post-await view-local writes
+  // (setFeedback / reload) so they never fire into an unmounted tree. Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';
   const inDetail = openIds.size > 0;
@@ -146,7 +158,7 @@ export const SprintDetailView = (): React.JSX.Element => {
   // non-draft sprint or the footer would advertise keys that do nothing. `m` (mark-current) and
   // `u` (unblock) follow the same declarative gate rather than conditional spreads.
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: 'n', label: 'flows' },
     { keys: '↵/o', label: inDetail ? 'expand/collapse' : 'expand' },
     // `esc/q` collapses all expanded cards; only shown while in detail mode so the hint
@@ -192,9 +204,10 @@ export const SprintDetailView = (): React.JSX.Element => {
       logger: deps.logger,
     });
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} unblocked "${target.name}"`);
     reload();
   };
@@ -242,9 +255,10 @@ export const SprintDetailView = (): React.JSX.Element => {
     const flow = createTicketRemoveFlow({ sprintRepo: deps.sprintRepo });
     const r = await flow.execute({ input: { sprintId: sprint.id, ticketId: target.id } });
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.error.message}`);
       return;
     }
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed "${target.title}"`);
     reload();
   };

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -8,7 +8,7 @@
  *   ↵   open the sprint's detail view.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { OverflowRow, useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -56,6 +56,19 @@ export const SprintsView = (): React.JSX.Element => {
 
   const [confirmDelete, setConfirmDelete] = useState<Sprint | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  // Mounted-ref guard for the async bulk-unblock / delete handlers: dismissing the confirm overlay
+  // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
+  // before the awaited repo writes resolve. The guard skips the post-await view-local writes
+  // (setFeedback / reload / setFocusedSprintTasks) so they never fire into an unmounted tree.
+  // Mirrors the guard in `useEditField`.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
 
   // Windowed cursor — owns ↑/↓ + j/k + PgUp/PgDn + Home/End + Enter; the cursor is the sprint id,
   // so a reload/reorder keeps focus on the same sprint. Enter selects (sets current + drills in).
@@ -105,7 +118,7 @@ export const SprintsView = (): React.JSX.Element => {
   // rather than advertise a no-op. `u` follows the same declarative gate on the stuck-task count.
   const focusedDone = focusedSprint?.status === 'done';
   useViewHints([
-    { keys: '↑/↓', label: 'move' },
+    { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
     { keys: 'c', label: 'create' },
     { keys: 'e', label: 'rename', enabledWhen: !focusedDone },
@@ -194,6 +207,7 @@ export const SprintsView = (): React.JSX.Element => {
       }
     }
     const total = stuckTasks.length;
+    if (!mountedRef.current) return;
     if (succeeded === total) {
       setFeedback(
         `${glyphs.check} unblocked ${String(succeeded)} task${succeeded === 1 ? '' : 's'} in "${focusedSprint.name}"`
@@ -205,7 +219,7 @@ export const SprintsView = (): React.JSX.Element => {
     }
     // Refresh task list so the hint and count update immediately.
     const refreshed = await deps.taskRepo.findBySprintId(focusedSprint.id);
-    if (refreshed.ok) setFocusedSprintTasks(refreshed.value);
+    if (mountedRef.current && refreshed.ok) setFocusedSprintTasks(refreshed.value);
   };
 
   const handleDeleteConfirmed = async (target: Sprint, confirmed: boolean): Promise<void> => {
@@ -213,10 +227,13 @@ export const SprintsView = (): React.JSX.Element => {
     if (!confirmed) return;
     const r = await deps.sprintRepo.remove(target.id);
     if (!r.ok) {
-      setFeedback(`${glyphs.cross} ${r.error.message}`);
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
       return;
     }
+    // Clearing the deleted sprint's selection targets the always-mounted SelectionProvider, so it
+    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
     if (selection.sprintId === target.id) selection.setSprint(undefined);
+    if (!mountedRef.current) return;
     setFeedback(`${glyphs.check} removed ${target.name}`);
     reload();
   };

--- a/src/business/task/compose-task-episodes.ts
+++ b/src/business/task/compose-task-episodes.ts
@@ -1,0 +1,92 @@
+import type { BlockedTask, DoneTask, Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { TaskEpisode } from '@src/domain/repository/episode/episode-types.ts';
+
+/** Per-line clamp for a blocked task's reason rendered into the episode's one-line learning. */
+const BLOCK_REASON_MAX_CHARS = 120;
+
+/**
+ * Deterministic sentinel for an attempt-less task (an upstream cascade-blocked task that never
+ * ran). The episode `timestamp` is metadata only — {@link import('./episode-summary.ts')
+ * summariseEpisodes} renders goal / outcome / keyLearnings and never the timestamp — so a task
+ * that carries no real attempt timestamp gets this fixed value rather than a fabricated clock
+ * read. Keeps the function pure (no `Date.now()`) and the field a valid ISO-8601 string.
+ */
+const EPOCH_SENTINEL = '1970-01-01T00:00:00.000Z' as IsoTimestamp;
+
+/** Collapse whitespace and clamp a blocked task's reason to a single bounded line. */
+const clampReason = (raw: string): string => {
+  const oneLine = raw.replace(/\s+/g, ' ').trim();
+  return oneLine.length > BLOCK_REASON_MAX_CHARS ? `${oneLine.slice(0, BLOCK_REASON_MAX_CHARS - 1)}…` : oneLine;
+};
+
+/** The goal line — the task's description when present and non-empty, else its display name. */
+const episodeGoal = (task: Task): string =>
+  task.description !== undefined && task.description.trim().length > 0 ? task.description : task.name;
+
+/**
+ * Real timestamp for the episode, derived from the task's last attempt: prefer its terminal
+ * `finishedAt`, fall back to `startedAt` for a still-running attempt, and finally to the epoch
+ * sentinel for an attempt-less (upstream cascade-blocked) task. Never fabricates a clock read.
+ */
+const lastAttemptTimestamp = (task: DoneTask | BlockedTask): IsoTimestamp => {
+  const last = task.attempts.at(-1);
+  if (last === undefined) return EPOCH_SENTINEL;
+  return last.finishedAt ?? last.startedAt;
+};
+
+/** Map a settled `done` task to a success episode with an honest attempt-count learning. */
+const doneEpisode = (task: DoneTask, sprintId: SprintId): TaskEpisode => {
+  const n = task.attempts.length;
+  const base = `verified after ${String(n)} ${n === 1 ? 'attempt' : 'attempts'}`;
+  const warning = task.attempts.at(-1)?.warning;
+  return {
+    taskId: String(task.id),
+    sprintId: String(sprintId),
+    goal: episodeGoal(task),
+    outcome: 'success',
+    keyLearnings: warning !== undefined ? `${base} (done-with-warning: ${warning.kind})` : base,
+    timestamp: lastAttemptTimestamp(task),
+  };
+};
+
+/**
+ * Map a `blocked` task to an episode. An upstream cascade-block (`blockKind: 'upstream'`) means a
+ * prerequisite failed, so the task was effectively abandoned rather than judged on its own merits;
+ * an own-failure block stays `blocked`. The reason carries the honest learning.
+ */
+const blockedEpisode = (task: BlockedTask, sprintId: SprintId): TaskEpisode => ({
+  taskId: String(task.id),
+  sprintId: String(sprintId),
+  goal: episodeGoal(task),
+  outcome: task.blockKind === 'upstream' ? 'abandoned' : 'blocked',
+  keyLearnings: clampReason(task.blockedReason),
+  timestamp: lastAttemptTimestamp(task),
+});
+
+/**
+ * Derive the sprint's episodic memory from the tasks already in hand — no new persistence. Only
+ * SETTLED siblings (`done` / `blocked`) other than the current task contribute, so a later task in
+ * the same sprint can orient on what an earlier task already solved or got blocked on. Input order
+ * is preserved; downstream `summariseEpisodes` keeps the most recent tail.
+ *
+ * Pure: no I/O, no clock. All fields are derived from real entity data (see
+ * {@link lastAttemptTimestamp} for the no-fabrication timestamp rule).
+ *
+ * @public
+ */
+export const composeTaskEpisodes = (
+  tasks: readonly Task[],
+  currentTaskId: TaskId,
+  sprintId: SprintId
+): readonly TaskEpisode[] => {
+  const episodes: TaskEpisode[] = [];
+  for (const task of tasks) {
+    if (task.id === currentTaskId) continue;
+    if (task.status === 'done') episodes.push(doneEpisode(task, sprintId));
+    else if (task.status === 'blocked') episodes.push(blockedEpisode(task, sprintId));
+  }
+  return episodes;
+};

--- a/src/business/task/episode-summary.ts
+++ b/src/business/task/episode-summary.ts
@@ -1,0 +1,27 @@
+import type { TaskEpisode } from '@src/domain/repository/episode/episode-types.ts';
+
+/** Maximum characters from the goal shown per episode line before ellipsis is appended. */
+const GOAL_MAX_CHARS = 80;
+
+const excerptGoal = (goal: string): string => {
+  const trimmed = goal.trim();
+  if (trimmed.length <= GOAL_MAX_CHARS) return trimmed;
+  return `${trimmed.slice(0, GOAL_MAX_CHARS).trimEnd()}…`;
+};
+
+/**
+ * Render a compact markdown bullet list of the most-recent episodes (up to `maxItems`).
+ *
+ * Each line is formatted as:
+ *   `- [goal excerpt] → outcome (keyLearnings)`
+ *
+ * Returns an empty string when `episodes` is empty so callers can collapse the section
+ * cleanly without a stray heading. Pure function — no I/O.
+ *
+ * @public
+ */
+export const summariseEpisodes = (episodes: readonly TaskEpisode[], maxItems = 5): string => {
+  if (episodes.length === 0) return '';
+  const recent = episodes.slice(-maxItems);
+  return recent.map((ep) => `- ${excerptGoal(ep.goal)} → ${ep.outcome} (${ep.keyLearnings.trim()})`).join('\n');
+};

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -143,6 +143,73 @@ export const decideEscalation = (props: DecideEscalationProps): EscalationDecisi
  */
 export const escalationBannerId = (taskId: string): string => `model-escalation-${taskId}`;
 
+/**
+ * Normalised Shannon entropy over the distribution of action kinds seen in a single gen-eval
+ * turn. Rationale: a turn that concentrates its reported actions on a single kind round after
+ * round has plateaued — the agent keeps choosing the same kind of move rather than exploring —
+ * so low action entropy is a useful break signal independent of the turn budget.
+ *
+ * Formula: H = -Σ(p · log₂ p) / log₂ K, where K = number of distinct action kinds.
+ *
+ * Returns 0 for a single-kind distribution (zero diversity — the agent chose only one action
+ * type). Returns 1 for a uniform distribution (maximum diversity). Returns 1 when
+ * `actionCounts` is empty (no data yet → no evidence of plateau).
+ */
+export const computeActionEntropy = (actionCounts: Map<string, number>): number => {
+  const K = actionCounts.size;
+  if (K === 0) return 1; // no data → assume max diversity, no plateau
+  if (K === 1) return 0; // single kind → zero diversity
+
+  let total = 0;
+  for (const count of actionCounts.values()) total += count;
+  if (total === 0) return 1; // all zero counts → treat as no data
+
+  let H = 0;
+  for (const count of actionCounts.values()) {
+    if (count === 0) continue;
+    const p = count / total;
+    H -= p * Math.log2(p);
+  }
+  return H / Math.log2(K);
+};
+
+/**
+ * Returns `true` when `entropy` falls below `threshold`, indicating that the agent is
+ * concentrating on too few action kinds — a leading indicator of algorithmic stasis.
+ *
+ * `threshold` defaults to 0.25 (calibrated: an agent using only 1 of 4 tools scores 0.0;
+ * 2 of 4 tools uniformly scores 0.5; the default catches the most degenerate cases while
+ * avoiding false positives on mildly skewed but still progressing runs).
+ *
+ * `threshold` is clamped to [0.1, 0.5] to prevent misconfiguration from either
+ * silencing the signal entirely or triggering on every turn.
+ */
+export const detectLowEntropy = (entropy: number, threshold = 0.25): boolean => {
+  const effective = Math.max(0.1, Math.min(0.5, threshold));
+  return entropy < effective;
+};
+
+/**
+ * Pure predicate — returns `true` when the last `windowSize` entries in `history` are all
+ * identical (the gen-eval loop is repeating the same failure fingerprint without progress).
+ * Returns `false` when `history` has fewer than `windowSize` entries (insufficient data) or
+ * when the tail is diverse.
+ *
+ * Rationale: a gen-eval loop that re-emits the identical failure fingerprint round after round
+ * has plateaued; detecting that repetition is a more reliable break signal than waiting out the
+ * turn budget.
+ *
+ * `windowSize` is clamped to ≥ 2 defensively — a window of 1 would fire after every single
+ * turn, which is not useful.
+ */
+export const detectRepetitiveLoop = (history: readonly string[], windowSize: number): boolean => {
+  const effective = Math.max(2, Math.trunc(windowSize));
+  if (history.length < effective) return false;
+  const tail = history.slice(-effective);
+  const first = tail[0];
+  return tail.every((f) => f === first);
+};
+
 export interface ApplyEscalationProps {
   readonly task: InProgressTask;
   readonly decision: EscalationDecision;

--- a/src/business/task/loop-diversity.ts
+++ b/src/business/task/loop-diversity.ts
@@ -1,0 +1,54 @@
+import { detectRepetitiveLoop } from '@src/business/task/escalation-policy.ts';
+
+/**
+ * Loop-diversity tracker — detects when the gen-eval inner loop is repeating the same failure
+ * fingerprint across consecutive turns. A gen-eval loop that re-emits the identical
+ * failed-dimension fingerprint round after round has plateaued; detecting that repetition is a
+ * more reliable break signal than waiting out the turn budget.
+ *
+ * Thin stateful wrapper over the canonical {@link detectRepetitiveLoop} predicate in
+ * escalation-policy.ts — there is ONE repetition predicate; this tracker only owns the bounded
+ * rolling buffer of fingerprints.
+ *
+ * Pure. No I/O, no side effects.
+ */
+interface LoopDiversityTracker {
+  /** Record a fingerprint for the current iteration. */
+  record(fingerprint: string): void;
+  /**
+   * Returns `false` when the last `windowSize` fingerprints are all identical — the loop is
+   * repeating the exact same failure pattern and diversity has collapsed.
+   * Returns `true` when there is insufficient history or the tail is diverse.
+   */
+  isDiverse(): boolean;
+}
+
+/**
+ * Create a loop-diversity tracker backed by a bounded rolling buffer.
+ *
+ * Maintains the last `windowSize * 2` fingerprints at most, capped on every `record` call so
+ * the buffer never grows unboundedly across a long run.
+ *
+ * @param windowSize - Number of consecutive identical fingerprints that constitute a non-diverse
+ *   loop. Clamped to ≥ 2 defensively.
+ */
+export const createLoopDiversityTracker = (windowSize = 3): LoopDiversityTracker => {
+  const effective = Math.max(2, Math.trunc(windowSize));
+  const history: string[] = [];
+
+  return {
+    record(fingerprint: string): void {
+      history.push(fingerprint);
+      // Bound the buffer to windowSize * 2 to prevent unbounded growth.
+      if (history.length > effective * 2) {
+        history.splice(0, history.length - effective * 2);
+      }
+    },
+    isDiverse(): boolean {
+      // ONE canonical predicate: `detectRepetitiveLoop` returns `true` when the tail is
+      // repetitive, so diversity is its negation. It already returns `false` on insufficient
+      // history (< windowSize), so a short buffer reads as diverse.
+      return !detectRepetitiveLoop(history, effective);
+    },
+  };
+};

--- a/src/domain/repository/episode/episode-types.ts
+++ b/src/domain/repository/episode/episode-types.ts
@@ -1,0 +1,23 @@
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * A single episodic record capturing the outcome of one completed task execution. Episodes
+ * are stored per-sprint and injected as a summary into the implement prompt so subsequent
+ * tasks within the same sprint (and later, across sprints) can learn from prior outcomes
+ * without re-discovering what worked or what didn't.
+ *
+ * Rationale: injecting a compact history of prior task outcomes lets a later task avoid
+ * re-discovering what an earlier task in the same sprint already solved or got blocked on.
+ *
+ * @public
+ */
+export type TaskEpisode = {
+  readonly taskId: string;
+  readonly sprintId: string;
+  /** The task's description / goal — one-liner or short paragraph. */
+  readonly goal: string;
+  readonly outcome: 'success' | 'partial' | 'blocked' | 'abandoned';
+  /** One-line summary of what worked or what didn't on this task. */
+  readonly keyLearnings: string;
+  readonly timestamp: IsoTimestamp;
+};

--- a/src/integration/ai/prompts/_engine/compress-section.ts
+++ b/src/integration/ai/prompts/_engine/compress-section.ts
@@ -1,0 +1,35 @@
+/**
+ * Tail-compression for large dynamic prompt sections.
+ *
+ * Research basis: "Lost in the Middle" (Liu et al., arXiv 2307.03172) shows that LLMs attend
+ * poorly to content placed in the middle of long contexts. Long PRIOR_PROGRESS / PRIOR_LEARNINGS
+ * substitutions push task-critical sections (goal, success-criteria, output contract) toward the
+ * middle. Keeping the MOST RECENT content (the tail) and dropping the oldest bytes is the correct
+ * strategy — the harness already applies the same principle to stderr via BoundedTail.
+ *
+ * The one-line notice is prepended (not appended) so it appears before the retained content and
+ * makes the truncation visible to the model without burying it after the dropped material.
+ */
+
+/** Maximum characters retained per large dynamic section before tail-truncation kicks in. */
+export const SECTION_CHAR_CAP = 4_000;
+
+/**
+ * Tail-compress `content` to at most `cap` characters.
+ *
+ * - Content at or below `cap`: returned unchanged.
+ * - Content above `cap`: trimmed to the last `cap` characters (tail preserved; head dropped)
+ *   and prefixed with a one-line notice so the model sees the truncation boundary.
+ *
+ * @param content - The section text to compress.
+ * @param cap     - Character ceiling. Defaults to {@link SECTION_CHAR_CAP}.
+ */
+export const compressSection = (content: string, cap: number = SECTION_CHAR_CAP): string => {
+  if (content.length <= cap) return content;
+  // `slice` counts UTF-16 code units: when the cap boundary straddles a surrogate pair the tail
+  // loses the pair's high half (a lone low surrogate). Acceptable for prompt delivery — the model
+  // tolerates one malformed glyph at the truncation seam, and no defensive scan belongs in this hot path.
+  const tail = content.slice(-cap);
+  const notice = `[… earlier content omitted — showing last ${String(cap)} chars of ${String(content.length)} total]\n\n`;
+  return notice + tail;
+};

--- a/src/integration/ai/prompts/_engine/substitute.ts
+++ b/src/integration/ai/prompts/_engine/substitute.ts
@@ -2,6 +2,7 @@ import { Result } from '@src/domain/result.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import { extractPlaceholders } from '@src/integration/ai/prompts/_engine/extract-placeholders.ts';
+import { compressSection, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
 
 /**
  * Placeholder substitution for `.md` prompt templates.
@@ -33,6 +34,15 @@ import { extractPlaceholders } from '@src/integration/ai/prompts/_engine/extract
 
 const PLACEHOLDER_PATTERN = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
 
+/**
+ * Keys whose substituted values are tail-compressed when they exceed {@link SECTION_CHAR_CAP}.
+ * These are large dynamic sections (progress journals, learning ledgers, episode history) that
+ * grow unboundedly over a long sprint. Keeping the tail (most recent content) follows the
+ * "Lost in the Middle" guidance — older entries are less useful and pushing them into the middle
+ * of the context degrades model attention on the task-critical sections that follow.
+ */
+const COMPRESSIBLE_KEYS = new Set(['PRIOR_PROGRESS', 'PRIOR_LEARNINGS', 'PRIOR_EPISODES']);
+
 export const substitute = (template: string, values: Readonly<Record<string, string>>): string =>
   template.replace(PLACEHOLDER_PATTERN, (match, key: string) => {
     if (!Object.prototype.hasOwnProperty.call(values, key)) return match;
@@ -40,7 +50,11 @@ export const substitute = (template: string, values: Readonly<Record<string, str
     // constructed from looser sources. Treat that the same as "absent" so we don't render
     // the literal "undefined".
     const value = values[key];
-    return value !== undefined ? value : match;
+    if (value === undefined) return match;
+    if (COMPRESSIBLE_KEYS.has(key) && value.length > SECTION_CHAR_CAP) {
+      return compressSection(value);
+    }
+    return value;
   });
 
 /**

--- a/src/integration/ai/prompts/detect-skills/template.md
+++ b/src/integration/ai/prompts/detect-skills/template.md
@@ -25,7 +25,7 @@ covers that responsibility for this repo.
 
 <inputs>
 <repository_path>{{REPOSITORY_PATH}}</repository_path>
-<skills_convention>{{SKILLS_CONVENTION}}</skills_convention>
+<skills_convention>See the full skills convention in the constraints section below.</skills_convention>
 </inputs>
 
 {{HARNESS_CONTEXT}}

--- a/src/integration/ai/prompts/distill-learnings/definition.ts
+++ b/src/integration/ai/prompts/distill-learnings/definition.ts
@@ -1,7 +1,9 @@
 /**
  * `distill-learnings` prompt: one-shot documentation edit that folds a curated set of
- * machine-collected learnings into an existing project context file's own idempotent
- * `## Learnings (ralphctl)` section.
+ * machine-collected learnings into an existing project context file's own idempotent learnings
+ * section. The section heading is a parameter ({@link DistillLearningsPromptParams.learningsSectionHeading})
+ * so the generic template never hardcodes a brand — it runs on downstream user projects, not just
+ * this one.
  *
  * The AI is an editor, not a researcher — every learning was produced and reviewed by an earlier
  * session and confirmed by the operator before this call. The prompt instructs the AI to write
@@ -21,11 +23,19 @@ import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 
+/**
+ * Default H2 heading text for the section this prompt owns (without the leading `## `). Generic and
+ * brand-free so the template stays portable across downstream user projects. Callers that want a
+ * project-specific heading pass {@link DistillLearningsPromptParams.learningsSectionHeading}.
+ */
+const DEFAULT_LEARNINGS_SECTION_HEADING = 'Learnings (AI sessions)';
+
 export interface DistillLearningsPromptParams {
   /**
    * Existing context-file body wrapped for prompting, or an explicit "no existing file" line. The
-   * AI reconciles the candidate learnings against this file's current `## Learnings (ralphctl)`
-   * section and writes the full updated file back.
+   * AI reconciles the candidate learnings against this file's current learnings section (the one
+   * headed by {@link DistillLearningsPromptParams.learningsSectionHeading}) and writes the full
+   * updated file back.
    */
   readonly existingContextFile: string;
   /**
@@ -45,6 +55,13 @@ export interface DistillLearningsPromptParams {
    * this section so the prompt copy never hardcodes a specific ecosystem's commands.
    */
   readonly projectTooling: string;
+  /**
+   * H2 heading text for the section this prompt owns (without the leading `## `). Optional — omit it
+   * to fall back to a generic, brand-free default ({@link DEFAULT_LEARNINGS_SECTION_HEADING}). The
+   * template is generic and runs on downstream user projects, so the heading must never hardcode a
+   * brand; callers that want a project-specific heading pass it here.
+   */
+  readonly learningsSectionHeading?: string;
 }
 
 const requireNonEmpty =
@@ -55,7 +72,7 @@ const requireNonEmpty =
 export const distillLearningsPromptDef: PromptDefinition<DistillLearningsPromptParams> = {
   templateName: 'distill-learnings',
   description:
-    'One-shot documentation edit that folds curated learnings into an existing project context file’s own idempotent `## Learnings (ralphctl)` section.',
+    'One-shot documentation edit that folds curated learnings into an existing project context file’s own idempotent learnings section (heading configurable, brand-free by default).',
   parameters: {
     existingContextFile: {
       placeholder: 'EXISTING_CONTEXT_FILE',
@@ -77,6 +94,12 @@ export const distillLearningsPromptDef: PromptDefinition<DistillLearningsPromptP
       description:
         'Detected build/test/task tooling, or "(none detected)". The only place package-manager commands may appear.',
     },
+    learningsSectionHeading: {
+      placeholder: 'LEARNINGS_SECTION_HEADING',
+      description:
+        'H2 heading text for the owned learnings section (without the leading `## `). Brand-free generic default applied by the builder when the caller omits it.',
+      optional: true,
+    },
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
@@ -90,6 +113,8 @@ export interface BuildDistillLearningsPromptInput {
   readonly candidateLearnings: string;
   readonly targetFilename: string;
   readonly projectTooling: string;
+  /** Optional H2 heading for the owned section; falls back to the brand-free default when omitted. */
+  readonly learningsSectionHeading?: string;
 }
 
 /**
@@ -107,4 +132,5 @@ export const buildDistillLearningsPrompt = async (
     candidateLearnings: input.candidateLearnings,
     targetFilename: input.targetFilename,
     projectTooling: input.projectTooling,
+    learningsSectionHeading: input.learningsSectionHeading ?? DEFAULT_LEARNINGS_SECTION_HEADING,
   });

--- a/src/integration/ai/prompts/distill-learnings/template.md
+++ b/src/integration/ai/prompts/distill-learnings/template.md
@@ -7,7 +7,7 @@ Your job is to integrate them cleanly, not to invent new ones.
 </role>
 
 <goal>
-Update `{{TARGET_FILENAME}}` so that it carries an up-to-date `## Learnings (ralphctl)` section containing
+Update `{{TARGET_FILENAME}}` so that it carries an up-to-date `## {{LEARNINGS_SECTION_HEADING}}` section containing
 the candidate learnings below — folded in idempotently, preserving everything else in the file verbatim.
 </goal>
 
@@ -26,15 +26,15 @@ the candidate learnings below — folded in idempotently, preserving everything 
 {{HARNESS_CONTEXT}}
 
 <owned_section>
-You own exactly one section of `{{TARGET_FILENAME}}` — the one headed `## Learnings (ralphctl)`. This is
+You own exactly one section of `{{TARGET_FILENAME}}` — the one headed `## {{LEARNINGS_SECTION_HEADING}}`. This is
 the only part of the file you may add, reorder, or rewrite. Everything outside that section is
 hand-authored or owned by another tool — preserve it byte-for-byte.
 
-- When the file already contains a `## Learnings (ralphctl)` section, treat its current bullets as the
+- When the file already contains a `## {{LEARNINGS_SECTION_HEADING}}` section, treat its current bullets as the
   prior state and reconcile the candidates against them (see the idempotency rule below).
 - When the file has no such section yet, append one at the end of the file — after the last existing
   section, separated by a single blank line.
-- Never create a second `## Learnings (ralphctl)` section — there must be exactly one.
+- Never create a second `## {{LEARNINGS_SECTION_HEADING}}` section — there must be exactly one.
   </owned_section>
 
 <idempotency_rule>
@@ -87,7 +87,7 @@ as "when present"; many repositories do not have one, and a learning must not as
 
 <output_contract>
 
-1. Read the existing context file body above and locate the `## Learnings (ralphctl)` section, if any.
+1. Read the existing context file body above and locate the `## {{LEARNINGS_SECTION_HEADING}}` section, if any.
 2. Reconcile the candidate learnings against the owned section per the idempotency rule.
 3. Write the COMPLETE, updated `{{TARGET_FILENAME}}` back to disk at its original path — the full file, not
    a diff and not only the section. Everything outside the owned section must be unchanged.

--- a/src/integration/ai/prompts/evaluate-continuation/template.md
+++ b/src/integration/ai/prompts/evaluate-continuation/template.md
@@ -63,16 +63,49 @@ For the complete history — older than the excerpt above — read `{{PROGRESS_F
 
 {{GENERATOR_HINTS_SECTION}}
 
+<checkpoint_protocol>
+After reviewing each acceptance criterion — before moving to the next — emit a one-line interim
+verdict inside a self-closing tag:
+
+<criterion_checkpoint criterion="N" verdict="pass|fail|partial">one-line observation</criterion_checkpoint>
+
+These tags are for your own mid-review tracking — the harness ignores them entirely. Before
+emitting your final verdict, write your step-by-step assessment inside
+<evaluation_thinking>…</evaluation_thinking> tags (the harness ignores them too — for your reasoning
+only). In that block, note whether any checkpoint changed verdict mid-review — a changed checkpoint
+is evidence of genuine investigation, not a defect. The final `signals.json` remains the only
+machine-readable output and must come last.
+</checkpoint_protocol>
+
 <protocol>
 **Checkpoint write — do this first, before re-grading**
 
-If you have not already written a checkpoint `signals.json` for this round, write one now before
-continuing. Use `status: "failed"`, all four floor dimensions present, each set to
-`passed: false` with `finding: "assessment in progress"`. Use the path named in the output
+If you have not already written a checkpoint `signals.json` for this round, write an `evaluation`
+signal now before continuing. Use `status: "failed"`, all four floor dimensions present, each set
+to `passed: false` with `finding: "assessment in progress"`. Use the path named in the output
 contract section at the bottom of this prompt. This placeholder is valid against the schema the
 harness validates — it ensures a recoverable file exists on disk if this session exhausts its
 token budget before you reach your final verdict. You will overwrite it after completing all steps
 below.
+
+```json
+{
+  "schemaVersion": 1,
+  "signals": [
+    {
+      "type": "evaluation",
+      "status": "failed",
+      "dimensions": [
+        { "dimension": "correctness", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "completeness", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "safety", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" }
+      ],
+      "timestamp": "<ISO-8601 timestamp>"
+    }
+  ]
+}
+```
 
 Re-grade this round the same way you graded the first:
 

--- a/src/integration/ai/prompts/evaluate/definition.ts
+++ b/src/integration/ai/prompts/evaluate/definition.ts
@@ -193,6 +193,17 @@ export interface BuildEvaluatePromptInput {
  * Top-level builder — accepts domain types, renders the param strings, calls `buildPrompt`.
  * The chain leaf consumes this via function injection. `task.extraDimensions` is threaded into
  * the rubric automatically; the rendered section is empty when the field is unset.
+ *
+ * The template includes a `<reasoning_protocol>` section instructing the evaluator to write its
+ * step-by-step assessment inside `<evaluation_thinking>` tags before emitting the verdict signal —
+ * externalising the reasoning reduces premature verdict commitment (a prompt-engineering
+ * approximation of an explicit think step).
+ *
+ * The template also includes a `<checkpoint_protocol>` section (R3) instructing the evaluator to
+ * emit a `<criterion_checkpoint criterion="N" verdict="pass|fail|partial">` tag after reviewing
+ * each acceptance criterion — before moving to the next. The tags are model-internal tracking only
+ * (the harness ignores them) and give the final `<evaluation_thinking>` block explicit per-criterion
+ * anchors to reference. Neither protocol requires changes to the headless provider layer.
  */
 export const buildEvaluatePrompt = async (
   deps: TemplateLoader,

--- a/src/integration/ai/prompts/evaluate/template.md
+++ b/src/integration/ai/prompts/evaluate/template.md
@@ -92,6 +92,30 @@ The block below mirrors that file for in-context reference.
 
 </task_specification>
 
+<reasoning_protocol>
+Before emitting your evaluation signal, write your step-by-step assessment inside
+<evaluation_thinking>…</evaluation_thinking> tags. The harness ignores these tags — they are
+for your reasoning only. Structure the block as:
+
+- Review each acceptance criterion against the evidence collected in Phases 1–2.
+- Identify what specifically changed vs. what the specification required.
+- Decide the verdict for each floor dimension with explicit reasoning.
+- THEN write the final `signals.json` with your concluded verdict.
+
+</reasoning_protocol>
+
+<checkpoint_protocol>
+After reviewing each acceptance criterion — before moving to the next — emit a one-line interim
+verdict inside a self-closing tag:
+
+<criterion_checkpoint criterion="N" verdict="pass|fail|partial">one-line observation</criterion_checkpoint>
+
+These tags are for your own mid-review tracking — the harness ignores them entirely. When you
+write the final <evaluation_thinking> block, note whether any checkpoint changed verdict mid-review
+— a changed checkpoint is evidence of genuine investigation, not a defect. The final `signals.json`
+remains the only machine-readable output and must come last.
+</checkpoint_protocol>
+
 <inputs>
   <project_path>{{PROJECT_PATH}}</project_path>
   <verify_script>{{VERIFY_SCRIPT_SECTION}}</verify_script>

--- a/src/integration/ai/prompts/implement-continuation/definition.ts
+++ b/src/integration/ai/prompts/implement-continuation/definition.ts
@@ -142,6 +142,7 @@ export const implementContinuationPromptDef: PromptDefinition<ImplementContinuat
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
+    DECISIONS_GUIDANCE: 'decisions',
   },
   // Same accepted signal union as the full implement prompt — a continuation turn is still a
   // generator turn and may emit the full narrative + lifecycle set.

--- a/src/integration/ai/prompts/implement-continuation/template.md
+++ b/src/integration/ai/prompts/implement-continuation/template.md
@@ -42,6 +42,8 @@ context to apply.
 For the complete history — older than the excerpt above — read `{{PROGRESS_FILE}}` on disk.
 </prior_progress>
 
+{{DECISIONS_GUIDANCE}}
+
 <goal>
 Address every dimension the evaluator flagged in `<prior_critique>`, then run each `auto`
 criterion's command once. Do NOT run the verify script — the harness runs it after your turn as
@@ -51,7 +53,8 @@ script once yourself. Emit `task-verified` with the verbatim command output, pro
 dimension is resolved and every criterion command passes. Removing or disabling a test to make
 verify pass counts as task failure — fix the implementation, not the test. When a flagged item is
 genuinely blocked (missing dependency, contradictory input, unresolvable ambiguity), emit
-`task-blocked` with the concrete reason instead of guessing.
+`task-blocked` with the concrete reason instead of guessing. Emit `change`, `learning`, and
+`note` signals as applicable — the harness records them in the sprint journal.
 </goal>
 
 {{OUTPUT_CONTRACT_SECTION}}

--- a/src/integration/ai/prompts/implement/definition.ts
+++ b/src/integration/ai/prompts/implement/definition.ts
@@ -119,6 +119,13 @@ export interface ImplementPromptParams {
    * string on a first attempt or when the prior post-verify passed.
    */
   readonly retryFeedbackSection: string;
+  /**
+   * Compact bullet list of prior task episodes for this sprint — each line is
+   * `- [goal excerpt] → outcome (keyLearnings)`. Built by `summariseEpisodes` from the
+   * sprint's episode log. Absent or empty → `{{PRIOR_EPISODES}}` collapses cleanly
+   * (no `<prior_task_episodes>` block is emitted). Default undefined (empty).
+   */
+  readonly priorEpisodesSection?: string;
 }
 
 const requireNonEmpty =
@@ -221,6 +228,13 @@ export const implementPromptDef: PromptDefinition<ImplementPromptParams> = {
       description:
         'Failing post-verify command + output tail from the previous attempt — empty on a first attempt or when the prior post-verify passed.',
     },
+    priorEpisodesSection: {
+      placeholder: 'PRIOR_EPISODES',
+      optional: true,
+      description:
+        'Compact bullet list of prior task episodes for this sprint rendered by `summariseEpisodes`. ' +
+        'Empty → `{{PRIOR_EPISODES}}` collapses (the renderer omits the `<prior_task_episodes>` wrapper).',
+    },
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
@@ -300,7 +314,24 @@ export interface BuildImplementPromptInput {
    * placeholder collapses inside `<retry_feedback>…</retry_feedback>`.
    */
   readonly retryFeedback?: string;
+  /**
+   * Pre-composed episode summary built by `summariseEpisodes` from the sprint's episode log.
+   * Absent or empty → `{{PRIOR_EPISODES}}` collapses (no `<prior_task_episodes>` block emitted).
+   */
+  readonly priorEpisodes?: string;
 }
+
+/**
+ * Render the optional `<prior_task_episodes>` block. Returns the full tagged block when the
+ * summary is non-empty so `{{PRIOR_EPISODES}}` collapses cleanly to nothing when episodes is
+ * empty — no XML wrapper is emitted.
+ */
+const renderPriorEpisodesSection = (summary: string | undefined): string => {
+  if (summary === undefined) return '';
+  const trimmed = summary.trim();
+  if (trimmed.length === 0) return '';
+  return ['<prior_task_episodes>', trimmed, '</prior_task_episodes>'].join('\n');
+};
 
 /**
  * Top-level builder — accepts domain types, renders the param strings, calls `buildPrompt`.
@@ -328,4 +359,5 @@ export const buildImplementPrompt = async (
     outputContractSection: input.outputContractSection,
     preVerifyResults: renderPreVerifyResultsSection(input.preVerifyOutput),
     retryFeedbackSection: renderRetryFeedbackSection(input.retryFeedback),
+    priorEpisodesSection: renderPriorEpisodesSection(input.priorEpisodes),
   });

--- a/src/integration/ai/prompts/implement/template.md
+++ b/src/integration/ai/prompts/implement/template.md
@@ -11,6 +11,8 @@ lifecycle and context compaction.
 
 {{HARNESS_CONTEXT}}
 
+{{PRIOR_EPISODES}}
+
 <goal>
 Complete every declared implementation step for the task defined below. Write `signals.json` to the
 path specified in the Output contract section at the bottom of this prompt. Emit `task-complete`

--- a/src/integration/ai/prompts/plan/template.md
+++ b/src/integration/ai/prompts/plan/template.md
@@ -140,7 +140,7 @@ implemented in a single session, and verified end-to-end against its criteria.
 
 **Do not split when:**
 
-- A utility and its first caller would be separated — create-and-use is always one task.
+- A utility and its first caller would be separated — create-and-use is always one task, unless the utility already exists in the codebase or a prior task in this plan produces it.
 - A feature and its tests would be separated.
 - The same pattern applies across N call sites — it is one refactor, not N tasks.
 

--- a/src/integration/ai/prompts/readiness/template.md
+++ b/src/integration/ai/prompts/readiness/template.md
@@ -33,8 +33,9 @@ warranted. Write all signals to the `signals.json` path described in `<output_co
 <target_file_conventions>
 {{TARGET_FILE_CONVENTIONS}}
 </target_file_conventions>
-{{HARNESS_CONTEXT}}
 </inputs>
+
+{{HARNESS_CONTEXT}}
 
 <constraints>
 

--- a/src/integration/ai/providers/_engine/abort-kill.ts
+++ b/src/integration/ai/providers/_engine/abort-kill.ts
@@ -1,0 +1,41 @@
+import type { ChildProcess } from 'node:child_process';
+import { DEFAULT_GRACE_MS } from '@src/integration/ai/providers/_engine/idle-watchdog.ts';
+
+/**
+ * Wire a caller {@link AbortSignal} to a SIGTERM → grace → SIGKILL kill ladder for a
+ * `stdio: 'inherit'` child (mirrors `installIdleWatchdog`'s abort path, minus idle detection).
+ *
+ * Shared by the interactive claude / codex / copilot adapters: each spawns with inherited stdio,
+ * so the harness keeps no read-side handle on the child once `run` returns — the abort signal is
+ * the only cancel lever a TUI-side stop has against a `stdio: 'inherit'` session. (Idle detection
+ * is a separate concern that stays in `idle-watchdog.ts`; only the grace constant is shared.)
+ *
+ * Returns a cleanup fn the caller MUST invoke once the child has exited — it cancels the pending
+ * SIGKILL escalation and drops the abort listener so a reused AbortController never fires kill
+ * against the now-dead pid. A signal already aborted when called kills the child immediately.
+ */
+export const attachAbortKill = (child: ChildProcess, abortSignal: AbortSignal | undefined): (() => void) => {
+  let graceTimer: NodeJS.Timeout | null = null;
+  const kill = (): void => {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // Child may already be dead (ESRCH) — best-effort.
+    }
+    graceTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already dead — best-effort.
+      }
+    }, DEFAULT_GRACE_MS);
+  };
+  const cleanup = (): void => {
+    if (graceTimer !== null) clearTimeout(graceTimer);
+    abortSignal?.removeEventListener('abort', kill);
+  };
+  if (abortSignal === undefined) return cleanup;
+  if (abortSignal.aborted) kill();
+  else abortSignal.addEventListener('abort', kill, { once: true });
+  return cleanup;
+};

--- a/src/integration/ai/providers/_engine/bounded-tail.ts
+++ b/src/integration/ai/providers/_engine/bounded-tail.ts
@@ -29,6 +29,29 @@ export const STDERR_TAIL_CAP = 16_384;
  */
 export const RATE_LIMIT_SCAN_TAIL_CAP = 8192;
 
+/**
+ * Hard ceiling on the in-flight NDJSON line-parse accumulator in the stdout stream parsers
+ * (`claude/parse-stream.ts`, `copilot/parse-stream.ts`). Those parsers grow `buffer += chunk`
+ * until a newline terminates the current line; a single record embedding a large file-read or
+ * bash tool result can inflate one line to tens of MB before the newline clears it, which is an
+ * OOM-class accumulation (same root cause as the TUI render-path leak). When the unterminated
+ * line crosses this cap the parser drops the OLDEST bytes back to the cap and keeps draining —
+ * 512 KiB leaves ample room for any legitimate JSONL record while pinning the worst-case
+ * per-line footprint regardless of how large a tool result the child streams.
+ */
+export const STDOUT_LINE_PARSE_CAP = 524_288;
+
+/**
+ * Retained-tail size for the Copilot forensic body mirror (`body.txt` when `session.bodyFile` is
+ * set). The adapter formerly retained EVERY stdout line for the whole spawn in an unbounded
+ * `events[]` array — an OOM-class accumulation on a multi-hour, chatty session. A bounded tail
+ * caps that footprint while keeping the most recent ~256 KiB, which is the diagnostic window an
+ * operator actually inspects when a proposal comes back empty (older lines rarely matter for that
+ * post-mortem). Larger than {@link RATE_LIMIT_SCAN_TAIL_CAP} because forensic capture wants more
+ * context than the narrow rate-limit marker scan.
+ */
+export const FORENSIC_BODY_TAIL_CAP = 262_144;
+
 /** @public */
 export interface BoundedTail {
   /** Append a chunk, trimming the retained window back to the cap when it overflows. */

--- a/src/integration/ai/providers/_engine/interactive-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/interactive-ai-provider.ts
@@ -46,6 +46,14 @@ export interface InteractiveAiProviderInput {
    * of `AiSession.effort` on the headless port.
    */
   readonly effort?: string;
+  /**
+   * Caller-controlled abort (Ctrl-C / TUI cancel). When it fires, the adapter tears the child
+   * down with a SIGTERM → grace → SIGKILL kill ladder — without it a `stdio: 'inherit'` child
+   * is unreachable once spawned (the harness holds no reference past `run`) and keeps running
+   * indefinitely after a cancel. A signal already aborted when `run` is called kills the child
+   * immediately. Sibling of `AiSession.abortSignal` on the headless port.
+   */
+  readonly abortSignal?: AbortSignal;
 }
 
 export interface InteractiveAiProviderOutput {

--- a/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
+++ b/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
@@ -156,11 +156,11 @@ export const runWithRateLimitRetry = async (
             cause: `attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
             at: IsoTimestamp.now(),
           });
-          await sleepCancellable(delayMs, opts.session.abortSignal);
+          await sleepCancellable(delayMs, session.abortSignal);
           // Clear once the wait completes (either elapsed or abort fired); the next attempt
           // re-publishes if it also hits the rate-limit.
           eventBus.publish({ type: 'banner-clear', id: bannerId, at: IsoTimestamp.now() });
-          if (opts.session.abortSignal?.aborted === true) {
+          if (session.abortSignal?.aborted === true) {
             // User cancel during the backoff sleep must surface as AbortError — the one error
             // chains propagate transparently (CLAUDE.md §AbortError). InvalidStateError is
             // classified as a recoverable turn error and would wrongly self-block the task.
@@ -186,7 +186,7 @@ export const runWithRateLimitRetry = async (
     if (
       resumeStaleRe !== undefined &&
       !coldRetried &&
-      opts.session.abortSignal?.aborted !== true &&
+      session.abortSignal?.aborted !== true &&
       session.resume !== undefined &&
       resumeStaleRe.test(outcome.error.message)
     ) {

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -12,6 +12,7 @@ import {
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
+import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -155,10 +156,17 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',

--- a/src/integration/ai/providers/claude/parse-stream.ts
+++ b/src/integration/ai/providers/claude/parse-stream.ts
@@ -29,10 +29,33 @@ import type {
   ClaudeStreamParser,
   ClaudeUsage,
 } from '@src/integration/ai/providers/_engine/claude-stream.ts';
+import { STDOUT_LINE_PARSE_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 
 export const createClaudeStreamParser = (): ClaudeStreamParser => {
   let buffer = '';
+  // One-shot latch: warn exactly once per parser so a child that streams a pathologically long
+  // unterminated line does not itself spam the console with one warning per chunk.
+  let overflowWarned = false;
+  // Cap the in-flight line accumulator. A single NDJSON record embedding a large file-read /
+  // bash tool result can grow `buffer` to tens of MB before its newline clears it — an OOM-class
+  // accumulation. `feed` is the SOLE append site, so capping here keeps the invariant for `flush`
+  // too (it only drains an already-bounded buffer). Drop the OLDEST bytes (keep the tail) so the
+  // record's terminating `}`/newline, when it finally arrives, still lands inside the window.
+  const appendCapped = (chunk: string): void => {
+    buffer += chunk;
+    if (buffer.length > STDOUT_LINE_PARSE_CAP) {
+      buffer = buffer.slice(-STDOUT_LINE_PARSE_CAP);
+      if (!overflowWarned) {
+        overflowWarned = true;
+        console.warn(
+          `[claude-stream] in-flight NDJSON line exceeded ${String(STDOUT_LINE_PARSE_CAP)} bytes — ` +
+            'truncating the parse buffer to its tail and continuing. A single record is streaming an ' +
+            'oversized tool result; the affected line will be emitted as a raw (unparsed) text line.'
+        );
+      }
+    }
+  };
   // `body` is reassigned from the latest `result` event's `.result` field in `ingest` (one
   // O(1) write), never built by per-line concatenation. Keep it that way — see the analogous
   // `bodyLines.push` + `.join('\n')` pattern in copilot/headless.ts for why.
@@ -120,7 +143,7 @@ export const createClaudeStreamParser = (): ClaudeStreamParser => {
 
   return {
     feed(chunk, onLine) {
-      buffer += chunk;
+      appendCapped(chunk);
       let nl = buffer.indexOf('\n');
       while (nl !== -1) {
         const line = buffer.slice(0, nl);

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -459,40 +459,40 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   let model: string | undefined;
   let inputTokens: number | undefined;
   let outputTokens: number | undefined;
+
+  const onMeta = (update: CodexMetaUpdate): void => {
+    if (update.sessionId !== undefined && sessionId === undefined) {
+      sessionId = update.sessionId;
+      deps.eventBus.publish({
+        type: 'log',
+        level: 'debug',
+        message: 'codex-provider: session id captured',
+        meta: { sessionId: update.sessionId },
+        at: IsoTimestamp.now(),
+      });
+    }
+    if (update.model !== undefined && model === undefined) {
+      model = update.model;
+    }
+    // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+    // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
+    if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
+    if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
+  };
+  const onLine = (obj: Record<string, unknown>): void => {
+    publishCodexStreamLineEvents(deps.eventBus, obj);
+    const text = agentMessageText(obj);
+    if (text !== undefined) {
+      agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
+        -RATE_LIMIT_SCAN_TAIL_CAP
+      );
+    }
+  };
+
   const { code, signal } = await runHeadlessSpawn({
     child,
     onStdout: (chunk) => {
-      stdoutLineBuf = consumeMetaLines(
-        stdoutLineBuf + chunk,
-        (update) => {
-          if (update.sessionId !== undefined && sessionId === undefined) {
-            sessionId = update.sessionId;
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'debug',
-              message: 'codex-provider: session id captured',
-              meta: { sessionId: update.sessionId },
-              at: IsoTimestamp.now(),
-            });
-          }
-          if (update.model !== undefined && model === undefined) {
-            model = update.model;
-          }
-          // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
-          // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
-          if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
-          if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
-        },
-        (obj) => {
-          publishCodexStreamLineEvents(deps.eventBus, obj);
-          const text = agentMessageText(obj);
-          if (text !== undefined) {
-            agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
-              -RATE_LIMIT_SCAN_TAIL_CAP
-            );
-          }
-        }
-      );
+      stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
     },
     onStderr: (chunk) => {
       stderrTail.append(chunk);
@@ -519,6 +519,13 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       });
     },
   });
+
+  // Flush any partial line remaining in the line buffer — codex may terminate without a
+  // trailing newline. Appending a synthetic '\n' forces the partial through the parser,
+  // matching the parser.flush(onLine) convention used in the claude and copilot adapters.
+  if (stdoutLineBuf.length > 0) {
+    consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
+  }
 
   const onSuccess = async (): Promise<AttemptOutcome> => {
     let body: string;

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -11,6 +11,7 @@ import {
   defaultInteractiveSpawn,
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -141,10 +142,17 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,6 +1,7 @@
 import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import {
+  FORENSIC_BODY_TAIL_CAP,
   RATE_LIMIT_SCAN_TAIL_CAP,
   STDERR_TAIL_CAP,
   createBoundedTail,
@@ -218,13 +219,21 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   // auto-discover their context file from cwd."
   const child = spawnFn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] as const, cwd: String(session.cwd) });
   const parser = createCopilotStreamParser();
-  // Two buffers, one tagged event log: assistant body text feeds signal parsing; the
-  // forensic body.txt mirrors every assistant + unrecognised-event line in stream order.
-  // Splitting matters because Copilot echoes the prompt as a `user.message` event whose raw
-  // JSONL would otherwise be matched by the harness signal regexes (literal `<task-blocked>`
-  // inside the prompt → fake signal). Order preservation: derive both views from one tagged
-  // event list rather than two parallel arrays.
-  const events: Array<{ readonly assistant: boolean; readonly text: string }> = [];
+  // Two BOUNDED tails fed in stream order — replaces a formerly-unbounded `events[]` that
+  // retained every stdout line for the whole spawn (an OOM-class accumulation on a chatty
+  // multi-hour session — same root cause as the PR #229 TUI render-path leak). `forensicTail`
+  // backs `body.txt`; `rateLimitTail` is the classifier's scan haystack. Both drop their oldest
+  // bytes once full, so the per-spawn stdout footprint is pinned regardless of child verbosity.
+  // The prior per-line `assistant` tag is gone: neither consumer ever filtered on it (signals
+  // land in `signals.json` via the file-based audit-[09] contract, not by re-parsing the body),
+  // and the prompt-echo leak it once guarded is moot since both views were already derived from
+  // every recorded line.
+  const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
+  const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
+  const recordLine = (text: string): void => {
+    forensicTail.append(`${text}\n`);
+    rateLimitTail.append(`${text}\n`);
+  };
   let sessionId: string | undefined;
   let model: string | undefined;
   let usage: CopilotUsage = {};
@@ -254,7 +263,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         usage = line.usage;
       }
       if (line.bodyText !== undefined && line.bodyText.length > 0) {
-        events.push({ assistant: true, text: line.bodyText });
+        recordLine(line.bodyText);
         // Per-line assistant debug event. The bus → logger consumer drops debug events at
         // the default `info` floor; only `RALPHCTL_LOG_LEVEL=debug` operators see them.
         const text = truncateField(line.bodyText);
@@ -271,7 +280,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
         // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
         // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
         // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
-        events.push({ assistant: false, text: line.raw });
+        recordLine(line.raw);
       }
       // Truncate the raw line like every other stream-originated debug field (see truncateField):
       // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
@@ -287,7 +296,7 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
       return;
     }
     // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
-    events.push({ assistant: false, text: line.raw });
+    recordLine(line.raw);
   };
 
   // Copilot reads the prompt from -p argv (no stdin payload). Tokens stream to stdout via the
@@ -326,9 +335,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
     // `session.outputDir`; the harness validates it post-spawn. The provider never writes
     // signals.json itself. The forensic body buffer below stays — operators inspect it when
     // a proposal comes back empty to decide whether the prompt, the AI, or the validator is
-    // at fault. On SIGTERM-recovery `events[]` may be partial; the join still produces a
-    // useful snapshot of what the model emitted before the watchdog stepped in.
-    const forensicBody = events.map((e) => e.text).join('\n');
+    // at fault. On SIGTERM-recovery the tail may be partial; it still produces a useful snapshot
+    // of what the model emitted before the watchdog stepped in (bounded to its most recent window).
+    const forensicBody = forensicTail.value();
     // Mirror raw body for diagnostic capture. Best-effort: a write failure here is logged but
     // does not fail the session. Critically, the body is captured even when the AI emits no
     // signals, so operators can see what the model actually produced.
@@ -389,12 +398,9 @@ const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> =>
   };
 
   // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota throttle in
-  // its result-record text (captured as a raw `events[]` line), not on stderr. Capped so a long
-  // session doesn't build a multi-MB scan string.
-  const stdoutTail = events
-    .map((e) => e.text)
-    .join('\n')
-    .slice(-RATE_LIMIT_SCAN_TAIL_CAP);
+  // its result-record text (recorded as a stream line), not on stderr. `rateLimitTail` is already
+  // bounded to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
+  const stdoutTail = rateLimitTail.value();
 
   return classifySpawnExit({
     session,

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -12,6 +12,7 @@ import {
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
+import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -135,10 +136,17 @@ export const createInteractiveCopilotProvider = (deps: InteractiveCopilotDeps): 
         );
       }
 
+      // A `stdio: 'inherit'` child is unreachable once spawned (the harness keeps no reference
+      // past `run`), so a TUI-side cancel can't stop it. Wire the caller's abort signal to a
+      // SIGTERM → grace → SIGKILL kill ladder; the cleanup runs on normal exit so a reused
+      // AbortController never fires kill against the dead pid.
+      const stopAbortKill = attachAbortKill(child, input.abortSignal);
+
       const exitCode = await new Promise<number | null>((resolve) => {
         child.on('close', (code) => resolve(code));
         child.on('error', () => resolve(-1));
       });
+      stopAbortKill();
 
       deps.eventBus.publish({
         type: 'log',

--- a/src/integration/ai/providers/copilot/parse-stream.ts
+++ b/src/integration/ai/providers/copilot/parse-stream.ts
@@ -15,6 +15,7 @@ import type {
   CopilotStreamParser,
   CopilotUsage,
 } from '@src/integration/ai/providers/_engine/copilot-stream.ts';
+import { STDOUT_LINE_PARSE_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 
 const extractUsage = (json: Record<string, unknown>): CopilotUsage | undefined => {
@@ -91,6 +92,28 @@ const extractBodyText = (json: Record<string, unknown>): string | undefined => {
 
 export const createCopilotStreamParser = (): CopilotStreamParser => {
   let buffer = '';
+  // One-shot latch: warn exactly once per parser so a child that streams a pathologically long
+  // unterminated line does not itself spam the console with one warning per chunk.
+  let overflowWarned = false;
+  // Cap the in-flight line accumulator. A single NDJSON record embedding a large file-read /
+  // bash tool result can grow `buffer` to tens of MB before its newline clears it — an OOM-class
+  // accumulation. `feed` is the SOLE append site, so capping here keeps the invariant for `flush`
+  // too (it only drains an already-bounded buffer). Drop the OLDEST bytes (keep the tail) so the
+  // record's terminating `}`/newline, when it finally arrives, still lands inside the window.
+  const appendCapped = (chunk: string): void => {
+    buffer += chunk;
+    if (buffer.length > STDOUT_LINE_PARSE_CAP) {
+      buffer = buffer.slice(-STDOUT_LINE_PARSE_CAP);
+      if (!overflowWarned) {
+        overflowWarned = true;
+        console.warn(
+          `[copilot-stream] in-flight NDJSON line exceeded ${String(STDOUT_LINE_PARSE_CAP)} bytes — ` +
+            'truncating the parse buffer to its tail and continuing. A single record is streaming an ' +
+            'oversized tool result; the affected line will be emitted as a raw (unparsed) text line.'
+        );
+      }
+    }
+  };
   const emit = (raw: string, onLine: (line: CopilotStreamLine) => void): void => {
     if (raw.length === 0) return;
     if (raw.startsWith('{') && raw.endsWith('}')) {
@@ -121,7 +144,7 @@ export const createCopilotStreamParser = (): CopilotStreamParser => {
   };
   return {
     feed(chunk, onLine) {
-      buffer += chunk;
+      appendCapped(chunk);
       let nl = buffer.indexOf('\n');
       while (nl !== -1) {
         const line = buffer.slice(0, nl);

--- a/tests/integration/ai/prompts/distill-learnings/definition.test.ts
+++ b/tests/integration/ai/prompts/distill-learnings/definition.test.ts
@@ -31,13 +31,31 @@ describe('distillLearningsPromptDef — completeness', () => {
     expect(report.unreferenced).toEqual([]);
   });
 
-  it('declares exactly the four spec placeholders', async () => {
+  it('declares exactly the five spec placeholders', async () => {
     const rawTemplate = await readTemplate();
     const partials = await loadPartialMap(distillLearningsPromptDef, loader);
     const report = computePlaceholderParity({ def: distillLearningsPromptDef, rawTemplate, partials });
     expect(report.declaredParameters).toEqual(
-      ['CANDIDATE_LEARNINGS', 'EXISTING_CONTEXT_FILE', 'PROJECT_TOOLING', 'TARGET_FILENAME'].sort()
+      [
+        'CANDIDATE_LEARNINGS',
+        'EXISTING_CONTEXT_FILE',
+        'LEARNINGS_SECTION_HEADING',
+        'PROJECT_TOOLING',
+        'TARGET_FILENAME',
+      ].sort()
     );
+  });
+
+  it('templates the owned-section heading instead of hardcoding the ralphctl brand', async () => {
+    const rawTemplate = await readTemplate();
+    // The template runs on downstream user projects — the owned-section heading must be a
+    // placeholder, never a literal brand, so each project gets its own (or the generic default).
+    expect(rawTemplate).toContain('{{LEARNINGS_SECTION_HEADING}}');
+    expect(rawTemplate).not.toMatch(/Learnings \(ralphctl\)/);
+    // …and that placeholder is backed by a declared parameter spec.
+    const partials = await loadPartialMap(distillLearningsPromptDef, loader);
+    const report = computePlaceholderParity({ def: distillLearningsPromptDef, rawTemplate, partials });
+    expect(report.declaredParameters).toContain('LEARNINGS_SECTION_HEADING');
   });
 
   it('the template hardcodes no package-manager commands outside PROJECT_TOOLING', async () => {
@@ -54,9 +72,22 @@ describe('buildDistillLearningsPrompt — end-to-end', () => {
     if (!result.ok) return;
     expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
     expect(result.value).toContain('CLAUDE.md');
-    expect(result.value).toContain('## Learnings (ralphctl)');
+    // No learningsSectionHeading supplied → the builder applies the brand-free default.
+    expect(result.value).toContain('## Learnings (AI sessions)');
+    expect(result.value).not.toContain('## Learnings (ralphctl)');
     expect(result.value).toContain('The build emits ESM only.');
     expect(result.value).toContain('Detected: pnpm + vitest.');
+  });
+
+  it('substitutes a caller-supplied learnings-section heading', async () => {
+    const result = await buildDistillLearningsPrompt(loader, {
+      ...VALID_INPUT,
+      learningsSectionHeading: 'Learnings (my-project)',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain('## Learnings (my-project)');
+    expect(result.value).not.toContain('## Learnings (AI sessions)');
   });
 
   it('rejects empty candidateLearnings', async () => {

--- a/tests/integration/ai/prompts/template-signal-coverage.test.ts
+++ b/tests/integration/ai/prompts/template-signal-coverage.test.ts
@@ -7,8 +7,10 @@ import { applyFeedbackPromptDef } from '@src/integration/ai/prompts/apply-feedba
 import { createPrPromptDef } from '@src/integration/ai/prompts/create-pr/definition.ts';
 import { detectScriptsPromptDef } from '@src/integration/ai/prompts/detect-scripts/definition.ts';
 import { detectSkillsPromptDef } from '@src/integration/ai/prompts/detect-skills/definition.ts';
+import { evaluateContinuationPromptDef } from '@src/integration/ai/prompts/evaluate-continuation/definition.ts';
 import { evaluatePromptDef } from '@src/integration/ai/prompts/evaluate/definition.ts';
 import { ideatePromptDef } from '@src/integration/ai/prompts/ideate/definition.ts';
+import { implementContinuationPromptDef } from '@src/integration/ai/prompts/implement-continuation/definition.ts';
 import { implementPromptDef } from '@src/integration/ai/prompts/implement/definition.ts';
 import { planPromptDef } from '@src/integration/ai/prompts/plan/definition.ts';
 import { readinessPromptDef } from '@src/integration/ai/prompts/readiness/definition.ts';
@@ -22,8 +24,8 @@ import { refinePromptDef } from '@src/integration/ai/prompts/refine/definition.t
  *
  * Mention forms recognised:
  *   - Backticked signal name:   `task-complete`
- *   - Inline tag form:          <task-complete>...</task-complete>
- *   - Header / list reference:  task-complete (when it appears as a discrete token)
+ *   - Inline tag form:          <task-complete>...</task-complete> (open, close, or with attributes)
+ *   - Backticked tag form:      `<task-complete>`
  *
  * The check is a substring scan against the rendered template plus its `_partials/` includes;
  * the auto-rendered `{{OUTPUT_CONTRACT_SECTION}}` block is composed at runtime by the contract
@@ -40,7 +42,9 @@ const FLOWS: ReadonlyArray<{ readonly name: string; readonly def: PromptDefiniti
   { name: 'plan', def: planPromptDef as PromptDefinition<never> },
   { name: 'ideate', def: ideatePromptDef as PromptDefinition<never> },
   { name: 'implement', def: implementPromptDef as PromptDefinition<never> },
+  { name: 'implement-continuation', def: implementContinuationPromptDef as PromptDefinition<never> },
   { name: 'evaluate', def: evaluatePromptDef as PromptDefinition<never> },
+  { name: 'evaluate-continuation', def: evaluateContinuationPromptDef as PromptDefinition<never> },
   { name: 'readiness', def: readinessPromptDef as PromptDefinition<never> },
   { name: 'detect-scripts', def: detectScriptsPromptDef as PromptDefinition<never> },
   { name: 'detect-skills', def: detectSkillsPromptDef as PromptDefinition<never> },
@@ -73,7 +77,7 @@ describe('prompt template signal coverage', () => {
       const missing: string[] = [];
       for (const signal of def.expectedSignals) {
         if (ignored.has(signal)) continue;
-        // Match the signal name as a backticked token, an XML-tag form, or a discrete word.
+        // Match the signal name as a backticked token or an XML-tag form (open, close, or with attributes).
         const patterns = [`\`${signal}\``, `<${signal}>`, `<${signal} `, `</${signal}>`, `\`<${signal}>\``];
         const found = patterns.some((p) => body.includes(p));
         if (!found) missing.push(signal);

--- a/tests/integration/application/flows/detect-scripts/leaves/detect-scripts-contract.test.ts
+++ b/tests/integration/application/flows/detect-scripts/leaves/detect-scripts-contract.test.ts
@@ -1,0 +1,283 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { HarnessSignal, SetupScriptSignal, VerifyScriptSignal } from '@src/domain/signal.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import type { AiSignalEvent, AppEvent } from '@src/business/observability/events.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
+import { absolutePath, makeProject, makeRepository } from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import {
+  proposeDetectScriptsLeaf,
+  type ProposeDetectScriptsLeafDeps,
+} from '@src/application/flows/detect-scripts/leaves/propose.ts';
+import type { DetectScriptsCtx } from '@src/application/flows/detect-scripts/ctx.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Audit-[10] contract grid for `proposeDetectScriptsLeaf` — audit-[09] detect-scripts contract.
+ *
+ * A `FakeProvider` writes the test payload directly to `session.signalsFile`, bypassing the
+ * real AI CLI. The propose leaf then calls `validateSignalsFile` against `detectScriptsOutputContract`
+ * and projects the result onto `ctx.proposal`. This exercises the full integration path from
+ * provider → validate → project, under a real tmpdir, without spawning a CLI process.
+ *
+ * Contract rules:
+ *  - All signal kinds (`setup-script`, `verify-script`, `verify-gates`, `note`) are optional.
+ *  - At most one of each kind per spawn.
+ *  - Empty signals array is a valid "no answer" response.
+ *  - `migrations[0]` lifts the legacy bare-array shape into the v1 `{ schemaVersion, signals }` wrapper.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+type EmitPayload =
+  | { readonly kind: 'signals'; readonly signals: readonly HarnessSignal[] }
+  | { readonly kind: 'raw'; readonly body: string }
+  | { readonly kind: 'omit' }
+  | { readonly kind: 'spawn-error'; readonly error: DomainError }
+  | { readonly kind: 'abort' };
+
+const fakeProvider = (payload: EmitPayload): HeadlessAiProvider => ({
+  async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+    if (payload.kind === 'spawn-error') return Result.error(payload.error);
+    if (payload.kind === 'abort')
+      throw new AbortError({ elementName: 'fake-detect-scripts-provider', reason: 'abort in test' });
+    if (payload.kind === 'signals') {
+      // Write the v1 wrapper so `validateSignalsFile` skips the legacy migration.
+      const wrote = await writeJsonAtomic(String(session.signalsFile), {
+        schemaVersion: 1,
+        signals: payload.signals,
+      });
+      if (!wrote.ok) return Result.error(wrote.error);
+    } else if (payload.kind === 'raw') {
+      await fs.writeFile(String(session.signalsFile), payload.body, 'utf8');
+    }
+    // `omit` → never touch signalsFile → `validateSignalsFile` returns InvalidStateError.
+    return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 });
+  },
+});
+
+const captureBus = (eventBus = createInMemoryEventBus()): { events: AppEvent[]; eventBus: typeof eventBus } => {
+  const events: AppEvent[] = [];
+  eventBus.subscribe((e) => {
+    events.push(e);
+  });
+  return { events, eventBus };
+};
+
+describe('proposeDetectScriptsLeaf — audit-[09] contract', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+  let runsRoot: ReturnType<typeof absolutePath>;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+    runsRoot = absolutePath(join(String(root.root), 'runs'));
+    repoPath = join(String(root.root), 'repo-a');
+    await fs.mkdir(repoPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const buildDeps = (payload: EmitPayload, eventBus = createInMemoryEventBus()): ProposeDetectScriptsLeafDeps => ({
+    provider: fakeProvider(payload),
+    templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+    signals: createInMemorySink<HarnessSignal>(),
+    eventBus,
+    logger: noopLogger,
+    model: 'claude-sonnet-4-6',
+    runsRoot,
+  });
+
+  const buildCtx = (): DetectScriptsCtx => {
+    const project = makeProject();
+    const repository = makeRepository({ path: repoPath, name: 'repo-a' });
+    return {
+      projectId: project.id,
+      repository,
+    };
+  };
+
+  const setupScriptSignal = (): SetupScriptSignal => ({
+    type: 'setup-script',
+    command: 'pnpm install',
+    timestamp: TS,
+  });
+
+  const verifyScriptSignal = (): VerifyScriptSignal => ({
+    type: 'verify-script',
+    command: 'pnpm typecheck && pnpm lint && pnpm test',
+    timestamp: TS,
+  });
+
+  // ── 1. Happy path — all valid signals present ────────────────────────────────
+
+  it('ok: setup-script + verify-script → parsed, projected onto ctx, fanned to bus', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupScriptSignal(), verifyScriptSignal()] }, eventBus);
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    // Bus fan-out: every validated signal as a typed `ai-signal` event with source 'detect-scripts'.
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-script', 'verify-script']);
+    for (const ev of aiSignals) expect(ev.source).toBe('detect-scripts');
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBe('pnpm install');
+    expect(result.value.ctx.proposal?.proposedVerifyScript).toBe('pnpm typecheck && pnpm lint && pnpm test');
+  });
+
+  // ── 2. Empty signals — valid "no answer" ────────────────────────────────────
+
+  it('ok: empty signals array — "no answer" is valid, proposal has no scripts', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [] });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBeUndefined();
+    expect(result.value.ctx.proposal?.proposedVerifyScript).toBeUndefined();
+    // runDir is always set on success.
+    expect(result.value.ctx.proposal?.runDir).toBeDefined();
+  });
+
+  // ── 3. Duplicate signal kind — at-most-one refine fails ─────────────────────
+
+  it('duplicate setup-script → ParseError (at-most-one violated)', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [setupScriptSignal(), setupScriptSignal()] });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 4. Invalid / unknown signal kind ─────────────────────────────────────────
+
+  it('unknown signal kind (commit-message) → ParseError(schema-mismatch)', async () => {
+    const unknown = [
+      { type: 'commit-message', subject: 'feat: not a detect-scripts signal', timestamp: TS },
+    ] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: unknown });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 5. Missing required field on a valid type ─────────────────────────────────
+
+  it('setup-script missing required command field → ParseError(schema-mismatch)', async () => {
+    const malformed = [{ type: 'setup-script', timestamp: TS }] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: malformed });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 6. Malformed JSON ──────────────────────────────────────────────────────────
+
+  it('malformed JSON in signals.json → ParseError(invalid-json)', async () => {
+    const deps = buildDeps({ kind: 'raw', body: '{ this is not valid json' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('malformed JSON');
+  });
+
+  // ── 7. signals.json not written ───────────────────────────────────────────────
+
+  it('signals-missing: provider omits signals.json → InvalidStateError', async () => {
+    const deps = buildDeps({ kind: 'omit' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.error.message).toContain('signals-missing');
+  });
+
+  // ── 8. Legacy bare-array migration ────────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    const { events, eventBus } = captureBus();
+    // Write legacy shape: a bare JSON array without the `{ schemaVersion, signals }` wrapper.
+    const legacyPayload = JSON.stringify([setupScriptSignal()]);
+    const deps = buildDeps({ kind: 'raw', body: legacyPayload }, eventBus);
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-script']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupScript).toBe('pnpm install');
+  });
+
+  // ── 9. Spawn error ────────────────────────────────────────────────────────────
+
+  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+    const spawnError = new InvalidStateError({
+      entity: 'provider',
+      currentState: 'broken',
+      attemptedAction: 'detect-scripts',
+      message: 'simulated spawn failure',
+    });
+    const deps = buildDeps({ kind: 'spawn-error', error: spawnError });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBe(spawnError);
+  });
+
+  // ── 10. AbortError propagation ────────────────────────────────────────────────
+
+  it('abort: AbortError surfaces as an aborted Result out of the leaf (chain framework design)', async () => {
+    // The provider throws AbortError mid-spawn (a TUI cancel). The `leaf` chain primitive
+    // catches it and returns `Result.error({ error, trace })` with the trace entry marked
+    // `aborted` — it does NOT re-throw. The runner's status machine routes that aborted Result
+    // to the interrupted exit path, so cancellation stays a first-class Result, not an exception.
+    const deps = buildDeps({ kind: 'abort' });
+    const leaf = proposeDetectScriptsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(result.error.trace.at(-1)?.status).toBe('aborted');
+  });
+});

--- a/tests/integration/application/flows/detect-skills/leaves/detect-skills-contract.test.ts
+++ b/tests/integration/application/flows/detect-skills/leaves/detect-skills-contract.test.ts
@@ -1,0 +1,321 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { HarnessSignal, SetupSkillProposalSignal, VerifySkillProposalSignal } from '@src/domain/signal.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import type { AiSignalEvent, AppEvent } from '@src/business/observability/events.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
+import { absolutePath, makeProject, makeRepository } from '@tests/fixtures/domain.ts';
+import { noopLogger } from '@tests/fixtures/noop-logger.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { writeJsonAtomic } from '@src/integration/io/fs.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import {
+  proposeDetectSkillsLeaf,
+  type ProposeDetectSkillsLeafDeps,
+} from '@src/application/flows/detect-skills/leaves/propose.ts';
+import type { DetectSkillsCtx } from '@src/application/flows/detect-skills/ctx.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Audit-[10] contract grid for `proposeDetectSkillsLeaf` — audit-[09] detect-skills contract.
+ *
+ * A `FakeProvider` writes the test payload directly to `session.signalsFile`, bypassing the
+ * real AI CLI. The propose leaf then calls `validateSignalsFile` against `detectSkillsOutputContract`,
+ * renders sidecars for the two optional `*-proposal` kinds, and projects the result onto
+ * `ctx.proposal`. This exercises the full integration path from provider → validate → sidecar →
+ * project, under a real tmpdir, without spawning a CLI process.
+ *
+ * Contract rules:
+ *  - `setup-skill-proposal`, `verify-skill-proposal`, and `note` are all optional.
+ *  - At most one of each kind per spawn.
+ *  - Empty signals array is a valid "no skill needed" response.
+ *  - `migrations[0]` lifts the legacy bare-array shape into the v1 `{ schemaVersion, signals }` wrapper.
+ *  - Sidecars (`setup-skill.md`, `verify-skill.md`) are rendered from the accepted proposals.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+type EmitPayload =
+  | { readonly kind: 'signals'; readonly signals: readonly HarnessSignal[] }
+  | { readonly kind: 'raw'; readonly body: string }
+  | { readonly kind: 'omit' }
+  | { readonly kind: 'spawn-error'; readonly error: DomainError }
+  | { readonly kind: 'abort' };
+
+const fakeProvider = (payload: EmitPayload): HeadlessAiProvider => ({
+  async generate(session: AiSession): Promise<Result<ProviderOutput, DomainError>> {
+    if (payload.kind === 'spawn-error') return Result.error(payload.error);
+    if (payload.kind === 'abort')
+      throw new AbortError({ elementName: 'fake-detect-skills-provider', reason: 'abort in test' });
+    if (payload.kind === 'signals') {
+      const wrote = await writeJsonAtomic(String(session.signalsFile), {
+        schemaVersion: 1,
+        signals: payload.signals,
+      });
+      if (!wrote.ok) return Result.error(wrote.error);
+    } else if (payload.kind === 'raw') {
+      await fs.writeFile(String(session.signalsFile), payload.body, 'utf8');
+    }
+    // `omit` → never touch signalsFile → `validateSignalsFile` returns InvalidStateError.
+    return Result.ok({ signalsFile: session.signalsFile, exitCode: 0 });
+  },
+});
+
+/**
+ * Real-disk WriteFile impl. The sidecar render path calls this for `setup-skill.md` and
+ * `verify-skill.md`; errors are surfaced as `StorageError` matching production behaviour.
+ */
+const makeWriteFile = (): WriteFile => async (path, content) => {
+  try {
+    await fs.mkdir(join(String(path), '..'), { recursive: true });
+    await fs.writeFile(String(path), content, 'utf8');
+    return Result.ok(undefined);
+  } catch (cause) {
+    return Result.error(new StorageError({ subCode: 'io', message: 'writeFile failed', path: String(path), cause }));
+  }
+};
+
+const captureBus = (eventBus = createInMemoryEventBus()): { events: AppEvent[]; eventBus: typeof eventBus } => {
+  const events: AppEvent[] = [];
+  eventBus.subscribe((e) => {
+    events.push(e);
+  });
+  return { events, eventBus };
+};
+
+describe('proposeDetectSkillsLeaf — audit-[09] contract', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+  let runsRoot: ReturnType<typeof absolutePath>;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+    runsRoot = absolutePath(join(String(root.root), 'runs'));
+    repoPath = join(String(root.root), 'repo-a');
+    await fs.mkdir(repoPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const buildDeps = (payload: EmitPayload, eventBus = createInMemoryEventBus()): ProposeDetectSkillsLeafDeps => ({
+    provider: fakeProvider(payload),
+    templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+    signals: createInMemorySink<HarnessSignal>(),
+    eventBus,
+    writeFile: makeWriteFile(),
+    logger: noopLogger,
+    skillsAdapter: noopSkillsAdapter,
+    model: 'claude-sonnet-4-6',
+    runsRoot,
+  });
+
+  const buildCtx = (): DetectSkillsCtx => {
+    const project = makeProject();
+    const repository = makeRepository({ path: repoPath, name: 'repo-a' });
+    return {
+      projectId: project.id,
+      repository,
+    };
+  };
+
+  const setupSkillSignal = (): SetupSkillProposalSignal => ({
+    type: 'setup-skill-proposal',
+    content: 'Run `mise install` then `pnpm install` before editing.',
+    timestamp: TS,
+  });
+
+  const verifySkillSignal = (): VerifySkillProposalSignal => ({
+    type: 'verify-skill-proposal',
+    content: 'Run `pnpm typecheck && pnpm lint && pnpm test` in sequence.',
+    timestamp: TS,
+  });
+
+  // ── 1. Happy path — both proposals present ──────────────────────────────────
+
+  it('ok: setup-skill + verify-skill → parsed, projected onto ctx, fanned to bus', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal(), verifySkillSignal()] }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    // Bus fan-out: every validated signal as a typed `ai-signal` event with source 'detect-skills'.
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal', 'verify-skill-proposal']);
+    for (const ev of aiSignals) expect(ev.source).toBe('detect-skills');
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toContain('pnpm typecheck');
+  });
+
+  // ── 2. Only one proposal — the other is absent ────────────────────────────────
+
+  it('ok: only setup-skill-proposal → verify-skill absent from ctx', async () => {
+    const { events, eventBus } = captureBus();
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal()] }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toBeUndefined();
+  });
+
+  // ── 3. Empty signals — valid "no skill needed" ─────────────────────────────────
+
+  it('ok: empty signals array — "no skill needed" is a valid response', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [] });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toBeUndefined();
+    expect(result.value.ctx.proposal?.proposedVerifySkill).toBeUndefined();
+    expect(result.value.ctx.proposal?.runDir).toBeDefined();
+  });
+
+  // ── 4. Duplicate signal kind — at-most-one refine fails ──────────────────────
+
+  it('duplicate setup-skill-proposal → ParseError (at-most-one violated)', async () => {
+    const deps = buildDeps({ kind: 'signals', signals: [setupSkillSignal(), setupSkillSignal()] });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 5. Invalid / unknown signal kind ────────────────────────────────────────────
+
+  it('unknown signal kind (refined-ticket) → ParseError(schema-mismatch)', async () => {
+    const unknown = [
+      { type: 'refined-ticket', body: 'not a skills signal', timestamp: TS },
+    ] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: unknown });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 6. Missing required field on a valid type ────────────────────────────────────
+
+  it('setup-skill-proposal missing required content field → ParseError(schema-mismatch)', async () => {
+    // `content` is required by setupSkillProposalSignalSchema but omitted here.
+    const malformed = [{ type: 'setup-skill-proposal', timestamp: TS }] as unknown as HarnessSignal[];
+    const deps = buildDeps({ kind: 'signals', signals: malformed });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('schema');
+  });
+
+  // ── 7. Malformed JSON ────────────────────────────────────────────────────────────
+
+  it('malformed JSON in signals.json → ParseError(invalid-json)', async () => {
+    const deps = buildDeps({ kind: 'raw', body: '{ this is not valid json either' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(ParseError);
+    expect(result.error.error.message).toContain('malformed JSON');
+  });
+
+  // ── 8. signals.json not written ──────────────────────────────────────────────────
+
+  it('signals-missing: provider omits signals.json → InvalidStateError', async () => {
+    const deps = buildDeps({ kind: 'omit' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.error.message).toContain('signals-missing');
+  });
+
+  // ── 9. Legacy bare-array migration ───────────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    const { events, eventBus } = captureBus();
+    // Write legacy shape: a bare JSON array without the `{ schemaVersion, signals }` wrapper.
+    const legacyPayload = JSON.stringify([setupSkillSignal()]);
+    const deps = buildDeps({ kind: 'raw', body: legacyPayload }, eventBus);
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['setup-skill-proposal']);
+
+    if (!result.ok) return;
+    expect(result.value.ctx.proposal?.proposedSetupSkill).toContain('mise install');
+  });
+
+  // ── 10. Spawn error ──────────────────────────────────────────────────────────────
+
+  it('spawn-error: leaf surfaces the spawn error, no validation attempted', async () => {
+    const spawnError = new InvalidStateError({
+      entity: 'provider',
+      currentState: 'broken',
+      attemptedAction: 'detect-skills',
+      message: 'simulated spawn failure',
+    });
+    const deps = buildDeps({ kind: 'spawn-error', error: spawnError });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBe(spawnError);
+  });
+
+  // ── 11. AbortError propagation ───────────────────────────────────────────────────
+
+  it('abort: AbortError surfaces as an aborted Result out of the leaf (chain framework design)', async () => {
+    // The provider throws AbortError mid-spawn (a TUI cancel). The `leaf` chain primitive
+    // catches it and returns `Result.error({ error, trace })` with the trace entry marked
+    // `aborted` — it does NOT re-throw. The runner's status machine routes that aborted Result
+    // to the interrupted exit path, so cancellation stays a first-class Result, not an exception.
+    const deps = buildDeps({ kind: 'abort' });
+    const leaf = proposeDetectSkillsLeaf(deps);
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(result.error.trace.at(-1)?.status).toBe('aborted');
+  });
+});

--- a/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
+++ b/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
+import type { AppEvent } from '@src/business/observability/events.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
 import { createInMemorySink } from '@tests/fixtures/in-memory-sink.ts';
@@ -198,7 +199,7 @@ describe('createGenEvalLoop — gen-eval-turn child order (step-order fence)', (
     ]);
   });
 
-  it('evaluator-guard body is [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf] in that order', () => {
+  it('evaluator-guard body is [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf, loop-diversity-check, entropy-check] in that order', () => {
     const { loop, task } = buildLoopShape();
     const id = String(task.id);
 
@@ -214,7 +215,13 @@ describe('createGenEvalLoop — gen-eval-turn child order (step-order fence)', (
     const evalChildren = evalStep?.children ?? [];
     const names = evalChildren.map((c) => c.name);
 
-    expect(names).toStrictEqual([`stamp-meta-evaluator-${id}`, `stamp-role-meta-evaluator-${id}`, `evaluator-${id}`]);
+    expect(names).toStrictEqual([
+      `stamp-meta-evaluator-${id}`,
+      `stamp-role-meta-evaluator-${id}`,
+      `evaluator-${id}`,
+      `loop-diversity-check-${id}`,
+      `entropy-check-${id}`,
+    ]);
   });
 });
 
@@ -317,5 +324,182 @@ describe('createGenEvalLoop — crash-attribution: meta sidecars land before gen
 
     expect(metaExists, 'rounds/1/generator/meta.json must exist before spawn (crash-attribution)').toBe(true);
     expect(roleMetaExists, 'rounds/1/generator/role-meta.json must exist before spawn (crash-attribution)').toBe(true);
+  });
+});
+
+// ── Behavioral test: entropy-check fires on a signal-kind-distribution plateau (R2) ───────────
+
+/**
+ * The entropy-check leaf is now LIVE (no longer dormant): the generator leaf stamps each turn's
+ * signal-kind distribution onto `ctx.lastTurnActionCounts`, and the entropy guard reads it as a
+ * proxy for action diversity. These tests drive the real loop so the wiring is exercised
+ * end-to-end, NOT a hand-fed input projection.
+ *
+ * To ISOLATE the entropy guard from the other two plateau sources that run first:
+ *  - the R1 fingerprint guard (loop-diversity-check): the scripted evaluator fails a DIFFERENT
+ *    floor dimension every turn, so the failure fingerprints stay diverse and it never fires.
+ *  - the evaluator's own count-based plateau predicate: the scripted critique is genuinely
+ *    dissimilar every turn, so the critique-shift exemption returns `progress` and it never fires
+ *    (the same technique the e2e "exhausted budget" test relies on).
+ * That leaves the entropy guard as the only possible plateau exit.
+ */
+describe('createGenEvalLoop — entropy-check (R2) live behavior', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const ts = FIXED_NOW;
+  const taskVerified = (output: string): HarnessSignal => ({ type: 'task-verified', output, timestamp: ts });
+  const note = (text: string): HarnessSignal => ({ type: 'note', text, timestamp: ts });
+  const decision = (text: string): HarnessSignal => ({ type: 'decision', text, timestamp: ts });
+  const change = (text: string): HarnessSignal => ({ type: 'change', text, timestamp: ts });
+  const learning = (text: string): HarnessSignal => ({ type: 'learning', text, timestamp: ts });
+
+  const FLOOR = ['correctness', 'completeness', 'safety', 'consistency'] as const;
+  // Pairwise-dissimilar critiques (trigram-Jaccard < 0.5) so the evaluator's critique-shift
+  // exemption keeps returning `progress` and its count-based plateau never fires.
+  const CRITIQUES = [
+    'first round complaint about a parser edge case in the tokenizer module',
+    'second turn raises a completely different retry-semantics concern entirely',
+    'third pass flags a SQL injection vector in the dynamic query builder layer',
+    'fourth review worries about timezone handling around daylight-saving boundaries',
+    'fifth look questions the cache eviction policy under sustained memory pressure',
+  ];
+  /**
+   * A FAILED verdict for turn `i` (0-indexed): the single failing dimension ROTATES (diverse
+   * fingerprints → loop-diversity stays quiet) and the critique is distinct (critique-shift
+   * exemption → the count-based evaluator plateau stays quiet).
+   */
+  const failTurn = (i: number): HarnessSignal => {
+    const failing = FLOOR[i % FLOOR.length] ?? 'correctness';
+    return {
+      type: 'evaluation',
+      status: 'failed',
+      dimensions: FLOOR.map((d) => ({ dimension: d, passed: d !== failing, finding: d === failing ? 'nope' : 'ok' })),
+      critique: CRITIQUES[i] ?? `fallback critique number ${String(i)} mentioning unique token ${String(i * 7919)}`,
+      timestamp: ts,
+    };
+  };
+
+  const buildEntropyLoop = (opts: {
+    readonly generatorSignals: readonly HarnessSignal[];
+    readonly maxTurns: number;
+    readonly eventBus: ReturnType<typeof createInMemoryEventBus>;
+  }) => {
+    const generatorProvider = createFakeAiProvider({
+      responses: { implement: '' },
+      signals: { implement: opts.generatorSignals },
+    });
+    // Rotate the failing dimension + critique per evaluate call (keeps loop-diversity AND the
+    // evaluator's count-based plateau both quiet — see the failTurn docstring).
+    let evalTurn = 0;
+    const evaluatorProvider = createFakeAiProvider({
+      responses: { evaluate: '' },
+      signals: {
+        evaluate: () => {
+          const sig = failTurn(evalTurn);
+          evalTurn += 1;
+          return [sig];
+        },
+      },
+    });
+    const task = makeInProgressTaskWithRunningAttempt();
+    const loop = createGenEvalLoop(
+      {
+        generatorProvider,
+        evaluatorProvider,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        signals: createInMemorySink<HarnessSignal>(),
+        writeFile: async () => Result.ok(undefined),
+        clock: () => FIXED_NOW,
+        logger: noopLogger,
+        eventBus: opts.eventBus,
+        readConfig: async () => ({ maxTurns: opts.maxTurns }),
+        maxTurns: opts.maxTurns,
+        plateauThreshold: 2,
+        gitRunner: {
+          async run() {
+            return Result.ok({ stdout: '', stderr: '', exitCode: 0 });
+          },
+        },
+      },
+      {
+        cwd: absolutePath('/tmp/ralph/fake-cwd'),
+        sprintDir: root.root,
+        progressFile: absolutePath('/tmp/ralph/fake-sprint-dir/progress.md'),
+        generator: { providerId: 'claude-code', model: 'claude-opus-4-8' },
+        evaluator: { providerId: 'claude-code', model: 'claude-opus-4-8' },
+      },
+      task.id
+    );
+    return { loop, task };
+  };
+
+  const ctxFor = (task: ReturnType<typeof makeInProgressTaskWithRunningAttempt>): ImplementCtx => ({
+    sprintId: task.id as unknown as ImplementCtx['sprintId'],
+    tasks: [task],
+    currentTask: task,
+    taskWorkspaceRoot: root.root,
+  });
+
+  it('exits with a plateau when the generator collapses to a single signal kind for >= window turns (budget remaining)', async () => {
+    const eventBus = createInMemoryEventBus();
+    const banners: AppEvent[] = [];
+    eventBus.subscribe((e) => {
+      if (e.type === 'banner-show') banners.push(e);
+    });
+    // Single narrative kind every turn → H = 0 (< 0.25). maxTurns = 5 leaves budget at turn 3.
+    const { loop, task } = buildEntropyLoop({
+      generatorSignals: [taskVerified('ok'), note('same kind of move')],
+      maxTurns: 5,
+      eventBus,
+    });
+
+    const result = await loop.execute(ctxFor(task));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The entropy guard reuses the plateau exit kind so the escalation ladder applies the remedy.
+    expect(result.value.ctx.lastExit?.kind).toBe('plateau');
+    // Fires exactly at the window boundary (turn 3 = DIVERSITY_WINDOW_SIZE), with budget remaining.
+    expect(result.value.ctx.genEvalTurn).toBe(3);
+    const entropyBanner = banners.find(
+      (e) => e.type === 'banner-show' && e.id === `entropy-plateau-${String(task.id)}`
+    );
+    expect(entropyBanner).toBeDefined();
+    if (entropyBanner?.type === 'banner-show') expect(entropyBanner.cause).toBe('low-action-entropy');
+  });
+
+  it('does NOT exit when the generator emits a diverse spread of signal kinds (high entropy)', async () => {
+    const eventBus = createInMemoryEventBus();
+    const banners: AppEvent[] = [];
+    eventBus.subscribe((e) => {
+      if (e.type === 'banner-show') banners.push(e);
+    });
+    // One of each narrative kind every turn → uniform 4-kind distribution → H = 1 (no plateau).
+    const { loop, task } = buildEntropyLoop({
+      generatorSignals: [taskVerified('ok'), decision('d'), change('c'), learning('l'), note('n')],
+      maxTurns: 4,
+      eventBus,
+    });
+
+    const result = await loop.execute(ctxFor(task));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // High entropy + diverse fingerprints → neither guard fires; the loop runs to its budget and
+    // leaves `lastExit` for finalize to synthesise (budget-exhausted) downstream.
+    expect(result.value.ctx.lastExit).toBeUndefined();
+    expect(result.value.ctx.genEvalTurn).toBe(4);
+    const entropyBanner = banners.find(
+      (e) => e.type === 'banner-show' && e.id === `entropy-plateau-${String(task.id)}`
+    );
+    expect(entropyBanner).toBeUndefined();
   });
 });

--- a/tests/integration/application/flows/readiness/fan-out.test.ts
+++ b/tests/integration/application/flows/readiness/fan-out.test.ts
@@ -710,8 +710,9 @@ describe('readiness fan-out across unique providers', () => {
 /**
  * Provider-scoping fan-out: the `providers` opt scopes the per-tool sub-chains the chain builds.
  * These tests inspect the static element tree (`flow.children`) rather than running the chain —
- * the per-tool sub-chains are the top-level `sequential('readiness', …)` children named
- * `tool-<tool>`, so the set of those names is exactly the scoped fan-out.
+ * each per-tool sub-chain (`sequential('tool-<tool>', …)`) is wrapped in a continue-on-error
+ * guard and sits among the top-level `sequential('readiness', …)` children, so unwrapping the
+ * guards and collecting the `tool-<tool>` names yields exactly the scoped fan-out.
  */
 describe('readiness fan-out provider scoping', () => {
   const buildFlow = (ai: AiSettings, opts: { readonly providers?: readonly AiProvider[] }) => {
@@ -743,9 +744,15 @@ describe('readiness fan-out provider scoping', () => {
     );
   };
 
-  /** Names of the per-tool sub-chain children of the top-level `sequential('readiness', …)`. */
+  /**
+   * Names of the per-tool sub-chains, unwrapping the per-provider continue-on-error guard each
+   * one is nested under (`continue-on-error(tool-<tool>)` → child `tool-<tool>`).
+   */
   const toolSubchainNames = (flow: ReturnType<typeof buildFlow>): readonly string[] =>
-    (flow.children ?? []).map((c) => c.name).filter((n) => n.startsWith('tool-'));
+    (flow.children ?? [])
+      .flatMap((c) => [c, ...(c.children ?? [])])
+      .map((c) => c.name)
+      .filter((n) => n.startsWith('tool-'));
 
   it('providers scoped to one provider → exactly that provider tool sub-chain is built', () => {
     // Settings reference three providers; scope to github-copilot only.

--- a/tests/integration/application/flows/review/leaves/ensure-feedback-file.test.ts
+++ b/tests/integration/application/flows/review/leaves/ensure-feedback-file.test.ts
@@ -1,0 +1,96 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ensureFeedbackFileLeaf } from '@src/application/flows/review/leaves/ensure-feedback-file.ts';
+import type { ReviewCtx } from '@src/application/flows/review/ctx.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Integration tests for `ensureFeedbackFileLeaf`.
+ *
+ * The leaf materialises `feedback.md` at a given path if the file is absent, threads the
+ * path forward on `ctx.feedbackFile`, and is idempotent (a pre-existing file is left
+ * untouched). These tests exercise the I/O contract against a real tmpdir.
+ */
+
+const makeCtx = (): ReviewCtx => ({
+  sprintId: makeDraftSprint().id,
+  distillRequested: false,
+});
+
+const parsePath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`invalid path: ${p}`);
+  return r.value;
+};
+
+describe('ensureFeedbackFileLeaf', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const feedbackPath = (): string => join(String(root.root), 'feedback.md');
+
+  it('creates file with template when absent', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    const result = await leaf.execute(makeCtx());
+
+    expect(result.ok).toBe(true);
+    const content = await fs.readFile(feedbackPath(), 'utf8');
+    expect(content).toContain('# Feedback');
+    expect(content).toContain('Round 1');
+    // The template includes the marker comment the round parser relies on.
+    expect(content).toContain('write your feedback below');
+  });
+
+  it('reuses existing file without overwriting its content', async () => {
+    const existingContent = '# My custom feedback\n\n- existing round instructions\n';
+    await fs.writeFile(feedbackPath(), existingContent, 'utf8');
+
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    const result = await leaf.execute(makeCtx());
+
+    expect(result.ok).toBe(true);
+    const content = await fs.readFile(feedbackPath(), 'utf8');
+    expect(content).toBe(existingContent);
+  });
+
+  it('threads feedbackFile path onto ctx', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+    const ctx = makeCtx();
+
+    const result = await leaf.execute(ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.feedbackFile).toBeDefined();
+    expect(String(result.value.ctx.feedbackFile)).toBe(feedbackPath());
+  });
+
+  it('is idempotent — second run succeeds and leaves file unchanged', async () => {
+    const feedbackFile = parsePath(feedbackPath());
+    const leaf = ensureFeedbackFileLeaf(feedbackFile);
+
+    await leaf.execute(makeCtx());
+    const contentAfterFirst = await fs.readFile(feedbackPath(), 'utf8');
+
+    const result2 = await leaf.execute(makeCtx());
+    expect(result2.ok).toBe(true);
+    const contentAfterSecond = await fs.readFile(feedbackPath(), 'utf8');
+
+    expect(contentAfterFirst).toBe(contentAfterSecond);
+  });
+});

--- a/tests/integration/application/flows/review/leaves/review-round-contract.test.ts
+++ b/tests/integration/application/flows/review/leaves/review-round-contract.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import { validateSignalsFile } from '@src/integration/ai/contract/_engine/validate-signals-file.ts';
+import { reviewRoundOutputContract } from '@src/application/flows/review/leaves/review-round.contract.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+/**
+ * Signal schema validation tests for `reviewRoundOutputContract` — audit-[09].
+ *
+ * The review-round leaf uses `validateSignalsFile` internally after each AI spawn. These
+ * tests exercise the contract rules directly (without going through the full leaf, which
+ * requires interactive, git, shell, and append-file ports) so regressions in the Zod
+ * schema surface quickly.
+ *
+ * Contract rules:
+ *  - Exactly one of `task-complete` or `task-blocked` must be present.
+ *  - No other signal kinds are permitted.
+ *  - `task-blocked` requires a `reason` string.
+ *  - `migrations[0]` lifts a legacy bare array into the `{ schemaVersion, signals }` wrapper.
+ */
+
+const TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+describe('reviewRoundOutputContract — signal schema validation', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  /**
+   * Allocate a fresh subdir under the tmproot, write `signals.json` with the supplied payload,
+   * and return the dir as an `AbsolutePath` for `validateSignalsFile`.
+   */
+  const arrange = async (payload: unknown, subdir = 'round'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    await fs.writeFile(join(dirStr, 'signals.json'), JSON.stringify(payload), 'utf8');
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  const arrangeRaw = async (body: string, subdir = 'round-raw'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    await fs.writeFile(join(dirStr, 'signals.json'), body, 'utf8');
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  const emptyDir = async (subdir = 'empty'): Promise<AbsolutePath> => {
+    const dirStr = join(String(root.root), subdir);
+    await fs.mkdir(dirStr, { recursive: true });
+    const dir = AbsolutePath.parse(dirStr);
+    if (!dir.ok) throw new Error('path parse failed');
+    return dir.value;
+  };
+
+  // ── 1. Happy paths ──────────────────────────────────────────────────────────
+
+  it('ok: task-complete → validates and returns signal', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'task-complete', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-complete');
+  });
+
+  it('ok: task-blocked with reason → validates and returns signal', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'task-blocked', reason: 'CI is red — dependency build failed', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-blocked');
+    // @ts-expect-error narrow to TaskBlockedSignal for the assertion
+    expect(result.value[0]?.reason).toBe('CI is red — dependency build failed');
+  });
+
+  // ── 2. Missing required terminal → refine rejects ──────────────────────────
+
+  it('empty signals array → ParseError (zero terminals)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('exactly one');
+  });
+
+  // ── 3. Both terminals → refine rejects ─────────────────────────────────────
+
+  it('both task-complete and task-blocked → ParseError (two terminals)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [
+        { type: 'task-complete', timestamp: TS },
+        { type: 'task-blocked', reason: 'contradicts complete', timestamp: TS },
+      ],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('exactly one');
+  });
+
+  // ── 4. Invalid / unknown signal kind ──────────────────────────────────────
+
+  it('unknown signal kind (commit-message) → ParseError(schema-mismatch)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: [{ type: 'commit-message', subject: 'feat: irrelevant', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('schema');
+  });
+
+  // ── 5. Missing required field on a valid type ──────────────────────────────
+
+  it('task-blocked missing required reason field → ParseError(schema-mismatch)', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      // `reason` is required by taskBlockedSignalSchema but omitted here.
+      signals: [{ type: 'task-blocked', timestamp: TS }],
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('schema');
+  });
+
+  // ── 6. Malformed JSON ──────────────────────────────────────────────────────
+
+  it('malformed JSON → ParseError(invalid-json)', async () => {
+    const outputDir = await arrangeRaw('{ this is not valid json at all');
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ParseError);
+    expect(result.error.message).toContain('malformed JSON');
+  });
+
+  // ── 7. Missing signals.json ─────────────────────────────────────────────────
+
+  it('signals-missing: no file → InvalidStateError', async () => {
+    const outputDir = await emptyDir();
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.message).toContain('signals-missing');
+  });
+
+  // ── 8. Legacy bare-array migration ─────────────────────────────────────────
+
+  it('migrations[0]: bare array → wraps into v1 envelope and validates', async () => {
+    // The legacy shape written by the headless adapter's stdout parser (pre-Wave-6). The
+    // contract's `migrations[0]` lifts it into `{ schemaVersion: 1, signals: [...] }`.
+    const outputDir = await arrange([{ type: 'task-complete', timestamp: TS }], 'round-legacy');
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.type).toBe('task-complete');
+  });
+
+  // ── 9. Example signals from the contract round-trip ───────────────────────
+
+  it('example signals in the contract round-trip through the schema', async () => {
+    const outputDir = await arrange({
+      schemaVersion: 1,
+      signals: reviewRoundOutputContract.exampleSignals,
+    });
+    const result = await validateSignalsFile(outputDir, reviewRoundOutputContract);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(reviewRoundOutputContract.exampleSignals.length);
+  });
+});

--- a/tests/integration/application/ui/tui/runtime/use-edit-field.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/use-edit-field.test.tsx
@@ -9,6 +9,7 @@ import { Text } from 'ink';
 import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { PromptQueueProvider } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
@@ -144,6 +145,49 @@ describe('useEditField', () => {
     queue.rejectHead(new Error('cancelled by user'));
     await flush();
     expect(latest?.feedback).toBeUndefined();
+    r.unmount();
+  });
+
+  it('re-throws an AbortError instead of silent-cancelling — operator cancellation must propagate', async () => {
+    // Both edit paths (single-option fast path and field-picker multi-option path) funnel through
+    // `openEditPrompt`, so proving the hook re-throws AbortError covers both. The blanket catch
+    // swallows a plain-Error esc-cancel (above) but must NOT swallow an AbortError, or the
+    // chain-runtime abort would be stranded at this seam.
+    const queue = createPromptQueue();
+    let captured: UseEditFieldState | undefined;
+    const Capture = (): React.JSX.Element => {
+      captured = useEditField();
+      return <Text>probe</Text>;
+    };
+    const r = render(
+      <UiStateProvider>
+        <PromptQueueProvider value={queue}>
+          <Capture />
+        </PromptQueueProvider>
+      </UiStateProvider>
+    );
+    await flush();
+    if (captured === undefined) throw new Error('useEditField api not captured');
+
+    // Drive the prompt directly so we can observe the returned promise's rejection.
+    let rejection: unknown;
+    const settled = captured
+      .openEditPrompt({
+        title: 'Edit name',
+        kind: 'short',
+        currentValue: 'old',
+        onSave: async () => Result.ok(undefined),
+      })
+      .catch((cause: unknown) => {
+        rejection = cause;
+      });
+    await flush();
+    queue.rejectHead(new AbortError({ elementName: 'edit' }));
+    await settled;
+
+    expect(rejection).toBeInstanceOf(AbortError);
+    // No "cancelled" feedback chip on a propagated abort — it is not a user esc-cancel.
+    expect(captured.feedback).toBeUndefined();
     r.unmount();
   });
 

--- a/tests/unit/application/chain/build/guard.test.ts
+++ b/tests/unit/application/chain/build/guard.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import type { TraceEntry } from '@src/application/chain/trace.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import { guard } from '@src/application/chain/build/guard.ts';
+
+interface Ctx {
+  readonly trail: readonly string[];
+}
+
+/** A leaf that appends its name to the ctx trail — proves the body actually ran and threaded ctx. */
+const tag = (name: string): Element<Ctx> =>
+  leaf<Ctx, Ctx, Ctx>(name, {
+    useCase: {
+      async execute(input) {
+        return Result.ok({ trail: [...input.trail, name] });
+      },
+    },
+    input: (c) => c,
+    output: (_c, o) => o,
+  });
+
+/** A leaf that always fails — proves a body error propagates through the guard. */
+const fail = (name: string): Element<Ctx> =>
+  leaf<Ctx, unknown, unknown>(name, {
+    useCase: {
+      async execute() {
+        return Result.error(new ValidationError({ field: name, value: 0, message: `${name} failed` }));
+      },
+    },
+    input: () => undefined,
+    output: (c) => c,
+  });
+
+describe('guard', () => {
+  it('skips the body and emits a skipped trace entry when the predicate returns false', async () => {
+    let bodyRan = false;
+    const body = leaf<Ctx, Ctx, Ctx>('body', {
+      useCase: {
+        async execute(input) {
+          bodyRan = true;
+          return Result.ok(input);
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const result = await guard<Ctx>('only-when', () => false, body).execute({ trail: ['start'] });
+
+    expect(bodyRan).toBe(false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // ctx is threaded through unchanged when the body is skipped.
+      expect(result.value.ctx).toEqual({ trail: ['start'] });
+      // The single trace entry names the BODY (not the guard) with `skipped` status.
+      expect(result.value.trace.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:skipped']);
+    }
+  });
+
+  it('forwards the skipped entry through onTrace so the live stream matches the final trace', async () => {
+    const emitted: TraceEntry[] = [];
+    await guard<Ctx>('only-when', () => false, tag('body')).execute({ trail: [] }, undefined, (e) => emitted.push(e));
+
+    expect(emitted.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:skipped']);
+  });
+
+  it('runs the body and returns its result when the predicate returns true', async () => {
+    const result = await guard<Ctx>('only-when', () => true, tag('body')).execute({ trail: ['start'] });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.ctx).toEqual({ trail: ['start', 'body'] });
+      expect(result.value.trace.map((e) => `${e.elementName}:${e.status}`)).toEqual(['body:completed']);
+    }
+  });
+
+  it('propagates the body failure verbatim when the predicate returns true and the body fails', async () => {
+    const result = await guard<Ctx>('only-when', () => true, fail('body')).execute({ trail: [] });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBeInstanceOf(ValidationError);
+      expect(result.error.trace.at(-1)?.elementName).toBe('body');
+      expect(result.error.trace.at(-1)?.status).toBe('failed');
+    }
+  });
+
+  it('short-circuits to aborted — evaluating neither predicate nor body — when the signal is already tripped', async () => {
+    let predicateRan = false;
+    let bodyRan = false;
+    const body = leaf<Ctx, Ctx, Ctx>('body', {
+      useCase: {
+        async execute(input) {
+          bodyRan = true;
+          return Result.ok(input);
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const ac = new AbortController();
+    ac.abort();
+    const result = await guard<Ctx>(
+      'only-when',
+      () => {
+        predicateRan = true;
+        return true;
+      },
+      body
+    ).execute({ trail: [] }, ac.signal);
+
+    expect(predicateRan).toBe(false);
+    expect(bodyRan).toBe(false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBeInstanceOf(AbortError);
+      // The pre-execution abort entry carries the GUARD name (built by `checkAborted`), not the body's.
+      expect(result.error.trace[0]?.elementName).toBe('only-when');
+      expect(result.error.trace[0]?.status).toBe('aborted');
+    }
+  });
+});

--- a/tests/unit/application/flows/create-pr/flow-shape.test.ts
+++ b/tests/unit/application/flows/create-pr/flow-shape.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
+import type { CreatePrDeps } from '@src/application/flows/create-pr/deps.ts';
+
+/**
+ * Topology fence for the create-pr chain. Construction-only: every leaf factory captures its deps in
+ * a closure read lazily inside `execute`, never called here, so the deps cast is sound (same
+ * rationale as the implement flow-shape fence). The AI sub-chain is a construction-time toggle
+ * (`useAi`), not a runtime branch — so each shape is fenced independently. Fails deterministically if
+ * a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): CreatePrDeps => ({}) as unknown as CreatePrDeps;
+
+describe('createCreatePrFlow — chain-shape fence', () => {
+  it('splices the AI authoring sub-chain ahead of the create-pr leaf when useAi is true (default)', () => {
+    expect(names(createCreatePrFlow(stubDeps()))).toStrictEqual([
+      'create-pr',
+      'push-branch',
+      'load-create-pr-context',
+      'build-create-pr-unit',
+      'render-prompt-to-file',
+      'generate-pr-content',
+      'create-pr',
+    ]);
+  });
+
+  it('omits the AI authoring sub-chain when useAi is false', () => {
+    expect(names(createCreatePrFlow(stubDeps(), { useAi: false }))).toStrictEqual([
+      'create-pr',
+      'push-branch',
+      'create-pr',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/ideate/flow-shape.test.ts
+++ b/tests/unit/application/flows/ideate/flow-shape.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createIdeateFlow, type CreateIdeateFlowOpts } from '@src/application/flows/ideate/flow.ts';
+import type { IdeateDeps } from '@src/application/flows/ideate/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID, makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the ideate chain. Construction-only: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, never called here, so the deps cast is sound (same rationale
+ * as the implement flow-shape fence). Fails deterministically if a leaf is dropped, added, or
+ * reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): IdeateDeps => ({}) as unknown as IdeateDeps;
+
+const makeOpts = (): CreateIdeateFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  projectId: FIXED_PROJECT_ID,
+  ideaTitle: 'an idea',
+  ideaText: 'flesh it out',
+  cwd: absolutePath('/repos/main'),
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  maxAttempts: 3,
+  ideateRoot: absolutePath('/sprints/s1/ideate'),
+});
+
+describe('createIdeateFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order', () => {
+    expect(names(createIdeateFlow(stubDeps(), makeOpts()))).toStrictEqual([
+      'ideate',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'load-project',
+      'load-tasks',
+      'build-ideate-unit',
+      'render-prompt-to-file',
+      'install-skills',
+      'stamp-meta-ideate',
+      'ideate-and-plan',
+      'uninstall-skills',
+      'transition-to-planned',
+      'save-tasks',
+      'save-sprint',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/plan/flow-shape.test.ts
+++ b/tests/unit/application/flows/plan/flow-shape.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { createPlanFlow, type CreatePlanFlowOpts } from '@src/application/flows/plan/flow.ts';
+import type { PlanDeps } from '@src/application/flows/plan/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID, makeDraftSprint } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the plan chain. Construction-only: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, never called here, so the deps cast is sound (same rationale
+ * as the implement flow-shape fence). Fails deterministically if a leaf is dropped, added, or
+ * reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): PlanDeps => ({}) as unknown as PlanDeps;
+
+const makeOpts = (): CreatePlanFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  projectId: FIXED_PROJECT_ID,
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  maxAttempts: 3,
+  planRoot: absolutePath('/sprints/s1/plan'),
+});
+
+describe('createPlanFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order', () => {
+    expect(names(createPlanFlow(stubDeps(), makeOpts()))).toStrictEqual([
+      'plan',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'load-project',
+      'load-sprint-execution',
+      'load-tasks',
+      'build-plan-unit',
+      'render-prompt-to-file',
+      'install-skills',
+      'stamp-meta-plan',
+      'call-planner-interactive',
+      'uninstall-skills',
+      'save-tasks',
+      'save-sprint',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/readiness/continue-on-error.test.ts
+++ b/tests/unit/application/flows/readiness/continue-on-error.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Behavioural fence for the readiness fan-out's `continue-on-error` wrapper.
+ *
+ * {@link wrapProviderContinue} decides, per provider sub-chain, whether a failure is a
+ * provider-specific infrastructure hiccup (skip this provider, warn, let the fan-out continue)
+ * or a real defect / cancellation (propagate, fail or cancel the whole run). The split is
+ * security-relevant: an operator AbortError must NEVER be swallowed, and a contract/spawn
+ * `invalid-state` must surface so a misconfiguration fails loudly rather than being hidden.
+ *
+ * These tests drive the wrapper against a raw `Element` stub — no leaves, no AI sessions — so the
+ * decision table is asserted in isolation.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { wrapProviderContinue } from '@src/application/flows/readiness/flow.ts';
+import type { ReadinessCtx } from '@src/application/flows/readiness/ctx.ts';
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import type { TraceEntry } from '@src/application/chain/trace.ts';
+import { Result } from '@src/domain/result.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { ProbeError } from '@src/domain/value/error/probe-error.ts';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import type { AppEvent, BannerShowEvent } from '@src/business/observability/events.ts';
+import { FIXED_PROJECT_ID } from '@tests/fixtures/domain.ts';
+
+const CTX: ReadinessCtx = { projectId: FIXED_PROJECT_ID, tools: [], entries: {} };
+
+const INNER_NAME = 'tool-claude-code';
+
+const failedEntry = (error: DomainError): TraceEntry => ({
+  elementName: INNER_NAME,
+  status: 'failed',
+  durationMs: 1,
+  error,
+});
+
+/** Inner sub-chain stub that always fails with `error`, carrying a one-entry failure trace. */
+const failingInner = (error: DomainError): Element<ReadinessCtx> => ({
+  name: INNER_NAME,
+  execute: (): Promise<ElementResult<ReadinessCtx>> =>
+    Promise.resolve(Result.error({ error, trace: [failedEntry(error)] })),
+});
+
+/** Inner sub-chain stub that succeeds, threading `CTX` straight through. */
+const succeedingInner = (): Element<ReadinessCtx> => ({
+  name: INNER_NAME,
+  execute: (): Promise<ElementResult<ReadinessCtx>> =>
+    Promise.resolve(Result.ok({ ctx: CTX, trace: [{ elementName: INNER_NAME, status: 'completed', durationMs: 1 }] })),
+});
+
+const recordingBus = (): { bus: EventBus; events: AppEvent[] } => {
+  const events: AppEvent[] = [];
+  const bus = createInMemoryEventBus();
+  bus.subscribe((e) => events.push(e));
+  return { bus, events };
+};
+
+const run = async (
+  inner: Element<ReadinessCtx>
+): Promise<{ result: ElementResult<ReadinessCtx>; events: AppEvent[] }> => {
+  const { bus, events } = recordingBus();
+  const wrapped = wrapProviderContinue(bus, 'claude-code', inner);
+  const result = await wrapped.execute(CTX);
+  return { result, events };
+};
+
+const banners = (events: readonly AppEvent[]): BannerShowEvent[] =>
+  events.filter((e): e is BannerShowEvent => e.type === 'banner-show');
+
+describe('wrapProviderContinue — continue-vs-propagate decision', () => {
+  it('exposes the inner sub-chain as its only child (so flattenLeaves still walks the plan)', () => {
+    const inner = succeedingInner();
+    const wrapped = wrapProviderContinue(createInMemoryEventBus(), 'claude-code', inner);
+    expect(wrapped.children).toEqual([inner]);
+  });
+
+  it('passes a successful inner result straight through and emits no banner', async () => {
+    const { result, events } = await run(succeedingInner());
+    expect(result.ok).toBe(true);
+    expect(banners(events)).toHaveLength(0);
+  });
+
+  it('SKIP path: a probe-error is swallowed — result is ok, a warn banner is emitted, inner trace preserved', async () => {
+    const error = new ProbeError({ subCode: 'fs-read', message: 'cannot read .claude dir' });
+    const { result, events } = await run(failingInner(error));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The outer ctx flows on unchanged; the inner failure trace is preserved for the TUI rail.
+      expect(result.value.ctx).toBe(CTX);
+      expect(result.value.trace).toHaveLength(1);
+      expect(result.value.trace[0]?.error).toBe(error);
+    }
+
+    const shown = banners(events);
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.tier).toBe('warn');
+    expect(shown[0]?.id).toContain('claude-code');
+    expect(shown[0]?.cause).toBe('cannot read .claude dir');
+  });
+
+  it('SKIP path: a rate-limit error (CLI throttle past adapter retries) is swallowed with a warn banner', async () => {
+    const error = new RateLimitError({ subCode: 'spawn-exit' });
+    const { result, events } = await run(failingInner(error));
+
+    expect(result.ok).toBe(true);
+    expect(banners(events)).toHaveLength(1);
+    expect(banners(events)[0]?.tier).toBe('warn');
+  });
+
+  it('PROPAGATE: an invalid-state error (contract / spawn failure) is NOT swallowed and emits no banner', async () => {
+    const error = new InvalidStateError({ entity: 'chain', currentState: 'propose', attemptedAction: 'emit signal' });
+    const { result, events } = await run(failingInner(error));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBe(error);
+      // The inner failure trace surfaces verbatim — the wrapper does not rewrite it.
+      expect(result.error.trace[0]?.error).toBe(error);
+    }
+    expect(banners(events)).toHaveLength(0);
+  });
+
+  it('PROPAGATE: an AbortError (operator cancellation) is NEVER swallowed and emits no banner', async () => {
+    const error = new AbortError({ elementName: INNER_NAME });
+    const { result, events } = await run(failingInner(error));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.error).toBe(error);
+    expect(banners(events)).toHaveLength(0);
+  });
+});

--- a/tests/unit/application/flows/readiness/flow-shape.test.ts
+++ b/tests/unit/application/flows/readiness/flow-shape.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AiProvider, AiSettings } from '@src/domain/entity/settings.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { createReadinessFlow, type CreateReadinessFlowOpts } from '@src/application/flows/readiness/flow.ts';
+import type { SetupReadinessDeps } from '@src/application/flows/readiness/deps.ts';
+
+import { absolutePath, FIXED_PROJECT_ID } from '@tests/fixtures/domain.ts';
+import { noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+
+/**
+ * Topology fence for the readiness chain. Construction-only — no leaf executes — so most deps are an
+ * inert cast. The two exceptions are `providerFor` / `skillsAdapterFor`, which the flow CALLS at
+ * construction to bake the per-provider adapters into each tool sub-chain; they must therefore be
+ * real callables (their return values are only stored, never invoked here). `opts.ai` is also read
+ * eagerly (to pick a model + effort per provider), so it carries real per-flow rows. Fails
+ * deterministically if a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): SetupReadinessDeps =>
+  ({
+    providerFor: () => undefined,
+    skillsAdapterFor: () => noopSkillsAdapter,
+    runsRoot: absolutePath('/data/runs'),
+  }) as unknown as SetupReadinessDeps;
+
+// All six per-flow rows on claude-code → `uniqueProvidersFromAi` resolves to a single provider, so
+// the fan-out builds exactly one `tool-claude-code` sub-chain.
+const row = { provider: 'claude-code', model: 'claude-opus-4-8' } as const;
+const ai: AiSettings = {
+  refine: row,
+  plan: row,
+  implement: { generator: row, evaluator: row },
+  readiness: row,
+  ideate: row,
+  createPr: row,
+};
+
+const makeOpts = (providers?: readonly AiProvider[]): CreateReadinessFlowOpts => ({
+  projectId: FIXED_PROJECT_ID,
+  cwd: absolutePath('/repos/main'),
+  ai,
+  ...(providers !== undefined ? { providers } : {}),
+});
+
+describe('createReadinessFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order, for a single-provider fan-out', () => {
+    expect(names(createReadinessFlow(stubDeps(), makeOpts(['claude-code'])))).toStrictEqual([
+      'readiness',
+      'load-project',
+      'pick-repository',
+      // Each per-provider sub-chain is wrapped in a continue-on-error guard (skips the provider
+      // on a provider-specific infra failure); the guard exposes the sub-chain as its child.
+      'continue-on-error(tool-claude-code)',
+      'tool-claude-code',
+      'probe-claude-code',
+      'install-skills-claude-code',
+      'allocate-run-dir-claude-code',
+      'stamp-meta-claude-code',
+      'propose-claude-code',
+      'uninstall-skills-claude-code',
+      'confirm-claude-code',
+      'write-claude-code',
+      'offer-skill-suggestions-claude-code',
+      'install-readiness-skills-claude-code',
+      'persist-suggested-skills',
+    ]);
+  });
+
+  it('fans out one tool-<tool> sub-chain per scoped provider, framed by load/pick and the terminal persist leaf', () => {
+    const top = createReadinessFlow(stubDeps(), makeOpts(['claude-code']));
+    expect((top.children ?? []).map((c) => c.name)).toStrictEqual([
+      'load-project',
+      'pick-repository',
+      // The per-provider sub-chain is wrapped in a continue-on-error guard at the top level.
+      'continue-on-error(tool-claude-code)',
+      'persist-suggested-skills',
+    ]);
+  });
+});

--- a/tests/unit/application/flows/refine/flow-shape.test.ts
+++ b/tests/unit/application/flows/refine/flow-shape.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PendingTicket } from '@src/domain/entity/ticket.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { createRefineFlow, type CreateRefineFlowOpts } from '@src/application/flows/refine/flow.ts';
+import type { RefineDeps } from '@src/application/flows/refine/deps.ts';
+
+import { absolutePath, makeDraftSprint, makePendingTicket } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the refine chain. `createRefineFlow` only CONSTRUCTS the element tree here —
+ * no leaf executes — so the deps can be an inert cast: every leaf factory captures its deps in a
+ * closure read lazily inside `execute`, which these tests never call (same rationale as the
+ * implement flow-shape fence). This asserts the OBSERVABLE chain shape (the thing the TUI walks to
+ * render the upfront plan) deterministically fails if a leaf is dropped, added, or reordered.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (): RefineDeps => ({}) as unknown as RefineDeps;
+
+const makeOpts = (pendingTickets: readonly PendingTicket[]): CreateRefineFlowOpts => ({
+  sprintId: makeDraftSprint().id,
+  pendingTickets,
+  providerId: 'claude-code',
+  model: 'claude-opus-4-8',
+  refinementRoot: absolutePath('/sprints/s1/refinement'),
+});
+
+describe('createRefineFlow — chain-shape fence', () => {
+  it('builds the exact leaf topology, in order, for a single ticket', () => {
+    const ticket = makePendingTicket({ title: 'do-work' });
+    const id = String(ticket.id);
+
+    expect(names(createRefineFlow(stubDeps(), makeOpts([ticket])))).toStrictEqual([
+      'refine',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'refine-tickets',
+      `refine-${id}`,
+      `fetch-issue-context-${id}`,
+      `build-refine-unit-${id}`,
+      `render-prompt-to-file-${id}`,
+      `install-skills-${id}`,
+      `stamp-meta-refine-${id}`,
+      `refine-ticket-${id}`,
+      `uninstall-skills-${id}`,
+      `save-after-${id}`,
+    ]);
+  });
+
+  it('fans out one refine-<id> sub-chain per pending ticket, in order', () => {
+    const t1 = makePendingTicket({ title: 't1' });
+    const t2 = makePendingTicket({ title: 't2' });
+
+    const top = createRefineFlow(stubDeps(), makeOpts([t1, t2]));
+    const ticketsNode = (top.children ?? []).find((c) => c.name === 'refine-tickets');
+
+    expect((ticketsNode?.children ?? []).map((c) => c.name)).toStrictEqual([
+      `refine-${String(t1.id)}`,
+      `refine-${String(t2.id)}`,
+    ]);
+  });
+});

--- a/tests/unit/business/task/compose-task-episodes.test.ts
+++ b/tests/unit/business/task/compose-task-episodes.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { composeTaskEpisodes } from '@src/business/task/compose-task-episodes.ts';
+import type { BlockedTask, Task } from '@src/domain/entity/task.ts';
+import type { TaskId } from '@src/domain/value/id/task-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import {
+  FIXED_LATER,
+  FIXED_NOW,
+  makeDoneTask,
+  makeDoneTaskWithWarning,
+  makeInProgressTaskWithRunningAttempt,
+  makeTodoTask,
+} from '@tests/fixtures/domain.ts';
+
+const SPRINT_ID = 'sprint-episodes-1' as unknown as SprintId;
+// A TaskId guaranteed not to collide with any fixture-generated uuid → no exclusion.
+const NO_CURRENT = '00000000-0000-0000-0000-000000000000' as unknown as TaskId;
+
+const makeBlockedTask = (opts: {
+  blockKind: 'own' | 'upstream';
+  blockedReason: string;
+  name?: string;
+  description?: string;
+  withAttempt?: boolean;
+}): BlockedTask => {
+  const base =
+    opts.withAttempt === true
+      ? makeInProgressTaskWithRunningAttempt()
+      : makeTodoTask(opts.name !== undefined ? { name: opts.name } : {});
+  return {
+    ...base,
+    ...(opts.name !== undefined ? { name: opts.name } : {}),
+    ...(opts.description !== undefined ? { description: opts.description } : {}),
+    status: 'blocked',
+    blockedReason: opts.blockedReason,
+    blockKind: opts.blockKind,
+  } as BlockedTask;
+};
+
+describe('composeTaskEpisodes', () => {
+  it('maps a done task to a success episode with an honest attempt-count learning', () => {
+    const done = makeDoneTask({ name: 'wire-the-thing' });
+    const episodes = composeTaskEpisodes([done], NO_CURRENT, SPRINT_ID);
+    expect(episodes).toHaveLength(1);
+    expect(episodes[0]).toMatchObject({
+      taskId: String(done.id),
+      sprintId: 'sprint-episodes-1',
+      goal: 'wire-the-thing',
+      outcome: 'success',
+      keyLearnings: 'verified after 1 attempt',
+      timestamp: FIXED_LATER, // verified attempt's finishedAt
+    });
+  });
+
+  it('names the done-with-warning kind in the success episode learning', () => {
+    const done = makeDoneTaskWithWarning({ warning: { kind: 'plateau', dimensions: ['correctness'] } });
+    const [episode] = composeTaskEpisodes([done], NO_CURRENT, SPRINT_ID);
+    expect(episode?.outcome).toBe('success');
+    expect(episode?.keyLearnings).toContain('done-with-warning: plateau');
+  });
+
+  it('maps an own-failure blocked task to a blocked episode carrying the block reason', () => {
+    const blocked = makeBlockedTask({
+      blockKind: 'own',
+      blockedReason: 'verify script kept failing on the migration step',
+      withAttempt: true,
+    });
+    const [episode] = composeTaskEpisodes([blocked], NO_CURRENT, SPRINT_ID);
+    expect(episode?.outcome).toBe('blocked');
+    expect(episode?.keyLearnings).toBe('verify script kept failing on the migration step');
+    // withAttempt → running attempt's startedAt is the real timestamp.
+    expect(episode?.timestamp).toBe(FIXED_NOW);
+  });
+
+  it('maps an upstream cascade-blocked task to an abandoned episode', () => {
+    const blocked = makeBlockedTask({
+      blockKind: 'upstream',
+      blockedReason: 'blocked upstream: prerequisite task did not complete',
+    });
+    const [episode] = composeTaskEpisodes([blocked], NO_CURRENT, SPRINT_ID);
+    expect(episode?.outcome).toBe('abandoned');
+    expect(episode?.keyLearnings).toBe('blocked upstream: prerequisite task did not complete');
+    // No attempts (cascade-blocked before running) → deterministic epoch sentinel, still valid ISO.
+    expect(episode?.timestamp).toBe('1970-01-01T00:00:00.000Z');
+    expect(() => new Date(String(episode?.timestamp)).toISOString()).not.toThrow();
+  });
+
+  it('excludes the current task from the derived episodes', () => {
+    const done = makeDoneTask({ name: 'sibling-done' });
+    const current = makeDoneTask({ name: 'the-current-one' });
+    const episodes = composeTaskEpisodes([done, current], current.id, SPRINT_ID);
+    expect(episodes.map((e) => e.taskId)).toEqual([String(done.id)]);
+  });
+
+  it('excludes unsettled tasks (todo / in_progress)', () => {
+    const todo = makeTodoTask({ name: 'not-started' });
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const done = makeDoneTask({ name: 'settled' });
+    const episodes = composeTaskEpisodes([todo, inProgress, done], NO_CURRENT, SPRINT_ID);
+    expect(episodes).toHaveLength(1);
+    expect(episodes[0]?.taskId).toBe(String(done.id));
+  });
+
+  it('preserves input order across mixed settled tasks', () => {
+    const done1 = makeDoneTask({ name: 'first' });
+    const blocked = makeBlockedTask({ blockKind: 'own', blockedReason: 'second failed' });
+    const done2 = makeDoneTask({ name: 'third' });
+    const episodes = composeTaskEpisodes([done1, blocked, done2], NO_CURRENT, SPRINT_ID);
+    expect(episodes.map((e) => e.taskId)).toEqual([String(done1.id), String(blocked.id), String(done2.id)]);
+  });
+
+  it('prefers the description over the name for the episode goal', () => {
+    const blocked = makeBlockedTask({
+      blockKind: 'own',
+      blockedReason: 'reason',
+      name: 'short-name',
+      description: 'A fuller description of what this task was meant to accomplish',
+    });
+    const [episode] = composeTaskEpisodes([blocked], NO_CURRENT, SPRINT_ID);
+    expect(episode?.goal).toBe('A fuller description of what this task was meant to accomplish');
+  });
+
+  it('clamps a very long block reason to a single bounded line', () => {
+    const longReason = 'x'.repeat(300);
+    const blocked = makeBlockedTask({ blockKind: 'own', blockedReason: longReason });
+    const [episode] = composeTaskEpisodes([blocked], NO_CURRENT, SPRINT_ID);
+    expect(episode?.keyLearnings.length).toBeLessThanOrEqual(120);
+    expect(episode?.keyLearnings.endsWith('…')).toBe(true);
+  });
+
+  it('returns an empty array when there are no settled siblings', () => {
+    const todo = makeTodoTask();
+    expect(composeTaskEpisodes([todo] as readonly Task[], NO_CURRENT, SPRINT_ID)).toEqual([]);
+    expect(composeTaskEpisodes([], NO_CURRENT, SPRINT_ID)).toEqual([]);
+  });
+});

--- a/tests/unit/business/task/episode-summary.test.ts
+++ b/tests/unit/business/task/episode-summary.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskEpisode } from '@src/domain/repository/episode/episode-types.ts';
+import { summariseEpisodes } from '@src/business/task/episode-summary.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+const TS = '2026-06-27T00:00:00.000Z' as IsoTimestamp;
+
+const makeEpisode = (overrides: Partial<TaskEpisode> = {}): TaskEpisode => ({
+  taskId: 'task-1',
+  sprintId: 'sprint-1',
+  goal: 'Wire up the CSV export endpoint',
+  outcome: 'success',
+  keyLearnings: 'Use streaming to avoid OOM on large result sets',
+  timestamp: TS,
+  ...overrides,
+});
+
+describe('summariseEpisodes', () => {
+  it('returns empty string for an empty episode list', () => {
+    expect(summariseEpisodes([])).toBe('');
+  });
+
+  it('formats a single episode as a bullet line', () => {
+    const ep = makeEpisode();
+    const out = summariseEpisodes([ep]);
+    expect(out).toBe('- Wire up the CSV export endpoint → success (Use streaming to avoid OOM on large result sets)');
+  });
+
+  it('formats multiple episodes as one bullet per line', () => {
+    const episodes = [
+      makeEpisode({ goal: 'Add rate-limit middleware', outcome: 'success', keyLearnings: 'Token bucket works well' }),
+      makeEpisode({
+        goal: 'Fix auth token refresh',
+        outcome: 'partial',
+        keyLearnings: 'Edge case with expired refresh token not covered',
+      }),
+      makeEpisode({
+        goal: 'Wire logging pipeline',
+        outcome: 'success',
+        keyLearnings: 'Use async transport to avoid blocking',
+      }),
+    ];
+    const out = summariseEpisodes(episodes);
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('Add rate-limit middleware');
+    expect(lines[0]).toContain('success');
+    expect(lines[0]).toContain('Token bucket works well');
+    expect(lines[1]).toContain('Fix auth token refresh');
+    expect(lines[1]).toContain('partial');
+    expect(lines[2]).toContain('Wire logging pipeline');
+  });
+
+  it('keeps only the last maxItems episodes when the list is longer', () => {
+    const episodes = Array.from({ length: 10 }, (_, i) =>
+      makeEpisode({
+        taskId: `task-${String(i)}`,
+        goal: `Task ${String(i)}`,
+        outcome: 'success',
+        keyLearnings: `learning ${String(i)}`,
+      })
+    );
+    const out = summariseEpisodes(episodes, 3);
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(3);
+    // Should be the last 3: Task 7, Task 8, Task 9
+    expect(lines[0]).toContain('Task 7');
+    expect(lines[1]).toContain('Task 8');
+    expect(lines[2]).toContain('Task 9');
+  });
+
+  it('defaults maxItems to 5 when not provided', () => {
+    const episodes = Array.from({ length: 8 }, (_, i) =>
+      makeEpisode({ taskId: `task-${String(i)}`, goal: `Task ${String(i)}`, outcome: 'success', keyLearnings: 'ok' })
+    );
+    const out = summariseEpisodes(episodes);
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(5);
+    // Last 5: Task 3–7
+    expect(lines[0]).toContain('Task 3');
+    expect(lines[4]).toContain('Task 7');
+  });
+
+  it('truncates long goals with an ellipsis at 80 characters', () => {
+    const longGoal = 'A'.repeat(100);
+    const out = summariseEpisodes([makeEpisode({ goal: longGoal })]);
+    // Should be truncated: 80 chars + ellipsis
+    expect(out).toContain('…');
+    // The full 100-char goal should NOT appear verbatim
+    expect(out).not.toContain(longGoal);
+    // The truncated portion should be present
+    expect(out).toContain('A'.repeat(80));
+  });
+
+  it('includes the outcome and keyLearnings for all outcome types', () => {
+    const outcomes = ['success', 'partial', 'blocked', 'abandoned'] as const;
+    for (const outcome of outcomes) {
+      const out = summariseEpisodes([makeEpisode({ outcome, keyLearnings: `learning for ${outcome}` })]);
+      expect(out).toContain(`→ ${outcome}`);
+      expect(out).toContain(`learning for ${outcome}`);
+    }
+  });
+
+  it('trims whitespace from keyLearnings', () => {
+    const out = summariseEpisodes([makeEpisode({ keyLearnings: '  padded learning  ' })]);
+    expect(out).toContain('(padded learning)');
+    expect(out).not.toContain('  padded learning  ');
+  });
+});

--- a/tests/unit/business/task/escalation-policy-entropy.test.ts
+++ b/tests/unit/business/task/escalation-policy-entropy.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { computeActionEntropy, detectLowEntropy } from '@src/business/task/escalation-policy.ts';
+
+describe('computeActionEntropy', () => {
+  it('returns 1 for an empty map (no data → max diversity assumed)', () => {
+    expect(computeActionEntropy(new Map())).toBe(1);
+  });
+
+  it('returns 0 for a single action kind (zero diversity)', () => {
+    const counts = new Map([['bash', 10]]);
+    expect(computeActionEntropy(counts)).toBe(0);
+  });
+
+  it('returns 1 for a two-kind uniform distribution', () => {
+    const counts = new Map([
+      ['edit', 5],
+      ['bash', 5],
+    ]);
+    expect(computeActionEntropy(counts)).toBeCloseTo(1, 10);
+  });
+
+  it('returns 1 for a four-kind uniform distribution', () => {
+    const counts = new Map([
+      ['edit', 3],
+      ['bash', 3],
+      ['read', 3],
+      ['write', 3],
+    ]);
+    expect(computeActionEntropy(counts)).toBeCloseTo(1, 10);
+  });
+
+  it('returns 0.5 for a two-of-four distribution where only 2 kinds are used uniformly', () => {
+    // 2 of 4 kinds used equally: normalised entropy = log2(2)/log2(4) = 1/2 = 0.5
+    const counts = new Map([
+      ['edit', 5],
+      ['bash', 5],
+      ['read', 0],
+      ['write', 0],
+    ]);
+    // K=4 (4 distinct keys), but p(read)=0 and p(write)=0 → H raw = -2*(0.5*log2(0.5)) = 1
+    // normalised = 1 / log2(4) = 1/2 = 0.5
+    expect(computeActionEntropy(counts)).toBeCloseTo(0.5, 10);
+  });
+
+  it('returns 1 for a map where all counts are zero (treated as no data)', () => {
+    const counts = new Map([
+      ['edit', 0],
+      ['bash', 0],
+    ]);
+    expect(computeActionEntropy(counts)).toBe(1);
+  });
+
+  it('returns a value between 0 and 1 for a skewed distribution', () => {
+    const counts = new Map([
+      ['bash', 9],
+      ['edit', 1],
+    ]);
+    const e = computeActionEntropy(counts);
+    expect(e).toBeGreaterThan(0);
+    expect(e).toBeLessThan(1);
+  });
+
+  it('is symmetric — swapping counts does not change entropy', () => {
+    const a = new Map([
+      ['bash', 7],
+      ['edit', 3],
+    ]);
+    const b = new Map([
+      ['edit', 7],
+      ['bash', 3],
+    ]);
+    expect(computeActionEntropy(a)).toBeCloseTo(computeActionEntropy(b), 10);
+  });
+});
+
+describe('detectLowEntropy', () => {
+  it('returns true when entropy is below the default threshold (0.25)', () => {
+    expect(detectLowEntropy(0.0)).toBe(true);
+    expect(detectLowEntropy(0.1)).toBe(true);
+    expect(detectLowEntropy(0.24)).toBe(true);
+  });
+
+  it('returns false when entropy equals or exceeds the default threshold', () => {
+    expect(detectLowEntropy(0.25)).toBe(false);
+    expect(detectLowEntropy(0.5)).toBe(false);
+    expect(detectLowEntropy(1.0)).toBe(false);
+  });
+
+  it('respects a custom threshold', () => {
+    expect(detectLowEntropy(0.3, 0.4)).toBe(true);
+    expect(detectLowEntropy(0.4, 0.4)).toBe(false);
+  });
+
+  it('clamps threshold below 0.1 to 0.1', () => {
+    // With threshold clamped to 0.1, entropy=0.05 is low but entropy=0.15 is not.
+    expect(detectLowEntropy(0.05, 0.0)).toBe(true);
+    expect(detectLowEntropy(0.15, 0.0)).toBe(false);
+  });
+
+  it('clamps threshold above 0.5 to 0.5', () => {
+    // With threshold clamped to 0.5, entropy=0.49 is low and entropy=0.5 is not.
+    expect(detectLowEntropy(0.49, 0.9)).toBe(true);
+    expect(detectLowEntropy(0.5, 0.9)).toBe(false);
+  });
+
+  it('returns false for max-diversity entropy (1.0) with any valid threshold', () => {
+    expect(detectLowEntropy(1.0, 0.1)).toBe(false);
+    expect(detectLowEntropy(1.0, 0.5)).toBe(false);
+  });
+});

--- a/tests/unit/business/task/loop-diversity.test.ts
+++ b/tests/unit/business/task/loop-diversity.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { createLoopDiversityTracker } from '@src/business/task/loop-diversity.ts';
+
+describe('createLoopDiversityTracker', () => {
+  it('reports diverse when there is insufficient history (fewer than windowSize entries)', () => {
+    const tracker = createLoopDiversityTracker(3);
+    expect(tracker.isDiverse()).toBe(true); // empty
+    tracker.record('a');
+    expect(tracker.isDiverse()).toBe(true); // 1 < 3
+    tracker.record('a');
+    expect(tracker.isDiverse()).toBe(true); // 2 < 3
+  });
+
+  it('reports NOT diverse when the last windowSize fingerprints are all identical', () => {
+    const tracker = createLoopDiversityTracker(3);
+    tracker.record('x');
+    tracker.record('x');
+    tracker.record('x');
+    expect(tracker.isDiverse()).toBe(false);
+  });
+
+  it('reports diverse when the tail differs even though some history repeats', () => {
+    const tracker = createLoopDiversityTracker(3);
+    tracker.record('a');
+    tracker.record('a');
+    tracker.record('b'); // tail [a, a, b] — not all identical
+    expect(tracker.isDiverse()).toBe(true);
+  });
+
+  it('flips back to NOT diverse once the tail collapses again after a diverse turn', () => {
+    const tracker = createLoopDiversityTracker(3);
+    tracker.record('a');
+    tracker.record('b');
+    tracker.record('a');
+    expect(tracker.isDiverse()).toBe(true); // [a, b, a]
+    tracker.record('a');
+    tracker.record('a'); // tail now [a, a, a]
+    expect(tracker.isDiverse()).toBe(false);
+  });
+
+  it('bounds the internal buffer to windowSize * 2 without affecting the predicate', () => {
+    const tracker = createLoopDiversityTracker(2);
+    // Push far more than the cap (windowSize*2 = 4); only the recent tail can matter.
+    for (let i = 0; i < 50; i += 1) tracker.record(`f-${String(i)}`);
+    // All distinct → diverse.
+    expect(tracker.isDiverse()).toBe(true);
+    // Now collapse the tail.
+    tracker.record('same');
+    tracker.record('same');
+    expect(tracker.isDiverse()).toBe(false);
+  });
+
+  it('clamps a windowSize below 2 up to 2 (a window of 1 would fire after every turn)', () => {
+    const tracker = createLoopDiversityTracker(1);
+    tracker.record('only');
+    // With an effective window of 2, a single entry is still insufficient history → diverse.
+    expect(tracker.isDiverse()).toBe(true);
+    tracker.record('only');
+    expect(tracker.isDiverse()).toBe(false);
+  });
+
+  it('defaults to a window of 3 when no size is given', () => {
+    const tracker = createLoopDiversityTracker();
+    tracker.record('z');
+    tracker.record('z');
+    expect(tracker.isDiverse()).toBe(true); // 2 < 3
+    tracker.record('z');
+    expect(tracker.isDiverse()).toBe(false); // 3 identical
+  });
+
+  it('a fresh tracker starts with no history (independent instances do not share state)', () => {
+    const first = createLoopDiversityTracker(2);
+    first.record('a');
+    first.record('a');
+    expect(first.isDiverse()).toBe(false);
+
+    const second = createLoopDiversityTracker(2);
+    expect(second.isDiverse()).toBe(true); // fresh — empty buffer
+    second.record('b');
+    expect(second.isDiverse()).toBe(true); // 1 < 2
+  });
+});

--- a/tests/unit/integration/ai/prompts/compress-section.test.ts
+++ b/tests/unit/integration/ai/prompts/compress-section.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { compressSection, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
+
+describe('compressSection', () => {
+  it('returns content unchanged when at or below the default cap', () => {
+    const short = 'a'.repeat(SECTION_CHAR_CAP);
+    expect(compressSection(short)).toBe(short);
+  });
+
+  it('returns content unchanged when strictly below the default cap', () => {
+    const short = 'hello world';
+    expect(compressSection(short)).toBe(short);
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(compressSection('')).toBe('');
+  });
+
+  it('tail-trims content above the default cap to exactly cap characters (plus notice)', () => {
+    const content = 'x'.repeat(SECTION_CHAR_CAP + 500);
+    const result = compressSection(content);
+    // The retained tail must be exactly the last SECTION_CHAR_CAP characters.
+    const tail = content.slice(-SECTION_CHAR_CAP);
+    expect(result.endsWith(tail)).toBe(true);
+    // The result is longer than the cap due to the notice prefix.
+    expect(result.length).toBeGreaterThan(SECTION_CHAR_CAP);
+  });
+
+  it('prepends a one-line notice with correct N (cap) and M (original length) values', () => {
+    const originalLength = SECTION_CHAR_CAP + 1_000;
+    const content = 'z'.repeat(originalLength);
+    const result = compressSection(content);
+    expect(result).toContain(
+      `[… earlier content omitted — showing last ${String(SECTION_CHAR_CAP)} chars of ${String(originalLength)} total]`
+    );
+  });
+
+  it('notice is followed by a blank line before the retained content', () => {
+    const content = 'y'.repeat(SECTION_CHAR_CAP + 100);
+    const result = compressSection(content);
+    // Notice line ends with \n\n (blank line separator).
+    const noticeEnd = result.indexOf(']\n\n');
+    expect(noticeEnd).toBeGreaterThan(-1);
+  });
+
+  it('respects a custom cap', () => {
+    const cap = 10;
+    const content = 'abcdefghijklmnopqrstuvwxyz'; // 26 chars, above cap=10
+    const result = compressSection(content, cap);
+    // Tail: last 10 chars of content
+    expect(result.endsWith('qrstuvwxyz')).toBe(true);
+    expect(result).toContain(`showing last ${String(cap)} chars of ${String(content.length)} total`);
+  });
+
+  it('returns content unchanged when equal to custom cap', () => {
+    const cap = 5;
+    const content = 'hello';
+    expect(compressSection(content, cap)).toBe(content);
+  });
+
+  it('does not drop content when content is exactly one char over the default cap', () => {
+    const content = 'a'.repeat(SECTION_CHAR_CAP + 1);
+    const result = compressSection(content);
+    // The tail should be exactly SECTION_CHAR_CAP 'a's.
+    const tail = 'a'.repeat(SECTION_CHAR_CAP);
+    expect(result.endsWith(tail)).toBe(true);
+    expect(result).toContain(`showing last ${String(SECTION_CHAR_CAP)} chars of ${String(SECTION_CHAR_CAP + 1)} total`);
+  });
+
+  it('survives a cap boundary that falls inside an emoji surrogate pair', () => {
+    // '😀' is a UTF-16 surrogate pair (😀, length 2). With this content/cap the slice
+    // boundary lands between the high and low halves of the second pair, so the tail begins with
+    // a lone low surrogate. The result is still a valid JS string (lone surrogates are permitted)
+    // and must carry the omission notice.
+    const content = '😀😀😀'; // 6 UTF-16 code units
+    const cap = 3; // boundary falls inside the second pair
+    const result = compressSection(content, cap);
+    expect(typeof result).toBe('string');
+    expect(result).toContain(`showing last ${String(cap)} chars of ${String(content.length)} total`);
+  });
+});

--- a/tests/unit/integration/ai/providers/_engine/abort-kill.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/abort-kill.test.ts
@@ -1,0 +1,117 @@
+import type { ChildProcess } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
+import { DEFAULT_GRACE_MS } from '@src/integration/ai/providers/_engine/idle-watchdog.ts';
+
+/**
+ * Minimal fake child exposing only the surface `attachAbortKill` touches: a `kill` method that
+ * records the signal so tests can assert the SIGTERM → SIGKILL ladder fired in order.
+ */
+const makeFakeChild = (): { readonly child: ChildProcess; readonly kills: string[] } => {
+  const kills: string[] = [];
+  const child = {
+    kill: (sig: NodeJS.Signals): boolean => {
+      kills.push(String(sig));
+      return true;
+    },
+  } as unknown as ChildProcess;
+  return { child, kills };
+};
+
+describe('attachAbortKill', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends SIGTERM on abort, then SIGKILL after the grace window', () => {
+    const { child, kills } = makeFakeChild();
+    const controller = new AbortController();
+    attachAbortKill(child, controller.signal);
+
+    controller.abort();
+    expect(kills).toEqual(['SIGTERM']);
+
+    vi.advanceTimersByTime(DEFAULT_GRACE_MS - 1);
+    expect(kills).toEqual(['SIGTERM']);
+    vi.advanceTimersByTime(1);
+    expect(kills).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+
+  it('kills immediately when the signal is already aborted at attach time', () => {
+    const { child, kills } = makeFakeChild();
+    const controller = new AbortController();
+    controller.abort();
+
+    attachAbortKill(child, controller.signal);
+    expect(kills).toEqual(['SIGTERM']);
+    vi.advanceTimersByTime(DEFAULT_GRACE_MS);
+    expect(kills).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+
+  it('cleanup cancels the pending SIGKILL escalation after a clean exit', () => {
+    const { child, kills } = makeFakeChild();
+    const controller = new AbortController();
+    const cleanup = attachAbortKill(child, controller.signal);
+
+    controller.abort(); // SIGTERM fired, grace timer armed
+    expect(kills).toEqual(['SIGTERM']);
+    cleanup(); // child exited before the grace window elapsed
+    vi.advanceTimersByTime(DEFAULT_GRACE_MS * 2);
+    expect(kills).toEqual(['SIGTERM']); // no SIGKILL against a dead pid
+  });
+
+  it('cleanup removes the abort listener so a reused AbortController collects no dead handlers', () => {
+    const { child } = makeFakeChild();
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const adds: EventListener[] = [];
+    const removes: EventListener[] = [];
+    const origAdd = signal.addEventListener.bind(signal);
+    const origRemove = signal.removeEventListener.bind(signal);
+    signal.addEventListener = ((type: string, listener: EventListener, options?: AddEventListenerOptions) => {
+      if (type === 'abort' && typeof listener === 'function') adds.push(listener);
+      origAdd(type, listener, options);
+    }) as typeof signal.addEventListener;
+    signal.removeEventListener = ((type: string, listener: EventListener, options?: EventListenerOptions) => {
+      if (type === 'abort' && typeof listener === 'function') removes.push(listener);
+      origRemove(type, listener, options);
+    }) as typeof signal.removeEventListener;
+
+    const cleanup = attachAbortKill(child, signal);
+    expect(adds).toHaveLength(1);
+
+    cleanup();
+    expect(removes).toHaveLength(1);
+    expect(removes[0]).toBe(adds[0]);
+  });
+
+  it('no signal → cleanup is a no-op and the child is never killed', () => {
+    const { child, kills } = makeFakeChild();
+    const cleanup = attachAbortKill(child, undefined);
+    expect(() => cleanup()).not.toThrow();
+    vi.advanceTimersByTime(DEFAULT_GRACE_MS * 2);
+    expect(kills).toEqual([]);
+  });
+
+  it('survives a child that already exited (kill throws ESRCH-style; swallowed)', () => {
+    const kills: string[] = [];
+    const child = {
+      kill: (sig: NodeJS.Signals): boolean => {
+        kills.push(String(sig));
+        throw new Error('ESRCH: no such process');
+      },
+    } as unknown as ChildProcess;
+    const controller = new AbortController();
+    attachAbortKill(child, controller.signal);
+
+    expect(() => {
+      controller.abort();
+      vi.advanceTimersByTime(DEFAULT_GRACE_MS);
+    }).not.toThrow();
+    expect(kills).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+});


### PR DESCRIPTION
## What this is

A round of harness improvements to the implement loop, the provider engine, and the TUI — reviewed adversarially and hardened before landing. The branch was reorganised into a clean, dependency-ordered history (fixes → features → tests → chore).

## Features

- **Gen-eval plateau detection.** Two signals now feed the escalation ladder so a stuck task escalates instead of burning its turn budget:
  - *loop-diversity* — exits when the last N turns repeat the same failed-dimension fingerprint (budget-exhaustion takes precedence over an early plateau exit).
  - *action-entropy* — a secondary signal over the per-turn distribution of generator signal kinds. Note: this is a **signal-kind-distribution proxy**, not raw tool-use entropy, and is intentionally conservative (threshold 0.25, only after a warm-up window). See *Follow-ups*.
- **Episodic task memory.** A later task in a sprint now receives a compact summary of earlier settled tasks' outcomes (`goal → outcome (key learning)`) in its round-1 prompt, derived in-memory from sprint state — **no new persistence** (in-sprint only today; cross-sprint is a follow-up).
- **Oversized prior-context compression.** `PRIOR_*` prompt sections are tail-compressed to their most-recent content when they exceed a cap (keeps the relevant tail; *Lost-in-the-Middle*, Liu et al. arXiv 2307.03172).
- **Evaluator reasoning + per-criterion checkpoint protocol.** The evaluator writes its assessment before the verdict and emits a harness-ignored checkpoint per acceptance criterion.
- **`add-ticket` flow** wired into the registry + TUI menu.

## Fixes

- **Provider OOM hardening** — bounded stdout parse buffers + forensic accumulators so a long (multi-hour) implement run can't pin multi-megabyte spawn buffers.
- **AbortSignal kill path** for interactive AI sessions (shared `attachAbortKill` in `_engine/`, SIGTERM → grace → SIGKILL).
- **Chain abort trace** — a thrown `AbortError` now surfaces as trace status `aborted` (propagation unchanged; never swallowed).
- **TUI robustness** — stale-setState guards on async handlers, `AbortError` propagation through the edit-field path, path-picker cancel guard, adaptive rows, consistent `j/k` nav hints.
- **Readiness continue-on-error** — provider probe / rate-limit errors skip and continue; contract / spawn failures still propagate.

## Review notes

This branch was reviewed adversarially (multi-dimension, with each finding independently verified). Acting on that review:

- **Dropped** a speculative `promptTransform` provider hook (no consumer + a type mismatch) — left no trace in the port.
- **Scrubbed fabricated research citations** from both code and commit messages (an invented arXiv id, an unsourced statistic, a misattributed paper, an unverifiable benchmark). Replaced with plain design rationale; the one verifiable citation was kept and attributed.
- Two items the review flagged as dormant/dead (entropy plateau, episodic memory) were **completed and wired** rather than removed.

## Follow-ups (tracked, not in this PR)

- **Validate + tune the action-entropy signal** on a real run; a legitimately single-kind turn could otherwise trip a premature escalation. Options: gate it behind no-progress, or upgrade to real per-turn tool-use counts.
- **Deepen episodic memory**: richer per-episode learnings + optional cross-sprint persistence (an `EpisodeRepository` + writer).

## Verification

typecheck · lint (0 errors) · knip · prettier · **4136 unit + integration** · **206 e2e** · build — all green. Docs (`.claude/docs/**`, `CHANGELOG.md`) synced to the changes.

https://claude.ai/code/session_01TPmwCSX8HGWTQm7wmq9aAE
