### PR TITLE
refactor(providers)+ci: collapse CLI adapters, gate lint/coverage, Codecov, model context-window (#226, #227)

### DIFF
--- a/.claude/agent-memory/designer/MEMORY.md
+++ b/.claude/agent-memory/designer/MEMORY.md
@@ -58,3 +58,7 @@
 ## Implement Header + Sidebar Layout
 
 - [project_implement_header_effort_sidebyside.md](project_implement_header_effort_sidebyside.md) — HeaderCard two-line gen/eval model+effort; side-by-side Baseline+Token at ≥xl (sidebarContextSideBySide); threading chain (Jun 2026)
+
+## Context-Window Visibility
+
+- [project_context_window_visibility.md](project_context_window_visibility.md) — 200K/1M label in every model selector + execution surface; domain helper at settings-models/context-window.ts mirrors integration adapter pending #226 (Jun 2026)

--- a/.claude/agent-memory/designer/project_context_window_visibility.md
+++ b/.claude/agent-memory/designer/project_context_window_visibility.md
@@ -1,0 +1,54 @@
+---
+name: project_context_window_visibility
+description: Context-window size (200K / 1M) visible in all model selectors and execution surfaces; domain helper mirrors integration adapter pending #226
+metadata:
+  type: project
+---
+
+Context-window labels added to every UI surface that shows or selects a model (Jun 2026, worktree ctxwin).
+
+**Why:** Users couldn't tell whether a run was on the 200K or 1M window. All picker options now carry
+`claude-sonnet-4-6  ·  200K` or `claude-opus-4-8[1m]  ·  1M` as label suffixes; unknown/Copilot/Codex
+models gracefully degrade (no suffix added).
+
+## New domain helper
+
+`src/domain/value/settings-models/context-window.ts` — pure, no I/O.
+
+- `contextWindowFor(model): number | undefined`
+- `contextWindowLabel(model): string | undefined` → `"200K"` / `"1M"` / undefined
+
+Intentionally duplicates `src/integration/ai/providers/_engine/context-window.ts`. Once #226 lands the
+integration copy should delegate here; until then keep both in sync when adding a new model entry.
+
+**Layer rationale:** `application/` layer cannot import `integration/_engine/` adapter — domain is the
+correct home for model IDs and their properties.
+
+## Annotation format
+
+`<model-id>  ·  <window>` (two spaces around the middot token `glyphs.bullet`).
+Composed with suspended note: `claude-fable-5[1m]  ·  1M  (suspended)`.
+`glyphs.bullet` from tokens.ts — never hardcoded inline.
+
+## Modified surfaces
+
+- **`settings-editor.tsx`** — `annotateModelLabel()` helper used for all three picker kinds: model
+  select, escalation FROM picker, escalation TO picker. One helper, three call sites.
+- **`flows-customize-picker.ts`** — `modelChoice()` updated. Added tokens import for `glyphs.bullet`.
+- **`execute-view-internals/header-card.tsx`** — `RoleLine` (both roles) + single-model fallback line.
+  `contextWindowLabel(model)` called inside the component, rendered as `· 200K` dim text after the model.
+- **`token-budget-card.tsx`** — `fmtTokens` fixed for ≥1M (was `1000k`, now `1M`); model + window label
+  added as a dim descriptor line in the Context group, omitted when model is undefined.
+- **`tasks-panel-internals/format.ts`** — `fmtTokens` same ≥1M fix for consistency.
+
+## Tests updated
+
+- New: `tests/unit/domain/value/settings-models/context-window.test.ts`
+- Updated: `tests/integration/application/ui/tui/components/token-budget-card.test.tsx` (+3 cases)
+- Updated: `tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx`
+  — Added `buildExpectedModelLabel()` helper, updated 6 assertions to use new format, changed
+  2 label-based lookups to value-based lookups (`o.value === otherModel`).
+
+**How to apply:** When adding a new model to CLAUDE_MODELS, add it to `context-window.ts` CONTEXT_WINDOW
+if its window size is known; also update `integration/ai/providers/_engine/context-window.ts` until #226
+unifies them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
   coverage:
     name: Coverage report
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v6
@@ -117,11 +116,19 @@ jobs:
       - name: Run tests with coverage
         run: pnpm coverage
 
+      - name: Upload to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ github.event.pull_request.number }}
+          name: coverage-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
           path: coverage/
           retention-days: 14
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ to [Semantic Versioning](https://semver.org/).
   explicit checkpoint before producing its verdict, improving grading consistency and reducing
   ungrounded pass/fail decisions.
 
+### Changed
+
+- **Lint warning ceiling added.** The `lint` script is now `eslint . --max-warnings 342`, capping
+  the accepted warning count at the baseline observed after the provider-engine refactor. Any future
+  increase above that count fails CI. The `lint:fix` script is left without the flag so local
+  autofix is not blocked. Maintainers may lower the ceiling incrementally as existing warnings are
+  resolved.
+
 ### Fixed
 
 - **Provider stdout parse-buffer OOM caps.** A single large tool-result line embedded in the AI's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,12 @@ the process smooth for everyone.
    duplicate work and gives us a chance to discuss the approach before you invest time.
 2. **Keep PRs focused.** One logical change per PR. If you find an unrelated bug while working, open a separate issue
    for it.
-3. **All checks must pass.** Lint, typecheck, and tests are non-negotiable.
+3. **All checks must pass.** Lint, typecheck, and tests are non-negotiable. Coverage is also enforced as a
+   required merge gate: a PR that drops coverage below the configured thresholds, or that fails the
+   cold-install reproducibility check, cannot be merged. Each PR's coverage run uploads to
+   [Codecov](https://codecov.io/gh/lukas-grigis/ralphctl), which backs the README badge — that published
+   number is the authoritative coverage figure for the project. The required status checks (including the
+   coverage and cold-install jobs) are configured via `scripts/setup-required-checks.sh`.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![npm version](https://img.shields.io/npm/v/ralphctl?style=flat&logo=npm&logoColor=white&color=cb3837)](https://www.npmjs.com/package/ralphctl)
 [![npm downloads](https://img.shields.io/npm/dm/ralphctl?style=flat&logo=npm&logoColor=white&color=cb3837)](https://www.npmjs.com/package/ralphctl)
 [![CI](https://github.com/lukas-grigis/ralphctl/actions/workflows/ci.yml/badge.svg)](https://github.com/lukas-grigis/ralphctl/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/lukas-grigis/ralphctl/graph/badge.svg)](https://codecov.io/gh/lukas-grigis/ralphctl)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat&logo=opensourceinitiative&logoColor=white)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178c6?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A5_24-5fa04e?style=flat&logo=nodedotjs&logoColor=white)](https://nodejs.org/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: false
+    patch: false

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coverage:unused": "tsx scripts/find-unused.ts",
     "deadcode": "knip",
     "skills:update": "tsx scripts/sync-skills.ts",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 342",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/setup-required-checks.sh
+++ b/scripts/setup-required-checks.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# scripts/setup-required-checks.sh
+#
+# Maintainer helper: add the coverage and cold-install jobs to the required
+# status checks on the main branch via the GitHub API.  Run once with a
+# repo-admin token; the script unions with the existing required set so no
+# pre-existing check is removed.
+#
+# IMPORTANT: The check names in WANT_CHECKS below MUST match the check-run
+# display names shown on the Checks tab of a recent CI run (job `name:` in
+# .github/workflows/ci.yml).  A name mismatch creates a required check that
+# can never be satisfied — verify against an actual CI run before renaming.
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated (run: gh auth status)
+#   - jq 1.6+ installed (https://jqlang.github.io/jq/)
+#   - Caller must have repository admin permission on this repository
+#   - The gh token must include the `repo` scope
+
+set -euo pipefail
+
+# Required check-run display names — must match job `name:` in ci.yml exactly.
+WANT_CHECKS=(
+  "Format, lint, typecheck & test"
+  "Coverage report"
+  "Cold-install smoke (fresh node_modules from lockfile)"
+)
+
+# ── preflight ────────────────────────────────────────────────────────────────
+if ! command -v gh &>/dev/null; then
+  echo "error: gh CLI not found — install from https://cli.github.com" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "error: jq not found — install from https://jqlang.github.io/jq/" >&2
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+  echo "error: could not detect GitHub repository — is gh authenticated?" >&2
+  echo "       run: gh auth status" >&2
+  exit 1
+}
+
+BRANCH="main"
+API="repos/${REPO}/branches/${BRANCH}/protection/required_status_checks"
+
+printf 'repo   : %s\nbranch : %s\n' "${REPO}" "${BRANCH}"
+
+# ── read current required status checks ─────────────────────────────────────
+echo "reading current required status checks..."
+
+TMP_ERR=$(mktemp)
+TMP_PAYLOAD=$(mktemp)
+trap 'rm -f "${TMP_ERR}" "${TMP_PAYLOAD}"' EXIT
+
+STRICT="false"
+EXISTING_CHECKS=()
+
+if CURRENT_RESPONSE=$(gh api "${API}" 2>"${TMP_ERR}"); then
+  STRICT=$(echo "${CURRENT_RESPONSE}" | jq -r '.strict // false')
+  while IFS= read -r name; do
+    [[ -n "${name}" ]] && EXISTING_CHECKS+=("${name}")
+  done < <(
+    echo "${CURRENT_RESPONSE}" | jq -r '
+      if .checks then .checks[].context
+      elif .contexts then .contexts[]
+      else empty
+      end
+    '
+  )
+else
+  GH_ERR=$(cat "${TMP_ERR}")
+  if echo "${GH_ERR}" | grep -qiE "Branch not protected|not protected|404|Not Found"; then
+    echo "note: no existing required-check protection — will create from scratch"
+  else
+    echo "error: cannot read branch protection" >&2
+    echo "       ensure you have repo admin permission and that your gh token includes the 'repo' scope" >&2
+    echo "       gh error: ${GH_ERR}" >&2
+    exit 1
+  fi
+fi
+
+# ── determine which checks need to be added ───────────────────────────────────
+MISSING=()
+for CHECK in "${WANT_CHECKS[@]}"; do
+  FOUND=0
+  if [[ ${#EXISTING_CHECKS[@]} -gt 0 ]]; then
+    for EXISTING in "${EXISTING_CHECKS[@]}"; do
+      if [[ "${EXISTING}" == "${CHECK}" ]]; then
+        FOUND=1
+        break
+      fi
+    done
+  fi
+  if [[ ${FOUND} -eq 0 ]]; then
+    MISSING+=("${CHECK}")
+    echo "  + will add : ${CHECK}"
+  else
+    echo "  ✓ present  : ${CHECK}"
+  fi
+done
+
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+  echo "all required checks already present — nothing to do"
+  exit 0
+fi
+
+# ── build union payload ───────────────────────────────────────────────────────
+ALL_CHECKS=()
+if [[ ${#EXISTING_CHECKS[@]} -gt 0 ]]; then
+  ALL_CHECKS+=("${EXISTING_CHECKS[@]}")
+fi
+ALL_CHECKS+=("${MISSING[@]}")
+
+printf '%s\n' "${ALL_CHECKS[@]}" \
+  | jq -R '{context: .}' \
+  | jq -s --argjson strict "${STRICT}" '{strict: $strict, checks: .}' \
+  > "${TMP_PAYLOAD}"
+
+# ── apply ─────────────────────────────────────────────────────────────────────
+echo "applying update..."
+if ! gh api --method PATCH "${API}" --input "${TMP_PAYLOAD}" >/dev/null 2>"${TMP_ERR}"; then
+  GH_ERR=$(cat "${TMP_ERR}")
+  echo "error: PATCH failed — caller must have repository admin permission and repo scope" >&2
+  echo "       gh error: ${GH_ERR}" >&2
+  exit 1
+fi
+
+echo "done — required status checks on '${BRANCH}' now include all three checks"

--- a/src/application/ui/tui/components/tasks-panel-internals/format.ts
+++ b/src/application/ui/tui/components/tasks-panel-internals/format.ts
@@ -33,13 +33,18 @@ export const EXPANDED_DISCLOSURE = '▾';
 export const FOCUS_CURSOR = '›';
 
 /**
- * Compact a token count for display: `200000` → `200k`, `1500` → `1.5k`, `120` → `120`. The
- * provider's reported numbers can be large (context windows trend 100k-200k); collapsing to a
- * one-or-two-char "k" suffix keeps the marker scannable inside one terminal row.
+ * Compact a token count for display: `200000` → `200k`, `1500` → `1.5k`, `120` → `120`,
+ * `1000000` → `1M`, `1200000` → `1.2M`. The provider's reported numbers can be large (context
+ * windows trend 200k–1M); values ≥ 1M use an `M` suffix so a 1M window renders as `1M`, not
+ * `1000k` — consistent with the token-budget card's formatter.
  */
 export const fmtTokens = (n: number): string => {
   if (!Number.isFinite(n) || n < 0) return String(n);
   if (n < 1000) return String(Math.round(n));
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
+  }
   const k = n / 1000;
   return k >= 100 ? `${String(Math.round(k))}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
 };

--- a/src/application/ui/tui/components/token-budget-card.tsx
+++ b/src/application/ui/tui/components/token-budget-card.tsx
@@ -39,8 +39,9 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
-import { CONTEXT_WIDTH, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { CONTEXT_WIDTH, glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import type { TokenUsage } from '@src/application/ui/tui/runtime/use-token-usage.ts';
+import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
 
 /** @public */
 export interface TokenBudgetCardProps {
@@ -52,12 +53,18 @@ export interface TokenBudgetCardProps {
 const BAR_WIDTH = 10;
 
 /**
- * Compact a token count for display: `200000` → `200k`, `12400` → `12.4k`, `120` → `120`. The
- * context column is narrow; truncating to a one-or-two-char `k` suffix keeps every row scannable.
+ * Compact a token count for display: `200000` → `200k`, `12400` → `12.4k`, `120` → `120`,
+ * `1000000` → `1M`, `1200000` → `1.2M`. The context column is narrow; single-char suffixes
+ * keep every row scannable. Values ≥ 1M use the `M` suffix so a 1M context-window renders
+ * as `1M`, not `1000k`.
  */
 const fmtTokens = (n: number): string => {
   if (!Number.isFinite(n) || n < 0) return String(n);
   if (n < 1000) return String(Math.round(n));
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
+  }
   const k = n / 1000;
   return k >= 100 ? `${String(Math.round(k))}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
 };
@@ -159,6 +166,9 @@ export const TokenBudgetCard = ({ sessionId, usage }: TokenBudgetCardProps): Rea
     usage.liveCacheCreationTokens !== undefined;
   const hasUsageData = usage.inputTokens !== undefined || output !== undefined || hasLive;
   const ctx = computeContext(usage);
+  // Model descriptor for the Context group — shown as a dim sub-label so the denominator
+  // (e.g. `53.6k / 200k`) is self-explanatory without needing to cross-reference the header.
+  const modelWindowLabel = contextWindowLabel(usage.model);
 
   return (
     <Box width={CONTEXT_WIDTH} flexDirection="column">
@@ -198,6 +208,20 @@ export const TokenBudgetCard = ({ sessionId, usage }: TokenBudgetCardProps): Rea
               <Text dimColor bold>
                 Context
               </Text>
+              {/* Model descriptor: shows which model's window is the denominator. Omitted when
+                  the model is unknown so the card degrades cleanly for providers that don't
+                  report a model name. */}
+              {usage.model !== undefined && (
+                <Box>
+                  <Text dimColor>{usage.model}</Text>
+                  {modelWindowLabel !== undefined && (
+                    <>
+                      <Text dimColor> {glyphs.bullet} </Text>
+                      <Text dimColor>{modelWindowLabel}</Text>
+                    </>
+                  )}
+                </Box>
+              )}
               {ctx.showCumulativeNote ? (
                 // Cumulative data over the window: raw total labelled as session-cumulative; no
                 // "/window" denominator and no % bar — a "2.2M / 200k 100%" bar would mislead.

--- a/src/application/ui/tui/views/execute-view-internals/header-card.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/header-card.tsx
@@ -26,6 +26,7 @@ import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { perAttemptRound, type TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
 
 interface HeaderCardProps {
   readonly descriptor: SessionDescriptor;
@@ -62,26 +63,35 @@ const RoleLine = ({
   readonly provider: string | undefined;
   readonly model: string;
   readonly effort: string | undefined;
-}): React.JSX.Element => (
-  <Box>
-    <Text dimColor>
-      {glyphs.activityArrow} {role}{' '}
-    </Text>
-    {provider !== undefined && (
-      <>
-        <Text dimColor>{provider}</Text>
-        <Text dimColor> {glyphs.bullet} </Text>
-      </>
-    )}
-    <Text color={inkColors.highlight}>{model}</Text>
-    {effort !== undefined && (
-      <>
-        <Text dimColor> {glyphs.bullet} </Text>
-        <Text dimColor>{effort}</Text>
-      </>
-    )}
-  </Box>
-);
+}): React.JSX.Element => {
+  const ctxWindow = contextWindowLabel(model);
+  return (
+    <Box>
+      <Text dimColor>
+        {glyphs.activityArrow} {role}{' '}
+      </Text>
+      {provider !== undefined && (
+        <>
+          <Text dimColor>{provider}</Text>
+          <Text dimColor> {glyphs.bullet} </Text>
+        </>
+      )}
+      <Text color={inkColors.highlight}>{model}</Text>
+      {ctxWindow !== undefined && (
+        <>
+          <Text dimColor> {glyphs.bullet} </Text>
+          <Text dimColor>{ctxWindow}</Text>
+        </>
+      )}
+      {effort !== undefined && (
+        <>
+          <Text dimColor> {glyphs.bullet} </Text>
+          <Text dimColor>{effort}</Text>
+        </>
+      )}
+    </Box>
+  );
+};
 
 const ModelLines = ({
   generatorModel,
@@ -108,10 +118,11 @@ const ModelLines = ({
     );
   }
 
-  // Non-implement flows: single model line (whichever is set), with its provider when available.
+  // Non-implement flows: single model line (whichever is set), with its provider + window when available.
   const model = generatorModel ?? evaluatorModel;
   const provider = generatorProvider ?? evaluatorProvider;
   if (model !== undefined) {
+    const ctxWindow = contextWindowLabel(model);
     return (
       <Box>
         <Text dimColor>{glyphs.activityArrow} model </Text>
@@ -122,6 +133,12 @@ const ModelLines = ({
           </>
         )}
         <Text color={inkColors.highlight}>{model}</Text>
+        {ctxWindow !== undefined && (
+          <>
+            <Text dimColor> {glyphs.bullet} </Text>
+            <Text dimColor>{ctxWindow}</Text>
+          </>
+        )}
       </Box>
     );
   }

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -25,6 +25,8 @@ import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
 import { PROVIDER_EFFORT_LEVELS } from '@src/domain/value/settings-models/effort.ts';
 import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
+import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { LaunchExtras } from '@src/application/ui/shared/launcher.ts';
@@ -60,15 +62,22 @@ const resolveModelCatalog = async (
 const KEEP = '__keep__';
 
 /**
- * Map a model id to a picker choice — flagging temporarily-suspended models in the LABEL only.
- * The `value` stays the bare id so a pre-pinned choice still round-trips; if the user picks it
- * anyway, the adapter guard rejects it at launch with a clear message. Applies to both the static
- * and account-narrowed catalogs, since both flow through `modelCatalog.map`.
+ * Map a model id to a picker choice. Appends the context-window size and (when applicable) the
+ * suspension note to the LABEL only — the `value` stays the bare id so a pre-pinned choice still
+ * round-trips; if the user picks a suspended model, the adapter guard rejects it at launch.
+ * Applies to both the static and account-narrowed catalogs.
+ *
+ *   'claude-sonnet-4-6'    →  'claude-sonnet-4-6  ·  200K'
+ *   'claude-opus-4-8[1m]' →  'claude-opus-4-8[1m]  ·  1M'
+ *   'gpt-5.5'             →  'gpt-5.5'   (no window known — no annotation)
  */
-const modelChoice = (m: string): Choice<string> => ({
-  label: isSuspendedModel(m) ? `${m} (${SUSPENSION_NOTE})` : m,
-  value: m,
-});
+const modelChoice = (m: string): Choice<string> => {
+  const windowPart = contextWindowLabel(m);
+  const suspendedPart = isSuspendedModel(m) ? `(${SUSPENSION_NOTE})` : undefined;
+  const annotations = [windowPart, suspendedPart].filter((s): s is string => s !== undefined);
+  const label = annotations.length > 0 ? `${m}  ${glyphs.bullet}  ${annotations.join('  ')}` : m;
+  return { label, value: m };
+};
 
 /**
  * Outcome of one picker session. `kind` discriminates:

--- a/src/application/ui/tui/views/settings-editor.tsx
+++ b/src/application/ui/tui/views/settings-editor.tsx
@@ -26,6 +26,25 @@ import {
   isProviderField,
 } from '@src/application/ui/tui/views/settings-view-model.ts';
 import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
+import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
+
+/**
+ * Build the display label for a model picker option. Appends the context-window size and (when
+ * applicable) the suspension note — both are additive so the bare model id is always visible.
+ *
+ *   'claude-sonnet-4-6'    →  'claude-sonnet-4-6  ·  200K'
+ *   'claude-opus-4-8[1m]' →  'claude-opus-4-8[1m]  ·  1M'
+ *   'claude-fable-5[1m]'  →  'claude-fable-5[1m]  ·  1M  (suspended)'
+ *   'claude-fable-5'      →  'claude-fable-5  ·  (suspended)'
+ *   'gpt-5.5'             →  'gpt-5.5'   (no window known — no annotation)
+ */
+const annotateModelLabel = (model: string): string => {
+  const windowPart = contextWindowLabel(model);
+  const suspendedPart = isSuspendedModel(model) ? `(${SUSPENSION_NOTE})` : undefined;
+  const annotations = [windowPart, suspendedPart].filter((s): s is string => s !== undefined);
+  if (annotations.length === 0) return model;
+  return `${model}  ${glyphs.bullet}  ${annotations.join('  ')}`;
+};
 
 interface ProviderChoice {
   readonly label: string;
@@ -87,7 +106,7 @@ const EscalationAddEditor = ({
     return (
       <SelectPrompt
         message="Escalate FROM which model? (step 1/2)"
-        options={escalationModelOptions().map((value) => ({ label: value, value }))}
+        options={escalationModelOptions().map((value) => ({ label: annotateModelLabel(value), value }))}
         onSubmit={(value) => setFromModel(String(value))}
         onCancel={onCancel}
       />
@@ -96,7 +115,7 @@ const EscalationAddEditor = ({
   return (
     <SelectPrompt
       message={`${fromModel} ${glyphs.arrowRight} which model? (step 2/2)`}
-      options={escalationTargetsFor(fromModel).map((value) => ({ label: value, value }))}
+      options={escalationTargetsFor(fromModel).map((value) => ({ label: annotateModelLabel(value), value }))}
       footer="esc goes back to the from-model pick"
       onSubmit={(value) => onSubmit(`${fromModel}=${String(value)}`)}
       onCancel={() => setFromModel(undefined)}
@@ -118,7 +137,7 @@ export const SettingsEditor = ({
       <SelectPrompt
         message={`${field.from} escalates to (current: ${field.to})`}
         options={[
-          ...escalationTargetsFor(field.from).map((value) => ({ label: value, value })),
+          ...escalationTargetsFor(field.from).map((value) => ({ label: annotateModelLabel(value), value })),
           { label: '(remove this override)', value: '' },
         ]}
         onSubmit={(value) => onSubmit(String(value))}
@@ -139,15 +158,16 @@ export const SettingsEditor = ({
         />
       );
     }
-    // Model selects flag temporarily-suspended ids in the LABEL only; the value stays the bare id
-    // so a pre-pinned choice round-trips (the adapter guard rejects it at launch). Every other
-    // select (log level, booleans, …) renders plain.
+    // Model selects annotate each option with its context-window size and (when applicable) the
+    // suspension note — labels only; the value stays the bare id so a pre-pinned choice
+    // round-trips and the adapter guard remains the single rejection point.
+    // Every other select (log level, booleans, …) renders plain.
     const annotate = isModelField(field);
     return (
       <SelectPrompt
         message={`${field.label} (current: ${field.current})`}
         options={field.options.map((value) => ({
-          label: annotate && isSuspendedModel(value) ? `${value} (${SUSPENSION_NOTE})` : value,
+          label: annotate ? annotateModelLabel(value) : value,
           value,
         }))}
         onSubmit={(value) => onSubmit(String(value))}

--- a/src/domain/value/settings-models/context-window.ts
+++ b/src/domain/value/settings-models/context-window.ts
@@ -1,0 +1,61 @@
+/**
+ * UI-facing context-window helper — maps a provider-reported model id to its total token-context
+ * budget and a compact display label.
+ *
+ * Lives in `domain/` (not `integration/`) for two reasons:
+ *  1. The `Settings` entity and its model identifiers are domain-owned; the table belongs next to
+ *     the other per-provider catalogs (`claude.ts`, `copilot.ts`, …).
+ *  2. The TUI (`application/`) cannot import the integration-layer adapter
+ *     (`providers/_engine/context-window.ts`) without violating the four-module layer rule.
+ *
+ * This intentionally duplicates the map that also lives in
+ * `src/integration/ai/providers/_engine/context-window.ts`. Once ticket #226 lands and the
+ * provider-engine is refactored, the integration copy should delegate here rather than maintaining
+ * its own table. Until then keep both in sync when adding a new model entry.
+ *
+ * Scope discipline: only entries we are confident about. A guess here surfaces as a wrong label or
+ * a wrong % bar in the TUI; an omission surfaces as "no label rendered". Prefer the latter — add a
+ * model only when the vendor publishes the figure.
+ *
+ *  - **Claude (Anthropic)** — 200 000 for the 4.x line (Haiku 4.5 / Sonnet 4.6 / Opus 4.8).
+ *    The `[1m]` suffix IS Claude Code's 1M-token long-context selector — the figure comes from
+ *    the id itself, not a model card.
+ *  - **Copilot / Codex** — omitted; the CLIs do not surface per-model window sizes.
+ *
+ * Pure domain — no `node:*` I/O.
+ */
+
+const CONTEXT_WINDOW: Readonly<Record<string, number>> = {
+  // Claude (claude-code adapter — Anthropic direct)
+  'claude-haiku-4-5': 200_000,
+  'claude-sonnet-4-6': 200_000,
+  'claude-opus-4-8': 200_000,
+  // `[1m]` is Claude Code's 1M-token long-context selector — the window IS the id suffix.
+  'claude-opus-4-8[1m]': 1_000_000,
+  'claude-fable-5[1m]': 1_000_000,
+};
+
+/**
+ * Look up the canonical context window for a provider-reported model id. Returns `undefined`
+ * for unknown / unset models — callers render raw counts or omit the window label entirely.
+ */
+export const contextWindowFor = (model: string | undefined): number | undefined => {
+  if (model === undefined) return undefined;
+  return CONTEXT_WINDOW[model];
+};
+
+/**
+ * Compact display label for a model's context window size:
+ *   `200_000` → `"200K"`, `1_000_000` → `"1M"`, `1_200_000` → `"1.2M"`.
+ * Returns `undefined` when the model is unknown or unset — callers should omit the label.
+ */
+export const contextWindowLabel = (model: string | undefined): string | undefined => {
+  const w = contextWindowFor(model);
+  if (w === undefined) return undefined;
+  if (w >= 1_000_000) {
+    const m = w / 1_000_000;
+    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  const k = w / 1_000;
+  return `${k.toFixed(1).replace(/\.0$/, '')}K`;
+};

--- a/src/integration/ai/providers/_engine/run-provider-attempt.ts
+++ b/src/integration/ai/providers/_engine/run-provider-attempt.ts
@@ -1,0 +1,307 @@
+import type { Result } from '@src/domain/result.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import { STDERR_TAIL_CAP, createBoundedTail } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { ProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
+import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
+import { runWithRateLimitRetry } from '@src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts';
+import { writeTextAtomic } from '@src/integration/io/fs.ts';
+import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
+import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import { classifySpawnExit, type ProviderName } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+
+export type { ProviderName };
+
+/**
+ * Token-usage payload supplied by each provider adapter. Fields map directly to the
+ * `TokenUsageEvent` shape; each provider fills only the subset it captures from its CLI stream.
+ */
+export interface TokenUsagePayload {
+  readonly provider: 'claude-code' | 'openai-codex' | 'github-copilot';
+  readonly model?: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheCreationTokens?: number;
+  readonly liveInputTokens?: number;
+  readonly liveCacheReadTokens?: number;
+  readonly liveCacheCreationTokens?: number;
+}
+
+/**
+ * Emit the per-spawn "session id captured" debug log. All three adapters publish the same
+ * event shape; only the provider-name prefix and the captured id differ.
+ */
+export const emitSessionIdCaptured = (eventBus: EventBus, providerName: string, sessionId: string): void => {
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: `${providerName}: session id captured`,
+    meta: { sessionId },
+    at: IsoTimestamp.now(),
+  });
+};
+
+/**
+ * Emit one `TokenUsageEvent` per success spawn. Handles the contextWindowFor lookup,
+ * chainSessionId / role threading, and all optional field spreads so each provider just
+ * passes its own payload fields.
+ */
+export const emitTokenUsage = (
+  eventBus: EventBus,
+  session: AiSession,
+  sessionId: string,
+  payload: TokenUsagePayload
+): void => {
+  const window = contextWindowFor(payload.model);
+  const chainSessionId = session.chainSessionId;
+  eventBus.publish({
+    type: 'token-usage',
+    sessionId,
+    ...(chainSessionId !== undefined ? { chainSessionId } : {}),
+    provider: payload.provider,
+    ...(payload.model !== undefined ? { model: payload.model } : {}),
+    ...(payload.inputTokens !== undefined ? { inputTokens: payload.inputTokens } : {}),
+    ...(payload.outputTokens !== undefined ? { outputTokens: payload.outputTokens } : {}),
+    ...(payload.cacheReadTokens !== undefined ? { cacheReadTokens: payload.cacheReadTokens } : {}),
+    ...(payload.cacheCreationTokens !== undefined ? { cacheCreationTokens: payload.cacheCreationTokens } : {}),
+    ...(payload.liveInputTokens !== undefined ? { liveInputTokens: payload.liveInputTokens } : {}),
+    ...(payload.liveCacheReadTokens !== undefined ? { liveCacheReadTokens: payload.liveCacheReadTokens } : {}),
+    ...(payload.liveCacheCreationTokens !== undefined
+      ? { liveCacheCreationTokens: payload.liveCacheCreationTokens }
+      : {}),
+    ...(window !== undefined ? { contextWindow: window } : {}),
+    ...(session.role !== undefined ? { role: session.role } : {}),
+    at: IsoTimestamp.now(),
+  });
+};
+
+/**
+ * Per-attempt spawn configuration. Each provider supplies its stdout consumer, flush callback,
+ * state getters, and token-usage emitter; the shared scaffold owns the child lifecycle, bounded
+ * tails, watchdog banner, `runHeadlessSpawn` wiring, `onSuccess` plumbing, and
+ * `classifySpawnExit` call.
+ */
+export interface ProviderAttemptInput {
+  readonly spawnFn: ProviderSpawn;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly session: AiSession;
+  readonly resolveOn: 'exit' | 'close';
+  /**
+   * Prompt piped to stdin. Omit for providers (Copilot) that pass the prompt as an argv
+   * argument — `runHeadlessSpawn` closes stdin immediately when this field is absent.
+   */
+  readonly stdin?: string;
+  readonly rateLimitRe: RegExp;
+  /** Receives each raw stdout chunk. */
+  readonly onStdoutChunk: (chunk: string) => void;
+  /**
+   * Flush any trailing partial-line state after `runHeadlessSpawn` resolves so no JSONL
+   * record is lost to a missing terminal newline.
+   */
+  readonly flush: () => void;
+  /** Returns the session id captured from the stream (called after flush). */
+  readonly getSessionId: () => string | undefined;
+  /** Returns the stdout body tail for the rate-limit haystack, or undefined to scan stderr only. */
+  readonly getStdoutTail: () => string | undefined;
+  /**
+   * Returns the assistant body for `bodyFile` mirroring. Only called when `session.bodyFile`
+   * is set. For providers that read from a tempfile (codex), may return a failure Result that
+   * surfaces as a hard error from `onSuccess`.
+   */
+  readonly getBody: () => Promise<Result<string, DomainError>>;
+  /**
+   * Emit the provider-specific token-usage event for this attempt's captured sessionId. Called
+   * from `onSuccess` only when `sessionId` is defined.
+   */
+  readonly emitProviderTokenUsage: (sessionId: string) => void;
+  readonly providerName: ProviderName;
+  readonly providerSlug: 'claude' | 'codex' | 'copilot';
+  readonly eventBus: EventBus;
+  readonly idleMs?: number;
+}
+
+/**
+ * Shared spawnAttempt scaffold for the three headless AI provider adapters. Owns:
+ *
+ * - Child spawn with cwd (context-file autoload depends on the child's `process.cwd()`).
+ * - Bounded stderr tail (`STDERR_TAIL_CAP`).
+ * - Watchdog banner id keyed by `watchdog-<slug>-<pid>`.
+ * - `runHeadlessSpawn` wiring — onStdout / onStderr / stdin / resolveOn / idleMs /
+ *   abortSignal / onIdle (idle-watchdog warn + banner-show).
+ * - `onSuccess` plumbing — `emitSessionIdCaptured`, `emitProviderTokenUsage`,
+ *   `persistSessionIdFile`, bodyFile mirror.
+ * - `classifySpawnExit` call with provider-specific rateLimitRe and stdoutTail.
+ *
+ * Each provider supplies only what genuinely differs: argv, stdout chunk consumer, flush
+ * callback, sessionId / stdoutTail / body getters, and token-usage payload.
+ */
+export const runProviderAttempt = async (input: ProviderAttemptInput): Promise<AttemptOutcome> => {
+  const {
+    spawnFn,
+    command,
+    args,
+    session,
+    resolveOn,
+    rateLimitRe,
+    onStdoutChunk,
+    flush,
+    getSessionId,
+    getStdoutTail,
+    providerName,
+    providerSlug,
+    eventBus,
+    idleMs,
+  } = input;
+
+  const child = spawnFn(command, args, {
+    stdio: ['pipe', 'pipe', 'pipe'] as const,
+    cwd: String(session.cwd),
+  });
+  const stderrTail = createBoundedTail(STDERR_TAIL_CAP);
+  const watchdogBannerId = `watchdog-${providerSlug}-${String(child.pid ?? 'unknown')}`;
+
+  const { code, signal } = await runHeadlessSpawn({
+    child,
+    onStdout: (chunk) => {
+      onStdoutChunk(chunk);
+    },
+    onStderr: (chunk) => {
+      stderrTail.append(chunk);
+    },
+    ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+    resolveOn,
+    ...(idleMs !== undefined ? { idleMs } : {}),
+    ...(session.abortSignal !== undefined ? { abortSignal: session.abortSignal } : {}),
+    onIdle: () => {
+      eventBus.publish({
+        type: 'log',
+        level: 'warn',
+        message: `${providerName}: no stdio activity${idleMs !== undefined ? ` for ${String(idleMs)}ms` : ''} — killing wedged child`,
+        ...(idleMs !== undefined ? { meta: { idleMs } } : {}),
+        at: IsoTimestamp.now(),
+      });
+      eventBus.publish({
+        type: 'banner-show',
+        id: watchdogBannerId,
+        tier: 'warn',
+        message: `Watchdog killed stuck ${providerSlug} process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
+        at: IsoTimestamp.now(),
+      });
+    },
+  });
+  flush();
+
+  const sessionId = getSessionId();
+
+  const onSuccess = async (): Promise<AttemptOutcome> => {
+    if (sessionId !== undefined) {
+      emitSessionIdCaptured(eventBus, providerName, sessionId);
+      input.emitProviderTokenUsage(sessionId);
+    }
+    const sidWrote = await persistSessionIdFile(session.signalsFile, sessionId);
+    if (sidWrote !== undefined && !sidWrote.ok) {
+      eventBus.publish({
+        type: 'log',
+        level: 'warn',
+        message: `${providerName}: failed to write sessionId file — resume re-attach may need log parsing`,
+        meta: { error: sidWrote.error.message },
+        at: IsoTimestamp.now(),
+      });
+    }
+    if (session.bodyFile !== undefined) {
+      const bodyResult = await input.getBody();
+      if (!bodyResult.ok) return { kind: 'error', error: bodyResult.error };
+      const bodyWrote = await writeTextAtomic(String(session.bodyFile), bodyResult.value);
+      if (!bodyWrote.ok) {
+        eventBus.publish({
+          type: 'log',
+          level: 'warn',
+          message: `${providerName}: failed to write body file — diagnostic capture skipped`,
+          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
+          at: IsoTimestamp.now(),
+        });
+      }
+    }
+    return {
+      kind: 'success',
+      output: {
+        signalsFile: session.signalsFile,
+        exitCode: code ?? 0,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      },
+    };
+  };
+
+  const stdoutTail = getStdoutTail();
+  return classifySpawnExit({
+    session,
+    exit: { code, signal },
+    stderr: stderrTail.value(),
+    rateLimitRe,
+    ...(stdoutTail !== undefined && stdoutTail.length > 0 ? { stdoutTail } : {}),
+    ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
+    providerName,
+    eventBus,
+    watchdogBannerId,
+    onSuccess,
+  });
+};
+
+/**
+ * Context created once per `generate()` call. Provides the attempt function (called for each
+ * retry) and optional cleanup run in a `finally` block after all attempts complete.
+ *
+ * Allows per-generate state (e.g. codex's output tempfile path) to be created once and shared
+ * across retries, while per-attempt stream state is created fresh inside `attempt`.
+ */
+export interface GenerateContext {
+  readonly attempt: (session: AiSession) => Promise<AttemptOutcome>;
+  readonly cleanup?: () => Promise<void>;
+}
+
+export interface CreateHeadlessProviderInput {
+  readonly providerSlug: 'claude' | 'codex' | 'copilot';
+  readonly providerName: ProviderName;
+  readonly resumeStaleRe: RegExp;
+  readonly rateLimitRetries: number;
+  readonly eventBus: EventBus;
+  readonly backoffSchedule?: readonly number[];
+  /**
+   * Called once at the start of each `generate()` call. Creates per-generate state (e.g.
+   * codex's output tempfile path) and returns the per-attempt function and optional cleanup.
+   * The attempt function is called once per retry; cleanup runs once after all attempts.
+   */
+  readonly createGenerateContext: () => GenerateContext;
+}
+
+/**
+ * Factory for the identical generate()->runWithRateLimitRetry boilerplate shared by all three
+ * headless provider adapters. Each adapter passes a `createGenerateContext` thunk that closes
+ * over its own resolved deps (spawnFn, command, etc.) so the factory stays dependency-free
+ * on provider-specific types.
+ */
+export const createHeadlessProvider = (config: CreateHeadlessProviderInput): HeadlessAiProvider => ({
+  async generate(session) {
+    const ctx = config.createGenerateContext();
+    try {
+      return await runWithRateLimitRetry({
+        session,
+        rateLimitRetries: config.rateLimitRetries,
+        ...(config.backoffSchedule !== undefined ? { backoffSchedule: config.backoffSchedule } : {}),
+        eventBus: config.eventBus,
+        providerSlug: config.providerSlug,
+        providerName: config.providerName,
+        resumeStaleRe: config.resumeStaleRe,
+        attempt: ctx.attempt,
+      });
+    } finally {
+      await ctx.cleanup?.();
+    }
+  },
+});

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -1,12 +1,10 @@
 import { Result } from '@src/domain/result.ts';
-import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
-import { STDERR_TAIL_CAP, createBoundedTail } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import { isRecord } from '@src/integration/ai/providers/_engine/json-field.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { ClaudeProviderDeps } from '@src/integration/ai/providers/_engine/claude-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
@@ -14,15 +12,13 @@ import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/setti
 import { createClaudeStreamParser } from '@src/integration/ai/providers/claude/parse-stream.ts';
 import type { ClaudeStreamLine } from '@src/integration/ai/providers/_engine/claude-stream.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
-import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
-import { runWithRateLimitRetry } from '@src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts';
-import { writeTextAtomic } from '@src/integration/io/fs.ts';
-import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
-import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
 import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
-import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
-import { classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
+import {
+  createHeadlessProvider,
+  emitTokenUsage,
+  runProviderAttempt,
+} from '@src/integration/ai/providers/_engine/run-provider-attempt.ts';
 
 /**
  * Real {@link HeadlessAiProvider} backed by the Claude Code CLI.
@@ -331,216 +327,87 @@ export const createClaudeProvider = (deps: ClaudeProviderDeps): HeadlessAiProvid
   const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
   const command = deps.command ?? 'claude';
 
-  return {
-    async generate(session) {
-      // The shared retry seam owns the loop, backoff, banners, abort-during-backoff, the
-      // session-resume rebuild (so a 429 retry passes `--resume <id>`), and the stale-resume
-      // cold fallback. The per-attempt closure builds argv from the CURRENT session, so a
-      // resumed retry naturally emits `--resume`. buildClaudeArgs validation surfaces up front.
-      const argsResult = buildClaudeArgs(session);
-      if (!argsResult.ok) return Result.error(argsResult.error) as Result<ProviderOutput, DomainError>;
-
-      return runWithRateLimitRetry({
-        session,
-        rateLimitRetries: deps.rateLimitRetries,
-        ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
-        eventBus: deps.eventBus,
-        providerSlug: 'claude',
-        providerName: 'claude-provider',
-        resumeStaleRe: RESUME_STALE_RE,
-        attempt: async (attemptSession) => {
-          const built = buildClaudeArgs(attemptSession);
-          if (!built.ok) return { kind: 'error', error: built.error };
-          return spawnAttempt({ deps, spawnFn, command, args: built.value, session: attemptSession });
-        },
-      });
-    },
-  };
-};
-
-interface SpawnAttemptArgs {
-  readonly deps: ClaudeProviderDeps;
-  readonly spawnFn: ProviderSpawn;
-  readonly command: string;
-  readonly args: readonly string[];
-  readonly session: AiSession;
-}
-
-/**
- * One spawn attempt: launch `claude`, write prompt, stream stdout JSONL through the
- * stream-json parser, then delegate exit classification to `classifySpawnExit` (decides
- * success / rate-limit / abort / signals-recovery / hard-fail uniformly across the three
- * adapters). Per-provider success block (token-usage publish, persistSessionIdFile,
- * optional bodyFile mirror) lives in the `onSuccess` closure passed to the classifier —
- * the closure runs on `code === 0` AND on signals-present recovery, so a watchdog SIGTERM
- * that landed after the AI completed its work still produces a success.
- *
- * The `envelope.body` string goes out of scope at function return — never retained on a
- * domain entity.
- */
-const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> => {
-  const { deps, spawnFn, command, args, session } = input;
-  // `cwd` is critical — the Claude Code CLI only auto-discovers `CLAUDE.md`, skills, agents,
-  // and `.mcp.json` from the child's `process.cwd()`. Without this, the native context-file
-  // pipeline silently misses and the AI runs without project guidance.
-  // See CLAUDE.md §Security — "Cwd is the repo because Claude / Copilot / Codex only
-  // auto-discover their context file from cwd."
-  const child = spawnFn(command, args, {
-    stdio: ['pipe', 'pipe', 'pipe'] as const,
-    cwd: String(session.cwd),
-  });
-  const parser = createClaudeStreamParser();
-  const stderrTail = createBoundedTail(STDERR_TAIL_CAP);
-
-  const onLine = (line: ClaudeStreamLine): void => {
-    parser.ingest(line);
-    // Per-line debug fan-out, published DIRECTLY to the EventBus — no gate at this site. The
-    // UI-floor filter lives in launch.ts's coalescing forwarder (applied at ingest against the
-    // live log-level gate); the persistent events.ndjson sink records every event regardless of
-    // that floor. `createEventBusLogger` is a producer, not a filter, and drops nothing here.
-    publishStreamLineEvents(deps.eventBus, line);
-  };
-
-  // Bound once so the onIdle banner-show id and the classifier's banner-clear id match.
-  const watchdogBannerId = `watchdog-claude-${String(child.pid ?? 'unknown')}`;
-
-  // Wait for the child to fully `'close'` — NOT just `'exit'`. `'exit'` can fire before the
-  // final stdout chunk has been delivered to our listener; `'close'` guarantees the streams
-  // have flushed. v1 uses the same event for the same reason.
-  //
-  // No wall-clock timeout: implement sessions can legitimately run for hours. The idle-stdout
-  // watchdog (installed inside runHeadlessSpawn) handles the "stuck child" failure mode, and
-  // `session.abortSignal` (Ctrl-C / TUI) threads through the same kill ladder.
-  const { code, signal } = await runHeadlessSpawn({
-    child,
-    onStdout: (chunk) => parser.feed(chunk, onLine),
-    onStderr: (chunk) => {
-      stderrTail.append(chunk);
-    },
-    stdin: session.prompt,
-    resolveOn: 'close',
-    ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
-    ...(session.abortSignal !== undefined ? { abortSignal: session.abortSignal } : {}),
-    onIdle: () => {
-      const idleMs = deps.idleMs ?? undefined;
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `claude-provider: no stdio activity${idleMs !== undefined ? ` for ${String(idleMs)}ms` : ''} — killing wedged child`,
-        ...(idleMs !== undefined ? { meta: { idleMs } } : {}),
-        at: IsoTimestamp.now(),
-      });
-      deps.eventBus.publish({
-        type: 'banner-show',
-        id: watchdogBannerId,
-        tier: 'warn',
-        message: `Watchdog killed stuck claude process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
-        at: IsoTimestamp.now(),
-      });
-    },
-  });
-  parser.flush(onLine);
-
-  // `envelope.body` is sourced from `parser.snapshot()` in O(1) — the parser holds a single
-  // string reassigned from the latest `result` event. No per-line concatenation in this
-  // adapter; preserve that invariant.
-  const envelope = parser.snapshot();
-
-  const onSuccess = async (): Promise<AttemptOutcome> => {
-    if (envelope.sessionId !== undefined) {
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'debug',
-        message: 'claude-provider: session id captured',
-        meta: { sessionId: envelope.sessionId },
-        at: IsoTimestamp.now(),
-      });
-      // Emit one TokenUsageEvent per success spawn — only when we have a sessionId
-      // (downstream subscribers correlate by it). Absence of usage counters is honest: the
-      // result event may carry zero usage subkeys on degenerate spawns or when the spawn
-      // was SIGTERM-recovered before the final result event landed.
-      const window = contextWindowFor(envelope.model);
-      const chainSessionId = session.chainSessionId;
-      deps.eventBus.publish({
-        type: 'token-usage',
-        sessionId: envelope.sessionId,
-        ...(chainSessionId !== undefined ? { chainSessionId } : {}),
-        provider: 'claude-code',
-        ...(envelope.model !== undefined ? { model: envelope.model } : {}),
-        ...(envelope.usage.inputTokens !== undefined ? { inputTokens: envelope.usage.inputTokens } : {}),
-        ...(envelope.usage.outputTokens !== undefined ? { outputTokens: envelope.usage.outputTokens } : {}),
-        ...(envelope.usage.cacheReadTokens !== undefined ? { cacheReadTokens: envelope.usage.cacheReadTokens } : {}),
-        ...(envelope.usage.cacheCreationTokens !== undefined
-          ? { cacheCreationTokens: envelope.usage.cacheCreationTokens }
-          : {}),
-        // Live/per-turn snapshot from the LAST assistant turn — true current context-window
-        // occupancy, distinct from the cumulative `*Tokens` above. Absent on copilot/codex and
-        // on spawns where no assistant event carried usage.
-        ...(envelope.liveUsage.inputTokens !== undefined ? { liveInputTokens: envelope.liveUsage.inputTokens } : {}),
-        ...(envelope.liveUsage.cacheReadTokens !== undefined
-          ? { liveCacheReadTokens: envelope.liveUsage.cacheReadTokens }
-          : {}),
-        ...(envelope.liveUsage.cacheCreationTokens !== undefined
-          ? { liveCacheCreationTokens: envelope.liveUsage.cacheCreationTokens }
-          : {}),
-        ...(window !== undefined ? { contextWindow: window } : {}),
-        ...(session.role !== undefined ? { role: session.role } : {}),
-        at: IsoTimestamp.now(),
-      });
-    }
-    // audit-[09]: the AI writes `signals.json` directly via its Write tool into
-    // `session.outputDir`; the harness validates it post-spawn. The provider never writes
-    // signals.json itself — every leaf consumes the contract path.
-    // Persist captured session id as a sibling `sessionId` file so `--resume` / forensic
-    // re-attach works without parsing chain.log. Skipped when the stream never carried an id
-    // (process crashed mid-init) — see persistSessionIdFile for the contract.
-    const sidWrote = await persistSessionIdFile(session.signalsFile, envelope.sessionId);
-    if (sidWrote !== undefined && !sidWrote.ok) {
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `claude-provider: failed to write sessionId file — resume re-attach may need log parsing`,
-        meta: { error: sidWrote.error.message },
-        at: IsoTimestamp.now(),
-      });
-    }
-    // Mirror raw body for diagnostic capture (detect-scripts / detect-skills empty-proposal
-    // debugging). Best-effort: a write failure here is logged but does not fail the session.
-    if (session.bodyFile !== undefined) {
-      const bodyWrote = await writeTextAtomic(String(session.bodyFile), envelope.body);
-      if (!bodyWrote.ok) {
-        deps.eventBus.publish({
-          type: 'log',
-          level: 'warn',
-          message: `claude-provider: failed to write body file — diagnostic capture skipped`,
-          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
-          at: IsoTimestamp.now(),
-        });
-      }
-    }
-    return {
-      kind: 'success',
-      output: {
-        signalsFile: session.signalsFile,
-        exitCode: code ?? 0,
-        ...(envelope.sessionId !== undefined ? { sessionId: envelope.sessionId } : {}),
-      },
-    };
-  };
-
-  return classifySpawnExit({
-    session,
-    exit: { code, signal },
-    stderr: stderrTail.value(),
-    rateLimitRe: RATE_LIMIT_RE,
-    // Claude's `-p stream-json` mode reports quota errors in the stdout `result` envelope, not
-    // on stderr. Feed the parsed body into the rate-limit haystack so a real throttle trips the
-    // overnight backoff instead of hard-failing the round.
-    ...(envelope.body.length > 0 ? { stdoutTail: envelope.body } : {}),
-    ...(envelope.sessionId !== undefined ? { capturedSessionId: envelope.sessionId } : {}),
+  return createHeadlessProvider({
+    providerSlug: 'claude',
     providerName: 'claude-provider',
+    resumeStaleRe: RESUME_STALE_RE,
+    rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
-    watchdogBannerId,
-    onSuccess,
+    ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
+    createGenerateContext: () => ({
+      attempt: async (attemptSession) => {
+        const built = buildClaudeArgs(attemptSession);
+        if (!built.ok) return { kind: 'error', error: built.error };
+
+        const parser = createClaudeStreamParser();
+        const onLine = (line: ClaudeStreamLine): void => {
+          parser.ingest(line);
+          // Per-line debug fan-out, published DIRECTLY to the EventBus — no gate at this site. The
+          // UI-floor filter lives in launch.ts's coalescing forwarder (applied at ingest against the
+          // live log-level gate); the persistent events.ndjson sink records every event regardless of
+          // that floor. `createEventBusLogger` is a producer, not a filter, and drops nothing here.
+          publishStreamLineEvents(deps.eventBus, line);
+        };
+
+        return runProviderAttempt({
+          spawnFn,
+          command,
+          args: built.value,
+          session: attemptSession,
+          resolveOn: 'close',
+          // `cwd` is critical — the Claude Code CLI only auto-discovers `CLAUDE.md`, skills, agents,
+          // and `.mcp.json` from the child's `process.cwd()`. Without this, the native context-file
+          // pipeline silently misses and the AI runs without project guidance. See CLAUDE.md §Security.
+          stdin: attemptSession.prompt,
+          rateLimitRe: RATE_LIMIT_RE,
+          onStdoutChunk: (chunk) => {
+            parser.feed(chunk, onLine);
+          },
+          flush: () => {
+            parser.flush(onLine);
+          },
+          getSessionId: () => parser.snapshot().sessionId,
+          // Claude's `-p stream-json` mode reports quota errors in the stdout `result` envelope, not
+          // on stderr. Feed the parsed body into the rate-limit haystack so a real throttle trips the
+          // overnight backoff instead of hard-failing the round.
+          getStdoutTail: () => {
+            const body = parser.snapshot().body;
+            return body.length > 0 ? body : undefined;
+          },
+          // `envelope.body` is sourced from `parser.snapshot()` in O(1) — the parser holds a single
+          // string reassigned from the latest `result` event. No per-line concatenation in this adapter.
+          getBody: () => Promise.resolve(Result.ok(parser.snapshot().body)),
+          emitProviderTokenUsage: (sessionId) => {
+            const env = parser.snapshot();
+            // Absence of usage counters is honest: the result event may carry zero usage subkeys on
+            // degenerate spawns or when the spawn was SIGTERM-recovered before the final result event.
+            emitTokenUsage(deps.eventBus, attemptSession, sessionId, {
+              provider: 'claude-code',
+              ...(env.model !== undefined ? { model: env.model } : {}),
+              ...(env.usage.inputTokens !== undefined ? { inputTokens: env.usage.inputTokens } : {}),
+              ...(env.usage.outputTokens !== undefined ? { outputTokens: env.usage.outputTokens } : {}),
+              ...(env.usage.cacheReadTokens !== undefined ? { cacheReadTokens: env.usage.cacheReadTokens } : {}),
+              ...(env.usage.cacheCreationTokens !== undefined
+                ? { cacheCreationTokens: env.usage.cacheCreationTokens }
+                : {}),
+              // Live/per-turn snapshot from the LAST assistant turn — true current context-window
+              // occupancy, distinct from the cumulative `*Tokens` above. Absent on codex/copilot and
+              // on spawns where no assistant event carried usage.
+              ...(env.liveUsage.inputTokens !== undefined ? { liveInputTokens: env.liveUsage.inputTokens } : {}),
+              ...(env.liveUsage.cacheReadTokens !== undefined
+                ? { liveCacheReadTokens: env.liveUsage.cacheReadTokens }
+                : {}),
+              ...(env.liveUsage.cacheCreationTokens !== undefined
+                ? { liveCacheCreationTokens: env.liveUsage.cacheCreationTokens }
+                : {}),
+            });
+          },
+          providerName: 'claude-provider',
+          providerSlug: 'claude',
+          eventBus: deps.eventBus,
+          ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
+        });
+      },
+    }),
   });
 };

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -2,31 +2,25 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
-import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
-import {
-  RATE_LIMIT_SCAN_TAIL_CAP,
-  STDERR_TAIL_CAP,
-  createBoundedTail,
-} from '@src/integration/ai/providers/_engine/bounded-tail.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import { RATE_LIMIT_SCAN_TAIL_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { CodexProviderDeps } from '@src/integration/ai/providers/_engine/codex-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
-import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
-import { runWithRateLimitRetry } from '@src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts';
-import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
-import { DEFAULT_RATE_LIMIT_RE, classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
-import { writeTextAtomic } from '@src/integration/io/fs.ts';
-import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
-import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import { DEFAULT_RATE_LIMIT_RE } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
+import {
+  createHeadlessProvider,
+  emitTokenUsage,
+  runProviderAttempt,
+} from '@src/integration/ai/providers/_engine/run-provider-attempt.ts';
 
 /**
  * {@link HeadlessAiProvider} backed by the OpenAI Codex CLI (`codex` v0.130.0+).
@@ -204,71 +198,6 @@ const defaultMkTempPath = (): string => {
   return join(tmpdir(), `ralphctl-codex-${String(process.pid)}-${String(Date.now())}-${String(tempCounter)}.txt`);
 };
 
-export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider => {
-  const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
-  const command = deps.command ?? 'codex';
-  const readFile = deps.readFile ?? ((path) => fs.readFile(path, 'utf8'));
-  const unlink =
-    deps.unlink ??
-    (async (path: string): Promise<void> => {
-      await fs.unlink(path).catch(() => {
-        // best-effort cleanup; orphan tempfiles are bounded by os.tmpdir() rotation
-      });
-    });
-  const mkTempPath = deps.mkTempPath ?? defaultMkTempPath;
-
-  return {
-    async generate(session) {
-      const outputFile = mkTempPath();
-      // Validate argv up front so a bad model / permission surfaces before any spawn.
-      const argsResult = buildCodexArgs(session, { outputFile });
-      if (!argsResult.ok) return Result.error(argsResult.error) as Result<ProviderOutput, DomainError>;
-
-      try {
-        // The shared retry seam owns the loop, backoff, banners, abort-during-backoff, the
-        // session-resume rebuild (so a 429 retry runs `exec resume <id>`), and the stale-resume
-        // cold fallback (drops resume for one cold respawn when the rollout is gone). The
-        // per-attempt closure rebuilds argv from the CURRENT session, so a resumed retry emits
-        // `exec resume` and a cold-fallback session emits the `-C cwd / -s sandbox` cold path.
-        return await runWithRateLimitRetry({
-          session,
-          rateLimitRetries: deps.rateLimitRetries,
-          ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
-          eventBus: deps.eventBus,
-          providerSlug: 'codex',
-          providerName: 'codex-provider',
-          resumeStaleRe: RESUME_STALE_RE,
-          attempt: async (attemptSession) => {
-            const built = buildCodexArgs(attemptSession, { outputFile });
-            if (!built.ok) return { kind: 'error', error: built.error };
-            return spawnAttempt({
-              deps,
-              spawnFn,
-              command,
-              args: built.value,
-              session: attemptSession,
-              readFile,
-              outputFile,
-            });
-          },
-        });
-      } finally {
-        await unlink(outputFile);
-      }
-    },
-  };
-};
-
-interface SpawnAttemptArgs {
-  readonly deps: CodexProviderDeps;
-  readonly spawnFn: ProviderSpawn;
-  readonly command: string;
-  readonly args: readonly string[];
-  readonly session: AiSession;
-  readonly readFile: (path: string) => Promise<string>;
-  readonly outputFile: string;
-}
-
 interface CodexMetaUpdate {
   readonly sessionId?: string;
   readonly model?: string;
@@ -435,187 +364,127 @@ const agentMessageText = (obj: Record<string, unknown>): string | undefined => {
   return stringField(item, 'text');
 };
 
-const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> => {
-  const { deps, spawnFn, command, args, session, readFile, outputFile } = input;
-  // `cwd` is set in addition to codex's argv `-C` so context-file autoload works on `exec resume`
-  // (which does not accept `-C`) and is consistent with the other two adapters.
-  // See CLAUDE.md §Security — "Cwd is the repo because Claude / Copilot / Codex only
-  // auto-discover their context file from cwd."
-  const child = spawnFn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] as const, cwd: String(session.cwd) });
-  const stderrTail = createBoundedTail(STDERR_TAIL_CAP);
-  let sessionId: string | undefined;
-  let stdoutLineBuf = '';
-  // Accumulate codex's `agent_message` text so the rate-limit classifier can scan it alongside
-  // stderr — codex surfaces a quota throttle ("quota exceeded" / 429) in the agent_message body,
-  // not always on stderr. Capped to bound memory on a long session (the tail is all we need).
-  let agentMessageTail = '';
-
-  // Bound once so onIdle's banner-show id and the classifier's banner-clear id match.
-  const watchdogBannerId = `watchdog-codex-${String(child.pid ?? 'unknown')}`;
-
-  // Codex `exec` reads the prompt from stdin; codex streams tokens to stdout so we attach a
-  // line-buffering session-id sniffer and wait for `'exit'` (no need to wait for streams to
-  // flush after exit — the session id is captured inline).
-  let model: string | undefined;
-  let inputTokens: number | undefined;
-  let outputTokens: number | undefined;
-
-  const onMeta = (update: CodexMetaUpdate): void => {
-    if (update.sessionId !== undefined && sessionId === undefined) {
-      sessionId = update.sessionId;
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'debug',
-        message: 'codex-provider: session id captured',
-        meta: { sessionId: update.sessionId },
-        at: IsoTimestamp.now(),
+export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider => {
+  const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
+  const command = deps.command ?? 'codex';
+  const readFile = deps.readFile ?? ((path) => fs.readFile(path, 'utf8'));
+  const unlink =
+    deps.unlink ??
+    (async (path: string): Promise<void> => {
+      await fs.unlink(path).catch(() => {
+        // best-effort cleanup; orphan tempfiles are bounded by os.tmpdir() rotation
       });
-    }
-    if (update.model !== undefined && model === undefined) {
-      model = update.model;
-    }
-    // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
-    // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
-    if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
-    if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
-  };
-  const onLine = (obj: Record<string, unknown>): void => {
-    publishCodexStreamLineEvents(deps.eventBus, obj);
-    const text = agentMessageText(obj);
-    if (text !== undefined) {
-      agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
-        -RATE_LIMIT_SCAN_TAIL_CAP
-      );
-    }
-  };
+    });
+  const mkTempPath = deps.mkTempPath ?? defaultMkTempPath;
 
-  const { code, signal } = await runHeadlessSpawn({
-    child,
-    onStdout: (chunk) => {
-      stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
-    },
-    onStderr: (chunk) => {
-      stderrTail.append(chunk);
-    },
-    stdin: session.prompt,
-    resolveOn: 'exit',
-    ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
-    ...(session.abortSignal !== undefined ? { abortSignal: session.abortSignal } : {}),
-    onIdle: () => {
-      const idleMs = deps.idleMs ?? undefined;
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `codex-provider: no stdio activity${idleMs !== undefined ? ` for ${String(idleMs)}ms` : ''} — killing wedged child`,
-        ...(idleMs !== undefined ? { meta: { idleMs } } : {}),
-        at: IsoTimestamp.now(),
-      });
-      deps.eventBus.publish({
-        type: 'banner-show',
-        id: watchdogBannerId,
-        tier: 'warn',
-        message: `Watchdog killed stuck codex process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
-        at: IsoTimestamp.now(),
-      });
-    },
-  });
-
-  // Flush any partial line remaining in the line buffer — codex may terminate without a
-  // trailing newline. Appending a synthetic '\n' forces the partial through the parser,
-  // matching the parser.flush(onLine) convention used in the claude and copilot adapters.
-  if (stdoutLineBuf.length > 0) {
-    consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
-  }
-
-  const onSuccess = async (): Promise<AttemptOutcome> => {
-    let body: string;
-    try {
-      // Single-shot read of the codex output tempfile — no per-line in-process accumulation.
-      // Preserve that: any future streaming variant must use an O(N) accumulator (see the
-      // `bodyLines.push` + `.join('\n')` pattern in copilot/headless.ts). On SIGTERM-recovery
-      // the tempfile may be partial or empty; bodyFile mirror simply writes what we have.
-      body = await readFile(outputFile);
-    } catch (err) {
-      return {
-        kind: 'error',
-        error: new InvalidStateError({
-          entity: 'codex-provider',
-          currentState: 'output-capture',
-          attemptedAction: 'read tempfile',
-          message: `codex-provider: failed to read output tempfile: ${err instanceof Error ? err.message : String(err)}`,
-        }),
-      };
-    }
-    // audit-[09]: the AI writes `signals.json` directly via its Write tool into
-    // `session.outputDir`; the harness validates it post-spawn. The provider never writes
-    // signals.json itself. The codex output tempfile body remains the forensic source for
-    // `session.bodyFile` mirroring below.
-    // Persist captured session id as a sibling `sessionId` file. Codex emits the id as
-    // `thread_id` on the leading `thread.started` JSONL record; missing → skip (no empty
-    // marker). See persistSessionIdFile.
-    const sidWrote = await persistSessionIdFile(session.signalsFile, sessionId);
-    if (sidWrote !== undefined && !sidWrote.ok) {
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `codex-provider: failed to write sessionId file — resume re-attach may need log parsing`,
-        meta: { error: sidWrote.error.message },
-        at: IsoTimestamp.now(),
-      });
-    }
-    if (session.bodyFile !== undefined) {
-      const bodyWrote = await writeTextAtomic(String(session.bodyFile), body);
-      if (!bodyWrote.ok) {
-        deps.eventBus.publish({
-          type: 'log',
-          level: 'warn',
-          message: `codex-provider: failed to write body file — diagnostic capture skipped`,
-          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
-          at: IsoTimestamp.now(),
-        });
-      }
-    }
-    if (sessionId !== undefined) {
-      // Emit one TokenUsageEvent per success spawn. Codex commonly omits token counts
-      // from the JSONL records on v0.130.x; the event still fires so subscribers can correlate
-      // sessionId → provider without inferring success from token-field absence.
-      const window = contextWindowFor(model);
-      const chainSessionId = session.chainSessionId;
-      deps.eventBus.publish({
-        type: 'token-usage',
-        sessionId,
-        ...(chainSessionId !== undefined ? { chainSessionId } : {}),
-        provider: 'openai-codex',
-        ...(model !== undefined ? { model } : {}),
-        ...(inputTokens !== undefined ? { inputTokens } : {}),
-        ...(outputTokens !== undefined ? { outputTokens } : {}),
-        ...(window !== undefined ? { contextWindow: window } : {}),
-        ...(session.role !== undefined ? { role: session.role } : {}),
-        at: IsoTimestamp.now(),
-      });
-    }
-    return {
-      kind: 'success',
-      output: {
-        signalsFile: session.signalsFile,
-        exitCode: code ?? 0,
-        ...(sessionId !== undefined ? { sessionId } : {}),
-      },
-    };
-  };
-
-  return classifySpawnExit({
-    session,
-    exit: { code, signal },
-    stderr: stderrTail.value(),
-    rateLimitRe: DEFAULT_RATE_LIMIT_RE,
-    // Codex reports a quota throttle in the agent_message body, not always on stderr. Feed the
-    // accumulated tail into the rate-limit haystack so it trips the overnight backoff.
-    ...(agentMessageTail.length > 0 ? { stdoutTail: agentMessageTail } : {}),
-    ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
+  return createHeadlessProvider({
+    providerSlug: 'codex',
     providerName: 'codex-provider',
+    resumeStaleRe: RESUME_STALE_RE,
+    rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
-    watchdogBannerId,
-    onSuccess,
+    ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
+    createGenerateContext: () => {
+      // One tempfile per generate() call, shared across all retry attempts so a rate-limit
+      // retry reuses the same -o path without leaving orphan files. Cleaned up in cleanup().
+      const outputFile = mkTempPath();
+      return {
+        attempt: async (attemptSession) => {
+          const built = buildCodexArgs(attemptSession, { outputFile });
+          if (!built.ok) return { kind: 'error', error: built.error };
+
+          let sessionId: string | undefined;
+          let model: string | undefined;
+          let inputTokens: number | undefined;
+          let outputTokens: number | undefined;
+          // Accumulate codex's `agent_message` text so the rate-limit classifier can scan it
+          // alongside stderr — codex surfaces a quota throttle in the agent_message body,
+          // not always on stderr. Capped to bound memory on a long session.
+          let agentMessageTail = '';
+          let stdoutLineBuf = '';
+
+          const onMeta = (update: CodexMetaUpdate): void => {
+            if (update.sessionId !== undefined && sessionId === undefined) {
+              sessionId = update.sessionId;
+            }
+            if (update.model !== undefined && model === undefined) {
+              model = update.model;
+            }
+            // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+            // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
+            if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
+            if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
+          };
+          const onLine = (obj: Record<string, unknown>): void => {
+            publishCodexStreamLineEvents(deps.eventBus, obj);
+            const text = agentMessageText(obj);
+            if (text !== undefined) {
+              agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
+                -RATE_LIMIT_SCAN_TAIL_CAP
+              );
+            }
+          };
+
+          return runProviderAttempt({
+            spawnFn,
+            command,
+            args: built.value,
+            session: attemptSession,
+            resolveOn: 'exit',
+            // `cwd` is set in addition to codex's argv `-C` so context-file autoload works on
+            // `exec resume` (which does not accept `-C`) and is consistent with the other adapters.
+            // See CLAUDE.md §Security.
+            stdin: attemptSession.prompt,
+            rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+            onStdoutChunk: (chunk) => {
+              stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
+            },
+            // Flush any partial line remaining in the buffer — codex may terminate without a
+            // trailing newline. Appending a synthetic '\n' forces the partial through the parser.
+            flush: () => {
+              if (stdoutLineBuf.length > 0) {
+                consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
+              }
+            },
+            getSessionId: () => sessionId,
+            // Codex reports a quota throttle in the agent_message body, not always on stderr.
+            // Feed the accumulated tail into the rate-limit haystack so it trips the backoff.
+            getStdoutTail: () => (agentMessageTail.length > 0 ? agentMessageTail : undefined),
+            // Single-shot read of the codex output tempfile — no per-line in-process accumulation.
+            // On SIGTERM-recovery the tempfile may be partial or empty.
+            getBody: async () => {
+              try {
+                return Result.ok(await readFile(outputFile));
+              } catch (err) {
+                return Result.error(
+                  new InvalidStateError({
+                    entity: 'codex-provider',
+                    currentState: 'output-capture',
+                    attemptedAction: 'read tempfile',
+                    message: `codex-provider: failed to read output tempfile: ${err instanceof Error ? err.message : String(err)}`,
+                  })
+                );
+              }
+            },
+            emitProviderTokenUsage: (sessionId_) => {
+              // Codex commonly omits token counts from the JSONL records on v0.130.x; the event
+              // still fires so subscribers can correlate sessionId → provider without inferring
+              // success from token-field absence.
+              emitTokenUsage(deps.eventBus, attemptSession, sessionId_, {
+                provider: 'openai-codex',
+                ...(model !== undefined ? { model } : {}),
+                ...(inputTokens !== undefined ? { inputTokens } : {}),
+                ...(outputTokens !== undefined ? { outputTokens } : {}),
+              });
+            },
+            providerName: 'codex-provider',
+            providerSlug: 'codex',
+            eventBus: deps.eventBus,
+            ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
+          });
+        },
+        cleanup: () => unlink(outputFile),
+      };
+    },
   });
 };

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,16 +1,14 @@
 import { Result } from '@src/domain/result.ts';
-import type { HeadlessAiProvider, ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import {
   FORENSIC_BODY_TAIL_CAP,
   RATE_LIMIT_SCAN_TAIL_CAP,
-  STDERR_TAIL_CAP,
   createBoundedTail,
 } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { CopilotProviderDeps } from '@src/integration/ai/providers/_engine/copilot-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
@@ -18,14 +16,13 @@ import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/setti
 import { createCopilotStreamParser } from '@src/integration/ai/providers/copilot/parse-stream.ts';
 import type { CopilotStreamLine, CopilotUsage } from '@src/integration/ai/providers/_engine/copilot-stream.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
-import { runHeadlessSpawn } from '@src/integration/ai/providers/_engine/run-headless-spawn.ts';
-import { runWithRateLimitRetry } from '@src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts';
-import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
-import { DEFAULT_RATE_LIMIT_RE, classifySpawnExit } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
-import { writeTextAtomic } from '@src/integration/io/fs.ts';
-import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
-import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
+import { DEFAULT_RATE_LIMIT_RE } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
+import {
+  createHeadlessProvider,
+  emitTokenUsage,
+  runProviderAttempt,
+} from '@src/integration/ai/providers/_engine/run-provider-attempt.ts';
 
 /**
  * {@link HeadlessAiProvider} backed by the GitHub Copilot CLI (`copilot`, v1.0.12+).
@@ -33,7 +30,6 @@ import { truncateField } from '@src/integration/ai/providers/_engine/truncate-de
  * Translation table (intent → Copilot CLI flag):
  *
  *   | AiSession field                                       | Copilot flag                                       |
- *   | ----------------------------------------------------- | -------------------------------------------------- |
  *   | (always)                                              | `--output-format=json --silent --no-ask-user`      |
  *   | model: <CopilotModel>                                 | `--model=<model>`                                  |
  *   | additionalRoots: [a, b]                               | `--add-dir=a --add-dir=b`                          |
@@ -175,243 +171,123 @@ export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProv
   const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
   const command = deps.command ?? 'copilot';
 
-  return {
-    async generate(session) {
-      // Validate argv up front so a bad model surfaces before any spawn.
-      const argsResult = buildCopilotArgs(session);
-      if (!argsResult.ok) return Result.error(argsResult.error) as Result<ProviderOutput, DomainError>;
-
-      // The shared retry seam owns the loop, backoff, banners, abort-during-backoff, the
-      // session-resume rebuild (so a 429 retry passes `--resume <id>`), and the stale-resume
-      // cold fallback. The per-attempt closure rebuilds argv from the CURRENT session.
-      return runWithRateLimitRetry({
-        session,
-        rateLimitRetries: deps.rateLimitRetries,
-        ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
-        eventBus: deps.eventBus,
-        providerSlug: 'copilot',
-        providerName: 'copilot-provider',
-        resumeStaleRe: RESUME_STALE_RE,
-        attempt: async (attemptSession) => {
-          const built = buildCopilotArgs(attemptSession);
-          if (!built.ok) return { kind: 'error', error: built.error };
-          return spawnAttempt({ deps, spawnFn, command, args: built.value, session: attemptSession });
-        },
-      });
-    },
-  };
-};
-
-interface SpawnAttemptArgs {
-  readonly deps: CopilotProviderDeps;
-  readonly spawnFn: ProviderSpawn;
-  readonly command: string;
-  readonly args: readonly string[];
-  readonly session: AiSession;
-}
-
-const spawnAttempt = async (input: SpawnAttemptArgs): Promise<AttemptOutcome> => {
-  const { deps, spawnFn, command, args, session } = input;
-  // `cwd` is critical — the Copilot CLI only auto-discovers `.github/copilot-instructions.md`,
-  // skills, agents, and `.mcp.json` from the child's `process.cwd()`. Without this, the
-  // native context-file pipeline silently misses and the AI runs without project guidance.
-  // See CLAUDE.md §Security — "Cwd is the repo because Claude / Copilot / Codex only
-  // auto-discover their context file from cwd."
-  const child = spawnFn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] as const, cwd: String(session.cwd) });
-  const parser = createCopilotStreamParser();
-  // Two BOUNDED tails fed in stream order — replaces a formerly-unbounded `events[]` that
-  // retained every stdout line for the whole spawn (an OOM-class accumulation on a chatty
-  // multi-hour session — same root cause as the PR #229 TUI render-path leak). `forensicTail`
-  // backs `body.txt`; `rateLimitTail` is the classifier's scan haystack. Both drop their oldest
-  // bytes once full, so the per-spawn stdout footprint is pinned regardless of child verbosity.
-  // The prior per-line `assistant` tag is gone: neither consumer ever filtered on it (signals
-  // land in `signals.json` via the file-based audit-[09] contract, not by re-parsing the body),
-  // and the prompt-echo leak it once guarded is moot since both views were already derived from
-  // every recorded line.
-  const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
-  const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
-  const recordLine = (text: string): void => {
-    forensicTail.append(`${text}\n`);
-    rateLimitTail.append(`${text}\n`);
-  };
-  let sessionId: string | undefined;
-  let model: string | undefined;
-  let usage: CopilotUsage = {};
-  const stderrTail = createBoundedTail(STDERR_TAIL_CAP);
-
-  // Bound once so onIdle's banner-show id and the classifier's banner-clear id match.
-  const watchdogBannerId = `watchdog-copilot-${String(child.pid ?? 'unknown')}`;
-
-  const onLine = (line: CopilotStreamLine): void => {
-    if (line.json !== undefined) {
-      if (line.sessionId !== undefined && sessionId === undefined) {
-        sessionId = line.sessionId;
-        deps.eventBus.publish({
-          type: 'log',
-          level: 'debug',
-          message: 'copilot-provider: session id captured',
-          meta: { sessionId },
-          at: IsoTimestamp.now(),
-        });
-      }
-      if (line.model !== undefined && model === undefined) {
-        model = line.model;
-      }
-      // Last-write-wins on usage. Copilot occasionally emits multiple meta lines through a
-      // spawn; whichever lands last is the most current cumulative count.
-      if (line.usage !== undefined) {
-        usage = line.usage;
-      }
-      if (line.bodyText !== undefined && line.bodyText.length > 0) {
-        recordLine(line.bodyText);
-        // Per-line assistant debug event. The bus → logger consumer drops debug events at
-        // the default `info` floor; only `RALPHCTL_LOG_LEVEL=debug` operators see them.
-        const text = truncateField(line.bodyText);
-        if (text !== undefined) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'debug',
-            message: 'copilot-provider: assistant',
-            meta: { text },
-            at: IsoTimestamp.now(),
-          });
-        }
-      } else if (line.sessionId === undefined && line.model === undefined && line.usage === undefined) {
-        // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
-        // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
-        // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
-        recordLine(line.raw);
-      }
-      // Truncate the raw line like every other stream-originated debug field (see truncateField):
-      // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
-      // each capped log-bus entry. The full raw stream is still captured in bodyFile when set.
-      const rawLine = truncateField(line.raw);
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'debug',
-        message: 'copilot-provider: stdout json line',
-        ...(rawLine !== undefined ? { meta: { raw: rawLine } } : {}),
-        at: IsoTimestamp.now(),
-      });
-      return;
-    }
-    // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
-    recordLine(line.raw);
-  };
-
-  // Copilot reads the prompt from -p argv (no stdin payload). Tokens stream to stdout via the
-  // ndjson `parser`; we wait for `'exit'` since the parser drains everything it sees inline.
-  const { code, signal } = await runHeadlessSpawn({
-    child,
-    onStdout: (chunk) => parser.feed(chunk, onLine),
-    onStderr: (chunk) => {
-      stderrTail.append(chunk);
-    },
-    resolveOn: 'exit',
-    ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
-    ...(session.abortSignal !== undefined ? { abortSignal: session.abortSignal } : {}),
-    onIdle: () => {
-      const idleMs = deps.idleMs ?? undefined;
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `copilot-provider: no stdio activity${idleMs !== undefined ? ` for ${String(idleMs)}ms` : ''} — killing wedged child`,
-        ...(idleMs !== undefined ? { meta: { idleMs } } : {}),
-        at: IsoTimestamp.now(),
-      });
-      deps.eventBus.publish({
-        type: 'banner-show',
-        id: watchdogBannerId,
-        tier: 'warn',
-        message: `Watchdog killed stuck copilot process${idleMs !== undefined ? ` (${String(Math.round(idleMs / 1000))}s idle)` : ''}`,
-        at: IsoTimestamp.now(),
-      });
-    },
-  });
-  parser.flush(onLine);
-
-  const onSuccess = async (): Promise<AttemptOutcome> => {
-    // audit-[09]: the AI writes `signals.json` directly via its Write tool into
-    // `session.outputDir`; the harness validates it post-spawn. The provider never writes
-    // signals.json itself. The forensic body buffer below stays — operators inspect it when
-    // a proposal comes back empty to decide whether the prompt, the AI, or the validator is
-    // at fault. On SIGTERM-recovery the tail may be partial; it still produces a useful snapshot
-    // of what the model emitted before the watchdog stepped in (bounded to its most recent window).
-    const forensicBody = forensicTail.value();
-    // Mirror raw body for diagnostic capture. Best-effort: a write failure here is logged but
-    // does not fail the session. Critically, the body is captured even when the AI emits no
-    // signals, so operators can see what the model actually produced.
-    if (session.bodyFile !== undefined) {
-      const bodyWrote = await writeTextAtomic(String(session.bodyFile), forensicBody);
-      if (!bodyWrote.ok) {
-        deps.eventBus.publish({
-          type: 'log',
-          level: 'warn',
-          message: `copilot-provider: failed to write body file — diagnostic capture skipped`,
-          meta: { bodyFile: String(session.bodyFile), error: bodyWrote.error.message },
-          at: IsoTimestamp.now(),
-        });
-      }
-    }
-    if (sessionId !== undefined) {
-      // Emit one TokenUsageEvent per success spawn — even when Copilot omits usage
-      // counters from the meta line, sessionId + provider + (maybe) model is still useful for
-      // a TUI widget that correlates rounds with provider sessions. Honest about absent fields.
-      const window = contextWindowFor(model);
-      const chainSessionId = session.chainSessionId;
-      deps.eventBus.publish({
-        type: 'token-usage',
-        sessionId,
-        ...(chainSessionId !== undefined ? { chainSessionId } : {}),
-        provider: 'github-copilot',
-        ...(model !== undefined ? { model } : {}),
-        ...(usage.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
-        ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
-        ...(window !== undefined ? { contextWindow: window } : {}),
-        ...(session.role !== undefined ? { role: session.role } : {}),
-        at: IsoTimestamp.now(),
-      });
-    }
-    // Persist captured session id as a sibling `sessionId` file. Copilot 1.0.51 emits the id as
-    // `sessionId` on the TRAILING `{type:"result"}` record (not a leading meta line); the parser
-    // captures it via first-`sessionId`-wins, and only that record carries the key so there is no
-    // false positive. If missing (banner-only streams, crash before the result record) we skip
-    // rather than write an empty marker. See persistSessionIdFile for the contract.
-    const sidWrote = await persistSessionIdFile(session.signalsFile, sessionId);
-    if (sidWrote !== undefined && !sidWrote.ok) {
-      deps.eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `copilot-provider: failed to write sessionId file — resume re-attach may need log parsing`,
-        meta: { error: sidWrote.error.message },
-        at: IsoTimestamp.now(),
-      });
-    }
-    return {
-      kind: 'success',
-      output: {
-        signalsFile: session.signalsFile,
-        exitCode: code ?? 0,
-        ...(sessionId !== undefined ? { sessionId } : {}),
-      },
-    };
-  };
-
-  // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota throttle in
-  // its result-record text (recorded as a stream line), not on stderr. `rateLimitTail` is already
-  // bounded to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
-  const stdoutTail = rateLimitTail.value();
-
-  return classifySpawnExit({
-    session,
-    exit: { code, signal },
-    stderr: stderrTail.value(),
-    rateLimitRe: DEFAULT_RATE_LIMIT_RE,
-    ...(stdoutTail.length > 0 ? { stdoutTail } : {}),
-    ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
+  return createHeadlessProvider({
+    providerSlug: 'copilot',
     providerName: 'copilot-provider',
+    resumeStaleRe: RESUME_STALE_RE,
+    rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
-    watchdogBannerId,
-    onSuccess,
+    ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
+    createGenerateContext: () => ({
+      attempt: async (attemptSession) => {
+        const built = buildCopilotArgs(attemptSession);
+        if (!built.ok) return { kind: 'error', error: built.error };
+
+        const parser = createCopilotStreamParser();
+        // Two bounded tails fed in stream order — the forensic tail backs body.txt and the
+        // rate-limit tail is the classifier's scan haystack. Both drop their oldest bytes once
+        // full, so per-spawn stdout footprint is pinned regardless of child verbosity.
+        const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
+        const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
+        const recordLine = (text: string): void => {
+          forensicTail.append(`${text}\n`);
+          rateLimitTail.append(`${text}\n`);
+        };
+        let sessionId: string | undefined;
+        let model: string | undefined;
+        let usage: CopilotUsage = {};
+
+        const onLine = (line: CopilotStreamLine): void => {
+          if (line.json !== undefined) {
+            if (line.sessionId !== undefined && sessionId === undefined) {
+              sessionId = line.sessionId;
+            }
+            if (line.model !== undefined && model === undefined) {
+              model = line.model;
+            }
+            // Last-write-wins on usage. Copilot occasionally emits multiple meta lines through a
+            // spawn; whichever lands last is the most current cumulative count.
+            if (line.usage !== undefined) {
+              usage = line.usage;
+            }
+            if (line.bodyText !== undefined && line.bodyText.length > 0) {
+              recordLine(line.bodyText);
+              // Per-line assistant debug event.
+              const text = truncateField(line.bodyText);
+              if (text !== undefined) {
+                deps.eventBus.publish({
+                  type: 'log',
+                  level: 'debug',
+                  message: 'copilot-provider: assistant',
+                  meta: { text },
+                  at: IsoTimestamp.now(),
+                });
+              }
+            } else if (line.sessionId === undefined && line.model === undefined && line.usage === undefined) {
+              // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
+              // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
+              // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
+              recordLine(line.raw);
+            }
+            // Truncate the raw line like every other stream-originated debug field (see truncateField):
+            // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
+            // each capped log-bus entry. The full raw stream is still captured in bodyFile when set.
+            const rawLine = truncateField(line.raw);
+            deps.eventBus.publish({
+              type: 'log',
+              level: 'debug',
+              message: 'copilot-provider: stdout json line',
+              ...(rawLine !== undefined ? { meta: { raw: rawLine } } : {}),
+              at: IsoTimestamp.now(),
+            });
+            return;
+          }
+          // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
+          recordLine(line.raw);
+        };
+
+        return runProviderAttempt({
+          spawnFn,
+          command,
+          args: built.value,
+          session: attemptSession,
+          resolveOn: 'exit',
+          // Copilot reads the prompt from -p argv (no stdin payload); omitting `stdin` causes
+          // runProviderAttempt to close the child's stdin immediately.
+          rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+          onStdoutChunk: (chunk) => {
+            parser.feed(chunk, onLine);
+          },
+          // Flush any partial line remaining in the buffer — Copilot may terminate without a
+          // trailing newline. The parser drains inline so flush is a no-op in the normal case.
+          flush: () => {
+            parser.flush(onLine);
+          },
+          getSessionId: () => sessionId,
+          // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota
+          // throttle in its result-record text, not on stderr. rateLimitTail is already bounded
+          // to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
+          getStdoutTail: () => {
+            const tail = rateLimitTail.value();
+            return tail.length > 0 ? tail : undefined;
+          },
+          // forensicTail is the accumulated body buffer; operators inspect it when a proposal
+          // comes back empty to decide whether the prompt, the AI, or the validator is at fault.
+          getBody: () => Promise.resolve(Result.ok(forensicTail.value())),
+          emitProviderTokenUsage: (sid) => {
+            emitTokenUsage(deps.eventBus, attemptSession, sid, {
+              provider: 'github-copilot',
+              ...(model !== undefined ? { model } : {}),
+              ...(usage.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
+              ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
+            });
+          },
+          providerName: 'copilot-provider',
+          providerSlug: 'copilot',
+          eventBus: deps.eventBus,
+          ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
+        });
+      },
+    }),
   });
 };

--- a/tests/integration/application/ui/tui/components/token-budget-card.test.tsx
+++ b/tests/integration/application/ui/tui/components/token-budget-card.test.tsx
@@ -151,4 +151,65 @@ describe('TokenBudgetCard', () => {
     expect(frame).not.toContain('cumulative');
     expect(frame).not.toContain('cache hit');
   });
+
+  it('renders the model name and window label in the Context group when model is known', () => {
+    const { lastFrame } = render(
+      <TokenBudgetCard
+        sessionId={SESSION}
+        usage={{
+          provider: 'claude-code',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 53600,
+          outputTokens: 5000,
+          contextWindow: 200000,
+        }}
+      />
+    );
+    const frame = lastFrame() ?? '';
+    // Model descriptor appears in Context section.
+    expect(frame).toContain('claude-sonnet-4-6');
+    // Window label is rendered alongside the model name.
+    expect(frame).toContain('200K');
+    // Usage figures still render correctly (the denominator is also 200k via fmtTokens).
+    expect(frame).toContain('53.6k');
+  });
+
+  it('renders model name without window label for providers with unknown window size', () => {
+    const { lastFrame } = render(
+      <TokenBudgetCard
+        sessionId={SESSION}
+        usage={{
+          provider: 'github-copilot',
+          model: 'gpt-5.5',
+          inputTokens: 10000,
+          outputTokens: 2000,
+          contextWindow: 128000,
+        }}
+      />
+    );
+    const frame = lastFrame() ?? '';
+    // Model name is shown even when contextWindowLabel returns undefined.
+    expect(frame).toContain('gpt-5.5');
+  });
+
+  it('renders a 1M context window as "1M" not "1000k"', () => {
+    const { lastFrame } = render(
+      <TokenBudgetCard
+        sessionId={SESSION}
+        usage={{
+          provider: 'claude-code',
+          model: 'claude-opus-4-8[1m]',
+          liveInputTokens: 50000,
+          liveCacheReadTokens: 0,
+          contextWindow: 1_000_000,
+        }}
+      />
+    );
+    const frame = lastFrame() ?? '';
+    // The denominator must render as "1M", not "1000k".
+    expect(frame).toContain('1M');
+    expect(frame).not.toContain('1000k');
+    // Window label from the model id.
+    expect(frame).toContain('claude-opus-4-8[1m]');
+  });
 });

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -29,6 +29,7 @@ import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { isSuspendedModel, SUSPENSION_NOTE } from '@src/domain/value/settings-models/suspended-models.ts';
+import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
 import {
   type CustomizePickerResult,
   modelCatalogFor,
@@ -103,6 +104,17 @@ const buildScriptedPrompt = (
     },
   };
   return { interactive, captured };
+};
+
+/**
+ * Mirrors the `modelChoice` label logic in `flows-customize-picker.ts` so the expected labels in
+ * these tests update automatically when the annotation format changes.
+ */
+const buildExpectedModelLabel = (model: string): string => {
+  const windowPart = contextWindowLabel(model);
+  const suspendedPart = isSuspendedModel(model) ? `(${SUSPENSION_NOTE})` : undefined;
+  const annotations = [windowPart, suspendedPart].filter((s): s is string => s !== undefined);
+  return annotations.length > 0 ? `${model}  ·  ${annotations.join('  ')}` : model;
 };
 
 const driveSettings = (overrides: Partial<Settings['ai']> = {}): Settings => ({
@@ -428,11 +440,11 @@ describe('runCustomizePicker — catalog source parity with settings', () => {
       settings: DEFAULT_SETTINGS,
     });
     // The first label is `Keep default (<saved model>)`; the rest must match the
-    // CLAUDE_MODELS catalog in order so a model bump or rename is caught immediately. Suspended
-    // models carry a ` (suspended)` suffix on the LABEL (value stays the bare id).
+    // CLAUDE_MODELS catalog in order so a model bump or rename is caught immediately. Each
+    // option label includes the context-window size and (when applicable) the suspension note.
     expect(modelStepOptions).toBeDefined();
     const catalogLabels = modelStepOptions!.slice(1);
-    expect(catalogLabels).toEqual(CLAUDE_MODELS.map((m) => (isSuspendedModel(m) ? `${m} (${SUSPENSION_NOTE})` : m)));
+    expect(catalogLabels).toEqual(CLAUDE_MODELS.map((m) => buildExpectedModelLabel(m)));
   });
 
   it('flags a suspended model on the LABEL only — value stays the bare id', async () => {
@@ -473,11 +485,12 @@ describe('runCustomizePicker — catalog source parity with settings', () => {
     expect(modelStepChoices).toBeDefined();
     const fable = modelStepChoices!.find((c) => c.value === 'claude-fable-5');
     expect(fable).toBeDefined();
-    expect(fable!.label).toBe(`claude-fable-5 (${SUSPENSION_NOTE})`);
+    // Suspended model: no window label (base fable-5 has none), but carries the suspension note.
+    expect(fable!.label).toBe(buildExpectedModelLabel('claude-fable-5'));
     expect(fable!.value).toBe('claude-fable-5');
-    // A live model is unannotated.
+    // A live model with a known window is annotated with the window label.
     const opus = modelStepChoices!.find((c) => c.value === 'claude-opus-4-8');
-    expect(opus!.label).toBe('claude-opus-4-8');
+    expect(opus!.label).toBe(buildExpectedModelLabel('claude-opus-4-8'));
   });
 });
 
@@ -641,7 +654,7 @@ describe('runCustomizePicker — effort-inheritance visibility (T14)', () => {
           return Result.ok(c!.value) as unknown as Result<T, DomainError>;
         }
         if (message.includes('Model:')) {
-          const c = options.find((o) => o.label === otherModel);
+          const c = options.find((o) => o.value === otherModel);
           return Result.ok(c!.value) as unknown as Result<T, DomainError>;
         }
         if (message.includes('Effort:')) {
@@ -697,7 +710,7 @@ describe('runCustomizePicker — effort-inheritance visibility (T14)', () => {
           return Result.ok(c!.value) as unknown as Result<T, DomainError>;
         }
         if (message.includes('Model:')) {
-          const c = options.find((o) => o.label === otherModel);
+          const c = options.find((o) => o.value === otherModel);
           return Result.ok(c!.value) as unknown as Result<T, DomainError>;
         }
         if (message.includes('Effort:')) {
@@ -840,11 +853,10 @@ describe('runCustomizePicker — availableModelsFor gates the model step', () =>
     ]);
     await runCustomizePicker({ interactive, flowId: 'refine', flowTitle: 'refine', settings: DEFAULT_SETTINGS });
     const modelOptions = modelOptionsFromCapture(captured);
-    // Keep-default is the first option; the rest are the full catalog. Suspended models render
-    // with a ` (suspended)` LABEL suffix (the value stays the bare id).
+    // Keep-default is the first option; the rest are the full catalog. Each label includes the
+    // context-window size and (when applicable) the suspension note.
     for (const model of fullCatalog) {
-      const expectedLabel = isSuspendedModel(model) ? `${model} (${SUSPENSION_NOTE})` : model;
-      expect(modelOptions).toContain(expectedLabel);
+      expect(modelOptions).toContain(buildExpectedModelLabel(model));
     }
   });
 
@@ -872,7 +884,7 @@ describe('runCustomizePicker — availableModelsFor gates the model step', () =>
       availableModelsFor,
     });
     const modelOptions = modelOptionsFromCapture(captured);
-    for (const model of subset) expect(modelOptions).toContain(model);
-    for (const model of excluded) expect(modelOptions).not.toContain(model);
+    for (const model of subset) expect(modelOptions).toContain(buildExpectedModelLabel(model));
+    for (const model of excluded) expect(modelOptions).not.toContain(buildExpectedModelLabel(model));
   });
 });

--- a/tests/unit/domain/value/settings-models/context-window.test.ts
+++ b/tests/unit/domain/value/settings-models/context-window.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the domain context-window helper. Pins the mapping and formatting so any
+ * model-catalog change that forgets to update this table fails here rather than silently
+ * displaying a wrong label in the TUI.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { contextWindowFor, contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
+
+describe('contextWindowFor', () => {
+  it('returns 200_000 for the standard 200K Claude models', () => {
+    expect(contextWindowFor('claude-haiku-4-5')).toBe(200_000);
+    expect(contextWindowFor('claude-sonnet-4-6')).toBe(200_000);
+    expect(contextWindowFor('claude-opus-4-8')).toBe(200_000);
+  });
+
+  it('returns 1_000_000 for [1m] long-context variants', () => {
+    expect(contextWindowFor('claude-opus-4-8[1m]')).toBe(1_000_000);
+    expect(contextWindowFor('claude-fable-5[1m]')).toBe(1_000_000);
+  });
+
+  it('returns undefined for models whose window size is not published', () => {
+    // Copilot / Codex ids — omitted by scope discipline.
+    expect(contextWindowFor('gpt-5.5')).toBeUndefined();
+    expect(contextWindowFor('claude-haiku-4.5')).toBeUndefined(); // Copilot-routed variant (different id)
+  });
+
+  it('returns undefined for a custom or unknown id', () => {
+    expect(contextWindowFor('my-custom-model')).toBeUndefined();
+    expect(contextWindowFor('')).toBeUndefined();
+  });
+
+  it('returns undefined when model is undefined', () => {
+    expect(contextWindowFor(undefined)).toBeUndefined();
+  });
+});
+
+describe('contextWindowLabel', () => {
+  it('formats 200K models as "200K"', () => {
+    expect(contextWindowLabel('claude-sonnet-4-6')).toBe('200K');
+    expect(contextWindowLabel('claude-haiku-4-5')).toBe('200K');
+    expect(contextWindowLabel('claude-opus-4-8')).toBe('200K');
+  });
+
+  it('formats 1M models as "1M" (not "1000k")', () => {
+    expect(contextWindowLabel('claude-opus-4-8[1m]')).toBe('1M');
+    expect(contextWindowLabel('claude-fable-5[1m]')).toBe('1M');
+  });
+
+  it('returns undefined for models with no published window size', () => {
+    expect(contextWindowLabel('gpt-5.5')).toBeUndefined();
+  });
+
+  it('returns undefined when model is undefined', () => {
+    expect(contextWindowLabel(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/integration/ai/providers/_engine/json-field.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/json-field.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
+
+describe('stringField', () => {
+  it('returns the value when the first candidate is a string', () => {
+    expect(stringField({ a: 'hello' }, 'a')).toBe('hello');
+  });
+
+  it('returns the first matching candidate name when multiple candidates present', () => {
+    expect(stringField({ a: 'first', b: 'second' }, 'a', 'b')).toBe('first');
+  });
+
+  it('skips non-matching candidates and returns the first string-valued one', () => {
+    expect(stringField({ a: 42, b: 'found' }, 'a', 'b')).toBe('found');
+  });
+
+  it('skips number-valued candidates', () => {
+    expect(stringField({ a: 99 }, 'a')).toBeUndefined();
+  });
+
+  it('skips boolean-valued candidates', () => {
+    expect(stringField({ a: true }, 'a')).toBeUndefined();
+  });
+
+  it('skips object-valued candidates', () => {
+    expect(stringField({ a: { nested: 1 } }, 'a')).toBeUndefined();
+  });
+
+  it('skips null-valued candidates', () => {
+    expect(stringField({ a: null }, 'a')).toBeUndefined();
+  });
+
+  it('skips undefined-valued candidates', () => {
+    expect(stringField({ a: undefined }, 'a')).toBeUndefined();
+  });
+
+  it('returns undefined when no candidate name matches', () => {
+    expect(stringField({ x: 'hello' }, 'a', 'b')).toBeUndefined();
+  });
+
+  it('treats the empty string as a valid present value (not skipped)', () => {
+    expect(stringField({ a: '' }, 'a')).toBe('');
+  });
+
+  it('candidate-order precedence: first matching name wins', () => {
+    // mirrors real provider usage where key order is load-bearing
+    expect(stringField({ session_id: 'sid', sessionId: 'camelId' }, 'session_id', 'sessionId')).toBe('sid');
+    expect(stringField({ sessionId: 'camelId' }, 'session_id', 'sessionId')).toBe('camelId');
+  });
+});
+
+describe('numberField', () => {
+  it('returns the value when the first candidate is a finite number', () => {
+    expect(numberField({ a: 42 }, 'a')).toBe(42);
+  });
+
+  it('returns the first matching candidate name when multiple candidates present', () => {
+    expect(numberField({ a: 1, b: 2 }, 'a', 'b')).toBe(1);
+  });
+
+  it('skips non-matching candidates and returns the first finite-number one', () => {
+    expect(numberField({ a: 'not-a-number', b: 7 }, 'a', 'b')).toBe(7);
+  });
+
+  it('treats 0 as a valid present value', () => {
+    expect(numberField({ a: 0 }, 'a')).toBe(0);
+  });
+
+  it('rejects NaN via the Number.isFinite gate', () => {
+    expect(numberField({ a: NaN }, 'a')).toBeUndefined();
+  });
+
+  it('rejects Infinity', () => {
+    expect(numberField({ a: Infinity }, 'a')).toBeUndefined();
+  });
+
+  it('rejects -Infinity', () => {
+    expect(numberField({ a: -Infinity }, 'a')).toBeUndefined();
+  });
+
+  it('rejects numeric strings', () => {
+    expect(numberField({ a: '42' }, 'a')).toBeUndefined();
+  });
+
+  it('rejects null', () => {
+    expect(numberField({ a: null }, 'a')).toBeUndefined();
+  });
+
+  it('returns undefined when no candidate name matches', () => {
+    expect(numberField({ x: 5 }, 'a', 'b')).toBeUndefined();
+  });
+
+  it('candidate-order precedence: first matching name wins', () => {
+    // mirrors codex reading 'thread_id' before 'session_id' before 'sessionId'
+    expect(numberField({ thread_id: 1, session_id: 2 }, 'thread_id', 'session_id')).toBe(1);
+    expect(numberField({ session_id: 2 }, 'thread_id', 'session_id')).toBe(2);
+  });
+});
+
+describe('isRecord', () => {
+  it('returns true for a plain object', () => {
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it('returns true for an empty object', () => {
+    expect(isRecord({})).toBe(true);
+  });
+
+  it('returns true for arrays (typeof [] === "object")', () => {
+    expect(isRecord([])).toBe(true);
+    expect(isRecord([1, 2, 3])).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isRecord(undefined)).toBe(false);
+  });
+
+  it('returns false for strings', () => {
+    expect(isRecord('hello')).toBe(false);
+  });
+
+  it('returns false for numbers', () => {
+    expect(isRecord(42)).toBe(false);
+  });
+
+  it('returns false for booleans', () => {
+    expect(isRecord(true)).toBe(false);
+    expect(isRecord(false)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'json-summary'],
+      reporter: ['text', 'html', 'json-summary', 'lcov'],
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**', 'src/application/ui/**'],


### PR DESCRIPTION
## Summary

Lands the work for issues **#226** (provider-adapter dedup + lint gate) and **#227** (coverage/CI gate + Codecov), plus two TUI/tooling commits that rode along on the branch.

### #226 — collapse duplicated CLI adapters + consolidate json helpers + gate lint
- Extract the shared headless run-flow into `integration/ai/providers/_engine/run-provider-attempt.ts`; `claude` / `codex` / `copilot` `headless.ts` now delegate to it (net −470 lines across the three).
- Direct unit tests for the shared `json-field.ts` helpers.
- Add a `--max-warnings 342` ceiling to the `lint` script so warning count can only go down.

### #227 — coverage + Codecov + cold-install gate
- Publish coverage to Codecov, emit `lcov`, baseline on `main` (`codecov.yml`, `vitest.config.ts`).
- `scripts/setup-required-checks.sh` admin helper to configure branch protection.
- Codecov badge in `README.md` + document the coverage merge gate in `CONTRIBUTING.md`.

### Also on this branch
- `feat(tui)`: surface model context-window (200K/1M) in selectors and displays (`context-window.ts` + token-budget / header / settings views).
- `chore`: designer subagent memory.

## Verification
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors, 342 warnings (at ceiling)
- `pnpm test` — 4178 passed / 474 files
- `pnpm format:check` — clean

Closes #226
Closes #227
