### PR TITLE
chore(lint): clear 88 safe warnings, lower cap 342→254

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coverage:unused": "tsx scripts/find-unused.ts",
     "deadcode": "knip",
     "skills:update": "tsx scripts/sync-skills.ts",
-    "lint": "eslint . --max-warnings 342",
+    "lint": "eslint . --max-warnings 254",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/application/flows/_shared/project/pick-repository.ts
+++ b/src/application/flows/_shared/project/pick-repository.ts
@@ -9,6 +9,9 @@ import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 
+/** Leaf name, reused as the `attemptedAction` on the leaf's error states. */
+const LEAF_NAME = 'pick-repository';
+
 /**
  * Minimum context shape the leaf reads (`project`, loaded by `loadProjectLeaf`) and writes
  * (`repository`). Generic over `<TCtx extends PickRepositoryCtx>` so each flow can plug its
@@ -62,7 +65,7 @@ const pickRepositoryUseCase = async (
       new InvalidStateError({
         entity: 'project',
         currentState: 'no-repositories',
-        attemptedAction: 'pick-repository',
+        attemptedAction: LEAF_NAME,
         message: `project '${input.project.slug}' has no repositories to ${emptyVerb}`,
       })
     );
@@ -97,7 +100,7 @@ export const pickRepositoryLeaf = <TCtx extends PickRepositoryCtx>(
   deps: PickRepositoryLeafDeps,
   config: PickRepositoryLeafConfig<TCtx>
 ): Element<TCtx> =>
-  leaf<TCtx, PickRepositoryInput, Repository>('pick-repository', {
+  leaf<TCtx, PickRepositoryInput, Repository>(LEAF_NAME, {
     useCase: {
       execute: async (input) => pickRepositoryUseCase(deps, input, config.promptMessage, config.emptyVerb),
     },
@@ -106,7 +109,7 @@ export const pickRepositoryLeaf = <TCtx extends PickRepositoryCtx>(
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-pick-repository',
-          attemptedAction: 'pick-repository',
+          attemptedAction: LEAF_NAME,
           message: 'pick-repository: ctx.project is undefined — load-project must run first',
         });
       }

--- a/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
+++ b/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
@@ -42,6 +42,12 @@ const PR_AUTHORING_PERMISSIONS = {
   autoApprove: true,
 } as const;
 
+/** Leaf name, reused as the `attemptedAction` on the leaf's error states. */
+const LEAF_NAME = 'generate-pr-content';
+
+/** Logger namespace for the create-pr AI authoring step. */
+const AI_LOGGER_NAME = 'create-pr.ai';
+
 export interface GeneratePrContentLeafDeps {
   readonly provider: HeadlessAiProvider;
   readonly templateLoader: TemplateLoader;
@@ -100,7 +106,7 @@ interface GeneratePrContentOutput {
  *   outputDir      = `<sprintDir>/create-pr/<run-slug>/` (auto-included as writable)
  */
 export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<CreatePrCtx> =>
-  leaf<CreatePrCtx, GeneratePrContentInput, GeneratePrContentOutput>('generate-pr-content', {
+  leaf<CreatePrCtx, GeneratePrContentInput, GeneratePrContentOutput>(LEAF_NAME, {
     useCase: {
       execute: async (input, signal) => {
         // Derive verbatim `Closes <ref>` lines from ticket + task externalRefs — the prompt
@@ -129,7 +135,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         });
         if (!promptResult.ok) {
           deps.logger
-            .named('create-pr.ai')
+            .named(AI_LOGGER_NAME)
             .warn(
               `create-pr: AI authoring skipped — prompt build failed: ${promptResult.error.message}; falling back to template`
             );
@@ -139,7 +145,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         const writePrompt = await deps.writeFile(input.promptFile, String(promptResult.value));
         if (!writePrompt.ok) {
           deps.logger
-            .named('create-pr.ai')
+            .named(AI_LOGGER_NAME)
             .warn(
               `create-pr: AI authoring skipped — prompt file write failed: ${writePrompt.error.message}; falling back to template`
             );
@@ -150,7 +156,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         const signalsFilePathResult = AbsolutePath.parse(`${String(input.unitRoot)}/signals.json`);
         if (!signalsFilePathResult.ok) {
           deps.logger
-            .named('create-pr.ai')
+            .named(AI_LOGGER_NAME)
             .warn(
               `create-pr: AI authoring skipped — could not resolve signals.json path: ${signalsFilePathResult.error.message}; falling back to template`
             );
@@ -179,7 +185,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           const spawn = await deps.provider.generate(session);
           if (!spawn.ok) {
             deps.logger
-              .named('create-pr.ai')
+              .named(AI_LOGGER_NAME)
               .warn(`create-pr: AI authoring failed, falling back to template (${spawn.error.message})`);
             return Result.ok({});
           }
@@ -187,7 +193,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           const validated = await validateSignalsFile(input.unitRoot, generatePrContentOutputContract);
           if (!validated.ok) {
             deps.logger
-              .named('create-pr.ai')
+              .named(AI_LOGGER_NAME)
               .warn(`create-pr: AI authoring failed, falling back to template (${validated.error.message})`);
             return Result.ok({});
           }
@@ -214,7 +220,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           if (prContent === undefined) {
             // Defensive — the contract's exactlyOne refine should have caught this upstream.
             deps.logger
-              .named('create-pr.ai')
+              .named(AI_LOGGER_NAME)
               .warn('create-pr: validated signals missing pr-content despite schema — falling back to template');
             return Result.ok({});
           }
@@ -225,7 +231,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           // through every wrapper without being absorbed by guards or fallbacks.
           if (err instanceof AbortError) throw err;
           deps.logger
-            .named('create-pr.ai')
+            .named(AI_LOGGER_NAME)
             .warn(
               `create-pr: AI authoring failed, falling back to template (${err instanceof Error ? err.message : String(err)})`
             );
@@ -238,7 +244,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-generate-pr-content',
-          attemptedAction: 'generate-pr-content',
+          attemptedAction: LEAF_NAME,
           message:
             'generate-pr-content: unit root / prompt file missing — build-create-pr-unit + render-prompt-to-file must run first',
         });
@@ -247,7 +253,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-generate-pr-content',
-          attemptedAction: 'generate-pr-content',
+          attemptedAction: LEAF_NAME,
           message: 'generate-pr-content: ctx.sprint is undefined — load-sprint must run first',
         });
       }

--- a/src/application/flows/create-pr/leaves/generate-pr-content.contract.ts
+++ b/src/application/flows/create-pr/leaves/generate-pr-content.contract.ts
@@ -27,8 +27,10 @@ import type { AiOutputContract, SidecarRule } from '@src/integration/ai/contract
 
 type CreatePrSignal = PrContentSignal;
 
+const PR_CONTENT_KIND = 'pr-content';
+
 const exactlyOnePrContent = (signals: ReadonlyArray<{ readonly type: string }>): boolean =>
-  signals.filter((s) => s.type === 'pr-content').length === 1;
+  signals.filter((s) => s.type === PR_CONTENT_KIND).length === 1;
 
 const signalsArraySchemaRaw = z
   .array(prContentSignalSchema)
@@ -44,7 +46,7 @@ const signalsArraySchemaRaw = z
 const signalsArraySchema = brandSignalArray<CreatePrSignal>(signalsArraySchemaRaw);
 
 const prContentSidecar: SidecarRule<'pr-content'> = {
-  signalKind: 'pr-content',
+  signalKind: PR_CONTENT_KIND,
   filename: 'pr-content.md',
   multiplicity: 'one',
   extract: (signal) => `# ${signal.title}\n\n${signal.body}`,
@@ -60,7 +62,7 @@ const EXAMPLE_TS = '2026-05-23T10:00:00.000Z' as IsoTimestamp;
  */
 const createPrExampleSignals: readonly CreatePrSignal[] = [
   {
-    type: 'pr-content',
+    type: PR_CONTENT_KIND,
     title: 'Add CSV export for transactions',
     body: 'Adds a CSV export action on the transactions list, mirroring the existing JSON export.\n\n## Changes\n\n- New export-csv use case + CLI flag.\n- Reuses the existing serialiser for column order.\n\n## Test plan\n\n- [ ] Manual: export 100 rows and diff against fixture.\n- [ ] Automated: unit tests for the serialiser.\n\nCloses #123',
     timestamp: EXAMPLE_TS,

--- a/src/application/flows/detect-skills/leaves/propose.contract.ts
+++ b/src/application/flows/detect-skills/leaves/propose.contract.ts
@@ -29,6 +29,9 @@ import type { AiOutputContract, SidecarRule } from '@src/integration/ai/contract
 
 type DetectSkillsSignal = SetupSkillProposalSignal | VerifySkillProposalSignal | NoteSignal;
 
+const SETUP_SKILL_PROPOSAL = 'setup-skill-proposal';
+const VERIFY_SKILL_PROPOSAL = 'verify-skill-proposal';
+
 const atMostOneOf =
   (kind: string) =>
   (signals: ReadonlyArray<{ readonly type: string }>): boolean =>
@@ -36,8 +39,8 @@ const atMostOneOf =
 
 const signalsArraySchemaRaw = z
   .array(z.union([setupSkillProposalSignalSchema, verifySkillProposalSignalSchema, noteSignalSchema]))
-  .refine(atMostOneOf('setup-skill-proposal'), 'at most one setup-skill-proposal per detect-skills spawn')
-  .refine(atMostOneOf('verify-skill-proposal'), 'at most one verify-skill-proposal per detect-skills spawn');
+  .refine(atMostOneOf(SETUP_SKILL_PROPOSAL), 'at most one setup-skill-proposal per detect-skills spawn')
+  .refine(atMostOneOf(VERIFY_SKILL_PROPOSAL), 'at most one verify-skill-proposal per detect-skills spawn');
 
 /**
  * Cast bridge between Zod's inferred shape (optional fields widened to `T | undefined`
@@ -62,13 +65,13 @@ const EXAMPLE_TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
 
 const EXAMPLE_SIGNALS: readonly DetectSkillsSignal[] = [
   {
-    type: 'setup-skill-proposal',
+    type: SETUP_SKILL_PROPOSAL,
     content:
       'This repo pins tool versions with mise. Before editing anything, run mise install to activate the exact versions declared in mise.toml. Then run the project install command documented in CLAUDE.md to hydrate the dependency tree.',
     timestamp: EXAMPLE_TS,
   },
   {
-    type: 'verify-skill-proposal',
+    type: VERIFY_SKILL_PROPOSAL,
     content:
       'Verification runs three gates in sequence documented in CLAUDE.md: typecheck, lint, then tests. A failure in any gate stops the chain; read the first failing gate output — later gates have not run yet.',
     timestamp: EXAMPLE_TS,
@@ -81,14 +84,14 @@ const EXAMPLE_SIGNALS: readonly DetectSkillsSignal[] = [
 ];
 
 const setupSkillSidecar: SidecarRule<'setup-skill-proposal'> = {
-  signalKind: 'setup-skill-proposal',
+  signalKind: SETUP_SKILL_PROPOSAL,
   filename: 'setup-skill.md',
   multiplicity: 'optional',
   extract: (signal) => signal.content,
 };
 
 const verifySkillSidecar: SidecarRule<'verify-skill-proposal'> = {
-  signalKind: 'verify-skill-proposal',
+  signalKind: VERIFY_SKILL_PROPOSAL,
   filename: 'verify-skill.md',
   multiplicity: 'optional',
   extract: (signal) => signal.content,

--- a/src/application/flows/doctor/flow.ts
+++ b/src/application/flows/doctor/flow.ts
@@ -61,11 +61,13 @@ const probeWritable = async (id: string, label: string, path: AbsolutePath): Pro
  * majors pass with an informational detail.
  */
 const probeNodeVersion = (nodeVersion: string): ProbeResult => {
+  const NODE_VERSION_ID = 'node-version';
+  const NODE_VERSION_LABEL = 'Node version';
   const match = /^v(\d+)\./.exec(nodeVersion);
   if (match === null || match[1] === undefined) {
     return {
-      id: 'node-version',
-      label: 'Node version',
+      id: NODE_VERSION_ID,
+      label: NODE_VERSION_LABEL,
       status: 'warn',
       detail: `could not parse '${nodeVersion}'`,
       group: 'runtime',
@@ -74,8 +76,8 @@ const probeNodeVersion = (nodeVersion: string): ProbeResult => {
   const major = Number.parseInt(match[1], 10);
   if (major < MIN_NODE_MAJOR) {
     return {
-      id: 'node-version',
-      label: 'Node version',
+      id: NODE_VERSION_ID,
+      label: NODE_VERSION_LABEL,
       status: 'fail',
       detail: `${nodeVersion} — ralphctl requires Node ≥ ${String(MIN_NODE_MAJOR)} (mise.toml)`,
       group: 'runtime',
@@ -83,8 +85,8 @@ const probeNodeVersion = (nodeVersion: string): ProbeResult => {
     };
   }
   return {
-    id: 'node-version',
-    label: 'Node version',
+    id: NODE_VERSION_ID,
+    label: NODE_VERSION_LABEL,
     status: 'pass',
     detail: `${nodeVersion} (mise.toml expects ≥ v${String(MIN_NODE_MAJOR)})`,
     group: 'runtime',
@@ -175,28 +177,30 @@ export const createDoctorFlow = (deps: DoctorDeps): Element<DoctorCtx> =>
         probes.push(probeNodeVersion(deps.nodeVersion));
 
         // ---- Settings ---------------------------------------------------------
+        const SETTINGS_PERSISTED_ID = 'settings-persisted';
+        const SETTINGS_PRESENT_LABEL = 'Settings file present';
         const settingsPath = deps.settingsRepo.path;
         const settingsExists = await deps.settingsRepo.exists();
         if (!settingsExists.ok) {
           probes.push({
-            id: 'settings-persisted',
-            label: 'Settings file present',
+            id: SETTINGS_PERSISTED_ID,
+            label: SETTINGS_PRESENT_LABEL,
             status: 'fail',
             detail: `${settingsPath} — ${settingsExists.error.message}`,
             group: 'settings',
           });
         } else if (settingsExists.value) {
           probes.push({
-            id: 'settings-persisted',
-            label: 'Settings file present',
+            id: SETTINGS_PERSISTED_ID,
+            label: SETTINGS_PRESENT_LABEL,
             status: 'pass',
             detail: settingsPath,
             group: 'settings',
           });
         } else {
           probes.push({
-            id: 'settings-persisted',
-            label: 'Settings file present',
+            id: SETTINGS_PERSISTED_ID,
+            label: SETTINGS_PRESENT_LABEL,
             status: 'warn',
             detail: `${settingsPath} — using built-in defaults (first run)`,
             hint: 'open the welcome flow to pick a provider and persist your settings',

--- a/src/application/flows/ideate/leaves/ideate-and-plan.ts
+++ b/src/application/flows/ideate/leaves/ideate-and-plan.ts
@@ -84,8 +84,11 @@ interface IdeateAndPlanOutput {
   readonly tasks: readonly Task[];
 }
 
+/** Leaf name, reused as the `entity` / `attemptedAction` on the leaf's error states. */
+const LEAF_NAME = 'ideate-and-plan';
+
 export const ideateAndPlanLeaf = (deps: IdeateAndPlanLeafDeps): Element<IdeateCtx> =>
-  leaf<IdeateCtx, IdeateAndPlanInput, IdeateAndPlanOutput>('ideate-and-plan', {
+  leaf<IdeateCtx, IdeateAndPlanInput, IdeateAndPlanOutput>(LEAF_NAME, {
     useCase: {
       execute: async (input) => {
         const session = await deps.runInTerminal(async () =>
@@ -120,7 +123,7 @@ export const ideateAndPlanLeaf = (deps: IdeateAndPlanLeafDeps): Element<IdeateCt
         if (ideatedSignal === undefined) {
           return Result.error(
             new InvalidStateError({
-              entity: 'ideate-and-plan',
+              entity: LEAF_NAME,
               currentState: 'post-validation',
               attemptedAction: 'project-signal',
               message: 'ideate: validated signals contained no ideated-tickets signal',
@@ -159,27 +162,28 @@ export const ideateAndPlanLeaf = (deps: IdeateAndPlanLeafDeps): Element<IdeateCt
       },
     },
     input: (ctx) => {
+      const PRE_IDEATE_STATE = 'pre-ideate';
       if (ctx.sprint === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-ideate',
-          attemptedAction: 'ideate-and-plan',
+          currentState: PRE_IDEATE_STATE,
+          attemptedAction: LEAF_NAME,
           message: 'ideate-and-plan: ctx.sprint is undefined — load-sprint must run first',
         });
       }
       if (ctx.project === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-ideate',
-          attemptedAction: 'ideate-and-plan',
+          currentState: PRE_IDEATE_STATE,
+          attemptedAction: LEAF_NAME,
           message: 'ideate-and-plan: ctx.project is undefined — load-project must run first',
         });
       }
       if (ctx.currentPromptFile === undefined || ctx.currentOutputFile === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-ideate',
-          attemptedAction: 'ideate-and-plan',
+          currentState: PRE_IDEATE_STATE,
+          attemptedAction: LEAF_NAME,
           message: 'ideate-and-plan: prompt/output paths missing — render-prompt-to-file must run first',
         });
       }

--- a/src/application/flows/implement/leaves/generator.contract.ts
+++ b/src/application/flows/implement/leaves/generator.contract.ts
@@ -59,8 +59,10 @@ type GeneratorSignal =
   | TaskBlockedSignal
   | CommitMessageSignal;
 
+const COMMIT_MESSAGE_KIND = 'commit-message';
+
 const atMostOneCommitMessage = (signals: ReadonlyArray<{ readonly type: string }>): boolean =>
-  signals.filter((s) => s.type === 'commit-message').length <= 1;
+  signals.filter((s) => s.type === COMMIT_MESSAGE_KIND).length <= 1;
 
 const signalsArraySchemaRaw = z
   .array(
@@ -109,7 +111,7 @@ const wrapLegacyArray = (raw: unknown): unknown => {
  * cast erases is preserved by the helper.
  */
 const commitMessageSidecar: SidecarRule<'commit-message'> = {
-  signalKind: 'commit-message',
+  signalKind: COMMIT_MESSAGE_KIND,
   filename: 'commit-message.txt',
   multiplicity: 'optional',
   extract: (signal) => renderCommitMessage(signal),
@@ -135,7 +137,7 @@ const generatorExampleSignals: readonly GeneratorSignal[] = [
   },
   { type: 'task-verified', output: '$ pnpm test\n... 42 passed', timestamp: EXAMPLE_TS },
   {
-    type: 'commit-message',
+    type: COMMIT_MESSAGE_KIND,
     subject: 'feat(foo): add helper for bar',
     body: 'Why: the call site repeated three times; centralising it removes a future drift hazard.',
     timestamp: EXAMPLE_TS,

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -655,10 +655,11 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
       },
     },
     input: (ctx) => {
+      const PRE_GENERATOR_STATE = 'pre-generator';
       if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-generator',
+          currentState: PRE_GENERATOR_STATE,
           attemptedAction: `generator-${String(taskId)}`,
           message: `generator-${String(taskId)}: ctx.currentTask missing or mismatched`,
         });
@@ -674,7 +675,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
       if (ctx.taskWorkspaceRoot === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-generator',
+          currentState: PRE_GENERATOR_STATE,
           attemptedAction: `generator-${String(taskId)}`,
           message: `generator-${String(taskId)}: ctx.taskWorkspaceRoot missing — buildTaskWorkspaceLeaf must run first`,
         });
@@ -682,7 +683,7 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
       if (ctx.currentRoundNum === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-generator',
+          currentState: PRE_GENERATOR_STATE,
           attemptedAction: `generator-${String(taskId)}`,
           message: `generator-${String(taskId)}: ctx.currentRoundNum missing — resolve-round-num must run first`,
         });

--- a/src/application/flows/implement/leaves/post-task-verify.ts
+++ b/src/application/flows/implement/leaves/post-task-verify.ts
@@ -24,6 +24,9 @@ import type { ShellScriptRunner } from '@src/integration/io/shell-script-runner.
 import { runVerifyShell } from '@src/application/flows/implement/leaves/pre-task-verify.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
+/** `VerifyRunOutcome` member tag for a shell that could not start the command. */
+const SPAWN_ERROR_OUTCOME = 'spawn-error';
+
 /**
  * Post-task verify gate — the harness's AUTHORITATIVE independent verification. Runs the
  * project's `verifyScript` after the AI commits its work, regardless of any `task-verified`
@@ -172,7 +175,7 @@ const legacyVerifyResult = (
 ): NonNullable<ImplementCtx['lastVerifyResult']> => {
   if (run.outcome === 'skipped') return { kind: 'skipped' };
   if (run.outcome === 'success') return { kind: 'passed' };
-  const stderr = run.outcome === 'spawn-error' ? (spawnErrorMessage ?? '') : rawOutput;
+  const stderr = run.outcome === SPAWN_ERROR_OUTCOME ? (spawnErrorMessage ?? '') : rawOutput;
   return { kind: 'verify-failed', exitCode: run.exitCode, stderr };
 };
 
@@ -370,7 +373,7 @@ export const postTaskVerifyLeaf = (
             message: `post-task-verify ${String(opts.cwd)}: fixed pre-existing failure (exit=0)`,
             at: deps.clock(),
           });
-        } else if (run.outcome === 'spawn-error') {
+        } else if (run.outcome === SPAWN_ERROR_OUTCOME) {
           deps.eventBus.publish({
             type: 'log',
             level: 'warn',
@@ -432,7 +435,7 @@ export const postTaskVerifyLeaf = (
       //   - fixed-baseline  — no block (post is green)
       //   - baseline-broken — no block (escape hatch; preserve AI's verdict)
       //   - undefined       — BLOCK on raw red post (no pre-verify evidence to clear it)
-      const isRed = out.run.outcome === 'failed' || out.run.outcome === 'spawn-error';
+      const isRed = out.run.outcome === 'failed' || out.run.outcome === SPAWN_ERROR_OUTCOME;
       const shouldBlock = isRed && out.attribution !== 'baseline-broken';
       const blockReason = shouldBlock
         ? out.attribution === 'regressed'

--- a/src/application/flows/implement/leaves/resolve-branch.ts
+++ b/src/application/flows/implement/leaves/resolve-branch.ts
@@ -13,6 +13,10 @@ import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
+/** Domain entity tag and leaf name, reused across this leaf's error states. */
+const SPRINT_EXECUTION_ENTITY = 'sprint-execution';
+const RESOLVE_BRANCH = 'resolve-branch';
+
 /**
  * One-shot leaf — pins every repo touched by the sprint to its designated branch before any
  * task runs.
@@ -74,8 +78,8 @@ const askCustomName = async (interactive: InteractivePrompt): Promise<Result<str
     if (!answer.ok) {
       return Result.error(
         new InvalidStateError({
-          entity: 'sprint-execution',
-          currentState: 'resolve-branch',
+          entity: SPRINT_EXECUTION_ENTITY,
+          currentState: RESOLVE_BRANCH,
           attemptedAction: 'ask-custom-branch-name',
           message: `resolve-branch: prompt cancelled — ${answer.error.message}`,
         })
@@ -114,8 +118,8 @@ const resolveFirstRun = async (
   if (!choice.ok) {
     return Result.error(
       new InvalidStateError({
-        entity: 'sprint-execution',
-        currentState: 'resolve-branch',
+        entity: SPRINT_EXECUTION_ENTITY,
+        currentState: RESOLVE_BRANCH,
         attemptedAction: 'ask-branch-strategy',
         message: `resolve-branch: prompt cancelled — ${choice.error.message}`,
       })
@@ -132,7 +136,7 @@ const resolveFirstRun = async (
 };
 
 export const resolveBranchLeaf = (deps: ResolveBranchLeafDeps, opts: ResolveBranchLeafOpts): Element<ImplementCtx> =>
-  leaf<ImplementCtx, ResolveBranchInput, ResolveBranchOutput>('resolve-branch', {
+  leaf<ImplementCtx, ResolveBranchInput, ResolveBranchOutput>(RESOLVE_BRANCH, {
     useCase: {
       execute: async (input) => {
         const log = deps.logger.named('branch.resolve');
@@ -164,9 +168,9 @@ export const resolveBranchLeaf = (deps: ResolveBranchLeafDeps, opts: ResolveBran
         if (!isValidBranchName(branch)) {
           return Result.error(
             new InvalidStateError({
-              entity: 'sprint-execution',
+              entity: SPRINT_EXECUTION_ENTITY,
               currentState: 'pre-resolve-branch',
-              attemptedAction: 'resolve-branch',
+              attemptedAction: RESOLVE_BRANCH,
               message: `resolve-branch: invalid branch name '${branch}'`,
             })
           );
@@ -186,7 +190,7 @@ export const resolveBranchLeaf = (deps: ResolveBranchLeafDeps, opts: ResolveBran
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-resolve-branch',
-          attemptedAction: 'resolve-branch',
+          attemptedAction: RESOLVE_BRANCH,
           message: 'resolve-branch: ctx.execution is undefined — load-sprint-execution must run first',
         });
       }

--- a/src/application/flows/implement/leaves/setup-script-runner.ts
+++ b/src/application/flows/implement/leaves/setup-script-runner.ts
@@ -133,6 +133,7 @@ export const setupScriptRunnerLeaf = (
     {
       useCase: {
         execute: async (input, signal): Promise<Result<LeafOutput, DomainError>> => {
+          const BANNER_SHOW = 'banner-show';
           let execution = input.execution;
           // Repos whose setup ran green in THIS invocation. Seeds the
           // `skipPreVerifyOnFreshSetup` fast path on the first pre-task-verify. The resume-skip
@@ -189,7 +190,7 @@ export const setupScriptRunnerLeaf = (
                 at: deps.clock(),
               });
               deps.eventBus.publish({
-                type: 'banner-show',
+                type: BANNER_SHOW,
                 id: `setup-script-skipped-${String(repo.repositoryId)}`,
                 tier: 'warn',
                 message: `No setup script configured for ${String(repo.path)} — nothing was validated before implement`,
@@ -238,7 +239,7 @@ export const setupScriptRunnerLeaf = (
                 at: deps.clock(),
               });
               deps.eventBus.publish({
-                type: 'banner-show',
+                type: BANNER_SHOW,
                 id: `setup-script-${String(repo.repositoryId)}`,
                 tier: 'error',
                 message: `Setup script failed for ${String(repo.path)}: ${command}`,
@@ -357,7 +358,7 @@ export const setupScriptRunnerLeaf = (
               });
             }
             deps.eventBus.publish({
-              type: 'banner-show',
+              type: BANNER_SHOW,
               id: `setup-script-${String(repo.repositoryId)}`,
               tier: 'error',
               message: `Setup script failed for ${String(repo.path)}: ${command}`,

--- a/src/application/flows/implement/leaves/working-tree-clean-check.ts
+++ b/src/application/flows/implement/leaves/working-tree-clean-check.ts
@@ -10,6 +10,9 @@ import { gitStatusPorcelain } from '@src/integration/io/git-operations.ts';
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
+/** Default leaf name, reused as the `attemptedAction` on the leaf's error states. */
+const WORKING_TREE_CLEAN_CHECK = 'working-tree-clean-check';
+
 /**
  * Pre-setup hard gate — fails the chain when the user's working tree at `cwd` is dirty.
  *
@@ -79,7 +82,7 @@ const detectResume = (tasks: readonly Task[] | undefined): boolean => {
 export const workingTreeCleanCheckLeaf = (
   deps: WorkingTreeCleanCheckLeafDeps,
   cwd: AbsolutePath,
-  name = 'working-tree-clean-check',
+  name = WORKING_TREE_CLEAN_CHECK,
   opts?: LeafOpts
 ): Element<ImplementCtx> =>
   leaf<ImplementCtx, LeafInput, void>(
@@ -94,7 +97,7 @@ export const workingTreeCleanCheckLeaf = (
               new InvalidStateError({
                 entity: 'repository',
                 currentState: 'unknown',
-                attemptedAction: 'working-tree-clean-check',
+                attemptedAction: WORKING_TREE_CLEAN_CHECK,
                 message: `working-tree-clean-check: git status failed at ${String(input.cwd)} — ${status.error.message}`,
                 hint: 'Ensure `git` is on PATH and the path is a git working tree.',
               })
@@ -111,7 +114,7 @@ export const workingTreeCleanCheckLeaf = (
               new InvalidStateError({
                 entity: 'repository',
                 currentState: 'dirty',
-                attemptedAction: 'working-tree-clean-check',
+                attemptedAction: WORKING_TREE_CLEAN_CHECK,
                 message: `working-tree-dirty at ${String(input.cwd)} (${String(status.value.length)} uncommitted change(s))`,
                 hint: `Commit, stash, or discard uncommitted changes in ${String(input.cwd)} before running implement.`,
               })

--- a/src/application/flows/plan/leaves/call-planner-interactive.ts
+++ b/src/application/flows/plan/leaves/call-planner-interactive.ts
@@ -101,8 +101,11 @@ interface CallPlannerOutput {
 
 const isDraft = (s: Sprint): s is DraftSprint => s.status === 'draft';
 
+/** Leaf name, reused as the `entity` / `attemptedAction` on the leaf's error states. */
+const LEAF_NAME = 'call-planner-interactive';
+
 export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): Element<PlanCtx> =>
-  leaf<PlanCtx, CallPlannerInput, CallPlannerOutput>('call-planner-interactive', {
+  leaf<PlanCtx, CallPlannerInput, CallPlannerOutput>(LEAF_NAME, {
     useCase: {
       execute: async (input) => {
         // `additionalRoots` are the project repos the AI may navigate. The output-file dir
@@ -142,7 +145,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         if (planSignal === undefined) {
           return Result.error(
             new InvalidStateError({
-              entity: 'call-planner-interactive',
+              entity: LEAF_NAME,
               currentState: 'post-validation',
               attemptedAction: 'project-signal',
               message: 'plan: validated signals contained no task-plan signal',
@@ -173,7 +176,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-plan',
-          attemptedAction: 'call-planner-interactive',
+          attemptedAction: LEAF_NAME,
           message: 'call-planner-interactive: ctx.sprint is undefined — load-sprint must run first',
         });
       }
@@ -181,7 +184,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         throw new InvalidStateError({
           entity: 'sprint',
           currentState: ctx.sprint.status,
-          attemptedAction: 'call-planner-interactive',
+          attemptedAction: LEAF_NAME,
           message: `call-planner-interactive: sprint must be draft — got '${ctx.sprint.status}'`,
         });
       }
@@ -189,7 +192,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-plan',
-          attemptedAction: 'call-planner-interactive',
+          attemptedAction: LEAF_NAME,
           message: 'call-planner-interactive: ctx.project is undefined — load-project must run first',
         });
       }
@@ -197,7 +200,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-plan',
-          attemptedAction: 'call-planner-interactive',
+          attemptedAction: LEAF_NAME,
           message: 'call-planner-interactive: prompt/output paths missing — render-prompt-to-file must run first',
         });
       }
@@ -205,7 +208,7 @@ export const callPlannerInteractiveLeaf = (deps: CallPlannerInteractiveDeps): El
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-plan',
-          attemptedAction: 'call-planner-interactive',
+          attemptedAction: LEAF_NAME,
           message: 'call-planner-interactive: unit root missing — build-plan-unit must run first',
         });
       }

--- a/src/application/flows/readiness/leaves/propose.ts
+++ b/src/application/flows/readiness/leaves/propose.ts
@@ -257,10 +257,11 @@ export const proposeReadinessLeaf = (deps: ProposeReadinessLeafDeps, tool: Assis
       execute: async (input, signal) => proposeReadinessUseCase(deps, tool, input, signal),
     },
     input: (ctx) => {
+      const PRE_PROPOSE_STATE = 'pre-propose';
       if (ctx.repository === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-propose',
+          currentState: PRE_PROPOSE_STATE,
           attemptedAction: 'propose',
           message: 'propose: ctx.repository is undefined — pick-repository must run first',
         });
@@ -269,7 +270,7 @@ export const proposeReadinessLeaf = (deps: ProposeReadinessLeafDeps, tool: Assis
       if (entry?.probedState === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-propose',
+          currentState: PRE_PROPOSE_STATE,
           attemptedAction: 'propose',
           message: `propose: ctx.entries[${tool}].probedState is undefined — probe must run first`,
         });
@@ -277,7 +278,7 @@ export const proposeReadinessLeaf = (deps: ProposeReadinessLeafDeps, tool: Assis
       if (entry.runDir === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-propose',
+          currentState: PRE_PROPOSE_STATE,
           attemptedAction: 'propose',
           message: `propose: ctx.entries[${tool}].runDir is undefined — allocate-run-dir must run first`,
         });

--- a/src/application/flows/refine/leaves/refine-ticket-interactive.ts
+++ b/src/application/flows/refine/leaves/refine-ticket-interactive.ts
@@ -191,12 +191,13 @@ const maybeCommentOnOrigin = async (
   ticket: ApprovedTicket,
   body: string
 ): Promise<void> => {
+  const PUSH_LOGGER = 'refine.push';
   if (deps.issuePusher === undefined) {
-    deps.logger.named('refine.push').warn('no IssuePusher wired — skipping issue comment');
+    deps.logger.named(PUSH_LOGGER).warn('no IssuePusher wired — skipping issue comment');
     return;
   }
   if (ticket.link === undefined) {
-    deps.logger.named('refine.push').warn('comment requested but ticket has no link — skipping');
+    deps.logger.named(PUSH_LOGGER).warn('comment requested but ticket has no link — skipping');
     return;
   }
   const now = new Date().toISOString();
@@ -204,9 +205,9 @@ const maybeCommentOnOrigin = async (
   const url = String(ticket.link);
   const result = await deps.issuePusher.comment(url, { body: fullBody });
   if (!result.ok) {
-    deps.logger.named('refine.push').warn(`issue comment failed (${url}): ${result.error.message}`);
+    deps.logger.named(PUSH_LOGGER).warn(`issue comment failed (${url}): ${result.error.message}`);
   } else {
-    deps.logger.named('refine.push').info(`posted comment on issue ${url}`);
+    deps.logger.named(PUSH_LOGGER).info(`posted comment on issue ${url}`);
   }
 };
 
@@ -303,10 +304,11 @@ export const refineTicketInteractiveLeaf = (
       },
     },
     input: (ctx) => {
+      const PRE_REFINE_STATE = 'pre-refine';
       if (ctx.sprint === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-refine',
+          currentState: PRE_REFINE_STATE,
           attemptedAction: `refine-ticket-${String(ticket.id)}`,
           message: `refine-ticket-${String(ticket.id)}: ctx.sprint is undefined — load-sprint must run first`,
         });
@@ -314,7 +316,7 @@ export const refineTicketInteractiveLeaf = (
       if (ctx.currentPromptFile === undefined || ctx.currentOutputFile === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-refine',
+          currentState: PRE_REFINE_STATE,
           attemptedAction: `refine-ticket-${String(ticket.id)}`,
           message: `refine-ticket-${String(ticket.id)}: prompt/output paths missing — render-prompt-to-file must run first`,
         });
@@ -322,7 +324,7 @@ export const refineTicketInteractiveLeaf = (
       if (ctx.currentUnitRoot === undefined) {
         throw new InvalidStateError({
           entity: 'chain',
-          currentState: 'pre-refine',
+          currentState: PRE_REFINE_STATE,
           attemptedAction: `refine-ticket-${String(ticket.id)}`,
           message: `refine-ticket-${String(ticket.id)}: unit root missing — build-refine-unit must run first`,
         });

--- a/src/application/flows/review/leaves/review-round.ts
+++ b/src/application/flows/review/leaves/review-round.ts
@@ -247,8 +247,11 @@ const ensureRoundDir = async (dir: AbsolutePath): Promise<Result<void, StorageEr
   }
 };
 
+/** Leaf name, reused as the signal `source` and the `attemptedAction` on error states. */
+const LEAF_NAME = 'review-round';
+
 export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeafOpts): Element<ReviewCtx> =>
-  leaf<ReviewCtx, ReviewRoundInput, RunReviewRoundOutput>('review-round', {
+  leaf<ReviewCtx, ReviewRoundInput, RunReviewRoundOutput>(LEAF_NAME, {
     useCase: {
       execute: async (input, signal) => {
         // Derive the active round index from the ON-DISK feedback.md, not from in-memory ctx.
@@ -344,7 +347,7 @@ export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeaf
             // two paths once every TUI consumer migrates to `ai-signal` events.
             for (const sig of validated.value) {
               deps.signals.emit(sig);
-              deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: 'review-round' });
+              deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: LEAF_NAME });
             }
             return Result.ok(validated.value as readonly HarnessSignal[]);
           },
@@ -394,7 +397,7 @@ export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeaf
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-review-round',
-          attemptedAction: 'review-round',
+          attemptedAction: LEAF_NAME,
           message: 'review-round: ctx.sprint missing',
         });
       }
@@ -402,7 +405,7 @@ export const reviewRoundLeaf = (deps: ReviewRoundLeafDeps, opts: ReviewRoundLeaf
         throw new InvalidStateError({
           entity: 'chain',
           currentState: 'pre-review-round',
-          attemptedAction: 'review-round',
+          attemptedAction: LEAF_NAME,
           message: 'review-round: ctx.feedbackFile missing — ensure-feedback-file must run first',
         });
       }

--- a/src/application/ui/cli/commands/task.ts
+++ b/src/application/ui/cli/commands/task.ts
@@ -9,6 +9,9 @@ interface SprintOpt {
   readonly sprint?: string;
 }
 
+const SPRINT_OPTION_FLAGS = '-s, --sprint <id>';
+const SPRINT_OPTION_DESC = 'sprint id (defaults to the current sprint)';
+
 /**
  * Register the `task` command group. Read-side plus a single recovery hatch (`unblock`) —
  * task creation is owned by the planning chain (AI generates the task graph from approved
@@ -29,7 +32,7 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('list')
     .description('list every task on the sprint, in order')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
@@ -57,7 +60,7 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('show <taskId>')
     .description('print a single task as JSON')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (rawTaskId: string, opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
@@ -85,7 +88,7 @@ export const registerTaskCommand = (program: Command): void => {
   task
     .command('unblock <taskId>')
     .description('flip a blocked task back to todo so the implement loop picks it up again')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (rawTaskId: string, opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);

--- a/src/application/ui/cli/commands/ticket.ts
+++ b/src/application/ui/cli/commands/ticket.ts
@@ -10,6 +10,9 @@ interface SprintOpt {
   readonly sprint?: string;
 }
 
+const SPRINT_OPTION_FLAGS = '-s, --sprint <id>';
+const SPRINT_OPTION_DESC = 'sprint id (defaults to the current sprint)';
+
 interface AddOpts extends SprintOpt {
   readonly title: string;
   readonly description?: string;
@@ -38,7 +41,7 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('list')
     .description('list every ticket on the sprint')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
@@ -66,7 +69,7 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('show <ticketId>')
     .description('print a single ticket as JSON')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (rawTicketId: string, opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);
@@ -100,7 +103,7 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('add')
     .description('append a pending ticket to a draft sprint')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .requiredOption('-t, --title <title>', 'ticket title')
     .option('-d, --description <text>', 'optional description')
     .option('-l, --link <url>', 'optional issue link (http/https)')
@@ -136,7 +139,7 @@ export const registerTicketCommand = (program: Command): void => {
   ticketCmd
     .command('remove <ticketId>')
     .description('drop a ticket from a draft sprint')
-    .option('-s, --sprint <id>', 'sprint id (defaults to the current sprint)')
+    .option(SPRINT_OPTION_FLAGS, SPRINT_OPTION_DESC)
     .action(async (rawTicketId: string, opts: SprintOpt) => {
       const { deps, storage } = await bootstrapCli();
       const sprintId = await resolveSprintId(opts.sprint, storage.stateRoot);

--- a/src/application/ui/tui/components/baseline-health-card.tsx
+++ b/src/application/ui/tui/components/baseline-health-card.tsx
@@ -50,6 +50,9 @@ import {
  */
 type Tier = 'ok' | 'warning' | 'error' | 'pending';
 
+/** Shared `outcome` discriminant for setup + verify runs that spawn a child process. */
+const SPAWN_ERROR_OUTCOME = 'spawn-error';
+
 /** @public */
 export interface BaselineHealthCardProps {
   readonly execution?: SprintExecution;
@@ -129,7 +132,7 @@ const setupTier = (rows: readonly SetupRun[]): Tier => {
   for (const row of rows) {
     if (row.outcome !== 'skipped') allSkipped = false;
     if (row.outcome === 'failed') hasFailed = true;
-    if (row.outcome === 'spawn-error') hasSpawnError = true;
+    if (row.outcome === SPAWN_ERROR_OUTCOME) hasSpawnError = true;
   }
   if (hasFailed || hasSpawnError) return 'error';
   if (allSkipped) return 'pending';
@@ -154,7 +157,7 @@ const setupRowData = (execution: SprintExecution | undefined, now: number): RowD
     return { label: 'Setup', tier, sublines: [`${repoLabel} · ${ago} ago`] };
   }
   if (tier === 'error') {
-    const failedCount = latest.filter((r) => r.outcome === 'failed' || r.outcome === 'spawn-error').length;
+    const failedCount = latest.filter((r) => r.outcome === 'failed' || r.outcome === SPAWN_ERROR_OUTCOME).length;
     return {
       label: 'Setup',
       tier,
@@ -191,7 +194,7 @@ const verifyRowData = (run: VerifyRun | undefined, now: number, shortLabel: stri
       sublines: [`exit ${String(run.exitCode)} · ${ago} ago`],
     };
   }
-  if (run.outcome === 'spawn-error') {
+  if (run.outcome === SPAWN_ERROR_OUTCOME) {
     return { label: shortLabel, tier: 'warning', status: 'spawn error', sublines: [`${ago} ago`] };
   }
   return { label: shortLabel, tier: 'pending', status: 'skipped', sublines: [`${ago} ago`] };

--- a/src/application/ui/tui/components/chain-log-degraded-banner.tsx
+++ b/src/application/ui/tui/components/chain-log-degraded-banner.tsx
@@ -33,10 +33,9 @@ export const ChainLogDegradedBanner = (): React.JSX.Element | null => {
   const [degraded, setDegraded] = useState(false);
 
   useEffect(() => {
-    const unsub = deps.eventBus.subscribe((event) => {
+    return deps.eventBus.subscribe((event) => {
       if (event.type === 'chain-log-degraded') setDegraded(true);
     });
-    return unsub;
   }, [deps.eventBus]);
 
   if (!degraded) return null;

--- a/src/application/ui/tui/components/help-overlay.tsx
+++ b/src/application/ui/tui/components/help-overlay.tsx
@@ -26,6 +26,9 @@ const CHROME_ROWS = 6;
 /** Floor on the scrollable body so a tiny terminal still shows something. */
 const MIN_BODY_ROWS = 4;
 
+/** `HelpRow.kind` discriminant for a section header row. */
+const SECTION_TITLE = 'section-title';
+
 interface HelpRow {
   readonly kind: 'section-title' | 'binding';
   readonly title?: string;
@@ -45,14 +48,14 @@ export const HelpOverlay = (): React.JSX.Element => {
     const rows: HelpRow[] = [];
 
     if (localHints.length > 0) {
-      rows.push({ kind: 'section-title', title: 'This view' });
+      rows.push({ kind: SECTION_TITLE, title: 'This view' });
       for (const h of localHints) {
         rows.push({ kind: 'binding', keys: [h.keys], label: h.label });
       }
     }
 
     for (const section of keySections) {
-      rows.push({ kind: 'section-title', title: section.title });
+      rows.push({ kind: SECTION_TITLE, title: section.title });
       for (const b of section.bindings) {
         rows.push({
           kind: 'binding',
@@ -118,7 +121,7 @@ export const HelpOverlay = (): React.JSX.Element => {
         </Box>
         <Box flexDirection="column" marginTop={spacing.section}>
           {visibleRows.map((row, idx) => {
-            if (row.kind === 'section-title') {
+            if (row.kind === SECTION_TITLE) {
               return (
                 <Box key={`title-${String(offset + idx)}`} marginTop={idx === 0 ? 0 : spacing.section}>
                   <Text bold>{row.title}</Text>

--- a/src/application/ui/tui/components/memory-pressure-banner.tsx
+++ b/src/application/ui/tui/components/memory-pressure-banner.tsx
@@ -25,10 +25,9 @@ export const MemoryPressureBanner = (): React.JSX.Element | null => {
   const [latest, setLatest] = useState<MemoryPressureEvent | undefined>(undefined);
 
   useEffect(() => {
-    const unsub = deps.eventBus.subscribe((event) => {
+    return deps.eventBus.subscribe((event) => {
       if (event.type === 'memory-pressure') setLatest(event);
     });
-    return unsub;
   }, [deps.eventBus]);
 
   if (latest === undefined || latest.severity === 'recovered') return null;

--- a/src/application/ui/tui/components/status-banner.tsx
+++ b/src/application/ui/tui/components/status-banner.tsx
@@ -111,7 +111,7 @@ export const StatusBanner = (): React.JSX.Element | null => {
     // rather than crashing the host view when the bus isn't wired.
     const bus = deps.eventBus;
     if (bus === undefined) return undefined;
-    const unsub = bus.subscribe((event) => {
+    return bus.subscribe((event) => {
       if (event.type === 'banner-show') {
         setBanners((prev) => upsert(prev, toActive(event)));
         return;
@@ -120,7 +120,6 @@ export const StatusBanner = (): React.JSX.Element | null => {
         setBanners((prev) => prev.filter((b) => b.id !== event.id));
       }
     });
-    return unsub;
   }, [deps.eventBus]);
 
   // Sort by tier (most-urgent first); within the same tier we preserve insertion order so a

--- a/src/application/ui/tui/components/tasks-panel-internals/keymap.ts
+++ b/src/application/ui/tui/components/tasks-panel-internals/keymap.ts
@@ -84,13 +84,11 @@ export const useTasksPanelInput = ({
       //     between cards without first clicking into a row).
       const rowCursorActive = focusedCardExpanded && flatKeys.length > 0 && focusedIndex >= 0;
       if (key.downArrow || input === 'j') {
-        if (rowCursorActive) {
-          if (focusedIndex < flatKeys.length - 1) {
-            setFocusedKey(flatKeys[focusedIndex + 1]);
-            return;
-          }
-          // Row cursor at the bottom — fall through to the card cursor.
+        if (rowCursorActive && focusedIndex < flatKeys.length - 1) {
+          setFocusedKey(flatKeys[focusedIndex + 1]);
+          return;
         }
+        // Row cursor at the bottom — fall through to the card cursor.
         const next = Math.min(bucketed.tasks.length - 1, effectiveCardCursor + 1);
         setCardCursor(next);
         // Reset the row cursor so the next expanded card starts un-anchored.
@@ -98,13 +96,11 @@ export const useTasksPanelInput = ({
         return;
       }
       if (key.upArrow || input === 'k') {
-        if (rowCursorActive) {
-          if (focusedIndex > 0) {
-            setFocusedKey(flatKeys[focusedIndex - 1]);
-            return;
-          }
-          // Row cursor at the top — fall through to the card cursor.
+        if (rowCursorActive && focusedIndex > 0) {
+          setFocusedKey(flatKeys[focusedIndex - 1]);
+          return;
         }
+        // Row cursor at the top — fall through to the card cursor.
         const next = Math.max(0, effectiveCardCursor - 1);
         setCardCursor(next);
         setFocusedKey(undefined);

--- a/src/application/ui/tui/migration/migration-gate.tsx
+++ b/src/application/ui/tui/migration/migration-gate.tsx
@@ -90,6 +90,9 @@ type GateState =
 /** Outcome reused across every "decline / proceed on tolerant readers" path. */
 const SKIPPED: MigrationGateOutcome = 'skipped';
 
+/** `GateState.kind` discriminant for the "dry-run found a problem / threw" screen. */
+const DRY_RUN_BLOCKED = 'dry-run-blocked';
+
 /** Subset of Ink's `Key` flags the consent handler reads — declared so the handler is unit-typeable. */
 type KeyFlags = Pick<Key, 'leftArrow' | 'rightArrow' | 'tab' | 'return' | 'escape'>;
 
@@ -128,7 +131,7 @@ export const MigrationGate = (props: MigrationGateProps): React.JSX.Element => {
         const report = await engine.dryRun(dataRoot);
         if (cancelled) return;
         if (report.problems.length > 0) {
-          setState({ kind: 'dry-run-blocked', issues: report.problems.map((p) => `${p.name} — ${p.reason}`) });
+          setState({ kind: DRY_RUN_BLOCKED, issues: report.problems.map((p) => `${p.name} — ${p.reason}`) });
           return;
         }
         // No-op migration (brand-new install, or everything already reconciled): there is nothing to
@@ -146,7 +149,7 @@ export const MigrationGate = (props: MigrationGateProps): React.JSX.Element => {
         // A dry-run that threw is treated like a blocking problem: surface it, do NOT apply, proceed
         // on the tolerant readers. The dry-run touches nothing, so a throw here left disk untouched.
         const msg = err instanceof Error ? err.message : String(err);
-        setState({ kind: 'dry-run-blocked', issues: [`could not scan data — ${msg}`] });
+        setState({ kind: DRY_RUN_BLOCKED, issues: [`could not scan data — ${msg}`] });
       }
     };
     void scan();
@@ -209,7 +212,7 @@ export const MigrationGate = (props: MigrationGateProps): React.JSX.Element => {
         handleConsentInput(state, input, key);
         break;
       case 'lock-held':
-      case 'dry-run-blocked':
+      case DRY_RUN_BLOCKED:
         // Only path forward is to continue on the tolerant readers; any key proceeds.
         onResolve(SKIPPED);
         break;
@@ -259,7 +262,7 @@ const renderBody = (state: GateState): React.JSX.Element => {
           <Text dimColor>Your data is untouched. Press any key to continue.</Text>
         </Card>
       );
-    case 'dry-run-blocked':
+    case DRY_RUN_BLOCKED:
       return (
         <Card title={SKIP_TITLE} tone="warning">
           <Text color={inkColors.warning}>

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -44,6 +44,9 @@ import { sectionFor, sectionRank, visibleFlowsFor } from '@src/application/ui/tu
 // without a React render. The view delegates section labelling, ordering, and the
 // per-status allow-list to that module.
 
+/** Flow id whose launch needs special sprint-rebinding handling (see the `onSelect` handler). */
+const CREATE_SPRINT_FLOW_ID = 'create-sprint';
+
 /**
  * Some flows in the registry are use-case shaped (one-shot, no chain runner) and the TUI
  * has dedicated views for them. Route those directly instead of falling through to
@@ -283,7 +286,7 @@ export const FlowsView = (): React.JSX.Element => {
           // additionally strips the launch-time sprint from the snapshot: the new sprint doesn't
           // exist yet, so pinning the PREVIOUS sprint onto the run's descriptor would mislabel
           // every panel; onSprintResolved pins the real one once known.
-          const sprintBound = entry.manifest.id === 'create-sprint' || entry.manifest.id === 'close-sprint';
+          const sprintBound = entry.manifest.id === CREATE_SPRINT_FLOW_ID || entry.manifest.id === 'close-sprint';
           let result;
           if (sprintBound) {
             const { sprint: _staleSprint, ...snapshotWithoutSprint } = snapshot;
@@ -291,11 +294,11 @@ export const FlowsView = (): React.JSX.Element => {
             result = await launchSprintBoundFlow(
               launcherDeps,
               entry.manifest.id,
-              entry.manifest.id === 'create-sprint' ? snapshotWithoutSprint : snapshot,
+              entry.manifest.id === CREATE_SPRINT_FLOW_ID ? snapshotWithoutSprint : snapshot,
               {
                 ...launchExtras,
                 onReseat: ({ id, name, status }) => {
-                  if (entry.manifest.id === 'create-sprint') {
+                  if (entry.manifest.id === CREATE_SPRINT_FLOW_ID) {
                     // A brand-new sprint can't collide with a mid-run switch — always reseat
                     // (and let the "✓ now on …" toast fire via lastSwitch).
                     selection.setSprint(id, name, status);

--- a/src/application/ui/tui/views/flows-visibility.ts
+++ b/src/application/ui/tui/views/flows-visibility.ts
@@ -22,6 +22,9 @@
 
 import type { SprintStatus } from '@src/domain/entity/sprint.ts';
 
+/** Flow id surfaced in both the sprint-scoped list and several per-status allow-lists. */
+const REMOVE_TICKET = 'remove-ticket';
+
 /** Sprint-scoped flow ids — only meaningful when a sprint is selected. */
 export const SPRINT_SCOPED_FLOW_IDS: readonly string[] = [
   'refine',
@@ -30,7 +33,7 @@ export const SPRINT_SCOPED_FLOW_IDS: readonly string[] = [
   'review',
   'close-sprint',
   'create-pr',
-  'remove-ticket',
+  REMOVE_TICKET,
 ];
 
 /**
@@ -68,8 +71,8 @@ const HIDDEN_SET: ReadonlySet<string> = new Set(HIDDEN_BY_DEFAULT_FLOW_IDS);
  * `showAll` is on).
  */
 const ALLOWED_BY_STATUS: Readonly<Record<SprintStatus, ReadonlySet<string>>> = {
-  draft: new Set(['refine', 'plan', 'remove-ticket']),
-  planned: new Set(['implement', 'remove-ticket']),
+  draft: new Set(['refine', 'plan', REMOVE_TICKET]),
+  planned: new Set(['implement', REMOVE_TICKET]),
   active: new Set(['implement']),
   review: new Set(['review', 'close-sprint']),
   done: new Set(['create-pr']),

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -126,6 +126,9 @@ export const PRESET_FAMILY_LABEL: Readonly<Record<PresetFamily, string>> = {
   frontier: 'Frontier',
 };
 
+/** Family shared by the four strong-gate presets. */
+const STRONG_GATE: PresetFamily = 'strong-gate';
+
 /** Maps each preset to its family — single source so preset-bar and any future caller stay in sync. */
 export const PRESET_FAMILY: Readonly<Record<PresetName, PresetFamily>> = {
   mixed: 'standard',
@@ -136,10 +139,10 @@ export const PRESET_FAMILY: Readonly<Record<PresetName, PresetFamily>> = {
   'claude-economic': 'economic',
   'copilot-economic': 'economic',
   'codex-economic': 'economic',
-  'mixed-strong-gate': 'strong-gate',
-  'claude-strong-gate': 'strong-gate',
-  'copilot-strong-gate': 'strong-gate',
-  'codex-strong-gate': 'strong-gate',
+  'mixed-strong-gate': STRONG_GATE,
+  'claude-strong-gate': STRONG_GATE,
+  'copilot-strong-gate': STRONG_GATE,
+  'codex-strong-gate': STRONG_GATE,
   'mixed-fast': 'fast',
   'claude-fast': 'fast',
   'copilot-fast': 'fast',

--- a/src/business/settings/apply-key.ts
+++ b/src/business/settings/apply-key.ts
@@ -24,6 +24,8 @@ import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
 const SETTINGS_KEY_HINT =
   'supported keys: ai.effort, ai.{flow}.{provider,model,effort} (flow in {refine,plan,readiness,ideate,createPr}), ai.implement.{generator,evaluator}.{provider,model,effort}, harness.{maxTurns,maxAttempts,rateLimitRetries,idleWatchdogMs,plateauThreshold,escalateOnPlateau,skipPreVerifyOnFreshSetup}, harness.escalationMap.<fromModel>, logging.level, concurrency.maxParallelTasks, scm.postRefinementComment, ui.notifications.enabled';
 
+const BOOLEAN_VALUE_HINT = "use 'true' or 'false'";
+
 const IMPLEMENT_ROLES: readonly AiImplementRole[] = ['generator', 'evaluator'];
 const isImplementRole = (raw: string): raw is AiImplementRole => (IMPLEMENT_ROLES as readonly string[]).includes(raw);
 
@@ -190,7 +192,7 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
             field: key,
             value: raw,
             message: `'${raw}' is not a boolean`,
-            hint: "use 'true' or 'false'",
+            hint: BOOLEAN_VALUE_HINT,
           })
         );
       }
@@ -204,7 +206,7 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
             field: key,
             value: raw,
             message: `'${raw}' is not a boolean`,
-            hint: "use 'true' or 'false'",
+            hint: BOOLEAN_VALUE_HINT,
           })
         );
       }
@@ -228,7 +230,7 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
             field: key,
             value: raw,
             message: `'${raw}' is not a boolean`,
-            hint: "use 'true' or 'false'",
+            hint: BOOLEAN_VALUE_HINT,
           })
         );
       }
@@ -242,7 +244,7 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
             field: key,
             value: raw,
             message: `'${raw}' is not a boolean`,
-            hint: "use 'true' or 'false'",
+            hint: BOOLEAN_VALUE_HINT,
           })
         );
       }

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -6,6 +6,13 @@ import {
 } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 
+// Model identifiers referenced more than once below, hoisted to named constants so each literal
+// appears once. The dash spelling (`claude-…-4-6`) is the claude-code catalog form.
+const CLAUDE_SONNET = 'claude-sonnet-4-6';
+const CLAUDE_OPUS = 'claude-opus-4-8';
+const GPT_5_MINI = 'gpt-5-mini';
+const GPT_5_4_MINI = 'gpt-5.4-mini';
+
 /**
  * Per-provider, per-flow default model picks. Used by the welcome flow when the user picks a
  * provider on first run, by `settings-set-provider` when the user re-aligns one flow's
@@ -16,33 +23,33 @@ import type { FlowId } from '@src/domain/value/flow-id.ts';
  */
 const DEFAULT_MODELS_BY_PROVIDER: Readonly<Record<AiProvider, Readonly<Record<FlowId, string>>>> = {
   'claude-code': {
-    refine: 'claude-sonnet-4-6',
-    plan: 'claude-opus-4-8',
-    implement: 'claude-opus-4-8',
-    readiness: 'claude-sonnet-4-6',
-    ideate: 'claude-opus-4-8',
+    refine: CLAUDE_SONNET,
+    plan: CLAUDE_OPUS,
+    implement: CLAUDE_OPUS,
+    readiness: CLAUDE_SONNET,
+    ideate: CLAUDE_OPUS,
     // PR-content drafting is a single-shot summarisation task — Sonnet matches refine's
     // light reasoning profile and avoids the Opus premium for a few-paragraph diff write-up.
-    createPr: 'claude-sonnet-4-6',
+    createPr: CLAUDE_SONNET,
   },
   'github-copilot': {
-    refine: 'gpt-5-mini',
+    refine: GPT_5_MINI,
     plan: 'gpt-5.4',
     implement: 'gpt-5.4',
-    readiness: 'gpt-5-mini',
+    readiness: GPT_5_MINI,
     ideate: 'gpt-5.4',
-    createPr: 'gpt-5-mini',
+    createPr: GPT_5_MINI,
   },
   'openai-codex': {
-    refine: 'gpt-5.4-mini',
+    refine: GPT_5_4_MINI,
     plan: 'gpt-5.5',
     // `gpt-5.3-codex` is deprecated for ChatGPT sign-in — the "reset implement to Codex" path
     // rides the frontier default `gpt-5.5` instead, matching the CODEX_ONLY preset decision so
     // the everyday autonomous loop works under ChatGPT auth and sits at the top of the ladder.
     implement: 'gpt-5.5',
-    readiness: 'gpt-5.4-mini',
+    readiness: GPT_5_4_MINI,
     ideate: 'gpt-5.5',
-    createPr: 'gpt-5.4-mini',
+    createPr: GPT_5_4_MINI,
   },
 };
 
@@ -86,7 +93,7 @@ export const DEFAULT_SETTINGS: Settings = {
   ai: {
     ...defaultAiSettingsForProvider('claude-code'),
     implement: {
-      generator: { provider: 'claude-code', model: 'claude-opus-4-8' },
+      generator: { provider: 'claude-code', model: CLAUDE_OPUS },
       evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
     },
   },

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -69,6 +69,21 @@ export const PRESET_NAMES: readonly PresetName[] = [
 
 export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as readonly string[]).includes(raw);
 
+// Provider and model identifiers referenced across the preset matrices below, hoisted so each
+// literal appears once. The dash vs dot spelling is provider-specific and load-bearing:
+// claude-code uses `claude-…-4-8` (dashes → OPUS / SONNET / HAIKU) while github-copilot uses
+// `claude-…-4.8` (dots → COPILOT_OPUS / COPILOT_SONNET). Do not normalise one into the other.
+const CLAUDE = 'claude-code';
+const COPILOT = 'github-copilot';
+const CODEX = 'openai-codex';
+const OPUS = 'claude-opus-4-8';
+const SONNET = 'claude-sonnet-4-6';
+const HAIKU = 'claude-haiku-4-5';
+const COPILOT_OPUS = 'claude-opus-4.8';
+const COPILOT_SONNET = 'claude-sonnet-4.6';
+const GPT_5_MINI = 'gpt-5-mini';
+const GPT_5_4_MINI = 'gpt-5.4-mini';
+
 /**
  * The `mixed` preset matrix — best-of-breed across the three providers. Effort pattern:
  * `implement` and `plan` at `xhigh` for the deeper-reasoning autonomous flows; `readiness`
@@ -80,17 +95,17 @@ export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as
  */
 const MIXED: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.5' },
-  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'xhigh' },
+  refine: { provider: CODEX, model: 'gpt-5.5' },
+  plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'xhigh' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+    generator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: OPUS },
   // PR content drafting mirrors refine's "light summary" reasoning profile — a fast Codex
   // model is fine, no need to pay for Opus tokens just to summarise a diff.
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 /**
@@ -107,43 +122,43 @@ const MIXED: AiSettings = {
  */
 const CLAUDE_ONLY: AiSettings = {
   effort: 'high',
-  refine: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  refine: { provider: CLAUDE, model: SONNET },
+  plan: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+    generator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
-  createPr: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
+  readiness: { provider: CLAUDE, model: HAIKU, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: OPUS },
+  createPr: { provider: CLAUDE, model: SONNET },
 };
 
 const COPILOT_ONLY: AiSettings = {
   effort: 'high',
-  refine: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
-  plan: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+  refine: { provider: COPILOT, model: COPILOT_SONNET },
+  plan: { provider: COPILOT, model: COPILOT_OPUS, effort: 'xhigh' },
   implement: {
-    generator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
-    evaluator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+    generator: { provider: COPILOT, model: COPILOT_OPUS, effort: 'xhigh' },
+    evaluator: { provider: COPILOT, model: COPILOT_OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'github-copilot', model: 'claude-opus-4.8' },
-  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: COPILOT, model: COPILOT_OPUS },
+  createPr: { provider: COPILOT, model: GPT_5_MINI },
 };
 
 const CODEX_ONLY: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4' },
-  plan: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  refine: { provider: CODEX, model: 'gpt-5.4' },
+  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   implement: {
     // gpt-5.3-codex is deprecated for ChatGPT sign-in — implement now rides the frontier
     // default so the everyday autonomous loop keeps working under ChatGPT auth.
-    generator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
-    evaluator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+    generator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   },
-  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'medium' },
-  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
+  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 /**
@@ -164,54 +179,54 @@ const CODEX_ONLY: AiSettings = {
  */
 const MIXED_ECONOMIC: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
+  plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'high' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
-    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'high' },
+    evaluator: { provider: CLAUDE, model: SONNET, effort: 'high' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: SONNET },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 const CLAUDE_ECONOMIC: AiSettings = {
   effort: 'high',
-  refine: { provider: 'claude-code', model: 'claude-haiku-4-5' },
-  plan: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+  refine: { provider: CLAUDE, model: HAIKU },
+  plan: { provider: CLAUDE, model: SONNET, effort: 'high' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
-    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'high' },
+    evaluator: { provider: CLAUDE, model: SONNET, effort: 'high' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  readiness: { provider: CLAUDE, model: HAIKU, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: SONNET },
+  createPr: { provider: CLAUDE, model: HAIKU },
 };
 
 const COPILOT_ECONOMIC: AiSettings = {
   effort: 'high',
-  refine: { provider: 'github-copilot', model: 'gpt-5.4-mini' },
-  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
+  refine: { provider: COPILOT, model: GPT_5_4_MINI },
+  plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'high' },
   implement: {
-    generator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
-    evaluator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
+    generator: { provider: COPILOT, model: COPILOT_SONNET, effort: 'high' },
+    evaluator: { provider: COPILOT, model: COPILOT_SONNET, effort: 'high' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
-  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: COPILOT, model: COPILOT_SONNET },
+  createPr: { provider: COPILOT, model: GPT_5_MINI },
 };
 
 const CODEX_ECONOMIC: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  plan: { provider: 'openai-codex', model: 'gpt-5.4', effort: 'high' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
+  plan: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
   implement: {
-    generator: { provider: 'openai-codex', model: 'gpt-5.4', effort: 'high' },
-    evaluator: { provider: 'openai-codex', model: 'gpt-5.4', effort: 'high' },
+    generator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
+    evaluator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
   },
-  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'medium' },
-  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
+  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 /**
@@ -229,17 +244,17 @@ const CODEX_ECONOMIC: AiSettings = {
  */
 const CLAUDE_STRONG_GATE: AiSettings = {
   effort: 'high',
-  refine: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  refine: { provider: CLAUDE, model: SONNET },
+  plan: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   implement: {
     // Cheap author: sonnet at high effort, climbs to opus on plateau via the default ladder.
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'high' },
     // Strong gate: opus from the first round, never cheapened.
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  readiness: { provider: CLAUDE, model: HAIKU, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: SONNET },
+  createPr: { provider: CLAUDE, model: HAIKU },
 };
 
 /**
@@ -260,42 +275,42 @@ const CLAUDE_STRONG_GATE: AiSettings = {
  */
 const MIXED_STRONG_GATE: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
+  plan: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'high' },
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'xhigh' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'high' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'claude-code', model: 'claude-sonnet-4-6' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: CLAUDE, model: SONNET },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 const COPILOT_STRONG_GATE: AiSettings = {
   effort: 'high',
-  refine: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
-  plan: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+  refine: { provider: COPILOT, model: COPILOT_SONNET },
+  plan: { provider: COPILOT, model: COPILOT_OPUS, effort: 'xhigh' },
   implement: {
-    generator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'high' },
-    evaluator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'xhigh' },
+    generator: { provider: COPILOT, model: COPILOT_SONNET, effort: 'high' },
+    evaluator: { provider: COPILOT, model: COPILOT_OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'medium' },
-  ideate: { provider: 'github-copilot', model: 'claude-sonnet-4.6' },
-  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'medium' },
+  ideate: { provider: COPILOT, model: COPILOT_SONNET },
+  createPr: { provider: COPILOT, model: GPT_5_MINI },
 };
 
 const CODEX_STRONG_GATE: AiSettings = {
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  plan: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
+  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   implement: {
     // Narrowest gate of the family: gpt-5.4 author climbs the single rung to the gpt-5.5 gate.
-    generator: { provider: 'openai-codex', model: 'gpt-5.4', effort: 'high' },
-    evaluator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+    generator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
+    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   },
-  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'medium' },
-  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
+  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 /**
@@ -311,54 +326,54 @@ const CODEX_STRONG_GATE: AiSettings = {
  */
 const MIXED_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
+  plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'low' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
-    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'low' },
+    evaluator: { provider: CLAUDE, model: SONNET, effort: 'low' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'low' },
-  ideate: { provider: 'claude-code', model: 'claude-haiku-4-5' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'low' },
+  ideate: { provider: CLAUDE, model: HAIKU },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 const CLAUDE_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: 'claude-code', model: 'claude-haiku-4-5' },
-  plan: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+  refine: { provider: CLAUDE, model: HAIKU },
+  plan: { provider: CLAUDE, model: SONNET, effort: 'low' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
-    evaluator: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'low' },
+    generator: { provider: CLAUDE, model: SONNET, effort: 'low' },
+    evaluator: { provider: CLAUDE, model: SONNET, effort: 'low' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-haiku-4-5', effort: 'low' },
-  ideate: { provider: 'claude-code', model: 'claude-haiku-4-5' },
-  createPr: { provider: 'claude-code', model: 'claude-haiku-4-5' },
+  readiness: { provider: CLAUDE, model: HAIKU, effort: 'low' },
+  ideate: { provider: CLAUDE, model: HAIKU },
+  createPr: { provider: CLAUDE, model: HAIKU },
 };
 
 const COPILOT_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: 'github-copilot', model: 'gpt-5-mini' },
-  plan: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+  refine: { provider: COPILOT, model: GPT_5_MINI },
+  plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'low' },
   implement: {
-    generator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
-    evaluator: { provider: 'github-copilot', model: 'claude-sonnet-4.6', effort: 'low' },
+    generator: { provider: COPILOT, model: COPILOT_SONNET, effort: 'low' },
+    evaluator: { provider: COPILOT, model: COPILOT_SONNET, effort: 'low' },
   },
-  readiness: { provider: 'github-copilot', model: 'gpt-5-mini', effort: 'low' },
-  ideate: { provider: 'github-copilot', model: 'gpt-5-mini' },
-  createPr: { provider: 'github-copilot', model: 'gpt-5-mini' },
+  readiness: { provider: COPILOT, model: GPT_5_MINI, effort: 'low' },
+  ideate: { provider: COPILOT, model: GPT_5_MINI },
+  createPr: { provider: COPILOT, model: GPT_5_MINI },
 };
 
 const CODEX_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
-  plan: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
+  plan: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
   implement: {
-    generator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
-    evaluator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+    generator: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
+    evaluator: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
   },
-  readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
-  ideate: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+  readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
+  ideate: { provider: CODEX, model: GPT_5_4_MINI },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
 };
 
 /**
@@ -373,55 +388,55 @@ const CODEX_FAST: AiSettings = {
  */
 const MIXED_FRONTIER: AiSettings = {
   effort: 'max',
-  refine: { provider: 'openai-codex', model: 'gpt-5.5' },
-  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  refine: { provider: CODEX, model: 'gpt-5.5' },
+  plan: { provider: CLAUDE, model: OPUS, effort: 'max' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+    generator: { provider: CLAUDE, model: OPUS, effort: 'max' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'max' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'high' },
-  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.5' },
+  readiness: { provider: CLAUDE, model: OPUS, effort: 'high' },
+  ideate: { provider: CLAUDE, model: OPUS },
+  createPr: { provider: CODEX, model: 'gpt-5.5' },
 };
 
 const CLAUDE_FRONTIER: AiSettings = {
   effort: 'max',
-  refine: { provider: 'claude-code', model: 'claude-opus-4-8' },
-  plan: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+  refine: { provider: CLAUDE, model: OPUS },
+  plan: { provider: CLAUDE, model: OPUS, effort: 'max' },
   implement: {
-    generator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
-    evaluator: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'max' },
+    generator: { provider: CLAUDE, model: OPUS, effort: 'max' },
+    evaluator: { provider: CLAUDE, model: OPUS, effort: 'max' },
   },
-  readiness: { provider: 'claude-code', model: 'claude-opus-4-8', effort: 'high' },
-  ideate: { provider: 'claude-code', model: 'claude-opus-4-8' },
-  createPr: { provider: 'claude-code', model: 'claude-opus-4-8' },
+  readiness: { provider: CLAUDE, model: OPUS, effort: 'high' },
+  ideate: { provider: CLAUDE, model: OPUS },
+  createPr: { provider: CLAUDE, model: OPUS },
 };
 
 const COPILOT_FRONTIER: AiSettings = {
   effort: 'max',
-  refine: { provider: 'github-copilot', model: 'claude-opus-4.8' },
-  plan: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
+  refine: { provider: COPILOT, model: COPILOT_OPUS },
+  plan: { provider: COPILOT, model: COPILOT_OPUS, effort: 'max' },
   implement: {
-    generator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
-    evaluator: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'max' },
+    generator: { provider: COPILOT, model: COPILOT_OPUS, effort: 'max' },
+    evaluator: { provider: COPILOT, model: COPILOT_OPUS, effort: 'max' },
   },
-  readiness: { provider: 'github-copilot', model: 'claude-opus-4.8', effort: 'high' },
-  ideate: { provider: 'github-copilot', model: 'claude-opus-4.8' },
-  createPr: { provider: 'github-copilot', model: 'claude-opus-4.8' },
+  readiness: { provider: COPILOT, model: COPILOT_OPUS, effort: 'high' },
+  ideate: { provider: COPILOT, model: COPILOT_OPUS },
+  createPr: { provider: COPILOT, model: COPILOT_OPUS },
 };
 
 const CODEX_FRONTIER: AiSettings = {
   // Codex ceiling — global stays `high` so nothing implies a `max` codex row.
   effort: 'high',
-  refine: { provider: 'openai-codex', model: 'gpt-5.5' },
-  plan: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+  refine: { provider: CODEX, model: 'gpt-5.5' },
+  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   implement: {
-    generator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
-    evaluator: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
+    generator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
   },
-  readiness: { provider: 'openai-codex', model: 'gpt-5.5', effort: 'high' },
-  ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
-  createPr: { provider: 'openai-codex', model: 'gpt-5.5' },
+  readiness: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  createPr: { provider: CODEX, model: 'gpt-5.5' },
 };
 
 /**

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -7,6 +7,9 @@ import { recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { ValidationError } from '@src/domain/value/error/validation-error.ts';
 
+/** Event `type` discriminant for the operator banner every escalation branch publishes. */
+const BANNER_SHOW_EVENT = 'banner-show';
+
 /**
  * The gen-eval exit kind that triggered the model-escalation policy. Threaded through so the
  * emitted `model-escalated` event + banner copy name the real cause rather than always saying
@@ -267,7 +270,7 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
         at: now,
       });
       eventBus.publish({
-        type: 'banner-show',
+        type: BANNER_SHOW_EVENT,
         id: bannerId,
         tier: 'info',
         message: `escalated generator model: ${decision.from} → ${decision.to}`,
@@ -292,7 +295,7 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
       const stamped = recordTaskEscalation(task, decision.currentModel, decision.currentModel);
       if (!stamped.ok) return Result.error(stamped.error);
       eventBus.publish({
-        type: 'banner-show',
+        type: BANNER_SHOW_EVENT,
         id: bannerId,
         tier: 'info',
         message: `${cause} on '${decision.currentModel}' (top of ladder) — retrying with a change-of-approach directive`,
@@ -313,7 +316,7 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
       // exhausted.
       const message = `ladder exhausted on '${decision.model}' (${cause}); keeping the work`;
       eventBus.publish({
-        type: 'banner-show',
+        type: BANNER_SHOW_EVENT,
         id: bannerId,
         tier: 'warn',
         message: 'ladder exhausted — keeping the work',
@@ -332,7 +335,7 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
       // the work.
       const message = `${cause} with attempt budget exhausted (attempts=${String(decision.attemptsUsed)}, maxAttempts=${String(decision.maxAttempts)}); keeping the work`;
       eventBus.publish({
-        type: 'banner-show',
+        type: BANNER_SHOW_EVENT,
         id: bannerId,
         tier: 'warn',
         message: `${cause}, attempt budget exhausted — keeping the work`,

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -14,6 +14,9 @@ import type { GenEvalExit, RunTaskVerdict } from '@src/business/task/gen-eval-ex
 import { applyEscalation, decideEscalation, type EscalationTrigger } from '@src/business/task/escalation-policy.ts';
 import { clearRunningAttemptPlateauWarning } from '@src/domain/entity/task-attempts.ts';
 
+/** {@link GenEvalExit} kind for a loop whose turn budget ran out without a terminal verdict. */
+const BUDGET_EXHAUSTED_EXIT = 'budget-exhausted';
+
 /**
  * Settle a finished gen-eval loop. Maps the loop's terminal `GenEvalExit` to the
  * `AttemptWarning` + `RunTaskVerdict` that downstream `settle-attempt` consumes, then persists
@@ -110,10 +113,10 @@ const mapExit = (exit: GenEvalExit): { verdict: RunTaskVerdict; warning?: Attemp
       return { verdict: 'malformed', warning: { kind: 'malformed', detail: exit.detail } };
     case 'plateau':
       return { verdict: 'failed', warning: { kind: 'plateau', dimensions: exit.dimensions } };
-    case 'budget-exhausted':
+    case BUDGET_EXHAUSTED_EXIT:
       return {
         verdict: 'failed',
-        warning: { kind: 'budget-exhausted', turnsUsed: exit.turnsUsed, turnBudget: exit.turnBudget },
+        warning: { kind: BUDGET_EXHAUSTED_EXIT, turnsUsed: exit.turnsUsed, turnBudget: exit.turnBudget },
       };
   }
 };
@@ -128,7 +131,7 @@ const mapExit = (exit: GenEvalExit): { verdict: RunTaskVerdict; warning?: Attemp
  * the caller. `passed` / `self-blocked` are terminal and never reach this predicate's branch.
  */
 const isEscalatableExit = (exit: GenEvalExit): exit is Extract<GenEvalExit, { kind: 'plateau' | 'budget-exhausted' }> =>
-  exit.kind === 'plateau' || exit.kind === 'budget-exhausted';
+  exit.kind === 'plateau' || exit.kind === BUDGET_EXHAUSTED_EXIT;
 
 interface Remedy {
   readonly task: InProgressTask;
@@ -217,7 +220,7 @@ export const finalizeGenEvalUseCase = async (
   if (props.exit !== undefined) {
     exit = props.exit;
   } else {
-    exit = { kind: 'budget-exhausted', turnsUsed: props.turnsUsed, turnBudget: Math.max(1, cfg.maxTurns) };
+    exit = { kind: BUDGET_EXHAUSTED_EXIT, turnsUsed: props.turnsUsed, turnBudget: Math.max(1, cfg.maxTurns) };
   }
 
   log.debug(`finalizing gen-eval (${exit.kind})`, { taskId: props.task.id, exitKind: exit.kind });

--- a/src/business/task/run-verify-script.ts
+++ b/src/business/task/run-verify-script.ts
@@ -6,6 +6,9 @@ import type { VerifyGate } from '@src/domain/entity/repository.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 
+/** {@link VerifyRunOutcome} value for a verify command the shell could not start. */
+const SPAWN_ERROR_OUTCOME = 'spawn-error';
+
 /**
  * Generic helper that runs the project's `verifyScript` once and projects the spawn result
  * into a structured {@link VerifyRun} row. Phase-agnostic — callers stamp `phase: 'pre'` or
@@ -118,7 +121,7 @@ export const runVerifyScriptUseCase = async (props: RunVerifyScriptProps): Promi
         command,
         exitCode: -1,
         durationMs: 0,
-        outcome: 'spawn-error',
+        outcome: SPAWN_ERROR_OUTCOME,
       },
       rawOutput: '',
       spawnErrorMessage: result.error.message,
@@ -310,7 +313,12 @@ const runOneGate = async (
       error: result.error.message,
     });
     state.executed.push({ command: gate.command, output: '' });
-    state.failure ??= { outcome: 'spawn-error', command: gate.command, exitCode: -1, message: result.error.message };
+    state.failure ??= {
+      outcome: SPAWN_ERROR_OUTCOME,
+      command: gate.command,
+      exitCode: -1,
+      message: result.error.message,
+    };
     return;
   }
 
@@ -393,7 +401,7 @@ export const attributeVerify = (
   pre: VerifyRun['outcome'],
   post: VerifyRun['outcome']
 ): 'clean' | 'regressed' | 'fixed-baseline' | 'baseline-broken' | undefined => {
-  if (pre === 'spawn-error' || post === 'spawn-error') return undefined;
+  if (pre === SPAWN_ERROR_OUTCOME || post === SPAWN_ERROR_OUTCOME) return undefined;
   if (pre === 'skipped' || post === 'skipped') return undefined;
   if (pre === 'success' && post === 'success') return 'clean';
   if (pre === 'success' && post === 'failed') return 'regressed';

--- a/src/business/task/start-attempt.ts
+++ b/src/business/task/start-attempt.ts
@@ -14,6 +14,13 @@ import type { ValidationError } from '@src/domain/value/error/validation-error.t
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 
 /**
+ * Conservative {@link AbortCause} for a leftover `running` attempt: a prior process exited without
+ * settling it (Ctrl-C, SIGTERM, watchdog, OOM all leave the same trace), so we cannot attribute a
+ * precise cause on the cross-process resume path.
+ */
+const PROCESS_CRASH_CAUSE = 'process-crash';
+
+/**
  * Start a fresh `running` attempt on a task and persist the transition. Domain transition +
  * single-task repo update + log. The chain leaf adapts ctx → props → ctx.
  *
@@ -113,9 +120,9 @@ export const startAttemptUseCase = async (
     log.info('recovering aborted attempt before resume', {
       taskId: props.task.id,
       priorAttemptN,
-      cause: 'process-crash',
+      cause: PROCESS_CRASH_CAUSE,
     });
-    const aborted = failCurrentAttempt(props.task, abortedAt, 'aborted', { abortCause: 'process-crash' });
+    const aborted = failCurrentAttempt(props.task, abortedAt, 'aborted', { abortCause: PROCESS_CRASH_CAUSE });
     if (!aborted.ok) {
       log.warn('failed to settle prior running attempt during resume', {
         taskId: props.task.id,
@@ -152,7 +159,7 @@ export const startAttemptUseCase = async (
       );
     }
     taskToStart = aborted.value;
-    recovering = { fromAttemptN: priorAttemptN, cause: 'process-crash', abortedAt };
+    recovering = { fromAttemptN: priorAttemptN, cause: PROCESS_CRASH_CAUSE, abortedAt };
   }
 
   const transitioned = startNextAttempt(taskToStart, props.clock(), undefined, recovering);

--- a/src/business/task/unblock-task.ts
+++ b/src/business/task/unblock-task.ts
@@ -15,6 +15,9 @@ import type { InvalidStateError } from '@src/domain/value/error/invalid-state-er
 import type { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 
+/** Log message shared by the persist-failure branches (primary update + cascade saveAll). */
+const PERSIST_FAILED_MSG = 'persist failed';
+
 /**
  * Manually unblock a task — recovery hatch for transient failures that leave a task stuck in
  * `blocked` (maxAttempts exhausted, verify failed) or `in_progress` with a settled last attempt
@@ -138,7 +141,7 @@ export const unblockTaskUseCase = async (
     });
     const persisted = await props.taskRepo.update(props.sprintId, primary);
     if (!persisted.ok) {
-      log.error('persist failed', { taskId: primary.id, error: persisted.error.message });
+      log.error(PERSIST_FAILED_MSG, { taskId: primary.id, error: persisted.error.message });
       return Result.error(persisted.error);
     }
     log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
@@ -153,7 +156,7 @@ export const unblockTaskUseCase = async (
   if (dependentIds.size === 0) {
     const persisted = await props.taskRepo.update(props.sprintId, primary);
     if (!persisted.ok) {
-      log.error('persist failed', { taskId: primary.id, error: persisted.error.message });
+      log.error(PERSIST_FAILED_MSG, { taskId: primary.id, error: persisted.error.message });
       return Result.error(persisted.error);
     }
     log.info(`unblocked task '${primary.name}'`, { taskId: primary.id, sprintId: props.sprintId });
@@ -175,7 +178,7 @@ export const unblockTaskUseCase = async (
 
   const saved = await props.taskRepo.saveAll(props.sprintId, nextTasks);
   if (!saved.ok) {
-    log.error('persist failed', { taskId: primary.id, error: saved.error.message });
+    log.error(PERSIST_FAILED_MSG, { taskId: primary.id, error: saved.error.message });
     return Result.error(saved.error);
   }
 

--- a/src/domain/entity/project.ts
+++ b/src/domain/entity/project.ts
@@ -23,6 +23,9 @@ import {
   setRepositoryVerifyTimeout,
 } from '@src/domain/entity/repository.ts';
 
+/** Field tag shared by every repository-collection validation failure on a {@link Project}. */
+const FIELD_PROJECT_REPOSITORIES = 'project.repositories';
+
 /**
  * Where ralphctl should create new issues when a refined ticket has no `link` and the user
  * picks "Approve & create origin" in the refine flow. `provider` selects gh vs glab; `owner`
@@ -98,7 +101,7 @@ export const createProject = (input: ProjectCreateInput): Result<Project, Valida
   if (input.repositories.length === 0) {
     return Result.error(
       new ValidationError({
-        field: 'project.repositories',
+        field: FIELD_PROJECT_REPOSITORIES,
         value: input.repositories,
         message: 'project must have at least one repository',
       })
@@ -111,7 +114,7 @@ export const createProject = (input: ProjectCreateInput): Result<Project, Valida
     if (seenIds.has(repo.id)) {
       return Result.error(
         new ValidationError({
-          field: 'project.repositories',
+          field: FIELD_PROJECT_REPOSITORIES,
           value: repo.id,
           message: `duplicate repository id '${repo.id}' (slug '${repo.slug}', name '${repo.name}')`,
         })
@@ -120,7 +123,7 @@ export const createProject = (input: ProjectCreateInput): Result<Project, Valida
     if (seenSlugs.has(repo.slug)) {
       return Result.error(
         new ValidationError({
-          field: 'project.repositories',
+          field: FIELD_PROJECT_REPOSITORIES,
           value: repo.slug,
           message: `duplicate repository slug '${repo.slug}' (id '${repo.id}', name '${repo.name}')`,
         })
@@ -168,7 +171,7 @@ export const removeRepository = (project: Project, id: RepositoryId): Result<Pro
   if (project.repositories.length <= 1) {
     return Result.error(
       new ValidationError({
-        field: 'project.repositories',
+        field: FIELD_PROJECT_REPOSITORIES,
         value: id,
         message: 'project must keep at least one repository — refusing to remove the last one',
       })
@@ -178,7 +181,7 @@ export const removeRepository = (project: Project, id: RepositoryId): Result<Pro
   if (next.length === project.repositories.length) {
     return Result.error(
       new ValidationError({
-        field: 'project.repositories',
+        field: FIELD_PROJECT_REPOSITORIES,
         value: id,
         message: `repository '${id}' not found on project '${project.slug}'`,
       })
@@ -216,7 +219,7 @@ export const updateRepository = (
   if (idx === -1) {
     return Result.error(
       new ValidationError({
-        field: 'project.repositories',
+        field: FIELD_PROJECT_REPOSITORIES,
         value: id,
         message: `repository '${id}' not found on project '${project.slug}'`,
       })
@@ -227,7 +230,7 @@ export const updateRepository = (
   if (target === undefined) {
     return Result.error(
       new ValidationError({
-        field: 'project.repositories',
+        field: FIELD_PROJECT_REPOSITORIES,
         value: id,
         message: `repository '${id}' lookup returned undefined`,
       })

--- a/src/domain/entity/repository.ts
+++ b/src/domain/entity/repository.ts
@@ -10,6 +10,9 @@ import { parsePositiveInt } from '@src/domain/value/parsers/parse-positive-int.t
 import { parseRequiredString } from '@src/domain/value/parsers/parse-required-string.ts';
 import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 
+/** Field tag for `repository.name` validation failures, shared across the name parsers. */
+const FIELD_REPOSITORY_NAME = 'repository.name';
+
 /**
  * One structured per-module verify gate. A monorepo-style repo chains module gates inside a
  * single opaque {@link Repository.verifyScript}, so every verify run pays for every module. A
@@ -232,7 +235,7 @@ export const setRepositoryPath = (repo: Repository, path: AbsolutePath): Reposit
 });
 
 export const setRepositoryName = (repo: Repository, name: string): Result<Repository, ValidationError> => {
-  const parsed = parseRequiredString('repository.name', name);
+  const parsed = parseRequiredString(FIELD_REPOSITORY_NAME, name);
   if (!parsed.ok) return Result.error(parsed.error);
   return Result.ok({ ...repo, name: parsed.value });
 };
@@ -311,7 +314,7 @@ const resolveName = (candidate: string | undefined, path: AbsolutePath): Result<
     if (fallback.length === 0) {
       return Result.error(
         new ValidationError({
-          field: 'repository.name',
+          field: FIELD_REPOSITORY_NAME,
           value: path,
           message: 'could not derive repository name from path',
           hint: 'pass an explicit name',
@@ -320,7 +323,7 @@ const resolveName = (candidate: string | undefined, path: AbsolutePath): Result<
     }
     return Result.ok(fallback);
   }
-  return parseRequiredString('repository.name', candidate);
+  return parseRequiredString(FIELD_REPOSITORY_NAME, candidate);
 };
 
 const resolveSlug = (candidate: Slug | undefined, name: string): Result<Slug, ValidationError> => {

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -34,7 +34,14 @@ const LogLevelSchema = z.enum(['silent', 'debug', 'info', 'warn', 'error']) sati
  */
 export type AiProvider = 'claude-code' | 'github-copilot' | 'openai-codex';
 
-const AiProviderSchema = z.enum(['claude-code', 'github-copilot', 'openai-codex']) satisfies z.ZodType<AiProvider>;
+/** The `claude-code` provider id — reused by the schema enum/literal and the legacy-row migration check. */
+const PROVIDER_CLAUDE_CODE = 'claude-code';
+
+const AiProviderSchema = z.enum([
+  PROVIDER_CLAUDE_CODE,
+  'github-copilot',
+  'openai-codex',
+]) satisfies z.ZodType<AiProvider>;
 
 /**
  * Effort-level vocabularies, per provider. Each row's `effort` value is checked against the
@@ -61,7 +68,7 @@ const CopilotModelSchema = z.union([z.enum(COPILOT_MODELS as readonly [string, .
 const CodexModelSchema = z.union([z.enum(CODEX_MODELS as readonly [string, ...string[]]), CustomModelStringSchema]);
 
 const ClaudeFlowRowSchema = z.object({
-  provider: z.literal('claude-code'),
+  provider: z.literal(PROVIDER_CLAUDE_CODE),
   model: ClaudeModelSchema,
   effort: ClaudeEffortSchema.optional(),
 });
@@ -146,7 +153,7 @@ const SUCCESSOR_CLAUDE_OPUS = 'claude-opus-4-8';
 const migrateRetiredOpusRow = (row: unknown): unknown => {
   if (typeof row !== 'object' || row === null) return row;
   const rowObj = row as Record<string, unknown>;
-  if (rowObj['provider'] === 'claude-code' && rowObj['model'] === RETIRED_CLAUDE_OPUS) {
+  if (rowObj['provider'] === PROVIDER_CLAUDE_CODE && rowObj['model'] === RETIRED_CLAUDE_OPUS) {
     return { ...rowObj, model: SUCCESSOR_CLAUDE_OPUS };
   }
   return row;

--- a/src/domain/value/absolute-path.ts
+++ b/src/domain/value/absolute-path.ts
@@ -7,12 +7,15 @@ export type AbsolutePath = string & { readonly [__absolutePath]: 'AbsolutePath' 
 
 const ENV_VAR_REGEX = /\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*/;
 
+/** `ValidationError.field` value shared by every failure branch of {@link AbsolutePath.parse}. */
+const ABSOLUTE_PATH_FIELD = 'absolute-path';
+
 export const AbsolutePath = {
   parse(input: unknown): Result<AbsolutePath, ValidationError> {
     if (typeof input !== 'string') {
       return Result.error(
         new ValidationError({
-          field: 'absolute-path',
+          field: ABSOLUTE_PATH_FIELD,
           value: input,
           message: 'absolute path must be a string',
         })
@@ -21,7 +24,7 @@ export const AbsolutePath = {
     if (input.trim().length === 0) {
       return Result.error(
         new ValidationError({
-          field: 'absolute-path',
+          field: ABSOLUTE_PATH_FIELD,
           value: input,
           message: 'absolute path must not be empty or whitespace-only',
         })
@@ -30,7 +33,7 @@ export const AbsolutePath = {
     if (input.includes('~')) {
       return Result.error(
         new ValidationError({
-          field: 'absolute-path',
+          field: ABSOLUTE_PATH_FIELD,
           value: input,
           message: 'absolute path must not contain "~"',
           hint: 'expand the home directory before constructing an AbsolutePath',
@@ -40,7 +43,7 @@ export const AbsolutePath = {
     if (ENV_VAR_REGEX.test(input)) {
       return Result.error(
         new ValidationError({
-          field: 'absolute-path',
+          field: ABSOLUTE_PATH_FIELD,
           value: input,
           message: 'absolute path must not contain environment variable references',
           hint: 'expand $VAR / ${VAR} via process.env before constructing an AbsolutePath',
@@ -50,7 +53,7 @@ export const AbsolutePath = {
     if (!isAbsolute(input)) {
       return Result.error(
         new ValidationError({
-          field: 'absolute-path',
+          field: ABSOLUTE_PATH_FIELD,
           value: input,
           message: 'path must be absolute',
           hint: 'use path.resolve() to convert a relative path before construction',

--- a/src/integration/ai/contract/_engine/validate-signals-file.ts
+++ b/src/integration/ai/contract/_engine/validate-signals-file.ts
@@ -11,6 +11,7 @@ import { isNodeErrnoCode } from '@src/integration/io/fs.ts';
 import type { AiOutputContract } from '@src/integration/ai/contract/_engine/types.ts';
 
 const SIGNALS_FILENAME = 'signals.json';
+const SCHEMA_MISMATCH = 'schema-mismatch';
 
 /**
  * Hard ceiling on the signals.json body before we read/parse it. The AI provider writes this file
@@ -59,7 +60,7 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
     if (stats.size > SIGNALS_FILE_MAX_BYTES) {
       return Result.error(
         new ParseError({
-          subCode: 'schema-mismatch',
+          subCode: SCHEMA_MISMATCH,
           message: `signals-invalid (too large) at ${path}: signals.json is ${stats.size} bytes, over the ${SIGNALS_FILE_MAX_BYTES}-byte (4 MB) cap — the AI wrote an implausibly large signals file; treating as malformed`,
           hint: 'The AI wrote a signals.json far larger than any plausible signals body. Inspect the per-spawn directory; the file was not parsed.',
         })
@@ -125,7 +126,7 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
   if (typeof current !== 'object' || current === null) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `signals-invalid (schema) at ${path}: signals.json root is not an object`,
         hint: 'The AI wrote signals.json but its root was not a JSON object (e.g. literal `null` or a string).',
       })
@@ -144,7 +145,7 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
   if (!parsed.success) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `signals-invalid (schema) at ${path}: ${parsed.error.message}`,
         cause: parsed.error,
         hint: 'The AI wrote signals.json but the shape failed the leaf contract. Issue path is in cause.issues.',

--- a/src/integration/ai/prompts/_engine/parse-task-list.ts
+++ b/src/integration/ai/prompts/_engine/parse-task-list.ts
@@ -15,6 +15,8 @@ import type { z } from 'zod';
 
 type ZodIssueLike = z.core.$ZodIssue;
 
+const SCHEMA_MISMATCH = 'schema-mismatch';
+
 /**
  * Shared task-list parser used by interactive flows that produce tasks: ideate (combined
  * refine+plan) and plan-interactive (plan only). Pure — no I/O.
@@ -85,7 +87,7 @@ export const parseTaskList = (
   if (!parsed.success) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `task-list: ${formatZodIssue(parsed.error.issues)}`,
         cause: parsed.error,
       })
@@ -107,7 +109,7 @@ export const parseTaskList = (
       if (idMap.has(t.id)) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `task-list: duplicate task id '${t.id}' at index ${String(i)}`,
           })
         );
@@ -131,7 +133,7 @@ export const parseTaskList = (
     if (repoId === undefined) {
       return Result.error(
         new ParseError({
-          subCode: 'schema-mismatch',
+          subCode: SCHEMA_MISMATCH,
           message: `task-list: tasks[${String(i)}].projectPath '${t.projectPath}' is not in the project's repositories`,
           hint: `available paths: ${Array.from(repoByPath.keys()).join(', ')}`,
         })
@@ -143,7 +145,7 @@ export const parseTaskList = (
       if (resolved === undefined) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `task-list: tasks[${String(i)}].blockedBy references unknown task id '${ref}'`,
           })
         );
@@ -184,7 +186,7 @@ export const parseTaskList = (
     if (!created.ok) {
       return Result.error(
         new ParseError({
-          subCode: 'schema-mismatch',
+          subCode: SCHEMA_MISMATCH,
           message: `task-list: tasks[${String(i)}] failed validation: ${created.error.message}`,
           cause: created.error,
         })
@@ -232,7 +234,7 @@ const scheduleAndFlatten = (tasks: readonly TodoTask[]): Result<ScheduledTasks, 
   if (!scheduled.ok) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `task-list: ${renderTaskGraphIssue(scheduled.error)}`,
       })
     );
@@ -282,7 +284,7 @@ const resolveTicketRef = (
   if (typeof t.ticketRef !== 'string' || t.ticketRef.trim().length === 0) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `task-list: tasks[${String(i)}].ticketRef missing — required when mode='lookup'`,
       })
     );
@@ -292,7 +294,7 @@ const resolveTicketRef = (
   if (match === undefined) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `task-list: tasks[${String(i)}].ticketRef '${ref}' is not an approved ticket on the sprint`,
         hint: `available ticket ids: ${mode.tickets.map((tk) => String(tk.id)).join(', ')}`,
       })
@@ -302,7 +304,7 @@ const resolveTicketRef = (
   if (!parsed.ok) {
     return Result.error(
       new ParseError({
-        subCode: 'schema-mismatch',
+        subCode: SCHEMA_MISMATCH,
         message: `task-list: tasks[${String(i)}].ticketRef '${ref}' is not a valid ticket id format`,
         cause: parsed.error,
       })

--- a/src/integration/ai/prompts/readiness/definition.ts
+++ b/src/integration/ai/prompts/readiness/definition.ts
@@ -52,6 +52,8 @@ export interface ReadinessPromptParams {
   readonly outputContractSection: string;
 }
 
+const CLAUDE_CODE = 'claude-code';
+
 /**
  * Map an {@link AssistantTool} to the XML tag the AI should emit around its proposed body.
  * Each tag matches what the harness will write to disk for that tool — no cross-tool envelope
@@ -59,7 +61,7 @@ export interface ReadinessPromptParams {
  */
 export const wireTagFor = (tool: AssistantTool): string => {
   switch (tool) {
-    case 'claude-code':
+    case CLAUDE_CODE:
       return 'claude-md';
     case 'copilot':
       return 'copilot-instructions';
@@ -77,7 +79,7 @@ export const conventionsPartialName = (
   tool: AssistantTool
 ): 'conventions-claude-md' | 'conventions-copilot-instructions' | 'conventions-agents-md' => {
   switch (tool) {
-    case 'claude-code':
+    case CLAUDE_CODE:
       return 'conventions-claude-md';
     case 'copilot':
       return 'conventions-copilot-instructions';
@@ -195,7 +197,7 @@ export const collectArtefactPaths = (state: ReadinessState): readonly string[] =
   if (!isPresent(state)) return [];
   const a = state.artifacts;
   const paths: string[] = [];
-  if (a.tool === 'claude-code') {
+  if (a.tool === CLAUDE_CODE) {
     if (a.claudeMd !== undefined) paths.push(String(a.claudeMd.path));
     if (a.agentsMd !== undefined) paths.push(String(a.agentsMd.path));
     if (a.settings !== undefined) paths.push(String(a.settings.path));
@@ -204,8 +206,8 @@ export const collectArtefactPaths = (state: ReadinessState): readonly string[] =
     for (const ref of a.skills) paths.push(String(ref.path));
     for (const ref of a.commands) paths.push(String(ref.path));
     for (const ref of a.agents) paths.push(String(ref.path));
-  } else if (a.tool === 'copilot') {
-    if (a.copilotInstructions !== undefined) paths.push(String(a.copilotInstructions.path));
+  } else if (a.tool === 'copilot' && a.copilotInstructions !== undefined) {
+    paths.push(String(a.copilotInstructions.path));
   }
   // Codex artefacts placeholder — see ai/readiness/codex/artifacts.ts. No fields to walk yet.
   return paths;

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -88,6 +88,8 @@ const RATE_LIMIT_RE = /rate.?limit|usage limit reached|\b5-hour limit\b|overload
  */
 const RESUME_STALE_RE = /No conversation found with session ID/i;
 
+const PROVIDER_NAME = 'claude-provider';
+
 const asString = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
 
 /**
@@ -275,7 +277,7 @@ export const buildClaudeArgs = (session: AiSession): Result<readonly string[], I
   if (!isClaudeModel(session.model)) {
     return Result.error(
       new InvalidStateError({
-        entity: 'claude-provider',
+        entity: PROVIDER_NAME,
         currentState: 'model-validation',
         attemptedAction: 'build argv',
         message: `claude-provider: '${session.model}' is not a known Claude model`,
@@ -287,7 +289,7 @@ export const buildClaudeArgs = (session: AiSession): Result<readonly string[], I
   if (isSuspendedModel(session.model)) {
     return Result.error(
       new InvalidStateError({
-        entity: 'claude-provider',
+        entity: PROVIDER_NAME,
         currentState: 'model-suspended',
         attemptedAction: 'build argv',
         message: suspendedModelMessage(session.model),
@@ -329,7 +331,7 @@ export const createClaudeProvider = (deps: ClaudeProviderDeps): HeadlessAiProvid
 
   return createHeadlessProvider({
     providerSlug: 'claude',
-    providerName: 'claude-provider',
+    providerName: PROVIDER_NAME,
     resumeStaleRe: RESUME_STALE_RE,
     rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
@@ -402,7 +404,7 @@ export const createClaudeProvider = (deps: ClaudeProviderDeps): HeadlessAiProvid
                 : {}),
             });
           },
-          providerName: 'claude-provider',
+          providerName: PROVIDER_NAME,
           providerSlug: 'claude',
           eventBus: deps.eventBus,
           ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -98,6 +98,8 @@ import {
  * a port, not an implementation detail of this file.
  */
 
+const PROVIDER_NAME = 'codex-provider';
+
 /**
  * Map our SessionPermissions onto codex's `-s/--sandbox` policy.
  *
@@ -137,7 +139,7 @@ export const buildCodexArgs = (
   if (!isCodexModel(session.model)) {
     return Result.error(
       new InvalidStateError({
-        entity: 'codex-provider',
+        entity: PROVIDER_NAME,
         currentState: 'model-validation',
         attemptedAction: 'build argv',
         message: `codex-provider: '${session.model}' is not a known Codex model`,
@@ -379,7 +381,7 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
 
   return createHeadlessProvider({
     providerSlug: 'codex',
-    providerName: 'codex-provider',
+    providerName: PROVIDER_NAME,
     resumeStaleRe: RESUME_STALE_RE,
     rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
@@ -458,7 +460,7 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
               } catch (err) {
                 return Result.error(
                   new InvalidStateError({
-                    entity: 'codex-provider',
+                    entity: PROVIDER_NAME,
                     currentState: 'output-capture',
                     attemptedAction: 'read tempfile',
                     message: `codex-provider: failed to read output tempfile: ${err instanceof Error ? err.message : String(err)}`,
@@ -477,7 +479,7 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
                 ...(outputTokens !== undefined ? { outputTokens } : {}),
               });
             },
-            providerName: 'codex-provider',
+            providerName: PROVIDER_NAME,
             providerSlug: 'codex',
             eventBus: deps.eventBus,
             ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -93,6 +93,8 @@ const RESUME_STALE_RE = /(session|conversation)[^\n]*not found|no (session|conve
 
 const isFullAuto = (p: SessionPermissions): boolean => p.autoApprove && p.canModifyRepoFiles && p.canRunShell;
 
+const PROVIDER_NAME = 'copilot-provider';
+
 /**
  * Build the argv for one Copilot invocation. Validates `session.model` is a known
  * {@link CopilotModel}; surfaces `InvalidStateError` for unknowns.
@@ -101,7 +103,7 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
   if (!isCopilotModel(session.model)) {
     return Result.error(
       new InvalidStateError({
-        entity: 'copilot-provider',
+        entity: PROVIDER_NAME,
         currentState: 'model-validation',
         attemptedAction: 'build argv',
         message: `copilot-provider: '${session.model}' is not a known Copilot model`,
@@ -113,7 +115,7 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
   if (isSuspendedModel(session.model)) {
     return Result.error(
       new InvalidStateError({
-        entity: 'copilot-provider',
+        entity: PROVIDER_NAME,
         currentState: 'model-suspended',
         attemptedAction: 'build argv',
         message: suspendedModelMessage(session.model),
@@ -173,7 +175,7 @@ export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProv
 
   return createHeadlessProvider({
     providerSlug: 'copilot',
-    providerName: 'copilot-provider',
+    providerName: PROVIDER_NAME,
     resumeStaleRe: RESUME_STALE_RE,
     rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
@@ -282,7 +284,7 @@ export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProv
               ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
             });
           },
-          providerName: 'copilot-provider',
+          providerName: PROVIDER_NAME,
           providerSlug: 'copilot',
           eventBus: deps.eventBus,
           ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),

--- a/src/integration/ai/readiness/_engine/probe-fs.ts
+++ b/src/integration/ai/readiness/_engine/probe-fs.ts
@@ -8,6 +8,8 @@ import { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import { isNodeErrnoCode } from '@src/integration/io/fs.ts';
 import type { ArtifactRef, NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
 
+const FS_PERMISSION = 'fs-permission';
+
 /**
  * Stat a single file and report a typed {@link ArtifactRef} if and only if it exists as a
  * regular file. Missing paths resolve to `undefined` (a normal absence); permission / I/O
@@ -23,7 +25,7 @@ export const probeFile = async (path: string): Promise<Result<ArtifactRef | unde
     if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
     if (isNodeErrnoCode(cause, 'EACCES')) {
       return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
+        new ProbeError({ subCode: FS_PERMISSION, message: `permission denied reading ${path}`, path, cause })
       );
     }
     return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
@@ -93,7 +95,7 @@ export const listDir = async (dir: string): Promise<Result<string[], ProbeError>
     if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok([]);
     if (isNodeErrnoCode(cause, 'EACCES')) {
       return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied listing ${dir}`, path: dir, cause })
+        new ProbeError({ subCode: FS_PERMISSION, message: `permission denied listing ${dir}`, path: dir, cause })
       );
     }
     return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${dir}`, path: dir, cause }));
@@ -114,7 +116,7 @@ export const statSafely = async (path: string): Promise<Result<Stats | undefined
     if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
     if (isNodeErrnoCode(cause, 'EACCES')) {
       return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied stat ${path}`, path, cause })
+        new ProbeError({ subCode: FS_PERMISSION, message: `permission denied stat ${path}`, path, cause })
       );
     }
     return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to stat ${path}`, path, cause }));
@@ -133,7 +135,7 @@ export const readFileSafely = async (path: AbsolutePath): Promise<Result<string 
     if (isNodeErrnoCode(cause, 'ENOENT')) return Result.ok(undefined);
     if (isNodeErrnoCode(cause, 'EACCES')) {
       return Result.error(
-        new ProbeError({ subCode: 'fs-permission', message: `permission denied reading ${path}`, path, cause })
+        new ProbeError({ subCode: FS_PERMISSION, message: `permission denied reading ${path}`, path, cause })
       );
     }
     return Result.error(new ProbeError({ subCode: 'fs-read', message: `failed to read ${path}`, path, cause }));

--- a/src/integration/ai/runs/_engine/run-enumeration.ts
+++ b/src/integration/ai/runs/_engine/run-enumeration.ts
@@ -46,6 +46,8 @@ export const parseRunTimestamp = (runDirName: string): Date | null => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+const DURATION_HINT = 'use a value like 24h, 7d, or 2w';
+
 /**
  * Parse a duration like `7d`, `24h`, `2w`. Suffixes are deliberately restricted to `h` / `d` /
  * `w` — minute granularity isn't useful when forensic dirs live for hours-to-weeks, and `m`
@@ -61,7 +63,7 @@ export const parseDuration = (input: string): Result<number, ValidationError> =>
         field: 'duration',
         value: input,
         message: 'duration must not be empty',
-        hint: 'use a value like 24h, 7d, or 2w',
+        hint: DURATION_HINT,
       })
     );
   }
@@ -72,7 +74,7 @@ export const parseDuration = (input: string): Result<number, ValidationError> =>
         field: 'duration',
         value: input,
         message: `unparsable duration: ${input}`,
-        hint: 'use a value like 24h, 7d, or 2w',
+        hint: DURATION_HINT,
       })
     );
   }
@@ -84,7 +86,7 @@ export const parseDuration = (input: string): Result<number, ValidationError> =>
         field: 'duration',
         value: input,
         message: `duration must be a positive number: ${input}`,
-        hint: 'use a value like 24h, 7d, or 2w',
+        hint: DURATION_HINT,
       })
     );
   }

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -20,51 +20,41 @@ import type { FlowId } from '@src/domain/value/flow-id.ts';
 
 export type { FlowId };
 
+const SKILL_ALIGNMENT = 'ralphctl-alignment';
+const SKILL_ITERATIVE_REVIEW = 'ralphctl-iterative-review';
+const SKILL_ABSTRACTION_FIRST = 'ralphctl-abstraction-first';
+const SKILL_MINIMAL_SCAFFOLDING = 'ralphctl-minimal-scaffolding';
+
 /** Skill ids referenced below — must each exist as `src/ai/skills/bundled/<id>/SKILL.md`. */
 export const FLOW_SKILLS: Record<FlowId, readonly string[]> = {
-  refine: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
-  ],
-  plan: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
-  ],
+  refine: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
+  plan: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
   implement: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
+    SKILL_ALIGNMENT,
+    SKILL_ITERATIVE_REVIEW,
+    SKILL_ABSTRACTION_FIRST,
+    SKILL_MINIMAL_SCAFFOLDING,
     'ralphctl-debugging-and-error-recovery',
     'ralphctl-test-driven-development',
     'ralphctl-code-review-and-quality',
     'ralphctl-surgical-simplicity',
   ],
-  readiness: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
-  ],
+  readiness: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
   ideate: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
+    SKILL_ALIGNMENT,
+    SKILL_ITERATIVE_REVIEW,
+    SKILL_ABSTRACTION_FIRST,
+    SKILL_MINIMAL_SCAFFOLDING,
     'ralphctl-surgical-simplicity',
   ],
   // `createPr` is the camelCase FlowId for the kebab-case orchestration flow `create-pr`.
   // The mapping lives in the registry test (and in the launcher's `aiFlowIdFor`). Skills
   // mirror the rest — same default bundle.
   createPr: [
-    'ralphctl-alignment',
-    'ralphctl-iterative-review',
-    'ralphctl-abstraction-first',
-    'ralphctl-minimal-scaffolding',
+    SKILL_ALIGNMENT,
+    SKILL_ITERATIVE_REVIEW,
+    SKILL_ABSTRACTION_FIRST,
+    SKILL_MINIMAL_SCAFFOLDING,
     'ralphctl-code-review-and-quality',
   ],
 };

--- a/src/integration/io/clipboard.ts
+++ b/src/integration/io/clipboard.ts
@@ -70,6 +70,8 @@ const resolveHelpers = ({ platform, env }: PlatformProbeOptions): readonly Helpe
   return [];
 };
 
+const SPAWN_FAILED = 'spawn-failed';
+
 const runHelper = (spawn: Spawn, helper: HelperCommand, text: string): Promise<Result<void, ClipboardError>> =>
   new Promise((resolve) => {
     let child: ReturnType<Spawn>;
@@ -78,7 +80,7 @@ const runHelper = (spawn: Spawn, helper: HelperCommand, text: string): Promise<R
     } catch (cause) {
       resolve(
         Result.error({
-          code: 'spawn-failed',
+          code: SPAWN_FAILED,
           message: `clipboard helper '${helper.cmd}' could not be spawned: ${String((cause as Error)?.message ?? cause)}`,
         })
       );
@@ -93,7 +95,7 @@ const runHelper = (spawn: Spawn, helper: HelperCommand, text: string): Promise<R
 
     child.on('error', (cause) => {
       // ENOENT lands here when the binary isn't on PATH.
-      const code = (cause as NodeJS.ErrnoException).code === 'ENOENT' ? 'no-helper' : 'spawn-failed';
+      const code = (cause as NodeJS.ErrnoException).code === 'ENOENT' ? 'no-helper' : SPAWN_FAILED;
       settle(Result.error({ code, message: `clipboard helper '${helper.cmd}' failed: ${cause.message}` }));
     });
     child.on('close', (exitCode) => {
@@ -117,7 +119,7 @@ const runHelper = (spawn: Spawn, helper: HelperCommand, text: string): Promise<R
     } catch (cause) {
       settle(
         Result.error({
-          code: 'spawn-failed',
+          code: SPAWN_FAILED,
           message: `clipboard helper '${helper.cmd}' stdin write failed: ${String((cause as Error)?.message ?? cause)}`,
         })
       );

--- a/src/integration/observability/sinks/file-log-sink.ts
+++ b/src/integration/observability/sinks/file-log-sink.ts
@@ -71,6 +71,8 @@ import type { FileLogSink, FileLogSinkDeps } from '@src/integration/observabilit
  */
 const MAX_QUEUE = 10_000;
 
+const CHAIN_LOG_DEGRADED = 'chain-log-degraded';
+
 interface ChainState {
   readonly flowId: string;
   readonly startedAtMs: number;
@@ -128,20 +130,18 @@ export const startFileLogSink = (deps: FileLogSinkDeps): FileLogSink => {
       const next = queue.shift();
       if (next === undefined) continue;
       const result = await deps.appendFile(deps.file, next);
-      if (!result.ok) {
-        // Best-effort write — never take down the chain. But fire the one-shot degradation
-        // marker so the operator knows the on-disk trace is incomplete. The `AppendFile`
-        // adapter retries dir-ensure on the next call, so a tmpfs cleanup mid-run heals
-        // itself on the next queued event.
-        if (!degraded) {
-          degraded = true;
-          deps.bus.publish({
-            type: 'chain-log-degraded',
-            reason: 'write-failed',
-            meta: { error: result.error.message },
-            at: IsoTimestamp.now(),
-          });
-        }
+      // Best-effort write — never take down the chain. But fire the one-shot degradation
+      // marker so the operator knows the on-disk trace is incomplete. The `AppendFile`
+      // adapter retries dir-ensure on the next call, so a tmpfs cleanup mid-run heals
+      // itself on the next queued event.
+      if (!result.ok && !degraded) {
+        degraded = true;
+        deps.bus.publish({
+          type: CHAIN_LOG_DEGRADED,
+          reason: 'write-failed',
+          meta: { error: result.error.message },
+          at: IsoTimestamp.now(),
+        });
       }
     }
     draining = undefined;
@@ -152,7 +152,7 @@ export const startFileLogSink = (deps: FileLogSinkDeps): FileLogSink => {
       if (!degraded) {
         degraded = true;
         deps.bus.publish({
-          type: 'chain-log-degraded',
+          type: CHAIN_LOG_DEGRADED,
           reason: 'queue-full',
           at: IsoTimestamp.now(),
         });
@@ -170,7 +170,7 @@ export const startFileLogSink = (deps: FileLogSinkDeps): FileLogSink => {
     // write failure would publish the marker, which would synchronously land back here and
     // get appended — round-tripping the event we are trying to surface and (worse) putting it
     // on a queue that may itself be in trouble.
-    if (event.type === 'chain-log-degraded') return;
+    if (event.type === CHAIN_LOG_DEGRADED) return;
 
     // Bracket state tracking — header BEFORE the chain-started event line, footer AFTER the
     // terminal event line. The boundary lines start with `=== ` so an NDJSON consumer skips

--- a/src/integration/persistence/data-migration/dry-run.ts
+++ b/src/integration/persistence/data-migration/dry-run.ts
@@ -19,6 +19,8 @@ const PROJECTS_DIR = 'projects';
 const SPRINTS_DIR = 'sprints';
 const MEMORY_DIR = 'memory';
 const SPRINT_JSON = 'sprint.json';
+const REASON_ALREADY_MIGRATED = 'already migrated (slugged name)';
+const REASON_MALFORMED_NAME = 'malformed name — not a uuidv7 id';
 
 /**
  * Mutable accumulators for a single dry-run pass. Returned (frozen) as a {@link DryRunReport}.
@@ -100,11 +102,11 @@ const scanFileFamily = async (
     }
     const base = name.slice(0, -'.json'.length);
     if (base.includes(NAME_SEPARATOR)) {
-      acc.skipped.push({ name, reason: 'already migrated (slugged name)' });
+      acc.skipped.push({ name, reason: REASON_ALREADY_MIGRATED });
       continue;
     }
     if (!isUuidv7(base)) {
-      acc.problems.push({ name, reason: 'malformed name — not a uuidv7 id' });
+      acc.problems.push({ name, reason: REASON_MALFORMED_NAME });
       continue;
     }
     const slug = await readSlug(join(parent, name));
@@ -145,11 +147,11 @@ const scanDirFamily = async (
       continue;
     }
     if (name.includes(NAME_SEPARATOR)) {
-      acc.skipped.push({ name, reason: 'already migrated (slugged name)' });
+      acc.skipped.push({ name, reason: REASON_ALREADY_MIGRATED });
       continue;
     }
     if (!isUuidv7(name)) {
-      acc.problems.push({ name, reason: 'malformed name — not a uuidv7 id' });
+      acc.problems.push({ name, reason: REASON_MALFORMED_NAME });
       continue;
     }
     const slug = await readSlug(full, name);
@@ -193,9 +195,9 @@ const classifyMemoryEntry = async (
   const full = join(parent, name);
   if (!(await isDirectory(full))) return void acc.skipped.push({ name, reason: 'not a directory' });
   if (name.includes(NAME_SEPARATOR)) {
-    return void acc.skipped.push({ name, reason: 'already migrated (slugged name)' });
+    return void acc.skipped.push({ name, reason: REASON_ALREADY_MIGRATED });
   }
-  if (!isUuidv7(name)) return void acc.problems.push({ name, reason: 'malformed name — not a uuidv7 id' });
+  if (!isUuidv7(name)) return void acc.problems.push({ name, reason: REASON_MALFORMED_NAME });
 
   const slug = await readProjectSlugForId(dataRoot, name);
   if (slug === undefined) return void acc.problems.push({ name, reason: 'missing or unreadable slug' });

--- a/src/integration/persistence/settings/json-settings-repository.ts
+++ b/src/integration/persistence/settings/json-settings-repository.ts
@@ -11,6 +11,7 @@ import { applyMigrations, readSchemaVersion } from '@src/business/settings/migra
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 
 const SETTINGS_FILE = 'settings.json';
+const SCHEMA_MISMATCH = 'schema-mismatch';
 
 /**
  * Re-run hint attached to every read-path `ParseError` — the CLI surfaces `.hint` in parentheses
@@ -60,7 +61,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
       if (sourceVersion > CURRENT_SCHEMA_VERSION) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `settings at ${path} are from a newer ralphctl (schemaVersion=${String(sourceVersion)}, expected ${String(CURRENT_SCHEMA_VERSION)}). Upgrade ralphctl.`,
             hint: 'upgrade ralphctl, or fix/delete settings.json to start from defaults',
           })
@@ -73,7 +74,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
       if (outcome.toVersion < CURRENT_SCHEMA_VERSION) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `settings at ${path} cannot be migrated: no chain from v${String(outcome.fromVersion)} to v${String(CURRENT_SCHEMA_VERSION)} (stopped at v${String(outcome.toVersion)}).`,
             hint: REPAIR_HINT,
           })
@@ -84,7 +85,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
       if (!parsed.success) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `settings at ${path} are invalid: ${parsed.error.message}`,
             cause: parsed.error,
             hint: REPAIR_HINT,
@@ -106,7 +107,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
       if (!parsed.success) {
         return Result.error(
           new ParseError({
-            subCode: 'schema-mismatch',
+            subCode: SCHEMA_MISMATCH,
             message: `settings validation failed before save: ${parsed.error.message}`,
             cause: parsed.error,
           })

--- a/src/integration/persistence/sprint-execution/repository.ts
+++ b/src/integration/persistence/sprint-execution/repository.ts
@@ -13,6 +13,9 @@ import { readJson, removeFile, writeJsonAtomic } from '@src/integration/io/fs.ts
 import { resolveSprintDir, sprintsDir } from '@src/integration/persistence/storage.ts';
 import { decode } from '@src/integration/persistence/shared/decode.ts';
 
+const ENTITY = 'sprint-execution';
+const EXECUTION_FILE = 'execution.json';
+
 export interface FsSprintExecutionRepositoryDeps {
   /** Root of the on-disk layout. Each sprint's execution lives at `<root>/sprints/<id>--<slug>/execution.json`. */
   readonly root: AbsolutePath;
@@ -37,32 +40,32 @@ export const createFsSprintExecutionRepository = (deps: FsSprintExecutionReposit
     async findById(id) {
       const dir = await resolveSprintDir(deps.root, id);
       if (dir === undefined) {
-        return Result.error(new NotFoundError({ entity: 'sprint-execution', id: String(id) }));
+        return Result.error(new NotFoundError({ entity: ENTITY, id: String(id) }));
       }
-      const path = join(dir, 'execution.json');
+      const path = join(dir, EXECUTION_FILE);
       const json = await readJson(path);
       if (!json.ok) {
         if (json.error instanceof NotFoundError) {
-          return Result.error(new NotFoundError({ entity: 'sprint-execution', id: String(id) }));
+          return Result.error(new NotFoundError({ entity: ENTITY, id: String(id) }));
         }
         return Result.error(json.error);
       }
-      return decode((input) => fromJsonSprintExecution(input, path), json.value, { entity: 'sprint-execution', path });
+      return decode((input) => fromJsonSprintExecution(input, path), json.value, { entity: ENTITY, path });
     },
 
     async save(execution: SprintExecution) {
-      const path = join(await dirFor(execution.sprintId), 'execution.json');
+      const path = join(await dirFor(execution.sprintId), EXECUTION_FILE);
       return writeJsonAtomic(path, toJsonSprintExecution(execution));
     },
 
     async remove(id) {
       const dir = await resolveSprintDir(deps.root, id);
       if (dir === undefined) {
-        return Result.error(new NotFoundError({ entity: 'sprint-execution', id: String(id) }));
+        return Result.error(new NotFoundError({ entity: ENTITY, id: String(id) }));
       }
-      const result = await removeFile(join(dir, 'execution.json'));
+      const result = await removeFile(join(dir, EXECUTION_FILE));
       if (!result.ok && result.error instanceof NotFoundError) {
-        return Result.error(new NotFoundError({ entity: 'sprint-execution', id: String(id) }));
+        return Result.error(new NotFoundError({ entity: ENTITY, id: String(id) }));
       }
       return result;
     },

--- a/src/integration/scm/issue-fetcher.ts
+++ b/src/integration/scm/issue-fetcher.ts
@@ -21,6 +21,7 @@ import type { Spawn } from '@src/integration/io/spawn.ts';
 
 const CLI_TIMEOUT_MS = 30_000;
 const MAX_COMMENTS = 20;
+const UNKNOWN_ERROR = 'unknown error';
 
 interface ParsedUrl {
   readonly host: 'github' | 'gitlab';
@@ -187,7 +188,7 @@ const fetchGitHub = async (
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `gh issue view failed: ${result.value.stderr.trim() || 'unknown error'}`,
+        message: `gh issue view failed: ${result.value.stderr.trim() || UNKNOWN_ERROR}`,
       })
     );
   }
@@ -246,7 +247,7 @@ const fetchGitLabNotes = async (
   if (result.value.exitCode !== 0) {
     return {
       comments: [],
-      failure: `glab issue note list exited ${String(result.value.exitCode)}: ${result.value.stderr.trim() || 'unknown error'}`,
+      failure: `glab issue note list exited ${String(result.value.exitCode)}: ${result.value.stderr.trim() || UNKNOWN_ERROR}`,
     };
   }
   let notes: readonly GlabNote[];
@@ -289,7 +290,7 @@ const fetchGitLab = async (
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `glab issue view failed: ${result.value.stderr.trim() || 'unknown error'}`,
+        message: `glab issue view failed: ${result.value.stderr.trim() || UNKNOWN_ERROR}`,
       })
     );
   }

--- a/src/integration/system/detect-cli.ts
+++ b/src/integration/system/detect-cli.ts
@@ -25,6 +25,10 @@ export const PROVIDER_BINARY: Readonly<Record<AiProvider, string>> = {
   'openai-codex': 'codex',
 };
 
+const NPM_INSTALL_CLAUDE = 'npm install -g @anthropic-ai/claude-code';
+const NPM_INSTALL_COPILOT = 'npm install -g @github/copilot';
+const NPM_INSTALL_CODEX = 'npm install -g @openai/codex';
+
 /**
  * Per-vendor install guidance entries. Sources (verified against vendor docs at the time of
  * writing):
@@ -41,39 +45,27 @@ export const PROVIDER_INSTALL_GUIDANCE: Readonly<Record<AiProvider, ProviderInst
   'claude-code': {
     docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup',
     commandsByPlatform: {
-      darwin: [
-        'brew install --cask claude-code',
-        'curl -fsSL https://claude.ai/install.sh | bash',
-        'npm install -g @anthropic-ai/claude-code',
-      ],
-      linux: ['curl -fsSL https://claude.ai/install.sh | bash', 'npm install -g @anthropic-ai/claude-code'],
-      win32: [
-        'winget install Anthropic.ClaudeCode',
-        'irm https://claude.ai/install.ps1 | iex',
-        'npm install -g @anthropic-ai/claude-code',
-      ],
+      darwin: ['brew install --cask claude-code', 'curl -fsSL https://claude.ai/install.sh | bash', NPM_INSTALL_CLAUDE],
+      linux: ['curl -fsSL https://claude.ai/install.sh | bash', NPM_INSTALL_CLAUDE],
+      win32: ['winget install Anthropic.ClaudeCode', 'irm https://claude.ai/install.ps1 | iex', NPM_INSTALL_CLAUDE],
     },
   },
   'github-copilot': {
     docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
     commandsByPlatform: {
-      darwin: ['brew install copilot-cli', 'npm install -g @github/copilot'],
-      linux: ['npm install -g @github/copilot', 'brew install copilot-cli'],
-      win32: ['winget install GitHub.Copilot', 'npm install -g @github/copilot'],
+      darwin: ['brew install copilot-cli', NPM_INSTALL_COPILOT],
+      linux: [NPM_INSTALL_COPILOT, 'brew install copilot-cli'],
+      win32: ['winget install GitHub.Copilot', NPM_INSTALL_COPILOT],
     },
   },
   'openai-codex': {
     docsUrl: 'https://github.com/openai/codex',
     commandsByPlatform: {
-      darwin: [
-        'brew install --cask codex',
-        'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
-        'npm install -g @openai/codex',
-      ],
-      linux: ['curl -fsSL https://chatgpt.com/codex/install.sh | sh', 'npm install -g @openai/codex'],
+      darwin: ['brew install --cask codex', 'curl -fsSL https://chatgpt.com/codex/install.sh | sh', NPM_INSTALL_CODEX],
+      linux: ['curl -fsSL https://chatgpt.com/codex/install.sh | sh', NPM_INSTALL_CODEX],
       win32: [
         'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
-        'npm install -g @openai/codex',
+        NPM_INSTALL_CODEX,
       ],
     },
   },


### PR DESCRIPTION
## Summary

Safe mechanical pass at the lint warning ratchet. The `lint` script (`eslint . --max-warnings N`) is pinned to the exact warning count; this clears the low-risk bucket and lowers the cap **342 → 254**.

Cleared all 88 low-risk warnings across 56 files:
- **81** `sonarjs/no-duplicate-string` → repeated literals extracted to named constants
- **4** `sonarjs/no-collapsible-if` → merged into `if (a && b)`
- **3** `sonarjs/prefer-immediate-return` → inlined

No behavior change — pure constant extraction / control-flow tidy-ups.

The `presets.ts` / `defaults.ts` model-ID constants preserve the load-bearing dash-vs-dot spelling (`claude-opus-4-8` for claude-code vs `claude-opus-4.8` for github-copilot).

## Out of scope

The remaining **254** warnings are all real-refactoring work — `max-lines-per-function` (122), `complexity` (66), `sonarjs/cognitive-complexity` (63), `max-lines` (2), `react-hooks/exhaustive-deps` (1) — deferred to a future pass.

## Verification

typecheck clean · `eslint` 254 warnings / 0 errors · prettier clean · 4256 tests passed