### PR TITLE
feat(models): add Claude Sonnet 5 and make it the default Sonnet

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -65,19 +65,30 @@ every `ai` row plus `harness.escalateOnPlateau` in one transaction; subsequent p
 
 **Model catalog versions used by the presets** (verified against the tool versions noted per row):
 
-- Claude Code — `claude-haiku-4-5` / `claude-sonnet-4-6` / `claude-opus-4-8` (verified against Claude
-  Code v2.1.169). The catalog additionally lists the frontier tier `claude-fable-5` plus the 1M-context
-  variants `claude-opus-4-8[1m]` and `claude-fable-5[1m]` (the `[1m]` suffix is Claude Code's
-  long-context syntax, passed through verbatim — on large repos the 1M window avoids mid-session
-  compaction during deep implement runs) as **opt-in only** — no preset, default, or built-in
-  escalation rung references them; pick per row or add an `'claude-opus-4-8': 'claude-fable-5'` rung
-  via `settings.harness.escalationMap`. **Temporarily suspended (2026-06-12 Anthropic export-control
-  directive):** the `claude-fable-5` family stays in the catalog but is currently rejected at launch
-  with a clear message and flagged `(suspended)` in the pickers; it will be restored when access
-  returns (single-list revert in `settings-models/suspended-models.ts`).
-- GitHub Copilot — adds `gpt-5.5`, `claude-opus-4.7`, `claude-opus-4.8`, the Gemini family
-  (`gemini-2.5-pro`, `gemini-3-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`),
-  plus `mai-code-1-flash`, `raptor-mini-preview` (verified against Copilot CLI v1.0.60).
+- Claude Code — `claude-haiku-4-5` / `claude-sonnet-4-6` / `claude-sonnet-5` / `claude-opus-4-8`
+  (verified against Claude Code v2.1.197; `claude-sonnet-5` requires v2.1.197+). `claude-sonnet-5` is
+  the Sonnet-5 successor to Sonnet 4.6 and the **default Sonnet** across presets, the new-install
+  defaults, and the escalation ladder; `claude-sonnet-4-6` is kept alongside it (both Active at
+  Anthropic) so pinned 4.6 configs keep working. Sonnet 5 has **no `[1m]` variant** — on the Anthropic
+  API it always runs at its native 1M window in Claude Code, so the 1M figure is recorded against the
+  bare id in the context-window tables (the only base id, not a `[1m]` variant, to carry 1M). The
+  catalog additionally lists the frontier tier `claude-fable-5` plus the 1M-context variants
+  `claude-opus-4-8[1m]` and `claude-fable-5[1m]` (the `[1m]` suffix is Claude Code's long-context
+  syntax for models whose Claude-Code default is 200K, passed through verbatim — on large repos the 1M
+  window avoids mid-session compaction during deep implement runs) as **opt-in only** — no preset,
+  default, or built-in escalation rung references them; pick per row or add an
+  `'claude-opus-4-8': 'claude-fable-5'` rung via `settings.harness.escalationMap`. **Temporarily
+  suspended (2026-06-12 Anthropic export-control directive):** the `claude-fable-5` family stays in the
+  catalog but is currently rejected at launch with a clear message and flagged `(suspended)` in the
+  pickers; it will be restored when access returns (single-list revert in
+  `settings-models/suspended-models.ts`).
+- GitHub Copilot — adds `gpt-5.5`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-sonnet-5`, the Gemini
+  family (`gemini-2.5-pro`, `gemini-3-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`),
+  plus `mai-code-1-flash`, `raptor-mini-preview` (Copilot reconciled to GitHub's supported-models doc
+  as of 2026-06-30; Sonnet 5 went GA for Copilot that day). Note: Sonnet 5's Copilot slug carries no
+  dot/date, so it is the SAME string (`claude-sonnet-5`) as the Claude-Code id — the escalation map
+  has one value per key, so the dash-form (Claude-Code) rung `claude-sonnet-5 → claude-opus-4-8` wins
+  it and Copilot's curated presets stay on `claude-sonnet-4.6` (see `escalation-map.ts`).
 - OpenAI Codex — adds `gpt-5.3-codex-spark` (text-only research preview, ChatGPT Pro only);
   `gpt-5.2` and `gpt-5.3-codex` are deprecated for ChatGPT sign-in but kept in the allowlist because
   they remain available via API-key auth. `gpt-5.5` is the frontier default — the model `codex-only`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,22 @@ to [Semantic Versioning](https://semver.org/).
   explicit checkpoint before producing its verdict, improving grading consistency and reducing
   ungrounded pass/fail decisions.
 
+- **Claude Sonnet 5 in the model catalog.** `claude-sonnet-5` is now selectable for the
+  `claude-code` provider (and `claude-sonnet-5` for `github-copilot`, where it went GA on
+  2026-06-30). It is recorded with a 1M context window: unlike Opus/Fable, Sonnet 5 has no `[1m]`
+  long-context variant because on the Anthropic API it always runs at its native 1M window in Claude
+  Code. Selecting `claude-sonnet-5` requires Claude Code v2.1.197+. Sonnet 4.6 (`claude-sonnet-4-6` /
+  `claude-sonnet-4.6`) stays in the catalog, so configs pinned to it keep working.
+
 ### Changed
+
+- **Sonnet 5 is now the default Sonnet for Claude Code.** New-install defaults (`refine` / `readiness`
+  / `createPr`), every preset's Claude-Code Sonnet row, and the escalation ladder
+  (`claude-haiku-4-5 → claude-sonnet-5 → claude-opus-4-8`) now use `claude-sonnet-5` instead of
+  `claude-sonnet-4-6`. The legacy `claude-sonnet-4-6 → claude-opus-4-8` escalation rung is retained so
+  pinned 4.6 configs still climb. Copilot's curated presets stay on `claude-sonnet-4.6`: Sonnet 5's
+  Copilot slug is the same string as the Claude-Code id, and the flat escalation map can hold only one
+  target per key, so the Claude-Code rung wins it.
 
 - **Lint warning ceiling added.** The `lint` script is now `eslint . --max-warnings 342`, capping
   the accepted warning count at the baseline observed after the provider-engine refactor. Any future

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -7,8 +7,9 @@ import {
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 
 // Model identifiers referenced more than once below, hoisted to named constants so each literal
-// appears once. The dash spelling (`claude-…-4-6`) is the claude-code catalog form.
-const CLAUDE_SONNET = 'claude-sonnet-4-6';
+// appears once. The dash spelling (`claude-sonnet-5`, `claude-opus-4-8`) is the claude-code
+// catalog form. Sonnet 5 is the default Sonnet for Claude Code.
+const CLAUDE_SONNET = 'claude-sonnet-5';
 const CLAUDE_OPUS = 'claude-opus-4-8';
 const GPT_5_MINI = 'gpt-5-mini';
 const GPT_5_4_MINI = 'gpt-5.4-mini';

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -71,13 +71,15 @@ export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as
 
 // Provider and model identifiers referenced across the preset matrices below, hoisted so each
 // literal appears once. The dash vs dot spelling is provider-specific and load-bearing:
-// claude-code uses `claude-…-4-8` (dashes → OPUS / SONNET / HAIKU) while github-copilot uses
-// `claude-…-4.8` (dots → COPILOT_OPUS / COPILOT_SONNET). Do not normalise one into the other.
+// claude-code uses the dash form (`claude-opus-4-8`, `claude-sonnet-5` → OPUS / SONNET / HAIKU)
+// while github-copilot uses the dotted form (`claude-…-4.8` → COPILOT_OPUS / COPILOT_SONNET). Do
+// not normalise one into the other. Sonnet 5 is the default Sonnet for Claude Code; Copilot's
+// curated presets stay on Sonnet 4.6 (its slug collides with the Claude-Code id — see escalation-map).
 const CLAUDE = 'claude-code';
 const COPILOT = 'github-copilot';
 const CODEX = 'openai-codex';
 const OPUS = 'claude-opus-4-8';
-const SONNET = 'claude-sonnet-4-6';
+const SONNET = 'claude-sonnet-5';
 const HAIKU = 'claude-haiku-4-5';
 const COPILOT_OPUS = 'claude-opus-4.8';
 const COPILOT_SONNET = 'claude-sonnet-4.6';

--- a/src/business/task/escalation-map.ts
+++ b/src/business/task/escalation-map.ts
@@ -29,12 +29,22 @@ import type { Logger } from '@src/business/observability/logger.ts';
  * Dash-form ids (`claude-haiku-4-5`) are the Claude-Code / Codex catalog ids; dot-form ids
  * (`claude-haiku-4.5`) are the Copilot catalog ids — both forms are seeded and kept in
  * lockstep with `domain/value/settings-models/`.
+ *
+ * Sonnet 5 is the default Sonnet for the dash-form (Claude-Code) ladder: Haiku climbs to
+ * `claude-sonnet-5`, which climbs to `claude-opus-4-8`. The legacy `claude-sonnet-4-6` rung is
+ * RETAINED so configs explicitly pinned to Sonnet 4.6 still climb to Opus. The Copilot dot-form
+ * ladder deliberately stays on `claude-sonnet-4.6`: Sonnet 5's slug carries no dot/date, so its
+ * Copilot id is the SAME string (`claude-sonnet-5`) as the Claude-Code id — a flat map has one
+ * value per key, and the dash form (the primary provider) wins it pointing at `claude-opus-4-8`.
+ * A Copilot row pinned to `claude-sonnet-5` therefore has no dot-form Opus rung; that edge is
+ * accepted rather than mis-routing the Claude-Code climb to a dot-form Opus id Claude Code rejects.
  */
 export const DEFAULT_ESCALATION_MAP: Readonly<Record<string, string>> = {
-  // Claude (Claude-Code / Codex dash-form) — Haiku → Sonnet → Opus.
-  'claude-haiku-4-5': 'claude-sonnet-4-6',
+  // Claude (Claude-Code / Codex dash-form) — Haiku → Sonnet 5 → Opus; Sonnet 4.6 still climbs.
+  'claude-haiku-4-5': 'claude-sonnet-5',
+  'claude-sonnet-5': 'claude-opus-4-8',
   'claude-sonnet-4-6': 'claude-opus-4-8',
-  // Claude (Copilot dot-form) — Haiku → Sonnet → Opus.
+  // Claude (Copilot dot-form) — Haiku → Sonnet 4.6 → Opus (Sonnet 5 shares the dash-form key above).
   'claude-haiku-4.5': 'claude-sonnet-4.6',
   'claude-sonnet-4.6': 'claude-opus-4.8',
   // Copilot/Codex GPT — mini variants step up to their full-tier frontier, and the

--- a/src/domain/value/settings-models/claude.ts
+++ b/src/domain/value/settings-models/claude.ts
@@ -16,10 +16,19 @@
  * entries are deliberate opt-in only: none is referenced by presets, defaults, or the built-in
  * escalation ladder — pick one per row, or extend `settings.harness.escalationMap` with a rung
  * such as `'claude-opus-4-8': 'claude-fable-5'`.
+ *
+ * `claude-sonnet-5` is the Sonnet-5 successor to Sonnet 4.6 and the default Sonnet across
+ * presets / defaults / the escalation ladder; `claude-sonnet-4-6` is KEPT alongside it (both
+ * remain Active at Anthropic) so configs pinned to 4.6 keep working. Sonnet 5 has NO `[1m]`
+ * variant — on the Anthropic API it always runs at its native 1M window in Claude Code (there is
+ * no 200K default to opt out of), unlike Opus/Fable whose Claude-Code default is 200K and whose
+ * `[1m]` suffix is the real 1M selector. The 1M figure is recorded in the context-window tables
+ * against the bare id, not via a suffix.
  */
 export type ClaudeModel =
   | 'claude-haiku-4-5'
   | 'claude-sonnet-4-6'
+  | 'claude-sonnet-5'
   | 'claude-opus-4-8'
   | 'claude-opus-4-8[1m]'
   | 'claude-fable-5'
@@ -28,6 +37,7 @@ export type ClaudeModel =
 export const CLAUDE_MODELS: readonly ClaudeModel[] = [
   'claude-haiku-4-5',
   'claude-sonnet-4-6',
+  'claude-sonnet-5',
   'claude-opus-4-8',
   'claude-opus-4-8[1m]',
   'claude-fable-5',

--- a/src/domain/value/settings-models/context-window.ts
+++ b/src/domain/value/settings-models/context-window.ts
@@ -19,7 +19,10 @@
  *
  *  - **Claude (Anthropic)** — 200 000 for the 4.x line (Haiku 4.5 / Sonnet 4.6 / Opus 4.8).
  *    The `[1m]` suffix IS Claude Code's 1M-token long-context selector — the figure comes from
- *    the id itself, not a model card.
+ *    the id itself, not a model card. Sonnet 5 (`claude-sonnet-5`) is the exception: it has NO
+ *    `[1m]` variant because on the Anthropic API it ALWAYS runs at its native 1 000 000 window in
+ *    Claude Code — so the 1M figure is keyed on the bare id, the first base id (not a `[1m]`
+ *    selector) to carry a 1M window here.
  *  - **Copilot / Codex** — omitted; the CLIs do not surface per-model window sizes.
  *
  * Pure domain — no `node:*` I/O.
@@ -30,6 +33,9 @@ const CONTEXT_WINDOW: Readonly<Record<string, number>> = {
   'claude-haiku-4-5': 200_000,
   'claude-sonnet-4-6': 200_000,
   'claude-opus-4-8': 200_000,
+  // Sonnet 5 always runs at its native 1M window on the Anthropic API — no `[1m]` selector, so
+  // the bare id carries the 1M figure directly.
+  'claude-sonnet-5': 1_000_000,
   // `[1m]` is Claude Code's 1M-token long-context selector — the window IS the id suffix.
   'claude-opus-4-8[1m]': 1_000_000,
   'claude-fable-5[1m]': 1_000_000,

--- a/src/domain/value/settings-models/copilot.ts
+++ b/src/domain/value/settings-models/copilot.ts
@@ -1,4 +1,4 @@
-// Reconciled to GitHub's official supported-models doc (as of 2026-06-10).
+// Reconciled to GitHub's official supported-models doc (as of 2026-06-30).
 // Docs: https://docs.github.com/en/copilot/reference/ai-models/supported-models
 
 /**
@@ -7,8 +7,12 @@
  * adapter validates `AiSession.model` against this set and surfaces `InvalidStateError` for
  * unknowns. The default model is Claude Sonnet 4.5 (`claude-sonnet-4.5`).
  *
- * This catalog is reconciled to GitHub's official supported-models doc (as of 2026-06-10):
+ * This catalog is reconciled to GitHub's official supported-models doc (as of 2026-06-30):
  * https://docs.github.com/en/copilot/reference/ai-models/supported-models
+ *
+ * Anthropic's Claude Sonnet 5 (`claude-sonnet-5`) went GA for GitHub Copilot on 2026-06-30 and is
+ * listed here; its slug carries no dot/date, so the Copilot dotted-lowercase form is identical to
+ * the Claude-Code dash form (`claude-sonnet-5`) — see `escalation-map.ts` for the consequence.
  *
  * The Copilot CLI cannot enumerate its model catalog non-interactively (github/copilot-cli
  * issue #700), so the slugs below are mapped from the doc's display names through the
@@ -37,6 +41,7 @@ export type CopilotModel =
   | 'claude-fable-5'
   | 'claude-sonnet-4.5'
   | 'claude-sonnet-4.6'
+  | 'claude-sonnet-5'
   // Google
   | 'gemini-2.5-pro'
   | 'gemini-3-flash'
@@ -65,6 +70,7 @@ export const COPILOT_MODELS: readonly CopilotModel[] = [
   'claude-fable-5',
   'claude-sonnet-4.5',
   'claude-sonnet-4.6',
+  'claude-sonnet-5',
   // Google
   'gemini-2.5-pro',
   'gemini-3-flash',

--- a/src/integration/ai/providers/_engine/context-window.ts
+++ b/src/integration/ai/providers/_engine/context-window.ts
@@ -11,7 +11,9 @@
  *  - **Claude (Anthropic)** — the public model cards on https://www.anthropic.com/news
  *    list 200 000 tokens for the 4.x line (Haiku 4.5 / Sonnet 4.6 / Opus 4.8). The `[1m]`
  *    variants are 1 000 000 by definition — the suffix IS Claude Code's selector for the
- *    1M-token window, so the figure comes from the id itself, not a model card. The BASE
+ *    1M-token window, so the figure comes from the id itself, not a model card. Sonnet 5
+ *    (`claude-sonnet-5`) is the exception: it has NO `[1m]` variant and always runs at its
+ *    native 1 000 000 window on the Anthropic API, so the bare id carries 1M directly. The BASE
  *    fable-5 id has no published window figure yet — omitted, so the TUI renders raw counts
  *    until Anthropic documents it.
  *  - **Copilot** — model windows vary by upstream; the Copilot CLI does not surface the
@@ -29,6 +31,8 @@ const CONTEXT_WINDOW: Readonly<Record<string, number>> = {
   'claude-haiku-4-5': 200_000,
   'claude-sonnet-4-6': 200_000,
   'claude-opus-4-8': 200_000,
+  // Sonnet 5 has no `[1m]` variant — it always runs at its native 1M window on the Anthropic API.
+  'claude-sonnet-5': 1_000_000,
   // `[1m]` is Claude Code's 1M-token long-context selector — the window is part of the id.
   'claude-opus-4-8[1m]': 1_000_000,
   'claude-fable-5[1m]': 1_000_000,

--- a/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
+++ b/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
@@ -77,14 +77,14 @@ describe('effectiveEscalationChains', () => {
   it('renders the built-in haiku→sonnet→opus chain uncustomised with no overrides', () => {
     const chains = effectiveEscalationChains({});
     const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
-    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8']);
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-4-8']);
     expect(claude?.customised).toBe(false);
   });
 
   it('extends a chain through a user rung and marks it customised', () => {
     const chains = effectiveEscalationChains({ 'claude-opus-4-8': 'claude-fable-5' });
     const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
-    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-fable-5']);
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-4-8', 'claude-fable-5']);
     expect(claude?.customised).toBe(true);
   });
 

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -342,13 +342,13 @@ describe('presets', () => {
 
       it('stamps the exact model + effort matrix', () => {
         expect(out.ai.effort).toBe('high');
-        expect(out.ai.refine.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.refine.model).toBe('claude-sonnet-5');
         expect(out.ai.refine.effort).toBeUndefined();
         expect(out.ai.plan.model).toBe('claude-opus-4-8');
         expect(out.ai.plan.effort).toBe('xhigh');
         expect(out.ai.readiness.model).toBe('claude-haiku-4-5');
         expect(out.ai.readiness.effort).toBe('medium');
-        expect(out.ai.ideate.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.ideate.model).toBe('claude-sonnet-5');
         expect(out.ai.ideate.effort).toBeUndefined();
         expect(out.ai.createPr.model).toBe('claude-haiku-4-5');
       });
@@ -356,7 +356,7 @@ describe('presets', () => {
       it('splits a cheap sonnet generator against a strong opus evaluator (same provider, different model)', () => {
         // The novel property no other family has: generator weaker than evaluator.
         expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
-        expect(out.ai.implement.generator.model).toBe('claude-sonnet-4-6');
+        expect(out.ai.implement.generator.model).toBe('claude-sonnet-5');
         expect(out.ai.implement.evaluator.model).toBe('claude-opus-4-8');
         expect(out.ai.implement.generator.model).not.toBe(out.ai.implement.evaluator.model);
         expect(out.ai.implement.generator.effort).toBe('high');

--- a/tests/unit/business/task/escalation-map.test.ts
+++ b/tests/unit/business/task/escalation-map.test.ts
@@ -50,8 +50,12 @@ describe('DEFAULT_ESCALATION_MAP', () => {
     expect(DEFAULT_ESCALATION_MAP['claude-sonnet-4.6']).toBe('claude-opus-4.8');
   });
 
-  it('keeps the dash-form Claude-Code/Codex Claude rungs (haiku → sonnet → opus)', () => {
-    expect(DEFAULT_ESCALATION_MAP['claude-haiku-4-5']).toBe('claude-sonnet-4-6');
+  it('climbs the dash-form Claude-Code/Codex ladder via Sonnet 5 (haiku → sonnet-5 → opus)', () => {
+    expect(DEFAULT_ESCALATION_MAP['claude-haiku-4-5']).toBe('claude-sonnet-5');
+    expect(DEFAULT_ESCALATION_MAP['claude-sonnet-5']).toBe('claude-opus-4-8');
+  });
+
+  it('retains the legacy claude-sonnet-4-6 → claude-opus-4-8 rung so pinned 4.6 configs still climb', () => {
     expect(DEFAULT_ESCALATION_MAP['claude-sonnet-4-6']).toBe('claude-opus-4-8');
   });
 });
@@ -176,9 +180,9 @@ describe('DEFAULT_ESCALATION_MAP — catalog lockstep (mechanizes the section 14
       .slice(0, 16);
 
   it('catalog fingerprints are unchanged — a failure means a model bump landed; run the model-bump audit', () => {
-    expect(fingerprint(CLAUDE_MODELS)).toBe('327427f07bd02409');
+    expect(fingerprint(CLAUDE_MODELS)).toBe('f49667dc324c37cc');
     expect(fingerprint(CODEX_MODELS)).toBe('d0af18882f9e15ac');
-    expect(fingerprint(COPILOT_MODELS)).toBe('d8e91df17f49d2a8');
+    expect(fingerprint(COPILOT_MODELS)).toBe('1f51a63b2cbf93f0');
   });
 });
 

--- a/tests/unit/business/task/escalation-policy.test.ts
+++ b/tests/unit/business/task/escalation-policy.test.ts
@@ -65,8 +65,8 @@ describe('decideEscalation', () => {
     if (decision.kind === 'escalate') expect(decision.to).toBe('custom-frontier-model');
   });
 
-  it('climbs the ladder one rung per plateau: haiku → sonnet → opus across successive plateaus', () => {
-    // Rung 1: fresh task on haiku plateaus → escalate to sonnet.
+  it('climbs the ladder one rung per plateau: haiku → sonnet-5 → opus across successive plateaus', () => {
+    // Rung 1: fresh task on haiku plateaus → escalate to the default Sonnet (Sonnet 5).
     const fresh = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const d1 = decideEscalation({
       task: fresh,
@@ -76,20 +76,20 @@ describe('decideEscalation', () => {
       fallbackMaxAttempts: 3,
     });
     expect(d1.kind).toBe('escalate');
-    if (d1.kind === 'escalate') expect(d1.to).toBe('claude-sonnet-4-6');
+    if (d1.kind === 'escalate') expect(d1.to).toBe('claude-sonnet-5');
 
     // Rung 2: task already escalated to sonnet, now running on sonnet, plateaus → escalate to opus.
-    const onSonnet = withEscalation(fresh, 'claude-haiku-4-5', 'claude-sonnet-4-6');
+    const onSonnet = withEscalation(fresh, 'claude-haiku-4-5', 'claude-sonnet-5');
     const d2 = decideEscalation({
       task: onSonnet,
-      generatorModel: 'claude-sonnet-4-6',
+      generatorModel: 'claude-sonnet-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
     });
     expect(d2.kind).toBe('escalate');
     if (d2.kind === 'escalate') {
-      expect(d2.from).toBe('claude-sonnet-4-6');
+      expect(d2.from).toBe('claude-sonnet-5');
       expect(d2.to).toBe('claude-opus-4-8');
     }
 

--- a/tests/unit/domain/value/settings-models.test.ts
+++ b/tests/unit/domain/value/settings-models.test.ts
@@ -51,6 +51,7 @@ describe('settings-models / copilot catalog', () => {
     'claude-fable-5',
     'claude-sonnet-4.5',
     'claude-sonnet-4.6',
+    'claude-sonnet-5',
     // Google
     'gemini-2.5-pro',
     'gemini-3-flash',

--- a/tests/unit/domain/value/settings-models/context-window.test.ts
+++ b/tests/unit/domain/value/settings-models/context-window.test.ts
@@ -19,6 +19,12 @@ describe('contextWindowFor', () => {
     expect(contextWindowFor('claude-fable-5[1m]')).toBe(1_000_000);
   });
 
+  it('returns 1_000_000 for the bare claude-sonnet-5 id (native 1M, no [1m] selector)', () => {
+    // Sonnet 5 always runs at its native 1M window on the Anthropic API — the only base id (not a
+    // `[1m]` variant) that carries a 1M window.
+    expect(contextWindowFor('claude-sonnet-5')).toBe(1_000_000);
+  });
+
   it('returns undefined for models whose window size is not published', () => {
     // Copilot / Codex ids — omitted by scope discipline.
     expect(contextWindowFor('gpt-5.5')).toBeUndefined();
@@ -45,6 +51,7 @@ describe('contextWindowLabel', () => {
   it('formats 1M models as "1M" (not "1000k")', () => {
     expect(contextWindowLabel('claude-opus-4-8[1m]')).toBe('1M');
     expect(contextWindowLabel('claude-fable-5[1m]')).toBe('1M');
+    expect(contextWindowLabel('claude-sonnet-5')).toBe('1M');
   });
 
   it('returns undefined for models with no published window size', () => {


### PR DESCRIPTION
## Summary

Adds **Claude Sonnet 5** (`claude-sonnet-5`) to the model catalog and makes it the default Sonnet for the `claude-code` provider.

- **Catalog:** `claude-sonnet-5` added for `claude-code` + `github-copilot`. Recorded with a native **1M context window** and *no* `[1m]` variant — on the Anthropic API Sonnet 5 always runs at 1M in Claude Code (unlike Opus/Fable, which default to 200K and need `[1m]`). Sonnet 4.6 stays in the catalog so pinned configs keep working.
- **Defaults / presets / escalation:** new-install defaults (`refine` / `readiness` / `createPr`), every preset's Claude-Code Sonnet row, and the ladder (`claude-haiku-4-5 → claude-sonnet-5 → claude-opus-4-8`) now use `claude-sonnet-5`. The legacy `claude-sonnet-4-6 → claude-opus-4-8` rung is retained.
- **Dash/dot slug collision:** a whole-number "Sonnet 5" renders to the same string (`claude-sonnet-5`) in both the dash (Claude-Code) and dot (Copilot) conventions. The flat escalation map holds one target per key, so the Claude-Code rung wins it; Copilot's curated presets stay on `claude-sonnet-4.6`.

## Rebase note — magic-strings resolution

`feature/models` was authored before the lint pass on `main` (#236) hoisted the model-id literals in `defaults.ts` / `presets.ts` into named constants (`CLAUDE_SONNET`, `SONNET`, …). Rebasing onto current `main` conflicted on exactly those two files. Resolved by **keeping main's extracted constants** and flipping the claude-code Sonnet constant value (`CLAUDE_SONNET` / `SONNET`) from `claude-sonnet-4-6` → `claude-sonnet-5` — every claude-code Sonnet preset now resolves to Sonnet 5, while Copilot's dot-form `COPILOT_SONNET = 'claude-sonnet-4.6'` is untouched. Comments updated to match.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓ (254 warnings, at the cap, 0 errors)
- `pnpm test` ✓ (4260 tests passing) — includes the escalation-map fingerprint test and preset/context-window suites.
