### PR TITLE
fix(harness): retry AI process crashes within maxAttempts; remove codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,14 +116,6 @@ jobs:
       - name: Run tests with coverage
         run: pnpm coverage
 
-      - name: Upload to Codecov
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
-
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,9 @@ the process smooth for everyone.
    for it.
 3. **All checks must pass.** Lint, typecheck, and tests are non-negotiable. Coverage is also enforced as a
    required merge gate: a PR that drops coverage below the configured thresholds, or that fails the
-   cold-install reproducibility check, cannot be merged. Each PR's coverage run uploads to
-   [Codecov](https://codecov.io/gh/lukas-grigis/ralphctl), which backs the README badge — that published
-   number is the authoritative coverage figure for the project. The required status checks (including the
-   coverage and cold-install jobs) are configured via `scripts/setup-required-checks.sh`.
+   cold-install reproducibility check, cannot be merged. Each PR's coverage run generates an lcov report
+   that CI uploads as a build artifact. The required status checks (including the coverage and cold-install
+   jobs) are configured via `scripts/setup-required-checks.sh`.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/ralphctl?style=flat&logo=npm&logoColor=white&color=cb3837)](https://www.npmjs.com/package/ralphctl)
 [![npm downloads](https://img.shields.io/npm/dm/ralphctl?style=flat&logo=npm&logoColor=white&color=cb3837)](https://www.npmjs.com/package/ralphctl)
 [![CI](https://github.com/lukas-grigis/ralphctl/actions/workflows/ci.yml/badge.svg)](https://github.com/lukas-grigis/ralphctl/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/lukas-grigis/ralphctl/graph/badge.svg)](https://codecov.io/gh/lukas-grigis/ralphctl)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat&logo=opensourceinitiative&logoColor=white)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178c6?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A5_24-5fa04e?style=flat&logo=nodedotjs&logoColor=white)](https://nodejs.org/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: false
-    patch: false

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -749,14 +749,24 @@ export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<
       // action diversity, never an accumulation across turns.
       const actionCountsCarry = { lastTurnActionCounts: countTurnActionKinds(out) };
       if (out.exit !== undefined) {
+        // Both exit kinds stop the inner loop + skip the evaluator (both key on `lastExit`), but
+        // they diverge on `lastBlockReason`:
+        //  - `self-blocked` (generator emitted `<task-blocked>` / codex-copilot signals-contract
+        //    failure) sets it → settle terminal-blocks the task after one attempt (unchanged).
+        //  - `crashed` (watchdog kill / spawn crash) sets ONLY `lastExit`. It must NOT set
+        //    `lastBlockReason`: finalize is the sole authority for whether a crash blocks (it grants
+        //    a retry within maxAttempts, then blocks at the cap). Because `finalizeGenEvalLeaf` only
+        //    ADDS a block reason (conditional spread) and never CLEARS a stale one, a block reason
+        //    stamped here would leak past finalize into settle and wrongly terminal-block the task.
+        const blockReasonCarry = out.exit.kind === 'self-blocked' ? { lastBlockReason: out.exit.reason } : {};
         return {
           ...ctx,
           currentTask: out.task,
           tasks,
           genEvalTurn: out.turn,
           currentRoundNum: out.roundNum,
-          lastExit: { kind: 'self-blocked', reason: out.exit.reason },
-          lastBlockReason: out.exit.reason,
+          lastExit: { kind: out.exit.kind, reason: out.exit.reason },
+          ...blockReasonCarry,
           ...carry,
           ...sessionCarry,
           ...decisionsCarry,

--- a/src/application/flows/implement/leaves/progress-journal.ts
+++ b/src/application/flows/implement/leaves/progress-journal.ts
@@ -161,6 +161,8 @@ const toJournalWarning = (warning: AttemptWarning): JournalWarning => {
       const detail = warning.stderr.trim().length > 0 ? `${exit} — ${warning.stderr.trim()}` : exit;
       return { kind: 'verify-failed', detail };
     }
+    case 'crashed':
+      return { kind: 'crashed', detail: warning.detail };
   }
 };
 
@@ -180,6 +182,15 @@ const toJournalEscalation = (task: Task): JournalEscalation | undefined =>
     : undefined;
 
 const latestAttempt = (task: Task): Attempt | undefined => task.attempts[task.attempts.length - 1];
+
+/**
+ * True when the attempt's warning kind retries WITHOUT burning a model-ladder rung (`malformed` —
+ * the evaluator's failure; `crashed` — a transient process death). On those exits the persisted
+ * `escalatedFromModel`/`To` stamp reflects a PRIOR climb, so projecting it would misrepresent this
+ * attempt's remedy — the caller suppresses the escalation projection when this returns true.
+ */
+const ladderBypassed = (warning: AttemptWarning | undefined): boolean =>
+  warning?.kind === 'malformed' || warning?.kind === 'crashed';
 
 const attemptDurationMs = (attempt: Attempt | undefined): number | undefined => {
   if (attempt === undefined || attempt.status === 'running') return undefined;
@@ -225,14 +236,15 @@ const buildStateHeader = (input: JournalInput, existing: string, clock: () => Is
  * Render this attempt's journal section. The warning / escalation fields are projected only when they
  * exist, so the clean-pass entry stays byte-identical to the pre-widening output (no `### Outcome
  * detail`). The model-ladder transition rides the `escalated` / `pass-with-warning` entry EXCEPT when
- * the exit was `malformed` — that retry bypasses the ladder, so any stamp is a stale prior climb.
+ * the exit was `malformed` or `crashed` — both retry WITHOUT burning a ladder rung, so any stamp is a
+ * stale prior climb that would misrepresent this attempt's remedy.
  */
 const buildAttemptSection = (input: JournalInput, totalRounds: number, clock: () => IsoTimestamp): string => {
   const attempt = latestAttempt(input.task);
   const verdict = deriveVerdict(input.task, attempt);
   const warning = attempt?.warning !== undefined ? toJournalWarning(attempt.warning) : undefined;
   const escalation =
-    (verdict === 'escalated' || verdict === 'pass-with-warning') && attempt?.warning?.kind !== 'malformed'
+    (verdict === 'escalated' || verdict === 'pass-with-warning') && !ladderBypassed(attempt?.warning)
       ? toJournalEscalation(input.task)
       : undefined;
   const durationMs = attemptDurationMs(attempt);

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -116,6 +116,12 @@ const createHeapWarningHandler = (args: {
 }): (() => void) => {
   const { logger, sessions } = args;
   return () => {
+    // Clear the perf-hooks timeline FIRST. React's dev-reconciler per-fiber measures are the
+    // dominant retainer, and they live outside every app buffer — `shedTerminal` below cannot
+    // reach them. Clearing here makes 0.80-band relief drop the real weight, not just finished
+    // records. Safe: React never reads its own measures back. See startPerfTimelineGuard.
+    performance.clearMeasures();
+    performance.clearMarks();
     const dropped = sessions.shedTerminal();
     if (dropped > 0) {
       logger.warn(`heap warning — shed ${dropped} finished session record(s) early to relieve pressure`);
@@ -146,6 +152,12 @@ const createHeapCriticalHandler = (args: {
     harnessBus.clear();
     logBus.clear();
 
+    // Clear the perf-hooks timeline too: React's dev-reconciler measures are the dominant retainer
+    // and live OUTSIDE every app buffer — which is exactly why shedTerminal here historically freed
+    // nothing. Safe: React never reads its own measures back. See startPerfTimelineGuard.
+    performance.clearMeasures();
+    performance.clearMarks();
+
     // Shed the dominant reachable retainer: drop EVERY terminal SessionRecord (with its trace
     // snapshot). The small-capped buffers above free little; completed/aborted/failed run records
     // accumulated across a long session are the real weight the app root can reach. shedTerminal
@@ -156,7 +168,7 @@ const createHeapCriticalHandler = (args: {
       logger.warn(`heap critical — shed ${dropped} finished session record(s) for memory relief`);
     } else {
       logger.warn(
-        'heap critical — no terminal records to shed; dominant retainer is the live session trace or chainEvents buffer'
+        'heap critical — no terminal records to shed; cleared the perf-hooks timeline (React dev-reconciler measures), the dominant retainer that lives outside app buffers'
       );
     }
 
@@ -178,6 +190,36 @@ const createHeapCriticalHandler = (args: {
       }
     });
   };
+};
+
+/**
+ * Bound Node's process-global performance timeline. React 19's DEVELOPMENT reconciler writes a
+ * `performance.measure()` per committed fiber on every commit (the changed-props diff is attached
+ * as the measure's `detail`), and Node's `perf_hooks` retains every entry unbounded. A multi-hour
+ * TUI run commits constantly, so the timeline grows without bound and OOMs from OUTSIDE every app
+ * buffer — the heap watchdog's `shedTerminal` structurally cannot reach it. Nothing in this process
+ * consumes marks/measures (the app + Ink only ever call `performance.now()`), so we drop the whole
+ * timeline on a fixed cadence. Under a production React build this is a silent no-op (the reconciler
+ * emits nothing), so it is safe to install unconditionally.
+ *
+ * Throw-safety (timing-independent): `clearMeasures()` / `clearMarks()` can never make React's
+ * `performance.measure` throw, because React 19.2's reconciler builds every measure from a numeric
+ * `{ start, end }` options object — never a named start-mark — and never reads the timeline back
+ * (zero `getEntries*` calls). So a clear can neither split a mark→measure pair nor perturb
+ * reconciliation, however it interleaves with a commit. Unref'd so it never keeps the process
+ * alive; `clear*` are cheap in-memory splices.
+ *
+ * INVARIANT: this clear is process-global. If a future dependency ever emits a `performance.measure`
+ * that references a NAMED start mark (not numeric `{ start, end }` options), or any TUI-process
+ * feature ever CONSUMES marks/measures, re-audit before assuming this guard stays safe.
+ */
+const startPerfTimelineGuard = (): { readonly stop: () => void } => {
+  const handle = setInterval(() => {
+    performance.clearMeasures();
+    performance.clearMarks();
+  }, 10_000);
+  handle.unref?.();
+  return { stop: (): void => clearInterval(handle) };
 };
 
 const bootstrap = async (): Promise<Bootstrapped> => {
@@ -235,6 +277,12 @@ const bootstrap = async (): Promise<Bootstrapped> => {
     onWarning: createHeapWarningHandler({ logger: deps.logger, sessions }),
     onCritical: createHeapCriticalHandler({ logger: deps.logger, logForwarder, harnessBus, logBus, sessions }),
   });
+
+  // Bound Node's perf-hooks timeline. React's dev reconciler writes a performance.measure per fiber
+  // per commit, retained unbounded by Node — a leak OUTSIDE every app buffer that the heap watchdog
+  // structurally cannot shed. The periodic guard drops it on a cadence; the watchdog handlers above
+  // also clear it the moment real pressure fires. No-op under a production React build.
+  const perfTimelineGuard = startPerfTimelineGuard();
 
   // OS-attention notifications. Wired here (not inside wire()) so tests that build wire() never
   // accidentally pop NotificationCenter dings on the dev machine — only the TUI bootstrap
@@ -304,6 +352,7 @@ const bootstrap = async (): Promise<Bootstrapped> => {
       unsubLogForward();
       logForwarder.stop();
       heapWatchdog.stop();
+      perfTimelineGuard.stop();
       unsubNotifications();
     },
     migration: {

--- a/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
@@ -39,6 +39,10 @@ const warningSummaryFor = (w: AttemptWarning): string => {
       return 'done with warning: evaluator output malformed';
     case 'verify-failed':
       return `done with warning: post-task verify red (${w.exitCode !== null ? `exit ${String(w.exitCode)}` : 'no exit code'})`;
+    case 'crashed':
+      // A `crashed` warning rides a FAILED (retried) attempt, not a done task's final attempt, so
+      // this arm is unreachable through the done-only caller above — present for exhaustiveness.
+      return 'retried after a process crash (watchdog/crash)';
   }
 };
 

--- a/src/application/ui/tui/views/sprint-detail-internals/attempt-card.tsx
+++ b/src/application/ui/tui/views/sprint-detail-internals/attempt-card.tsx
@@ -122,6 +122,8 @@ const renderWarningDetail = (w: NonNullable<Attempt['warning']>): string => {
       return `  ${glyphs.bullet} ${firstLine(w.detail)}`;
     case 'verify-failed':
       return `  ${glyphs.bullet} exit ${String(w.exitCode ?? '?')}${w.stderr.length > 0 ? ` · ${firstLine(w.stderr)}` : ''}`;
+    case 'crashed':
+      return `  ${glyphs.bullet} ${firstLine(w.detail)}`;
   }
 };
 

--- a/src/business/sprint/render-journal-entry.ts
+++ b/src/business/sprint/render-journal-entry.ts
@@ -27,13 +27,14 @@ export type JournalVerdict = 'pass' | 'pass-with-warning' | 'escalated' | 'block
  * what failed and on which dimensions.
  *
  *  - `kind`        — the warning discriminant (`budget-exhausted` / `plateau` / `malformed` /
- *                    `verify-failed`).
- *  - `detail`      — one-line human detail (malformed parse error, verify stderr head, …).
+ *                    `verify-failed` / `crashed`).
+ *  - `detail`      — one-line human detail (malformed parse error, verify stderr head, crash
+ *                    exit/signal text, …).
  *  - `dimensions`  — failed-criterion ids, present only for the `plateau` kind.
  *  - `turnsUsed` / `turnBudget` — present only for the `budget-exhausted` kind.
  */
 export interface JournalWarning {
-  readonly kind: 'budget-exhausted' | 'plateau' | 'malformed' | 'verify-failed';
+  readonly kind: 'budget-exhausted' | 'plateau' | 'malformed' | 'verify-failed' | 'crashed';
   readonly detail?: string;
   readonly dimensions?: readonly string[];
   readonly turnsUsed?: number;
@@ -195,6 +196,10 @@ const appendLearningsSubsection = (lines: string[], entries: readonly LearningEn
   lines.push('');
 };
 
+/** ` (detail)` when a non-empty detail is present, else '' — shared by the malformed + crashed arms. */
+const parenDetail = (detail: string | undefined): string =>
+  detail !== undefined && detail.trim().length > 0 ? ` (${detail.trim()})` : '';
+
 /**
  * One plain-prose sentence describing what the warning means for the next attempt. The journal
  * is the generator's cross-attempt memory, so this names the failure mode explicitly instead of
@@ -216,16 +221,15 @@ const warningSentence = (warning: JournalWarning): string => {
           : '';
       return `The evaluator plateaued — two consecutive evaluations flagged the identical failure${dims}.`;
     }
-    case 'malformed': {
-      const detail =
-        warning.detail !== undefined && warning.detail.trim().length > 0 ? ` (${warning.detail.trim()})` : '';
-      return `The evaluator output could not be parsed${detail}.`;
-    }
+    case 'malformed':
+      return `The evaluator output could not be parsed${parenDetail(warning.detail)}.`;
     case 'verify-failed': {
       const detail =
         warning.detail !== undefined && warning.detail.trim().length > 0 ? `: ${warning.detail.trim()}` : '';
       return `The post-task verify script ran red after the commit${detail}.`;
     }
+    case 'crashed':
+      return `The AI process was killed (watchdog/crash) before finishing${parenDetail(warning.detail)}; the attempt was retried.`;
   }
 };
 

--- a/src/business/sprint/views/pr-content.ts
+++ b/src/business/sprint/views/pr-content.ts
@@ -25,6 +25,10 @@ const warningDetail = (w: AttemptWarning): string => {
         ? `post-task verify red (${exit}: ${w.stderr.trim()})`
         : `post-task verify red (${exit})`;
     }
+    case 'crashed':
+      return w.detail.trim().length > 0
+        ? `process killed (watchdog/crash): ${w.detail.trim()}`
+        : 'process killed (watchdog/crash)';
   }
 };
 

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -31,6 +31,8 @@ const BUDGET_EXHAUSTED_EXIT = 'budget-exhausted';
  * attempt fails so the outer loop re-enters — is gated by the escalation policy / attempt budget):
  *   passed             → verdict 'passed',    no warning,                       never retries
  *   self-blocked       → verdict 'failed',    blockedReason set (settle blocks), never retries
+ *   crashed            → verdict 'failed',    warning { kind: 'crashed' },       retry within maxAttempts
+ *                          (no ladder rung), blocks at cap via failCurrentAttempt
  *   plateau            → verdict 'failed',    warning { kind: 'plateau' },       escalation policy
  *   budget-exhausted   → verdict 'failed',    warning { kind: 'budget-exhausted' }, escalation policy
  *   malformed          → verdict 'malformed', warning { kind: 'malformed' },     plain same-model retry
@@ -109,6 +111,8 @@ const mapExit = (exit: GenEvalExit): { verdict: RunTaskVerdict; warning?: Attemp
       return { verdict: 'passed' };
     case 'self-blocked':
       return { verdict: 'failed', blockedReason: exit.reason };
+    case 'crashed':
+      return { verdict: 'failed', warning: { kind: 'crashed', detail: exit.reason } };
     case 'malformed':
       return { verdict: 'malformed', warning: { kind: 'malformed', detail: exit.detail } };
     case 'plateau':
@@ -244,6 +248,13 @@ export const finalizeGenEvalUseCase = async (
     remedy = resolved.value;
   } else if (exit.kind === 'malformed') {
     remedy = resolveMalformedRemedy(props, cfg, log);
+  } else if (exit.kind === 'crashed') {
+    // A process crash (watchdog kill / spawn crash) is not a quality plateau — retry
+    // UNCONDITIONALLY, regardless of `escalateOnPlateau`, and WITHOUT stamping the escalation
+    // model fields (no ladder rung). `failCurrentAttempt` transitions the task to `blocked` on its
+    // own once attempts hit the cap, so `shouldFailAttempt: true` is correct even on the final
+    // attempt — the retry budget itself decides when to stop.
+    remedy = { task: props.task, shouldFailAttempt: true };
   }
 
   const taskForPersist: InProgressTask = remedy.task;

--- a/src/business/task/gen-eval-exit.ts
+++ b/src/business/task/gen-eval-exit.ts
@@ -14,6 +14,9 @@ export type RunTaskVerdict = 'passed' | 'failed' | 'malformed';
  *                          `status: 'passed'`; attempt succeeds.
  *   - `self-blocked`      — generator's `signals.json` carried a `task-blocked` signal; task
  *                          settles as blocked.
+ *   - `crashed`           — AI process died (watchdog kill / spawn crash) before producing a
+ *                          terminal verdict; the attempt is retried within maxAttempts, then
+ *                          blocked at the cap.
  *   - `malformed`         — evaluator emitted no terminal verdict; attempt fails with warning.
  *   - `plateau`           — two consecutive evaluator runs flagged the same failed dimensions.
  *   - `budget-exhausted`  — `maxTurns` reached without a terminal verdict.
@@ -21,6 +24,7 @@ export type RunTaskVerdict = 'passed' | 'failed' | 'malformed';
 export type GenEvalExit =
   | { readonly kind: 'passed' }
   | { readonly kind: 'self-blocked'; readonly reason: string }
+  | { readonly kind: 'crashed'; readonly reason: string }
   | { readonly kind: 'malformed'; readonly detail: string }
   | { readonly kind: 'plateau'; readonly dimensions: readonly string[] }
   | { readonly kind: 'budget-exhausted'; readonly turnsUsed: number; readonly turnBudget: number };

--- a/src/business/task/run-generator-turn.ts
+++ b/src/business/task/run-generator-turn.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@src/business/observability/logger.ts';
 import type { InProgressTask } from '@src/domain/entity/task.ts';
 import { recordRunningAttemptVerification } from '@src/domain/entity/task-attempts.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts';
 
@@ -22,7 +23,7 @@ import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts'
  * for reading the provider's `signalsFile` and forwarding signals to the harness sink before
  * calling this use case.
  */
-export type GeneratorTurnExit = { readonly kind: 'self-blocked'; readonly reason: string };
+export type GeneratorTurnExit = { readonly kind: 'self-blocked' | 'crashed'; readonly reason: string };
 
 export interface RunGeneratorTurnProps {
   readonly task: InProgressTask;
@@ -72,12 +73,27 @@ export const runGeneratorTurnUseCase = async (
   if (!signalsResult.ok) {
     const err = signalsResult.error;
     // Fatal errors (user abort, rate-limit-after-retries) must abort the whole run — propagate.
-    // Everything else is a recoverable signals-contract failure: block THIS task (so it surfaces
-    // and re-runs next launch) instead of taking down every remaining task. The error message
-    // lands in the block reason so the operator/progress.md shows WHY the turn failed.
+    // Everything else is recoverable, but splits two ways by error TYPE:
+    //  - a `ProcessCrash` (watchdog kill / spawn crash / non-zero exit with no signals.json) is a
+    //    TRANSIENT process death → a `crashed` exit, which finalize retries within maxAttempts
+    //    (then blocks at the cap) instead of terminally blocking after one attempt.
+    //  - anything else is a genuine signals-contract failure (codex/copilot wrote the wrong shape,
+    //    wrong place, or nothing) → a `self-blocked` exit that blocks THIS task so it surfaces and
+    //    re-runs next launch, without taking down every remaining task.
+    // The error message rides the exit reason so the operator / progress.md shows WHY the turn failed.
     if (!isRecoverableTurnError(err)) {
       log.error('implement call failed (fatal — propagating)', { taskId: props.task.id, error: err.message });
       return Result.error(err);
+    }
+    if (err.code === ErrorCode.ProcessCrash) {
+      log.warn('AI process was killed before producing signals.json — retrying attempt', {
+        taskId: props.task.id,
+        error: err.message,
+      });
+      return Result.ok({
+        task: props.task,
+        exit: { kind: 'crashed', reason: `AI process was killed before producing signals.json: ${err.message}` },
+      });
     }
     log.warn('generator did not produce a valid signals.json — blocking task', {
       taskId: props.task.id,

--- a/src/domain/entity/attempt.ts
+++ b/src/domain/entity/attempt.ts
@@ -31,22 +31,30 @@ export interface Evaluation {
 
 /**
  * Structured warning attached to an attempt when the gen-eval inner loop terminates without a
- * passed evaluation but the task still settles as `done` (vs `blocked`). The four kinds:
+ * passed evaluation but the task still settles as `done` (vs `blocked`), OR when an attempt is
+ * failed-and-retried. The kinds:
  *
  *  - `budget-exhausted` — turn budget hit without the evaluator passing.
  *  - `plateau`          — two consecutive evals flagged the identical failed-dimension set.
  *  - `malformed`        — evaluator output couldn't be parsed (no verdict signal).
  *  - `verify-failed`    — post-task check script ran red after commit; non-fatal but surfaced.
+ *  - `crashed`          — the AI process died (watchdog kill / spawn crash) before producing a
+ *                         terminal verdict. Recorded on the failed attempt so the operator can
+ *                         SEE the retry in attempt history + the progress journal (rather than the
+ *                         task silently blocking after one attempt).
  *
  * Why warnings on a "done" task: the locked policy is that only `<task-blocked>` from the
  * generator → `markTaskBlocked`. Everything else (budget / plateau / malformed eval / red
- * verify) → `markTaskDone` with the structured warning attached so the operator can review.
+ * verify) → `markTaskDone` with the structured warning attached so the operator can review. The
+ * `crashed` kind is the exception in provenance — it rides a FAILED (retried) attempt, not a
+ * done one — but shares the same audit purpose.
  */
 export type AttemptWarning =
   | { readonly kind: 'budget-exhausted'; readonly turnsUsed: number; readonly turnBudget: number }
   | { readonly kind: 'plateau'; readonly dimensions: readonly string[] }
   | { readonly kind: 'malformed'; readonly detail: string }
-  | { readonly kind: 'verify-failed'; readonly exitCode: number | null; readonly stderr: string };
+  | { readonly kind: 'verify-failed'; readonly exitCode: number | null; readonly stderr: string }
+  | { readonly kind: 'crashed'; readonly detail: string };
 
 /**
  * Discriminated reason why an attempt was settled as `aborted`. Capture point varies:

--- a/src/domain/value/error/domain-error.ts
+++ b/src/domain/value/error/domain-error.ts
@@ -6,6 +6,7 @@ import type { InvalidStateError } from '@src/domain/value/error/invalid-state-er
 import type { MigrationGapError } from '@src/domain/value/error/migration-gap-error.ts';
 import type { ParseError } from '@src/domain/value/error/parse-error.ts';
 import type { ProbeError } from '@src/domain/value/error/probe-error.ts';
+import type { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import type { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 
@@ -18,5 +19,6 @@ export type DomainError =
   | MigrationGapError
   | ParseError
   | ProbeError
+  | ProcessCrashError
   | RateLimitError
   | StorageError;

--- a/src/domain/value/error/error-code.ts
+++ b/src/domain/value/error/error-code.ts
@@ -9,6 +9,7 @@ export const ErrorCode = {
   Probe: 'probe-error',
   Aborted: 'aborted',
   MigrationGap: 'migration-gap',
+  ProcessCrash: 'process-crash',
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/src/domain/value/error/process-crash-error.ts
+++ b/src/domain/value/error/process-crash-error.ts
@@ -1,0 +1,39 @@
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+
+export interface ProcessCrashErrorOptions {
+  readonly entity: string;
+  /** Short state discriminator for logs — e.g. `exit-143`, `spawn-failed`. */
+  readonly state: string;
+  readonly message: string;
+  readonly hint?: string;
+}
+
+/**
+ * A transient death of an AI child process that is worth RETRYING: the idle-stdout watchdog
+ * SIGTERM'd a wedged child, the spawn itself failed before stdin drained, or the process exited
+ * non-zero without ever writing its `signals.json`. Distinct from {@link InvalidStateError}
+ * precisely so the retry decision can be made on the error TYPE: a `ProcessCrash` re-runs the
+ * generator within `maxAttempts` (then blocks at the cap), whereas a config failure
+ * (model-unavailable) keeps surfacing as an `InvalidStateError` and blocks after one attempt —
+ * retrying it would just burn the whole budget on the same misconfiguration.
+ *
+ * Carries the exit-code / signal / stderr-tail context in `message` (not just `.hint`) so the
+ * text survives unchanged through `run-generator-turn`'s crash-reason string into the progress
+ * journal and the TUI without touching the render layer.
+ */
+export class ProcessCrashError extends Error {
+  readonly code = ErrorCode.ProcessCrash;
+  readonly entity: string;
+  readonly state: string;
+  readonly hint?: string;
+
+  constructor(opts: ProcessCrashErrorOptions) {
+    super(opts.message);
+    this.name = 'ProcessCrashError';
+    this.entity = opts.entity;
+    this.state = opts.state;
+    if (opts.hint !== undefined) {
+      this.hint = opts.hint;
+    }
+  }
+}

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -1,5 +1,6 @@
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -57,6 +58,14 @@ export const DEFAULT_RATE_LIMIT_RE = /rate.?limit|quota|\b429\b/i;
  * `rate-limit` — backoff/retry is the right response even if a partial `signals.json` from
  * a previous attempt happens to be on disk (per-round outputDir means it shouldn't be, but
  * the precedence keeps the semantics safe under reuse).
+ *
+ * **Retryable crash vs. non-retryable config error.** Two failure branches surface a
+ * `ProcessCrashError` (a TRANSIENT process death worth retrying within the attempt budget):
+ * step 2 (spawn-failed — the child never ran) and step 7 (non-zero exit with no signals.json —
+ * the idle-stdout watchdog SIGTERM shape). Both let the harness re-run the generator and only
+ * block once `maxAttempts` is exhausted. Step 5 (model-unavailable) deliberately stays an
+ * `InvalidStateError`: a model-availability failure is a CONFIG error, so retrying just burns the
+ * whole budget on the same misconfiguration — it must keep blocking after one attempt.
  */
 export type ProviderName = 'claude-provider' | 'codex-provider' | 'copilot-provider';
 
@@ -151,15 +160,16 @@ export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<
   // 2. Spawn error precedence (before any exit-code branch). The child never ran — a missing /
   // non-executable binary (ENOENT / EACCES) or a death before stdin drained. Without this the
   // unhandled `'error'` event would have killed the whole process; runHeadlessSpawn captured it
-  // so we surface a typed, actionable failure instead.
+  // so we surface a typed, actionable failure instead. Classified as a RETRYABLE `ProcessCrash`
+  // (distinct from step 5's non-retryable config error): a spawn that died transiently is worth
+  // re-running within the attempt budget rather than blocking after one attempt.
   if (exit.spawnError !== undefined) {
     const errno = exit.spawnError.code ?? exit.spawnError.name;
     return {
       kind: 'error',
-      error: new InvalidStateError({
+      error: new ProcessCrashError({
         entity: providerName,
-        currentState: 'spawn-failed',
-        attemptedAction: 'spawn provider CLI',
+        state: 'spawn-failed',
         message: `${providerName}: spawn failed: ${errno} — ${exit.spawnError.message}`,
         hint: 'verify the provider CLI is installed and on PATH',
       }),
@@ -242,13 +252,16 @@ export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<
     return outcome;
   }
 
-  // 7. Hard fail. Mirrors the historical per-adapter exit-N error shape.
+  // 7. Hard fail — non-zero exit with no signals.json. This is the watchdog-SIGTERM-before-signals
+  // shape (idle-stdout kill of a wedged child): a TRANSIENT process death worth retrying, so it
+  // surfaces a RETRYABLE `ProcessCrash` (distinct from step 5's non-retryable config error). The
+  // message text is unchanged from the historical per-adapter exit-N shape so logs / progress read
+  // the same (exit code + signal + stderr tail).
   return {
     kind: 'error',
-    error: new InvalidStateError({
+    error: new ProcessCrashError({
       entity: providerName,
-      currentState: `exit-${String(exit.code ?? 'null')}`,
-      attemptedAction: 'complete generation',
+      state: `exit-${String(exit.code ?? 'null')}`,
       message: `${providerName}: process exited with code ${String(exit.code)}${exit.signal !== null ? ` (signal=${exit.signal})` : ''}: ${stderr.trim() || '<empty stderr>'}`,
     }),
   };

--- a/src/integration/persistence/task/attempt.schema.ts
+++ b/src/integration/persistence/task/attempt.schema.ts
@@ -25,11 +25,16 @@ const VerifyFailedWarningSchema = z.object({
   exitCode: z.number().int().nullable(),
   stderr: z.string(),
 });
+const CrashedWarningSchema = z.object({
+  kind: z.literal('crashed'),
+  detail: z.string(),
+});
 const AttemptWarningSchema = z.discriminatedUnion('kind', [
   BudgetExhaustedWarningSchema,
   PlateauWarningSchema,
   MalformedWarningSchema,
   VerifyFailedWarningSchema,
+  CrashedWarningSchema,
 ]);
 
 const AbortCauseSchema = z.enum([

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -22,6 +22,7 @@ import type { Task } from '@src/domain/entity/task.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import {
   absolutePath,
   FIXED_LATER,
@@ -2566,5 +2567,147 @@ describe('createImplementFlow — gen-eval loop', () => {
     // that aborted). A leaked second loop iteration would re-emit it.
     const generatorEntries = runner.trace.filter((e) => e.elementName === `generator-${String(f.tasks[0]?.id)}`);
     expect(generatorEntries.length).toBeLessThanOrEqual(1);
+  });
+
+  it('watchdog kill before signals.json: retries up to maxAttempts then blocks "attempt budget exhausted" — NOT after one attempt', async () => {
+    // Headline regression. A ProcessCrashError from the generator provider (watchdog SIGTERM /
+    // spawn crash that died before writing signals.json — the classify-spawn step-7 shape) must
+    // RETRY the attempt up to `maxAttempts` and only THEN block, consuming the retry budget.
+    // Before the fix, a crash-before-signals folded into a `self-blocked` exit and terminally
+    // blocked the task after a SINGLE attempt, never touching the `maxAttempts` budget.
+    const f = await buildFixture(1, 3); // maxAttempts = 3
+    tracking(f);
+    const sprintRepo = inMemorySprintRepo(f.sprint);
+    const taskRepo = inMemoryTaskRepo(f.tasks);
+
+    // Generator provider that always dies before producing signals.json. Returns the retryable
+    // ProcessCrashError the headless wrapper surfaces after classify-spawn step 7 (non-zero exit,
+    // no signals.json). No signals.json is written, so the generator leaf never reaches validate.
+    let genCalls = 0;
+    const crashingProvider: HeadlessAiProvider = {
+      async generate() {
+        genCalls += 1;
+        return Result.error(
+          new ProcessCrashError({
+            entity: 'claude-provider',
+            state: 'exit-143',
+            message: 'claude-provider: process exited with code 143 (signal=SIGTERM): <empty stderr>',
+          })
+        );
+      },
+    };
+
+    const flow = createImplementFlow(
+      buildDeps(
+        sprintRepo.repo,
+        inMemoryExecutionRepo(f.execution).repo,
+        taskRepo.repo,
+        crashingProvider,
+        f.dir,
+        makeCleanGit()
+      ),
+      {
+        sprintId: f.sprint.id,
+        todoTasks: f.tasks,
+        repositories: FAKE_REPOSITORIES,
+        generatorProviderId: 'claude-code',
+        generatorModel: 'claude-opus-4-8',
+        evaluatorProviderId: 'claude-code',
+        evaluatorModel: 'claude-opus-4-8',
+        progressFile: absolutePath(f.progressFile),
+        sprintDir: absolutePath(f.dir),
+        memoryRoot: FAKE_MEMORY_ROOT,
+        projectId: FAKE_PROJECT_ID,
+        projectSlug: FAKE_PROJECT_SLUG,
+      }
+    );
+
+    const runner = createRunner({
+      id: 'r-impl-crash-retry',
+      element: flow,
+      initialCtx: { sprintId: f.sprint.id } satisfies ImplementCtx,
+    });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+
+    const finalTask = taskRepo.tasks()[0];
+    // Retried up to the cap, THEN blocked via failCurrentAttempt's budget branch — not after one.
+    expect(finalTask?.status).toBe('blocked');
+    expect(finalTask?.attempts).toHaveLength(3);
+    if (finalTask?.status === 'blocked') {
+      expect(finalTask.blockedReason).toContain('attempt budget exhausted');
+      expect(finalTask.blockedReason).toContain('maxAttempts=3');
+    }
+
+    // start-attempt + settle-attempt each ran once per attempt — the outer loop genuinely
+    // re-entered twice, not just recorded one settle. This is the load-bearing "it retried" proof.
+    const startEntries = runner.trace.filter((e) => e.elementName === `start-attempt-${String(finalTask?.id)}`);
+    expect(startEntries).toHaveLength(3);
+    const settleEntries = runner.trace.filter((e) => e.elementName === `settle-attempt-${String(finalTask?.id)}`);
+    expect(settleEntries).toHaveLength(3);
+    // The generator was spawned once per attempt (3 crashes) — not silenced after the first.
+    expect(genCalls).toBe(3);
+
+    // Operator visibility: every failed attempt records the crash as a structured warning so the
+    // retry is SEEN (attempt history + progress journal), addressing "the actions never happen".
+    for (const attempt of finalTask?.attempts ?? []) {
+      expect(attempt.warning?.kind).toBe('crashed');
+    }
+
+    // No done task → the sprint stays active so a re-run picks it up after the cause is fixed.
+    expect(sprintRepo.current().status).toBe('active');
+  });
+
+  it('self-block fence: a genuine <task-blocked> STILL blocks after ONE attempt even with maxAttempts=3 (semantic self-blocks must not retry)', async () => {
+    // Fence for the crash-retry change: only a ProcessCrash takes the retry path. A generator
+    // <task-blocked> signal is a SEMANTIC self-block (the AI decided it cannot proceed) and must
+    // remain terminal after a single attempt regardless of the attempt budget — otherwise every
+    // block would waste the whole budget re-running work the AI already declared blocked.
+    const f = await buildFixture(1, 3); // maxAttempts = 3 — the retry budget is available…
+    tracking(f);
+    const sprintRepo = inMemorySprintRepo(f.sprint);
+    const taskRepo = inMemoryTaskRepo(f.tasks);
+
+    const provider = createFakeAiProvider({
+      signals: { implement: [taskBlocked('missing API key')] },
+    });
+
+    const flow = createImplementFlow(
+      buildDeps(sprintRepo.repo, inMemoryExecutionRepo(f.execution).repo, taskRepo.repo, provider, f.dir),
+      {
+        sprintId: f.sprint.id,
+        todoTasks: f.tasks,
+        repositories: FAKE_REPOSITORIES,
+        generatorProviderId: 'claude-code',
+        generatorModel: 'claude-opus-4-8',
+        evaluatorProviderId: 'claude-code',
+        evaluatorModel: 'claude-opus-4-8',
+        progressFile: absolutePath(f.progressFile),
+        sprintDir: absolutePath(f.dir),
+        memoryRoot: FAKE_MEMORY_ROOT,
+        projectId: FAKE_PROJECT_ID,
+        projectSlug: FAKE_PROJECT_SLUG,
+      }
+    );
+
+    const runner = createRunner({
+      id: 'r-impl-selfblock-fence',
+      element: flow,
+      initialCtx: { sprintId: f.sprint.id } satisfies ImplementCtx,
+    });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+
+    const finalTask = taskRepo.tasks()[0];
+    // …but the self-block is terminal: blocked with the AI's own reason after exactly ONE attempt.
+    expect(finalTask?.status).toBe('blocked');
+    expect(finalTask?.attempts).toHaveLength(1);
+    if (finalTask?.status === 'blocked') {
+      expect(finalTask.blockedReason).toBe('missing API key');
+    }
+    const startEntries = runner.trace.filter((e) => e.elementName === `start-attempt-${String(finalTask?.id)}`);
+    expect(startEntries).toHaveLength(1);
   });
 });

--- a/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
+++ b/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
@@ -12,6 +12,7 @@ import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 
 const PROMPT = 'fake prompt' as unknown as Prompt;
@@ -183,7 +184,11 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     }
   });
 
-  it('non-zero exit + signals.json absent hard-fails with InvalidStateError', async () => {
+  it('non-zero exit + signals.json absent hard-fails with a RETRYABLE ProcessCrashError (watchdog-kill shape)', async () => {
+    // A non-zero exit with no signals.json is the idle-stdout-watchdog SIGTERM shape: a transient
+    // process death worth retrying within the attempt budget, so it surfaces a ProcessCrashError
+    // (code 'process-crash') rather than a terminal InvalidStateError. The exact message text is
+    // preserved (exit code + stderr tail) so logs / progress read the same as before.
     const session = baseSession();
     // Do NOT write signals.json.
     let invoked = 0;
@@ -203,7 +208,8 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     expect(invoked).toBe(0);
     expect(outcome.kind).toBe('error');
     if (outcome.kind === 'error') {
-      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.code).toBe('process-crash');
       expect(outcome.error.message).toContain('process exited with code 2');
       expect(outcome.error.message).toContain('some-real-failure');
     }
@@ -232,10 +238,11 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     expect(outcome.kind).toBe('success');
   });
 
-  it('spawn error maps to InvalidStateError before any exit-code branch (missing binary)', async () => {
+  it('spawn error maps to a RETRYABLE ProcessCrashError before any exit-code branch (missing binary)', async () => {
     // FINDING 1 — a spawn `'error'` event (ENOENT / EACCES) means the child never ran; classify
     // it as a typed, actionable failure before the clean-exit / rate-limit branches. The errno
-    // and message must surface so the operator knows the CLI is missing.
+    // and message must surface so the operator knows the CLI is missing. It is a ProcessCrashError
+    // (code 'process-crash') so a transient spawn death retries within the attempt budget.
     const session = baseSession();
     const spawnError = Object.assign(new Error('spawn claude ENOENT'), {
       code: 'ENOENT',
@@ -257,7 +264,8 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     expect(invoked).toBe(0);
     expect(outcome.kind).toBe('error');
     if (outcome.kind === 'error') {
-      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.code).toBe('process-crash');
       expect(outcome.error.message).toContain('spawn failed');
       expect(outcome.error.message).toContain('ENOENT');
       expect(outcome.error.message).toContain(providerName);
@@ -349,7 +357,11 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     expect(invoked).toBe(0);
     expect(outcome.kind).toBe('error');
     if (outcome.kind === 'error') {
+      // A config failure must keep BLOCKING (InvalidStateError), never retry — retrying a
+      // model-availability error would burn the whole attempt budget on the same misconfiguration.
       expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error).not.toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.code).toBe('invalid-state');
       expect(outcome.error.message).toContain('model not available');
     }
   });
@@ -374,8 +386,9 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     });
     expect(outcome.kind).toBe('error');
     if (outcome.kind === 'error') {
-      expect(outcome.error).toBeInstanceOf(InvalidStateError);
-      // Falls through to generic hard-fail — the model hint must NOT appear.
+      // Falls through to the generic hard-fail (step 7) — a retryable ProcessCrashError, and the
+      // model hint must NOT appear (the false-positive guard: a stdout-only phrase is not a config error).
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
       expect(outcome.error.message).not.toContain('pick another model in settings');
       expect(outcome.error.message).toContain('process exited with code 1');
     }
@@ -395,7 +408,8 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     });
     expect(outcome.kind).toBe('error');
     if (outcome.kind === 'error') {
-      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      // Generic non-zero exit → the retryable hard-fail branch, and no model hint.
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
       expect(outcome.error.message).not.toContain('pick another model in settings');
     }
   });

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -591,6 +591,71 @@ describe('finalizeGenEvalUseCase', () => {
     expect(result.value.blockedReason).toBeUndefined();
   });
 
+  // ── Crashed: unconditional retry (watchdog kill / spawn crash), no ladder rung ────────────────
+
+  it('crashed exit (flag OFF, budget remaining): verdict failed, warning kind=crashed with detail, shouldFailAttempt=true, NO escalation, no blockedReason', async () => {
+    // A process crash is NOT a quality plateau: it retries UNCONDITIONALLY (regardless of
+    // escalateOnPlateau) and WITHOUT stamping the escalation model fields. shouldFailAttempt keeps
+    // the task in_progress so the outer loop re-enters. Mutant-kill: a mutant that gates the retry
+    // on the flag (like malformed) would leave shouldFailAttempt falsy here.
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 3 });
+    const bus = newBus();
+    const events: Array<{ type: string }> = [];
+    bus.subscribe((e) => events.push(e));
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'crashed', reason: 'AI process was killed before producing signals.json: exit 143 (SIGTERM)' },
+      turnsUsed: 1,
+      readConfig: cfg({ escalateOnPlateau: false, maxAttempts: 3 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: bus,
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.verdict).toBe('failed');
+    expect(result.value.warning?.kind).toBe('crashed');
+    expect((result.value.warning as { kind: 'crashed'; detail: string } | undefined)?.detail).toContain(
+      'AI process was killed before producing signals.json'
+    );
+    expect(result.value.shouldFailAttempt).toBe(true);
+    // No ladder rung burned — a crash is not a generator weakness.
+    expect(result.value.task.escalatedFromModel).toBeUndefined();
+    expect(result.value.task.escalatedToModel).toBeUndefined();
+    expect(result.value.blockedReason).toBeUndefined();
+    expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
+  });
+
+  it('crashed exit on the FINAL attempt (maxAttempts=1): STILL shouldFailAttempt=true — failCurrentAttempt blocks at the cap, not finalize', async () => {
+    // The retry budget itself decides when to stop: finalize always grants shouldFailAttempt for a
+    // crash, and failCurrentAttempt transitions the task to blocked once attempts hit the cap. So
+    // even on what turns out to be the last allowed attempt, finalize sets shouldFailAttempt=true
+    // and never sets blockedReason (finalize must not pre-empt the domain's budget branch).
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 1 });
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'crashed', reason: 'AI process was killed before producing signals.json: spawn failed ENOENT' },
+      turnsUsed: 1,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 1 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.verdict).toBe('failed');
+    expect(result.value.warning?.kind).toBe('crashed');
+    expect(result.value.shouldFailAttempt).toBe(true);
+    expect(result.value.blockedReason).toBeUndefined();
+    expect(result.value.task.escalatedToModel).toBeUndefined();
+  });
+
   // ── Legacy-task budget fallback (task.maxAttempts unset) ──────────────────────────────────────
 
   it('legacy task (no maxAttempts) plateau escalate: verdict failed, plateau warning, shouldFailAttempt=true, escalation stamps set', async () => {

--- a/tests/unit/business/task/run-generator-turn.test.ts
+++ b/tests/unit/business/task/run-generator-turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import type { HarnessSignal } from '@src/domain/signal.ts';
 import { FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@tests/fixtures/domain.ts';
@@ -59,6 +60,31 @@ describe('runGeneratorTurnUseCase', () => {
       expect(result.value.exit?.reason).toContain('generator did not produce a valid signals.json');
       expect(result.value.exit?.reason).toContain('signals-invalid (schema) at root');
       expect(result.value.task).toBe(task); // unchanged — no verification recorded
+    }
+  });
+
+  it('returns a CRASHED exit (not self-blocked) on a ProcessCrashError — the retry path', async () => {
+    // A watchdog kill / spawn crash surfaces a ProcessCrashError. Unlike a signals-contract
+    // ParseError (which self-blocks), a crash must route to a `crashed` exit so finalize retries
+    // the attempt within maxAttempts instead of terminally blocking after one. The crash message
+    // rides the exit reason for the operator / progress.md.
+    const task = makeInProgressTaskWithRunningAttempt();
+    const err = new ProcessCrashError({
+      entity: 'claude-provider',
+      state: 'exit-143',
+      message: 'claude-provider: process exited with code 143 (signal=SIGTERM): <empty stderr>',
+    });
+    const result = await runGeneratorTurnUseCase({
+      task,
+      callImplement: async () => Result.error(err),
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.exit?.kind).toBe('crashed');
+      expect(result.value.exit?.reason).toContain('AI process was killed before producing signals.json');
+      expect(result.value.exit?.reason).toContain('process exited with code 143 (signal=SIGTERM)');
+      expect(result.value.task).toBe(task); // unchanged — no verification recorded on a crash
     }
   });
 


### PR DESCRIPTION
## Summary

Three commits:

1. **fix(tui): bound Node perf-hooks timeline to stop dev-React OOM** (`ed045d3d`) — pre-existing TUI fix, included via rebase.

2. **chore: remove codecov** — drops `codecov.yml`, the Codecov upload step in `ci.yml`, the README badge, and the Codecov reference in `CONTRIBUTING.md`. Local coverage generation (`pnpm coverage` → lcov) and the CI coverage artifact are kept, so a replacement service can consume the report. (The `CODECOV_TOKEN` Actions secret is now unused and can be deleted from repo settings.)

3. **fix(harness): retry AI process crashes within `maxAttempts`** — the headline fix.

### The watchdog-retry bug

During long implement sessions, when the idle-stdout watchdog SIGTERM'd a wedged AI child (default 5 min of stdout silence) **before** it wrote `signals.json`, the task was **terminally blocked after a single attempt** — the `settings.harness.maxAttempts` budget (default 3) was never spent. A transient infrastructure death was classified identically to the AI deliberately emitting `<task-blocked>`.

Now a process crash surfaces a retryable `ProcessCrashError`, maps to a new `crashed` gen-eval exit that sets `shouldFailAttempt`, and routes through the existing `failCurrentAttempt` path: it **retries up to `maxAttempts`, then hard-fails with `attempt budget exhausted`**. Each crashed attempt is recorded as a `crashed` `AttemptWarning` so the retries are visible in attempt history / `progress.md`.

Deliberate boundaries:
- **Model-unavailable** errors stay non-retryable (retrying a config error would just burn the whole budget).
- A genuine `<task-blocked>` self-block still blocks after one attempt (unchanged; fenced by a test).

## Test plan

- `pnpm typecheck` clean; `pnpm lint` under the warning ratchet; full suite green (4265 tests).
- Targeted: 113 tests across the 4 watchdog test files pass, including the headline regression (crash every turn → 3 attempts → `blocked` "attempt budget exhausted (maxAttempts=3)") and the self-block fence.
- Codecov: repo-wide grep confirms zero remaining references.
