### PR TITLE
refactor: post-0.14.0 quality sweep + lint-warning reduction (253→115)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coverage:unused": "tsx scripts/find-unused.ts",
     "deadcode": "knip",
     "skills:update": "tsx scripts/sync-skills.ts",
-    "lint": "eslint . --max-warnings 254",
+    "lint": "eslint . --max-warnings 115",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/application/flows/_shared/memory/ledger-writer.ts
+++ b/src/application/flows/_shared/memory/ledger-writer.ts
@@ -11,6 +11,7 @@ import { renderLearningsMd } from '@src/application/flows/_shared/memory/render-
 import {
   type LedgerLine,
   readLedgerLines,
+  serializeLedgerBody,
   statLedgerExceedsThreshold,
 } from '@src/application/flows/_shared/memory/read-ledger.ts';
 import { type LedgerRow, compactLedger } from '@src/application/flows/_shared/memory/compact-ledger.ts';
@@ -108,7 +109,7 @@ export const boundLedgerIfNeeded = async (
   const compacted = compactLedger(rows);
   if (compacted.evictedCount === 0 && compacted.deduplicatedCount === 0) return Result.ok(undefined);
 
-  const body = compacted.rows.map((r) => ensureTrailingNewline(r.raw)).join('');
+  const body = serializeLedgerBody(compacted.rows);
   const written = await deps.writeFile(ledgerPath, body);
   if (!written.ok) {
     deps.log.warn('ledger bounding rewrite failed (ledger still authoritative)', {
@@ -151,10 +152,3 @@ export const appendMemoryRecords = async (
   await boundLedgerIfNeeded(ledgerPath, { writeFile: deps.writeFile, log: deps.log });
   return Result.ok(undefined) as Result<void, StorageError>;
 };
-
-/**
- * `readLedgerLines` strips the trailing newline off each raw line (`split('\n')`);
- * `serializeLearningRecord` keeps it. Normalise so the NDJSON rewrite is one well-formed line per
- * row regardless of source.
- */
-const ensureTrailingNewline = (raw: string): string => (raw.endsWith('\n') ? raw : `${raw}\n`);

--- a/src/application/flows/_shared/memory/read-ledger.ts
+++ b/src/application/flows/_shared/memory/read-ledger.ts
@@ -163,3 +163,18 @@ export const statLedgerExceedsThreshold = async (path: AbsolutePath): Promise<bo
     return false;
   }
 };
+
+/**
+ * `readLedgerLines` strips the trailing newline off each raw line (`split('\n')`);
+ * `serializeLearningRecord` keeps it. Normalise so the NDJSON rewrite is one well-formed line per
+ * row regardless of source.
+ */
+export const ensureTrailingNewline = (raw: string): string => (raw.endsWith('\n') ? raw : `${raw}\n`);
+
+/**
+ * Join compacted ledger rows into a well-formed NDJSON body. Shared by both ledger-rewrite paths
+ * (`stampPromotedLeaf` and `boundLedgerIfNeeded`) so they emit byte-for-byte-identical output for
+ * the same input rows.
+ */
+export const serializeLedgerBody = (rows: ReadonlyArray<{ readonly raw: string }>): string =>
+  rows.map((r) => ensureTrailingNewline(r.raw)).join('');

--- a/src/application/flows/_shared/memory/stamp-promoted.ts
+++ b/src/application/flows/_shared/memory/stamp-promoted.ts
@@ -13,6 +13,7 @@ import { isAbortedRead } from '@src/application/flows/_shared/memory/abort-guard
 import {
   type LedgerLine,
   readLedgerLines,
+  serializeLedgerBody,
   statLedgerExceedsThreshold,
 } from '@src/application/flows/_shared/memory/read-ledger.ts';
 import { type LedgerRow, compactLedger } from '@src/application/flows/_shared/memory/compact-ledger.ts';
@@ -156,7 +157,7 @@ const stamp = async (
   // byte forward-compat holds across the dedup; promoted tombstones are never evicted.
   const compacted = compactLedger(rows);
 
-  const body = compacted.rows.map((r) => ensureTrailingNewline(r.raw)).join('');
+  const body = serializeLedgerBody(compacted.rows);
   const written = await deps.writeFile(path, body);
   if (!written.ok) return Result.error(written.error);
 
@@ -240,10 +241,3 @@ const stampPass = (
 
 /** Not already retired (so a second decline never re-serializes / re-dates an existing tombstone). */
 const isLive = (record: LearningRecord): boolean => record.retiredAt === undefined || record.retiredAt === null;
-
-/**
- * `readLedgerLines` strips the trailing newline off each raw line (`split('\n')`);
- * `serializeLearningRecord` keeps it. Normalise so the NDJSON rewrite is one well-formed line per
- * row regardless of source.
- */
-const ensureTrailingNewline = (raw: string): string => (raw.endsWith('\n') ? raw : `${raw}\n`);

--- a/src/application/flows/_shared/progress/read-sprint-progress.ts
+++ b/src/application/flows/_shared/progress/read-sprint-progress.ts
@@ -1,0 +1,26 @@
+import { dirname, join } from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+
+/**
+ * Read `<sprintDir>/progress.md` for the inline `## Prior progress` section (audit-[07]), CAPPED to
+ * the same token budget the implement gen-eval loop uses so a long sprint's journal doesn't blow up
+ * the planning-prompt token cost. There is no "current task" in planning, so only the recent-siblings
+ * bound applies; short journals pass through unchanged. Shared by every planning flow — plan, ideate,
+ * and refine each nest their unit root exactly one level under the sprint dir (`<sprintDir>/plan/
+ * <run-slug>/`, `<sprintDir>/ideate/<run-slug>/`, `<sprintDir>/refinement/<ticket-slug>/`), so the
+ * sprint dir is always the parent of the supplied unit root. Best-effort: missing or unreadable
+ * degrades to empty string.
+ *
+ * @public
+ */
+export const readCappedSprintProgress = async (unitRoot: AbsolutePath, model: string): Promise<string> => {
+  const sprintDir = dirname(String(unitRoot));
+  try {
+    const raw = await fs.readFile(join(sprintDir, 'progress.md'), 'utf8');
+    return capProgressBody(raw, { recentBudgetTokens: progressCapBudgetForModel(model) });
+  } catch {
+    return '';
+  }
+};

--- a/src/application/flows/create-pr/leaves/create-pr-leaf.ts
+++ b/src/application/flows/create-pr/leaves/create-pr-leaf.ts
@@ -1,7 +1,12 @@
 import { Result } from '@src/domain/result.ts';
 import { recordExecutionPullRequestUrl } from '@src/domain/entity/sprint-execution.ts';
+import type { SprintExecution } from '@src/domain/entity/sprint-execution.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { Task } from '@src/domain/entity/task.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { derivePrContent, renderWarningsSection } from '@src/business/sprint/views/pr-content.ts';
+import type { PullRequestCreatorOutput } from '@src/business/scm/pull-request-creator.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 
@@ -9,6 +14,86 @@ import type { CreatePrCtx, CreatePrInput, CreatePrOutput } from '@src/applicatio
 import type { CreatePrDeps } from '@src/application/flows/create-pr/deps.ts';
 
 const ALLOWED_STATUSES = ['review', 'done'] as const;
+
+/** Status whitelist guard — PRs open after work is implemented (see module doc for rationale). */
+const assertSprintEligible = (sprint: Sprint): Result<void, InvalidStateError> => {
+  if (ALLOWED_STATUSES.includes(sprint.status as (typeof ALLOWED_STATUSES)[number])) return Result.ok(undefined);
+  return Result.error(
+    new InvalidStateError({
+      entity: 'sprint',
+      currentState: sprint.status,
+      attemptedAction: 'create-pr',
+      message: `cannot create-pr on sprint in '${sprint.status}' status — allowed: ${ALLOWED_STATUSES.join(', ')}`,
+    })
+  );
+};
+
+/** Honour the caller-supplied tasks override (ctx-input seam); otherwise load from the repo. */
+const resolveTasks = async (
+  deps: CreatePrDeps,
+  input: CreatePrInput
+): Promise<Result<readonly Task[], DomainError>> => {
+  if (input.tasks !== undefined) return Result.ok(input.tasks);
+  const loaded = await deps.taskRepo.findBySprintId(input.sprintId);
+  if (!loaded.ok) return Result.error(loaded.error);
+  return Result.ok(loaded.value);
+};
+
+/**
+ * Derive the PR title/body, honouring precedence `explicit override > AI-authored content >
+ * template-derived default`, and append the harness-side warnings section when the winning
+ * body isn't the template-derived one (see module doc: "Warnings honesty").
+ */
+const resolvePrContent = (
+  sprint: Sprint,
+  tasks: readonly Task[],
+  input: CreatePrInput
+): { readonly title: string; readonly body: string } => {
+  const derived = derivePrContent(sprint, tasks);
+  const title = input.title ?? input.aiContent?.title ?? derived.title;
+  const resolvedBody = input.body ?? input.aiContent?.body ?? derived.body;
+  const usingDerivedBody = input.body === undefined && input.aiContent?.body === undefined;
+  const warningsSection = usingDerivedBody ? '' : renderWarningsSection(tasks);
+  const body = warningsSection.length > 0 ? `${resolvedBody}\n\n${warningsSection}` : resolvedBody;
+  return { title, body };
+};
+
+/**
+ * Record the newly-created PR's URL onto the execution and persist it. Logs (and returns) the
+ * failure at either step so the URL isn't silently lost when validation or persistence fails
+ * after a successful PR open.
+ */
+const persistPrResult = async (
+  deps: CreatePrDeps,
+  execution: SprintExecution,
+  created: PullRequestCreatorOutput
+): Promise<Result<SprintExecution, DomainError>> => {
+  const recorded = recordExecutionPullRequestUrl(execution, created.url);
+  if (!recorded.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `create-pr: PR opened at ${created.url} but URL failed validation — record manually`,
+      meta: { url: created.url },
+      at: deps.clock(),
+    });
+    return Result.error(recorded.error);
+  }
+
+  const saved = await deps.sprintExecutionRepo.save(recorded.value);
+  if (!saved.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `create-pr: PR opened at ${created.url} but persistence failed — re-run will not re-open the PR`,
+      meta: { url: created.url },
+      at: deps.clock(),
+    });
+    return Result.error(saved.error);
+  }
+
+  return Result.ok(recorded.value);
+};
 
 /**
  * Open a pull/merge request for the sprint's branch and persist the resulting URL.
@@ -31,16 +116,8 @@ export const createCreatePrLeaf = (deps: CreatePrDeps): Element<CreatePrCtx> =>
         const sprint = await deps.sprintRepo.findById(input.sprintId);
         if (!sprint.ok) return Result.error(sprint.error);
 
-        if (!ALLOWED_STATUSES.includes(sprint.value.status as (typeof ALLOWED_STATUSES)[number])) {
-          return Result.error(
-            new InvalidStateError({
-              entity: 'sprint',
-              currentState: sprint.value.status,
-              attemptedAction: 'create-pr',
-              message: `cannot create-pr on sprint in '${sprint.value.status}' status — allowed: ${ALLOWED_STATUSES.join(', ')}`,
-            })
-          );
-        }
+        const eligible = assertSprintEligible(sprint.value);
+        if (!eligible.ok) return Result.error(eligible.error);
 
         const execLoaded = await deps.sprintExecutionRepo.findById(input.sprintId);
         if (!execLoaded.ok) return Result.error(execLoaded.error);
@@ -57,24 +134,11 @@ export const createCreatePrLeaf = (deps: CreatePrDeps): Element<CreatePrCtx> =>
           );
         }
 
-        // Honour caller-supplied tasks (override seam); otherwise load from the repo.
-        let tasks = input.tasks;
-        if (tasks === undefined) {
-          const loaded = await deps.taskRepo.findBySprintId(input.sprintId);
-          if (!loaded.ok) return Result.error(loaded.error);
-          tasks = loaded.value;
-        }
-        const derived = derivePrContent(sprint.value, tasks);
-        // Precedence: explicit override > AI-authored content > template-derived default.
-        const title = input.title ?? input.aiContent?.title ?? derived.title;
-        const resolvedBody = input.body ?? input.aiContent?.body ?? derived.body;
-        // Warnings honesty: `derived.body` already carries the `## Completed with warnings`
-        // section; the override / AI-authored bodies do not. Append it harness-side for those two
-        // paths so a flagged task never lands in the PR without qualification regardless of which
-        // body wins. Deterministic + reliable — no template param to thread or keep in sync.
-        const usingDerivedBody = input.body === undefined && input.aiContent?.body === undefined;
-        const warningsSection = usingDerivedBody ? '' : renderWarningsSection(tasks);
-        const body = warningsSection.length > 0 ? `${resolvedBody}\n\n${warningsSection}` : resolvedBody;
+        const tasksLoaded = await resolveTasks(deps, input);
+        if (!tasksLoaded.ok) return Result.error(tasksLoaded.error);
+        const tasks = tasksLoaded.value;
+
+        const { title, body } = resolvePrContent(sprint.value, tasks, input);
 
         deps.eventBus.publish({
           type: 'log',
@@ -94,36 +158,15 @@ export const createCreatePrLeaf = (deps: CreatePrDeps): Element<CreatePrCtx> =>
         });
         if (!created.ok) return Result.error(created.error);
 
-        const recorded = recordExecutionPullRequestUrl(execution, created.value.url);
-        if (!recorded.ok) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'error',
-            message: `create-pr: PR opened at ${created.value.url} but URL failed validation — record manually`,
-            meta: { url: created.value.url },
-            at: deps.clock(),
-          });
-          return Result.error(recorded.error);
-        }
-
-        const saved = await deps.sprintExecutionRepo.save(recorded.value);
-        if (!saved.ok) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'error',
-            message: `create-pr: PR opened at ${created.value.url} but persistence failed — re-run will not re-open the PR`,
-            meta: { url: created.value.url },
-            at: deps.clock(),
-          });
-          return Result.error(saved.error);
-        }
+        const persisted = await persistPrResult(deps, execution, created.value);
+        if (!persisted.ok) return Result.error(persisted.error);
 
         deps.eventBus.publish({
           type: 'log',
           level: 'info',
           message: `create-pr: ${created.value.platform === 'github' ? 'PR' : 'MR'} opened at ${created.value.url}`,
           meta: {
-            sprintId: String(execution.sprintId),
+            sprintId: String(persisted.value.sprintId),
             url: created.value.url,
             platform: created.value.platform,
           },

--- a/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
+++ b/src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts
@@ -109,6 +109,8 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
   leaf<CreatePrCtx, GeneratePrContentInput, GeneratePrContentOutput>(LEAF_NAME, {
     useCase: {
       execute: async (input, signal) => {
+        const log = deps.logger.named(AI_LOGGER_NAME);
+
         // Derive verbatim `Closes <ref>` lines from ticket + task externalRefs — the prompt
         // embeds the rendered string and instructs the AI to mirror it at the bottom of the
         // body. Pre-computing here keeps the trailing refs deterministic instead of relying
@@ -134,32 +136,26 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           outputContractSection: renderContractSectionFor(generatePrContentOutputContract, input.unitRoot),
         });
         if (!promptResult.ok) {
-          deps.logger
-            .named(AI_LOGGER_NAME)
-            .warn(
-              `create-pr: AI authoring skipped — prompt build failed: ${promptResult.error.message}; falling back to template`
-            );
+          log.warn(
+            `create-pr: AI authoring skipped — prompt build failed: ${promptResult.error.message}; falling back to template`
+          );
           return Result.ok({});
         }
 
         const writePrompt = await deps.writeFile(input.promptFile, String(promptResult.value));
         if (!writePrompt.ok) {
-          deps.logger
-            .named(AI_LOGGER_NAME)
-            .warn(
-              `create-pr: AI authoring skipped — prompt file write failed: ${writePrompt.error.message}; falling back to template`
-            );
+          log.warn(
+            `create-pr: AI authoring skipped — prompt file write failed: ${writePrompt.error.message}; falling back to template`
+          );
           return Result.ok({});
         }
 
         // The signalsFile path mirrors the audit-[09] convention: <outputDir>/signals.json.
         const signalsFilePathResult = AbsolutePath.parse(`${String(input.unitRoot)}/signals.json`);
         if (!signalsFilePathResult.ok) {
-          deps.logger
-            .named(AI_LOGGER_NAME)
-            .warn(
-              `create-pr: AI authoring skipped — could not resolve signals.json path: ${signalsFilePathResult.error.message}; falling back to template`
-            );
+          log.warn(
+            `create-pr: AI authoring skipped — could not resolve signals.json path: ${signalsFilePathResult.error.message}; falling back to template`
+          );
           return Result.ok({});
         }
 
@@ -184,17 +180,13 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
         try {
           const spawn = await deps.provider.generate(session);
           if (!spawn.ok) {
-            deps.logger
-              .named(AI_LOGGER_NAME)
-              .warn(`create-pr: AI authoring failed, falling back to template (${spawn.error.message})`);
+            log.warn(`create-pr: AI authoring failed, falling back to template (${spawn.error.message})`);
             return Result.ok({});
           }
 
           const validated = await validateSignalsFile(input.unitRoot, generatePrContentOutputContract);
           if (!validated.ok) {
-            deps.logger
-              .named(AI_LOGGER_NAME)
-              .warn(`create-pr: AI authoring failed, falling back to template (${validated.error.message})`);
+            log.warn(`create-pr: AI authoring failed, falling back to template (${validated.error.message})`);
             return Result.ok({});
           }
           const signals = validated.value;
@@ -219,9 +211,7 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           const prContent = signals.find((s): s is PrContentSignal => s.type === 'pr-content');
           if (prContent === undefined) {
             // Defensive — the contract's exactlyOne refine should have caught this upstream.
-            deps.logger
-              .named(AI_LOGGER_NAME)
-              .warn('create-pr: validated signals missing pr-content despite schema — falling back to template');
+            log.warn('create-pr: validated signals missing pr-content despite schema — falling back to template');
             return Result.ok({});
           }
 
@@ -230,11 +220,9 @@ export const generatePrContentLeaf = (deps: GeneratePrContentLeafDeps): Element<
           // AbortError MUST propagate per CLAUDE.md — user-initiated cancellation flows
           // through every wrapper without being absorbed by guards or fallbacks.
           if (err instanceof AbortError) throw err;
-          deps.logger
-            .named(AI_LOGGER_NAME)
-            .warn(
-              `create-pr: AI authoring failed, falling back to template (${err instanceof Error ? err.message : String(err)})`
-            );
+          log.warn(
+            `create-pr: AI authoring failed, falling back to template (${err instanceof Error ? err.message : String(err)})`
+          );
           return Result.ok({});
         }
       },

--- a/src/application/flows/detect-scripts/leaves/confirm.ts
+++ b/src/application/flows/detect-scripts/leaves/confirm.ts
@@ -70,67 +70,74 @@ type EmptyDecision = 'manual' | 'skip';
  * Edge case — no proposed scripts at all: the user is still queried with an "Enter manually /
  * Skip" choice so they're never silently no-op'd. Manual entry pre-fills any existing values.
  */
-const confirmUseCase = async (
+
+/**
+ * Handle the case where the AI returned no proposals: show the raw body when available,
+ * then offer manual entry or skip. Manual entry pre-fills any existing values and returns
+ * the user's input; skip returns an empty proposal with `accepted: false`.
+ */
+const handleEmptyProposal = async (
   deps: ConfirmDetectScriptsLeafDeps,
   input: ConfirmInput
 ): Promise<Result<ConfirmOutput, DomainError>> => {
-  const {
-    proposedSetupScript: nextSetup,
-    proposedVerifyScript: nextVerify,
-    proposedVerifyGates: nextGates,
-  } = input.proposal;
-
-  if (nextSetup === undefined && nextVerify === undefined) {
-    // AI returned no proposals — surface that to the user instead of silently no-op'ing.
-    // Show the raw body when available so a permission request / read-error / format slip is
-    // visible inline, not buried in the run dir. Then offer manual entry or skip.
-    const bodyPreview =
-      input.runDir !== undefined
-        ? await readRunBodyPreview(input.runDir, {
-            truncatedSuffix: `\n[…truncated; full body at ${String(input.runDir)}/body.txt]`,
-          })
-        : undefined;
-    const header = `AI returned no proposals for ${input.repository.name} (${String(input.repository.slug)}).`;
-    const promptLines: string[] = [header];
-    if (bodyPreview !== undefined) {
-      promptLines.push('', 'AI response:', bodyPreview);
-    } else if (input.runDir !== undefined) {
-      promptLines.push('', `Run artifacts: ${String(input.runDir)}`);
-    }
-    promptLines.push('', 'What would you like to do?');
-
-    const emptyChoices: ReadonlyArray<Choice<EmptyDecision>> = [
-      { label: 'Enter manually', value: 'manual', description: 'Type setup / verify scripts yourself.' },
-      { label: 'Skip', value: 'skip', description: 'Leave the repository unchanged.' },
-    ];
-    const decision = await deps.interactive.askChoice<EmptyDecision>(promptLines.join('\n'), emptyChoices);
-    if (!decision.ok) return Result.error(decision.error);
-    if (decision.value === 'skip') {
-      return Result.ok({ accepted: false, proposal: {} });
-    }
-    const manualSetup = await deps.interactive.askText('Setup script (empty to skip):', {
-      ...(input.repository.setupScript !== undefined ? { initial: input.repository.setupScript } : {}),
-    });
-    if (!manualSetup.ok) return Result.error(manualSetup.error);
-    const manualVerify = await deps.interactive.askText('Verify script (empty to skip):', {
-      ...(input.repository.verifyScript !== undefined ? { initial: input.repository.verifyScript } : {}),
-    });
-    if (!manualVerify.ok) return Result.error(manualVerify.error);
-    const setupOut = manualSetup.value.length > 0 ? manualSetup.value : undefined;
-    const verifyOut = manualVerify.value.length > 0 ? manualVerify.value : undefined;
-    const accepted = setupOut !== undefined || verifyOut !== undefined;
-    return Result.ok({
-      accepted,
-      proposal: {
-        ...(setupOut !== undefined ? { proposedSetupScript: setupOut } : {}),
-        ...(verifyOut !== undefined ? { proposedVerifyScript: verifyOut } : {}),
-      },
-    });
+  const bodyPreview =
+    input.runDir !== undefined
+      ? await readRunBodyPreview(input.runDir, {
+          truncatedSuffix: `\n[…truncated; full body at ${String(input.runDir)}/body.txt]`,
+        })
+      : undefined;
+  const header = `AI returned no proposals for ${input.repository.name} (${String(input.repository.slug)}).`;
+  const promptLines: string[] = [header];
+  if (bodyPreview !== undefined) {
+    promptLines.push('', 'AI response:', bodyPreview);
+  } else if (input.runDir !== undefined) {
+    promptLines.push('', `Run artifacts: ${String(input.runDir)}`);
   }
+  promptLines.push('', 'What would you like to do?');
 
-  const currentSetup = input.repository.setupScript;
-  const currentVerify = input.repository.verifyScript;
-  const preview: string[] = [`Detected scripts for ${input.repository.name} (${String(input.repository.slug)}):`, ''];
+  const emptyChoices: ReadonlyArray<Choice<EmptyDecision>> = [
+    { label: 'Enter manually', value: 'manual', description: 'Type setup / verify scripts yourself.' },
+    { label: 'Skip', value: 'skip', description: 'Leave the repository unchanged.' },
+  ];
+  const decision = await deps.interactive.askChoice<EmptyDecision>(promptLines.join('\n'), emptyChoices);
+  if (!decision.ok) return Result.error(decision.error);
+  if (decision.value === 'skip') {
+    return Result.ok({ accepted: false, proposal: {} });
+  }
+  const manualSetup = await deps.interactive.askText('Setup script (empty to skip):', {
+    ...(input.repository.setupScript !== undefined ? { initial: input.repository.setupScript } : {}),
+  });
+  if (!manualSetup.ok) return Result.error(manualSetup.error);
+  const manualVerify = await deps.interactive.askText('Verify script (empty to skip):', {
+    ...(input.repository.verifyScript !== undefined ? { initial: input.repository.verifyScript } : {}),
+  });
+  if (!manualVerify.ok) return Result.error(manualVerify.error);
+  const setupOut = manualSetup.value.length > 0 ? manualSetup.value : undefined;
+  const verifyOut = manualVerify.value.length > 0 ? manualVerify.value : undefined;
+  const accepted = setupOut !== undefined || verifyOut !== undefined;
+  return Result.ok({
+    accepted,
+    proposal: {
+      ...(setupOut !== undefined ? { proposedSetupScript: setupOut } : {}),
+      ...(verifyOut !== undefined ? { proposedVerifyScript: verifyOut } : {}),
+    },
+  });
+};
+
+/**
+ * Build the diff preview showing current vs. next scripts and verify gates.
+ * Pure function — no I/O or side effects.
+ */
+const buildProposalPreview = (
+  nextSetup: string | undefined,
+  nextVerify: string | undefined,
+  nextGates: readonly VerifyGateProposal[] | undefined,
+  currentSetup: string | undefined,
+  currentVerify: string | undefined,
+  repositoryName: string,
+  repositorySlug: string
+): string[] => {
+  const preview: string[] = [`Detected scripts for ${repositoryName} (${repositorySlug}):`, ''];
   if (nextSetup !== undefined) {
     preview.push('Setup script (sprint-start prep):');
     preview.push(`  current: ${renderScript(currentSetup)}`);
@@ -152,6 +159,70 @@ const confirmUseCase = async (
     }
     preview.push('');
   }
+  return preview;
+};
+
+/**
+ * Handle the 'Edit & approve' flow: prompt for edits to each proposed script,
+ * drop empty ones, and carry gates verbatim. Gates are not line-editable but
+ * count toward acceptance even if script lines are dropped.
+ */
+const handleEditDecision = async (
+  deps: ConfirmDetectScriptsLeafDeps,
+  nextSetup: string | undefined,
+  nextVerify: string | undefined,
+  nextGates: readonly VerifyGateProposal[] | undefined
+): Promise<Result<ConfirmOutput, DomainError>> => {
+  let editedSetup: string | undefined;
+  if (nextSetup !== undefined) {
+    const answer = await deps.interactive.askText('Edit setup script (empty to drop):', { initial: nextSetup });
+    if (!answer.ok) return Result.error(answer.error);
+    if (answer.value.length > 0) editedSetup = answer.value;
+  }
+  let editedVerify: string | undefined;
+  if (nextVerify !== undefined) {
+    const answer = await deps.interactive.askText('Edit verify script (empty to drop):', { initial: nextVerify });
+    if (!answer.ok) return Result.error(answer.error);
+    if (answer.value.length > 0) editedVerify = answer.value;
+  }
+
+  const keepGates = nextGates !== undefined && nextGates.length > 0;
+  const accepted = editedSetup !== undefined || editedVerify !== undefined || keepGates;
+  return Result.ok({
+    accepted,
+    proposal: {
+      ...(editedSetup !== undefined ? { proposedSetupScript: editedSetup } : {}),
+      ...(editedVerify !== undefined ? { proposedVerifyScript: editedVerify } : {}),
+      ...(keepGates ? { proposedVerifyGates: nextGates } : {}),
+    },
+  });
+};
+
+const confirmUseCase = async (
+  deps: ConfirmDetectScriptsLeafDeps,
+  input: ConfirmInput
+): Promise<Result<ConfirmOutput, DomainError>> => {
+  const {
+    proposedSetupScript: nextSetup,
+    proposedVerifyScript: nextVerify,
+    proposedVerifyGates: nextGates,
+  } = input.proposal;
+
+  if (nextSetup === undefined && nextVerify === undefined) {
+    return handleEmptyProposal(deps, input);
+  }
+
+  const currentSetup = input.repository.setupScript;
+  const currentVerify = input.repository.verifyScript;
+  const preview = buildProposalPreview(
+    nextSetup,
+    nextVerify,
+    nextGates,
+    currentSetup,
+    currentVerify,
+    input.repository.name,
+    String(input.repository.slug)
+  );
 
   const choices: ReadonlyArray<Choice<Decision>> = [
     { label: 'Approve', value: 'approve', description: 'Apply the proposal as-is.' },
@@ -179,33 +250,7 @@ const confirmUseCase = async (
     });
   }
 
-  // 'edit' — ask for each proposed line with the AI's suggestion pre-filled.
-  let editedSetup: string | undefined;
-  if (nextSetup !== undefined) {
-    const answer = await deps.interactive.askText('Edit setup script (empty to drop):', { initial: nextSetup });
-    if (!answer.ok) return Result.error(answer.error);
-    if (answer.value.length > 0) editedSetup = answer.value;
-  }
-  let editedVerify: string | undefined;
-  if (nextVerify !== undefined) {
-    const answer = await deps.interactive.askText('Edit verify script (empty to drop):', { initial: nextVerify });
-    if (!answer.ok) return Result.error(answer.error);
-    if (answer.value.length > 0) editedVerify = answer.value;
-  }
-
-  // Gates are not line-editable — they ride along verbatim when the user reaches the edit path.
-  // They count toward acceptance: a monorepo proposal whose script lines were both dropped still
-  // has meaningful verification to persist.
-  const keepGates = nextGates !== undefined && nextGates.length > 0;
-  const accepted = editedSetup !== undefined || editedVerify !== undefined || keepGates;
-  return Result.ok({
-    accepted,
-    proposal: {
-      ...(editedSetup !== undefined ? { proposedSetupScript: editedSetup } : {}),
-      ...(editedVerify !== undefined ? { proposedVerifyScript: editedVerify } : {}),
-      ...(keepGates ? { proposedVerifyGates: nextGates } : {}),
-    },
-  });
+  return handleEditDecision(deps, nextSetup, nextVerify, nextGates);
 };
 
 const renderScript = (script: string | undefined): string => (script === undefined ? '(none)' : script);

--- a/src/application/flows/doctor/flow.ts
+++ b/src/application/flows/doctor/flow.ts
@@ -154,6 +154,222 @@ const probeCliAuth = async (
   return { id, label, status: 'warn', detail, hint, group };
 };
 
+/** Probe storage paths for readability and writability. */
+const probeStorageGroup = async (input: DoctorInput): Promise<readonly ProbeResult[]> => {
+  const probes: ProbeResult[] = [];
+  probes.push(await probePath('data-root', 'Data root readable', input.dataRoot, 'storage'));
+  probes.push(await probePath('config-root', 'Config root readable', input.configRoot, 'storage'));
+  probes.push(await probeWritable('data-root-writable', 'Data root writable', input.dataRoot));
+  probes.push(await probeWritable('config-root-writable', 'Config root writable', input.configRoot));
+  return probes;
+};
+
+/** Probe settings file persistence. */
+const probeSettingsGroup = async (deps: DoctorDeps): Promise<readonly ProbeResult[]> => {
+  const probes: ProbeResult[] = [];
+  const SETTINGS_PERSISTED_ID = 'settings-persisted';
+  const SETTINGS_PRESENT_LABEL = 'Settings file present';
+  const settingsPath = deps.settingsRepo.path;
+  const settingsExists = await deps.settingsRepo.exists();
+  if (!settingsExists.ok) {
+    probes.push({
+      id: SETTINGS_PERSISTED_ID,
+      label: SETTINGS_PRESENT_LABEL,
+      status: 'fail',
+      detail: `${settingsPath} — ${settingsExists.error.message}`,
+      group: 'settings',
+    });
+  } else if (settingsExists.value) {
+    probes.push({
+      id: SETTINGS_PERSISTED_ID,
+      label: SETTINGS_PRESENT_LABEL,
+      status: 'pass',
+      detail: settingsPath,
+      group: 'settings',
+    });
+  } else {
+    probes.push({
+      id: SETTINGS_PERSISTED_ID,
+      label: SETTINGS_PRESENT_LABEL,
+      status: 'warn',
+      detail: `${settingsPath} — using built-in defaults (first run)`,
+      hint: 'open the welcome flow to pick a provider and persist your settings',
+      group: 'settings',
+    });
+  }
+  return probes;
+};
+
+/** Probe VCS tooling: git, GitHub CLI, GitLab CLI, and their authentication. */
+const probeVcsToolingGroup = async (deps: DoctorDeps): Promise<readonly ProbeResult[]> => {
+  const probes: ProbeResult[] = [];
+
+  const gitInstalled = await deps.commandExists('git');
+  probes.push({
+    id: 'git-installed',
+    label: 'Git installed',
+    status: gitInstalled ? 'pass' : 'fail',
+    detail: gitInstalled ? 'git found on PATH' : 'git not found on PATH',
+    group: 'vcs',
+    ...(gitInstalled ? {} : { hint: 'install git — required for implement / review flows' }),
+  });
+  if (gitInstalled) {
+    probes.push(
+      await probeGitConfig(
+        'git-user-name',
+        'Git user.name',
+        'user.name',
+        deps.runCommand,
+        'run `git config --global user.name "<your name>"` so commits are attributed correctly'
+      )
+    );
+    probes.push(
+      await probeGitConfig(
+        'git-user-email',
+        'Git user.email',
+        'user.email',
+        deps.runCommand,
+        'run `git config --global user.email "<you@example.com>"` so commits are attributed correctly'
+      )
+    );
+  }
+
+  const ghInstalled = await deps.commandExists('gh');
+  probes.push({
+    id: 'gh-installed',
+    label: 'GitHub CLI (`gh`) installed',
+    status: ghInstalled ? 'pass' : 'warn',
+    detail: ghInstalled ? 'gh found on PATH' : 'gh not found on PATH',
+    group: 'vcs',
+    ...(ghInstalled ? {} : { hint: 'install gh from https://cli.github.com if you target GitHub' }),
+  });
+  if (ghInstalled) {
+    probes.push(
+      await probeCliAuth(
+        'gh-auth',
+        'GitHub CLI authenticated',
+        'gh',
+        ['auth', 'status'],
+        'run `gh auth login` to sign in',
+        deps.runCommand
+      )
+    );
+  }
+
+  const glabInstalled = await deps.commandExists('glab');
+  probes.push({
+    id: 'glab-installed',
+    label: 'GitLab CLI (`glab`) installed',
+    status: glabInstalled ? 'pass' : 'warn',
+    detail: glabInstalled ? 'glab found on PATH' : 'glab not found on PATH',
+    group: 'vcs',
+    ...(glabInstalled ? {} : { hint: 'install glab from https://gitlab.com/gitlab-org/cli if you target GitLab' }),
+  });
+  if (glabInstalled) {
+    probes.push(
+      await probeCliAuth(
+        'glab-auth',
+        'GitLab CLI authenticated',
+        'glab',
+        ['auth', 'status'],
+        'run `glab auth login` to sign in',
+        deps.runCommand
+      )
+    );
+  }
+
+  return probes;
+};
+
+/** Probe AI provider CLIs and their authentication. */
+const probeAiProvidersGroup = async (deps: DoctorDeps): Promise<readonly ProbeResult[]> => {
+  const probes: ProbeResult[] = [];
+
+  const settings = await deps.settingsRepo.load();
+  // Per-flow rows can each pick a provider; surface every provider that appears on any row
+  // as "configured" so the doctor flags binaries the user actually relies on.
+  const configuredProviders: ReadonlySet<AiProvider> = settings.ok
+    ? new Set<AiProvider>([
+        settings.value.ai.refine.provider,
+        settings.value.ai.plan.provider,
+        settings.value.ai.implement.generator.provider,
+        settings.value.ai.implement.evaluator.provider,
+        settings.value.ai.readiness.provider,
+        settings.value.ai.ideate.provider,
+      ])
+    : new Set<AiProvider>();
+
+  let codexInstalled = false;
+  for (const provider of Object.keys(PROVIDER_BINARY) as readonly AiProvider[]) {
+    const binary = PROVIDER_BINARY[provider];
+    const isConfigured = configuredProviders.has(provider);
+    const probe = await probeBinary(
+      `ai-${provider}`,
+      `${PROVIDER_LABEL[provider]}${isConfigured ? ' (configured)' : ''}`,
+      binary,
+      'ai',
+      deps.commandExists,
+      `install the '${binary}' CLI and ensure it is on your PATH`
+    );
+    if (provider === 'openai-codex') codexInstalled = probe.status === 'pass';
+    if (probe.status === 'fail') {
+      probes.push({ ...probe, status: 'warn' });
+    } else {
+      probes.push(probe);
+    }
+  }
+
+  if (configuredProviders.has('openai-codex') && codexInstalled) {
+    probes.push(
+      await probeCliAuth(
+        'codex-auth',
+        'OpenAI Codex CLI authenticated',
+        'codex',
+        ['login', 'status'],
+        'run `codex login` to sign in',
+        deps.runCommand,
+        'ai'
+      )
+    );
+  }
+
+  return probes;
+};
+
+/** Probe repository lists and data integrity. */
+const probeRepositoriesAndIntegrityGroup = async (deps: DoctorDeps): Promise<readonly ProbeResult[]> => {
+  const probes: ProbeResult[] = [];
+
+  const projects = await deps.projectRepo.list();
+  probes.push({
+    id: 'projects-list',
+    label: 'Project repository responds',
+    status: projects.ok ? 'pass' : 'fail',
+    detail: projects.ok ? `${String(projects.value.length)} project(s)` : projects.error.message,
+    group: 'repositories',
+  });
+
+  const sprints = await deps.sprintRepo.list();
+  probes.push({
+    id: 'sprints-list',
+    label: 'Sprint repository responds',
+    status: sprints.ok ? 'pass' : 'fail',
+    detail: sprints.ok ? `${String(sprints.value.length)} sprint(s)` : sprints.error.message,
+    group: 'repositories',
+  });
+
+  if (projects.ok && projects.value.length > 0) {
+    probes.push(...(await probeProjectRepoPaths(projects.value)));
+    probes.push(...(await probeProjectDefaultBranches(projects.value, deps.runCommand)));
+  }
+
+  if (sprints.ok && sprints.value.length > 0) {
+    probes.push(await probeSprintExecutionPairing(sprints.value, deps.sprintExecutionRepo));
+  }
+
+  return probes;
+};
+
 /**
  * Run the standard sanity probes and report each one's outcome. Always resolves to ok — a
  * failed probe is data, not an error.
@@ -167,199 +383,12 @@ export const createDoctorFlow = (deps: DoctorDeps): Element<DoctorCtx> =>
       async execute(input) {
         const probes: ProbeResult[] = [];
 
-        // ---- Storage ----------------------------------------------------------
-        probes.push(await probePath('data-root', 'Data root readable', input.dataRoot, 'storage'));
-        probes.push(await probePath('config-root', 'Config root readable', input.configRoot, 'storage'));
-        probes.push(await probeWritable('data-root-writable', 'Data root writable', input.dataRoot));
-        probes.push(await probeWritable('config-root-writable', 'Config root writable', input.configRoot));
-
-        // ---- Runtime ----------------------------------------------------------
+        probes.push(...(await probeStorageGroup(input)));
         probes.push(probeNodeVersion(deps.nodeVersion));
-
-        // ---- Settings ---------------------------------------------------------
-        const SETTINGS_PERSISTED_ID = 'settings-persisted';
-        const SETTINGS_PRESENT_LABEL = 'Settings file present';
-        const settingsPath = deps.settingsRepo.path;
-        const settingsExists = await deps.settingsRepo.exists();
-        if (!settingsExists.ok) {
-          probes.push({
-            id: SETTINGS_PERSISTED_ID,
-            label: SETTINGS_PRESENT_LABEL,
-            status: 'fail',
-            detail: `${settingsPath} — ${settingsExists.error.message}`,
-            group: 'settings',
-          });
-        } else if (settingsExists.value) {
-          probes.push({
-            id: SETTINGS_PERSISTED_ID,
-            label: SETTINGS_PRESENT_LABEL,
-            status: 'pass',
-            detail: settingsPath,
-            group: 'settings',
-          });
-        } else {
-          probes.push({
-            id: SETTINGS_PERSISTED_ID,
-            label: SETTINGS_PRESENT_LABEL,
-            status: 'warn',
-            detail: `${settingsPath} — using built-in defaults (first run)`,
-            hint: 'open the welcome flow to pick a provider and persist your settings',
-            group: 'settings',
-          });
-        }
-
-        // ---- VCS tooling: git + hosting CLIs ----------------------------------
-        const gitInstalled = await deps.commandExists('git');
-        probes.push({
-          id: 'git-installed',
-          label: 'Git installed',
-          status: gitInstalled ? 'pass' : 'fail',
-          detail: gitInstalled ? 'git found on PATH' : 'git not found on PATH',
-          group: 'vcs',
-          ...(gitInstalled ? {} : { hint: 'install git — required for implement / review flows' }),
-        });
-        if (gitInstalled) {
-          probes.push(
-            await probeGitConfig(
-              'git-user-name',
-              'Git user.name',
-              'user.name',
-              deps.runCommand,
-              'run `git config --global user.name "<your name>"` so commits are attributed correctly'
-            )
-          );
-          probes.push(
-            await probeGitConfig(
-              'git-user-email',
-              'Git user.email',
-              'user.email',
-              deps.runCommand,
-              'run `git config --global user.email "<you@example.com>"` so commits are attributed correctly'
-            )
-          );
-        }
-
-        const ghInstalled = await deps.commandExists('gh');
-        probes.push({
-          id: 'gh-installed',
-          label: 'GitHub CLI (`gh`) installed',
-          status: ghInstalled ? 'pass' : 'warn',
-          detail: ghInstalled ? 'gh found on PATH' : 'gh not found on PATH',
-          group: 'vcs',
-          ...(ghInstalled ? {} : { hint: 'install gh from https://cli.github.com if you target GitHub' }),
-        });
-        if (ghInstalled) {
-          probes.push(
-            await probeCliAuth(
-              'gh-auth',
-              'GitHub CLI authenticated',
-              'gh',
-              ['auth', 'status'],
-              'run `gh auth login` to sign in',
-              deps.runCommand
-            )
-          );
-        }
-
-        const glabInstalled = await deps.commandExists('glab');
-        probes.push({
-          id: 'glab-installed',
-          label: 'GitLab CLI (`glab`) installed',
-          status: glabInstalled ? 'pass' : 'warn',
-          detail: glabInstalled ? 'glab found on PATH' : 'glab not found on PATH',
-          group: 'vcs',
-          ...(glabInstalled
-            ? {}
-            : { hint: 'install glab from https://gitlab.com/gitlab-org/cli if you target GitLab' }),
-        });
-        if (glabInstalled) {
-          probes.push(
-            await probeCliAuth(
-              'glab-auth',
-              'GitLab CLI authenticated',
-              'glab',
-              ['auth', 'status'],
-              'run `glab auth login` to sign in',
-              deps.runCommand
-            )
-          );
-        }
-
-        // ---- AI providers -----------------------------------------------------
-        const settings = await deps.settingsRepo.load();
-        // Per-flow rows can each pick a provider; surface every provider that appears on any row
-        // as "configured" so the doctor flags binaries the user actually relies on.
-        const configuredProviders: ReadonlySet<AiProvider> = settings.ok
-          ? new Set<AiProvider>([
-              settings.value.ai.refine.provider,
-              settings.value.ai.plan.provider,
-              settings.value.ai.implement.generator.provider,
-              settings.value.ai.implement.evaluator.provider,
-              settings.value.ai.readiness.provider,
-              settings.value.ai.ideate.provider,
-            ])
-          : new Set<AiProvider>();
-        let codexInstalled = false;
-        for (const provider of Object.keys(PROVIDER_BINARY) as readonly AiProvider[]) {
-          const binary = PROVIDER_BINARY[provider];
-          const isConfigured = configuredProviders.has(provider);
-          const probe = await probeBinary(
-            `ai-${provider}`,
-            `${PROVIDER_LABEL[provider]}${isConfigured ? ' (configured)' : ''}`,
-            binary,
-            'ai',
-            deps.commandExists,
-            `install the '${binary}' CLI and ensure it is on your PATH`
-          );
-          if (provider === 'openai-codex') codexInstalled = probe.status === 'pass';
-          if (probe.status === 'fail') {
-            probes.push({ ...probe, status: 'warn' });
-          } else {
-            probes.push(probe);
-          }
-        }
-        if (configuredProviders.has('openai-codex') && codexInstalled) {
-          probes.push(
-            await probeCliAuth(
-              'codex-auth',
-              'OpenAI Codex CLI authenticated',
-              'codex',
-              ['login', 'status'],
-              'run `codex login` to sign in',
-              deps.runCommand,
-              'ai'
-            )
-          );
-        }
-
-        // ---- Repositories -----------------------------------------------------
-        const projects = await deps.projectRepo.list();
-        probes.push({
-          id: 'projects-list',
-          label: 'Project repository responds',
-          status: projects.ok ? 'pass' : 'fail',
-          detail: projects.ok ? `${String(projects.value.length)} project(s)` : projects.error.message,
-          group: 'repositories',
-        });
-
-        const sprints = await deps.sprintRepo.list();
-        probes.push({
-          id: 'sprints-list',
-          label: 'Sprint repository responds',
-          status: sprints.ok ? 'pass' : 'fail',
-          detail: sprints.ok ? `${String(sprints.value.length)} sprint(s)` : sprints.error.message,
-          group: 'repositories',
-        });
-
-        // ---- Integrity --------------------------------------------------------
-        if (projects.ok && projects.value.length > 0) {
-          probes.push(...(await probeProjectRepoPaths(projects.value)));
-          probes.push(...(await probeProjectDefaultBranches(projects.value, deps.runCommand)));
-        }
-
-        if (sprints.ok && sprints.value.length > 0) {
-          probes.push(await probeSprintExecutionPairing(sprints.value, deps.sprintExecutionRepo));
-        }
+        probes.push(...(await probeSettingsGroup(deps)));
+        probes.push(...(await probeVcsToolingGroup(deps)));
+        probes.push(...(await probeAiProvidersGroup(deps)));
+        probes.push(...(await probeRepositoriesAndIntegrityGroup(deps)));
 
         const hasFailures = probes.some((p) => p.status === 'fail');
         const allPassed = probes.every((p) => p.status === 'pass');

--- a/src/application/flows/ideate/flow.ts
+++ b/src/application/flows/ideate/flow.ts
@@ -1,5 +1,4 @@
-import { dirname, join } from 'node:path';
-import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -16,7 +15,7 @@ import { saveTasksLeaf } from '@src/application/flows/_shared/task/save.ts';
 import { buildUnitLeaf } from '@src/application/flows/_shared/build-unit.ts';
 import { renderPromptToFileLeaf } from '@src/application/flows/_shared/render-prompt-to-file.ts';
 import { buildIdeatePrompt } from '@src/integration/ai/prompts/ideate/definition.ts';
-import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+import { readCappedSprintProgress } from '@src/application/flows/_shared/progress/read-sprint-progress.ts';
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
 import { ideateOutputContract } from '@src/application/flows/ideate/leaves/ideate.contract.ts';
 import type { IdeateCtx } from '@src/application/flows/ideate/ctx.ts';
@@ -78,24 +77,6 @@ export interface CreateIdeateFlowOpts {
  * "tasks are ready" signal — saving it last means a crash mid-save leaves the sprint `draft` even
  * if the tasks already landed.
  */
-/**
- * Read `<sprintDir>/progress.md` for the inline `## Prior progress` section (audit-[07]), CAPPED to
- * the same token budget the implement gen-eval loop uses so a long sprint's journal doesn't blow up
- * the planning-prompt token cost. No "current task" in ideate, so only the recent-siblings bound
- * applies; short journals pass through unchanged. Ideate runs under `<sprintDir>/ideate/<run-slug>/`,
- * so the sprint dir is the parent of the supplied ideate root. Best-effort: missing or unreadable
- * degrades to empty string.
- */
-const readSprintProgress = async (ideateRoot: AbsolutePath, model: string): Promise<string> => {
-  const sprintDir = dirname(String(ideateRoot));
-  try {
-    const raw = await fs.readFile(join(sprintDir, 'progress.md'), 'utf8');
-    return capProgressBody(raw, { recentBudgetTokens: progressCapBudgetForModel(model) });
-  } catch {
-    return '';
-  }
-};
-
 /**
  * Transition the ctx draft sprint `draft → planned` after `ideate-and-plan` has appended an
  * approved ticket + its tasks. Reuses the SAME domain transition the plan flow runs
@@ -159,7 +140,7 @@ export const createIdeateFlow = (deps: IdeateDeps, opts: CreateIdeateFlowOpts): 
         buildPrompt: async (ctx) => {
           if (ctx.project === undefined) throw new Error('project missing');
           if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          const priorProgress = await readSprintProgress(opts.ideateRoot, opts.model);
+          const priorProgress = await readCappedSprintProgress(opts.ideateRoot, opts.model);
           return buildIdeatePrompt(deps.templateLoader, {
             ideaTitle: opts.ideaTitle,
             ideaDescription: opts.ideaText,

--- a/src/application/flows/implement/deps.ts
+++ b/src/application/flows/implement/deps.ts
@@ -17,6 +17,7 @@ import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-sourc
 import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
 import type { WriteFile } from '@src/business/io/write-file.ts';
 import type { AppendFile } from '@src/business/io/append-file.ts';
+import type { FoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 
 /**
  * Narrow dependency contract for the implement chain. Composition root constructs each field
@@ -75,7 +76,16 @@ export interface ImplementDeps {
   readonly writeFile: WriteFile;
   /**
    * Append-only writer — used by `append-journal-separator-leaf` to grow `<sprintDir>/progress.md`
-   * (audit-[07]). The `progress-journal-leaf` uses {@link writeFile} instead (read-regenerate-write).
+   * (audit-[07]). The `progress-journal-leaf` uses {@link writeFile} instead (read-regenerate-write,
+   * guarded by {@link journalMutex}).
    */
   readonly appendFile: AppendFile;
+  /**
+   * Mutex guarding `progress-journal-<taskId>`'s read → regenerate-header → append-section →
+   * write critical section on `<sprintDir>/progress.md`. Built once per run by the launcher, so on
+   * the parallel wave path every branch inherits the SAME instance (branches spread this deps bag)
+   * and their journal leaves never race the shared sprint journal file; the serial path is a single
+   * caller that never contends with itself. See `wave-branch.ts`'s `FoldQueue`/`createFoldQueue`.
+   */
+  readonly journalMutex: FoldQueue;
 }

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -440,6 +440,9 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
       maxAttempts: deps.config.harness.maxAttempts,
     });
 
+  // The serial path is a single caller — no other branch ever contends with it — so the run's
+  // `deps.journalMutex` acts as an effective no-op for `progress-journal-<taskId>`'s critical
+  // section (which always runs inside the mutex, whether or not there is contention).
   const perTaskChains = opts.todoTasks.map((task) =>
     createPerTaskSubchain(
       deps,

--- a/src/application/flows/implement/leaves/_shared/dedupe-texts.ts
+++ b/src/application/flows/implement/leaves/_shared/dedupe-texts.ts
@@ -1,0 +1,22 @@
+/**
+ * Trim + dedupe a per-attempt signal-text accumulator (changes / decisions / notes), preserving
+ * first-seen order. Entries that are empty / whitespace-only after trimming are dropped; a later
+ * duplicate of an already-seen trimmed text is discarded. Undefined / empty input resolves to an
+ * empty array — callers never need an `?? []` guard.
+ *
+ * Shared by the progress-journal and append-learnings leaves (both leaves fold their own
+ * change/decision/note accumulators through this exact contract before rendering / persisting).
+ */
+export const dedupeTexts = (texts: readonly string[] | undefined): readonly string[] => {
+  if (texts === undefined || texts.length === 0) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of texts) {
+    const trimmed = t.trim();
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+};

--- a/src/application/flows/implement/leaves/append-learnings.ts
+++ b/src/application/flows/implement/leaves/append-learnings.ts
@@ -21,6 +21,7 @@ import { resolveWritableLearningsLedgerPath } from '@src/application/flows/_shar
 import { appendMemoryRecords } from '@src/application/flows/_shared/memory/ledger-writer.ts';
 import type { Slug } from '@src/domain/value/slug.ts';
 import { dedupeLearnings } from '@src/application/flows/implement/leaves/_shared/dedupe-learnings.ts';
+import { dedupeTexts } from '@src/application/flows/implement/leaves/_shared/dedupe-texts.ts';
 import type { LearningEntry } from '@src/domain/signal.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
@@ -134,19 +135,6 @@ const buildRecords = (
   return [...learningRecords, ...decisionRecords];
 };
 
-/** Trim + dedupe a per-attempt decision-text accumulator (first-seen order); drops empties. */
-const dedupeDecisions = (texts: readonly string[]): readonly string[] => {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const t of texts) {
-    const trimmed = t.trim();
-    if (trimmed.length === 0 || seen.has(trimmed)) continue;
-    seen.add(trimmed);
-    out.push(trimmed);
-  }
-  return out;
-};
-
 /**
  * Factory — `append-learnings-<taskId>`. Looks up the just-settled task by id (settle-attempt
  * clears `currentTask`), builds one {@link LearningRecord} per deduped learning AND per deduped
@@ -208,7 +196,7 @@ export const appendLearningsLeaf = (
       // Read the STILL-POPULATED accumulators (progress-journal clears them AFTER us). Dedupe so an
       // identical signal emitted twice in one attempt produces one row.
       const learnings = dedupeLearnings(ctx.currentAttemptLearnings ?? []);
-      const decisions = dedupeDecisions(ctx.currentAttemptDecisions ?? []);
+      const decisions = dedupeTexts(ctx.currentAttemptDecisions);
       const records = buildRecords(deps, opts, task, String(ctx.sprintId), learnings, decisions);
       // The path is resolved at execute time (async tolerant write-side resolver), so the still-sync
       // input projection just threads the resolver thunk through.

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -233,226 +233,299 @@ const buildEvaluatorPrompt = async (
   });
 };
 
+/**
+ * Build one evaluator turn's corrective-retry `reinvoke` callback — resumes the just-spawned
+ * thread (falling back to the prior round's session id when this spawn never reported one to
+ * disk) so the corrective message lands as a follow-up turn on the SAME conversation the AI
+ * just wrote invalid/missing signals from. Mirrors the generator-leaf helper of the same shape.
+ */
+const makeEvaluatorReinvoke =
+  (
+    deps: Pick<EvaluatorLeafDeps, 'provider' | 'cwd' | 'sprintDir' | 'model' | 'effort'>,
+    args: {
+      readonly workspaceRoot: AbsolutePath;
+      readonly roundNum: number;
+      readonly signalsFile: AbsolutePath;
+      readonly priorEvaluatorSessionId: SessionId | undefined;
+      readonly signal: AbortSignal | undefined;
+    }
+  ): ((corrective: Prompt) => Promise<Result<void, DomainError>>) =>
+  async (corrective) => {
+    // Resume the reviewer's just-spawned thread so the corrective lands as a follow-up turn —
+    // read the session id this spawn captured to disk. Falls back to the prior-round id when
+    // this spawn never reported one.
+    const resume =
+      (await readRoundSessionId(args.workspaceRoot, args.roundNum, 'evaluator')) ?? args.priorEvaluatorSessionId;
+    const respawn = await deps.provider.generate(
+      implementSession(
+        args.workspaceRoot,
+        deps.cwd,
+        deps.sprintDir,
+        corrective as Prompt,
+        deps.model,
+        args.signalsFile,
+        'evaluator',
+        resume,
+        deps.effort,
+        args.signal
+      )
+    );
+    return respawn.ok ? Result.ok(undefined) : Result.error(respawn.error);
+  };
+
+/**
+ * Build this turn's `callEvaluate` — selects + builds + persists the prompt, spawns the reviewer,
+ * validates `signals.json` with one corrective retry (self-contained against a cold resume so a
+ * context-free retry can't fabricate a verdict), fans the parsed signals out to the sink/bus, and
+ * renders harness-owned sidecars (`evaluation.md`). Returns the parsed signals for
+ * `runEvaluatorTurnUseCase` to interpret.
+ */
+const makeEvaluatorCallEvaluate =
+  (
+    deps: EvaluatorLeafDeps,
+    args: {
+      readonly input: EvaluatorInput;
+      readonly signalsFile: AbsolutePath;
+      readonly outputDir: AbsolutePath;
+      readonly signal: AbortSignal | undefined;
+    }
+  ): RunEvaluatorTurnProps['callEvaluate'] =>
+  async (task) => {
+    const outputContractSection = renderContractSectionFor(evaluatorOutputContract, args.outputDir);
+    const prompt = await buildEvaluatorPrompt(deps, {
+      task,
+      workspaceRoot: args.input.workspaceRoot,
+      roundNum: args.input.roundNum,
+      outputContractSection,
+      priorEvaluatorSessionId: args.input.priorEvaluatorSessionId,
+      generatorHints: args.input.generatorHints,
+    });
+    if (!prompt.ok) return Result.error(prompt.error) as Result<readonly HarnessSignal[], DomainError>;
+    // Persist the rendered prompt under `rounds/<N>/evaluator/prompt.md` BEFORE the AI
+    // call so a crash mid-spawn still leaves the prompt on disk for post-hoc replay.
+    // Best-effort: the writer logs and swallows on failure.
+    await writeRoundPrompt(
+      args.input.workspaceRoot,
+      args.input.roundNum,
+      'evaluator',
+      String(prompt.value),
+      deps.logger
+    );
+
+    const spawn = await deps.provider.generate(
+      implementSession(
+        args.input.workspaceRoot,
+        deps.cwd,
+        deps.sprintDir,
+        prompt.value,
+        deps.model,
+        args.signalsFile,
+        'evaluator',
+        args.input.priorEvaluatorSessionId,
+        deps.effort,
+        args.signal
+      )
+    );
+    if (!spawn.ok) return Result.error(spawn.error);
+
+    // Validate `signals.json` against the evaluator contract. On a RECOVERABLE failure
+    // (signals-missing / invalid-json / schema-mismatch) re-prompt the reviewer ONCE on
+    // the resumed session with a corrective message + the Zod issue list, then re-validate
+    // — one near-miss element no longer blocks the whole verdict. `runEvaluatorTurnUseCase`
+    // converts a still-failing validation into a `self-blocked` exit (task settles as
+    // blocked — the ungraded change is NOT marked done; run continues); only a fatal
+    // `Aborted`/`RateLimit` propagates.
+    const validated = await validateSignalsFileWithCorrectiveRetry(
+      {
+        outputDir: args.outputDir,
+        logger: deps.logger,
+        // Self-containment for a COLD corrective spawn (no resumable id / codex stale-resume
+        // fallback): the per-round output contract plus the reviewer's grounding — without
+        // this, a context-free retry's whole prompt is the error text, which is exactly
+        // enough scaffolding to fabricate a schema-valid verdict for unseen work.
+        selfContainedContext: [
+          `Task spec (read it): \`${join(String(args.input.workspaceRoot), 'contract.md')}\``,
+          'Your PRIMARY INPUT is the uncommitted working-tree diff — inspect it via shell',
+          '(`git status` / `git diff HEAD`) before grading. A verdict must reflect the actual',
+          'work, never this message.',
+          '',
+          outputContractSection,
+        ].join('\n'),
+        reinvoke: makeEvaluatorReinvoke(deps, {
+          workspaceRoot: args.input.workspaceRoot,
+          roundNum: args.input.roundNum,
+          signalsFile: args.signalsFile,
+          priorEvaluatorSessionId: args.input.priorEvaluatorSessionId,
+          signal: args.signal,
+        }),
+      },
+      evaluatorOutputContract
+    );
+    if (!validated.ok) return Result.error(validated.error);
+    const signals = validated.value;
+
+    // Fan out to BOTH the legacy `HarnessSignalSink` (TUI panels, decisions-log) and
+    // the application bus's typed `ai-signal` event. The bus carries every kind the
+    // contract accepts; the sink keeps its existing per-kind consumers happy until
+    // Wave 6 collapses the two paths.
+    for (const sig of signals) {
+      deps.signals.emit(sig);
+      deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: 'evaluator' });
+    }
+
+    // Render harness-owned sidecars (`evaluation.md`). Write failures log warn inside
+    // `renderSidecars`; the helper always returns `Result.ok` (sidecars are operator UX
+    // only — `runEvaluatorTurnUseCase` consumes the in-memory `evaluation` signal, never
+    // the rendered file).
+    await renderSidecars(deps.writeFile, args.outputDir, signals, evaluatorOutputContract.sidecars, deps.logger);
+
+    // `runEvaluatorTurnUseCase` expects `readonly HarnessSignal[]`. `EvaluatorContractSignal`
+    // is a strict subset of `HarnessSignal`, but TS's array variance doesn't infer that
+    // automatically — cast through `AiSignal[]` (the canonical union alias) to keep the
+    // call site honest about the underlying domain shape.
+    return Result.ok(signals as readonly AiSignal[]) as Result<readonly HarnessSignal[], DomainError>;
+  };
+
+/**
+ * Build this leaf's `execute` — resolves the round's `signals.json` path, fingerprints the
+ * working tree's uncommitted changes for the plateau predicate's progress exemption, drives one
+ * evaluator turn via `runEvaluatorTurnUseCase` (see {@link makeEvaluatorCallEvaluate}), then reads
+ * back the captured session id into {@link EvaluatorOutput}.
+ */
+const makeEvaluatorExecute =
+  (
+    deps: EvaluatorLeafDeps
+  ): ((input: EvaluatorInput, signal?: AbortSignal) => Promise<Result<EvaluatorOutput, DomainError>>) =>
+  async (input, signal) => {
+    const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, input.roundNum, 'evaluator'));
+    if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
+    const signalsFile = signalsFilePath.value;
+
+    // `outputDir` is the per-round directory (`rounds/<N>/evaluator/`);
+    // `validateSignalsFile` resolves `<outputDir>/signals.json` and `renderSidecars`
+    // writes harness-rendered sidecars into the same directory. We derive it once from
+    // `signalsFile` so the two paths stay structurally coupled.
+    const outputDirPath = AbsolutePath.parse(dirname(String(signalsFile)));
+    if (!outputDirPath.ok) return Result.error(outputDirPath.error);
+    const outputDir = outputDirPath.value;
+
+    const callEvaluate = makeEvaluatorCallEvaluate(deps, { input, signalsFile, outputDir, signal });
+
+    // Fingerprint the working tree's uncommitted changes for this round so the plateau
+    // predicate's progress exemption measures real code change instead of commit-message
+    // rewording. Best-effort — a git failure yields `undefined` and the predicate degrades
+    // to the commit-subject proxy. Computed BEFORE the use case so the record carries it.
+    const changedFilesHash = await computeWorkProductFingerprint(deps.gitRunner, deps.cwd);
+
+    const result = await runEvaluatorTurnUseCase({
+      task: input.task,
+      priorTurns: input.priorTurns,
+      plateauThreshold: deps.plateauThreshold,
+      ...(input.currentCommitSubject !== undefined ? { currentCommitSubject: input.currentCommitSubject } : {}),
+      ...(changedFilesHash !== undefined ? { changedFilesHash } : {}),
+      callEvaluate,
+      evaluationFile: roundEvaluationRelativePath(input.roundNum),
+      logger: deps.logger,
+    });
+    if (!result.ok) return Result.error(result.error);
+
+    // Read THIS turn's captured sessionId from disk (the Claude adapter just wrote it as a
+    // sibling of `signals.json` via `persistSessionIdFile`). Undefined when the spawn never
+    // reported an id — left undefined so the next round cold-starts cleanly.
+    const capturedSessionId = await readRoundSessionId(input.workspaceRoot, input.roundNum, 'evaluator');
+
+    return Result.ok({
+      task: result.value.task,
+      ...(result.value.evaluation !== undefined ? { evaluation: result.value.evaluation } : {}),
+      ...(result.value.exit !== undefined ? { exit: result.value.exit } : {}),
+      ...(result.value.turnRecord !== undefined ? { turnRecord: result.value.turnRecord } : {}),
+      ...(capturedSessionId !== undefined ? { capturedSessionId } : {}),
+    });
+  };
+
+/**
+ * Build this leaf's `input` projection — validates the ctx preconditions the evaluator turn needs
+ * (`currentTask`, `taskWorkspaceRoot`, `currentRoundNum`), then composes the same-round
+ * `<generator_hints>` block (T5) from pure ctx reads before assembling {@link EvaluatorInput}.
+ */
+const makeEvaluatorInput =
+  (taskId: TaskId): ((ctx: ImplementCtx) => EvaluatorInput) =>
+  (ctx) => {
+    if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
+      throw new InvalidStateError({
+        entity: 'chain',
+        currentState: 'pre-evaluator',
+        attemptedAction: `evaluator-${String(taskId)}`,
+        message: `evaluator-${String(taskId)}: ctx.currentTask missing or mismatched`,
+      });
+    }
+    if (ctx.currentTask.status !== 'in_progress') {
+      throw new InvalidStateError({
+        entity: 'task',
+        currentState: ctx.currentTask.status,
+        attemptedAction: `evaluator-${String(taskId)}`,
+        message: `evaluator-${String(taskId)}: expected in_progress task`,
+      });
+    }
+    if (ctx.taskWorkspaceRoot === undefined || ctx.currentRoundNum === undefined) {
+      throw new InvalidStateError({
+        entity: 'chain',
+        currentState: 'pre-evaluator',
+        attemptedAction: `evaluator-${String(taskId)}`,
+        message: `evaluator-${String(taskId)}: ctx.taskWorkspaceRoot/currentRoundNum missing — generator leaf must run first`,
+      });
+    }
+    const currentCommitSubject = ctx.proposedCommitMessage?.subject;
+    // T5: compose the same-round generator hints from the per-attempt ctx accumulators. Pure
+    // read — `composeGeneratorHints` caps + clamps so a deep multi-round attempt's accumulators
+    // can't balloon the evaluator prompt. Empty across all sources → '' → placeholder collapses.
+    const hintsInput: GeneratorHintsInput = {
+      ...(currentCommitSubject !== undefined ? { commitSubject: currentCommitSubject } : {}),
+      ...(ctx.currentAttemptChanges !== undefined ? { changes: ctx.currentAttemptChanges } : {}),
+      ...(ctx.currentAttemptLearnings !== undefined ? { learnings: ctx.currentAttemptLearnings } : {}),
+      ...(ctx.currentAttemptNotes !== undefined ? { notes: ctx.currentAttemptNotes } : {}),
+    };
+    return {
+      task: ctx.currentTask,
+      priorTurns: ctx.plateauHistory ?? [],
+      workspaceRoot: ctx.taskWorkspaceRoot,
+      roundNum: ctx.currentRoundNum,
+      generatorHints: composeGeneratorHints(hintsInput),
+      ...(currentCommitSubject !== undefined ? { currentCommitSubject } : {}),
+      ...(ctx.priorEvaluatorSessionId !== undefined ? { priorEvaluatorSessionId: ctx.priorEvaluatorSessionId } : {}),
+    };
+  };
+
+/**
+ * Merge one evaluator turn's output into ctx — task/tasks list, plateau history, captured
+ * session id, and the verdict / terminal-exit fields.
+ */
+const evaluatorOutput = (ctx: ImplementCtx, out: EvaluatorOutput): ImplementCtx => {
+  const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? out.task : t));
+  const nextHistory =
+    out.turnRecord !== undefined ? [...(ctx.plateauHistory ?? []), out.turnRecord] : ctx.plateauHistory;
+  // Latest captured evaluator sessionId wins; only OVERWRITE when this turn produced one
+  // (preserves the prior turn's thread when this spawn failed to report an id).
+  const sessionCarry = out.capturedSessionId !== undefined ? { priorEvaluatorSessionId: out.capturedSessionId } : {};
+  const next: ImplementCtx = {
+    ...ctx,
+    currentTask: out.task,
+    tasks,
+    // Direct assignment (NOT a conditional spread): a self-blocked / signals-missing turn
+    // returns `out.evaluation === undefined`, and we must CLEAR `ctx.lastEvaluation` so
+    // `settle-attempt` never writes the prior round's verdict into this round's `outcome.md`.
+    // `ctx.ts` types `lastEvaluation?` so assigning `undefined` is valid + explicit.
+    lastEvaluation: out.evaluation,
+    ...(nextHistory !== undefined ? { plateauHistory: nextHistory } : {}),
+    ...sessionCarry,
+  };
+  if (out.exit === undefined) return next;
+  return { ...next, lastExit: out.exit };
+};
+
 export const evaluatorLeaf = (deps: EvaluatorLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
   leaf<ImplementCtx, EvaluatorInput, EvaluatorOutput>(`evaluator-${String(taskId)}`, {
-    useCase: {
-      execute: async (input, signal) => {
-        const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, input.roundNum, 'evaluator'));
-        if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
-        const signalsFile = signalsFilePath.value;
-
-        // `outputDir` is the per-round directory (`rounds/<N>/evaluator/`);
-        // `validateSignalsFile` resolves `<outputDir>/signals.json` and `renderSidecars`
-        // writes harness-rendered sidecars into the same directory. We derive it once from
-        // `signalsFile` so the two paths stay structurally coupled.
-        const outputDirPath = AbsolutePath.parse(dirname(String(signalsFile)));
-        if (!outputDirPath.ok) return Result.error(outputDirPath.error);
-        const outputDir = outputDirPath.value;
-
-        const callEvaluate: RunEvaluatorTurnProps['callEvaluate'] = async (task) => {
-          const outputContractSection = renderContractSectionFor(evaluatorOutputContract, outputDir);
-          const prompt = await buildEvaluatorPrompt(deps, {
-            task,
-            workspaceRoot: input.workspaceRoot,
-            roundNum: input.roundNum,
-            outputContractSection,
-            priorEvaluatorSessionId: input.priorEvaluatorSessionId,
-            generatorHints: input.generatorHints,
-          });
-          if (!prompt.ok) return Result.error(prompt.error) as Result<readonly HarnessSignal[], DomainError>;
-          // Persist the rendered prompt under `rounds/<N>/evaluator/prompt.md` BEFORE the AI
-          // call so a crash mid-spawn still leaves the prompt on disk for post-hoc replay.
-          // Best-effort: the writer logs and swallows on failure.
-          await writeRoundPrompt(input.workspaceRoot, input.roundNum, 'evaluator', String(prompt.value), deps.logger);
-
-          const spawn = await deps.provider.generate(
-            implementSession(
-              input.workspaceRoot,
-              deps.cwd,
-              deps.sprintDir,
-              prompt.value,
-              deps.model,
-              signalsFile,
-              'evaluator',
-              input.priorEvaluatorSessionId,
-              deps.effort,
-              signal
-            )
-          );
-          if (!spawn.ok) return Result.error(spawn.error);
-
-          // Validate `signals.json` against the evaluator contract. On a RECOVERABLE failure
-          // (signals-missing / invalid-json / schema-mismatch) re-prompt the reviewer ONCE on
-          // the resumed session with a corrective message + the Zod issue list, then re-validate
-          // — one near-miss element no longer blocks the whole verdict. `runEvaluatorTurnUseCase`
-          // converts a still-failing validation into a `self-blocked` exit (task settles as
-          // blocked — the ungraded change is NOT marked done; run continues); only a fatal
-          // `Aborted`/`RateLimit` propagates.
-          const validated = await validateSignalsFileWithCorrectiveRetry(
-            {
-              outputDir,
-              logger: deps.logger,
-              // Self-containment for a COLD corrective spawn (no resumable id / codex stale-resume
-              // fallback): the per-round output contract plus the reviewer's grounding — without
-              // this, a context-free retry's whole prompt is the error text, which is exactly
-              // enough scaffolding to fabricate a schema-valid verdict for unseen work.
-              selfContainedContext: [
-                `Task spec (read it): \`${join(String(input.workspaceRoot), 'contract.md')}\``,
-                'Your PRIMARY INPUT is the uncommitted working-tree diff — inspect it via shell',
-                '(`git status` / `git diff HEAD`) before grading. A verdict must reflect the actual',
-                'work, never this message.',
-                '',
-                outputContractSection,
-              ].join('\n'),
-              reinvoke: async (corrective) => {
-                // Resume the reviewer's just-spawned thread so the corrective lands as a
-                // follow-up turn — read the session id this spawn captured to disk. Falls back
-                // to the prior-round id when this spawn never reported one.
-                const resume =
-                  (await readRoundSessionId(input.workspaceRoot, input.roundNum, 'evaluator')) ??
-                  input.priorEvaluatorSessionId;
-                const respawn = await deps.provider.generate(
-                  implementSession(
-                    input.workspaceRoot,
-                    deps.cwd,
-                    deps.sprintDir,
-                    corrective as Prompt,
-                    deps.model,
-                    signalsFile,
-                    'evaluator',
-                    resume,
-                    deps.effort,
-                    signal
-                  )
-                );
-                return respawn.ok ? Result.ok(undefined) : Result.error(respawn.error);
-              },
-            },
-            evaluatorOutputContract
-          );
-          if (!validated.ok) return Result.error(validated.error);
-          const signals = validated.value;
-
-          // Fan out to BOTH the legacy `HarnessSignalSink` (TUI panels, decisions-log) and
-          // the application bus's typed `ai-signal` event. The bus carries every kind the
-          // contract accepts; the sink keeps its existing per-kind consumers happy until
-          // Wave 6 collapses the two paths.
-          for (const sig of signals) {
-            deps.signals.emit(sig);
-            deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: 'evaluator' });
-          }
-
-          // Render harness-owned sidecars (`evaluation.md`). Write failures log warn inside
-          // `renderSidecars`; the helper always returns `Result.ok` (sidecars are operator UX
-          // only — `runEvaluatorTurnUseCase` consumes the in-memory `evaluation` signal, never
-          // the rendered file).
-          await renderSidecars(deps.writeFile, outputDir, signals, evaluatorOutputContract.sidecars, deps.logger);
-
-          // `runEvaluatorTurnUseCase` expects `readonly HarnessSignal[]`. `EvaluatorContractSignal`
-          // is a strict subset of `HarnessSignal`, but TS's array variance doesn't infer that
-          // automatically — cast through `AiSignal[]` (the canonical union alias) to keep the
-          // call site honest about the underlying domain shape.
-          return Result.ok(signals as readonly AiSignal[]) as Result<readonly HarnessSignal[], DomainError>;
-        };
-
-        // Fingerprint the working tree's uncommitted changes for this round so the plateau
-        // predicate's progress exemption measures real code change instead of commit-message
-        // rewording. Best-effort — a git failure yields `undefined` and the predicate degrades
-        // to the commit-subject proxy. Computed BEFORE the use case so the record carries it.
-        const changedFilesHash = await computeWorkProductFingerprint(deps.gitRunner, deps.cwd);
-
-        const result = await runEvaluatorTurnUseCase({
-          task: input.task,
-          priorTurns: input.priorTurns,
-          plateauThreshold: deps.plateauThreshold,
-          ...(input.currentCommitSubject !== undefined ? { currentCommitSubject: input.currentCommitSubject } : {}),
-          ...(changedFilesHash !== undefined ? { changedFilesHash } : {}),
-          callEvaluate,
-          evaluationFile: roundEvaluationRelativePath(input.roundNum),
-          logger: deps.logger,
-        });
-        if (!result.ok) return Result.error(result.error);
-
-        // Read THIS turn's captured sessionId from disk (the Claude adapter just wrote it as a
-        // sibling of `signals.json` via `persistSessionIdFile`). Undefined when the spawn never
-        // reported an id — left undefined so the next round cold-starts cleanly.
-        const capturedSessionId = await readRoundSessionId(input.workspaceRoot, input.roundNum, 'evaluator');
-
-        return Result.ok({
-          task: result.value.task,
-          ...(result.value.evaluation !== undefined ? { evaluation: result.value.evaluation } : {}),
-          ...(result.value.exit !== undefined ? { exit: result.value.exit } : {}),
-          ...(result.value.turnRecord !== undefined ? { turnRecord: result.value.turnRecord } : {}),
-          ...(capturedSessionId !== undefined ? { capturedSessionId } : {}),
-        });
-      },
-    },
-    input: (ctx) => {
-      if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: 'pre-evaluator',
-          attemptedAction: `evaluator-${String(taskId)}`,
-          message: `evaluator-${String(taskId)}: ctx.currentTask missing or mismatched`,
-        });
-      }
-      if (ctx.currentTask.status !== 'in_progress') {
-        throw new InvalidStateError({
-          entity: 'task',
-          currentState: ctx.currentTask.status,
-          attemptedAction: `evaluator-${String(taskId)}`,
-          message: `evaluator-${String(taskId)}: expected in_progress task`,
-        });
-      }
-      if (ctx.taskWorkspaceRoot === undefined || ctx.currentRoundNum === undefined) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: 'pre-evaluator',
-          attemptedAction: `evaluator-${String(taskId)}`,
-          message: `evaluator-${String(taskId)}: ctx.taskWorkspaceRoot/currentRoundNum missing — generator leaf must run first`,
-        });
-      }
-      const currentCommitSubject = ctx.proposedCommitMessage?.subject;
-      // T5: compose the same-round generator hints from the per-attempt ctx accumulators. Pure
-      // read — `composeGeneratorHints` caps + clamps so a deep multi-round attempt's accumulators
-      // can't balloon the evaluator prompt. Empty across all sources → '' → placeholder collapses.
-      const hintsInput: GeneratorHintsInput = {
-        ...(currentCommitSubject !== undefined ? { commitSubject: currentCommitSubject } : {}),
-        ...(ctx.currentAttemptChanges !== undefined ? { changes: ctx.currentAttemptChanges } : {}),
-        ...(ctx.currentAttemptLearnings !== undefined ? { learnings: ctx.currentAttemptLearnings } : {}),
-        ...(ctx.currentAttemptNotes !== undefined ? { notes: ctx.currentAttemptNotes } : {}),
-      };
-      return {
-        task: ctx.currentTask,
-        priorTurns: ctx.plateauHistory ?? [],
-        workspaceRoot: ctx.taskWorkspaceRoot,
-        roundNum: ctx.currentRoundNum,
-        generatorHints: composeGeneratorHints(hintsInput),
-        ...(currentCommitSubject !== undefined ? { currentCommitSubject } : {}),
-        ...(ctx.priorEvaluatorSessionId !== undefined ? { priorEvaluatorSessionId: ctx.priorEvaluatorSessionId } : {}),
-      };
-    },
-    output: (ctx, out) => {
-      const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? out.task : t));
-      const nextHistory =
-        out.turnRecord !== undefined ? [...(ctx.plateauHistory ?? []), out.turnRecord] : ctx.plateauHistory;
-      // Latest captured evaluator sessionId wins; only OVERWRITE when this turn produced one
-      // (preserves the prior turn's thread when this spawn failed to report an id).
-      const sessionCarry =
-        out.capturedSessionId !== undefined ? { priorEvaluatorSessionId: out.capturedSessionId } : {};
-      const next: ImplementCtx = {
-        ...ctx,
-        currentTask: out.task,
-        tasks,
-        // Direct assignment (NOT a conditional spread): a self-blocked / signals-missing turn
-        // returns `out.evaluation === undefined`, and we must CLEAR `ctx.lastEvaluation` so
-        // `settle-attempt` never writes the prior round's verdict into this round's `outcome.md`.
-        // `ctx.ts` types `lastEvaluation?` so assigning `undefined` is valid + explicit.
-        lastEvaluation: out.evaluation,
-        ...(nextHistory !== undefined ? { plateauHistory: nextHistory } : {}),
-        ...sessionCarry,
-      };
-      if (out.exit === undefined) return next;
-      return { ...next, lastExit: out.exit };
-    },
+    useCase: { execute: makeEvaluatorExecute(deps) },
+    input: makeEvaluatorInput(taskId),
+    output: evaluatorOutput,
   });

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -439,356 +439,468 @@ const composeVerifyBlocks = async (
   };
 };
 
+/** Per-turn signal-text accumulators — mutated in place by {@link accumulateAndEmitSignals}. */
+interface GeneratorTurnAccumulators {
+  readonly decisionsEmitted: string[];
+  readonly changesEmitted: string[];
+  readonly learningsEmitted: LearningEntry[];
+  readonly notesEmitted: string[];
+}
+
+/**
+ * Fan out this turn's validated signals to BOTH the legacy `HarnessSignalSink` (TUI panels,
+ * decisions-log) and the application bus's typed `ai-signal` event, while pushing each kind's
+ * text onto the turn's accumulator arrays for the leaf's `execute` to read back afterward. The
+ * bus carries every kind the contract accepts; the sink keeps its existing per-kind consumers
+ * happy until Wave 6 collapses the two paths.
+ */
+const accumulateAndEmitSignals = (
+  deps: Pick<GeneratorLeafDeps, 'signals' | 'eventBus'>,
+  signals: readonly AiSignal[],
+  accumulators: GeneratorTurnAccumulators
+): void => {
+  for (const sig of signals) {
+    deps.signals.emit(sig);
+    deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: 'generator' });
+    if (sig.type === 'decision') accumulators.decisionsEmitted.push(sig.text);
+    else if (sig.type === 'change') accumulators.changesEmitted.push(sig.text);
+    else if (sig.type === 'learning')
+      accumulators.learningsEmitted.push({
+        text: sig.text,
+        ...(sig.context !== undefined ? { context: sig.context } : {}),
+        ...(sig.appliesTo !== undefined ? { appliesTo: sig.appliesTo } : {}),
+      });
+    else if (sig.type === 'note') accumulators.notesEmitted.push(sig.text);
+  }
+};
+
+/**
+ * Publish the discrete `task-round-started` boundary marker — fired BEFORE the AI call so the
+ * TUI's per-task round counter and the persistent `chain.log` see the round-start before any of
+ * this turn's generator-leaf trace entries. `attemptN` is `task.attempts.length`: the running
+ * attempt was already started by `start-attempt-<taskId>` upstream, so this counts the n-th
+ * attempt-within-task (1-indexed; matches `task.maxAttempts`). Also releases any prior escalation
+ * banner (idempotent against an absent one — once a new round starts, the operator-facing
+ * "escalated to <model>" message has served its purpose) and logs the round-start line.
+ */
+const announceRoundStart = (
+  deps: Pick<GeneratorLeafDeps, 'eventBus' | 'clock' | 'logger' | 'maxTurns'>,
+  taskId: TaskId,
+  task: InProgressTask,
+  roundNum: number
+): void => {
+  deps.eventBus.publish({
+    type: 'task-round-started',
+    taskId: String(taskId),
+    attemptN: task.attempts.length,
+    roundN: roundNum,
+    totalCap: deps.maxTurns,
+    at: deps.clock(),
+  });
+  deps.eventBus.publish({
+    type: 'banner-clear',
+    id: escalationBannerId(String(taskId)),
+    at: deps.clock(),
+  });
+  deps.logger
+    .named('task.round-started')
+    .info(`round ${String(roundNum)}/${String(deps.maxTurns)} of attempt ${String(task.attempts.length)}`, {
+      taskId: task.id,
+      attemptN: task.attempts.length,
+      roundN: roundNum,
+      totalCap: deps.maxTurns,
+    });
+};
+
+/**
+ * Build one generator turn's corrective-retry `reinvoke` callback — resumes the just-spawned
+ * thread (falling back to the prior round's session id when this spawn never reported one to
+ * disk) so the corrective message lands as a follow-up turn on the SAME conversation the AI
+ * just wrote invalid/missing signals from.
+ */
+const makeGeneratorReinvoke =
+  (
+    deps: Pick<GeneratorLeafDeps, 'provider' | 'cwd' | 'sprintDir' | 'effort'>,
+    args: {
+      readonly workspaceRoot: AbsolutePath;
+      readonly roundNum: number;
+      readonly signalsFile: AbsolutePath;
+      readonly effectiveModel: string;
+      readonly priorGeneratorSessionId: SessionId | undefined;
+      readonly signal: AbortSignal | undefined;
+    }
+  ): ((corrective: Prompt) => Promise<Result<void, DomainError>>) =>
+  async (corrective) => {
+    const resume =
+      (await readRoundSessionId(args.workspaceRoot, args.roundNum, 'generator')) ?? args.priorGeneratorSessionId;
+    const respawn = await deps.provider.generate(
+      implementSession(
+        args.workspaceRoot,
+        deps.cwd,
+        deps.sprintDir,
+        corrective as Prompt,
+        args.effectiveModel,
+        args.signalsFile,
+        'generator',
+        resume,
+        deps.effort,
+        args.signal
+      )
+    );
+    return respawn.ok ? Result.ok(undefined) : Result.error(respawn.error);
+  };
+
+/**
+ * Build this turn's `callImplement` — composes the harness-verify prompt blocks, builds + persists
+ * the prompt, spawns the generator (on the task's escalated model when present), validates
+ * `signals.json` with one corrective retry, fans the parsed signals out to the sink/bus while
+ * accumulating their texts, and renders harness-owned sidecars. Returns the parsed signals for
+ * `runGeneratorTurnUseCase` to interpret.
+ */
+const makeGeneratorCallImplement =
+  (
+    deps: GeneratorLeafDeps,
+    taskId: TaskId,
+    args: {
+      readonly input: GeneratorInput;
+      readonly roundNum: number;
+      readonly signalsFile: AbsolutePath;
+      readonly outputDir: AbsolutePath;
+      readonly logTailReader: LogTailReader;
+      readonly signal: AbortSignal | undefined;
+      readonly accumulators: GeneratorTurnAccumulators;
+    }
+  ): RunGeneratorTurnProps['callImplement'] =>
+  async (task) => {
+    const outputContractSection = renderContractSectionFor(generatorOutputContract, args.outputDir);
+
+    // T4: surface the harness's pre-task verify result (so the generator reviews baseline
+    // state instead of re-running the verify script in-turn) and the prior attempt's failing
+    // post-verify (so a retry fixes the regression first). All best-effort — see helper.
+    const { preVerifyOutput, retryFeedback } = await composeVerifyBlocks(
+      args.logTailReader,
+      deps.sprintDir,
+      taskId,
+      task
+    );
+
+    const prompt = await buildGeneratorPrompt(deps, {
+      task,
+      workspaceRoot: args.input.workspaceRoot,
+      roundNum: args.roundNum,
+      outputContractSection,
+      priorGeneratorSessionId: args.input.priorGeneratorSessionId,
+      dimensionTrajectory: args.input.dimensionTrajectory ?? '',
+      priorLearnings: args.input.priorLearnings ?? '',
+      priorEpisodes: args.input.priorEpisodes ?? '',
+      preVerifyOutput,
+      retryFeedback,
+    });
+    if (!prompt.ok) return Result.error(prompt.error) as Result<readonly HarnessSignal[], DomainError>;
+    // Persist the rendered prompt under `rounds/<N>/generator/prompt.md` BEFORE the AI
+    // call so a crash mid-spawn still leaves the prompt that triggered it on disk for
+    // post-hoc replay. Best-effort: the writer logs and swallows on failure (the audit
+    // trail must never take down the chain).
+    await writeRoundPrompt(args.input.workspaceRoot, args.roundNum, 'generator', String(prompt.value), deps.logger);
+
+    // Per-task generator-model escalation: when the task carries an `escalatedToModel`
+    // (stamped by the prior plateau's escalation policy), spawn the generator on that
+    // upgraded model instead of the configured row. Evaluator model is intentionally
+    // unaffected — escalation only touches the generator role.
+    const effectiveModel = task.escalatedToModel ?? deps.model;
+    const spawn = await deps.provider.generate(
+      implementSession(
+        args.input.workspaceRoot,
+        deps.cwd,
+        deps.sprintDir,
+        prompt.value,
+        effectiveModel,
+        args.signalsFile,
+        'generator',
+        args.input.priorGeneratorSessionId,
+        deps.effort,
+        args.signal
+      )
+    );
+    if (!spawn.ok) return Result.error(spawn.error);
+
+    // Validate `signals.json` against the generator contract. On a RECOVERABLE failure
+    // (signals-missing / invalid-json / schema-mismatch) re-prompt the generator ONCE on
+    // the resumed session with a corrective message + the Zod issue list, then re-validate.
+    // `runGeneratorTurnUseCase` converts a still-failing validation into a `self-blocked`
+    // exit (task settles as blocked, run continues); only a fatal `Aborted`/`RateLimit`
+    // propagates and aborts the run.
+    const validated = await validateSignalsFileWithCorrectiveRetry(
+      {
+        outputDir: args.outputDir,
+        logger: deps.logger,
+        // Self-containment for a COLD corrective spawn (no resumable id / codex stale-resume
+        // fallback): the per-round output contract + the on-disk task spec, so a fresh
+        // session re-reads its grounding instead of emitting signals from the error text.
+        selfContainedContext: [
+          `Task spec (read it): \`${join(String(args.input.workspaceRoot), 'contract.md')}\``,
+          '',
+          outputContractSection,
+        ].join('\n'),
+        reinvoke: makeGeneratorReinvoke(deps, {
+          workspaceRoot: args.input.workspaceRoot,
+          roundNum: args.roundNum,
+          signalsFile: args.signalsFile,
+          effectiveModel,
+          priorGeneratorSessionId: args.input.priorGeneratorSessionId,
+          signal: args.signal,
+        }),
+      },
+      generatorOutputContract
+    );
+    if (!validated.ok) return Result.error(validated.error);
+    const signals = validated.value;
+
+    accumulateAndEmitSignals(deps, signals, args.accumulators);
+
+    // Render harness-owned sidecars (`commit-message.txt` when present). Write
+    // failures log warn inside `renderSidecars`; the helper always returns
+    // `Result.ok` (sidecars are operator UX only — downstream leaves read in-memory
+    // signals from ctx, never the sidecar file).
+    await renderSidecars(deps.writeFile, args.outputDir, signals, generatorOutputContract.sidecars, deps.logger);
+
+    // `runGeneratorTurnUseCase` expects `readonly HarnessSignal[]`. `GeneratorContractSignal`
+    // is a strict subset of `HarnessSignal`, but TS's array variance doesn't infer
+    // that automatically — cast through `AiSignal[]` (the canonical union alias) to
+    // keep the call site honest about the underlying domain shape.
+    return Result.ok(signals as readonly AiSignal[]) as Result<readonly HarnessSignal[], DomainError>;
+  };
+
+/**
+ * Build this leaf's `execute` — resolves the round's `signals.json` path, announces the round
+ * boundary, drives one generator turn via `runGeneratorTurnUseCase` (see
+ * {@link makeGeneratorCallImplement}), then reads back the captured session id and the turn's
+ * accumulated signal texts into {@link GeneratorOutput}.
+ */
+const makeGeneratorExecute =
+  (
+    deps: GeneratorLeafDeps,
+    taskId: TaskId
+  ): ((input: GeneratorInput, signal?: AbortSignal) => Promise<Result<GeneratorOutput, DomainError>>) =>
+  async (input, signal) => {
+    const roundNum = input.roundNum;
+    const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, roundNum, 'generator'));
+    if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
+    const signalsFile = signalsFilePath.value;
+
+    announceRoundStart(deps, taskId, input.task, roundNum);
+
+    // `outputDir` is the per-round directory (`rounds/<N>/generator/`); `validateSignalsFile`
+    // resolves `<outputDir>/signals.json` and `renderSidecars` writes harness-rendered
+    // sidecars into the same directory. We derive it once from `signalsFile` so the two
+    // paths stay structurally coupled.
+    const outputDirPath = AbsolutePath.parse(dirname(String(signalsFile)));
+    if (!outputDirPath.ok) return Result.error(outputDirPath.error);
+    const outputDir = outputDirPath.value;
+
+    // Per-turn signal accumulators — closure-captured so the leaf can stamp the
+    // emitted texts onto ctx in `output(...)`. The journal leaf reads the aggregate
+    // across all gen-eval rounds for the attempt.
+    const accumulators: GeneratorTurnAccumulators = {
+      decisionsEmitted: [],
+      changesEmitted: [],
+      learningsEmitted: [],
+      notesEmitted: [],
+    };
+    const logTailReader = deps.logTailReader ?? createFsLogTailReader();
+    const callImplement = makeGeneratorCallImplement(deps, taskId, {
+      input,
+      roundNum,
+      signalsFile,
+      outputDir,
+      logTailReader,
+      signal,
+      accumulators,
+    });
+
+    const result = await runGeneratorTurnUseCase({
+      task: input.task,
+      callImplement,
+      logger: deps.logger,
+    });
+    if (!result.ok) return Result.error(result.error);
+
+    // Read THIS turn's captured sessionId from disk (the Claude adapter just wrote it as a
+    // sibling of `signals.json` via `persistSessionIdFile`). Undefined when the spawn never
+    // reported an id — left undefined so the next round cold-starts cleanly rather than
+    // forwarding a stale id from a prior task.
+    const capturedSessionId = await readRoundSessionId(input.workspaceRoot, roundNum, 'generator');
+
+    return Result.ok({
+      task: result.value.task,
+      turn: input.turn,
+      roundNum,
+      ...accumulators,
+      ...(result.value.exit !== undefined ? { exit: result.value.exit } : {}),
+      ...(result.value.proposedCommitMessage !== undefined
+        ? { proposedCommitMessage: result.value.proposedCommitMessage }
+        : {}),
+      ...(capturedSessionId !== undefined ? { capturedSessionId } : {}),
+    });
+  };
+
+/**
+ * Build this leaf's `input` projection — validates the ctx preconditions the generator turn
+ * needs (`currentTask`, `taskWorkspaceRoot`, `currentRoundNum`), then composes the three
+ * feed-forward prompt blocks (dimension trajectory, prior learnings, prior episodes) from pure
+ * ctx reads before assembling {@link GeneratorInput}.
+ */
+const makeGeneratorInput =
+  (
+    deps: Pick<GeneratorLeafDeps, 'plateauThreshold' | 'maxTurns'>,
+    taskId: TaskId
+  ): ((ctx: ImplementCtx) => GeneratorInput) =>
+  (ctx) => {
+    const PRE_GENERATOR_STATE = 'pre-generator';
+    if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
+      throw new InvalidStateError({
+        entity: 'chain',
+        currentState: PRE_GENERATOR_STATE,
+        attemptedAction: `generator-${String(taskId)}`,
+        message: `generator-${String(taskId)}: ctx.currentTask missing or mismatched`,
+      });
+    }
+    if (ctx.currentTask.status !== 'in_progress') {
+      throw new InvalidStateError({
+        entity: 'task',
+        currentState: ctx.currentTask.status,
+        attemptedAction: `generator-${String(taskId)}`,
+        message: `generator-${String(taskId)}: expected in_progress task`,
+      });
+    }
+    if (ctx.taskWorkspaceRoot === undefined) {
+      throw new InvalidStateError({
+        entity: 'chain',
+        currentState: PRE_GENERATOR_STATE,
+        attemptedAction: `generator-${String(taskId)}`,
+        message: `generator-${String(taskId)}: ctx.taskWorkspaceRoot missing — buildTaskWorkspaceLeaf must run first`,
+      });
+    }
+    if (ctx.currentRoundNum === undefined) {
+      throw new InvalidStateError({
+        entity: 'chain',
+        currentState: PRE_GENERATOR_STATE,
+        attemptedAction: `generator-${String(taskId)}`,
+        message: `generator-${String(taskId)}: ctx.currentRoundNum missing — resolve-round-num must run first`,
+      });
+    }
+    // Compose the dimension-trajectory feed-forward (principles 6 + 15) from the per-attempt
+    // evaluator-turn history. Pure ctx read — `composeDimensionTrajectory` returns '' until there
+    // are two turns to diff (round 1 has none), so the prompt's PRIOR_CRITIQUE_SECTION collapses
+    // cleanly on the first round.
+    const dimensionTrajectory = composeDimensionTrajectory({
+      history: ctx.plateauHistory ?? [],
+      plateauThreshold: deps.plateauThreshold,
+      roundNum: ctx.currentRoundNum,
+      maxTurns: deps.maxTurns,
+    });
+    // Cross-sprint procedural memory (principle 3) loaded once by the prologue's `load-learnings`.
+    // Pure ctx read; '' when the ledger was absent/empty so the prompt placeholder collapses.
+    const priorLearnings = composePriorLearnings(ctx.priorLearnings ?? []);
+    // Episodic memory (R4) derived from this sprint's already-settled sibling tasks. Pure ctx
+    // read; '' until a sibling has settled (done/blocked) so the prompt placeholder collapses.
+    const priorEpisodes = summariseEpisodes(composeTaskEpisodes(ctx.tasks ?? [], taskId, ctx.sprintId));
+    return {
+      task: ctx.currentTask,
+      turn: (ctx.genEvalTurn ?? 0) + 1,
+      workspaceRoot: ctx.taskWorkspaceRoot,
+      roundNum: ctx.currentRoundNum,
+      ...(ctx.priorGeneratorSessionId !== undefined ? { priorGeneratorSessionId: ctx.priorGeneratorSessionId } : {}),
+      ...(dimensionTrajectory.length > 0 ? { dimensionTrajectory } : {}),
+      ...(priorLearnings.length > 0 ? { priorLearnings } : {}),
+      ...(priorEpisodes.length > 0 ? { priorEpisodes } : {}),
+    };
+  };
+
+/**
+ * Merge one generator turn's output into ctx — task/tasks list, round bookkeeping, latest
+ * proposed commit message, captured session id, per-attempt signal accumulators, and the
+ * per-turn action-kind distribution (R2).
+ */
+const generatorOutput = (ctx: ImplementCtx, out: GeneratorOutput): ImplementCtx => {
+  const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? out.task : t));
+  // Latest non-undefined proposed commit message wins across turns.
+  const proposedCommitMessage = out.proposedCommitMessage ?? ctx.proposedCommitMessage;
+  const carry = proposedCommitMessage !== undefined ? { proposedCommitMessage } : {};
+  // Latest captured generator sessionId wins; only OVERWRITE when this turn produced one.
+  // A turn that failed to capture an id (provider crash mid-stream) preserves whatever the
+  // prior turn captured so the next round still has a thread to resume.
+  const sessionCarry = out.capturedSessionId !== undefined ? { priorGeneratorSessionId: out.capturedSessionId } : {};
+  // Accumulate this turn's signal texts onto the per-attempt aggregates. Cleared by the
+  // progress-journal leaf after the attempt settles. Each kind has its own field on ctx so
+  // the journal renderer can drop empty subsections without inspecting the signal type.
+  const decisionsCarry =
+    out.decisionsEmitted.length > 0
+      ? { currentAttemptDecisions: [...(ctx.currentAttemptDecisions ?? []), ...out.decisionsEmitted] }
+      : {};
+  const changesCarry =
+    out.changesEmitted.length > 0
+      ? { currentAttemptChanges: [...(ctx.currentAttemptChanges ?? []), ...out.changesEmitted] }
+      : {};
+  const learningsCarry =
+    out.learningsEmitted.length > 0
+      ? { currentAttemptLearnings: [...(ctx.currentAttemptLearnings ?? []), ...out.learningsEmitted] }
+      : {};
+  const notesCarry =
+    out.notesEmitted.length > 0
+      ? { currentAttemptNotes: [...(ctx.currentAttemptNotes ?? []), ...out.notesEmitted] }
+      : {};
+  // Per-turn signal-kind distribution (R2) — stamped fresh every turn (overwrites the prior
+  // turn's map) so the entropy-plateau heuristic in the gen-eval loop sees the current turn's
+  // action diversity, never an accumulation across turns.
+  const actionCountsCarry = { lastTurnActionCounts: countTurnActionKinds(out) };
+  if (out.exit !== undefined) {
+    // Both exit kinds stop the inner loop + skip the evaluator (both key on `lastExit`), but
+    // they diverge on `lastBlockReason`:
+    //  - `self-blocked` (generator emitted `<task-blocked>` / codex-copilot signals-contract
+    //    failure) sets it → settle terminal-blocks the task after one attempt (unchanged).
+    //  - `crashed` (watchdog kill / spawn crash) sets ONLY `lastExit`. It must NOT set
+    //    `lastBlockReason`: finalize is the sole authority for whether a crash blocks (it grants
+    //    a retry within maxAttempts, then blocks at the cap). Because `finalizeGenEvalLeaf` only
+    //    ADDS a block reason (conditional spread) and never CLEARS a stale one, a block reason
+    //    stamped here would leak past finalize into settle and wrongly terminal-block the task.
+    const blockReasonCarry = out.exit.kind === 'self-blocked' ? { lastBlockReason: out.exit.reason } : {};
+    return {
+      ...ctx,
+      currentTask: out.task,
+      tasks,
+      genEvalTurn: out.turn,
+      currentRoundNum: out.roundNum,
+      lastExit: { kind: out.exit.kind, reason: out.exit.reason },
+      ...blockReasonCarry,
+      ...carry,
+      ...sessionCarry,
+      ...decisionsCarry,
+      ...changesCarry,
+      ...learningsCarry,
+      ...notesCarry,
+      ...actionCountsCarry,
+    };
+  }
+  return {
+    ...ctx,
+    currentTask: out.task,
+    tasks,
+    genEvalTurn: out.turn,
+    currentRoundNum: out.roundNum,
+    ...carry,
+    ...sessionCarry,
+    ...decisionsCarry,
+    ...changesCarry,
+    ...learningsCarry,
+    ...notesCarry,
+    ...actionCountsCarry,
+  };
+};
+
 export const generatorLeaf = (deps: GeneratorLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
   leaf<ImplementCtx, GeneratorInput, GeneratorOutput>(`generator-${String(taskId)}`, {
-    useCase: {
-      execute: async (input, signal) => {
-        const roundNum = input.roundNum;
-        const signalsFilePath = AbsolutePath.parse(roundSignalsPath(input.workspaceRoot, roundNum, 'generator'));
-        if (!signalsFilePath.ok) return Result.error(signalsFilePath.error);
-        const signalsFile = signalsFilePath.value;
-
-        // Discrete boundary marker — fired BEFORE the AI call so the TUI's per-task round
-        // counter and the persistent `chain.log` see the round-start before any of its
-        // generator-leaf trace entries. `attemptN` is `task.attempts.length`: the running
-        // attempt was already started by `start-attempt-<taskId>` upstream, so this counts the
-        // n-th attempt-within-task (1-indexed; matches `task.maxAttempts`).
-        deps.eventBus.publish({
-          type: 'task-round-started',
-          taskId: String(taskId),
-          attemptN: input.task.attempts.length,
-          roundN: roundNum,
-          totalCap: deps.maxTurns,
-          at: deps.clock(),
-        });
-        // Release any prior escalation banner — once a new generator round starts on this
-        // task, the operator-facing "escalated to <model>" message has served its purpose and
-        // shouldn't hang around blocking the banner slot. Idempotent against an absent banner.
-        deps.eventBus.publish({
-          type: 'banner-clear',
-          id: escalationBannerId(String(taskId)),
-          at: deps.clock(),
-        });
-        deps.logger
-          .named('task.round-started')
-          .info(`round ${String(roundNum)}/${String(deps.maxTurns)} of attempt ${String(input.task.attempts.length)}`, {
-            taskId: input.task.id,
-            attemptN: input.task.attempts.length,
-            roundN: roundNum,
-            totalCap: deps.maxTurns,
-          });
-
-        // `outputDir` is the per-round directory (`rounds/<N>/generator/`); `validateSignalsFile`
-        // resolves `<outputDir>/signals.json` and `renderSidecars` writes harness-rendered
-        // sidecars into the same directory. We derive it once from `signalsFile` so the two
-        // paths stay structurally coupled.
-        const outputDirPath = AbsolutePath.parse(dirname(String(signalsFile)));
-        if (!outputDirPath.ok) return Result.error(outputDirPath.error);
-        const outputDir = outputDirPath.value;
-
-        // Per-turn signal accumulators — closure-captured so the leaf can stamp the
-        // emitted texts onto ctx in `output(...)`. The journal leaf reads the aggregate
-        // across all gen-eval rounds for the attempt.
-        const decisionsEmitted: string[] = [];
-        const changesEmitted: string[] = [];
-        const learningsEmitted: LearningEntry[] = [];
-        const notesEmitted: string[] = [];
-        const logTailReader = deps.logTailReader ?? createFsLogTailReader();
-        const callImplement: RunGeneratorTurnProps['callImplement'] = async (task) => {
-          const outputContractSection = renderContractSectionFor(generatorOutputContract, outputDir);
-
-          // T4: surface the harness's pre-task verify result (so the generator reviews baseline
-          // state instead of re-running the verify script in-turn) and the prior attempt's failing
-          // post-verify (so a retry fixes the regression first). All best-effort — see helper.
-          const { preVerifyOutput, retryFeedback } = await composeVerifyBlocks(
-            logTailReader,
-            deps.sprintDir,
-            taskId,
-            task
-          );
-
-          const prompt = await buildGeneratorPrompt(deps, {
-            task,
-            workspaceRoot: input.workspaceRoot,
-            roundNum,
-            outputContractSection,
-            priorGeneratorSessionId: input.priorGeneratorSessionId,
-            dimensionTrajectory: input.dimensionTrajectory ?? '',
-            priorLearnings: input.priorLearnings ?? '',
-            priorEpisodes: input.priorEpisodes ?? '',
-            preVerifyOutput,
-            retryFeedback,
-          });
-          if (!prompt.ok) return Result.error(prompt.error) as Result<readonly HarnessSignal[], DomainError>;
-          // Persist the rendered prompt under `rounds/<N>/generator/prompt.md` BEFORE the AI
-          // call so a crash mid-spawn still leaves the prompt that triggered it on disk for
-          // post-hoc replay. Best-effort: the writer logs and swallows on failure (the audit
-          // trail must never take down the chain).
-          await writeRoundPrompt(input.workspaceRoot, roundNum, 'generator', String(prompt.value), deps.logger);
-
-          // Per-task generator-model escalation: when the task carries an `escalatedToModel`
-          // (stamped by the prior plateau's escalation policy), spawn the generator on that
-          // upgraded model instead of the configured row. Evaluator model is intentionally
-          // unaffected — escalation only touches the generator role.
-          const effectiveModel = task.escalatedToModel ?? deps.model;
-          const spawn = await deps.provider.generate(
-            implementSession(
-              input.workspaceRoot,
-              deps.cwd,
-              deps.sprintDir,
-              prompt.value,
-              effectiveModel,
-              signalsFile,
-              'generator',
-              input.priorGeneratorSessionId,
-              deps.effort,
-              signal
-            )
-          );
-          if (!spawn.ok) return Result.error(spawn.error);
-
-          // Validate `signals.json` against the generator contract. On a RECOVERABLE failure
-          // (signals-missing / invalid-json / schema-mismatch) re-prompt the generator ONCE on
-          // the resumed session with a corrective message + the Zod issue list, then re-validate.
-          // `runGeneratorTurnUseCase` converts a still-failing validation into a `self-blocked`
-          // exit (task settles as blocked, run continues); only a fatal `Aborted`/`RateLimit`
-          // propagates and aborts the run.
-          const validated = await validateSignalsFileWithCorrectiveRetry(
-            {
-              outputDir,
-              logger: deps.logger,
-              // Self-containment for a COLD corrective spawn (no resumable id / codex stale-resume
-              // fallback): the per-round output contract + the on-disk task spec, so a fresh
-              // session re-reads its grounding instead of emitting signals from the error text.
-              selfContainedContext: [
-                `Task spec (read it): \`${join(String(input.workspaceRoot), 'contract.md')}\``,
-                '',
-                outputContractSection,
-              ].join('\n'),
-              reinvoke: async (corrective) => {
-                // Resume the generator's just-spawned thread so the corrective lands as a
-                // follow-up turn. Falls back to the prior-round id when this spawn never
-                // reported one to disk.
-                const resume =
-                  (await readRoundSessionId(input.workspaceRoot, roundNum, 'generator')) ??
-                  input.priorGeneratorSessionId;
-                const respawn = await deps.provider.generate(
-                  implementSession(
-                    input.workspaceRoot,
-                    deps.cwd,
-                    deps.sprintDir,
-                    corrective as Prompt,
-                    effectiveModel,
-                    signalsFile,
-                    'generator',
-                    resume,
-                    deps.effort,
-                    signal
-                  )
-                );
-                return respawn.ok ? Result.ok(undefined) : Result.error(respawn.error);
-              },
-            },
-            generatorOutputContract
-          );
-          if (!validated.ok) return Result.error(validated.error);
-          const signals = validated.value;
-
-          // Fan out to BOTH the legacy `HarnessSignalSink` (TUI panels, decisions-log) and
-          // the application bus's typed `ai-signal` event. The bus carries every kind the
-          // contract accepts; the sink keeps its existing per-kind consumers happy until
-          // Wave 6 collapses the two paths.
-          for (const sig of signals) {
-            deps.signals.emit(sig);
-            deps.eventBus.publish({ type: 'ai-signal', signal: sig, source: 'generator' });
-            if (sig.type === 'decision') decisionsEmitted.push(sig.text);
-            else if (sig.type === 'change') changesEmitted.push(sig.text);
-            else if (sig.type === 'learning')
-              learningsEmitted.push({
-                text: sig.text,
-                ...(sig.context !== undefined ? { context: sig.context } : {}),
-                ...(sig.appliesTo !== undefined ? { appliesTo: sig.appliesTo } : {}),
-              });
-            else if (sig.type === 'note') notesEmitted.push(sig.text);
-          }
-
-          // Render harness-owned sidecars (`commit-message.txt` when present). Write
-          // failures log warn inside `renderSidecars`; the helper always returns
-          // `Result.ok` (sidecars are operator UX only — downstream leaves read in-memory
-          // signals from ctx, never the sidecar file).
-          await renderSidecars(deps.writeFile, outputDir, signals, generatorOutputContract.sidecars, deps.logger);
-
-          // `runGeneratorTurnUseCase` expects `readonly HarnessSignal[]`. `GeneratorContractSignal`
-          // is a strict subset of `HarnessSignal`, but TS's array variance doesn't infer
-          // that automatically — cast through `AiSignal[]` (the canonical union alias) to
-          // keep the call site honest about the underlying domain shape.
-          return Result.ok(signals as readonly AiSignal[]) as Result<readonly HarnessSignal[], DomainError>;
-        };
-
-        const result = await runGeneratorTurnUseCase({
-          task: input.task,
-          callImplement,
-          logger: deps.logger,
-        });
-        if (!result.ok) return Result.error(result.error);
-
-        // Read THIS turn's captured sessionId from disk (the Claude adapter just wrote it as a
-        // sibling of `signals.json` via `persistSessionIdFile`). Undefined when the spawn never
-        // reported an id — left undefined so the next round cold-starts cleanly rather than
-        // forwarding a stale id from a prior task.
-        const capturedSessionId = await readRoundSessionId(input.workspaceRoot, roundNum, 'generator');
-
-        return Result.ok({
-          task: result.value.task,
-          turn: input.turn,
-          roundNum,
-          decisionsEmitted,
-          changesEmitted,
-          learningsEmitted,
-          notesEmitted,
-          ...(result.value.exit !== undefined ? { exit: result.value.exit } : {}),
-          ...(result.value.proposedCommitMessage !== undefined
-            ? { proposedCommitMessage: result.value.proposedCommitMessage }
-            : {}),
-          ...(capturedSessionId !== undefined ? { capturedSessionId } : {}),
-        });
-      },
-    },
-    input: (ctx) => {
-      const PRE_GENERATOR_STATE = 'pre-generator';
-      if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: PRE_GENERATOR_STATE,
-          attemptedAction: `generator-${String(taskId)}`,
-          message: `generator-${String(taskId)}: ctx.currentTask missing or mismatched`,
-        });
-      }
-      if (ctx.currentTask.status !== 'in_progress') {
-        throw new InvalidStateError({
-          entity: 'task',
-          currentState: ctx.currentTask.status,
-          attemptedAction: `generator-${String(taskId)}`,
-          message: `generator-${String(taskId)}: expected in_progress task`,
-        });
-      }
-      if (ctx.taskWorkspaceRoot === undefined) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: PRE_GENERATOR_STATE,
-          attemptedAction: `generator-${String(taskId)}`,
-          message: `generator-${String(taskId)}: ctx.taskWorkspaceRoot missing — buildTaskWorkspaceLeaf must run first`,
-        });
-      }
-      if (ctx.currentRoundNum === undefined) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: PRE_GENERATOR_STATE,
-          attemptedAction: `generator-${String(taskId)}`,
-          message: `generator-${String(taskId)}: ctx.currentRoundNum missing — resolve-round-num must run first`,
-        });
-      }
-      // Compose the dimension-trajectory feed-forward (principles 6 + 15) from the per-attempt
-      // evaluator-turn history. Pure ctx read — `composeDimensionTrajectory` returns '' until there
-      // are two turns to diff (round 1 has none), so the prompt's PRIOR_CRITIQUE_SECTION collapses
-      // cleanly on the first round.
-      const dimensionTrajectory = composeDimensionTrajectory({
-        history: ctx.plateauHistory ?? [],
-        plateauThreshold: deps.plateauThreshold,
-        roundNum: ctx.currentRoundNum,
-        maxTurns: deps.maxTurns,
-      });
-      // Cross-sprint procedural memory (principle 3) loaded once by the prologue's `load-learnings`.
-      // Pure ctx read; '' when the ledger was absent/empty so the prompt placeholder collapses.
-      const priorLearnings = composePriorLearnings(ctx.priorLearnings ?? []);
-      // Episodic memory (R4) derived from this sprint's already-settled sibling tasks. Pure ctx
-      // read; '' until a sibling has settled (done/blocked) so the prompt placeholder collapses.
-      const priorEpisodes = summariseEpisodes(composeTaskEpisodes(ctx.tasks ?? [], taskId, ctx.sprintId));
-      return {
-        task: ctx.currentTask,
-        turn: (ctx.genEvalTurn ?? 0) + 1,
-        workspaceRoot: ctx.taskWorkspaceRoot,
-        roundNum: ctx.currentRoundNum,
-        ...(ctx.priorGeneratorSessionId !== undefined ? { priorGeneratorSessionId: ctx.priorGeneratorSessionId } : {}),
-        ...(dimensionTrajectory.length > 0 ? { dimensionTrajectory } : {}),
-        ...(priorLearnings.length > 0 ? { priorLearnings } : {}),
-        ...(priorEpisodes.length > 0 ? { priorEpisodes } : {}),
-      };
-    },
-    output: (ctx, out) => {
-      const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? out.task : t));
-      // Latest non-undefined proposed commit message wins across turns.
-      const proposedCommitMessage = out.proposedCommitMessage ?? ctx.proposedCommitMessage;
-      const carry = proposedCommitMessage !== undefined ? { proposedCommitMessage } : {};
-      // Latest captured generator sessionId wins; only OVERWRITE when this turn produced one.
-      // A turn that failed to capture an id (provider crash mid-stream) preserves whatever the
-      // prior turn captured so the next round still has a thread to resume.
-      const sessionCarry =
-        out.capturedSessionId !== undefined ? { priorGeneratorSessionId: out.capturedSessionId } : {};
-      // Accumulate this turn's signal texts onto the per-attempt aggregates. Cleared by the
-      // progress-journal leaf after the attempt settles. Each kind has its own field on ctx so
-      // the journal renderer can drop empty subsections without inspecting the signal type.
-      const decisionsCarry =
-        out.decisionsEmitted.length > 0
-          ? { currentAttemptDecisions: [...(ctx.currentAttemptDecisions ?? []), ...out.decisionsEmitted] }
-          : {};
-      const changesCarry =
-        out.changesEmitted.length > 0
-          ? { currentAttemptChanges: [...(ctx.currentAttemptChanges ?? []), ...out.changesEmitted] }
-          : {};
-      const learningsCarry =
-        out.learningsEmitted.length > 0
-          ? { currentAttemptLearnings: [...(ctx.currentAttemptLearnings ?? []), ...out.learningsEmitted] }
-          : {};
-      const notesCarry =
-        out.notesEmitted.length > 0
-          ? { currentAttemptNotes: [...(ctx.currentAttemptNotes ?? []), ...out.notesEmitted] }
-          : {};
-      // Per-turn signal-kind distribution (R2) — stamped fresh every turn (overwrites the prior
-      // turn's map) so the entropy-plateau heuristic in the gen-eval loop sees the current turn's
-      // action diversity, never an accumulation across turns.
-      const actionCountsCarry = { lastTurnActionCounts: countTurnActionKinds(out) };
-      if (out.exit !== undefined) {
-        // Both exit kinds stop the inner loop + skip the evaluator (both key on `lastExit`), but
-        // they diverge on `lastBlockReason`:
-        //  - `self-blocked` (generator emitted `<task-blocked>` / codex-copilot signals-contract
-        //    failure) sets it → settle terminal-blocks the task after one attempt (unchanged).
-        //  - `crashed` (watchdog kill / spawn crash) sets ONLY `lastExit`. It must NOT set
-        //    `lastBlockReason`: finalize is the sole authority for whether a crash blocks (it grants
-        //    a retry within maxAttempts, then blocks at the cap). Because `finalizeGenEvalLeaf` only
-        //    ADDS a block reason (conditional spread) and never CLEARS a stale one, a block reason
-        //    stamped here would leak past finalize into settle and wrongly terminal-block the task.
-        const blockReasonCarry = out.exit.kind === 'self-blocked' ? { lastBlockReason: out.exit.reason } : {};
-        return {
-          ...ctx,
-          currentTask: out.task,
-          tasks,
-          genEvalTurn: out.turn,
-          currentRoundNum: out.roundNum,
-          lastExit: { kind: out.exit.kind, reason: out.exit.reason },
-          ...blockReasonCarry,
-          ...carry,
-          ...sessionCarry,
-          ...decisionsCarry,
-          ...changesCarry,
-          ...learningsCarry,
-          ...notesCarry,
-          ...actionCountsCarry,
-        };
-      }
-      return {
-        ...ctx,
-        currentTask: out.task,
-        tasks,
-        genEvalTurn: out.turn,
-        currentRoundNum: out.roundNum,
-        ...carry,
-        ...sessionCarry,
-        ...decisionsCarry,
-        ...changesCarry,
-        ...learningsCarry,
-        ...notesCarry,
-        ...actionCountsCarry,
-      };
-    },
+    useCase: { execute: makeGeneratorExecute(deps, taskId) },
+    input: makeGeneratorInput(deps, taskId),
+    output: generatorOutput,
   });

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -382,7 +382,12 @@ export const createPerTaskSubchain = (
             // duration, and the deduped signals for the just-settled attempt. Fail-loud / self-healing:
             // a failed section write retries once, then writes a visible gap marker + logs at error level.
             progressJournalLeaf(
-              { writeFile: deps.writeFile, clock: deps.clock, logger: deps.logger },
+              {
+                writeFile: deps.writeFile,
+                clock: deps.clock,
+                logger: deps.logger,
+                journalMutex: deps.journalMutex,
+              },
               { progressFile: opts.progressFile, totalRounds: deps.config.harness.maxTurns },
               taskId
             ),

--- a/src/application/flows/implement/leaves/post-task-verify.ts
+++ b/src/application/flows/implement/leaves/post-task-verify.ts
@@ -5,6 +5,7 @@ import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Attribution, VerifyRun, VerifyRunOutcome } from '@src/domain/entity/attempt.ts';
 import { attributeVerify, normalizeVerifyGates, runVerifyGatesUseCase } from '@src/business/task/run-verify-script.ts';
+import type { RunVerifyScriptOutput } from '@src/business/task/run-verify-script.ts';
 import type { VerifyGate } from '@src/domain/entity/repository.ts';
 import { gitDiffFootprint } from '@src/integration/io/git-operations.ts';
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
@@ -235,235 +236,312 @@ const computeScope = async (
   return footprint.value;
 };
 
+/**
+ * Zero-turn short-circuit result. When pre-task-verify hard-blocked the task BEFORE any
+ * generator spawned (the gen-eval loop's `shouldContinue` refused entry on a pre-existing
+ * `lastExit`), there is no AI work on the tree to verify — re-running the dominant-cost verify
+ * script is pure waste, and there is nothing to attribute (HARNESS-PRINCIPLES § 9). Synthesises a
+ * `'skipped'` VerifyRun so the ctx carry stays consistent: `legacyVerifyResult` maps `'skipped'`
+ * to `{ kind: 'skipped' }` (no spurious verify-failed warning downstream), attribution stays
+ * undefined (it needs both pre and post outcomes), and `priorPostVerifyOutcome` carries
+ * `'skipped'` so the NEXT task's pre-verify carry-baseline does not short-circuit (that path
+ * requires `'success'`).
+ */
+const buildZeroTurnSkippedResult = (deps: Pick<PostTaskVerifyLeafDeps, 'clock'>, task: InProgressTask): LeafOutput => {
+  const skipped: VerifyRun = {
+    phase: 'post',
+    ranAt: deps.clock(),
+    command: '',
+    exitCode: 0,
+    durationMs: 0,
+    outcome: 'skipped',
+  };
+  return { task, run: skipped, rawOutput: '' };
+};
+
+/**
+ * Normalise legacy script + structured gates into ONE gate list (gates win when present), then
+ * run it via {@link runVerifyGatesUseCase}. Diff-scopes the gates to the attempt's footprint —
+ * but ONLY when the repo actually configured structured gates. The legacy single catch-all gate
+ * matches every path, so computing a footprint for it is wasted git work; leave `scope` undefined
+ * (all-run subset = the one gate). When gates ARE configured we compute the footprint and pass it
+ * as scope; fail-fast stops at the first red scoped gate. CRITICAL fallback: a footprint failure
+ * or an empty result runs ALL gates (scope undefined) — we never silently skip a gate.
+ */
+const runPostVerifyGates = async (
+  deps: PostTaskVerifyLeafDeps,
+  opts: PostTaskVerifyLeafOpts,
+  signal?: AbortSignal
+): Promise<RunVerifyScriptOutput> => {
+  const gates = normalizeVerifyGates(opts.verifyScript, opts.verifyGates);
+  const usingStructuredGates = opts.verifyGates !== undefined && opts.verifyGates.length > 0;
+  const scope = usingStructuredGates ? await computeScope(deps, opts.cwd) : undefined;
+  return runVerifyGatesUseCase({
+    cwd: opts.cwd,
+    phase: 'post',
+    gates,
+    mode: 'fail-fast',
+    ...(scope !== undefined ? { scope } : {}),
+    ...(opts.timeoutMs !== undefined ? { defaultTimeoutMs: opts.timeoutMs } : {}),
+    clock: deps.clock,
+    // Thread the chain abort signal so a Ctrl-C mid-verify kills the child promptly instead
+    // of stranding the repo lock for the full verifyTimeout. `runVerifyShell` collapses the
+    // runner's widened `AbortError` to a `StorageError` shape for the use-case port — the
+    // real cancellation is surfaced verbatim by the `signal.aborted` check in the caller.
+    runShellScript: (cwd, script, scriptOpts) =>
+      runVerifyShell(deps.shellScriptRunner, cwd, script, {
+        ...scriptOpts,
+        ...(signal !== undefined ? { signal } : {}),
+      }),
+    logger: deps.logger,
+  });
+};
+
+/**
+ * Audit [01] / [03]: persist the full untruncated output to
+ * `<sprintDir>/logs/verify/<task-id>/post-attempt-<N>.log`. Caller only invokes this when
+ * `opts.sprintDir` is set AND `rawOutput` is non-empty.
+ */
+const persistPostVerifyLog = async (
+  deps: PostTaskVerifyLeafDeps,
+  opts: PostTaskVerifyLeafOpts,
+  task: InProgressTask,
+  rawOutput: string
+): Promise<void> => {
+  const attemptN = task.attempts.length;
+  const logPath = join(
+    String(opts.sprintDir),
+    'logs',
+    'verify',
+    String(task.id),
+    `post-attempt-${String(attemptN)}.log`
+  );
+  const wrote = await writeTextAtomic(logPath, rawOutput);
+  if (!wrote.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `post-task-verify ${String(opts.cwd)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
+      at: deps.clock(),
+    });
+  }
+};
+
+/**
+ * Append the {@link VerifyRun} row to the attempt, stamp {@link Attribution} when both pre and
+ * post outcomes are known (`attributeVerify` returns undefined for a spawn-error/skipped pre —
+ * the field stays unset), and persist the updated task. A persist failure is logged but does not
+ * fail the leaf — the audit row already lives on the in-memory task carried forward on ctx.
+ */
+const recordVerifyRun = async (
+  deps: PostTaskVerifyLeafDeps,
+  input: LeafInput,
+  run: VerifyRun,
+  taskId: TaskId
+): Promise<Result<{ readonly task: InProgressTask; readonly attribution?: Attribution }, DomainError>> => {
+  let updated = appendAttemptVerifyRun(input.task, run);
+  if (!updated.ok) return Result.error(updated.error);
+
+  const attribution = input.preOutcome !== undefined ? attributeVerify(input.preOutcome, run.outcome) : undefined;
+  if (attribution !== undefined) {
+    const stamped = setAttemptAttribution(updated.value, attribution);
+    if (!stamped.ok) return Result.error(stamped.error);
+    updated = stamped;
+  }
+
+  const persisted = await deps.taskRepo.update(input.sprintId, updated.value);
+  if (!persisted.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `post-task-verify audit persist failed for task ${String(taskId)} — ${persisted.error.message}`,
+      at: deps.clock(),
+    });
+  }
+
+  return Result.ok({ task: updated.value, ...(attribution !== undefined ? { attribution } : {}) });
+};
+
+/**
+ * Emit the outcome-specific log line for the attribution decision (or a raw spawn-error).
+ * Logging only — the block/retry policy itself lives in {@link projectLeafOutput}.
+ */
+const logAttributionOutcome = (
+  deps: PostTaskVerifyLeafDeps,
+  opts: PostTaskVerifyLeafOpts,
+  run: VerifyRun,
+  attribution: Attribution | undefined,
+  spawnErrorMessage: string | undefined
+): void => {
+  if (attribution === 'regressed') {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `post-task-verify ${String(opts.cwd)}: regressed baseline (exit=${String(run.exitCode)}) — blocking task`,
+      at: deps.clock(),
+    });
+  } else if (attribution === 'baseline-broken') {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `post-task-verify ${String(opts.cwd)}: baseline still red but task started on broken baseline — preserving verdict`,
+      at: deps.clock(),
+    });
+  } else if (attribution === 'fixed-baseline') {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'info',
+      message: `post-task-verify ${String(opts.cwd)}: fixed pre-existing failure (exit=0)`,
+      at: deps.clock(),
+    });
+  } else if (run.outcome === SPAWN_ERROR_OUTCOME) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `post-task-verify ${String(opts.cwd)}: spawn-error — ${spawnErrorMessage ?? 'unknown spawn error'}; attribution skipped`,
+      at: deps.clock(),
+    });
+  }
+};
+
+/**
+ * Factory for the leaf's `execute`. Threads `deps` / `opts` / `taskId` once so the returned
+ * closure matches {@link LeafUseCase}'s `(input, signal) => Promise<Result<LeafOutput, DomainError>>`
+ * shape. Sequences the steps documented on {@link postTaskVerifyLeaf}: zero-turn short-circuit,
+ * run the gates, propagate cancellation, persist the audit log, record + attribute the run, log
+ * the outcome, then project the final {@link LeafOutput}.
+ */
+const createPostTaskVerifyExecute =
+  (deps: PostTaskVerifyLeafDeps, opts: PostTaskVerifyLeafOpts, taskId: TaskId) =>
+  async (input: LeafInput, signal?: AbortSignal): Promise<Result<LeafOutput, DomainError>> => {
+    if (input.preVerifyBlockedZeroTurn) {
+      return Result.ok(buildZeroTurnSkippedResult(deps, input.task));
+    }
+
+    const { run, rawOutput, spawnErrorMessage } = await runPostVerifyGates(deps, opts, signal);
+
+    // Cancellation propagates verbatim. `runVerifyScriptUseCase` folds a runner
+    // `Result.error` into a `spawn-error` row, so the abort would otherwise be swallowed as an
+    // unknown-attribution outcome. Detect the cancel at the leaf boundary and surface the
+    // codebase's transparently-propagated `AbortError` — the chain tears down rather than
+    // recording a misleading spawn-error attribution.
+    if (signal?.aborted === true) {
+      return Result.error(
+        new AbortError({
+          elementName: `post-task-verify-${String(taskId)}`,
+          reason: 'aborted during post-task verify',
+        })
+      );
+    }
+
+    if (opts.sprintDir !== undefined && rawOutput.length > 0) {
+      await persistPostVerifyLog(deps, opts, input.task, rawOutput);
+    }
+
+    const recorded = await recordVerifyRun(deps, input, run, taskId);
+    if (!recorded.ok) return Result.error(recorded.error);
+
+    logAttributionOutcome(deps, opts, run, recorded.value.attribution, spawnErrorMessage);
+
+    return Result.ok({
+      task: recorded.value.task,
+      run,
+      rawOutput,
+      ...(spawnErrorMessage !== undefined ? { spawnErrorMessage } : {}),
+      ...(recorded.value.attribution !== undefined ? { attribution: recorded.value.attribution } : {}),
+    });
+  };
+
+/** Project ctx → {@link LeafInput}. See the field docs on {@link LeafInput} for the derivation rules. */
+const resolveLeafInput = (ctx: ImplementCtx, taskId: TaskId): LeafInput => {
+  if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
+    throw new InvalidStateError({
+      entity: 'chain',
+      currentState: 'pre-post-task-verify',
+      attemptedAction: `post-task-verify-${String(taskId)}`,
+      message: `post-task-verify-${String(taskId)}: ctx.currentTask is missing or mismatched`,
+    });
+  }
+  if (ctx.currentTask.status !== 'in_progress') {
+    throw new InvalidStateError({
+      entity: 'task',
+      currentState: ctx.currentTask.status,
+      attemptedAction: `post-task-verify-${String(taskId)}`,
+      message: `post-task-verify-${String(taskId)}: expected in_progress task — got '${ctx.currentTask.status}'`,
+    });
+  }
+  // Zero-turn discriminant: a block reason is on ctx AND no generator turn ran this attempt.
+  // `start-attempt` resets `genEvalTurn` to undefined per attempt and the generator leaf bumps
+  // it to ≥1 on its first turn, so `genEvalTurn === undefined` is precisely "zero turns ran" —
+  // the pre-task-verify hard-block case. A turn-1 generator self-block has `genEvalTurn === 1`
+  // and falls through to the real verify script.
+  const preVerifyBlockedZeroTurn = ctx.lastBlockReason !== undefined && ctx.genEvalTurn === undefined;
+  return {
+    task: ctx.currentTask,
+    sprintId: ctx.sprintId,
+    preVerifyBlockedZeroTurn,
+    ...(ctx.lastPreVerifyOutcome !== undefined ? { preOutcome: ctx.lastPreVerifyOutcome } : {}),
+  };
+};
+
+/**
+ * Merge the use-case's {@link LeafOutput} into ctx: derive the legacy `lastVerifyResult` shape,
+ * the block/retry decision (see the policy table on {@link postTaskVerifyLeaf}), and carry
+ * `priorPostVerifyOutcome` forward for the next task's pre-task-verify short-circuit.
+ */
+const projectLeafOutput = (ctx: ImplementCtx, out: LeafOutput, opts: PostTaskVerifyLeafOpts): ImplementCtx => {
+  const verifyResult = legacyVerifyResult(out.run, out.rawOutput, out.spawnErrorMessage);
+  const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? (out.task as Task) : t));
+  // Default policy: a red post-verify blocks the task — the AI's `task-verified`
+  // self-report is overruled by the harness's independent verdict. The ONE escape hatch
+  // is `attribution === 'baseline-broken'`: when both pre and post ran red, we have
+  // explicit evidence the failure pre-existed the AI's work, so we preserve the AI's
+  // verdict (the operator can fix the baseline without losing the AI's work).
+  //
+  //   - clean           — no block (post is green)
+  //   - regressed       — BLOCK with explicit "regressed baseline" reason
+  //   - fixed-baseline  — no block (post is green)
+  //   - baseline-broken — no block (escape hatch; preserve AI's verdict)
+  //   - undefined       — BLOCK on raw red post (no pre-verify evidence to clear it)
+  const isRed = out.run.outcome === 'failed' || out.run.outcome === SPAWN_ERROR_OUTCOME;
+  const shouldBlock = isRed && out.attribution !== 'baseline-broken';
+  const blockReason = shouldBlock
+    ? out.attribution === 'regressed'
+      ? `verify script regressed baseline (exit=${String(out.run.exitCode)}); harness will not commit on red`
+      : `verify script failed (exit=${String(out.run.exitCode)}); harness will not commit on red`
+    : undefined;
+  // Bounded red-post-verify RETRY (T6). ONLY a `'regressed'` attribution (an evaluator-passed
+  // attempt that broke a GREEN baseline) qualifies — not raw red (no pre-verify evidence),
+  // `baseline-broken` (pre-existing failure, no block at all), `clean`, or `fixed-baseline`.
+  // While the task's attempt budget remains we also set `lastShouldFailAttempt`: settle's
+  // PRECEDENCE then keeps the task in_progress for one more attempt (commit was already skipped
+  // by the block guard; the retry-diff quarantine stashes the rejected diff). On the last
+  // allowed attempt `budgetRemains` is false → block only, matching today's behaviour. The
+  // running attempt counts as spent (start-attempt appended it), so a 3rd-of-3 attempt blocks.
+  const grantRetry = out.attribution === 'regressed' && budgetRemains(out.task, opts.maxAttempts);
+  return {
+    ...ctx,
+    currentTask: out.task,
+    tasks,
+    lastVerifyResult: verifyResult,
+    // Carry the (cwd, outcome) tuple onto ctx so the NEXT task's pre-task-verify can
+    // short-circuit when this post ran green AND its working tree is still clean. The
+    // pre-task-verify leaf re-checks the tree itself via `git status --porcelain` — this
+    // field only asserts "the script ran here and got this outcome." Survives
+    // `settle-attempt` (which clears per-attempt fields only).
+    priorPostVerifyOutcome: { cwd: opts.cwd, outcome: out.run.outcome },
+    ...(blockReason !== undefined ? { lastBlockReason: blockReason } : {}),
+    ...(grantRetry ? { lastShouldFailAttempt: true } : {}),
+  };
+};
+
 export const postTaskVerifyLeaf = (
   deps: PostTaskVerifyLeafDeps,
   opts: PostTaskVerifyLeafOpts,
   taskId: TaskId
 ): Element<ImplementCtx> =>
   leaf<ImplementCtx, LeafInput, LeafOutput>(`post-task-verify-${String(taskId)}`, {
-    useCase: {
-      execute: async (input, signal): Promise<Result<LeafOutput, DomainError>> => {
-        // Zero-turn short-circuit. When pre-task-verify hard-blocked the task BEFORE any
-        // generator spawned (the gen-eval loop's `shouldContinue` refused entry on a
-        // pre-existing `lastExit`), there is no AI work on the tree to verify — re-running the
-        // dominant-cost verify script is pure waste, and there is nothing to attribute
-        // (HARNESS-PRINCIPLES § 9). Synthesise a `'skipped'` VerifyRun so the ctx carry stays
-        // consistent: `legacyVerifyResult` maps `'skipped'` to `{ kind: 'skipped' }` (no spurious
-        // verify-failed warning downstream), attribution stays undefined (it needs both pre and
-        // post outcomes), and `priorPostVerifyOutcome` carries `'skipped'` so the NEXT task's
-        // pre-verify carry-baseline does not short-circuit (that path requires `'success'`).
-        if (input.preVerifyBlockedZeroTurn) {
-          const skipped: VerifyRun = {
-            phase: 'post',
-            ranAt: deps.clock(),
-            command: '',
-            exitCode: 0,
-            durationMs: 0,
-            outcome: 'skipped',
-          };
-          return Result.ok({ task: input.task, run: skipped, rawOutput: '' });
-        }
-
-        // Normalise legacy script + structured gates into ONE gate list (gates win when present).
-        const gates = normalizeVerifyGates(opts.verifyScript, opts.verifyGates);
-        // Diff-scope the gates to the attempt's footprint — but ONLY when the repo actually
-        // configured structured gates. The legacy single catch-all gate matches every path, so
-        // computing a footprint for it is wasted git work; leave `scope` undefined (all-run subset
-        // = the one gate). When gates ARE configured we compute the footprint and pass it as scope;
-        // fail-fast stops at the first red scoped gate. CRITICAL fallback: a footprint failure or
-        // an empty result runs ALL gates (scope undefined) — we never silently skip a gate.
-        const usingStructuredGates = opts.verifyGates !== undefined && opts.verifyGates.length > 0;
-        const scope = usingStructuredGates ? await computeScope(deps, opts.cwd) : undefined;
-        const { run, rawOutput, spawnErrorMessage } = await runVerifyGatesUseCase({
-          cwd: opts.cwd,
-          phase: 'post',
-          gates,
-          mode: 'fail-fast',
-          ...(scope !== undefined ? { scope } : {}),
-          ...(opts.timeoutMs !== undefined ? { defaultTimeoutMs: opts.timeoutMs } : {}),
-          clock: deps.clock,
-          // Thread the chain abort signal so a Ctrl-C mid-verify kills the child promptly instead
-          // of stranding the repo lock for the full verifyTimeout. `runVerifyShell` collapses the
-          // runner's widened `AbortError` to a `StorageError` shape for the use-case port — the
-          // real cancellation is surfaced verbatim by the `signal.aborted` check below.
-          runShellScript: (cwd, script, scriptOpts) =>
-            runVerifyShell(deps.shellScriptRunner, cwd, script, {
-              ...scriptOpts,
-              ...(signal !== undefined ? { signal } : {}),
-            }),
-          logger: deps.logger,
-        });
-
-        // Cancellation propagates verbatim. `runVerifyScriptUseCase` folds a runner
-        // `Result.error` into a `spawn-error` row, so the abort would otherwise be swallowed as an
-        // unknown-attribution outcome. Detect the cancel at the leaf boundary and surface the
-        // codebase's transparently-propagated `AbortError` — the chain tears down rather than
-        // recording a misleading spawn-error attribution.
-        if (signal?.aborted === true) {
-          return Result.error(
-            new AbortError({
-              elementName: `post-task-verify-${String(taskId)}`,
-              reason: 'aborted during post-task verify',
-            })
-          );
-        }
-
-        // Audit [01] / [03]: persist the full untruncated output to
-        // `<sprintDir>/logs/verify/<task-id>/post-attempt-<N>.log`.
-        if (opts.sprintDir !== undefined && rawOutput.length > 0) {
-          const attemptN = input.task.attempts.length;
-          const logPath = join(
-            String(opts.sprintDir),
-            'logs',
-            'verify',
-            String(input.task.id),
-            `post-attempt-${String(attemptN)}.log`
-          );
-          const wrote = await writeTextAtomic(logPath, rawOutput);
-          if (!wrote.ok) {
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'warn',
-              message: `post-task-verify ${String(opts.cwd)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
-              at: deps.clock(),
-            });
-          }
-        }
-
-        let updated = appendAttemptVerifyRun(input.task, run);
-        if (!updated.ok) return Result.error(updated.error);
-
-        // Attribution requires both pre and post outcomes. If pre was spawn-error or skipped,
-        // `attributeVerify` returns undefined and we leave the field unset.
-        const attribution = input.preOutcome !== undefined ? attributeVerify(input.preOutcome, run.outcome) : undefined;
-        if (attribution !== undefined) {
-          const stamped = setAttemptAttribution(updated.value, attribution);
-          if (!stamped.ok) return Result.error(stamped.error);
-          updated = stamped;
-        }
-
-        const persisted = await deps.taskRepo.update(input.sprintId, updated.value);
-        if (!persisted.ok) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'warn',
-            message: `post-task-verify audit persist failed for task ${String(taskId)} — ${persisted.error.message}`,
-            at: deps.clock(),
-          });
-        }
-
-        if (attribution === 'regressed') {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'error',
-            message: `post-task-verify ${String(opts.cwd)}: regressed baseline (exit=${String(run.exitCode)}) — blocking task`,
-            at: deps.clock(),
-          });
-        } else if (attribution === 'baseline-broken') {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'warn',
-            message: `post-task-verify ${String(opts.cwd)}: baseline still red but task started on broken baseline — preserving verdict`,
-            at: deps.clock(),
-          });
-        } else if (attribution === 'fixed-baseline') {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'info',
-            message: `post-task-verify ${String(opts.cwd)}: fixed pre-existing failure (exit=0)`,
-            at: deps.clock(),
-          });
-        } else if (run.outcome === SPAWN_ERROR_OUTCOME) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'warn',
-            message: `post-task-verify ${String(opts.cwd)}: spawn-error — ${spawnErrorMessage ?? 'unknown spawn error'}; attribution skipped`,
-            at: deps.clock(),
-          });
-        }
-
-        return Result.ok({
-          task: updated.value,
-          run,
-          rawOutput,
-          ...(spawnErrorMessage !== undefined ? { spawnErrorMessage } : {}),
-          ...(attribution !== undefined ? { attribution } : {}),
-        });
-      },
-    },
-    input: (ctx) => {
-      if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: 'pre-post-task-verify',
-          attemptedAction: `post-task-verify-${String(taskId)}`,
-          message: `post-task-verify-${String(taskId)}: ctx.currentTask is missing or mismatched`,
-        });
-      }
-      if (ctx.currentTask.status !== 'in_progress') {
-        throw new InvalidStateError({
-          entity: 'task',
-          currentState: ctx.currentTask.status,
-          attemptedAction: `post-task-verify-${String(taskId)}`,
-          message: `post-task-verify-${String(taskId)}: expected in_progress task — got '${ctx.currentTask.status}'`,
-        });
-      }
-      // Zero-turn discriminant: a block reason is on ctx AND no generator turn ran this attempt.
-      // `start-attempt` resets `genEvalTurn` to undefined per attempt and the generator leaf bumps
-      // it to ≥1 on its first turn, so `genEvalTurn === undefined` is precisely "zero turns ran" —
-      // the pre-task-verify hard-block case. A turn-1 generator self-block has `genEvalTurn === 1`
-      // and falls through to the real verify script.
-      const preVerifyBlockedZeroTurn = ctx.lastBlockReason !== undefined && ctx.genEvalTurn === undefined;
-      return {
-        task: ctx.currentTask,
-        sprintId: ctx.sprintId,
-        preVerifyBlockedZeroTurn,
-        ...(ctx.lastPreVerifyOutcome !== undefined ? { preOutcome: ctx.lastPreVerifyOutcome } : {}),
-      };
-    },
-    output: (ctx, out) => {
-      const verifyResult = legacyVerifyResult(out.run, out.rawOutput, out.spawnErrorMessage);
-      const tasks = (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? (out.task as Task) : t));
-      // Default policy: a red post-verify blocks the task — the AI's `task-verified`
-      // self-report is overruled by the harness's independent verdict. The ONE escape hatch
-      // is `attribution === 'baseline-broken'`: when both pre and post ran red, we have
-      // explicit evidence the failure pre-existed the AI's work, so we preserve the AI's
-      // verdict (the operator can fix the baseline without losing the AI's work).
-      //
-      //   - clean           — no block (post is green)
-      //   - regressed       — BLOCK with explicit "regressed baseline" reason
-      //   - fixed-baseline  — no block (post is green)
-      //   - baseline-broken — no block (escape hatch; preserve AI's verdict)
-      //   - undefined       — BLOCK on raw red post (no pre-verify evidence to clear it)
-      const isRed = out.run.outcome === 'failed' || out.run.outcome === SPAWN_ERROR_OUTCOME;
-      const shouldBlock = isRed && out.attribution !== 'baseline-broken';
-      const blockReason = shouldBlock
-        ? out.attribution === 'regressed'
-          ? `verify script regressed baseline (exit=${String(out.run.exitCode)}); harness will not commit on red`
-          : `verify script failed (exit=${String(out.run.exitCode)}); harness will not commit on red`
-        : undefined;
-      // Bounded red-post-verify RETRY (T6). ONLY a `'regressed'` attribution (an evaluator-passed
-      // attempt that broke a GREEN baseline) qualifies — not raw red (no pre-verify evidence),
-      // `baseline-broken` (pre-existing failure, no block at all), `clean`, or `fixed-baseline`.
-      // While the task's attempt budget remains we also set `lastShouldFailAttempt`: settle's
-      // PRECEDENCE then keeps the task in_progress for one more attempt (commit was already skipped
-      // by the block guard; the retry-diff quarantine stashes the rejected diff). On the last
-      // allowed attempt `budgetRemains` is false → block only, matching today's behaviour. The
-      // running attempt counts as spent (start-attempt appended it), so a 3rd-of-3 attempt blocks.
-      const grantRetry = out.attribution === 'regressed' && budgetRemains(out.task, opts.maxAttempts);
-      return {
-        ...ctx,
-        currentTask: out.task,
-        tasks,
-        lastVerifyResult: verifyResult,
-        // Carry the (cwd, outcome) tuple onto ctx so the NEXT task's pre-task-verify can
-        // short-circuit when this post ran green AND its working tree is still clean. The
-        // pre-task-verify leaf re-checks the tree itself via `git status --porcelain` — this
-        // field only asserts "the script ran here and got this outcome." Survives
-        // `settle-attempt` (which clears per-attempt fields only).
-        priorPostVerifyOutcome: { cwd: opts.cwd, outcome: out.run.outcome },
-        ...(blockReason !== undefined ? { lastBlockReason: blockReason } : {}),
-        ...(grantRetry ? { lastShouldFailAttempt: true } : {}),
-      };
-    },
+    useCase: { execute: createPostTaskVerifyExecute(deps, opts, taskId) },
+    input: (ctx) => resolveLeafInput(ctx, taskId),
+    output: (ctx, out) => projectLeafOutput(ctx, out, opts),
   });

--- a/src/application/flows/implement/leaves/pre-task-verify.ts
+++ b/src/application/flows/implement/leaves/pre-task-verify.ts
@@ -5,6 +5,7 @@ import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { VerifyRun, VerifyRunOutcome } from '@src/domain/entity/attempt.ts';
 import { normalizeVerifyGates, runVerifyGatesUseCase } from '@src/business/task/run-verify-script.ts';
+import type { RunVerifyScriptOutput } from '@src/business/task/run-verify-script.ts';
 import type { VerifyGate } from '@src/domain/entity/repository.ts';
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { appendAttemptVerifyRun, markAttemptBaselineBroken } from '@src/domain/entity/task-attempts.ts';
@@ -219,6 +220,348 @@ const askRedBaselineDecision = async (
   );
 };
 
+/**
+ * True iff the previous task's post-task-verify ran green on this same cwd (carried from
+ * `input.priorPostVerifyOutcome`). Drives {@link tryCarryBaselineShortCircuit} AND gates
+ * {@link tryFreshSetupShortCircuit} — the two short-circuits never overlap; once a task has
+ * post-verified green, the carry path owns the subsequent skip.
+ */
+const isCarriedGreenForThisCwd = (input: LeafInput, cwd: AbsolutePath): boolean =>
+  input.priorPostVerifyOutcome?.outcome === 'success' && String(input.priorPostVerifyOutcome.cwd) === String(cwd);
+
+/**
+ * Carry-baseline short-circuit. When the previous task on this same cwd post-verified green and
+ * the working tree is still clean, the script's outcome can only be the same — re-running it is
+ * wasted compute (~2m30s on a typical repo). Skips the script, the audit-row append (no extra
+ * `phase: 'pre'` row), the log file write, and the prompt. The synthetic `VerifyRun` returned is
+ * for the leaf's contract only — `lastPreVerifyOutcome` correctly carries `'success'` through the
+ * output projection so post-task-verify's attribution computation sees `pre=success`.
+ *
+ * Git status returning an error (corrupt repo, fs error) demotes to "ineligible" — the real
+ * script runs instead, matching today's behavior verbatim. Returns `undefined` when the
+ * short-circuit does not fire, so the caller falls through to the real verify path.
+ */
+const tryCarryBaselineShortCircuit = async (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  input: LeafInput,
+  carriedGreenForThisCwd: boolean
+): Promise<LeafOutput | undefined> => {
+  if (!carriedGreenForThisCwd) return undefined;
+  const dirty = await gitHasUncommittedChanges(deps.gitRunner, opts.cwd);
+  if (!dirty.ok || dirty.value) return undefined;
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'info',
+    message: `pre-task-verify ${String(opts.cwd)}: short-circuited (carried green baseline, tree clean)`,
+    at: deps.clock(),
+  });
+  return { task: input.task, run: syntheticGreenPreRun(deps.clock), execution: input.execution };
+};
+
+/**
+ * Fresh-setup short-circuit (T13) — a strict generalisation of {@link tryCarryBaselineShortCircuit}
+ * for the FIRST pre-verify of the run on this repo. The carry path only seeds from a PRIOR TASK's
+ * green post-verify, so the first task of every launch always re-ran the gate even when this
+ * launch's setup script just built+tested the same tree seconds earlier. When the operator has
+ * opted in (`skipPreVerifyOnFreshSetup`), this launch's setup verified this repo green (the
+ * run-scoped marker — NOT a persisted prior-launch success), and the tree is clean, synthesize
+ * the SAME green baseline so downstream attribution + the PRE_VERIFY_RESULTS rendering fold to
+ * the identical path. Gated on the carry being absent so the two short-circuits never overlap.
+ */
+const tryFreshSetupShortCircuit = async (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  input: LeafInput,
+  carriedGreenForThisCwd: boolean
+): Promise<LeafOutput | undefined> => {
+  const eligible =
+    opts.skipPreVerifyOnFreshSetup === true &&
+    !carriedGreenForThisCwd &&
+    (input.setupVerifiedRepoIds ?? []).some((id) => String(id) === String(input.repositoryId));
+  if (!eligible) return undefined;
+  const dirty = await gitHasUncommittedChanges(deps.gitRunner, opts.cwd);
+  if (!dirty.ok || dirty.value) return undefined;
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'info',
+    message: `pre-task-verify ${String(opts.cwd)}: short-circuited (this run's setup verified the tree green, tree clean)`,
+    at: deps.clock(),
+  });
+  return { task: input.task, run: syntheticGreenPreRun(deps.clock), execution: input.execution };
+};
+
+/**
+ * Normalise legacy script + structured gates into ONE gate list (gates win when present), then
+ * run the FULL set with NO scope — `all-run` mode. Pre-verify is the attribution baseline; it
+ * must run every gate so post-verify's diff-scoped subset is a subset of what pre already ran
+ * (like-vs-like per gate, HARNESS-PRINCIPLES § 9).
+ */
+const runPreVerifyGate = (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  signal: AbortSignal | undefined
+): Promise<RunVerifyScriptOutput> => {
+  const gates = normalizeVerifyGates(opts.verifyScript, opts.verifyGates);
+  return runVerifyGatesUseCase({
+    cwd: opts.cwd,
+    phase: 'pre',
+    gates,
+    mode: 'all-run',
+    ...(opts.timeoutMs !== undefined ? { defaultTimeoutMs: opts.timeoutMs } : {}),
+    clock: deps.clock,
+    // Thread the chain abort signal so a Ctrl-C mid-verify kills the child promptly instead of
+    // stranding the repo lock for the full verifyTimeout. The runner now widens its error to
+    // `StorageError | AbortError`; `runVerifyScriptUseCase` only knows `StorageError`, so
+    // collapse an abort to a storage shape here (the runner has already killed the child) — the
+    // real abort is surfaced verbatim by the `signal.aborted` check the caller runs immediately
+    // after, before the folded spawn-error row is ever acted on.
+    runShellScript: (cwd, script, scriptOpts) =>
+      runVerifyShell(deps.shellScriptRunner, cwd, script, {
+        ...scriptOpts,
+        ...(signal !== undefined ? { signal } : {}),
+      }),
+    logger: deps.logger,
+  });
+};
+
+/**
+ * Audit [01] / [03]: persist the full untruncated verify output to
+ * `<sprintDir>/logs/verify/<task-id>/pre-attempt-<N>.log`. Best-effort — write failures log warn
+ * and never abort the chain.
+ */
+const persistPreVerifyLog = async (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  input: LeafInput,
+  rawOutput: string
+): Promise<void> => {
+  if (opts.sprintDir === undefined || rawOutput.length === 0) return;
+  const attemptN = input.task.attempts.length;
+  const logPath = join(
+    String(opts.sprintDir),
+    'logs',
+    'verify',
+    String(input.task.id),
+    `pre-attempt-${String(attemptN)}.log`
+  );
+  const wrote = await writeTextAtomic(logPath, rawOutput);
+  if (!wrote.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `pre-task-verify ${String(opts.cwd)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
+      at: deps.clock(),
+    });
+  }
+};
+
+/**
+ * Appends the row to the running attempt. A red baseline also stamps `baselineBroken` so the TUI
+ * can warn the operator. `spawn-error` leaves `baselineBroken` unset — the baseline state is
+ * unknown, not known-bad. Persists so the audit row survives a crash — a persistence failure is
+ * logged but non-fatal, the chain has already captured the meaningful side effect (the script
+ * ran); losing the audit at most causes a re-record on the next resume.
+ */
+const appendAndPersistPreVerifyRun = async (
+  deps: PreTaskVerifyLeafDeps,
+  input: LeafInput,
+  taskId: TaskId,
+  run: VerifyRun
+): Promise<Result<InProgressTask, DomainError>> => {
+  let updated = appendAttemptVerifyRun(input.task, run);
+  if (!updated.ok) return Result.error(updated.error);
+  if (run.outcome === 'failed') {
+    const flagged = markAttemptBaselineBroken(updated.value);
+    if (!flagged.ok) return Result.error(flagged.error);
+    updated = flagged;
+  }
+
+  const persisted = await deps.taskRepo.update(input.sprintId, updated.value);
+  if (!persisted.ok) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `pre-task-verify audit persist failed for task ${String(taskId)} — ${persisted.error.message}`,
+      at: deps.clock(),
+    });
+  }
+  return Result.ok(updated.value);
+};
+
+/**
+ * Handles a red (`outcome === 'failed'`) pre-verify. Prior in-sprint amnesty falls through
+ * silently with the warning banner. Non-interactive context hard-blocks (the operator can't
+ * answer; silently running AI on broken state is the surprising behaviour the gate exists to
+ * prevent). Interactive context asks the operator to proceed / skip / abort, persisting the
+ * "proceed" amnesty so the rest of the sprint's tasks don't re-prompt.
+ */
+const handleRedBaseline = async (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  env: PreTaskVerifyEnvironment,
+  taskId: TaskId,
+  updatedTask: InProgressTask,
+  run: VerifyRun,
+  execution: SprintExecution
+): Promise<Result<LeafOutput, DomainError>> => {
+  // Prior in-sprint amnesty — fall through silently with today's warning banner.
+  if (execution.baselineBrokenPolicy === 'proceed') {
+    emitBaselineRedLog(deps, opts, run);
+    emitBaselineRedBanner(deps, taskId);
+    return Result.ok({ task: updatedTask, run, execution });
+  }
+
+  // Non-interactive context — hard-block. The operator can't answer; silently running AI on
+  // broken state is the surprising behaviour the gate exists to prevent.
+  if (!isInteractive(env)) {
+    const reason = 'baseline already red at task start (non-interactive — operator could not be prompted)';
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `pre-task-verify ${String(opts.cwd)}: ${reason}`,
+      at: deps.clock(),
+    });
+    return Result.ok({ task: updatedTask, run, execution, blockReason: reason });
+  }
+
+  // Interactive context, no prior amnesty — ask the operator.
+  const decision = await askRedBaselineDecision(deps.interactive, opts.cwd, run.exitCode);
+  if (!decision.ok) return Result.error(decision.error);
+  if (decision.value === 'abort') {
+    return Result.error(
+      new AbortError({
+        elementName: `pre-task-verify-${String(taskId)}`,
+        reason: 'operator aborted sprint on broken baseline',
+      })
+    );
+  }
+  if (decision.value === 'skip') {
+    const reason = 'operator skipped task on broken baseline';
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `pre-task-verify ${String(opts.cwd)}: ${reason}`,
+      at: deps.clock(),
+    });
+    return Result.ok({ task: updatedTask, run, execution, blockReason: reason });
+  }
+  // decision.value === 'proceed' — persist the amnesty so the rest of the sprint's tasks don't
+  // re-prompt, then fall through to today's warning banner.
+  const nextExecution = setExecutionBaselineBrokenPolicy(execution, 'proceed');
+  const saved = await deps.sprintExecutionRepo.save(nextExecution);
+  if (!saved.ok) return Result.error(saved.error);
+  emitBaselineRedLog(deps, opts, run);
+  emitBaselineRedBanner(deps, taskId);
+  return Result.ok({ task: updatedTask, run, execution: nextExecution });
+};
+
+/**
+ * Handles a non-failed (`spawn-error` or `success`) pre-verify. A spawn-error is logged and
+ * attribution is skipped downstream. A green pre-verify clears any stale baseline-broken banner
+ * from a prior attempt of this same task (no-op when no such banner exists) and clears a
+ * one-shot "proceed" amnesty so a fresh red later in the sprint re-prompts rather than silently
+ * proceeding.
+ */
+const handleNonFailedOutcome = async (
+  deps: PreTaskVerifyLeafDeps,
+  opts: PreTaskVerifyLeafOpts,
+  taskId: TaskId,
+  run: VerifyRun,
+  execution: SprintExecution,
+  spawnErrorMessage: string | undefined
+): Promise<Result<SprintExecution, DomainError>> => {
+  if (run.outcome === 'spawn-error') {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'warn',
+      message: `pre-task-verify ${String(opts.cwd)}: spawn-error — ${spawnErrorMessage ?? 'unknown spawn error'}; attribution will be skipped`,
+      at: deps.clock(),
+    });
+    return Result.ok(execution);
+  }
+
+  deps.eventBus.publish({
+    type: 'banner-clear',
+    id: `baseline-broken-${String(taskId)}`,
+    at: deps.clock(),
+  });
+  if (execution.baselineBrokenPolicy === 'proceed') {
+    const nextExecution = setExecutionBaselineBrokenPolicy(execution, undefined);
+    const saved = await deps.sprintExecutionRepo.save(nextExecution);
+    if (!saved.ok) return Result.error(saved.error);
+    return Result.ok(nextExecution);
+  }
+  return Result.ok(execution);
+};
+
+/** Projects `ImplementCtx` onto the leaf's `LeafInput`, throwing on ctx-shape violations. */
+const buildPreTaskVerifyInput = (ctx: ImplementCtx, taskId: TaskId): LeafInput => {
+  if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
+    throw new InvalidStateError({
+      entity: 'chain',
+      currentState: 'pre-pre-task-verify',
+      attemptedAction: `pre-task-verify-${String(taskId)}`,
+      message: `pre-task-verify-${String(taskId)}: ctx.currentTask is missing or mismatched`,
+    });
+  }
+  if (ctx.currentTask.status !== 'in_progress') {
+    throw new InvalidStateError({
+      entity: 'task',
+      currentState: ctx.currentTask.status,
+      attemptedAction: `pre-task-verify-${String(taskId)}`,
+      message: `pre-task-verify-${String(taskId)}: expected in_progress task — got '${ctx.currentTask.status}'`,
+    });
+  }
+  if (ctx.execution === undefined) {
+    throw new InvalidStateError({
+      entity: 'chain',
+      currentState: 'pre-pre-task-verify',
+      attemptedAction: `pre-task-verify-${String(taskId)}`,
+      message: `pre-task-verify-${String(taskId)}: ctx.execution is undefined — load-sprint-execution must run first`,
+    });
+  }
+  return {
+    task: ctx.currentTask,
+    sprintId: ctx.sprintId,
+    execution: ctx.execution,
+    repositoryId: ctx.currentTask.repositoryId,
+    ...(ctx.priorPostVerifyOutcome !== undefined ? { priorPostVerifyOutcome: ctx.priorPostVerifyOutcome } : {}),
+    ...(ctx.setupVerifiedRepoIdsThisRun !== undefined ? { setupVerifiedRepoIds: ctx.setupVerifiedRepoIdsThisRun } : {}),
+  };
+};
+
+/**
+ * Projects the leaf's `LeafOutput` back onto `ImplementCtx`. When the leaf decided to
+ * short-circuit the task (non-interactive block or skip), lifts the reason onto `ctx.lastExit` /
+ * `ctx.lastBlockReason`. The gen-eval loop's `shouldContinue` predicate sees `lastExit !==
+ * undefined` at loop entry and REFUSES to enter any turn — no round folder is claimed, no meta
+ * sidecar is stamped, and the generator never spawns on the broken tree the gate just refused.
+ * finalize-gen-eval then reads the self-blocked exit and stamps `verdict: 'failed'` +
+ * `blockedReason` so settle-attempt routes the task to `blocked`. post-task-verify also
+ * short-circuits to a synthetic `'skipped'` run (`lastBlockReason` set AND `genEvalTurn ===
+ * undefined`) so the dominant-cost verify script is not re-run when there was no AI work to
+ * verify. Self-blocked is the existing GenEvalExit kind that already carries an arbitrary reason
+ * string — there's no need for a separate `baseline-broken` exit kind to wire the same outcome.
+ */
+const projectPreTaskVerifyOutput = (ctx: ImplementCtx, out: LeafOutput): ImplementCtx => {
+  const next: ImplementCtx = {
+    ...ctx,
+    currentTask: out.task,
+    tasks: (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? (out.task as Task) : t)),
+    execution: out.execution,
+    lastPreVerifyOutcome: out.run.outcome,
+  };
+  if (out.blockReason !== undefined) {
+    return {
+      ...next,
+      lastExit: { kind: 'self-blocked', reason: out.blockReason },
+      lastBlockReason: out.blockReason,
+    };
+  }
+  return next;
+};
+
 export const preTaskVerifyLeaf = (
   deps: PreTaskVerifyLeafDeps,
   opts: PreTaskVerifyLeafOpts,
@@ -228,91 +571,17 @@ export const preTaskVerifyLeaf = (
   return leaf<ImplementCtx, LeafInput, LeafOutput>(`pre-task-verify-${String(taskId)}`, {
     useCase: {
       execute: async (input, signal): Promise<Result<LeafOutput, DomainError>> => {
-        // Carry-baseline short-circuit. When the previous task on this same cwd post-verified
-        // green and the working tree is still clean, the script's outcome can only be the
-        // same — re-running it is wasted compute (~2m30s on a typical repo). Skip the script,
-        // skip the audit-row append (no extra `phase: 'pre'` row), skip the log file write,
-        // skip the prompt. The synthetic `VerifyRun` we return is for the leaf's contract
-        // only — `lastPreVerifyOutcome` correctly carries `'success'` through the output
-        // projection so post-task-verify's attribution computation sees `pre=success`.
-        //
-        // Git status returning an error (corrupt repo, fs error) demotes to "ineligible" —
-        // the real script runs instead, matching today's behavior verbatim.
-        const carriedGreenForThisCwd =
-          input.priorPostVerifyOutcome?.outcome === 'success' &&
-          String(input.priorPostVerifyOutcome.cwd) === String(opts.cwd);
-        if (carriedGreenForThisCwd) {
-          const dirty = await gitHasUncommittedChanges(deps.gitRunner, opts.cwd);
-          if (dirty.ok && !dirty.value) {
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'info',
-              message: `pre-task-verify ${String(opts.cwd)}: short-circuited (carried green baseline, tree clean)`,
-              at: deps.clock(),
-            });
-            return Result.ok({ task: input.task, run: syntheticGreenPreRun(deps.clock), execution: input.execution });
-          }
-          // Dirty tree, or git probe failed — fall through to the real verify path. Don't
-          // surface the git-status error: the operator gets the existing behavior, not a
-          // regression.
-        }
+        const carriedGreenForThisCwd = isCarriedGreenForThisCwd(input, opts.cwd);
 
-        // Fresh-setup short-circuit (T13) — a strict generalisation of the carry-baseline path
-        // above, for the FIRST pre-verify of the run on this repo. The carry path only seeds from a
-        // PRIOR TASK's green post-verify, so the first task of every launch always re-ran the gate
-        // even when this launch's setup script just built+tested the same tree seconds earlier.
-        // When the operator has opted in (`skipPreVerifyOnFreshSetup`), this launch's setup verified
-        // this repo green (the run-scoped marker — NOT a persisted prior-launch success), and the
-        // tree is clean, synthesize the SAME green baseline so downstream attribution + the
-        // PRE_VERIFY_RESULTS rendering fold to the identical path. Gated on the carry being absent so
-        // the two short-circuits never overlap — once a task has post-verified green, the carry path
-        // owns the subsequent skip.
-        if (
-          opts.skipPreVerifyOnFreshSetup === true &&
-          !carriedGreenForThisCwd &&
-          (input.setupVerifiedRepoIds ?? []).some((id) => String(id) === String(input.repositoryId))
-        ) {
-          const dirty = await gitHasUncommittedChanges(deps.gitRunner, opts.cwd);
-          if (dirty.ok && !dirty.value) {
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'info',
-              message: `pre-task-verify ${String(opts.cwd)}: short-circuited (this run's setup verified the tree green, tree clean)`,
-              at: deps.clock(),
-            });
-            return Result.ok({ task: input.task, run: syntheticGreenPreRun(deps.clock), execution: input.execution });
-          }
-          // Dirty tree or git probe failed — fall through to the real verify gate (same demotion
-          // policy as the carry path: never surface the git-status error as a regression).
-        }
+        const carried = await tryCarryBaselineShortCircuit(deps, opts, input, carriedGreenForThisCwd);
+        if (carried !== undefined) return Result.ok(carried);
 
-        // Normalise legacy script + structured gates into ONE gate list (gates win when present),
-        // then run the FULL set with NO scope — `all-run` mode. Pre-verify is the attribution
-        // baseline; it must run every gate so post-verify's diff-scoped subset is a subset of what
-        // pre already ran (like-vs-like per gate, HARNESS-PRINCIPLES § 9).
-        const gates = normalizeVerifyGates(opts.verifyScript, opts.verifyGates);
-        const { run, rawOutput, spawnErrorMessage } = await runVerifyGatesUseCase({
-          cwd: opts.cwd,
-          phase: 'pre',
-          gates,
-          mode: 'all-run',
-          ...(opts.timeoutMs !== undefined ? { defaultTimeoutMs: opts.timeoutMs } : {}),
-          clock: deps.clock,
-          // Thread the chain abort signal so a Ctrl-C mid-verify kills the child promptly instead
-          // of stranding the repo lock for the full verifyTimeout. The runner now widens its
-          // error to `StorageError | AbortError`; `runVerifyScriptUseCase` only knows
-          // `StorageError`, so collapse an abort to a storage shape here (the runner has already
-          // killed the child) — the real abort is surfaced verbatim by the `signal.aborted` check
-          // below, before the folded spawn-error row is ever acted on.
-          runShellScript: (cwd, script, scriptOpts) =>
-            runVerifyShell(deps.shellScriptRunner, cwd, script, {
-              ...scriptOpts,
-              ...(signal !== undefined ? { signal } : {}),
-            }),
-          logger: deps.logger,
-        });
+        const freshSetup = await tryFreshSetupShortCircuit(deps, opts, input, carriedGreenForThisCwd);
+        if (freshSetup !== undefined) return Result.ok(freshSetup);
 
-        // Cancellation propagates verbatim. `runVerifyScriptUseCase` folds a runner
+        const { run, rawOutput, spawnErrorMessage } = await runPreVerifyGate(deps, opts, signal);
+
+        // Cancellation propagates verbatim. `runVerifyGatesUseCase` folds a runner
         // `Result.error` into a `spawn-error` row, so the abort would otherwise be swallowed as an
         // unknown-baseline outcome. Detect the cancel at the leaf boundary and surface the
         // codebase's transparently-propagated `AbortError` instead — the chain tears down rather
@@ -326,200 +595,30 @@ export const preTaskVerifyLeaf = (
           );
         }
 
-        // Audit [01] / [03]: persist the full untruncated output to
-        // `<sprintDir>/logs/verify/<task-id>/pre-attempt-<N>.log`. Best-effort — write
-        // failures log warn and never abort the chain.
-        if (opts.sprintDir !== undefined && rawOutput.length > 0) {
-          const attemptN = input.task.attempts.length;
-          const logPath = join(
-            String(opts.sprintDir),
-            'logs',
-            'verify',
-            String(input.task.id),
-            `pre-attempt-${String(attemptN)}.log`
-          );
-          const wrote = await writeTextAtomic(logPath, rawOutput);
-          if (!wrote.ok) {
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'warn',
-              message: `pre-task-verify ${String(opts.cwd)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
-              at: deps.clock(),
-            });
-          }
-        }
+        await persistPreVerifyLog(deps, opts, input, rawOutput);
 
-        // Append the row to the running attempt. A red baseline also stamps `baselineBroken`
-        // so the TUI can warn the operator. `spawn-error` leaves `baselineBroken` unset —
-        // the baseline state is unknown, not known-bad.
-        let updated = appendAttemptVerifyRun(input.task, run);
-        if (!updated.ok) return Result.error(updated.error);
-        if (run.outcome === 'failed') {
-          const flagged = markAttemptBaselineBroken(updated.value);
-          if (!flagged.ok) return Result.error(flagged.error);
-          updated = flagged;
-        }
-
-        // Persist so the audit row survives a crash. A persistence failure is logged but
-        // non-fatal — the chain has already captured the meaningful side effect (the script
-        // ran); losing the audit at most causes a re-record on the next resume.
-        const persisted = await deps.taskRepo.update(input.sprintId, updated.value);
-        if (!persisted.ok) {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'warn',
-            message: `pre-task-verify audit persist failed for task ${String(taskId)} — ${persisted.error.message}`,
-            at: deps.clock(),
-          });
-        }
-
-        let execution = input.execution;
+        const appended = await appendAndPersistPreVerifyRun(deps, input, taskId, run);
+        if (!appended.ok) return Result.error(appended.error);
 
         if (run.outcome === 'failed') {
-          // Prior in-sprint amnesty — fall through silently with today's warning banner.
-          if (execution.baselineBrokenPolicy === 'proceed') {
-            emitBaselineRedLog(deps, opts, run);
-            emitBaselineRedBanner(deps, taskId);
-            return Result.ok({ task: updated.value, run, execution });
-          }
-
-          // Non-interactive context — hard-block. The operator can't answer; silently running
-          // AI on broken state is the surprising behaviour the gate exists to prevent.
-          if (!isInteractive(env)) {
-            const reason = 'baseline already red at task start (non-interactive — operator could not be prompted)';
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'warn',
-              message: `pre-task-verify ${String(opts.cwd)}: ${reason}`,
-              at: deps.clock(),
-            });
-            return Result.ok({ task: updated.value, run, execution, blockReason: reason });
-          }
-
-          // Interactive context, no prior amnesty — ask the operator.
-          const decision = await askRedBaselineDecision(deps.interactive, opts.cwd, run.exitCode);
-          if (!decision.ok) return Result.error(decision.error);
-          if (decision.value === 'abort') {
-            return Result.error(
-              new AbortError({
-                elementName: `pre-task-verify-${String(taskId)}`,
-                reason: 'operator aborted sprint on broken baseline',
-              })
-            );
-          }
-          if (decision.value === 'skip') {
-            const reason = 'operator skipped task on broken baseline';
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'warn',
-              message: `pre-task-verify ${String(opts.cwd)}: ${reason}`,
-              at: deps.clock(),
-            });
-            return Result.ok({ task: updated.value, run, execution, blockReason: reason });
-          }
-          // decision.value === 'proceed' — persist the amnesty so the rest of the sprint's
-          // tasks don't re-prompt, then fall through to today's warning banner.
-          const nextExecution = setExecutionBaselineBrokenPolicy(execution, 'proceed');
-          const saved = await deps.sprintExecutionRepo.save(nextExecution);
-          if (!saved.ok) return Result.error(saved.error);
-          execution = nextExecution;
-          emitBaselineRedLog(deps, opts, run);
-          emitBaselineRedBanner(deps, taskId);
-          return Result.ok({ task: updated.value, run, execution });
+          return handleRedBaseline(deps, opts, env, taskId, appended.value, run, input.execution);
         }
 
-        if (run.outcome === 'spawn-error') {
-          deps.eventBus.publish({
-            type: 'log',
-            level: 'warn',
-            message: `pre-task-verify ${String(opts.cwd)}: spawn-error — ${spawnErrorMessage ?? 'unknown spawn error'}; attribution will be skipped`,
-            at: deps.clock(),
-          });
-        } else {
-          // Green pre-verify — clear any stale baseline-broken banner from a prior attempt of
-          // this same task. No-op when no such banner exists.
-          deps.eventBus.publish({
-            type: 'banner-clear',
-            id: `baseline-broken-${String(taskId)}`,
-            at: deps.clock(),
-          });
-          // Amnesty is one-shot: once the baseline turns green again, clear the policy so a
-          // fresh red later in the sprint re-prompts rather than silently proceeding.
-          if (execution.baselineBrokenPolicy === 'proceed') {
-            const nextExecution = setExecutionBaselineBrokenPolicy(execution, undefined);
-            const saved = await deps.sprintExecutionRepo.save(nextExecution);
-            if (!saved.ok) return Result.error(saved.error);
-            execution = nextExecution;
-          }
-        }
+        const executionResult = await handleNonFailedOutcome(
+          deps,
+          opts,
+          taskId,
+          run,
+          input.execution,
+          spawnErrorMessage
+        );
+        if (!executionResult.ok) return Result.error(executionResult.error);
 
-        return Result.ok({ task: updated.value, run, execution });
+        return Result.ok({ task: appended.value, run, execution: executionResult.value });
       },
     },
-    input: (ctx) => {
-      if (ctx.currentTask === undefined || ctx.currentTask.id !== taskId) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: 'pre-pre-task-verify',
-          attemptedAction: `pre-task-verify-${String(taskId)}`,
-          message: `pre-task-verify-${String(taskId)}: ctx.currentTask is missing or mismatched`,
-        });
-      }
-      if (ctx.currentTask.status !== 'in_progress') {
-        throw new InvalidStateError({
-          entity: 'task',
-          currentState: ctx.currentTask.status,
-          attemptedAction: `pre-task-verify-${String(taskId)}`,
-          message: `pre-task-verify-${String(taskId)}: expected in_progress task — got '${ctx.currentTask.status}'`,
-        });
-      }
-      if (ctx.execution === undefined) {
-        throw new InvalidStateError({
-          entity: 'chain',
-          currentState: 'pre-pre-task-verify',
-          attemptedAction: `pre-task-verify-${String(taskId)}`,
-          message: `pre-task-verify-${String(taskId)}: ctx.execution is undefined — load-sprint-execution must run first`,
-        });
-      }
-      return {
-        task: ctx.currentTask,
-        sprintId: ctx.sprintId,
-        execution: ctx.execution,
-        repositoryId: ctx.currentTask.repositoryId,
-        ...(ctx.priorPostVerifyOutcome !== undefined ? { priorPostVerifyOutcome: ctx.priorPostVerifyOutcome } : {}),
-        ...(ctx.setupVerifiedRepoIdsThisRun !== undefined
-          ? { setupVerifiedRepoIds: ctx.setupVerifiedRepoIdsThisRun }
-          : {}),
-      };
-    },
-    output: (ctx, out) => {
-      const next: ImplementCtx = {
-        ...ctx,
-        currentTask: out.task,
-        tasks: (ctx.tasks ?? []).map((t) => (t.id === out.task.id ? (out.task as Task) : t)),
-        execution: out.execution,
-        lastPreVerifyOutcome: out.run.outcome,
-      };
-      // When the leaf decided to short-circuit the task (non-interactive block or skip), lift
-      // the reason onto `lastExit` + `lastBlockReason`. The gen-eval loop's `shouldContinue`
-      // predicate sees `lastExit !== undefined` at loop entry and REFUSES to enter any turn —
-      // no round folder is claimed, no meta sidecar is stamped, and the generator never spawns
-      // on the broken tree the gate just refused. finalize-gen-eval then reads the self-blocked
-      // exit and stamps `verdict: 'failed'` + `blockedReason` so settle-attempt routes the task
-      // to `blocked`. post-task-verify also short-circuits to a synthetic `'skipped'` run
-      // (`lastBlockReason` set AND `genEvalTurn === undefined`) so the dominant-cost verify
-      // script is not re-run when there was no AI work to verify. Self-blocked is the existing
-      // GenEvalExit kind that already carries an arbitrary reason string — there's no need for a
-      // separate `baseline-broken` exit kind to wire the same outcome.
-      if (out.blockReason !== undefined) {
-        return {
-          ...next,
-          lastExit: { kind: 'self-blocked', reason: out.blockReason },
-          lastBlockReason: out.blockReason,
-        };
-      }
-      return next;
-    },
+    input: (ctx) => buildPreTaskVerifyInput(ctx, taskId),
+    output: projectPreTaskVerifyOutput,
   });
 };
 

--- a/src/application/flows/implement/leaves/progress-journal.ts
+++ b/src/application/flows/implement/leaves/progress-journal.ts
@@ -23,8 +23,10 @@ import { renderSectionHeader } from '@src/business/sprint/journal-structure.ts';
 import { renderSprintStateHeader, type SprintStateTask } from '@src/business/sprint/render-sprint-state-header.ts';
 import { parseJournalCreatedAt, regenerateJournal } from '@src/business/sprint/regenerate-journal-header.ts';
 import { dedupeLearnings } from '@src/application/flows/implement/leaves/_shared/dedupe-learnings.ts';
+import { dedupeTexts } from '@src/application/flows/implement/leaves/_shared/dedupe-texts.ts';
 import type { LearningEntry } from '@src/domain/signal.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { FoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 
 /**
  * Write the just-settled task-attempt section into `<sprintDir>/progress.md` (audit-[07]) and
@@ -39,6 +41,14 @@ import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
  * execution), append the new attempt section, and write the whole file atomically. The header band
  * stays an accurate machine-derived snapshot; the attempt sections are never rewritten.
  *
+ * MUTEX-GUARDED read-modify-write: on the parallel wave path, 2+ branches share the SAME sprint
+ * `progress.md`. Each branch's read (a bare `fs.readFile`, outside any port) → regenerate-header →
+ * append-section → write is a critical section — without serialising it end-to-end, two branches
+ * can both read the same base, append only their own section, and the last `writeFile` rename wins,
+ * silently dropping a sibling's just-appended section. Serialising only the `writeFile` port is
+ * insufficient (the read happens BEFORE the port call); the whole `execute` body runs inside
+ * {@link ProgressJournalLeafDeps.journalMutex} instead.
+ *
  * FAIL-LOUD / self-healing for the section write: the per-attempt section is the NEXT attempt's
  * memory, so a dropped write silently removes a warning/escalation the next session must honour. A
  * failed write is retried once; if it still fails, a VISIBLE in-file gap marker is written instead so
@@ -50,6 +60,13 @@ export interface ProgressJournalLeafDeps {
   readonly writeFile: WriteFile;
   readonly clock: () => IsoTimestamp;
   readonly logger: Logger;
+  /**
+   * Mutex guarding this leaf's ENTIRE read → regenerate-header → append-section → write critical
+   * section. The parallel launcher threads ONE shared instance across every branch of a run (see
+   * `wave-branch.ts` / `launch/implement.ts`); the serial path gets a fresh, effectively-unshared
+   * instance (a single caller never contends with itself). See `wave-branch.ts`'s `FoldQueue`.
+   */
+  readonly journalMutex: FoldQueue;
 }
 
 export interface ProgressJournalLeafOpts {
@@ -72,24 +89,6 @@ interface JournalInput {
   /** Every task in the sprint — drives the per-task table, blockers, and stale lists. */
   readonly allTasks: readonly Task[];
 }
-
-/**
- * Trim + dedupe a per-attempt signal-text accumulator. Returns the deduped list in first-seen
- * order. Empty / undefined input → empty array; the renderer drops empty subsections.
- */
-const dedupeTexts = (texts: readonly string[] | undefined): readonly string[] => {
-  if (texts === undefined || texts.length === 0) return [];
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const t of texts) {
-    const trimmed = t.trim();
-    if (trimmed.length === 0) continue;
-    if (seen.has(trimmed)) continue;
-    seen.add(trimmed);
-    out.push(trimmed);
-  }
-  return out;
-};
 
 const renderOutcomeParagraph = (task: Task, attempt: Attempt | undefined): string => {
   if (task.status === 'blocked') {
@@ -330,24 +329,28 @@ export const progressJournalLeaf = (
 ): Element<ImplementCtx> =>
   leaf<ImplementCtx, JournalInput, void>(`progress-journal-${String(taskId)}`, {
     useCase: {
-      execute: async (input) => {
-        const newSection = buildAttemptSection(input, opts.totalRounds, deps.clock);
+      // The ENTIRE read → regenerate-header → append-section → write sequence is the critical
+      // section — the read is a bare `fs.readFile` outside any port, so serialising only the
+      // `writeFile` call would leave a window where two branches both read the same stale base.
+      execute: (input) =>
+        deps.journalMutex.run(async () => {
+          const newSection = buildAttemptSection(input, opts.totalRounds, deps.clock);
 
-        // Regenerate the always-kept header band from canonical state, then append this attempt
-        // section. The existing file's append-only sections ride through verbatim.
-        const existing = await readExisting(input.progressFile);
-        const stateHeader = buildStateHeader(input, existing, deps.clock);
-        const content = regenerateJournal({ existing, stateHeader, newSection });
+          // Regenerate the always-kept header band from canonical state, then append this attempt
+          // section. The existing file's append-only sections ride through verbatim.
+          const existing = await readExisting(input.progressFile);
+          const stateHeader = buildStateHeader(input, existing, deps.clock);
+          const content = regenerateJournal({ existing, stateHeader, newSection });
 
-        // Fallback payload if the section write keeps failing: a forgery-safe section header (so the
-        // delimiter + id token still parse for the next attempt) with a visible gap marker body.
-        const markerSection = `\n${renderSectionHeader(input.task.name, input.task.attempts.length, String(input.task.id))}\n\n_section for the latest attempt is missing — see signals.json / git log_\n`;
-        const markerContent = regenerateJournal({ existing, stateHeader, newSection: markerSection });
+          // Fallback payload if the section write keeps failing: a forgery-safe section header (so
+          // the delimiter + id token still parse for the next attempt) with a visible gap marker body.
+          const markerSection = `\n${renderSectionHeader(input.task.name, input.task.attempts.length, String(input.task.id))}\n\n_section for the latest attempt is missing — see signals.json / git log_\n`;
+          const markerContent = regenerateJournal({ existing, stateHeader, newSection: markerSection });
 
-        await writeJournalFailLoud(deps, taskId, input.progressFile, content, markerContent);
-        // The journal is a derived artefact — never halt the chain; fail-loud surfaced any loss.
-        return Result.ok(undefined) as Result<void, StorageError | InvalidStateError>;
-      },
+          await writeJournalFailLoud(deps, taskId, input.progressFile, content, markerContent);
+          // The journal is a derived artefact — never halt the chain; fail-loud surfaced any loss.
+          return Result.ok(undefined) as Result<void, StorageError | InvalidStateError>;
+        }),
     },
     input: (ctx) => {
       const allTasks = ctx.tasks ?? [];

--- a/src/application/flows/implement/leaves/setup-script-runner.ts
+++ b/src/application/flows/implement/leaves/setup-script-runner.ts
@@ -18,7 +18,7 @@ import { ErrorCode } from '@src/domain/value/error/error-code.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
-import type { ShellScriptRunner } from '@src/integration/io/shell-script-runner.ts';
+import type { ShellScriptResult, ShellScriptRunner } from '@src/integration/io/shell-script-runner.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 /** Per-line cap for setup-script tail rows surfaced to the TUI. JS code units; see comment
@@ -29,6 +29,9 @@ const MAX_TAIL_LINES = 20;
 /** Display-clip marker (audit-[03]). Mirrors `glyphs.clipEllipsis` in TUI tokens — duplicated
  *  here because the chains layer cannot import from UI (ESLint fence). One char, U+2026. */
 const CLIP_ELLIPSIS = '…';
+/** Event-bus event type for dismissible TUI banners. Named constant so the string literal
+ *  doesn't drift across the several publish sites below. */
+const BANNER_SHOW = 'banner-show';
 
 /**
  * Harness-side setup-script gate. The leaf runs at the start of every implement chain —
@@ -119,6 +122,328 @@ interface LeafOutput {
   readonly verifiedThisRun: readonly RepositoryId[];
 }
 
+/**
+ * Resume gate: if a prior chain on this sprint already ran setup successfully for this repo
+ * under the *same* command, skip. The previous success entry remains canonical; no new row
+ * is appended. Command drift (operator edited `project.json#setupScript`) breaks the gate and
+ * re-runs the script — logged here, but the caller still proceeds to the actual run.
+ */
+const shouldSkipOnResume = (
+  execution: SprintExecution,
+  repo: SetupRepoEntry,
+  command: string,
+  deps: SetupScriptRunnerLeafDeps
+): boolean => {
+  const priorSuccess = execution.setupRanAt.find(
+    (r) => String(r.repositoryId) === String(repo.repositoryId) && r.outcome === 'success'
+  );
+  if (priorSuccess && priorSuccess.command === command) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'info',
+      message: `setup-script ${String(repo.path)}: skipped on resume (succeeded earlier on this sprint)`,
+      at: deps.clock(),
+    });
+    return true;
+  }
+  if (priorSuccess && priorSuccess.command !== command) {
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'info',
+      message: `setup-script ${String(repo.path)}: re-running — configured command changed since prior success (was: ${priorSuccess.command}, now: ${command})`,
+      at: deps.clock(),
+    });
+  }
+  return false;
+};
+
+/**
+ * No script configured is NOT a failure — the chain continues. But it is also not a silent
+ * pass: the operator deserves to know that *nothing was validated* before the AI starts
+ * touching the tree. Surface as a warn-tier banner (dismissible) and a warn-level log row so
+ * it lands in both the Recent-log tail and the persistent chain.log. Banner id is repo-keyed
+ * so re-runs replace rather than stack.
+ */
+const runNoScriptSkip = async (
+  execution: SprintExecution,
+  repo: SetupRepoEntry,
+  deps: SetupScriptRunnerLeafDeps
+): Promise<SprintExecution> => {
+  const run = makeSetupRun({
+    repositoryId: repo.repositoryId,
+    ranAt: deps.clock(),
+    command: '',
+    exitCode: 0,
+    durationMs: 0,
+    outcome: 'skipped',
+  });
+  const next = await persistRun(execution, run, deps);
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'warn',
+    message: `setup-script ${String(repo.path)}: skipped — no script configured (nothing was validated)`,
+    at: deps.clock(),
+  });
+  deps.eventBus.publish({
+    type: BANNER_SHOW,
+    id: `setup-script-skipped-${String(repo.repositoryId)}`,
+    tier: 'warn',
+    message: `No setup script configured for ${String(repo.path)} — nothing was validated before implement`,
+    cause: 'configure one via `project` settings to gate the working tree',
+    at: deps.clock(),
+  });
+  return next;
+};
+
+/**
+ * Spawns the configured setup command. Cancellation propagates verbatim: a
+ * `Result.error(AbortError)` from the runner is a user-initiated abort, not a setup failure —
+ * returned untouched so the chain tears down per "AbortError is the one error chains
+ * propagate transparently" — never folded into a `spawn-error` row or a failed-gate banner.
+ *
+ * A genuine spawn-time failure (the shell could not start the command at all — ENOENT, etc)
+ * is recorded here with `exitCode: -1` so consumers can distinguish "ran and failed" from
+ * "could not run" without parsing the message string, and returns the `InvalidStateError` for
+ * the caller to propagate.
+ */
+const runSetupSpawn = async (
+  repo: SetupRepoEntry,
+  command: string,
+  opts: SetupScriptRunnerLeafOpts,
+  execution: SprintExecution,
+  deps: SetupScriptRunnerLeafDeps,
+  signal?: AbortSignal
+): Promise<Result<ShellScriptResult, DomainError>> => {
+  const spawnResult = await deps.shellScriptRunner.run(repo.path, command, {
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+    env: { RALPHCTL_LIFECYCLE_EVENT: 'setup' },
+    // Thread the chain abort signal so a Ctrl-C mid-setup kills the child promptly
+    // instead of waiting out the timeout while the repo lock is held. A cancel surfaces
+    // as `AbortError` below (propagated verbatim — never folded into a spawn-error row).
+    ...(signal !== undefined ? { signal } : {}),
+  });
+
+  if (!spawnResult.ok && spawnResult.error.code === ErrorCode.Aborted) {
+    return Result.error(spawnResult.error);
+  }
+
+  if (!spawnResult.ok) {
+    // The spawn error message is surfaced on the abort log + banner cause (no longer
+    // persisted on the row).
+    const run = makeSetupRun({
+      repositoryId: repo.repositoryId,
+      ranAt: deps.clock(),
+      command,
+      exitCode: -1,
+      durationMs: 0,
+      outcome: 'spawn-error',
+    });
+    await persistRun(execution, run, deps);
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `setup-script ${String(repo.path)}: spawn-error — ${spawnResult.error.message}`,
+      at: deps.clock(),
+    });
+    deps.eventBus.publish({
+      type: BANNER_SHOW,
+      id: `setup-script-${String(repo.repositoryId)}`,
+      tier: 'error',
+      message: `Setup script failed for ${String(repo.path)}: ${command}`,
+      cause: `spawn-error — ${spawnResult.error.message}`,
+      at: deps.clock(),
+    });
+    return Result.error(
+      new InvalidStateError({
+        entity: 'sprint',
+        currentState: 'pre-implement',
+        attemptedAction: 'setup-script',
+        message: `setup-script (${basename(String(repo.path))}) could not spawn: ${spawnResult.error.message}`,
+        hint: 'Ensure the setup command is on PATH and is executable from the repo root.',
+      })
+    );
+  }
+
+  return spawnResult;
+};
+
+/**
+ * Builds the failure error for a setup script that spawned but exited non-zero: detects the
+ * pnpm-no-TTY marker for a targeted hint, surfaces the last few output lines as error-level
+ * logs (audit-[03]: clip at display, never at persistence), and shows the failed-gate banner.
+ * Returns the `InvalidStateError` for the caller to wrap in `Result.error`.
+ */
+const buildSetupFailureError = (
+  repo: SetupRepoEntry,
+  command: string,
+  exitCode: number | null,
+  output: string,
+  deps: SetupScriptRunnerLeafDeps
+): DomainError => {
+  // pnpm 11 hardened `removeModulesDirSafe` to abort on missing TTY rather than
+  // silently re-creating `node_modules` (pnpm/pnpm#9966 / #11562). The shell runner
+  // now sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on every setup/verify
+  // child — the only lever that suppresses this on pnpm 11, where every
+  // `confirm-modules-purge=false` form is ignored. So this marker should fire only when
+  // `CI` has been explicitly overridden in the operator's environment; the hint points
+  // there rather than asking the project under development to adapt.
+  const noTtyDetected = output.includes(PNPM_NO_TTY_ERROR_MARKER);
+  const pnpmTtyHint = noTtyDetected
+    ? 'pnpm no-TTY abort. The harness sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on setup/verify to prevent this — `CI` looks overridden in your environment. Clear `CI`, or run the install once in a terminal to resync `node_modules`.'
+    : undefined;
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'error',
+    message: `setup-script ${String(repo.path)}: failed (exit=${String(exitCode ?? 'null')})`,
+    at: deps.clock(),
+  });
+  // Surface the last few lines of script output as error-level logs so the TUI's
+  // Recent-log tail renders the actionable bit alongside the headline. The full
+  // output already landed verbatim at `<sprintDir>/logs/setup/<repo-id>.log`;
+  // these bus events are a *display* surface, so per-line + per-count clipping is
+  // valid here (audit-[03]: clip at display, never at persistence). Headline first,
+  // detail rows after.
+  //
+  // Clip unit: JS string `.length` (UTF-16 code units) at the per-line cap. ralphctl's
+  // setup output is shell stdout — overwhelmingly ASCII (paths, exit codes, npm/pnpm
+  // diagnostic strings); grapheme-aware clipping via Intl.Segmenter would be
+  // overkill for the actual content. A pathological emoji-in-script string could be
+  // split mid-surrogate, in which case Ink renders the broken pair as a replacement
+  // glyph — still visually obvious that the line was clipped. If/when we surface
+  // user-authored prose through this path, switch to Intl.Segmenter and update the
+  // banner-clip unit test fixtures.
+  const tailLines = output
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0)
+    .slice(-MAX_TAIL_LINES);
+  const totalCount = output.split('\n').filter((l) => l.trim().length > 0).length;
+  const elided = Math.max(0, totalCount - tailLines.length);
+  const repoBasename = basename(String(repo.path));
+  if (elided > 0) {
+    // Multi-line collapse marker: signals to the operator that earlier lines were
+    // dropped from this surface (the full log is on disk).
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `setup-script (${repoBasename}): ${CLIP_ELLIPSIS} ${String(elided)} earlier line${elided === 1 ? '' : 's'} elided — full log at logs/setup/${String(repo.repositoryId)}.log`,
+      at: deps.clock(),
+    });
+  }
+  for (const line of tailLines) {
+    const clipped = line.length > BANNER_LINE_MAX ? `${line.slice(0, BANNER_LINE_MAX - 1)}${CLIP_ELLIPSIS}` : line;
+    deps.eventBus.publish({
+      type: 'log',
+      level: 'error',
+      message: `setup-script (${repoBasename}): ${clipped}`,
+      at: deps.clock(),
+    });
+  }
+  deps.eventBus.publish({
+    type: BANNER_SHOW,
+    id: `setup-script-${String(repo.repositoryId)}`,
+    tier: 'error',
+    message: `Setup script failed for ${String(repo.path)}: ${command}`,
+    cause:
+      pnpmTtyHint !== undefined
+        ? `exit ${String(exitCode ?? 'null')} — ${pnpmTtyHint}`
+        : `exit ${String(exitCode ?? 'null')}`,
+    at: deps.clock(),
+  });
+  return new InvalidStateError({
+    entity: 'sprint',
+    currentState: 'pre-implement',
+    attemptedAction: 'setup-script',
+    // The rail row already prefixes `setup-script · <repo>`; the message stays
+    // minimal so the operator's eye is not retracing the same name. The full
+    // command + path are in the banner / log / execution.json audit row.
+    message:
+      pnpmTtyHint !== undefined
+        ? `exited ${String(exitCode ?? 'null')} (no-tty pnpm)`
+        : `exited ${String(exitCode ?? 'null')}`,
+    hint: pnpmTtyHint ?? 'Inspect <sprintDir>/logs/setup/<repo-id>.log for the failing repo and fix the environment.',
+  });
+};
+
+/**
+ * Iterates every repo, running (or skipping) its configured setup script per the
+ * resume/command-drift/no-script gates documented above the leaf. See `setupScriptRunnerLeaf`
+ * for the full outcome/audit contract.
+ */
+const executeSetupScriptRunner = async (
+  deps: SetupScriptRunnerLeafDeps,
+  opts: SetupScriptRunnerLeafOpts,
+  input: LeafInput,
+  signal?: AbortSignal
+): Promise<Result<LeafOutput, DomainError>> => {
+  let execution = input.execution;
+  // Repos whose setup ran green in THIS invocation. Seeds the
+  // `skipPreVerifyOnFreshSetup` fast path on the first pre-task-verify. The resume-skip
+  // and no-script paths deliberately do NOT contribute — only a fresh green run proves
+  // the tree was verified by this launch.
+  const verifiedThisRun: RepositoryId[] = [];
+  for (const repo of opts.repos) {
+    const command = repo.setupScript?.trim() ?? '';
+
+    if (command.length > 0 && shouldSkipOnResume(execution, repo, command, deps)) {
+      continue;
+    }
+    if (command.length === 0) {
+      execution = await runNoScriptSkip(execution, repo, deps);
+      continue;
+    }
+
+    const startedAt = deps.clock();
+    const spawnResult = await runSetupSpawn(repo, command, opts, execution, deps, signal);
+    if (!spawnResult.ok) {
+      return spawnResult;
+    }
+
+    const { passed, exitCode, output, durationMs } = spawnResult.value;
+
+    // Audit [01] / [03]: persist the full untruncated output to `<sprintDir>/logs/setup/`
+    // so the operator can grep / tail the real failure. Best-effort — a write failure
+    // logs warn and never aborts the chain (the audit row remains canonical).
+    if (opts.sprintDir !== undefined) {
+      const logPath = join(String(opts.sprintDir), 'logs', 'setup', `${String(repo.repositoryId)}.log`);
+      const wrote = await writeTextAtomic(logPath, output);
+      if (!wrote.ok) {
+        deps.eventBus.publish({
+          type: 'log',
+          level: 'warn',
+          message: `setup-script ${String(repo.path)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
+          at: deps.clock(),
+        });
+      }
+    }
+    const normalisedExit = exitCode ?? -1;
+    const outcome: SetupRunOutcome = passed ? 'success' : 'failed';
+    const run = makeSetupRun({
+      repositoryId: repo.repositoryId,
+      ranAt: startedAt,
+      command,
+      exitCode: normalisedExit,
+      durationMs,
+      outcome,
+    });
+    execution = await persistRun(execution, run, deps);
+
+    if (passed) {
+      verifiedThisRun.push(repo.repositoryId);
+      deps.eventBus.publish({
+        type: 'log',
+        level: 'info',
+        message: `setup-script ${String(repo.path)}: success (exit=0, ${String(durationMs)}ms)`,
+        at: deps.clock(),
+      });
+      continue;
+    }
+
+    return Result.error(buildSetupFailureError(repo, command, exitCode, output, deps));
+  }
+  return Result.ok({ execution, verifiedThisRun });
+};
+
 export const setupScriptRunnerLeaf = (
   deps: SetupScriptRunnerLeafDeps,
   opts: SetupScriptRunnerLeafOpts
@@ -132,262 +457,7 @@ export const setupScriptRunnerLeaf = (
     'setup-script-runner',
     {
       useCase: {
-        execute: async (input, signal): Promise<Result<LeafOutput, DomainError>> => {
-          const BANNER_SHOW = 'banner-show';
-          let execution = input.execution;
-          // Repos whose setup ran green in THIS invocation. Seeds the
-          // `skipPreVerifyOnFreshSetup` fast path on the first pre-task-verify. The resume-skip
-          // and no-script paths deliberately do NOT contribute — only a fresh green run proves
-          // the tree was verified by this launch.
-          const verifiedThisRun: RepositoryId[] = [];
-          for (const repo of opts.repos) {
-            const command = repo.setupScript?.trim() ?? '';
-            // Resume gate: if a prior chain on this sprint already ran setup successfully
-            // for this repo under the *same* command, skip. The previous success entry
-            // remains canonical; no new row is appended. Command drift (operator edited
-            // `project.json#setupScript`) breaks the gate and re-runs the script.
-            if (command.length > 0) {
-              const priorSuccess = execution.setupRanAt.find(
-                (r) => String(r.repositoryId) === String(repo.repositoryId) && r.outcome === 'success'
-              );
-              if (priorSuccess && priorSuccess.command === command) {
-                deps.eventBus.publish({
-                  type: 'log',
-                  level: 'info',
-                  message: `setup-script ${String(repo.path)}: skipped on resume (succeeded earlier on this sprint)`,
-                  at: deps.clock(),
-                });
-                continue;
-              }
-              if (priorSuccess && priorSuccess.command !== command) {
-                deps.eventBus.publish({
-                  type: 'log',
-                  level: 'info',
-                  message: `setup-script ${String(repo.path)}: re-running — configured command changed since prior success (was: ${priorSuccess.command}, now: ${command})`,
-                  at: deps.clock(),
-                });
-              }
-            }
-            if (command.length === 0) {
-              // No script configured is NOT a failure — the chain continues. But it is also not
-              // a silent pass: the operator deserves to know that *nothing was validated* before
-              // the AI starts touching the tree. Surface as a warn-tier banner (dismissible) and
-              // a warn-level log row so it lands in both the Recent-log tail and the persistent
-              // chain.log. Banner id is repo-keyed so re-runs replace rather than stack.
-              const run = makeSetupRun({
-                repositoryId: repo.repositoryId,
-                ranAt: deps.clock(),
-                command: '',
-                exitCode: 0,
-                durationMs: 0,
-                outcome: 'skipped',
-              });
-              execution = await persistRun(execution, run, deps);
-              deps.eventBus.publish({
-                type: 'log',
-                level: 'warn',
-                message: `setup-script ${String(repo.path)}: skipped — no script configured (nothing was validated)`,
-                at: deps.clock(),
-              });
-              deps.eventBus.publish({
-                type: BANNER_SHOW,
-                id: `setup-script-skipped-${String(repo.repositoryId)}`,
-                tier: 'warn',
-                message: `No setup script configured for ${String(repo.path)} — nothing was validated before implement`,
-                cause: 'configure one via `project` settings to gate the working tree',
-                at: deps.clock(),
-              });
-              continue;
-            }
-
-            const startedAt = deps.clock();
-            const spawnResult = await deps.shellScriptRunner.run(repo.path, command, {
-              ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
-              env: { RALPHCTL_LIFECYCLE_EVENT: 'setup' },
-              // Thread the chain abort signal so a Ctrl-C mid-setup kills the child promptly
-              // instead of waiting out the timeout while the repo lock is held. A cancel surfaces
-              // as `AbortError` below (propagated verbatim — never folded into a spawn-error row).
-              ...(signal !== undefined ? { signal } : {}),
-            });
-
-            // Cancellation propagates verbatim: a `Result.error(AbortError)` from the runner is a
-            // user-initiated abort, not a setup failure. Return it untouched so the chain tears
-            // down per "AbortError is the one error chains propagate transparently" — do NOT
-            // record it as a `spawn-error` audit row or a failed-gate banner.
-            if (!spawnResult.ok && spawnResult.error.code === ErrorCode.Aborted) {
-              return Result.error(spawnResult.error);
-            }
-
-            if (!spawnResult.ok) {
-              // Spawn-time failure: the shell could not start the command at all (ENOENT, etc).
-              // Recorded with `exitCode: -1` so consumers can distinguish "ran and failed" from
-              // "could not run" without parsing the message string. The spawn error message is
-              // surfaced on the abort log + banner cause (no longer persisted on the row).
-              const run = makeSetupRun({
-                repositoryId: repo.repositoryId,
-                ranAt: deps.clock(),
-                command,
-                exitCode: -1,
-                durationMs: 0,
-                outcome: 'spawn-error',
-              });
-              await persistRun(execution, run, deps);
-              deps.eventBus.publish({
-                type: 'log',
-                level: 'error',
-                message: `setup-script ${String(repo.path)}: spawn-error — ${spawnResult.error.message}`,
-                at: deps.clock(),
-              });
-              deps.eventBus.publish({
-                type: BANNER_SHOW,
-                id: `setup-script-${String(repo.repositoryId)}`,
-                tier: 'error',
-                message: `Setup script failed for ${String(repo.path)}: ${command}`,
-                cause: `spawn-error — ${spawnResult.error.message}`,
-                at: deps.clock(),
-              });
-              return Result.error(
-                new InvalidStateError({
-                  entity: 'sprint',
-                  currentState: 'pre-implement',
-                  attemptedAction: 'setup-script',
-                  message: `setup-script (${basename(String(repo.path))}) could not spawn: ${spawnResult.error.message}`,
-                  hint: 'Ensure the setup command is on PATH and is executable from the repo root.',
-                })
-              );
-            }
-
-            const { passed, exitCode, output, durationMs } = spawnResult.value;
-
-            // Audit [01] / [03]: persist the full untruncated output to `<sprintDir>/logs/setup/`
-            // so the operator can grep / tail the real failure. Best-effort — a write failure
-            // logs warn and never aborts the chain (the audit row remains canonical).
-            if (opts.sprintDir !== undefined) {
-              const logPath = join(String(opts.sprintDir), 'logs', 'setup', `${String(repo.repositoryId)}.log`);
-              const wrote = await writeTextAtomic(logPath, output);
-              if (!wrote.ok) {
-                deps.eventBus.publish({
-                  type: 'log',
-                  level: 'warn',
-                  message: `setup-script ${String(repo.path)}: failed to persist full log to ${logPath} — ${wrote.error.message}`,
-                  at: deps.clock(),
-                });
-              }
-            }
-            const normalisedExit = exitCode ?? -1;
-            const outcome: SetupRunOutcome = passed ? 'success' : 'failed';
-            const run = makeSetupRun({
-              repositoryId: repo.repositoryId,
-              ranAt: startedAt,
-              command,
-              exitCode: normalisedExit,
-              durationMs,
-              outcome,
-            });
-            execution = await persistRun(execution, run, deps);
-
-            if (passed) {
-              verifiedThisRun.push(repo.repositoryId);
-              deps.eventBus.publish({
-                type: 'log',
-                level: 'info',
-                message: `setup-script ${String(repo.path)}: success (exit=0, ${String(durationMs)}ms)`,
-                at: deps.clock(),
-              });
-              continue;
-            }
-
-            // pnpm 11 hardened `removeModulesDirSafe` to abort on missing TTY rather than
-            // silently re-creating `node_modules` (pnpm/pnpm#9966 / #11562). The shell runner
-            // now sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on every setup/verify
-            // child — the only lever that suppresses this on pnpm 11, where every
-            // `confirm-modules-purge=false` form is ignored. So this marker should fire only when
-            // `CI` has been explicitly overridden in the operator's environment; the hint points
-            // there rather than asking the project under development to adapt.
-            const noTtyDetected = output.includes(PNPM_NO_TTY_ERROR_MARKER);
-            const pnpmTtyHint = noTtyDetected
-              ? 'pnpm no-TTY abort. The harness sets `CI=true` (+ `PNPM_CONFIG_FROZEN_LOCKFILE=false`) on setup/verify to prevent this — `CI` looks overridden in your environment. Clear `CI`, or run the install once in a terminal to resync `node_modules`.'
-              : undefined;
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'error',
-              message: `setup-script ${String(repo.path)}: failed (exit=${String(exitCode ?? 'null')})`,
-              at: deps.clock(),
-            });
-            // Surface the last few lines of script output as error-level logs so the TUI's
-            // Recent-log tail renders the actionable bit alongside the headline. The full
-            // output already landed verbatim at `<sprintDir>/logs/setup/<repo-id>.log` (above);
-            // these bus events are a *display* surface, so per-line + per-count clipping is
-            // valid here (audit-[03]: clip at display, never at persistence). Headline first,
-            // detail rows after.
-            //
-            // Clip unit: JS string `.length` (UTF-16 code units) at the per-line cap. ralphctl's
-            // setup output is shell stdout — overwhelmingly ASCII (paths, exit codes, npm/pnpm
-            // diagnostic strings); grapheme-aware clipping via Intl.Segmenter would be
-            // overkill for the actual content. A pathological emoji-in-script string could be
-            // split mid-surrogate, in which case Ink renders the broken pair as a replacement
-            // glyph — still visually obvious that the line was clipped. If/when we surface
-            // user-authored prose through this path, switch to Intl.Segmenter and update the
-            // banner-clip unit test fixtures.
-            const tailLines = output
-              .split('\n')
-              .map((l) => l.trimEnd())
-              .filter((l) => l.length > 0)
-              .slice(-MAX_TAIL_LINES);
-            const totalCount = output.split('\n').filter((l) => l.trim().length > 0).length;
-            const elided = Math.max(0, totalCount - tailLines.length);
-            const repoBasename = basename(String(repo.path));
-            if (elided > 0) {
-              // Multi-line collapse marker: signals to the operator that earlier lines were
-              // dropped from this surface (the full log is on disk).
-              deps.eventBus.publish({
-                type: 'log',
-                level: 'error',
-                message: `setup-script (${repoBasename}): ${CLIP_ELLIPSIS} ${String(elided)} earlier line${elided === 1 ? '' : 's'} elided — full log at logs/setup/${String(repo.repositoryId)}.log`,
-                at: deps.clock(),
-              });
-            }
-            for (const line of tailLines) {
-              const clipped =
-                line.length > BANNER_LINE_MAX ? `${line.slice(0, BANNER_LINE_MAX - 1)}${CLIP_ELLIPSIS}` : line;
-              deps.eventBus.publish({
-                type: 'log',
-                level: 'error',
-                message: `setup-script (${repoBasename}): ${clipped}`,
-                at: deps.clock(),
-              });
-            }
-            deps.eventBus.publish({
-              type: BANNER_SHOW,
-              id: `setup-script-${String(repo.repositoryId)}`,
-              tier: 'error',
-              message: `Setup script failed for ${String(repo.path)}: ${command}`,
-              cause:
-                pnpmTtyHint !== undefined
-                  ? `exit ${String(exitCode ?? 'null')} — ${pnpmTtyHint}`
-                  : `exit ${String(exitCode ?? 'null')}`,
-              at: deps.clock(),
-            });
-            return Result.error(
-              new InvalidStateError({
-                entity: 'sprint',
-                currentState: 'pre-implement',
-                attemptedAction: 'setup-script',
-                // The rail row already prefixes `setup-script · <repo>`; the message stays
-                // minimal so the operator's eye is not retracing the same name. The full
-                // command + path are in the banner / log / execution.json audit row.
-                message:
-                  pnpmTtyHint !== undefined
-                    ? `exited ${String(exitCode ?? 'null')} (no-tty pnpm)`
-                    : `exited ${String(exitCode ?? 'null')}`,
-                hint:
-                  pnpmTtyHint ??
-                  'Inspect <sprintDir>/logs/setup/<repo-id>.log for the failing repo and fix the environment.',
-              })
-            );
-          }
-          return Result.ok({ execution, verifiedThisRun });
-        },
+        execute: (input, signal) => executeSetupScriptRunner(deps, opts, input, signal),
       },
       input: (ctx) => {
         if (ctx.execution === undefined) {

--- a/src/application/flows/implement/wave-branch.ts
+++ b/src/application/flows/implement/wave-branch.ts
@@ -82,14 +82,19 @@ export const createFoldQueue = (): FoldQueue => {
 
 /**
  * Wrap an {@link AppendFile} so concurrent calls serialise through one in-process mutex. The
- * parallel path runs N branches at once, and several of them append to the SAME shared files —
- * `<sprintDir>/progress.md` (the journal) and `<memoryRoot>/<projectId>/learnings.ndjson` (the
- * learning ledger). Two overlapping `fs.appendFile` calls to one file can interleave their writes
- * and tear an NDJSON / journal line; the read side (ledger dedup, the human reading `progress.md`)
- * tolerates duplicate lines but NOT torn ones. Funnelling every append through one {@link FoldQueue}
- * makes each line atomic with respect to the others — cheap (a promise chain), and it also yields a
- * deterministic FIFO append order. Per-task artefacts (`prompt.md`, `signals.json`) are written to
- * task-scoped paths and never collide, so only the append port needs this.
+ * parallel path runs N branches at once, and several of them append to the SAME shared
+ * `<memoryRoot>/<projectId>/learnings.ndjson` learning ledger (and, via
+ * `append-journal-separator-leaf`, the prologue/epilogue's `<sprintDir>/progress.md` separator
+ * lines). Two overlapping `fs.appendFile` calls to one file can interleave their writes and tear an
+ * NDJSON line; the read side (ledger dedup) tolerates duplicate lines but NOT torn ones. Funnelling
+ * every append through one {@link FoldQueue} makes each line atomic with respect to the others —
+ * cheap (a promise chain), and it also yields a deterministic FIFO append order.
+ *
+ * `progress-journal-<taskId>`'s per-attempt SECTION write is a SEPARATE concern — it is a
+ * read-modify-write of the WHOLE file (not this append port), so it is guarded by the dedicated
+ * `journalMutex` instead (see `ProgressJournalLeafDeps` / `ImplementDeps`), not by this append
+ * mutex. Per-task artefacts (`prompt.md`, `signals.json`) are written to task-scoped paths and
+ * never collide, so only these two shared files need serialisation.
  *
  * @public
  */
@@ -514,8 +519,9 @@ const buildOneBranch = (
   const worktreePath = worktreePathFor(opts.sprintDir, task.id);
   const branchRef = gitWorktreeRef(String(opts.sprintId), String(task.id));
 
-  // Per-branch deps clone — only the harness-signal sink differs, keyed on this task's id so
-  // concurrent branches don't cross-attribute their `<change>`/`<learning>`/`<note>` signals.
+  // Per-branch deps clone — only the harness-signal sink differs (keyed on this task's id so
+  // concurrent branches don't cross-attribute their `<change>`/`<learning>`/`<note>` signals).
+  // Everything else, including the run's shared `journalMutex`, is inherited from `deps.implement`.
   const branchDeps: ImplementDeps = {
     ...deps.implement,
     signals: perBranchSignalSink(deps.appSignals, deps.eventBus, task.id),

--- a/src/application/flows/plan/flow.ts
+++ b/src/application/flows/plan/flow.ts
@@ -1,5 +1,4 @@
-import { dirname, join } from 'node:path';
-import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
@@ -15,7 +14,7 @@ import { saveTasksLeaf } from '@src/application/flows/_shared/task/save.ts';
 import { buildUnitLeaf } from '@src/application/flows/_shared/build-unit.ts';
 import { renderPromptToFileLeaf } from '@src/application/flows/_shared/render-prompt-to-file.ts';
 import { buildPlanPrompt } from '@src/integration/ai/prompts/plan/definition.ts';
-import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+import { readCappedSprintProgress } from '@src/application/flows/_shared/progress/read-sprint-progress.ts';
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
 import { planOutputContract } from '@src/application/flows/plan/leaves/plan.contract.ts';
 import type { PlanCtx } from '@src/application/flows/plan/ctx.ts';
@@ -74,24 +73,6 @@ export interface CreatePlanFlowOpts {
  * "tasks are ready" signal — saving it last means a crash mid-save leaves the sprint as
  * `draft` even if the tasks already landed; the next plan run is idempotent.
  */
-/**
- * Read `<sprintDir>/progress.md` for the inline `## Prior progress` section (audit-[07]), CAPPED to
- * the same token budget the implement gen-eval loop uses so a long sprint's journal doesn't blow up
- * the planning-prompt token cost. There is no "current task" in planning, so only the recent-siblings
- * bound applies; short journals pass through unchanged. Plan runs under `<sprintDir>/plan/<run-slug>/`,
- * so the sprint dir is the parent of the supplied plan root. Best-effort: missing or unreadable
- * degrades to empty string.
- */
-const readSprintProgress = async (planRoot: AbsolutePath, model: string): Promise<string> => {
-  const sprintDir = dirname(String(planRoot));
-  try {
-    const raw = await fs.readFile(join(sprintDir, 'progress.md'), 'utf8');
-    return capProgressBody(raw, { recentBudgetTokens: progressCapBudgetForModel(model) });
-  } catch {
-    return '';
-  }
-};
-
 export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Element<PlanCtx> => {
   const slug = opts.runSlug ?? `session-${String(Date.now())}`;
 
@@ -131,7 +112,7 @@ export const createPlanFlow = (deps: PlanDeps, opts: CreatePlanFlowOpts): Elemen
           if (ctx.sprint === undefined) throw new Error('sprint missing');
           if (ctx.project === undefined) throw new Error('project missing');
           if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-          const priorProgress = await readSprintProgress(opts.planRoot, opts.model);
+          const priorProgress = await readCappedSprintProgress(opts.planRoot, opts.model);
           return buildPlanPrompt(deps.templateLoader, {
             sprint: ctx.sprint,
             project: ctx.project,

--- a/src/application/flows/refine/flow.ts
+++ b/src/application/flows/refine/flow.ts
@@ -1,5 +1,4 @@
-import { dirname, join } from 'node:path';
-import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { type PendingTicket, type Ticket } from '@src/domain/entity/ticket.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
@@ -16,7 +15,7 @@ import type { RefineDeps } from '@src/application/flows/refine/deps.ts';
 import { fetchIssueContextLeaf } from '@src/application/flows/refine/leaves/fetch-issue-context.ts';
 import { refineTicketInteractiveLeaf } from '@src/application/flows/refine/leaves/refine-ticket-interactive.ts';
 import { buildRefinePrompt } from '@src/integration/ai/prompts/refine/definition.ts';
-import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+import { readCappedSprintProgress } from '@src/application/flows/_shared/progress/read-sprint-progress.ts';
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
 import { refineOutputContract } from '@src/application/flows/refine/leaves/refine.contract.ts';
 import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
@@ -65,24 +64,6 @@ export interface CreateRefineFlowOpts {
  * write its final markdown to `<unit-root>/requirements.md`, which the harness reads back
  * after the session exits.
  */
-/**
- * Read `<sprintDir>/progress.md` for the inline `## Prior progress` section (audit-[07]), CAPPED to
- * the same token budget the implement gen-eval loop uses so a long sprint's journal doesn't blow up
- * the refine-prompt token cost. No "current task" in refine, so only the recent-siblings bound
- * applies; short journals pass through unchanged. Refinement runs under
- * `<sprintDir>/refinement/<ticket-slug>/`, so the sprint dir is the parent of the supplied
- * refinement root. Best-effort: a missing or unreadable file degrades to the empty string.
- */
-const readSprintProgress = async (refinementRoot: AbsolutePath, model: string): Promise<string> => {
-  const sprintDir = dirname(String(refinementRoot));
-  try {
-    const raw = await fs.readFile(join(sprintDir, 'progress.md'), 'utf8');
-    return capProgressBody(raw, { recentBudgetTokens: progressCapBudgetForModel(model) });
-  } catch {
-    return '';
-  }
-};
-
 export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): Element<RefineCtx> => {
   const ticketSlug = (ticket: Ticket): string => {
     const fromTitle = toKebabCase(ticket.title);
@@ -132,7 +113,7 @@ export const createRefineFlow = (deps: RefineDeps, opts: CreateRefineFlowOpts): 
           },
           buildPrompt: async (ctx) => {
             if (ctx.currentUnitRoot === undefined) throw new Error('currentUnitRoot missing');
-            const priorProgress = await readSprintProgress(opts.refinementRoot, opts.model);
+            const priorProgress = await readCappedSprintProgress(opts.refinementRoot, opts.model);
             return buildRefinePrompt(deps.templateLoader, {
               ticket,
               outputContractSection: renderContractSectionFor(refineOutputContract, ctx.currentUnitRoot),

--- a/src/application/ui/cli/commands/runs.ts
+++ b/src/application/ui/cli/commands/runs.ts
@@ -23,6 +23,18 @@ interface PruneOpts {
   readonly yes?: boolean;
 }
 
+interface PruneFilters {
+  readonly olderThanMs: number | undefined;
+  readonly keepLast: number | undefined;
+}
+
+type PruneFiltersResult = ({ readonly ok: true } & PruneFilters) | { readonly ok: false };
+
+type ScopedRunsResult =
+  { readonly ok: true; readonly grouped: ReadonlyMap<string, readonly RunEntry[]> } | { readonly ok: false };
+
+type FlowFilterResult = { readonly ok: true; readonly flowFilter: string | undefined } | { readonly ok: false };
+
 /**
  * Register the `runs` command group — inspection + tidy-up for per-run forensic artifacts
  * under `<dataRoot>/runs/<flow>/<run-id>/`.
@@ -109,13 +121,47 @@ const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
     return;
   }
 
+  const filters = parsePruneFilters(opts);
+  if (!filters.ok) return;
+
+  const scopedResult = await resolveScopedRuns(opts.flow);
+  if (!scopedResult.ok) return;
+
+  if (filters.olderThanMs === undefined && filters.keepLast === undefined) {
+    process.stderr.write(
+      'error: --older-than or --keep-last is required (or invoke `ralphctl runs prune` with no flags for the interactive picker)\n'
+    );
+    process.exit(1);
+    return;
+  }
+
+  const candidates = computeAndAnnouncePruneCandidates(scopedResult.grouped, {
+    olderThanMs: filters.olderThanMs,
+    keepLast: filters.keepLast,
+  });
+  if (candidates === undefined) return;
+
+  if (opts.dryRun === true) {
+    return;
+  }
+
+  if (opts.yes !== true) {
+    const confirmed = await confirmNonInteractivePrune(candidates.length);
+    if (!confirmed) return;
+  }
+
+  await performPrune(candidates);
+};
+
+/** Validate `--older-than` / `--keep-last`, reporting + exiting on the first malformed value. */
+const parsePruneFilters = (opts: PruneOpts): PruneFiltersResult => {
   let olderThanMs: number | undefined;
   if (opts.olderThan !== undefined) {
     const parsed = parseDuration(opts.olderThan);
     if (!parsed.ok) {
       process.stderr.write(`error: ${parsed.error.message}\n`);
       process.exit(1);
-      return;
+      return { ok: false };
     }
     olderThanMs = parsed.value;
   }
@@ -126,42 +172,48 @@ const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
     if (!Number.isInteger(parsed) || parsed < 0) {
       process.stderr.write(`error: --keep-last must be a non-negative integer\n`);
       process.exit(1);
-      return;
+      return { ok: false };
     }
     keepLast = parsed;
   }
 
+  return { ok: true, olderThanMs, keepLast };
+};
+
+/** List runs, verify the requested `--flow` exists, and group the scoped entries by flow. */
+const resolveScopedRuns = async (flow: string | undefined): Promise<ScopedRunsResult> => {
   const { storage } = await bootstrapCli();
   const result = await listRuns(storage.runsRoot);
   if (!result.ok) {
     process.stderr.write(`error: ${result.error.message}\n`);
     process.exit(1);
-    return;
+    return { ok: false };
   }
 
   const allEntries = result.value;
 
-  if (opts.flow !== undefined) {
-    const flowExists = allEntries.some((r) => r.flow === opts.flow);
+  if (flow !== undefined) {
+    const flowExists = allEntries.some((r) => r.flow === flow);
     if (!flowExists) {
-      process.stderr.write(`error: no such flow '${opts.flow}' under ${String(storage.runsRoot)}\n`);
+      process.stderr.write(`error: no such flow '${flow}' under ${String(storage.runsRoot)}\n`);
       process.exit(1);
-      return;
+      return { ok: false };
     }
   }
 
-  const scoped = opts.flow !== undefined ? allEntries.filter((r) => r.flow === opts.flow) : allEntries;
-  const grouped = groupByFlow(scoped);
+  const scoped = flow !== undefined ? allEntries.filter((r) => r.flow === flow) : allEntries;
+  return { ok: true, grouped: groupByFlow(scoped) };
+};
 
-  if (olderThanMs === undefined && keepLast === undefined) {
-    process.stderr.write(
-      'error: --older-than or --keep-last is required (or invoke `ralphctl runs prune` with no flags for the interactive picker)\n'
-    );
-    process.exit(1);
-    return;
-  }
-
-  const { candidates, unknownStampWarnings } = selectCandidates(grouped, { olderThanMs, keepLast });
+/**
+ * Shared tail of both prune paths: select candidates, surface unknown-timestamp warnings, and
+ * print the summary. Returns `undefined` when there is nothing to prune (caller should stop).
+ */
+const computeAndAnnouncePruneCandidates = (
+  grouped: ReadonlyMap<string, readonly RunEntry[]>,
+  filters: PruneFilters
+): readonly RunEntry[] | undefined => {
+  const { candidates, unknownStampWarnings } = selectCandidates(grouped, filters);
 
   for (const warning of unknownStampWarnings) {
     process.stdout.write(`warning: skipping run with non-conforming dir name (no timestamp): ${warning}\n`);
@@ -169,33 +221,28 @@ const runPruneCommand = async (opts: PruneOpts): Promise<void> => {
 
   if (candidates.length === 0) {
     process.stdout.write('nothing to prune\n');
-    return;
+    return undefined;
   }
 
   printCandidateSummary(candidates);
+  return candidates;
+};
 
-  if (opts.dryRun === true) {
-    return;
-  }
-
-  if (opts.yes !== true) {
-    if (process.stdin.isTTY !== true) {
-      process.stderr.write(
-        'error: refusing to delete without confirmation on a non-TTY stdin — re-run with --yes to bypass, or --dry-run to list candidates only\n'
-      );
-      process.exit(1);
-      return;
-    }
-    const confirmed = await confirmYesNo(
-      `delete ${String(candidates.length)} run${candidates.length === 1 ? '' : 's'}? [y/N] `
+/** Non-interactive `--yes`-less confirm: refuse on a non-TTY stdin, otherwise prompt y/N. */
+const confirmNonInteractivePrune = async (count: number): Promise<boolean> => {
+  if (process.stdin.isTTY !== true) {
+    process.stderr.write(
+      'error: refusing to delete without confirmation on a non-TTY stdin — re-run with --yes to bypass, or --dry-run to list candidates only\n'
     );
-    if (!confirmed) {
-      process.stdout.write('aborted\n');
-      return;
-    }
+    process.exit(1);
+    return false;
   }
-
-  await performPrune(candidates);
+  const confirmed = await confirmYesNo(`delete ${String(count)} run${count === 1 ? '' : 's'}? [y/N] `);
+  if (!confirmed) {
+    process.stdout.write('aborted\n');
+    return false;
+  }
+  return true;
 };
 
 const runInteractivePrune = async (): Promise<void> => {
@@ -219,64 +266,25 @@ const runInteractivePrune = async (): Promise<void> => {
   }
   const groups = groupByFlow(listed.value);
   const flows = Array.from(groups.keys());
-  process.stdout.write('current runs:\n');
-  for (const [flow, runs] of groups) {
-    const flowBytes = runs.reduce((acc, r) => acc + r.sizeBytes, 0);
-    process.stdout.write(
-      `  ${flow}  (${String(runs.length)} run${runs.length === 1 ? '' : 's'}, ${formatBytes(flowBytes)})\n`
-    );
-  }
-  process.stdout.write('\n');
+  printRunsOverview(groups);
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const criterion = (await question(rl, 'prune by [1] age threshold or [2] keep-last N? ')).trim();
-    let olderThanMs: number | undefined;
-    let keepLast: number | undefined;
-    if (criterion === '1') {
-      const duration = (await question(rl, 'duration (e.g. 7d, 24h, 2w): ')).trim();
-      const parsed = parseDuration(duration);
-      if (!parsed.ok) {
-        process.stderr.write(`error: ${parsed.error.message}\n`);
-        process.exit(1);
-        return;
-      }
-      olderThanMs = parsed.value;
-    } else if (criterion === '2') {
-      const n = (await question(rl, 'keep last N runs per flow: ')).trim();
-      const parsed = Number(n);
-      if (!Number.isInteger(parsed) || parsed < 0) {
-        process.stderr.write('error: keep-last must be a non-negative integer\n');
-        process.exit(1);
-        return;
-      }
-      keepLast = parsed;
-    } else {
-      process.stderr.write(`error: unrecognised choice '${criterion}' — expected 1 or 2\n`);
-      process.exit(1);
-      return;
-    }
-    const flowAnswer = (
-      await question(rl, `restrict to a flow? [enter for all, or one of: ${flows.join(', ')}] `)
-    ).trim();
-    const flowFilter = flowAnswer.length === 0 ? undefined : flowAnswer;
-    if (flowFilter !== undefined && !flows.includes(flowFilter)) {
-      process.stderr.write(`error: no such flow '${flowFilter}'\n`);
-      process.exit(1);
-      return;
-    }
+    const filterChoice = await promptPruneFilterChoice(rl);
+    if (!filterChoice.ok) return;
 
-    const scoped = flowFilter !== undefined ? listed.value.filter((r) => r.flow === flowFilter) : listed.value;
+    const flowChoice = await promptFlowFilterChoice(rl, flows);
+    if (!flowChoice.ok) return;
+
+    const scoped =
+      flowChoice.flowFilter !== undefined ? listed.value.filter((r) => r.flow === flowChoice.flowFilter) : listed.value;
     const grouped = groupByFlow(scoped);
-    const { candidates, unknownStampWarnings } = selectCandidates(grouped, { olderThanMs, keepLast });
-    for (const warning of unknownStampWarnings) {
-      process.stdout.write(`warning: skipping run with non-conforming dir name (no timestamp): ${warning}\n`);
-    }
-    if (candidates.length === 0) {
-      process.stdout.write('nothing to prune\n');
-      return;
-    }
-    printCandidateSummary(candidates);
+    const candidates = computeAndAnnouncePruneCandidates(grouped, {
+      olderThanMs: filterChoice.olderThanMs,
+      keepLast: filterChoice.keepLast,
+    });
+    if (candidates === undefined) return;
+
     const ok = (
       await question(rl, `delete ${String(candidates.length)} run${candidates.length === 1 ? '' : 's'}? [y/N] `)
     ).trim();
@@ -290,6 +298,62 @@ const runInteractivePrune = async (): Promise<void> => {
   }
 };
 
+const printRunsOverview = (groups: ReadonlyMap<string, readonly RunEntry[]>): void => {
+  process.stdout.write('current runs:\n');
+  for (const [flow, runs] of groups) {
+    const flowBytes = runs.reduce((acc, r) => acc + r.sizeBytes, 0);
+    process.stdout.write(
+      `  ${flow}  (${String(runs.length)} run${runs.length === 1 ? '' : 's'}, ${formatBytes(flowBytes)})\n`
+    );
+  }
+  process.stdout.write('\n');
+};
+
+/** Prompt for age-vs-keep-last, then the matching follow-up value, validating as it goes. */
+const promptPruneFilterChoice = async (rl: ReturnType<typeof createInterface>): Promise<PruneFiltersResult> => {
+  const criterion = (await question(rl, 'prune by [1] age threshold or [2] keep-last N? ')).trim();
+  if (criterion === '1') {
+    const duration = (await question(rl, 'duration (e.g. 7d, 24h, 2w): ')).trim();
+    const parsed = parseDuration(duration);
+    if (!parsed.ok) {
+      process.stderr.write(`error: ${parsed.error.message}\n`);
+      process.exit(1);
+      return { ok: false };
+    }
+    return { ok: true, olderThanMs: parsed.value, keepLast: undefined };
+  }
+  if (criterion === '2') {
+    const n = (await question(rl, 'keep last N runs per flow: ')).trim();
+    const parsed = Number(n);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      process.stderr.write('error: keep-last must be a non-negative integer\n');
+      process.exit(1);
+      return { ok: false };
+    }
+    return { ok: true, olderThanMs: undefined, keepLast: parsed };
+  }
+  process.stderr.write(`error: unrecognised choice '${criterion}' — expected 1 or 2\n`);
+  process.exit(1);
+  return { ok: false };
+};
+
+/** Prompt for an optional flow restriction, validating it against the known flow list. */
+const promptFlowFilterChoice = async (
+  rl: ReturnType<typeof createInterface>,
+  flows: readonly string[]
+): Promise<FlowFilterResult> => {
+  const flowAnswer = (
+    await question(rl, `restrict to a flow? [enter for all, or one of: ${flows.join(', ')}] `)
+  ).trim();
+  const flowFilter = flowAnswer.length === 0 ? undefined : flowAnswer;
+  if (flowFilter !== undefined && !flows.includes(flowFilter)) {
+    process.stderr.write(`error: no such flow '${flowFilter}'\n`);
+    process.exit(1);
+    return { ok: false };
+  }
+  return { ok: true, flowFilter };
+};
+
 /**
  * Per-flow candidate selection. When both criteria are set, a dir qualifies only when it is
  * older than the duration AND not among the N most-recent for its flow. When only one is set,
@@ -300,33 +364,50 @@ const runInteractivePrune = async (): Promise<void> => {
  */
 const selectCandidates = (
   grouped: ReadonlyMap<string, readonly RunEntry[]>,
-  filters: { readonly olderThanMs: number | undefined; readonly keepLast: number | undefined }
+  filters: PruneFilters
 ): { readonly candidates: readonly RunEntry[]; readonly unknownStampWarnings: readonly string[] } => {
   const { olderThanMs, keepLast } = filters;
   const candidates: RunEntry[] = [];
   const unknownStampWarnings: string[] = [];
   const nowMs = Date.now();
   for (const [, runsForFlow] of grouped) {
-    let keep: Set<string> | undefined;
-    if (keepLast !== undefined) {
-      keep = new Set<string>();
-      for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
-    }
+    const keep = buildKeepSet(runsForFlow, keepLast);
     for (const run of runsForFlow) {
-      let ageQualifies = true;
-      if (olderThanMs !== undefined) {
-        if (run.timestamp === null) {
-          unknownStampWarnings.push(run.path);
-          ageQualifies = false;
-        } else {
-          ageQualifies = nowMs - run.timestamp.getTime() >= olderThanMs;
-        }
-      }
-      const keepQualifies = keep === undefined ? true : !keep.has(run.path);
-      if (ageQualifies && keepQualifies) candidates.push(run);
+      const { qualifies, unknownStamp } = evaluatePruneQualification(run, keep, olderThanMs, nowMs);
+      if (unknownStamp) unknownStampWarnings.push(run.path);
+      if (qualifies) candidates.push(run);
     }
   }
   return { candidates, unknownStampWarnings };
+};
+
+/** The set of run paths to retain under `--keep-last` for one flow's run list. */
+const buildKeepSet = (runsForFlow: readonly RunEntry[], keepLast: number | undefined): Set<string> | undefined => {
+  if (keepLast === undefined) return undefined;
+  const keep = new Set<string>();
+  for (const r of runsForFlow.slice(0, keepLast)) keep.add(r.path);
+  return keep;
+};
+
+/** Age + keep-last gating for one run; `unknownStamp` flags a dir name with no embedded timestamp. */
+const evaluatePruneQualification = (
+  run: RunEntry,
+  keepSet: Set<string> | undefined,
+  olderThanMs: number | undefined,
+  nowMs: number
+): { readonly qualifies: boolean; readonly unknownStamp: boolean } => {
+  let ageQualifies = true;
+  let unknownStamp = false;
+  if (olderThanMs !== undefined) {
+    if (run.timestamp === null) {
+      unknownStamp = true;
+      ageQualifies = false;
+    } else {
+      ageQualifies = nowMs - run.timestamp.getTime() >= olderThanMs;
+    }
+  }
+  const keepQualifies = keepSet === undefined ? true : !keepSet.has(run.path);
+  return { qualifies: ageQualifies && keepQualifies, unknownStamp };
 };
 
 const printCandidateSummary = (candidates: readonly RunEntry[]): void => {

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -25,6 +25,9 @@ import { renderTaskGraphIssue, validateTaskGraph } from '@src/domain/entity/task
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
+import type { Repository } from '@src/domain/entity/repository.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { Project } from '@src/domain/entity/project.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { Sink } from '@src/business/observability/sink.ts';
@@ -32,9 +35,12 @@ import type { HarnessSignalSink } from '@src/business/observability/harness-sign
 import { broadcastSink } from '@src/integration/observability/sinks/broadcast-sink.ts';
 import type { AiFlowSettings, AiImplementSettings, Settings } from '@src/domain/entity/settings.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
 import type { LaunchContext } from '@src/application/ui/shared/launch/context.ts';
-import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
+import type { LaunchResult, LauncherDeps } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 /**
@@ -218,6 +224,234 @@ const buildParallelElement = (
   });
 };
 
+/**
+ * Direct-build the canonical `<id>--<slug>/` sprint dir plus its `progress.md` / `events.ndjson`
+ * siblings, collapsing the three `AbsolutePath.parse` checks into one `Result` chain. The launcher
+ * holds the full sprint entity, so no async resolver scan is needed — building the bare `<id>`
+ * path here would split-brain against a slug-renamed dir the repos converge on.
+ */
+const resolveImplementSprintPaths = (
+  dataRoot: AbsolutePath,
+  sprint: Pick<Sprint, 'id' | 'slug'>
+): Result<
+  {
+    readonly sprintDirPath: AbsolutePath;
+    readonly progressPath: AbsolutePath;
+    readonly eventsNdjsonPath: AbsolutePath;
+  },
+  string
+> => {
+  const sprintDirPath = AbsolutePath.parse(sprintDir(dataRoot, sprint.id, sprint.slug));
+  if (!sprintDirPath.ok) return Result.error(sprintDirPath.error.message);
+  const progressPath = AbsolutePath.parse(join(String(sprintDirPath.value), 'progress.md'));
+  if (!progressPath.ok) return Result.error(progressPath.error.message);
+  const eventsNdjsonPath = AbsolutePath.parse(join(String(sprintDirPath.value), 'events.ndjson'));
+  if (!eventsNdjsonPath.ok) return Result.error(eventsNdjsonPath.error.message);
+  return Result.ok({
+    sprintDirPath: sprintDirPath.value,
+    progressPath: progressPath.value,
+    eventsNdjsonPath: eventsNdjsonPath.value,
+  });
+};
+
+/**
+ * Signal mirror: `<change>` / `<learning>` / `<note>` signals are republished as structured
+ * `harness-signal` events on the EventBus so the TUI panels (and the opt-in events.ndjson tee)
+ * see them with a queryable shape.
+ *
+ * The OLD single-slot `currentTaskId` tracker (keyed off the bus's `task-attempt-started` event)
+ * is DELETED: that event has zero production publishers, so the slot was always `undefined` —
+ * every serial-path `harness-signal` was already unattributed. The parallel `>1` path attaches a
+ * PER-BRANCH sink keyed on the branch's `taskId` (see `wave-branch.ts`), the only correct model
+ * under concurrency. The serial path keeps emitting unattributed events, byte-for-byte with
+ * today's behaviour — renderers that group by task simply skip unattributed entries.
+ */
+const buildImplementSignalSink = (deps: LauncherDeps): HarnessSignalSink => {
+  const serialSignalBusMirror: Sink<HarnessSignal> = {
+    emit(signal) {
+      if (signal.type !== 'change' && signal.type !== 'learning' && signal.type !== 'note') return;
+      deps.app.eventBus.publish({
+        type: 'harness-signal',
+        signalKind: signal.type,
+        text: signal.text,
+        at: IsoTimestamp.now(),
+      });
+    },
+  };
+  return broadcastSink<HarnessSignal>([deps.app.signals, serialSignalBusMirror]);
+};
+
+/** Project repositories → `RepoExecConfig` map keyed by id, the per-task subchain's repo lookup. */
+const buildRepoExecConfigs = (repositories: readonly Repository[]): Map<RepositoryId, RepoExecConfig> => {
+  const configs = new Map<RepositoryId, RepoExecConfig>();
+  for (const r of repositories) {
+    configs.set(r.id, {
+      path: r.path,
+      name: r.name,
+      ...(r.verifyScript !== undefined ? { verifyScript: r.verifyScript } : {}),
+      ...(r.verifyGates !== undefined ? { verifyGates: r.verifyGates } : {}),
+      ...(r.verifyTimeout !== undefined ? { verifyTimeout: r.verifyTimeout } : {}),
+      ...(r.setupScript !== undefined ? { setupScript: r.setupScript } : {}),
+    });
+  }
+  return configs;
+};
+
+/**
+ * Build one `HeadlessAiProvider` per role from the effective implement pair. The two roles may
+ * target distinct providers — they're constructed independently rather than routed through
+ * `primaryFlowRow` so a cross-provider configuration spawns the right CLI per role. `ctx.provider`
+ * (the launcher-rebuilt primary adapter) is deliberately left unused by the implement launcher —
+ * implement bypasses the single-row seam.
+ */
+const buildImplementProviders = (
+  implementPair: AiImplementSettings,
+  effectiveSettings: Settings,
+  deps: LauncherDeps
+): {
+  readonly generatorProvider: HeadlessAiProvider;
+  readonly evaluatorProvider: HeadlessAiProvider;
+  readonly generatorEffort: string | undefined;
+  readonly evaluatorEffort: string | undefined;
+} => {
+  const generatorProvider = createAiProvider({
+    row: implementPair.generator,
+    harnessConfig: effectiveSettings.harness,
+    eventBus: deps.app.eventBus,
+  });
+  const evaluatorProvider = createAiProvider({
+    row: implementPair.evaluator,
+    harnessConfig: effectiveSettings.harness,
+    eventBus: deps.app.eventBus,
+  });
+  const generatorEffort = resolveEffortForRow(implementPair.generator, effectiveSettings.ai.effort);
+  const evaluatorEffort = resolveEffortForRow(implementPair.evaluator, effectiveSettings.ai.effort);
+  return { generatorProvider, evaluatorProvider, generatorEffort, evaluatorEffort };
+};
+
+/** Assemble the `ImplementDeps` bag handed to `createImplementFlow` / `buildParallelElement`. */
+const buildImplementDepsBag = (
+  deps: LauncherDeps,
+  effectiveSettings: Settings,
+  signals: HarnessSignalSink,
+  providers: { readonly generatorProvider: HeadlessAiProvider; readonly evaluatorProvider: HeadlessAiProvider },
+  skillsAdapter: SkillsAdapter,
+  skillSource: SkillSource
+): ImplementDeps => ({
+  sprintRepo: deps.app.sprintRepo,
+  sprintExecutionRepo: deps.app.sprintExecutionRepo,
+  taskRepo: deps.app.taskRepo,
+  generatorProvider: providers.generatorProvider,
+  evaluatorProvider: providers.evaluatorProvider,
+  templateLoader: deps.app.templateLoader,
+  signals,
+  eventBus: deps.app.eventBus,
+  logger: deps.app.logger,
+  clock: deps.app.clock,
+  config: effectiveSettings,
+  gitRunner: deps.app.gitRunner,
+  shellScriptRunner: deps.app.shellScriptRunner,
+  fileLocker: deps.app.fileLocker,
+  locksRoot: deps.storage.locksRoot,
+  skillsAdapter,
+  skillSource,
+  interactive: deps.interactive,
+  writeFile: deps.app.writeFile,
+  appendFile: deps.app.appendFile,
+  // ONE journal mutex per run. Every parallel branch inherits this instance (branches spread this
+  // deps bag), so their `progress-journal-<taskId>` leaves serialise their read-regenerate-write
+  // of the shared `progress.md` through it; the serial path is a single caller, so it is a no-op.
+  journalMutex: createFoldQueue(),
+});
+
+/**
+ * Assemble the `CreateImplementFlowOpts` bag — pure object-literal assembly, no branching.
+ * `repositories` is derived here (via {@link buildRepoExecConfigs}) rather than passed in, so
+ * callers only need to hand over the raw project.
+ */
+const buildImplementOptsBag = (
+  sprint: Pick<Sprint, 'id'>,
+  project: Pick<Project, 'id' | 'slug' | 'repositories'>,
+  todoTasks: readonly Task[],
+  sprintPaths: { readonly progressPath: AbsolutePath; readonly sprintDirPath: AbsolutePath },
+  implementPair: AiImplementSettings,
+  providers: { readonly generatorEffort: string | undefined; readonly evaluatorEffort: string | undefined },
+  memoryRoot: AbsolutePath
+): CreateImplementFlowOpts => ({
+  sprintId: sprint.id,
+  todoTasks,
+  repositories: buildRepoExecConfigs(project.repositories),
+  progressFile: sprintPaths.progressPath,
+  sprintDir: sprintPaths.sprintDirPath,
+  generatorProviderId: implementPair.generator.provider,
+  generatorModel: implementPair.generator.model,
+  ...(providers.generatorEffort !== undefined ? { generatorEffort: providers.generatorEffort } : {}),
+  evaluatorProviderId: implementPair.evaluator.provider,
+  evaluatorModel: implementPair.evaluator.model,
+  ...(providers.evaluatorEffort !== undefined ? { evaluatorEffort: providers.evaluatorEffort } : {}),
+  memoryRoot,
+  projectId: String(project.id),
+  projectSlug: project.slug,
+});
+
+/**
+ * Stop the file-log + bus subscriptions when the runner reaches a terminal state. Pending writes
+ * still drain in the background — events.ndjson remains consistent post-exit. The subscription
+ * self-unsubscribes on the terminal event so we don't pin a dead listener (and its closure scope)
+ * to the runner's internal listener Set across a long multi-run TUI session — historically a
+ * load-bearing OOM contributor.
+ */
+const wireChainLogStop = (
+  runner: Runner<ImplementCtx>,
+  chainLog: { readonly stop: () => void; readonly flush: () => Promise<void> }
+): void => {
+  const unsubRunner: () => void = runner.subscribe((evt) => {
+    if (evt.type === 'completed' || evt.type === 'failed' || evt.type === 'aborted') {
+      chainLog.stop();
+      void chainLog.flush();
+      unsubRunner();
+    }
+  });
+};
+
+/**
+ * Detect resumes at launch time: any task whose last attempt is still `running` (the v8 OOM /
+ * Ctrl-C / SIGTERM signature in a prior process) gets a `RecoveryContext` pinned to its id. We
+ * pre-derive here — rather than waiting for the chain's start-attempt leaf to settle — so the
+ * TUI's resume-from-aborted banner shows up *before* the chain starts executing, not after the
+ * first leaf finishes. Keyed on the leftover running attempt, NOT on `status === 'in_progress'`:
+ * a crash can persist a status-corrupt `todo` task whose last attempt is still `running` (which
+ * `startAttemptUseCase` heals), and the banner must fire for it too. `process-crash` is the
+ * conservative cause for the cross-process inference; P1j's signal-aware path will refine it.
+ */
+const computeTaskRecovering = (todoTasks: readonly Task[], now: IsoTimestamp): Map<string, RecoveryContext> => {
+  const taskRecovering = new Map<string, RecoveryContext>();
+  for (const t of todoTasks) {
+    const last = t.attempts.at(-1);
+    if (last === undefined || last.status !== 'running') continue;
+    taskRecovering.set(String(t.id), {
+      fromAttemptN: t.attempts.length,
+      cause: 'process-crash',
+      abortedAt: now,
+    });
+  }
+  return taskRecovering;
+};
+
+/**
+ * Plan-time label lookup — keyed by element name so the rail can render friendly labels for rows
+ * that haven't traced yet (pending / running). Once a leaf executes, the trace entry's own `label`
+ * carries the same value and supersedes this lookup. Only leaves that supplied a non-empty label
+ * are entered; lookups fall through to the raw name for everything else.
+ */
+const computePlanLabels = (flattened: ReadonlyArray<Element<ImplementCtx>>): Map<string, string> => {
+  const planLabelByName = new Map<string, string>();
+  for (const leaf of flattened) {
+    if (leaf.label !== undefined && leaf.label.length > 0) planLabelByName.set(leaf.name, leaf.label);
+  }
+  return planLabelByName;
+};
+
 export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult> => {
   const { deps, snapshot, extras, settings, skillsAdapter, skillSource, bridge, sessionId } = ctx;
   // Apply per-role overrides (from CLI flags via `LaunchExtras.implementRoleOverrides`) onto
@@ -246,122 +480,35 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   if (!queue.ok) return { ok: false, reason: queue.error };
   const todoTasks = queue.value;
   if (todoTasks.length === 0) return { ok: false, reason: 'No tasks to implement or resume.' };
-  // Direct-build the canonical `<id>--<slug>/` sprint dir — the launcher holds the full sprint
-  // entity, so no async resolver scan is needed. Building the bare `<id>` path here would
-  // split-brain against a slug-renamed dir the repos converge on.
-  const sprintDirPath = AbsolutePath.parse(sprintDir(deps.storage.dataRoot, snapshot.sprint.id, snapshot.sprint.slug));
-  if (!sprintDirPath.ok) return { ok: false, reason: sprintDirPath.error.message };
-  const progressPath = AbsolutePath.parse(join(String(sprintDirPath.value), 'progress.md'));
-  if (!progressPath.ok) return { ok: false, reason: progressPath.error.message };
-  const eventsNdjsonPath = AbsolutePath.parse(join(String(sprintDirPath.value), 'events.ndjson'));
-  if (!eventsNdjsonPath.ok) return { ok: false, reason: eventsNdjsonPath.error.message };
+  const sprintPaths = resolveImplementSprintPaths(deps.storage.dataRoot, snapshot.sprint);
+  if (!sprintPaths.ok) return { ok: false, reason: sprintPaths.error };
+  const { sprintDirPath, progressPath, eventsNdjsonPath } = sprintPaths.value;
 
   // Tee every AppEvent on the bus to <sprintDir>/events.ndjson for postmortem debugging.
-  // Stopped when the runner exits (success or fail) — wired below via subscribe().
+  // Stopped when the runner exits (success or fail) — wired below via `wireChainLogStop`.
   // The factory is env-gated at `wire()` time: when `RALPHCTL_DEBUG_TRACE` is unset the
   // returned handle is a no-op, so production runs do not write the file unless the operator
   // explicitly opts in.
-  const chainLog = deps.app.chainLogSink({ file: eventsNdjsonPath.value, bus: deps.app.eventBus });
+  const chainLog = deps.app.chainLogSink({ file: eventsNdjsonPath, bus: deps.app.eventBus });
 
-  // Signal mirror: `<change>` / `<learning>` / `<note>` signals are republished as structured
-  // `harness-signal` events on the EventBus so the TUI panels (and the opt-in events.ndjson tee)
-  // see them with a queryable shape.
-  //
-  // The OLD single-slot `currentTaskId` tracker (keyed off the bus's `task-attempt-started` event)
-  // is DELETED: that event has zero production publishers, so the slot was always `undefined` —
-  // every serial-path `harness-signal` was already unattributed. The parallel `>1` path attaches a
-  // PER-BRANCH sink keyed on the branch's `taskId` (see `wave-branch.ts`), the only correct model
-  // under concurrency. The serial path keeps emitting unattributed events, byte-for-byte with
-  // today's behaviour — renderers that group by task simply skip unattributed entries.
-  const serialSignalBusMirror: Sink<HarnessSignal> = {
-    emit(signal) {
-      if (signal.type !== 'change' && signal.type !== 'learning' && signal.type !== 'note') return;
-      deps.app.eventBus.publish({
-        type: 'harness-signal',
-        signalKind: signal.type,
-        text: signal.text,
-        at: IsoTimestamp.now(),
-      });
-    },
-  };
   // Fan out every harness signal to the existing app sink (TUI bus + subscribers) and the serial
-  // event-bus mirror. Decisions are accumulated on ctx by the gen-eval leaves and rendered into
-  // `progress.md` by the journal leaf (audit-[07]). The parallel path builds its own per-branch
-  // sinks in `wave-branch.ts` from `deps.app.signals`, so this `signals` is the serial-path sink.
-  const signals: HarnessSignalSink = broadcastSink<HarnessSignal>([deps.app.signals, serialSignalBusMirror]);
-
-  const repositories = new Map<RepositoryId, RepoExecConfig>();
-  for (const r of snapshot.project.repositories) {
-    repositories.set(r.id, {
-      path: r.path,
-      name: r.name,
-      ...(r.verifyScript !== undefined ? { verifyScript: r.verifyScript } : {}),
-      ...(r.verifyGates !== undefined ? { verifyGates: r.verifyGates } : {}),
-      ...(r.verifyTimeout !== undefined ? { verifyTimeout: r.verifyTimeout } : {}),
-      ...(r.setupScript !== undefined ? { setupScript: r.setupScript } : {}),
-    });
-  }
-
-  // Build one HeadlessAiProvider per role from the effective implement pair. The two roles
-  // may target distinct providers — the launcher constructs them independently rather than
-  // routing through `primaryFlowRow` so a cross-provider configuration spawns the right CLI
-  // per role. `ctx.provider` (the launcher-rebuilt primary adapter) is left unused here;
-  // implement deliberately bypasses the single-row seam.
-  const generatorProvider = createAiProvider({
-    row: implementPair.generator,
-    harnessConfig: effectiveSettings.harness,
-    eventBus: deps.app.eventBus,
-  });
-  const evaluatorProvider = createAiProvider({
-    row: implementPair.evaluator,
-    harnessConfig: effectiveSettings.harness,
-    eventBus: deps.app.eventBus,
-  });
-  const generatorEffort = resolveEffortForRow(implementPair.generator, effectiveSettings.ai.effort);
-  const evaluatorEffort = resolveEffortForRow(implementPair.evaluator, effectiveSettings.ai.effort);
-
-  const implementDeps: ImplementDeps = {
-    sprintRepo: deps.app.sprintRepo,
-    sprintExecutionRepo: deps.app.sprintExecutionRepo,
-    taskRepo: deps.app.taskRepo,
-    generatorProvider,
-    evaluatorProvider,
-    templateLoader: deps.app.templateLoader,
-    signals,
-    eventBus: deps.app.eventBus,
-    logger: deps.app.logger,
-    clock: deps.app.clock,
-    config: effectiveSettings,
-    gitRunner: deps.app.gitRunner,
-    shellScriptRunner: deps.app.shellScriptRunner,
-    fileLocker: deps.app.fileLocker,
-    locksRoot: deps.storage.locksRoot,
-    skillsAdapter,
-    skillSource,
-    interactive: deps.interactive,
-    writeFile: deps.app.writeFile,
-    appendFile: deps.app.appendFile,
-    // ONE journal mutex per run. Every parallel branch inherits this instance (branches spread this
-    // deps bag), so their `progress-journal-<taskId>` leaves serialise their read-regenerate-write
-    // of the shared `progress.md` through it; the serial path is a single caller, so it is a no-op.
-    journalMutex: createFoldQueue(),
-  };
-  const implementOpts = {
-    sprintId: snapshot.sprint.id,
+  // event-bus mirror. The parallel path builds its own per-branch sinks in `wave-branch.ts` from
+  // `deps.app.signals`, so this `signals` is the serial-path sink.
+  const signals = buildImplementSignalSink(deps);
+  // Two independent per-role adapters — the roles may target distinct providers (see
+  // `buildImplementProviders`'s doc comment for why `ctx.provider` is unused here).
+  const providers = buildImplementProviders(implementPair, effectiveSettings, deps);
+  const implementDeps = buildImplementDepsBag(deps, effectiveSettings, signals, providers, skillsAdapter, skillSource);
+  const implementOpts = buildImplementOptsBag(
+    snapshot.sprint,
+    snapshot.project,
     todoTasks,
-    repositories,
-    progressFile: progressPath.value,
-    sprintDir: sprintDirPath.value,
-    generatorProviderId: implementPair.generator.provider,
-    generatorModel: implementPair.generator.model,
-    ...(generatorEffort !== undefined ? { generatorEffort } : {}),
-    evaluatorProviderId: implementPair.evaluator.provider,
-    evaluatorModel: implementPair.evaluator.model,
-    ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
-    memoryRoot: deps.storage.memoryRoot,
-    projectId: String(snapshot.project.id),
-    projectSlug: snapshot.project.slug,
-  };
+    { progressPath, sprintDirPath },
+    implementPair,
+    providers,
+    deps.storage.memoryRoot
+  );
+  const { generatorEffort, evaluatorEffort } = providers;
 
   // Parallel cap: clamp `settings.concurrency.maxParallelTasks` to `[1,5]`. `=== 1` →
   // today's serial path: `createImplementFlow` built directly, the chain owning its own internal
@@ -384,48 +531,13 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     element,
     initialCtx: { sprintId: snapshot.sprint.id },
   });
-  // Stop the file-log + bus subscriptions when the runner reaches a terminal state.
-  // Pending writes still drain in the background — events.ndjson remains consistent
-  // post-exit. The subscription self-unsubscribes on the terminal event so we don't pin
-  // a dead listener (and its closure scope) to the runner's internal listener Set across
-  // a long multi-run TUI session — historically a load-bearing OOM contributor.
-  const unsubRunner: () => void = runner.subscribe((evt) => {
-    if (evt.type === 'completed' || evt.type === 'failed' || evt.type === 'aborted') {
-      chainLog.stop();
-      void chainLog.flush();
-      unsubRunner();
-    }
-  });
+  wireChainLogStop(runner, chainLog);
+
   const taskNames = new Map<string, string>(todoTasks.map((t) => [String(t.id), t.name]));
-  // Detect resumes at launch time: any task whose last attempt is still `running` (the v8 OOM /
-  // Ctrl-C / SIGTERM signature in a prior process) gets a `RecoveryContext` pinned to its id. We
-  // pre-derive here — rather than waiting for the chain's start-attempt leaf to settle — so the
-  // TUI's resume-from-aborted banner shows up *before* the chain starts executing, not after the
-  // first leaf finishes. Keyed on the leftover running attempt, NOT on `status === 'in_progress'`:
-  // a crash can persist a status-corrupt `todo` task whose last attempt is still `running` (which
-  // `startAttemptUseCase` heals), and the banner must fire for it too. `process-crash` is the
-  // conservative cause for the cross-process inference; P1j's signal-aware path will refine it.
-  const taskRecovering = new Map<string, RecoveryContext>();
-  const nowAtLaunch = deps.app.clock();
-  for (const t of todoTasks) {
-    const last = t.attempts.at(-1);
-    if (last === undefined || last.status !== 'running') continue;
-    taskRecovering.set(String(t.id), {
-      fromAttemptN: t.attempts.length,
-      cause: 'process-crash',
-      abortedAt: nowAtLaunch,
-    });
-  }
+  const taskRecovering = computeTaskRecovering(todoTasks, deps.app.clock());
   const flattened = flattenLeaves(element);
   const plannedLeaves = flattened.map((e) => e.name);
-  // Plan-time label lookup — keyed by element name so the rail can render friendly labels for
-  // rows that haven't traced yet (pending / running). Once a leaf executes, the trace entry's
-  // own `label` carries the same value and supersedes this lookup. Only leaves that supplied
-  // a non-empty label are entered; lookups fall through to the raw name for everything else.
-  const planLabelByName = new Map<string, string>();
-  for (const leaf of flattened) {
-    if (leaf.label !== undefined && leaf.label.length > 0) planLabelByName.set(leaf.name, leaf.label);
-  }
+  const planLabelByName = computePlanLabels(flattened);
   // Both role models are drawn from the post-merge implementPair so per-launch role overrides
   // (TUI customize picker or CLI flags) flow through to the rail/banner without a second
   // settings read.

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -192,9 +192,11 @@ const buildParallelElement = (
     });
 
   // Serialise every append for the WHOLE parallel run — prologue, all branches, and the epilogue
-  // share ONE mutex. Concurrent branches append to the same `progress.md` journal and project
-  // learnings ledger; funnelling them through one queue keeps each line atomic (no torn NDJSON /
-  // journal lines under fan-out). The serial path keeps the raw port — it has no concurrency.
+  // share ONE mutex. Concurrent branches append to the same project learnings ledger (and the
+  // prologue/epilogue's `progress.md` separator lines); funnelling them through one queue keeps
+  // each line atomic (no torn NDJSON lines under fan-out). The serial path keeps the raw port — it
+  // has no concurrency. `progress.md`'s per-attempt SECTION write is a SEPARATE read-modify-write
+  // path guarded by `ImplementDeps.journalMutex` (built once per run, below), not by this append mutex.
   const parallelDeps: ImplementDeps = { ...implementDeps, appendFile: serializeAppendFile(implementDeps.appendFile) };
 
   const branchDeps: BuildWaveBranchesDeps = {
@@ -339,6 +341,10 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
     interactive: deps.interactive,
     writeFile: deps.app.writeFile,
     appendFile: deps.app.appendFile,
+    // ONE journal mutex per run. Every parallel branch inherits this instance (branches spread this
+    // deps bag), so their `progress-journal-<taskId>` leaves serialise their read-regenerate-write
+    // of the shared `progress.md` through it; the serial path is a single caller, so it is a no-op.
+    journalMutex: createFoldQueue(),
   };
   const implementOpts = {
     sprintId: snapshot.sprint.id,

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -187,51 +187,53 @@ export interface LauncherDeps {
 
 const sessionId = (): string => `r-${Math.random().toString(36).slice(2, 10)}-${String(Date.now())}`;
 
+/** The `ok: true` branch of {@link LaunchResult} — the shape {@link sessionHintsFromLaunchResult} reads. */
+type LaunchOk = Extract<LaunchResult, { readonly ok: true }>;
+
+/**
+ * Optional UI-hint field names projected by {@link sessionHintsFromLaunchResult}. Declared once
+ * as a `satisfies`-checked tuple so adding a new hint is a one-line edit that stays in sync with
+ * both the picker call and its inferred return type.
+ */
+const HINT_KEYS = [
+  'taskNames',
+  'maxTurns',
+  'maxAttempts',
+  'plannedLeaves',
+  'planLabelByName',
+  'terminalSubstepName',
+  'taskRecovering',
+  'generatorModel',
+  'evaluatorModel',
+  'generatorProvider',
+  'evaluatorProvider',
+  'generatorEffort',
+  'evaluatorEffort',
+  'pinnedProjectId',
+  'pinnedProjectLabel',
+  'pinnedSprintId',
+  'pinnedSprintLabel',
+] as const satisfies ReadonlyArray<keyof LaunchOk>;
+
+/** Copy the subset of `keys` whose value on `obj` is not `undefined` into a fresh object. */
+const pickDefined = <T extends object, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> => {
+  const picked = {} as Pick<T, K>;
+  for (const key of keys) {
+    const value = obj[key];
+    if (value !== undefined) picked[key] = value;
+  }
+  return picked;
+};
+
 /**
  * Project the optional UI-hint fields from a successful {@link LaunchResult} into the shape
  * `SessionManager.register` accepts. Centralised so the four call sites (flows-view,
  * pick-sprint-view, project-detail-view, sprints-view) don't each stamp the same
- * conditional-spread pattern. Adding a new UI hint becomes one edit here instead of four.
+ * conditional-spread pattern. Adding a new UI hint becomes one edit to {@link HINT_KEYS} instead
+ * of four.
  */
-export const sessionHintsFromLaunchResult = (
-  result: Extract<LaunchResult, { readonly ok: true }>
-): {
-  readonly taskNames?: ReadonlyMap<string, string>;
-  readonly maxTurns?: number;
-  readonly maxAttempts?: number;
-  readonly plannedLeaves?: readonly string[];
-  readonly planLabelByName?: ReadonlyMap<string, string>;
-  readonly terminalSubstepName?: string;
-  readonly taskRecovering?: ReadonlyMap<string, RecoveryContext>;
-  readonly generatorModel?: string;
-  readonly evaluatorModel?: string;
-  readonly generatorProvider?: AiProvider;
-  readonly evaluatorProvider?: AiProvider;
-  readonly generatorEffort?: string;
-  readonly evaluatorEffort?: string;
-  readonly pinnedProjectId?: ProjectId;
-  readonly pinnedProjectLabel?: string;
-  readonly pinnedSprintId?: SprintId;
-  readonly pinnedSprintLabel?: string;
-} => ({
-  ...(result.taskNames !== undefined ? { taskNames: result.taskNames } : {}),
-  ...(result.maxTurns !== undefined ? { maxTurns: result.maxTurns } : {}),
-  ...(result.maxAttempts !== undefined ? { maxAttempts: result.maxAttempts } : {}),
-  ...(result.plannedLeaves !== undefined ? { plannedLeaves: result.plannedLeaves } : {}),
-  ...(result.planLabelByName !== undefined ? { planLabelByName: result.planLabelByName } : {}),
-  ...(result.terminalSubstepName !== undefined ? { terminalSubstepName: result.terminalSubstepName } : {}),
-  ...(result.taskRecovering !== undefined ? { taskRecovering: result.taskRecovering } : {}),
-  ...(result.generatorModel !== undefined ? { generatorModel: result.generatorModel } : {}),
-  ...(result.evaluatorModel !== undefined ? { evaluatorModel: result.evaluatorModel } : {}),
-  ...(result.generatorProvider !== undefined ? { generatorProvider: result.generatorProvider } : {}),
-  ...(result.evaluatorProvider !== undefined ? { evaluatorProvider: result.evaluatorProvider } : {}),
-  ...(result.generatorEffort !== undefined ? { generatorEffort: result.generatorEffort } : {}),
-  ...(result.evaluatorEffort !== undefined ? { evaluatorEffort: result.evaluatorEffort } : {}),
-  ...(result.pinnedProjectId !== undefined ? { pinnedProjectId: result.pinnedProjectId } : {}),
-  ...(result.pinnedProjectLabel !== undefined ? { pinnedProjectLabel: result.pinnedProjectLabel } : {}),
-  ...(result.pinnedSprintId !== undefined ? { pinnedSprintId: result.pinnedSprintId } : {}),
-  ...(result.pinnedSprintLabel !== undefined ? { pinnedSprintLabel: result.pinnedSprintLabel } : {}),
-});
+export const sessionHintsFromLaunchResult = (result: LaunchOk): Pick<LaunchOk, (typeof HINT_KEYS)[number]> =>
+  pickDefined(result, HINT_KEYS);
 
 /**
  * Map a launcher flow id to the {@link FlowId} that owns the AI session, or `undefined` for
@@ -324,37 +326,39 @@ const cwdFromSnapshot = (snapshot: AppStateSnapshot): AbsolutePath | undefined =
   return repo?.path;
 };
 
-export const launchFlow = async (
-  deps: LauncherDeps,
-  flowId: string,
-  snapshot: AppStateSnapshot,
-  extras: LaunchExtras = {}
-): Promise<LaunchResult> => {
-  // Settings priority: caller-supplied snapshot > on-disk reload > boot-time snapshot. The
-  // boot-time `app.settings` is the floor; it's stale across any Settings-view edit, and the
-  // adapter-rebuild block below depends on the per-flow row's provider matching the user's
-  // current choice. Callers that already reloaded (e.g. flows-view, for its model picker) just
-  // pass their fresh snapshot via `extras.settingsSnapshot`; callers that didn't (project-
-  // detail-view) implicitly opt into a one-roundtrip reload here so they don't have to remember.
+/**
+ * Settings priority: caller-supplied snapshot > on-disk reload > boot-time snapshot, with the
+ * picker's per-launch override applied on top. The boot-time `app.settings` is the floor; it's
+ * stale across any Settings-view edit, and the adapter-rebuild in {@link buildLaunchAdapters}
+ * depends on the per-flow row's provider matching the user's current choice. Callers that
+ * already reloaded (e.g. flows-view, for its model picker) just pass their fresh snapshot via
+ * `extras.settingsSnapshot`; callers that didn't (project-detail-view) implicitly opt into a
+ * one-roundtrip reload here so they don't have to remember.
+ *
+ * The override is applied BEFORE the adapter rebuild so a provider override re-keys it. Implement
+ * is handled inside its own launcher because its two roles need independent merges; for every
+ * other AI flow the override applies to the single row identified by `aiFlowIdFor` (review and
+ * detect-* aliases included).
+ */
+const resolveLaunchSettings = async (deps: LauncherDeps, flowId: string, extras: LaunchExtras): Promise<Settings> => {
   let baseSettings = extras.settingsSnapshot ?? deps.app.settings;
   if (extras.settingsSnapshot === undefined) {
     const reloaded = await deps.app.settingsRepo.load();
     if (reloaded.ok) baseSettings = reloaded.value;
   }
-  // Apply the picker's per-launch override BEFORE constructing adapters / resolving effort so
-  // a provider override re-keys the adapter rebuild below. Implement is handled inside its
-  // launcher because its two roles need independent merges; for every other AI flow the
-  // override applies to the single row identified by aiFlowIdFor (review and detect-* aliases
-  // included).
-  const settings = applyOverrideToSettings(baseSettings, flowId, extras.override);
+  return applyOverrideToSettings(baseSettings, flowId, extras.override);
+};
 
-  // Rebuild the provider-bound adapters from the fresh settings every launch, keyed on the
-  // dispatched flow's id. `app.provider`, `app.interactiveAi`, and `app.skillsAdapter` are
-  // wired once at `wire()` time from a placeholder flow (see `wire.ts`); without this rebuild,
-  // a user who configured refine on Claude and implement on Codex would get whichever provider
-  // happened to seed wire(). These factories are tiny (no I/O, no async) so a per-launch
-  // rebuild is essentially free. Flows that don't open an AI session fall through to whatever
-  // wire() seeded — they never call `.generate(...)`.
+/**
+ * Rebuild the provider-bound adapters from the resolved settings every launch, keyed on the
+ * dispatched flow's id. `app.provider`, `app.interactiveAi`, and `app.skillsAdapter` are wired
+ * once at `wire()` time from a placeholder flow (see `wire.ts`); without this rebuild, a user who
+ * configured refine on Claude and implement on Codex would get whichever provider happened to
+ * seed wire(). These factories are tiny (no I/O, no async) so a per-launch rebuild is essentially
+ * free. Flows that don't open an AI session fall through to whatever wire() seeded — they never
+ * call `.generate(...)`.
+ */
+const buildLaunchAdapters = (deps: LauncherDeps, flowId: string, settings: Settings) => {
   const aiFlow = aiFlowIdFor(flowId);
   const adapterFlow: FlowId = aiFlow ?? 'refine';
   const provider = createAiProvider({
@@ -374,17 +378,22 @@ export const launchFlow = async (
     logger: deps.app.logger,
   });
   const effort = aiFlow !== undefined ? resolveEffort(aiFlow, settings) : undefined;
+  return { provider, interactiveAi, skillsAdapter, resolvedProvider, effort };
+};
 
-  // Compose the static bundled skill source with a project-scoped source that emits per-repo
-  // setup / verify skills authored via the detect-skills flow. The project-source closure reads
-  // through `snapshot.project` so every install-skills leaf during this chain run sees the latest
-  // skills as of launch time. Flows that run without a project (none today) fall back cleanly
-  // to bundled-only.
+/**
+ * Compose the static bundled skill source with a project-scoped source that emits per-repo
+ * setup / verify skills authored via the detect-skills flow, plus the global, provider-specific
+ * operator drop-in skills under `<appRoot>/skills/<providerDir>/`. The project source's closure
+ * reads through `snapshot.project` so every install-skills leaf during this chain run sees the
+ * latest skills as of launch time; flows that run without a project (none today) fall back
+ * cleanly to bundled-only. The operator source is keyed on `resolvedProvider` so a mixed config
+ * installs each flow's operator skills for that flow's provider only — installed through the
+ * same adapter as bundled (same `ralphctl-` namespace + `.git/info/exclude` wildcard + tracked
+ * uninstall); a missing dir yields an empty source.
+ */
+const buildComposedSkillSource = (deps: LauncherDeps, snapshot: AppStateSnapshot, resolvedProvider: AiProvider) => {
   const projectSource = createProjectSkillSource({ getProject: () => snapshot.project });
-  // Global, provider-specific operator drop-in skills under `<appRoot>/skills/<providerDir>/`.
-  // Keyed on the resolved provider so a mixed config installs each flow's operator skills for
-  // that flow's provider only. Installed through the same adapter as bundled — same `ralphctl-`
-  // namespace + `.git/info/exclude` wildcard + tracked uninstall. A missing dir = empty source.
   const operatorSource = createOperatorSkillSource({
     operatorSkillsRoot: deps.storage.operatorSkillsRoot,
     provider: resolvedProvider,
@@ -396,7 +405,42 @@ export const launchFlow = async (
       checkContract(deps.app.logger, skill.name, skill.content);
     },
   });
-  const composedSkillSource = composeSkillSources(deps.app.skillSource, projectSource, operatorSource);
+  return composeSkillSources(deps.app.skillSource, projectSource, operatorSource);
+};
+
+/**
+ * Pin the launch snapshot's project / sprint onto a successful dispatch result. create-sprint
+ * never pins the snapshot sprint: the run's sprint does not exist at launch time, so a sprint on
+ * the snapshot is by definition the PREVIOUS selection — pinning it would mislabel the run's
+ * execute view / breadcrumb. The sprint-bound launch wrapper pins the real one via
+ * `setPinnedSprint` once the chain resolves it.
+ */
+const pinLaunchResult = (dispatchResult: LaunchResult, snapshot: AppStateSnapshot, flowId: string): LaunchResult => {
+  if (!dispatchResult.ok) return dispatchResult;
+  return {
+    ...dispatchResult,
+    ...(snapshot.project !== undefined
+      ? { pinnedProjectId: snapshot.project.id, pinnedProjectLabel: snapshot.project.displayName }
+      : {}),
+    ...(snapshot.sprint !== undefined && flowId !== 'create-sprint'
+      ? { pinnedSprintId: snapshot.sprint.id, pinnedSprintLabel: snapshot.sprint.name }
+      : {}),
+  };
+};
+
+export const launchFlow = async (
+  deps: LauncherDeps,
+  flowId: string,
+  snapshot: AppStateSnapshot,
+  extras: LaunchExtras = {}
+): Promise<LaunchResult> => {
+  const settings = await resolveLaunchSettings(deps, flowId, extras);
+  const { provider, interactiveAi, skillsAdapter, resolvedProvider, effort } = buildLaunchAdapters(
+    deps,
+    flowId,
+    settings
+  );
+  const composedSkillSource = buildComposedSkillSource(deps, snapshot, resolvedProvider);
 
   // Every launched runner gets bridged to the event bus so subscribers (TUI panels,
   // progress files, future webhooks) see chain progress without per-flow emission wiring. The
@@ -451,19 +495,5 @@ export const launchFlow = async (
     }
   })();
 
-  if (!dispatchResult.ok) return dispatchResult;
-
-  return {
-    ...dispatchResult,
-    ...(snapshot.project !== undefined
-      ? { pinnedProjectId: snapshot.project.id, pinnedProjectLabel: snapshot.project.displayName }
-      : {}),
-    // create-sprint never pins the snapshot sprint: the run's sprint does not exist at launch
-    // time, so a sprint on the snapshot is by definition the PREVIOUS selection — pinning it
-    // would mislabel the run's execute view / breadcrumb. The sprint-bound launch wrapper pins
-    // the real one via `setPinnedSprint` once the chain resolves it.
-    ...(snapshot.sprint !== undefined && flowId !== 'create-sprint'
-      ? { pinnedSprintId: snapshot.sprint.id, pinnedSprintLabel: snapshot.sprint.name }
-      : {}),
-  };
+  return pinLaunchResult(dispatchResult, snapshot, flowId);
 };

--- a/src/application/ui/tui/components/action-menu.tsx
+++ b/src/application/ui/tui/components/action-menu.tsx
@@ -62,6 +62,200 @@ export interface ActionMenuProps {
 
 const isEnabled = (item: MenuItem): boolean => item.disabledReason === undefined;
 
+/** Seed the cursor from `initialIndex` (index into the full items array). */
+const findInitialCursorId = (
+  items: readonly MenuItem[],
+  initialIndex: number,
+  enabledItems: readonly MenuItem[]
+): string => {
+  for (let i = initialIndex; i < items.length; i++) {
+    const it = items[i];
+    if (it !== undefined && isEnabled(it)) return it.id;
+  }
+  return enabledItems[0]?.id ?? '';
+};
+
+/** Hotkey match for the space-as-select / hotkey `useInput` handler (skips global hotkeys). */
+const matchHotkey = (items: readonly MenuItem[], input: string): MenuItem | undefined =>
+  items.find((it) => it.hotkey === input && it.globalHotkey !== true && isEnabled(it));
+
+interface RenderRow {
+  readonly item: MenuItem;
+  readonly focused: boolean;
+  readonly showHeader: boolean;
+}
+
+/**
+ * An enabled item is visible when it falls inside the current window; a disabled item is
+ * visible only when its section is also represented in the window (or the window is empty).
+ */
+const isRowVisible = (
+  it: MenuItem,
+  enabled: boolean,
+  visibleEnabledIds: ReadonlySet<string>,
+  windowedEnabled: readonly MenuItem[]
+): boolean => {
+  if (enabled) return visibleEnabledIds.has(it.id);
+  if (windowedEnabled.length === 0) return true;
+  return windowedEnabled.some((w) => w.section === it.section);
+};
+
+/**
+ * Walk the full items array, skipping enabled items outside the window and disabled items not
+ * adjacent to a visible section. Section headers render only when at least one of their members
+ * will render.
+ */
+const buildRenderRows = (
+  items: readonly MenuItem[],
+  windowedEnabled: readonly MenuItem[],
+  cursorId: string
+): RenderRow[] => {
+  const visibleEnabledIds = new Set(windowedEnabled.map((it) => it.id));
+  const renderRows: RenderRow[] = [];
+  let lastSection: string | undefined;
+  let lastRenderedSection: string | undefined;
+
+  for (const it of items) {
+    const enabled = isEnabled(it);
+    const visible = isRowVisible(it, enabled, visibleEnabledIds, windowedEnabled);
+
+    if (!visible) {
+      // Track section transitions even for skipped rows so the header logic stays correct.
+      if (it.section !== undefined) lastSection = it.section;
+      continue;
+    }
+
+    const sectionChanged = it.section !== undefined && it.section !== lastSection;
+    if (it.section !== undefined) lastSection = it.section;
+
+    const showHeader = sectionChanged && it.section !== lastRenderedSection;
+    if (showHeader && it.section !== undefined) lastRenderedSection = it.section;
+
+    renderRows.push({ item: it, focused: it.id === cursorId, showHeader });
+  }
+
+  return renderRows;
+};
+
+const SectionHeader = ({
+  section,
+  renderIdx,
+}: {
+  readonly section: string | undefined;
+  readonly renderIdx: number;
+}): React.JSX.Element => (
+  <Box paddingX={spacing.indent} marginTop={renderIdx === 0 ? 0 : 1}>
+    <Text color={inkColors.muted} bold>
+      {(section ?? '').toUpperCase()}
+    </Text>
+  </Box>
+);
+
+const RowHotkeyHint = ({
+  hotkey,
+  enabled,
+}: {
+  readonly hotkey: string | undefined;
+  readonly enabled: boolean;
+}): React.JSX.Element | null => {
+  if (hotkey === undefined) return null;
+  return (
+    <Text>
+      {'  '}
+      <Text color={enabled ? inkColors.highlight : inkColors.muted} bold={enabled}>
+        [{hotkey}]
+      </Text>
+    </Text>
+  );
+};
+
+const RowDescription = ({
+  focused,
+  description,
+}: {
+  readonly focused: boolean;
+  readonly description: string | undefined;
+}): React.JSX.Element | null => {
+  if (!focused || description === undefined || description.length === 0) return null;
+  return (
+    <Box paddingX={spacing.indent}>
+      <Text dimColor>{description}</Text>
+    </Box>
+  );
+};
+
+const RowCostHint = ({
+  focused,
+  costHint,
+}: {
+  readonly focused: boolean;
+  readonly costHint: string | undefined;
+}): React.JSX.Element | null => {
+  if (!focused || costHint === undefined || costHint.length === 0) return null;
+  return (
+    <Box paddingX={spacing.indent}>
+      <Text color={inkColors.muted} dimColor>
+        {glyphs.bullet} {costHint}
+      </Text>
+    </Box>
+  );
+};
+
+const RowDisabledReason = ({
+  enabled,
+  focused,
+  disabledReason,
+}: {
+  readonly enabled: boolean;
+  readonly focused: boolean;
+  readonly disabledReason: string | undefined;
+}): React.JSX.Element | null => {
+  if (enabled || disabledReason === undefined) return null;
+  return (
+    <Box paddingX={spacing.indent}>
+      {focused ? (
+        <Text color={inkColors.warning} wrap="truncate-end">
+          {glyphs.warningGlyph} {disabledReason}
+        </Text>
+      ) : (
+        <Text color={inkColors.muted} dimColor wrap="truncate-end">
+          {disabledReason}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+interface ActionMenuRowProps {
+  readonly item: MenuItem;
+  readonly focused: boolean;
+  readonly showHeader: boolean;
+  readonly renderIdx: number;
+}
+
+const ActionMenuRow = ({ item: it, focused, showHeader, renderIdx }: ActionMenuRowProps): React.JSX.Element => {
+  const enabled = isEnabled(it);
+  return (
+    <Box flexDirection="column">
+      {showHeader && <SectionHeader section={it.section} renderIdx={renderIdx} />}
+      <Box flexDirection="column" paddingX={spacing.indent}>
+        <Box>
+          <Text color={focused ? inkColors.primary : inkColors.muted} bold={focused}>
+            {focused ? glyphs.actionCursor : ' '}{' '}
+          </Text>
+          <Text {...(enabled ? {} : { color: inkColors.muted })} bold={focused && enabled} dimColor={!enabled}>
+            {it.label}
+          </Text>
+          <RowHotkeyHint hotkey={it.hotkey} enabled={enabled} />
+        </Box>
+        <RowDescription focused={focused} description={it.description} />
+        <RowCostHint focused={focused} costHint={it.costHint} />
+        <RowDisabledReason enabled={enabled} focused={focused} disabledReason={it.disabledReason} />
+      </Box>
+    </Box>
+  );
+};
+
 export const ActionMenu = ({
   items,
   initialIndex = 0,
@@ -73,13 +267,10 @@ export const ActionMenu = ({
   const enabledItems = useMemo(() => items.filter(isEnabled), [items]);
 
   // Seed the cursor from `initialIndex` (index into the full items array).
-  const initialCursorId = useMemo(() => {
-    for (let i = initialIndex; i < items.length; i++) {
-      const it = items[i];
-      if (it !== undefined && isEnabled(it)) return it.id;
-    }
-    return enabledItems[0]?.id ?? '';
-  }, [items, initialIndex, enabledItems]);
+  const initialCursorId = useMemo(
+    () => findInitialCursorId(items, initialIndex, enabledItems),
+    [items, initialIndex, enabledItems]
+  );
 
   const effectiveVisibleRows = visibleRows ?? enabledItems.length;
 
@@ -108,7 +299,7 @@ export const ActionMenu = ({
         return;
       }
       if (input.length > 0) {
-        const hit = items.find((it) => it.hotkey === input && it.globalHotkey !== true && isEnabled(it));
+        const hit = matchHotkey(items, input);
         hit?.onSelect();
       }
     },
@@ -123,106 +314,16 @@ export const ActionMenu = ({
     );
   }
 
-  // Build the set of enabled-item ids in the current window for O(1) lookup.
-  const visibleEnabledIds = new Set(windowedEnabled.map((it) => it.id));
   const aboveCount = window.start;
   const belowCount = enabledItems.length - window.end;
-
-  // Render pass: walk the full items array, skipping enabled items outside the window and
-  // disabled items not adjacent to a visible section. Section headers render only when at
-  // least one of their members will render.
-  const renderRows: Array<{ item: MenuItem; focused: boolean; showHeader: boolean }> = [];
-  let lastSection: string | undefined;
-  let lastRenderedSection: string | undefined;
-
-  for (const it of items) {
-    const enabled = isEnabled(it);
-    const inWindow = enabled && visibleEnabledIds.has(it.id);
-
-    if (enabled && !inWindow) {
-      // Track section transitions even for skipped rows so the header logic stays correct.
-      if (it.section !== undefined) lastSection = it.section;
-      continue;
-    }
-
-    if (!enabled) {
-      // Render disabled items only when their section is also represented in the window.
-      const sectionVisible = windowedEnabled.some((w) => w.section === it.section);
-      if (!sectionVisible && windowedEnabled.length > 0) {
-        if (it.section !== undefined) lastSection = it.section;
-        continue;
-      }
-    }
-
-    const sectionChanged = it.section !== undefined && it.section !== lastSection;
-    if (it.section !== undefined) lastSection = it.section;
-
-    const showHeader = sectionChanged && it.section !== lastRenderedSection;
-    if (showHeader && it.section !== undefined) lastRenderedSection = it.section;
-
-    renderRows.push({ item: it, focused: it.id === cursorId, showHeader });
-  }
+  const renderRows = buildRenderRows(items, windowedEnabled, cursorId);
 
   return (
     <Box flexDirection="column">
       <OverflowRow direction="above" count={aboveCount} />
-      {renderRows.map(({ item: it, focused, showHeader }, renderIdx) => {
-        const enabled = isEnabled(it);
-        return (
-          <Box key={it.id} flexDirection="column">
-            {showHeader && (
-              <Box paddingX={spacing.indent} marginTop={renderIdx === 0 ? 0 : 1}>
-                <Text color={inkColors.muted} bold>
-                  {(it.section ?? '').toUpperCase()}
-                </Text>
-              </Box>
-            )}
-            <Box flexDirection="column" paddingX={spacing.indent}>
-              <Box>
-                <Text color={focused ? inkColors.primary : inkColors.muted} bold={focused}>
-                  {focused ? glyphs.actionCursor : ' '}{' '}
-                </Text>
-                <Text {...(enabled ? {} : { color: inkColors.muted })} bold={focused && enabled} dimColor={!enabled}>
-                  {it.label}
-                </Text>
-                {it.hotkey !== undefined && (
-                  <Text>
-                    {'  '}
-                    <Text color={enabled ? inkColors.highlight : inkColors.muted} bold={enabled}>
-                      [{it.hotkey}]
-                    </Text>
-                  </Text>
-                )}
-              </Box>
-              {focused && it.description !== undefined && it.description.length > 0 && (
-                <Box paddingX={spacing.indent}>
-                  <Text dimColor>{it.description}</Text>
-                </Box>
-              )}
-              {focused && it.costHint !== undefined && it.costHint.length > 0 && (
-                <Box paddingX={spacing.indent}>
-                  <Text color={inkColors.muted} dimColor>
-                    {glyphs.bullet} {it.costHint}
-                  </Text>
-                </Box>
-              )}
-              {!enabled && it.disabledReason !== undefined && (
-                <Box paddingX={spacing.indent}>
-                  {focused ? (
-                    <Text color={inkColors.warning} wrap="truncate-end">
-                      {glyphs.warningGlyph} {it.disabledReason}
-                    </Text>
-                  ) : (
-                    <Text color={inkColors.muted} dimColor wrap="truncate-end">
-                      {it.disabledReason}
-                    </Text>
-                  )}
-                </Box>
-              )}
-            </Box>
-          </Box>
-        );
-      })}
+      {renderRows.map(({ item: it, focused, showHeader }, renderIdx) => (
+        <ActionMenuRow key={it.id} item={it} focused={focused} showHeader={showHeader} renderIdx={renderIdx} />
+      ))}
       <OverflowRow direction="below" count={belowCount} />
     </Box>
   );

--- a/src/application/ui/tui/components/format.ts
+++ b/src/application/ui/tui/components/format.ts
@@ -1,0 +1,18 @@
+/**
+ * Compact a token count for display: `200000` → `200k`, `12400` → `12.4k`, `1500` → `1.5k`,
+ * `120` → `120`, `1000000` → `1M`, `1200000` → `1.2M`. Token counts in the TUI can run large
+ * (context windows trend 200k–1M) and the surfaces that render them are narrow columns; values
+ * ≥ 1M use an `M` suffix so a 1M context window renders as `1M`, not `1000k`. Shared by the
+ * token-budget card and the tasks-panel formatters so both surfaces agree on the same
+ * compaction rules.
+ */
+export const fmtTokens = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return String(n);
+  if (n < 1000) return String(Math.round(n));
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  const k = n / 1000;
+  return k >= 100 ? `${String(Math.round(k))}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
+};

--- a/src/application/ui/tui/components/progress-overlay.tsx
+++ b/src/application/ui/tui/components/progress-overlay.tsx
@@ -20,6 +20,8 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import React, { useEffect, useState } from 'react';
 import { resolveSprintDir } from '@src/integration/persistence/storage.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { Box, Text, useInput } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
@@ -58,25 +60,15 @@ const formatAgo = (modifiedAtMs: number, now: number): string => {
   return `${fmtDuration(elapsed)} ago`;
 };
 
-export const ProgressOverlay = (): React.JSX.Element => {
-  const selection = useSelection();
-  const ui = useUiState();
-  const storage = useStorage();
-  const term = useTerminalSize();
+/**
+ * Loads `<sprintDir>/progress.md` on mount / whenever `sprintId` or `dataRoot` change. The sprint
+ * dir is resolved via the tolerant id-prefix resolver so both the new `<id>--<slug>/` and legacy
+ * bare `<id>/` names are found — building the bare path here would split-brain against a
+ * slug-renamed dir. We don't tail the file; a re-open (close + `g` again) gets the latest snapshot.
+ */
+const useProgressFile = (sprintId: SprintId | undefined, dataRoot: AbsolutePath): ProgressState => {
   const [state, setState] = useState<ProgressState>({ kind: 'loading' });
-  const [offset, setOffset] = useState<number>(0);
-  // Frozen "now" at mount so the "(Xs ago)" header doesn't tick mid-view; pressing `g` again
-  // re-mounts the overlay and refreshes the file + the timestamp.
-  const [now] = useState<number>(() => Date.now());
 
-  // When an Execute view is focused, prefer its pinned sprint so `g` opens the run's own
-  // progress file rather than whatever the global selection happens to be.
-  const sprintId = ui.focusedRunSprintId ?? selection.sprintId;
-
-  // Re-read on mount. The harness's progress-file-sink is the writer; we don't tail. A
-  // re-open (close + `g` again) gets the latest snapshot. The sprint dir is resolved via the
-  // tolerant id-prefix resolver so both the new `<id>--<slug>/` and legacy bare `<id>/` names
-  // are found — building the bare path here would split-brain against a slug-renamed dir.
   useEffect(() => {
     let cancelled = false;
     if (sprintId === undefined) {
@@ -85,7 +77,7 @@ export const ProgressOverlay = (): React.JSX.Element => {
     }
     const load = async (): Promise<void> => {
       try {
-        const dir = await resolveSprintDir(storage.dataRoot, sprintId);
+        const dir = await resolveSprintDir(dataRoot, sprintId);
         if (cancelled) return;
         if (dir === undefined) {
           setState({ kind: 'missing' });
@@ -117,22 +109,37 @@ export const ProgressOverlay = (): React.JSX.Element => {
     return () => {
       cancelled = true;
     };
-  }, [sprintId, storage.dataRoot]);
+  }, [sprintId, dataRoot]);
 
-  // Reset offset whenever the underlying line count changes (e.g. re-open of a longer file).
+  return state;
+};
+
+interface ProgressScroll {
+  readonly offset: number;
+  readonly maxOffset: number;
+  readonly visibleLines: readonly string[];
+  readonly lineCount: number;
+}
+
+/**
+ * Owns the scroll offset + keyboard handling for the progress body. Resets to the top whenever
+ * the underlying line count changes (e.g. re-open of a longer file). No `g` / `G` bindings here —
+ * `g` is the global open / close toggle, so claiming it inside the overlay would be a UX landmine.
+ * PgUp / PgDn / Ctrl+b/f/u/d cover the same ground.
+ */
+const useProgressScroll = (state: ProgressState, bodyRows: number): ProgressScroll => {
+  const [offset, setOffset] = useState<number>(0);
+
   const lineCount = state.kind === 'ok' ? state.lines.length : 0;
   useEffect(() => {
     setOffset(0);
   }, [lineCount]);
 
-  const bodyRows = Math.max(MIN_BODY_ROWS, term.rows - CHROME_ROWS);
   const maxOffset = Math.max(0, lineCount - bodyRows);
   const clamp = (n: number): number => Math.max(0, Math.min(n, maxOffset));
 
   useInput((input, key) => {
-    // Only scroll when there's an actual document and it overflows the viewport. No `g` / `G`
-    // bindings here — `g` is the global open / close toggle, so claiming it inside the overlay
-    // would be a UX landmine. PgUp / PgDn / Ctrl+b/f/u/d cover the same ground.
+    // Only scroll when there's an actual document and it overflows the viewport.
     if (state.kind !== 'ok' || maxOffset === 0) return;
     if (key.upArrow) {
       setOffset((o) => clamp(o - 1));
@@ -160,6 +167,99 @@ export const ProgressOverlay = (): React.JSX.Element => {
   });
 
   const visibleLines = state.kind === 'ok' ? state.lines.slice(offset, offset + bodyRows) : [];
+
+  return { offset, maxOffset, visibleLines, lineCount };
+};
+
+interface ProgressBodyProps {
+  readonly state: ProgressState;
+  readonly visibleLines: readonly string[];
+  readonly offset: number;
+  readonly bodyRows: number;
+  readonly lineCount: number;
+  readonly modifiedAgo: string | undefined;
+}
+
+/** Renders the scrollable body (one branch per {@link ProgressState} kind) plus the paginated footer. */
+const ProgressBody = ({
+  state,
+  visibleLines,
+  offset,
+  bodyRows,
+  lineCount,
+  modifiedAgo,
+}: ProgressBodyProps): React.JSX.Element => {
+  const maxOffset = Math.max(0, lineCount - bodyRows);
+  return (
+    <>
+      <Box flexDirection="column" marginTop={spacing.section}>
+        {state.kind === 'loading' && <Spinner label="Loading…" />}
+        {state.kind === 'missing' && (
+          <Box flexDirection="column">
+            <Text>{glyphs.infoGlyph} No progress file yet.</Text>
+            <Box marginTop={1}>
+              <Text dimColor>
+                The harness writes <Text>progress.md</Text> as the implementer reports signals. It will appear once a
+                run starts.
+              </Text>
+            </Box>
+          </Box>
+        )}
+        {state.kind === 'empty' && (
+          <Box flexDirection="column">
+            <Text>{glyphs.infoGlyph} Progress file exists but is empty.</Text>
+            <Box marginTop={1}>
+              <Text dimColor>Touched {modifiedAgo}; no signals have been recorded yet.</Text>
+            </Box>
+          </Box>
+        )}
+        {state.kind === 'failed' && (
+          <Box flexDirection="column">
+            <Text color={inkColors.error}>{glyphs.cross} Could not read progress file.</Text>
+            <Box marginTop={1}>
+              <Text dimColor>{state.message}</Text>
+            </Box>
+          </Box>
+        )}
+        {state.kind === 'ok' && (
+          <Box flexDirection="column">
+            {visibleLines.map((line, idx) => (
+              <Text key={`row-${String(offset + idx)}`}>{line.length === 0 ? ' ' : line}</Text>
+            ))}
+          </Box>
+        )}
+      </Box>
+      {state.kind === 'ok' && maxOffset > 0 && (
+        <Box marginTop={spacing.section} justifyContent="space-between">
+          <Text dimColor>
+            lines {String(offset + 1)}–{String(Math.min(lineCount, offset + bodyRows))} of {String(lineCount)}
+          </Text>
+          <Text dimColor>
+            {glyphs.bullet} ↑/↓ scroll {glyphs.bullet} PgUp/PgDn page
+          </Text>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export const ProgressOverlay = (): React.JSX.Element => {
+  const selection = useSelection();
+  const ui = useUiState();
+  const storage = useStorage();
+  const term = useTerminalSize();
+  // Frozen "now" at mount so the "(Xs ago)" header doesn't tick mid-view; pressing `g` again
+  // re-mounts the overlay and refreshes the file + the timestamp.
+  const [now] = useState<number>(() => Date.now());
+
+  // When an Execute view is focused, prefer its pinned sprint so `g` opens the run's own
+  // progress file rather than whatever the global selection happens to be.
+  const sprintId = ui.focusedRunSprintId ?? selection.sprintId;
+
+  const state = useProgressFile(sprintId, storage.dataRoot);
+
+  const bodyRows = Math.max(MIN_BODY_ROWS, term.rows - CHROME_ROWS);
+  const { offset, visibleLines, lineCount } = useProgressScroll(state, bodyRows);
 
   const sprintLabel =
     ui.focusedRunSprintLabel ?? selection.sprintLabel ?? (sprintId !== undefined ? String(sprintId) : '(no sprint)');
@@ -190,53 +290,14 @@ export const ProgressOverlay = (): React.JSX.Element => {
           </Box>
           <Text dimColor>esc · g to close</Text>
         </Box>
-        <Box flexDirection="column" marginTop={spacing.section}>
-          {state.kind === 'loading' && <Spinner label="Loading…" />}
-          {state.kind === 'missing' && (
-            <Box flexDirection="column">
-              <Text>{glyphs.infoGlyph} No progress file yet.</Text>
-              <Box marginTop={1}>
-                <Text dimColor>
-                  The harness writes <Text>progress.md</Text> as the implementer reports signals. It will appear once a
-                  run starts.
-                </Text>
-              </Box>
-            </Box>
-          )}
-          {state.kind === 'empty' && (
-            <Box flexDirection="column">
-              <Text>{glyphs.infoGlyph} Progress file exists but is empty.</Text>
-              <Box marginTop={1}>
-                <Text dimColor>Touched {modifiedAgo}; no signals have been recorded yet.</Text>
-              </Box>
-            </Box>
-          )}
-          {state.kind === 'failed' && (
-            <Box flexDirection="column">
-              <Text color={inkColors.error}>{glyphs.cross} Could not read progress file.</Text>
-              <Box marginTop={1}>
-                <Text dimColor>{state.message}</Text>
-              </Box>
-            </Box>
-          )}
-          {state.kind === 'ok' && (
-            <Box flexDirection="column">
-              {visibleLines.map((line, idx) => (
-                <Text key={`row-${String(offset + idx)}`}>{line.length === 0 ? ' ' : line}</Text>
-              ))}
-            </Box>
-          )}
-        </Box>
-        {state.kind === 'ok' && maxOffset > 0 && (
-          <Box marginTop={spacing.section} justifyContent="space-between">
-            <Text dimColor>
-              lines {String(offset + 1)}–{String(Math.min(lineCount, offset + bodyRows))} of {String(lineCount)}
-            </Text>
-            <Text dimColor>
-              {glyphs.bullet} ↑/↓ scroll {glyphs.bullet} PgUp/PgDn page
-            </Text>
-          </Box>
-        )}
+        <ProgressBody
+          state={state}
+          visibleLines={visibleLines}
+          offset={offset}
+          bodyRows={bodyRows}
+          lineCount={lineCount}
+          modifiedAgo={modifiedAgo}
+        />
       </Box>
     </Box>
   );

--- a/src/application/ui/tui/components/tasks-panel-internals/format.ts
+++ b/src/application/ui/tui/components/tasks-panel-internals/format.ts
@@ -7,6 +7,7 @@
 import type { AbortCause } from '@src/domain/entity/attempt.ts';
 import type { ContextCompactedSignal, HarnessSignal } from '@src/domain/signal.ts';
 import type { TaskProjection } from '@src/application/ui/tui/components/tasks-projection.ts';
+import { fmtTokens } from '@src/application/ui/tui/components/format.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 
 /**
@@ -31,23 +32,6 @@ export const COLLAPSED_DISCLOSURE = '▸';
 export const EXPANDED_DISCLOSURE = '▾';
 /** Cursor caret for the focused signal row. Same vocabulary as the global action cursor. */
 export const FOCUS_CURSOR = '›';
-
-/**
- * Compact a token count for display: `200000` → `200k`, `1500` → `1.5k`, `120` → `120`,
- * `1000000` → `1M`, `1200000` → `1.2M`. The provider's reported numbers can be large (context
- * windows trend 200k–1M); values ≥ 1M use an `M` suffix so a 1M window renders as `1M`, not
- * `1000k` — consistent with the token-budget card's formatter.
- */
-export const fmtTokens = (n: number): string => {
-  if (!Number.isFinite(n) || n < 0) return String(n);
-  if (n < 1000) return String(Math.round(n));
-  if (n >= 1_000_000) {
-    const m = n / 1_000_000;
-    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
-  }
-  const k = n / 1000;
-  return k >= 100 ? `${String(Math.round(k))}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
-};
 
 /**
  * Render the parenthetical detail block of a `context-compacted` marker. Returns `undefined`

--- a/src/application/ui/tui/components/tasks-panel-internals/keymap.ts
+++ b/src/application/ui/tui/components/tasks-panel-internals/keymap.ts
@@ -7,7 +7,7 @@
  * from the render tree.
  */
 
-import { useInput } from 'ink';
+import { useInput, type Key } from 'ink';
 import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import { isCommitMessageKey } from '@src/application/ui/tui/components/tasks-panel-internals/focus-keys.ts';
 
@@ -30,6 +30,149 @@ export interface UseTasksPanelInputArgs {
   readonly setCriteriaExpandedIds: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void;
 }
 
+/** Toggles membership of `id` in `set`, returning a fresh `Set` (never mutates the input). */
+const toggleSetMembership = <T>(set: ReadonlySet<T>, id: T): Set<T> => {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+};
+
+const handleCriteriaToggle = (
+  input: string,
+  activeTaskId: string | undefined,
+  setCriteriaExpandedIds: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void
+): boolean => {
+  // Done-criteria toggle for the active task. Independent of the card / row cursors: the
+  // operator is virtually always reading the running task when this hotkey is reached.
+  if (input !== 'e' || activeTaskId === undefined) return false;
+  setCriteriaExpandedIds((prev) => toggleSetMembership(prev, activeTaskId));
+  return true;
+};
+
+const handleEscapeCollapse = (
+  key: Key,
+  focusedCardId: string | undefined,
+  expandedTaskIds: ReadonlySet<string>,
+  setExpandedTaskIds: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void
+): boolean => {
+  // Esc collapses an expanded focused card. Works on any expanded card, including the
+  // active task — the auto-expand-on-activation seed only fires when the active id
+  // transitions, so collapsing it stays collapsed until the next transition.
+  if (!key.escape) return false;
+  if (focusedCardId !== undefined && expandedTaskIds.has(focusedCardId)) {
+    setExpandedTaskIds((prev) => {
+      const next = new Set(prev);
+      next.delete(focusedCardId);
+      return next;
+    });
+  }
+  return true;
+};
+
+interface VerticalMoveArgs {
+  readonly focusedCardExpanded: boolean;
+  readonly flatKeys: readonly string[];
+  readonly focusedIndex: number;
+  readonly tasksLength: number;
+  readonly effectiveCardCursor: number;
+  readonly setFocusedKey: (key: string | undefined) => void;
+  readonly setCardCursor: (index: number) => void;
+}
+
+// j / k AND ↑ / ↓ share one cursor; the scope shifts with the focused card's state and
+// the current row-cursor anchor:
+//   - collapsed card → card cursor moves between cards.
+//   - expanded card AND a row cursor is already anchored → row cursor moves within the
+//     card; jumping past either edge hands off to the card cursor (no need to collapse
+//     the card first).
+//   - expanded card with no row anchor yet → card cursor (lets the operator pan
+//     between cards without first clicking into a row).
+const handleVerticalMove = (direction: 1 | -1, input: string, key: Key, args: VerticalMoveArgs): boolean => {
+  const isDown = direction === 1;
+  const matchesKey = isDown ? key.downArrow || input === 'j' : key.upArrow || input === 'k';
+  if (!matchesKey) return false;
+
+  const {
+    focusedCardExpanded,
+    flatKeys,
+    focusedIndex,
+    tasksLength,
+    effectiveCardCursor,
+    setFocusedKey,
+    setCardCursor,
+  } = args;
+  const rowCursorActive = focusedCardExpanded && flatKeys.length > 0 && focusedIndex >= 0;
+  if (isDown) {
+    if (rowCursorActive && focusedIndex < flatKeys.length - 1) {
+      setFocusedKey(flatKeys[focusedIndex + 1]);
+      return true;
+    }
+    // Row cursor at the bottom — fall through to the card cursor.
+    const next = Math.min(tasksLength - 1, effectiveCardCursor + 1);
+    setCardCursor(next);
+    // Reset the row cursor so the next expanded card starts un-anchored.
+    setFocusedKey(undefined);
+    return true;
+  }
+  if (rowCursorActive && focusedIndex > 0) {
+    setFocusedKey(flatKeys[focusedIndex - 1]);
+    return true;
+  }
+  // Row cursor at the top — fall through to the card cursor.
+  const next = Math.max(0, effectiveCardCursor - 1);
+  setCardCursor(next);
+  setFocusedKey(undefined);
+  return true;
+};
+
+interface SelectKeyArgs {
+  readonly bucketed: BucketedExecution;
+  readonly flatKeys: readonly string[];
+  readonly focusedKey: string | undefined;
+  readonly focusedIndex: number;
+  readonly effectiveFocusedKey: string | undefined;
+  readonly focusedCardId: string | undefined;
+  readonly focusedCardExpanded: boolean;
+  readonly setFocusedKey: (key: string | undefined) => void;
+  readonly setExpandedKeys: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void;
+  readonly setExpandedTaskIds: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void;
+}
+
+const handleSelectKey = (input: string, key: Key, args: SelectKeyArgs): void => {
+  if (!(key.return || input === ' ')) return;
+  const {
+    bucketed,
+    flatKeys,
+    focusedKey,
+    focusedIndex,
+    effectiveFocusedKey,
+    focusedCardId,
+    focusedCardExpanded,
+    setFocusedKey,
+    setExpandedKeys,
+    setExpandedTaskIds,
+  } = args;
+
+  // Card-scope: toggle the focused card's expansion. Row-scope only kicks in when the
+  // card is already expanded AND a row cursor is anchored.
+  const rowCursorAnchored = focusedCardExpanded && flatKeys.length > 0 && focusedIndex >= 0;
+  if (focusedCardId !== undefined && !rowCursorAnchored) {
+    setExpandedTaskIds((prev) => toggleSetMembership(prev, focusedCardId));
+    return;
+  }
+  // Row-scope: existing commit-message toggle behaviour.
+  if (flatKeys.length === 0) return;
+  const target = focusedIndex >= 0 ? focusedKey : flatKeys[flatKeys.length - 1];
+  if (target === undefined) return;
+  if (!isCommitMessageKey(target, bucketed)) {
+    if (effectiveFocusedKey === undefined) setFocusedKey(target);
+    return;
+  }
+  setExpandedKeys((prev) => toggleSetMembership(prev, target));
+  if (effectiveFocusedKey === undefined) setFocusedKey(target);
+};
+
 export const useTasksPanelInput = ({
   inputActive,
   bucketed,
@@ -50,91 +193,31 @@ export const useTasksPanelInput = ({
 }: UseTasksPanelInputArgs): void => {
   useInput(
     (input, key) => {
-      // Done-criteria toggle for the active task. Independent of the card / row cursors: the
-      // operator is virtually always reading the running task when this hotkey is reached.
-      if (input === 'e' && activeTaskId !== undefined) {
-        setCriteriaExpandedIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(activeTaskId)) next.delete(activeTaskId);
-          else next.add(activeTaskId);
-          return next;
-        });
-        return;
-      }
-      // Esc collapses an expanded focused card. Works on any expanded card, including the
-      // active task — the auto-expand-on-activation seed only fires when the active id
-      // transitions, so collapsing it stays collapsed until the next transition.
-      if (key.escape) {
-        if (focusedCardId !== undefined && expandedTaskIds.has(focusedCardId)) {
-          setExpandedTaskIds((prev) => {
-            const next = new Set(prev);
-            next.delete(focusedCardId);
-            return next;
-          });
-        }
-        return;
-      }
-      // j / k AND ↑ / ↓ share one cursor; the scope shifts with the focused card's state and
-      // the current row-cursor anchor:
-      //   - collapsed card → card cursor moves between cards.
-      //   - expanded card AND a row cursor is already anchored → row cursor moves within the
-      //     card; jumping past either edge hands off to the card cursor (no need to collapse
-      //     the card first).
-      //   - expanded card with no row anchor yet → card cursor (lets the operator pan
-      //     between cards without first clicking into a row).
-      const rowCursorActive = focusedCardExpanded && flatKeys.length > 0 && focusedIndex >= 0;
-      if (key.downArrow || input === 'j') {
-        if (rowCursorActive && focusedIndex < flatKeys.length - 1) {
-          setFocusedKey(flatKeys[focusedIndex + 1]);
-          return;
-        }
-        // Row cursor at the bottom — fall through to the card cursor.
-        const next = Math.min(bucketed.tasks.length - 1, effectiveCardCursor + 1);
-        setCardCursor(next);
-        // Reset the row cursor so the next expanded card starts un-anchored.
-        setFocusedKey(undefined);
-        return;
-      }
-      if (key.upArrow || input === 'k') {
-        if (rowCursorActive && focusedIndex > 0) {
-          setFocusedKey(flatKeys[focusedIndex - 1]);
-          return;
-        }
-        // Row cursor at the top — fall through to the card cursor.
-        const next = Math.max(0, effectiveCardCursor - 1);
-        setCardCursor(next);
-        setFocusedKey(undefined);
-        return;
-      }
-      if (key.return || input === ' ') {
-        // Card-scope: toggle the focused card's expansion. Row-scope only kicks in when the
-        // card is already expanded AND a row cursor is anchored.
-        const rowCursorAnchored = focusedCardExpanded && flatKeys.length > 0 && focusedIndex >= 0;
-        if (focusedCardId !== undefined && !rowCursorAnchored) {
-          setExpandedTaskIds((prev) => {
-            const next = new Set(prev);
-            if (next.has(focusedCardId)) next.delete(focusedCardId);
-            else next.add(focusedCardId);
-            return next;
-          });
-          return;
-        }
-        // Row-scope: existing commit-message toggle behaviour.
-        if (flatKeys.length === 0) return;
-        const target = focusedIndex >= 0 ? focusedKey : flatKeys[flatKeys.length - 1];
-        if (target === undefined) return;
-        if (!isCommitMessageKey(target, bucketed)) {
-          if (effectiveFocusedKey === undefined) setFocusedKey(target);
-          return;
-        }
-        setExpandedKeys((prev) => {
-          const next = new Set(prev);
-          if (next.has(target)) next.delete(target);
-          else next.add(target);
-          return next;
-        });
-        if (effectiveFocusedKey === undefined) setFocusedKey(target);
-      }
+      if (handleCriteriaToggle(input, activeTaskId, setCriteriaExpandedIds)) return;
+      if (handleEscapeCollapse(key, focusedCardId, expandedTaskIds, setExpandedTaskIds)) return;
+      const verticalMoveArgs: VerticalMoveArgs = {
+        focusedCardExpanded,
+        flatKeys,
+        focusedIndex,
+        tasksLength: bucketed.tasks.length,
+        effectiveCardCursor,
+        setFocusedKey,
+        setCardCursor,
+      };
+      if (handleVerticalMove(1, input, key, verticalMoveArgs)) return;
+      if (handleVerticalMove(-1, input, key, verticalMoveArgs)) return;
+      handleSelectKey(input, key, {
+        bucketed,
+        flatKeys,
+        focusedKey,
+        focusedIndex,
+        effectiveFocusedKey,
+        focusedCardId,
+        focusedCardExpanded,
+        setFocusedKey,
+        setExpandedKeys,
+        setExpandedTaskIds,
+      });
     },
     { isActive: inputActive }
   );

--- a/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
+++ b/src/application/ui/tui/components/tasks-panel-internals/task-row.tsx
@@ -7,6 +7,9 @@
  * Smaller card parts (status / sub-step presentation maps, {@link RecoveryLine},
  * {@link SubStepLine}, {@link CriteriaBlock}) live in `task-card-parts.tsx` so this file stays
  * focused on header layout + the card sub-sections (criteria / sub-steps / eval verdict / signals).
+ * Within this file, {@link TaskBlock} itself only composes card sub-sections — each sub-section is
+ * a small, self-gating component (checks its own `cardExpanded` / data-presence condition and
+ * returns `null` when it has nothing to show) so the composing card never repeats a gate.
  *
  * The eval verdict is sourced from the AUTHORITATIVE per-task `taskEvaluation` prop (the task
  * entity's last attempt, keyed by task id) — never the timestamp-bucketed `TaskBucket.evaluations`
@@ -46,31 +49,510 @@ import {
   SubStepLine,
 } from '@src/application/ui/tui/components/tasks-panel-internals/task-card-parts.tsx';
 
-export const TaskBlock = ({
-  task,
+/**
+ * Cursor caret, status glyph/spinner, display name, duration, and status word — the header's
+ * fixed-position core, rendered collapsed OR expanded.
+ */
+const TaskHeaderCore = ({
+  cardFocused,
   running,
+  status,
   display,
-  maxSignals,
-  maxSubSteps,
-  recovering,
+  durationMs,
+}: {
+  readonly cardFocused: boolean;
+  readonly running: boolean;
+  readonly status: TaskBucket['status'];
+  readonly display: string;
+  readonly durationMs: number | undefined;
+}): React.JSX.Element => {
+  const presentation = STATUS_PRESENTATION[status];
+  const isSpinning = status === 'running';
+  return (
+    <>
+      <Text color={cardFocused ? inkColors.highlight : inkColors.muted} bold={cardFocused}>
+        {cardFocused ? FOCUS_CURSOR : ' '}{' '}
+      </Text>
+      {isSpinning ? (
+        <Spinner active={running} color={presentation.color} />
+      ) : (
+        <Text color={presentation.color} bold>
+          {presentation.glyph}
+        </Text>
+      )}
+      <Text bold> {display}</Text>
+      {durationMs !== undefined && (
+        <Text dimColor>
+          {' '}
+          {glyphs.bullet} {fmtDuration(durationMs)}
+        </Text>
+      )}
+      <Text dimColor>
+        {' '}
+        {glyphs.bullet} {status}
+      </Text>
+    </>
+  );
+};
+
+/** Collapsed-header trailing chips (attempt count / latest commit SHA). Self-gates on `cardExpanded`. */
+const HeaderSummaryChips = ({
+  cardExpanded,
+  taskProjection,
+}: {
+  readonly cardExpanded: boolean;
+  readonly taskProjection: TaskProjection | undefined;
+}): React.JSX.Element | null => {
+  // Most recent commit SHA for the collapsed summary line — sourced from the projection's
+  // lastAttempt when a TaskProjection is supplied. Truncated to 7 chars (git's `--short`
+  // default).
+  const latestCommitSha = useMemo<string | undefined>(() => {
+    const sha = taskProjection?.lastAttempt?.commitSha;
+    return sha !== undefined ? String(sha).slice(0, 7) : undefined;
+  }, [taskProjection]);
+  if (cardExpanded) return null;
+  const attemptsCount = taskProjection?.attemptsCount ?? 0;
+  return (
+    <>
+      {attemptsCount > 0 && (
+        <Text dimColor>
+          {' '}
+          {glyphs.bullet} {String(attemptsCount)}×
+        </Text>
+      )}
+      {latestCommitSha !== undefined && (
+        <Text dimColor>
+          {' '}
+          {glyphs.bullet} {latestCommitSha}
+        </Text>
+      )}
+    </>
+  );
+};
+
+/**
+ * Expanded-header `round N/M` (+ `attempt A/X` when relevant) chip for an active gen-eval task.
+ * Self-gates on `cardExpanded` and on the task having entered a gen-eval round yet.
+ */
+const RoundAttemptChip = ({
+  cardExpanded,
+  task,
+}: {
+  readonly cardExpanded: boolean;
+  readonly task: TaskBucket;
+}): React.JSX.Element | null => {
+  if (!cardExpanded) return null;
+  const round = task.genEvalRound;
+  if (round === undefined || round <= 0) return null;
+  const maxTurns = task.genEvalMaxRounds;
+  // No per-attempt cap known → show the bare round (no `/M` that could overshoot).
+  if (maxTurns === undefined) {
+    return (
+      <Text color={inkColors.info}>
+        {' '}
+        {glyphs.bullet} round {String(round)}
+      </Text>
+    );
+  }
+  // `genEvalRound` is monotonic across the whole task; fold it back into the
+  // per-attempt window so a 2nd+ attempt reads `attempt A · round R/maxTurns`
+  // instead of overshooting (`round 4/3`).
+  const { attemptN, roundInAttempt } = perAttemptRound(round, maxTurns);
+  const maxAttempts = task.genEvalMaxAttempts;
+  const showAttempt = attemptN > 1 || (maxAttempts !== undefined && maxAttempts > 1);
+  return (
+    <Text color={inkColors.info}>
+      {' '}
+      {glyphs.bullet}{' '}
+      {showAttempt
+        ? `attempt ${String(attemptN)}${maxAttempts !== undefined ? `/${String(maxAttempts)}` : ''} ${glyphs.bullet} `
+        : ''}
+      round {String(roundInAttempt)}/{String(maxTurns)}
+    </Text>
+  );
+};
+
+/**
+ * Expanded-header ETA chip, active task only. Self-gates on `cardExpanded` / `isActive` / the task
+ * having entered a gen-eval round, then drops (returns null) once no estimate applies.
+ */
+const EtaChip = ({
+  cardExpanded,
+  isActive,
+  taskProjection,
+  task,
+}: {
+  readonly cardExpanded: boolean;
+  readonly isActive: boolean;
+  readonly taskProjection: TaskProjection | undefined;
+  readonly task: TaskBucket;
+}): React.JSX.Element | null => {
+  const round = task.genEvalRound;
+  if (!cardExpanded || !isActive || round === undefined || round <= 0) return null;
+  const eta = formatEtaChip(taskProjection, round, task.genEvalMaxRounds);
+  if (eta === undefined) return null;
+  return <Text dimColor> {eta}</Text>;
+};
+
+/**
+ * One indented, optionally-truncated notice line under the header — shared shape for the
+ * blocked-reason / warning-summary / idle-ticker / first-run-waiting rows. `truncate` mirrors
+ * whether the original render wrapped the `Text` in a `flexGrow`/`flexShrink`/`minWidth: 0` Box
+ * with `wrap="truncate-end"` (the blocked/warning/idle rows) or rendered a bare `Text` (the
+ * first-run-waiting row).
+ */
+const IndentedNotice = ({
+  tone,
+  icon,
+  text,
+  truncate = false,
+}: {
+  readonly tone: 'warning' | 'dim';
+  readonly icon: string;
+  readonly text: string;
+  readonly truncate?: boolean;
+}): React.JSX.Element => {
+  const colorProps = tone === 'warning' ? { color: inkColors.warning } : {};
+  const line = (
+    <Text {...colorProps} dimColor={tone === 'dim'} wrap={truncate ? 'truncate-end' : undefined}>
+      {icon} {text}
+    </Text>
+  );
+  return (
+    <Box paddingLeft={2}>
+      {truncate ? (
+        <Box flexGrow={1} flexShrink={1} minWidth={0}>
+          {line}
+        </Box>
+      ) : (
+        line
+      )}
+    </Box>
+  );
+};
+
+/**
+ * Blocked-reason / flagged-completion notice lines under the header. Rendered collapsed OR
+ * expanded — a blocked card's reason, or a done card's final-attempt warning, is its most
+ * important line regardless of expand state. Self-gates: renders nothing when both are empty.
+ */
+const HeaderNotices = ({
+  task,
+  blockedReason,
+  warningSummary,
+}: {
+  readonly task: TaskBucket;
+  readonly blockedReason: string | undefined;
+  readonly warningSummary: string | undefined;
+}): React.JSX.Element => {
+  // Guard an empty / whitespace-only blockedReason (both `BlockedTask.blockedReason` and the
+  // task-blocked signal permit ''): without this an AI that self-blocks with a blank reason
+  // renders a lone warning glyph. trim() first — `collapseWhitespace('')` is '' but a
+  // whitespace-only string collapses to a single space, which `!== undefined` alone wouldn't catch.
+  const blockedReasonText = blockedReason?.trim() ?? '';
+  // Warning summary for a flagged completion — rendered only for a done (`completed`) card so it
+  // never competes with the blocked-reason line (mutually exclusive by status). Empty / absent →
+  // no line, keeping a clean pass visually identical to its pre-change rendering.
+  const warningSummaryText = task.status === 'completed' ? (warningSummary?.trim() ?? '') : '';
+  return (
+    <>
+      {blockedReasonText.length > 0 && (
+        <IndentedNotice
+          tone="warning"
+          icon={glyphs.warningGlyph}
+          text={collapseWhitespace(blockedReasonText)}
+          truncate
+        />
+      )}
+      {warningSummaryText.length > 0 && (
+        <IndentedNotice
+          tone="warning"
+          icon={glyphs.warningGlyph}
+          text={collapseWhitespace(warningSummaryText)}
+          truncate
+        />
+      )}
+    </>
+  );
+};
+
+/** Two-role gen-eval activity indicator, active+expanded task only. Self-gates internally. */
+const ActiveBusyIndicator = ({
+  cardExpanded,
+  isActive,
+  task,
+}: {
+  readonly cardExpanded: boolean;
+  readonly isActive: boolean;
+  readonly task: TaskBucket;
+}): React.JSX.Element | null => {
+  const isSpinning = task.status === 'running';
+  if (!cardExpanded || !isActive || !isSpinning) return null;
+  return <BusyIndicator role={resolveActiveRole(task.subSteps)} />;
+};
+
+/** Executed + pending sub-step rows under an expanded card. */
+const SubStepsSection = ({
+  taskId,
+  subStepRows,
+  subStepElided,
+  pendingSubSteps,
+  running,
+}: {
+  readonly taskId: string;
+  readonly subStepRows: TaskBucket['subSteps'];
+  readonly subStepElided: number;
+  readonly pendingSubSteps: readonly string[] | undefined;
+  readonly running: boolean;
+}): React.JSX.Element => (
+  <Box flexDirection="column" paddingLeft={2}>
+    {subStepElided > 0 && <Text dimColor>{`${glyphs.clipEllipsis} ${String(subStepElided)} earlier sub-steps`}</Text>}
+    {subStepRows.map((s, i) => (
+      <SubStepLine key={`${taskId}-sub-${String(i)}`} sub={s} running={running} />
+    ))}
+    {/* Pending sub-steps from the plan — not yet executed. Grey ◇ rows, matching the Steps rail. */}
+    {pendingSubSteps !== undefined &&
+      pendingSubSteps.map((leafName) => (
+        <Box key={`${taskId}-pending-${leafName}`}>
+          <Text color={inkColors.muted}>
+            {glyphs.activityArrow} {glyphs.phasePending}
+          </Text>
+          <Text dimColor> {leafName}</Text>
+        </Box>
+      ))}
+  </Box>
+);
+
+/**
+ * Eval verdict block under an expanded card. Dev-gated per-dimension panel visibility is driven
+ * by the AUTHORITATIVE verdict (or a failed/blocked task status) — never by a bucketed FAILED
+ * signal, which can leak from another lane onto a passed task's card. When it does render it may
+ * read the most recent matching bucketed FAILED signal for dimension/critique DISPLAY detail; if
+ * none exists we render the compact authoritative line instead.
+ */
+const EvalVerdictSection = ({
+  taskEvaluation,
+  taskStatus,
+  evaluations,
+  showEvaluatorFailureUI,
+}: {
+  readonly taskEvaluation: TaskEvaluation;
+  readonly taskStatus: TaskBucket['status'];
+  readonly evaluations: TaskBucket['evaluations'];
+  readonly showEvaluatorFailureUI: boolean;
+}): React.JSX.Element => {
+  const authoritativeFailed = taskEvaluation.status === 'failed' || taskStatus === 'failed' || taskStatus === 'aborted';
+  if (showEvaluatorFailureUI && authoritativeFailed) {
+    const failureSignal = [...evaluations].reverse().find((e) => e.status === 'failed');
+    if (failureSignal !== undefined) {
+      // Still running ⇒ the harness will feed the critique into another round.
+      return (
+        <Box flexDirection="column" paddingLeft={2} marginTop={1}>
+          <EvaluatorFailurePanel evaluation={failureSignal} isFinalRound={taskStatus !== 'running'} />
+        </Box>
+      );
+    }
+  }
+  return (
+    <Box flexDirection="column" paddingLeft={2} marginTop={1}>
+      <EvaluationLine evaluation={taskEvaluation} />
+    </Box>
+  );
+};
+
+/** Signals block under an expanded card. */
+const SignalsSection = ({
+  taskId,
+  signalRows,
+  signalsElided,
   focusedKey,
   expandedKeys,
   scopeId,
   sliceStart,
-  taskCriteria,
-  criteriaExpanded,
-  showEvaluatorFailureUI,
-  taskProjection,
-  isActive,
-  firstRun,
-  cardExpanded,
-  cardFocused,
-  nowMs,
-  blockedReason,
-  warningSummary,
-  taskEvaluation,
-  pendingSubSteps,
 }: {
+  readonly taskId: string;
+  readonly signalRows: TaskBucket['signals'];
+  readonly signalsElided: number;
+  readonly focusedKey: string | undefined;
+  readonly expandedKeys: ReadonlySet<string>;
+  readonly scopeId: string;
+  readonly sliceStart: number;
+}): React.JSX.Element => (
+  <Box flexDirection="column" paddingLeft={2} marginTop={1}>
+    <Text dimColor>signals</Text>
+    <Box flexDirection="column" paddingLeft={2}>
+      {signalsElided > 0 && (
+        <Text
+          dimColor
+        >{`${glyphs.clipEllipsis} ${String(signalsElided)} earlier signal${signalsElided === 1 ? '' : 's'}`}</Text>
+      )}
+      {signalRows.map((s, i) => {
+        const key = focusKey(scopeId, sliceStart + i);
+        return (
+          <StreamSignalRow
+            key={`${taskId}-sig-${String(sliceStart + i)}`}
+            signal={s}
+            focused={focusedKey === key}
+            expanded={expandedKeys.has(key)}
+          />
+        );
+      })}
+    </Box>
+  </Box>
+);
+
+/**
+ * Idle ticker / resume banner / first-run hint / criteria / error message — the "notice-ish"
+ * rows directly under the header. Self-gates on `cardExpanded`.
+ */
+const ExpandedNotices = ({
+  cardExpanded,
+  task,
+  nowMs,
+  isActive,
+  recovering,
+  firstRun,
+  criteriaBullets,
+  criteriaExpanded,
+}: {
+  readonly cardExpanded: boolean;
+  readonly task: TaskBucket;
+  readonly nowMs: number;
+  readonly isActive: boolean;
+  readonly recovering: RecoveryContext | undefined;
+  readonly firstRun: boolean;
+  readonly criteriaBullets: readonly string[] | undefined;
+  readonly criteriaExpanded: boolean;
+}): React.JSX.Element | null => {
+  const isSpinning = task.status === 'running';
+  // Idle ticker — surfaces the last 1–2 note / learning signals when the task is running and
+  // the most recent stream signal is older than IDLE_TICKER_THRESHOLD_MS. Provides reassurance
+  // that the harness is alive during long tool calls; hides immediately when a new signal
+  // lands. Active task only — completed / blocked cards have no use for "what's the AI been
+  // thinking about" hints.
+  const idleSnippets = useMemo<readonly string[]>(() => {
+    if (!isActive || !isSpinning) return [];
+    const latest = task.signals[task.signals.length - 1];
+    if (latest === undefined) return [];
+    const latestMs = new Date(String(latest.timestamp)).getTime();
+    if (!Number.isFinite(latestMs)) return [];
+    if (nowMs - latestMs < IDLE_TICKER_THRESHOLD_MS) return [];
+    return latestIdleSnippets(task.signals);
+  }, [task.signals, isActive, isSpinning, nowMs]);
+  if (!cardExpanded) return null;
+  return (
+    <>
+      {idleSnippets.length > 0 && (
+        <IndentedNotice
+          tone="dim"
+          icon={glyphs.activityArrow}
+          text={idleSnippets.map((s) => collapseWhitespace(s)).join(`  ${glyphs.bullet}  `)}
+          truncate
+        />
+      )}
+      {recovering !== undefined && <RecoveryLine attemptN={recovering.fromAttemptN + 1} context={recovering} />}
+      {firstRun && isActive && isSpinning && (
+        <IndentedNotice tone="dim" icon={glyphs.activityArrow} text="waiting for first attempt…" />
+      )}
+      {criteriaBullets !== undefined && criteriaBullets.length > 0 && (
+        <CriteriaBlock bullets={criteriaBullets} expanded={criteriaExpanded} />
+      )}
+      {task.errorMessage !== undefined && (
+        <Box paddingLeft={2}>
+          <Text color={inkColors.error}>{task.errorMessage}</Text>
+        </Box>
+      )}
+    </>
+  );
+};
+
+/**
+ * Sub-steps, eval verdict (or its "awaiting eval" placeholder), and signals — the trailing,
+ * data-heavy rows of an expanded card. Self-gates on `cardExpanded`; slices `task.subSteps` /
+ * `task.signals` to the render window itself so the caller only threads the raw task + limits.
+ */
+const ExpandedProgressBlock = ({
+  cardExpanded,
+  task,
+  maxSubSteps,
+  maxSignals,
+  pendingSubSteps,
+  running,
+  isActive,
+  taskEvaluation,
+  showEvaluatorFailureUI,
+  focusedKey,
+  expandedKeys,
+  scopeId,
+  sliceStart,
+}: {
+  readonly cardExpanded: boolean;
+  readonly task: TaskBucket;
+  readonly maxSubSteps: number;
+  readonly maxSignals: number;
+  readonly pendingSubSteps: readonly string[] | undefined;
+  readonly running: boolean;
+  readonly isActive: boolean;
+  readonly taskEvaluation: TaskEvaluation | undefined;
+  readonly showEvaluatorFailureUI: boolean;
+  readonly focusedKey: string | undefined;
+  readonly expandedKeys: ReadonlySet<string>;
+  readonly scopeId: string;
+  readonly sliceStart: number;
+}): React.JSX.Element | null => {
+  if (!cardExpanded) return null;
+  const subStepRows = task.subSteps.slice(-maxSubSteps);
+  const subStepElided = task.subSteps.length - subStepRows.length;
+  const signalRows = task.signals.slice(-maxSignals);
+  const signalsElided = task.signals.length - signalRows.length;
+  return (
+    <>
+      {(subStepRows.length > 0 || (pendingSubSteps !== undefined && pendingSubSteps.length > 0)) && (
+        <SubStepsSection
+          taskId={task.id}
+          subStepRows={subStepRows}
+          subStepElided={subStepElided}
+          pendingSubSteps={pendingSubSteps}
+          running={running}
+        />
+      )}
+      {isActive && taskEvaluation === undefined && (
+        // An active card with no AUTHORITATIVE evaluation yet — surface a single dim placeholder
+        // so the operator sees the eval slot is live-but-empty rather than missing. We gate on the
+        // ABSENCE of an authoritative verdict (not the bucketed signal stream, which can mis-
+        // attribute a stale signal). `activityArrow` matches the other indented continuation lines.
+        <Box paddingLeft={2} marginTop={1}>
+          <Text dimColor>{glyphs.activityArrow} awaiting eval</Text>
+        </Box>
+      )}
+      {taskEvaluation !== undefined && (
+        <EvalVerdictSection
+          taskEvaluation={taskEvaluation}
+          taskStatus={task.status}
+          evaluations={task.evaluations}
+          showEvaluatorFailureUI={showEvaluatorFailureUI}
+        />
+      )}
+      {signalRows.length > 0 && (
+        <SignalsSection
+          taskId={task.id}
+          signalRows={signalRows}
+          signalsElided={signalsElided}
+          focusedKey={focusedKey}
+          expandedKeys={expandedKeys}
+          scopeId={scopeId}
+          sliceStart={sliceStart}
+        />
+      )}
+    </>
+  );
+};
+
+/**
+ * Props for {@link TaskBlock}. Named (rather than inlined on the function) purely to keep the
+ * function body's own line count legible — the shape and every field's contract are unchanged.
+ */
+type TaskBlockProps = {
   readonly task: TaskBucket;
   readonly running: boolean;
   readonly display: string;
@@ -145,252 +627,75 @@ export const TaskBlock = ({
    * Absent when `descriptor.plannedLeaves` is not available (legacy sessions / non-implement flows).
    */
   readonly pendingSubSteps?: readonly string[];
-}): React.JSX.Element => {
-  const presentation = STATUS_PRESENTATION[task.status];
-  const isSpinning = task.status === 'running';
-  const signalRows = task.signals.slice(-maxSignals);
-  const signalsElided = task.signals.length - signalRows.length;
-  const subStepRows = task.subSteps.slice(-maxSubSteps);
-  const subStepElided = task.subSteps.length - subStepRows.length;
-  const criteriaBullets = taskCriteria;
-  // Guard an empty / whitespace-only blockedReason (both `BlockedTask.blockedReason` and the
-  // task-blocked signal permit ''): without this an AI that self-blocks with a blank reason
-  // renders a lone warning glyph. trim() first — `collapseWhitespace('')` is '' but a
-  // whitespace-only string collapses to a single space, which `!== undefined` alone wouldn't catch.
-  const blockedReasonText = blockedReason?.trim() ?? '';
-  // Warning summary for a flagged completion — rendered only for a done (`completed`) card so it
-  // never competes with the blocked-reason line (mutually exclusive by status). Empty / absent →
-  // no line, keeping a clean pass visually identical to its pre-change rendering.
-  const warningSummaryText = task.status === 'completed' ? (warningSummary?.trim() ?? '') : '';
-  // Most recent commit SHA for the collapsed summary line — sourced from the projection's
-  // lastAttempt when a TaskProjection is supplied. Truncated to 7 chars (git's `--short`
-  // default).
-  const latestCommitSha = useMemo<string | undefined>(() => {
-    const sha = taskProjection?.lastAttempt?.commitSha;
-    return sha !== undefined ? String(sha).slice(0, 7) : undefined;
-  }, [taskProjection]);
-  const attemptsCount = taskProjection?.attemptsCount ?? 0;
-  // Idle ticker — surfaces the last 1–2 note / learning signals when the task is running and
-  // the most recent stream signal is older than IDLE_TICKER_THRESHOLD_MS. Provides reassurance
-  // that the harness is alive during long tool calls; hides immediately when a new signal
-  // lands. Active task only — completed / blocked cards have no use for "what's the AI been
-  // thinking about" hints.
-  const idleSnippets = useMemo<readonly string[]>(() => {
-    if (!isActive || !isSpinning) return [];
-    const latest = task.signals[task.signals.length - 1];
-    if (latest === undefined) return [];
-    const latestMs = new Date(String(latest.timestamp)).getTime();
-    if (!Number.isFinite(latestMs)) return [];
-    if (nowMs - latestMs < IDLE_TICKER_THRESHOLD_MS) return [];
-    return latestIdleSnippets(task.signals);
-  }, [task.signals, isActive, isSpinning, nowMs]);
-  return (
-    <Box flexDirection="column" marginBottom={spacing.section}>
-      <Box>
-        <Text color={cardFocused ? inkColors.highlight : inkColors.muted} bold={cardFocused}>
-          {cardFocused ? FOCUS_CURSOR : ' '}{' '}
-        </Text>
-        {isSpinning ? (
-          <Spinner active={running} color={presentation.color} />
-        ) : (
-          <Text color={presentation.color} bold>
-            {presentation.glyph}
-          </Text>
-        )}
-        <Text bold> {display}</Text>
-        {task.durationMs !== undefined && (
-          <Text dimColor>
-            {' '}
-            {glyphs.bullet} {fmtDuration(task.durationMs)}
-          </Text>
-        )}
-        <Text dimColor>
-          {' '}
-          {glyphs.bullet} {task.status}
-        </Text>
-        {!cardExpanded && attemptsCount > 0 && (
-          <Text dimColor>
-            {' '}
-            {glyphs.bullet} {String(attemptsCount)}×
-          </Text>
-        )}
-        {!cardExpanded && latestCommitSha !== undefined && (
-          <Text dimColor>
-            {' '}
-            {glyphs.bullet} {latestCommitSha}
-          </Text>
-        )}
-        {cardExpanded &&
-          task.genEvalRound !== undefined &&
-          task.genEvalRound > 0 &&
-          (() => {
-            const maxTurns = task.genEvalMaxRounds;
-            // No per-attempt cap known → show the bare round (no `/M` that could overshoot).
-            if (maxTurns === undefined) {
-              return (
-                <Text color={inkColors.info}>
-                  {' '}
-                  {glyphs.bullet} round {String(task.genEvalRound)}
-                </Text>
-              );
-            }
-            // `genEvalRound` is monotonic across the whole task; fold it back into the
-            // per-attempt window so a 2nd+ attempt reads `attempt A · round R/maxTurns`
-            // instead of overshooting (`round 4/3`).
-            const { attemptN, roundInAttempt } = perAttemptRound(task.genEvalRound, maxTurns);
-            const maxAttempts = task.genEvalMaxAttempts;
-            const showAttempt = attemptN > 1 || (maxAttempts !== undefined && maxAttempts > 1);
-            return (
-              <Text color={inkColors.info}>
-                {' '}
-                {glyphs.bullet}{' '}
-                {showAttempt
-                  ? `attempt ${String(attemptN)}${maxAttempts !== undefined ? `/${String(maxAttempts)}` : ''} ${glyphs.bullet} `
-                  : ''}
-                round {String(roundInAttempt)}/{String(maxTurns)}
-              </Text>
-            );
-          })()}
-        {cardExpanded &&
-          isActive &&
-          task.genEvalRound !== undefined &&
-          task.genEvalRound > 0 &&
-          (() => {
-            const eta = formatEtaChip(taskProjection, task.genEvalRound, task.genEvalMaxRounds);
-            if (eta === undefined) return null;
-            return <Text dimColor> {eta}</Text>;
-          })()}
-      </Box>
-      {cardExpanded && isActive && isSpinning && <BusyIndicator role={resolveActiveRole(task.subSteps)} />}
-      {blockedReasonText.length > 0 && (
-        // Shown collapsed OR expanded — a blocked card's reason is its most important line.
-        <Box paddingLeft={2}>
-          <Box flexGrow={1} flexShrink={1} minWidth={0}>
-            <Text color={inkColors.warning} wrap="truncate-end">
-              {glyphs.warningGlyph} {collapseWhitespace(blockedReasonText)}
-            </Text>
-          </Box>
-        </Box>
-      )}
-      {warningSummaryText.length > 0 && (
-        // A done card that carries a final-attempt warning — surfaced collapsed OR expanded so the
-        // operator never reads a flagged completion as a clean pass. Same warning glyph as the
-        // attempt-card / blocked line; the tasks list previously showed it only for blockedReason.
-        <Box paddingLeft={2}>
-          <Box flexGrow={1} flexShrink={1} minWidth={0}>
-            <Text color={inkColors.warning} wrap="truncate-end">
-              {glyphs.warningGlyph} {collapseWhitespace(warningSummaryText)}
-            </Text>
-          </Box>
-        </Box>
-      )}
-      {cardExpanded && idleSnippets.length > 0 && (
-        <Box paddingLeft={2}>
-          <Box flexGrow={1} flexShrink={1} minWidth={0}>
-            <Text dimColor wrap="truncate-end">
-              {glyphs.activityArrow} {idleSnippets.map((s) => collapseWhitespace(s)).join(`  ${glyphs.bullet}  `)}
-            </Text>
-          </Box>
-        </Box>
-      )}
-      {cardExpanded && recovering !== undefined && (
-        <RecoveryLine attemptN={recovering.fromAttemptN + 1} context={recovering} />
-      )}
-      {cardExpanded && firstRun && isActive && isSpinning && (
-        <Box paddingLeft={2}>
-          <Text dimColor>{glyphs.activityArrow} waiting for first attempt…</Text>
-        </Box>
-      )}
-      {cardExpanded && criteriaBullets !== undefined && criteriaBullets.length > 0 && (
-        <CriteriaBlock bullets={criteriaBullets} expanded={criteriaExpanded} />
-      )}
-      {cardExpanded && task.errorMessage !== undefined && (
-        <Box paddingLeft={2}>
-          <Text color={inkColors.error}>{task.errorMessage}</Text>
-        </Box>
-      )}
-      {cardExpanded && (subStepRows.length > 0 || (pendingSubSteps !== undefined && pendingSubSteps.length > 0)) && (
-        <Box flexDirection="column" paddingLeft={2}>
-          {subStepElided > 0 && (
-            <Text dimColor>{`${glyphs.clipEllipsis} ${String(subStepElided)} earlier sub-steps`}</Text>
-          )}
-          {subStepRows.map((s, i) => (
-            <SubStepLine key={`${task.id}-sub-${String(i)}`} sub={s} running={running} />
-          ))}
-          {/* Pending sub-steps from the plan — not yet executed. Grey ◇ rows, matching the Steps rail. */}
-          {pendingSubSteps !== undefined &&
-            pendingSubSteps.map((leafName) => (
-              <Box key={`${task.id}-pending-${leafName}`}>
-                <Text color={inkColors.muted}>
-                  {glyphs.activityArrow} {glyphs.phasePending}
-                </Text>
-                <Text dimColor> {leafName}</Text>
-              </Box>
-            ))}
-        </Box>
-      )}
-      {cardExpanded && isActive && taskEvaluation === undefined && (
-        // An active card with no AUTHORITATIVE evaluation yet — surface a single dim placeholder
-        // so the operator sees the eval slot is live-but-empty rather than missing. We gate on the
-        // ABSENCE of an authoritative verdict (not the bucketed signal stream, which can mis-
-        // attribute a stale signal). `activityArrow` matches the other indented continuation lines.
-        <Box paddingLeft={2} marginTop={1}>
-          <Text dimColor>{glyphs.activityArrow} awaiting eval</Text>
-        </Box>
-      )}
-      {cardExpanded &&
-        taskEvaluation !== undefined &&
-        (() => {
-          // Dev-gated per-dimension panel. Its VISIBILITY is driven by the AUTHORITATIVE verdict
-          // (or a failed/blocked task status) — never by a bucketed FAILED signal, which can leak
-          // from another lane onto a passed task's card. When it does render it may read the most
-          // recent matching bucketed FAILED signal for dimension/critique DISPLAY detail; if none
-          // exists we render the compact authoritative line instead.
-          const authoritativeFailed =
-            taskEvaluation.status === 'failed' || task.status === 'failed' || task.status === 'aborted';
-          if (showEvaluatorFailureUI && authoritativeFailed) {
-            const failureSignal = [...task.evaluations].reverse().find((e) => e.status === 'failed');
-            if (failureSignal !== undefined) {
-              // Still running ⇒ the harness will feed the critique into another round.
-              return (
-                <Box flexDirection="column" paddingLeft={2} marginTop={1}>
-                  <EvaluatorFailurePanel evaluation={failureSignal} isFinalRound={task.status !== 'running'} />
-                </Box>
-              );
-            }
-          }
-          return (
-            <Box flexDirection="column" paddingLeft={2} marginTop={1}>
-              <EvaluationLine evaluation={taskEvaluation} />
-            </Box>
-          );
-        })()}
-      {cardExpanded && signalRows.length > 0 && (
-        <Box flexDirection="column" paddingLeft={2} marginTop={1}>
-          <Text dimColor>signals</Text>
-          <Box flexDirection="column" paddingLeft={2}>
-            {signalsElided > 0 && (
-              <Text
-                dimColor
-              >{`${glyphs.clipEllipsis} ${String(signalsElided)} earlier signal${signalsElided === 1 ? '' : 's'}`}</Text>
-            )}
-            {signalRows.map((s, i) => {
-              const key = focusKey(scopeId, sliceStart + i);
-              return (
-                <StreamSignalRow
-                  key={`${task.id}-sig-${String(sliceStart + i)}`}
-                  signal={s}
-                  focused={focusedKey === key}
-                  expanded={expandedKeys.has(key)}
-                />
-              );
-            })}
-          </Box>
-        </Box>
-      )}
-    </Box>
-  );
 };
+
+export const TaskBlock = ({
+  task,
+  running,
+  display,
+  maxSignals,
+  maxSubSteps,
+  recovering,
+  focusedKey,
+  expandedKeys,
+  scopeId,
+  sliceStart,
+  taskCriteria,
+  criteriaExpanded,
+  showEvaluatorFailureUI,
+  taskProjection,
+  isActive,
+  firstRun,
+  cardExpanded,
+  cardFocused,
+  nowMs,
+  blockedReason,
+  warningSummary,
+  taskEvaluation,
+  pendingSubSteps,
+}: TaskBlockProps): React.JSX.Element => (
+  <Box flexDirection="column" marginBottom={spacing.section}>
+    <Box>
+      <TaskHeaderCore
+        cardFocused={cardFocused}
+        running={running}
+        status={task.status}
+        display={display}
+        durationMs={task.durationMs}
+      />
+      <HeaderSummaryChips cardExpanded={cardExpanded} taskProjection={taskProjection} />
+      <RoundAttemptChip cardExpanded={cardExpanded} task={task} />
+      <EtaChip cardExpanded={cardExpanded} isActive={isActive} taskProjection={taskProjection} task={task} />
+    </Box>
+    <ActiveBusyIndicator cardExpanded={cardExpanded} isActive={isActive} task={task} />
+    <HeaderNotices task={task} blockedReason={blockedReason} warningSummary={warningSummary} />
+    <ExpandedNotices
+      cardExpanded={cardExpanded}
+      task={task}
+      nowMs={nowMs}
+      isActive={isActive}
+      recovering={recovering}
+      firstRun={firstRun}
+      criteriaBullets={taskCriteria}
+      criteriaExpanded={criteriaExpanded}
+    />
+    <ExpandedProgressBlock
+      cardExpanded={cardExpanded}
+      task={task}
+      maxSubSteps={maxSubSteps}
+      maxSignals={maxSignals}
+      pendingSubSteps={pendingSubSteps}
+      running={running}
+      isActive={isActive}
+      taskEvaluation={taskEvaluation}
+      showEvaluatorFailureUI={showEvaluatorFailureUI}
+      focusedKey={focusedKey}
+      expandedKeys={expandedKeys}
+      scopeId={scopeId}
+      sliceStart={sliceStart}
+    />
+  </Box>
+);
 
 export const OrphanSignals = ({
   signals,

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -21,7 +21,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
-import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import type { SprintState, TaskProjection } from '@src/application/ui/tui/components/tasks-projection.ts';
 import type { TaskEvaluation } from '@src/application/ui/tui/components/tasks-panel-internals/evaluation-row.tsx';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
@@ -158,48 +158,29 @@ export interface TasksPanelProps {
   readonly onFocusedCardChange?: (taskId: string | undefined) => void;
 }
 
-export const TasksPanel = ({
-  bucketed,
-  running,
-  nameById,
-  maxSignalsPerTask = 8,
-  maxTasks,
-  maxOrphanSignals = 6,
-  maxSubStepsPerTask = 12,
-  recoveringByTaskId,
-  inputActive = false,
-  taskCriteriaById,
-  pendingSubStepsByTaskId,
-  blockedReasonById,
-  warningSummaryById,
-  taskEvaluationById,
-  showEvaluatorFailureUI = false,
-  sprintState,
-  nowMs,
-  onFocusedCardChange,
-}: TasksPanelProps): React.JSX.Element => {
-  // Render-time fallback for the idle-ticker clock. The execute view passes a polled `now` so
-  // the ticker can re-evaluate on each heartbeat; isolated unit renders fall through to this
-  // default, which freezes the clock at mount-time and so naturally suppresses the ticker
-  // unless a test explicitly supplies an old timestamp.
-  const effectiveNowMs = nowMs ?? Date.now();
-  const flatKeys = useMemo(
-    () => buildFlatFocusKeys(bucketed, maxSignalsPerTask, maxOrphanSignals),
-    [bucketed, maxSignalsPerTask, maxOrphanSignals]
-  );
+interface TaskCardState {
+  /** Index of the first non-completed task in `bucketed.tasks`; `-1` when every task is done. */
+  readonly activeTaskIdx: number;
+  readonly activeTaskId: string | undefined;
+  readonly expandedTaskIds: ReadonlySet<string>;
+  readonly setExpandedTaskIds: (updater: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void;
+  readonly isCardExpanded: (taskId: string) => boolean;
+  readonly setCardCursor: (index: number) => void;
+  readonly effectiveCardCursor: number;
+  readonly focusedCardId: string | undefined;
+  readonly focusedCardExpanded: boolean;
+}
 
-  // Cursor identity is the focused row's stable key (not its index). When a new signal lands
-  // the index of the existing row may shift, but its key is unchanged, so the cursor sticks
-  // to the same row. When the focused key falls off the visible slice (cap-elision), the
-  // cursor collapses to `undefined` and Enter/Space re-anchors at the latest row.
-  const [focusedKey, setFocusedKey] = useState<string | undefined>(undefined);
-  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set<string>());
-  // No lazy hydration — `taskCriteriaById` is supplied synchronously by the host view from
-  // `Task.verificationCriteria`. Empty array → render the placeholder; missing key (task not
-  // yet in view's poll) → criteria UI is suppressed for that task.
-  // Task ids whose criteria block is currently expanded (full bullet list). Default state is
-  // the 3-line summary. Toggled by pressing `e` while the panel owns input.
-  const [criteriaExpandedIds, setCriteriaExpandedIds] = useState<ReadonlySet<string>>(() => new Set());
+/**
+ * Card-cursor / expansion state cluster for the Tasks panel — which card is focused, which
+ * cards are expanded, and the auto-expand-on-activation + focused-card-change side effects.
+ * Extracted from `TasksPanel` (mirrors the `useTasksPanelInput` split next door) so the render
+ * body only has to thread the resulting values, not own the effects that produce them.
+ */
+const useTaskCardState = (
+  bucketed: BucketedExecution,
+  onFocusedCardChange: ((taskId: string | undefined) => void) | undefined
+): TaskCardState => {
   // The active (first non-completed) task — anchor for the `e` criteria hotkey AND the
   // default card-cursor position. Recomputed each render so the `useInput` callback always
   // sees the latest active id.
@@ -264,9 +245,6 @@ export const TasksPanel = ({
   const focusedCardId = effectiveCardCursor >= 0 ? bucketed.tasks[effectiveCardCursor]?.id : undefined;
   const focusedCardExpanded = focusedCardId !== undefined ? isCardExpanded(focusedCardId) : false;
 
-  const focusedIndex = focusedKey !== undefined ? flatKeys.indexOf(focusedKey) : -1;
-  const effectiveFocusedKey = focusedIndex >= 0 ? focusedKey : undefined;
-
   // Report focused card id upward (passive sidebar minimap). Deduped — only fires when the id
   // changes. Uses a ref for the callback so a non-memoised caller doesn't cause an extra effect
   // run on every render; the ref is kept current on every render before the effect fires.
@@ -280,6 +258,192 @@ export const TasksPanel = ({
     }
   });
 
+  return {
+    activeTaskIdx,
+    activeTaskId,
+    expandedTaskIds,
+    setExpandedTaskIds,
+    isCardExpanded,
+    setCardCursor,
+    effectiveCardCursor,
+    focusedCardId,
+    focusedCardExpanded,
+  };
+};
+
+/**
+ * Collapses the repeated `value !== undefined ? { key: value } : {}` conditional-spread
+ * pattern into one call — keeps only the defined fields of a partial props bag. The return
+ * type strips `| undefined` per field (unlike `Partial<T>`, which would keep it) so the
+ * result satisfies `exactOptionalPropertyTypes` targets such as `TaskBlockProps`, matching
+ * the guarantee the ternary-spread idiom got "for free" from `!== undefined` narrowing.
+ */
+const pickDefined = <T extends Record<string, unknown>>(fields: T): { [K in keyof T]?: NonNullable<T[K]> } => {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(fields) as Array<keyof T>) {
+    const value = fields[key];
+    if (value !== undefined) result[key as string] = value;
+  }
+  return result as { [K in keyof T]?: NonNullable<T[K]> };
+};
+
+/**
+ * `undefined` and an empty array both mean "nothing to show" for a criteria / pending-sub-step
+ * list — collapses the length check formerly repeated at each of those two call sites.
+ */
+const nonEmptyOrUndefined = <T,>(arr: readonly T[] | undefined): readonly T[] | undefined =>
+  arr !== undefined && arr.length > 0 ? arr : undefined;
+
+type TaskBlockProps = React.ComponentProps<typeof TaskBlock>;
+
+/**
+ * The `TasksPanelProps` fields consumed only inside {@link buildTaskRowProps} — everything
+ * except the handful `TasksPanel` also needs directly, which it destructures by name and
+ * therefore excludes from its own `...rest` binding (see the component below).
+ */
+type TaskRowProps = Omit<
+  TasksPanelProps,
+  'bucketed' | 'maxSignalsPerTask' | 'maxTasks' | 'maxOrphanSignals' | 'inputActive' | 'nowMs' | 'onFocusedCardChange'
+>;
+
+/**
+ * Render-derived values shared by every row this render — the card-cursor/expansion state
+ * (via `useTaskCardState`) plus the row-focus key and first-run flag, bundled so
+ * {@link buildTaskRowProps} takes one argument instead of a dozen positional ones.
+ */
+interface TaskRowDerived {
+  readonly effectiveFocusedKey: string | undefined;
+  readonly expandedKeys: ReadonlySet<string>;
+  readonly criteriaExpandedIds: ReadonlySet<string>;
+  readonly noSignalsYet: boolean;
+  readonly activeTaskIdx: number;
+  readonly effectiveCardCursor: number;
+  readonly isCardExpanded: (taskId: string) => boolean;
+  readonly effectiveNowMs: number;
+  readonly maxSignalsPerTask: number;
+}
+
+/**
+ * Pure per-task derivation for one `TaskBlock` row — absolute index, display name, and the
+ * optional-prop lookups (recovery / criteria / projection / blocked reason / warning / eval /
+ * pending sub-steps), each omitted when its map has no entry for this task.
+ */
+const buildTaskRowProps = (
+  task: TaskBucket,
+  idx: number,
+  rest: TaskRowProps,
+  derived: TaskRowDerived
+): TaskBlockProps => {
+  // Deliberate stylistic 8-char short-uuid fallback (NOT a width-driven clip) — keeps
+  // the header readable when the launcher hasn't supplied a friendly name. The friendly
+  // name path goes through `nameById` and renders verbatim; if a future design makes
+  // the name itself overflow, wrap that path in a `<Box flexGrow>` + `wrap="truncate-end"`.
+  const display = rest.nameById?.get(task.id) ?? `${task.id.slice(0, 8)}${glyphs.clipEllipsis}`;
+  const sliceLen = Math.min(task.signals.length, derived.maxSignalsPerTask);
+  const sliceStart = task.signals.length - sliceLen;
+  // Match by id when a projection is supplied so the order of `sprintState.tasks`
+  // doesn't have to mirror the bucketed order (projections are stored by `order`; bucketed
+  // tasks track the runtime sequence).
+  const taskProjection = rest.sprintState?.tasks.find((t: TaskProjection) => t.id === task.id);
+  return {
+    task,
+    running: rest.running,
+    display,
+    maxSignals: derived.maxSignalsPerTask,
+    // `maxSubStepsPerTask` defaults to 12 on `TasksPanelProps` — reapplied here since this
+    // field is read straight off `rest`, not destructured with a default in `TasksPanel`.
+    maxSubSteps: rest.maxSubStepsPerTask ?? 12,
+    focusedKey: derived.effectiveFocusedKey,
+    expandedKeys: derived.expandedKeys,
+    scopeId: task.id,
+    sliceStart,
+    criteriaExpanded: derived.criteriaExpandedIds.has(task.id),
+    // `showEvaluatorFailureUI` defaults to `false` on `TasksPanelProps` — same reapplication.
+    showEvaluatorFailureUI: rest.showEvaluatorFailureUI ?? false,
+    isActive: idx === derived.activeTaskIdx,
+    firstRun: derived.noSignalsYet,
+    cardExpanded: derived.isCardExpanded(task.id),
+    cardFocused: idx === derived.effectiveCardCursor,
+    nowMs: derived.effectiveNowMs,
+    ...pickDefined({
+      recovering: rest.recoveringByTaskId?.get(task.id),
+      taskCriteria: nonEmptyOrUndefined(rest.taskCriteriaById?.get(task.id)),
+      taskProjection,
+      blockedReason: rest.blockedReasonById?.get(task.id),
+      warningSummary: rest.warningSummaryById?.get(task.id),
+      taskEvaluation: rest.taskEvaluationById?.get(task.id),
+      pendingSubSteps: nonEmptyOrUndefined(rest.pendingSubStepsByTaskId?.get(task.id)),
+    }),
+  };
+};
+
+/** Empty-run placeholder — no tasks and no orphan signals yet. */
+const EmptyTasksPanel = (): React.JSX.Element => (
+  <Box paddingX={spacing.indent}>
+    <Text dimColor>
+      {glyphs.bullet} Tasks panel empty {glyphs.bullet} Run plan to generate tasks
+    </Text>
+  </Box>
+);
+
+/** Dim "N more above/below" cue for the anchored card window's elided rows. */
+const HiddenCountHint = ({
+  glyph,
+  count,
+  label,
+}: {
+  readonly glyph: string;
+  readonly count: number;
+  readonly label: string;
+}): React.JSX.Element => (
+  <Box paddingX={spacing.indent}>
+    <Text dimColor>
+      {glyph} {count} {label}
+    </Text>
+  </Box>
+);
+
+export const TasksPanel = ({
+  bucketed,
+  maxSignalsPerTask = 8,
+  maxTasks,
+  maxOrphanSignals = 6,
+  inputActive = false,
+  nowMs,
+  onFocusedCardChange,
+  ...rest
+}: TasksPanelProps): React.JSX.Element => {
+  // Render-time fallback for the idle-ticker clock. The execute view passes a polled `now` so
+  // the ticker can re-evaluate on each heartbeat; isolated unit renders fall through to this
+  // default, which freezes the clock at mount-time and so naturally suppresses the ticker
+  // unless a test explicitly supplies an old timestamp.
+  const effectiveNowMs = nowMs ?? Date.now();
+  const flatKeys = useMemo(
+    () => buildFlatFocusKeys(bucketed, maxSignalsPerTask, maxOrphanSignals),
+    [bucketed, maxSignalsPerTask, maxOrphanSignals]
+  );
+
+  // Cursor identity is the focused row's stable key (not its index). When a new signal lands
+  // the index of the existing row may shift, but its key is unchanged, so the cursor sticks
+  // to the same row. When the focused key falls off the visible slice (cap-elision), the
+  // cursor collapses to `undefined` and Enter/Space re-anchors at the latest row.
+  const [focusedKey, setFocusedKey] = useState<string | undefined>(undefined);
+  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set<string>());
+  // No lazy hydration — `taskCriteriaById` is supplied synchronously by the host view from
+  // `Task.verificationCriteria`. Empty array → render the placeholder; missing key (task not
+  // yet in view's poll) → criteria UI is suppressed for that task.
+  // Task ids whose criteria block is currently expanded (full bullet list). Default state is
+  // the 3-line summary. Toggled by pressing `e` while the panel owns input.
+  const [criteriaExpandedIds, setCriteriaExpandedIds] = useState<ReadonlySet<string>>(() => new Set());
+
+  // Card-cursor / expansion state — see `useTaskCardState`. Spread wholesale below (into both
+  // `useTasksPanelInput` and `derived`) rather than destructured field-by-field so this
+  // orchestrator stays a thin threading layer instead of re-enumerating the cluster's shape.
+  const cardState = useTaskCardState(bucketed, onFocusedCardChange);
+
+  const focusedIndex = focusedKey !== undefined ? flatKeys.indexOf(focusedKey) : -1;
+  const effectiveFocusedKey = focusedIndex >= 0 ? focusedKey : undefined;
+
   useTasksPanelInput({
     inputActive,
     bucketed,
@@ -287,26 +451,14 @@ export const TasksPanel = ({
     focusedKey,
     focusedIndex,
     effectiveFocusedKey,
-    effectiveCardCursor,
-    focusedCardId,
-    focusedCardExpanded,
-    activeTaskId,
-    expandedTaskIds,
     setFocusedKey,
     setExpandedKeys,
-    setCardCursor,
-    setExpandedTaskIds,
     setCriteriaExpandedIds,
+    ...cardState,
   });
 
   if (bucketed.tasks.length === 0 && bucketed.orphanSignals.length === 0) {
-    return (
-      <Box paddingX={spacing.indent}>
-        <Text dimColor>
-          {glyphs.bullet} Tasks panel empty {glyphs.bullet} Run plan to generate tasks
-        </Text>
-      </Box>
-    );
+    return <EmptyTasksPanel />;
   }
   // First-run state — tasks exist but no harness signal has fired yet across the whole run.
   // The kinds bar is suppressed (it's already empty when no signals are present) and the
@@ -315,20 +467,27 @@ export const TasksPanel = ({
   const noSignalsYet =
     bucketed.orphanSignals.length === 0 &&
     bucketed.tasks.every((t) => t.signals.length === 0 && t.evaluations.length === 0);
-  const kinds = collectKinds(bucketed);
-  const orphanSliceLen = Math.min(bucketed.orphanSignals.length, maxOrphanSignals);
-  const orphanSliceStart = bucketed.orphanSignals.length - orphanSliceLen;
+  const orphanSliceStart = bucketed.orphanSignals.length - Math.min(bucketed.orphanSignals.length, maxOrphanSignals);
   // Anchored card window: keep the active / focused card visible and cap the rendered card
   // count to the terminal-derived budget so the column stops growing past the viewport. Absent
   // `maxTasks` ⇒ full range (no windowing), preserving isolated-render behaviour.
   const taskWindow = computeAnchoredWindow(
     bucketed.tasks.length,
-    effectiveCardCursor,
+    cardState.effectiveCardCursor,
     maxTasks ?? bucketed.tasks.length
   );
+  const derived: TaskRowDerived = {
+    ...cardState,
+    effectiveFocusedKey,
+    expandedKeys,
+    criteriaExpandedIds,
+    noSignalsYet,
+    effectiveNowMs,
+    maxSignalsPerTask,
+  };
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
-      <InlineKindsBar kinds={kinds} />
+      <InlineKindsBar kinds={collectKinds(bucketed)} />
       <OrphanSignals
         signals={bucketed.orphanSignals}
         max={maxOrphanSignals}
@@ -337,76 +496,17 @@ export const TasksPanel = ({
         sliceStart={orphanSliceStart}
       />
       {taskWindow.hiddenBefore > 0 && (
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>
-            {glyphs.moreAbove} {taskWindow.hiddenBefore} more above
-          </Text>
-        </Box>
+        <HiddenCountHint glyph={glyphs.moreAbove} count={taskWindow.hiddenBefore} label="more above" />
       )}
       {bucketed.tasks.slice(taskWindow.start, taskWindow.end).map((task, sliceIdx) => {
         // Absolute index into `bucketed.tasks` — the window slices a sub-range, but `isActive`
         // and `cardFocused` compare against absolute indices (`activeTaskIdx`,
         // `effectiveCardCursor`), so recover the absolute position from the slice offset.
         const idx = taskWindow.start + sliceIdx;
-        // Deliberate stylistic 8-char short-uuid fallback (NOT a width-driven clip) — keeps
-        // the header readable when the launcher hasn't supplied a friendly name. The friendly
-        // name path goes through `nameById` and renders verbatim; if a future design makes
-        // the name itself overflow, wrap that path in a `<Box flexGrow>` + `wrap="truncate-end"`.
-        const display = nameById?.get(task.id) ?? `${task.id.slice(0, 8)}${glyphs.clipEllipsis}`;
-        const recovering = recoveringByTaskId?.get(task.id);
-        const sliceLen = Math.min(task.signals.length, maxSignalsPerTask);
-        const sliceStart = task.signals.length - sliceLen;
-        // Read criteria synchronously from props (audit [05]). Empty arrays / missing keys
-        // suppress the block entirely; non-empty arrays render the "definition of done" criteria
-        // (collapsed 3-line summary, expandable via `e`) — un-marked, no per-criterion verdict.
-        const criteriaBullets = taskCriteriaById?.get(task.id);
-        const taskCriteria = criteriaBullets !== undefined && criteriaBullets.length > 0 ? criteriaBullets : undefined;
-        // Match by id when a projection is supplied so the order of `sprintState.tasks`
-        // doesn't have to mirror the bucketed order (projections are stored by `order`; bucketed
-        // tasks track the runtime sequence).
-        const taskProjection = sprintState?.tasks.find((t: TaskProjection) => t.id === task.id);
-        const blockedReason = blockedReasonById?.get(task.id);
-        const warningSummary = warningSummaryById?.get(task.id);
-        // Authoritative verdict for this task id — drives the card's eval line + the
-        // EvaluatorFailurePanel visibility gate. Never the bucketed signal stream.
-        const taskEvaluation = taskEvaluationById?.get(task.id);
-        const pendingSubSteps = pendingSubStepsByTaskId?.get(task.id);
-        const isActive = idx === activeTaskIdx;
-        return (
-          <TaskBlock
-            key={task.id}
-            task={task}
-            running={running}
-            display={display}
-            maxSignals={maxSignalsPerTask}
-            maxSubSteps={maxSubStepsPerTask}
-            focusedKey={effectiveFocusedKey}
-            expandedKeys={expandedKeys}
-            scopeId={task.id}
-            sliceStart={sliceStart}
-            criteriaExpanded={criteriaExpandedIds.has(task.id)}
-            showEvaluatorFailureUI={showEvaluatorFailureUI}
-            isActive={isActive}
-            firstRun={noSignalsYet}
-            cardExpanded={isCardExpanded(task.id)}
-            cardFocused={idx === effectiveCardCursor}
-            nowMs={effectiveNowMs}
-            {...(recovering !== undefined ? { recovering } : {})}
-            {...(taskCriteria !== undefined ? { taskCriteria } : {})}
-            {...(taskProjection !== undefined ? { taskProjection } : {})}
-            {...(blockedReason !== undefined ? { blockedReason } : {})}
-            {...(warningSummary !== undefined ? { warningSummary } : {})}
-            {...(taskEvaluation !== undefined ? { taskEvaluation } : {})}
-            {...(pendingSubSteps !== undefined && pendingSubSteps.length > 0 ? { pendingSubSteps } : {})}
-          />
-        );
+        return <TaskBlock key={task.id} {...buildTaskRowProps(task, idx, rest, derived)} />;
       })}
       {taskWindow.hiddenAfter > 0 && (
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>
-            {glyphs.moreBelow} {taskWindow.hiddenAfter} more below
-          </Text>
-        </Box>
+        <HiddenCountHint glyph={glyphs.moreBelow} count={taskWindow.hiddenAfter} label="more below" />
       )}
     </Box>
   );

--- a/src/application/ui/tui/components/token-budget-card.tsx
+++ b/src/application/ui/tui/components/token-budget-card.tsx
@@ -39,6 +39,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
+import { fmtTokens } from '@src/application/ui/tui/components/format.ts';
 import { CONTEXT_WIDTH, glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import type { TokenUsage } from '@src/application/ui/tui/runtime/use-token-usage.ts';
 import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
@@ -51,23 +52,6 @@ export interface TokenBudgetCardProps {
 
 /** Width of the context-window progress bar in cells. Sized to fit inside {@link CONTEXT_WIDTH}. */
 const BAR_WIDTH = 10;
-
-/**
- * Compact a token count for display: `200000` → `200k`, `12400` → `12.4k`, `120` → `120`,
- * `1000000` → `1M`, `1200000` → `1.2M`. The context column is narrow; single-char suffixes
- * keep every row scannable. Values ≥ 1M use the `M` suffix so a 1M context-window renders
- * as `1M`, not `1000k`.
- */
-const fmtTokens = (n: number): string => {
-  if (!Number.isFinite(n) || n < 0) return String(n);
-  if (n < 1000) return String(Math.round(n));
-  if (n >= 1_000_000) {
-    const m = n / 1_000_000;
-    return `${m.toFixed(1).replace(/\.0$/, '')}M`;
-  }
-  const k = n / 1000;
-  return k >= 100 ? `${String(Math.round(k))}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
-};
 
 /** Render an ASCII progress bar of the configured width — filled-blocks for used, light-shade for remaining. */
 const renderBar = (filled: number): string => {

--- a/src/application/ui/tui/components/token-budget-card.tsx
+++ b/src/application/ui/tui/components/token-budget-card.tsx
@@ -90,20 +90,45 @@ interface ContextView {
   readonly filled: number;
 }
 
-const computeContext = (usage: TokenUsage): ContextView => {
-  const contextWindow = usage.contextWindow;
-  const hasWindow = contextWindow !== undefined && contextWindow > 0;
+interface LiveUsage {
+  readonly hasLive: boolean;
+  readonly liveUsed: number;
+}
 
+/** Sum of the per-turn LIVE counters (claude `-p` only) — the true window fill when present. */
+const resolveLiveUsage = (usage: TokenUsage): LiveUsage => {
   const hasLive =
     usage.liveInputTokens !== undefined ||
     usage.liveCacheReadTokens !== undefined ||
     usage.liveCacheCreationTokens !== undefined;
   const liveUsed =
     (usage.liveInputTokens ?? 0) + (usage.liveCacheReadTokens ?? 0) + (usage.liveCacheCreationTokens ?? 0);
+  return { hasLive, liveUsed };
+};
 
+interface CumulativeUsage {
+  readonly cumulativeUsed: number;
+  readonly cumulativeFitsWindow: boolean;
+}
+
+/** Cumulative-derived fallback used when the provider reports no per-turn LIVE counters. */
+const resolveCumulativeUsage = (
+  usage: TokenUsage,
+  contextWindow: number | undefined,
+  hasWindow: boolean
+): CumulativeUsage => {
   // Output tokens don't occupy the window, so cumulative context used = input + cacheRead.
   const cumulativeUsed = (usage.inputTokens ?? 0) + (usage.cacheReadTokens ?? 0);
   const cumulativeFitsWindow = hasWindow && contextWindow !== undefined && cumulativeUsed <= contextWindow;
+  return { cumulativeUsed, cumulativeFitsWindow };
+};
+
+const computeContext = (usage: TokenUsage): ContextView => {
+  const contextWindow = usage.contextWindow;
+  const hasWindow = contextWindow !== undefined && contextWindow > 0;
+
+  const { hasLive, liveUsed } = resolveLiveUsage(usage);
+  const { cumulativeUsed, cumulativeFitsWindow } = resolveCumulativeUsage(usage, contextWindow, hasWindow);
 
   const used = hasLive ? liveUsed : cumulativeUsed;
   const showBar = hasWindow && (hasLive || cumulativeFitsWindow);
@@ -113,6 +138,112 @@ const computeContext = (usage: TokenUsage): ContextView => {
 
   return { used, showBar, showCumulativeNote, pct, filled };
 };
+
+interface UsageGroupValues {
+  /** Raw (possibly-undefined) input-token count — rendered as `?` when the provider omitted it. */
+  readonly inputTokens: number | undefined;
+  readonly output: number | undefined;
+  readonly cacheRead: number;
+  readonly cacheTotal: number;
+  readonly cachePct: number | undefined;
+}
+
+/** Cumulative throughput / billing figures for the Usage group, derived from a {@link TokenUsage} record. */
+const computeUsageGroup = (usage: TokenUsage): UsageGroupValues => {
+  const input = usage.inputTokens ?? 0;
+  const cacheRead = usage.cacheReadTokens ?? 0;
+  const cacheCreate = usage.cacheCreationTokens ?? 0;
+  const cacheTotal = cacheRead + cacheCreate;
+
+  // Cache-hit rate: fraction of the prompt served from cache (always 0–100%).
+  // Formula: cacheRead / (cacheRead + input), i.e. how much of the prompt was already cached.
+  const cacheBase = cacheRead + input;
+  const cachePct = cacheBase > 0 && cacheRead > 0 ? Math.round((cacheRead / cacheBase) * 100) : undefined;
+
+  return { inputTokens: usage.inputTokens, output: usage.outputTokens, cacheRead, cacheTotal, cachePct };
+};
+
+/** Cumulative throughput / billing group — input/output totals plus the optional cache-hit row. */
+const UsageGroup = ({ inputTokens, output, cacheRead, cacheTotal, cachePct }: UsageGroupValues): React.JSX.Element => (
+  <>
+    <Text dimColor bold>
+      Usage
+    </Text>
+    {/* input/output row: use a single outer Text wrapper so Ink treats the entire
+        line as one text block — no flex-column splitting between label and value.
+        Inner Text nodes only apply colour; they do not create separate flex items. */}
+    <Text>
+      <Text dimColor>in/out:</Text> {inputTokens !== undefined ? fmtTokens(inputTokens) : '?'} /{' '}
+      {output !== undefined ? fmtTokens(output) : '?'}
+    </Text>
+    {cacheTotal > 0 && (
+      <Box>
+        {/* Explicit standalone space node — Ink collapses trailing spaces inside a
+            styled Text node, so the gap between label and value must be a plain
+            un-styled adjacent node. */}
+        <Text dimColor>cache hit:</Text>
+        <Text> </Text>
+        <Text>{fmtTokens(cacheRead)}</Text>
+        {cachePct !== undefined && (
+          <>
+            <Text> </Text>
+            <Text dimColor>({String(cachePct)}%)</Text>
+          </>
+        )}
+      </Box>
+    )}
+  </>
+);
+
+interface ContextGroupProps {
+  readonly usage: TokenUsage;
+  readonly modelWindowLabel: string | undefined;
+  readonly ctx: ContextView;
+  readonly contextWindow: number | undefined;
+}
+
+/** Effective context-window occupancy group — model label, used/window figure, and the optional % bar. */
+const ContextGroup = ({ usage, modelWindowLabel, ctx, contextWindow }: ContextGroupProps): React.JSX.Element => (
+  <Box marginTop={spacing.gutter} flexDirection="column">
+    <Text dimColor bold>
+      Context
+    </Text>
+    {/* Model descriptor: shows which model's window is the denominator. Omitted when
+        the model is unknown so the card degrades cleanly for providers that don't
+        report a model name. */}
+    {usage.model !== undefined && (
+      <Box>
+        <Text dimColor>{usage.model}</Text>
+        {modelWindowLabel !== undefined && (
+          <>
+            <Text dimColor> {glyphs.bullet} </Text>
+            <Text dimColor>{modelWindowLabel}</Text>
+          </>
+        )}
+      </Box>
+    )}
+    {ctx.showCumulativeNote ? (
+      // Cumulative data over the window: raw total labelled as session-cumulative; no
+      // "/window" denominator and no % bar — a "2.2M / 200k 100%" bar would mislead.
+      <Text>
+        <Text dimColor>session:</Text>
+        {` ${fmtTokens(ctx.used)} `}
+        <Text dimColor>(cumulative)</Text>
+      </Text>
+    ) : (
+      <Text>
+        {fmtTokens(ctx.used)} / {contextWindow !== undefined ? fmtTokens(contextWindow) : '?'}
+      </Text>
+    )}
+    {ctx.showBar && (
+      <Box>
+        <Text color={pctColor(ctx.pct)}>{renderBar(ctx.filled)}</Text>
+        <Text> </Text>
+        <Text color={pctColor(ctx.pct)}>{String(ctx.pct)}%</Text>
+      </Box>
+    )}
+  </Box>
+);
 
 export const TokenBudgetCard = ({ sessionId, usage }: TokenBudgetCardProps): React.JSX.Element => {
   const title = `Tokens · ${shortSession(sessionId)}`;
@@ -130,25 +261,14 @@ export const TokenBudgetCard = ({ sessionId, usage }: TokenBudgetCardProps): Rea
     );
   }
 
-  // ── Usage group: cumulative throughput / billing ──────────────────────────────────────────
-  const input = usage.inputTokens ?? 0;
-  const output = usage.outputTokens;
-  const cacheRead = usage.cacheReadTokens ?? 0;
-  const cacheCreate = usage.cacheCreationTokens ?? 0;
-  const cacheTotal = cacheRead + cacheCreate;
+  const usageGroup = computeUsageGroup(usage);
 
-  // Cache-hit rate: fraction of the prompt served from cache (always 0–100%).
-  // Formula: cacheRead / (cacheRead + input), i.e. how much of the prompt was already cached.
-  const cacheBase = cacheRead + input;
-  const cachePct = cacheBase > 0 && cacheRead > 0 ? Math.round((cacheRead / cacheBase) * 100) : undefined;
-
-  // ── Context group: effective window occupancy ─────────────────────────────────────────────
   const contextWindow = usage.contextWindow;
   const hasLive =
     usage.liveInputTokens !== undefined ||
     usage.liveCacheReadTokens !== undefined ||
     usage.liveCacheCreationTokens !== undefined;
-  const hasUsageData = usage.inputTokens !== undefined || output !== undefined || hasLive;
+  const hasUsageData = usage.inputTokens !== undefined || usage.outputTokens !== undefined || hasLive;
   const ctx = computeContext(usage);
   // Model descriptor for the Context group — shown as a dim sub-label so the denominator
   // (e.g. `53.6k / 200k`) is self-explanatory without needing to cross-reference the header.
@@ -159,74 +279,11 @@ export const TokenBudgetCard = ({ sessionId, usage }: TokenBudgetCardProps): Rea
       <Card title={title} tone="info">
         <Box flexDirection="column">
           {/* ── Usage group (cumulative / billing) ── */}
-          <Text dimColor bold>
-            Usage
-          </Text>
-          {/* input/output row: use a single outer Text wrapper so Ink treats the entire
-              line as one text block — no flex-column splitting between label and value.
-              Inner Text nodes only apply colour; they do not create separate flex items. */}
-          <Text>
-            <Text dimColor>in/out:</Text> {usage.inputTokens !== undefined ? fmtTokens(usage.inputTokens) : '?'} /{' '}
-            {output !== undefined ? fmtTokens(output) : '?'}
-          </Text>
-          {cacheTotal > 0 && (
-            <Box>
-              {/* Explicit standalone space node — Ink collapses trailing spaces inside a
-                  styled Text node, so the gap between label and value must be a plain
-                  un-styled adjacent node. */}
-              <Text dimColor>cache hit:</Text>
-              <Text> </Text>
-              <Text>{fmtTokens(cacheRead)}</Text>
-              {cachePct !== undefined && (
-                <>
-                  <Text> </Text>
-                  <Text dimColor>({String(cachePct)}%)</Text>
-                </>
-              )}
-            </Box>
-          )}
+          <UsageGroup {...usageGroup} />
 
           {/* ── Context group (effective window occupancy) ── */}
           {hasUsageData && (
-            <Box marginTop={spacing.gutter} flexDirection="column">
-              <Text dimColor bold>
-                Context
-              </Text>
-              {/* Model descriptor: shows which model's window is the denominator. Omitted when
-                  the model is unknown so the card degrades cleanly for providers that don't
-                  report a model name. */}
-              {usage.model !== undefined && (
-                <Box>
-                  <Text dimColor>{usage.model}</Text>
-                  {modelWindowLabel !== undefined && (
-                    <>
-                      <Text dimColor> {glyphs.bullet} </Text>
-                      <Text dimColor>{modelWindowLabel}</Text>
-                    </>
-                  )}
-                </Box>
-              )}
-              {ctx.showCumulativeNote ? (
-                // Cumulative data over the window: raw total labelled as session-cumulative; no
-                // "/window" denominator and no % bar — a "2.2M / 200k 100%" bar would mislead.
-                <Text>
-                  <Text dimColor>session:</Text>
-                  {` ${fmtTokens(ctx.used)} `}
-                  <Text dimColor>(cumulative)</Text>
-                </Text>
-              ) : (
-                <Text>
-                  {fmtTokens(ctx.used)} / {contextWindow !== undefined ? fmtTokens(contextWindow) : '?'}
-                </Text>
-              )}
-              {ctx.showBar && (
-                <Box>
-                  <Text color={pctColor(ctx.pct)}>{renderBar(ctx.filled)}</Text>
-                  <Text> </Text>
-                  <Text color={pctColor(ctx.pct)}>{String(ctx.pct)}%</Text>
-                </Box>
-              )}
-            </Box>
+            <ContextGroup usage={usage} modelWindowLabel={modelWindowLabel} ctx={ctx} contextWindow={contextWindow} />
           )}
         </Box>
       </Card>

--- a/src/application/ui/tui/prompts/path-picker-prompt.tsx
+++ b/src/application/ui/tui/prompts/path-picker-prompt.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useState } from 'react';
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, type Key } from 'ink';
 import { TextPrompt } from '@src/application/ui/tui/prompts/text-prompt.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 
@@ -59,18 +59,16 @@ const expandHome = (input: string): string => {
   return input;
 };
 
-export const PathPickerPrompt = ({
-  message,
-  onSubmit,
-  onCancel,
-  initial,
-}: PathPickerPromptProps): React.JSX.Element => {
-  const [cwd, setCwd] = useState<string>(() => expandHome(initial ?? process.cwd()));
+interface DirectoryEntriesState {
+  readonly entries: readonly Entry[];
+  readonly error: string | undefined;
+  readonly setError: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
+
+/** Loads and filters the subdirectories of `cwd`, re-running whenever `cwd` or `showHidden` change. */
+const useDirectoryEntries = (cwd: string, showHidden: boolean): DirectoryEntriesState => {
   const [entries, setEntries] = useState<readonly Entry[]>([]);
-  const [cursor, setCursor] = useState(1); // Default to `[Select this directory]`.
-  const [showHidden, setShowHidden] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [typing, setTyping] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -97,6 +95,168 @@ export const PathPickerPrompt = ({
     };
   }, [cwd, showHidden]);
 
+  return { entries, error, setError };
+};
+
+/** Jumps `cwd` to its parent directory, resetting the cursor onto `[Select this directory]`. */
+const goToParent = (
+  cwd: string,
+  setCwd: React.Dispatch<React.SetStateAction<string>>,
+  setCursor: React.Dispatch<React.SetStateAction<number>>
+): void => {
+  const parent = dirname(cwd);
+  if (parent !== cwd) {
+    setCwd(parent);
+    setCursor(1);
+  }
+};
+
+/** Resolves the `↵` key against the currently focused row: parent / select / open-directory. */
+const handleReturnKey = (
+  rows: readonly Row[],
+  cursor: number,
+  cwd: string,
+  onSubmit: (path: string) => void,
+  setCwd: React.Dispatch<React.SetStateAction<string>>,
+  setCursor: React.Dispatch<React.SetStateAction<number>>
+): void => {
+  const row = rows[cursor];
+  if (row === undefined) return;
+  if (row.kind === 'parent') {
+    goToParent(cwd, setCwd, setCursor);
+    return;
+  }
+  if (row.kind === 'select') {
+    onSubmit(cwd);
+    return;
+  }
+  setCwd(join(cwd, row.entry.name));
+  setCursor(1);
+};
+
+interface PathPickerKeyDeps {
+  readonly cwd: string;
+  readonly rows: readonly Row[];
+  readonly cursor: number;
+  readonly onCancel: () => void;
+  readonly onSubmit: (path: string) => void;
+  readonly setCwd: React.Dispatch<React.SetStateAction<string>>;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+  readonly setShowHidden: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly setError: React.Dispatch<React.SetStateAction<string | undefined>>;
+  readonly setTyping: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+/** Dispatches a single keypress to the matching navigation/action handler. Flat guard sequence — no nesting. */
+const handlePathPickerKey = (input: string, key: Key, deps: PathPickerKeyDeps): void => {
+  const { cwd, rows, cursor, onCancel, onSubmit, setCwd, setCursor, setShowHidden, setError, setTyping } = deps;
+  if (key.escape) {
+    onCancel();
+    return;
+  }
+  if (key.upArrow || input === 'k') {
+    setCursor((c) => clamp(c - 1, 0, rows.length - 1));
+    return;
+  }
+  if (key.downArrow || input === 'j') {
+    setCursor((c) => clamp(c + 1, 0, rows.length - 1));
+    return;
+  }
+  if (key.backspace || key.delete) {
+    goToParent(cwd, setCwd, setCursor);
+    return;
+  }
+  if (input === '~') {
+    setCwd(homedir());
+    setCursor(1);
+    return;
+  }
+  if (input === '.') {
+    setShowHidden((v) => !v);
+    return;
+  }
+  if (input === 't') {
+    setError(undefined);
+    setTyping(true);
+    return;
+  }
+  if (key.return) {
+    handleReturnKey(rows, cursor, cwd, onSubmit, setCwd, setCursor);
+  }
+};
+
+interface SubmitTypedPathDeps {
+  readonly setError: React.Dispatch<React.SetStateAction<string | undefined>>;
+  readonly setTyping: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly onSubmit: (path: string) => void;
+}
+
+/** Validates a manually-typed path exists and is a directory, then submits or reports an error. */
+const submitTypedPath = async (raw: string, { setError, setTyping, onSubmit }: SubmitTypedPathDeps): Promise<void> => {
+  const expanded = expandHome(raw.trim());
+  if (expanded.length === 0) {
+    setTyping(false);
+    return;
+  }
+  try {
+    const stat = await fs.stat(expanded);
+    if (!stat.isDirectory()) {
+      setError(`${expanded} is not a directory`);
+      setTyping(false);
+      return;
+    }
+    setTyping(false);
+    onSubmit(expanded);
+  } catch (err) {
+    setError(err instanceof Error ? err.message : String(err));
+    setTyping(false);
+  }
+};
+
+interface PathPickerRowsProps {
+  readonly rows: readonly Row[];
+  readonly start: number;
+  readonly end: number;
+  readonly cursor: number;
+}
+
+/** Renders the windowed slice of rows plus the "N of M" counter when the list overflows. */
+const PathPickerRows = ({ rows, start, end, cursor }: PathPickerRowsProps): React.JSX.Element => (
+  <>
+    {rows.slice(start, end).map((row, localIdx) => {
+      const idx = start + localIdx;
+      const focused = idx === cursor;
+      const label = labelFor(row);
+      return (
+        <Box key={`${row.kind}-${idx}`} paddingX={spacing.indent}>
+          <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
+            {focused ? glyphs.actionCursor : ' '} {label}
+          </Text>
+        </Box>
+      );
+    })}
+    {rows.length > VISIBLE_ROWS && (
+      <Box paddingX={spacing.indent}>
+        <Text dimColor>
+          {String(cursor + 1)} of {String(rows.length)}
+        </Text>
+      </Box>
+    )}
+  </>
+);
+
+export const PathPickerPrompt = ({
+  message,
+  onSubmit,
+  onCancel,
+  initial,
+}: PathPickerPromptProps): React.JSX.Element => {
+  const [cwd, setCwd] = useState<string>(() => expandHome(initial ?? process.cwd()));
+  const [showHidden, setShowHidden] = useState(false);
+  const { entries, error, setError } = useDirectoryEntries(cwd, showHidden);
+  const [cursor, setCursor] = useState(1); // Default to `[Select this directory]`.
+  const [typing, setTyping] = useState(false);
+
   // Synthetic rows: parent (..) → [Select this directory] → directory entries.
   const rows: readonly Row[] = [
     { kind: 'parent' },
@@ -110,83 +270,21 @@ export const PathPickerPrompt = ({
   }, [rows.length]);
 
   useInput(
-    (input, key) => {
-      if (key.escape) {
-        onCancel();
-        return;
-      }
-      if (key.upArrow || input === 'k') {
-        setCursor((c) => clamp(c - 1, 0, rows.length - 1));
-        return;
-      }
-      if (key.downArrow || input === 'j') {
-        setCursor((c) => clamp(c + 1, 0, rows.length - 1));
-        return;
-      }
-      if (key.backspace || key.delete) {
-        const parent = dirname(cwd);
-        if (parent !== cwd) {
-          setCwd(parent);
-          setCursor(1);
-        }
-        return;
-      }
-      if (input === '~') {
-        setCwd(homedir());
-        setCursor(1);
-        return;
-      }
-      if (input === '.') {
-        setShowHidden((v) => !v);
-        return;
-      }
-      if (input === 't') {
-        setError(undefined);
-        setTyping(true);
-        return;
-      }
-      if (key.return) {
-        const row = rows[cursor];
-        if (row === undefined) return;
-        if (row.kind === 'parent') {
-          const parent = dirname(cwd);
-          if (parent !== cwd) {
-            setCwd(parent);
-            setCursor(1);
-          }
-          return;
-        }
-        if (row.kind === 'select') {
-          onSubmit(cwd);
-          return;
-        }
-        setCwd(join(cwd, row.entry.name));
-        setCursor(1);
-      }
-    },
+    (input, key) =>
+      handlePathPickerKey(input, key, {
+        cwd,
+        rows,
+        cursor,
+        onCancel,
+        onSubmit,
+        setCwd,
+        setCursor,
+        setShowHidden,
+        setError,
+        setTyping,
+      }),
     { isActive: !typing }
   );
-
-  const submitTyped = async (raw: string): Promise<void> => {
-    const expanded = expandHome(raw.trim());
-    if (expanded.length === 0) {
-      setTyping(false);
-      return;
-    }
-    try {
-      const stat = await fs.stat(expanded);
-      if (!stat.isDirectory()) {
-        setError(`${expanded} is not a directory`);
-        setTyping(false);
-        return;
-      }
-      setTyping(false);
-      onSubmit(expanded);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setTyping(false);
-    }
-  };
 
   // Windowed slice around the cursor so deep directories stay scrollable.
   const half = Math.floor(VISIBLE_ROWS / 2);
@@ -209,25 +307,7 @@ export const PathPickerPrompt = ({
         </Box>
       )}
       <Box flexDirection="column" marginTop={1}>
-        {rows.slice(start, end).map((row, localIdx) => {
-          const idx = start + localIdx;
-          const focused = idx === cursor;
-          const label = labelFor(row);
-          return (
-            <Box key={`${row.kind}-${idx}`} paddingX={spacing.indent}>
-              <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
-                {focused ? glyphs.actionCursor : ' '} {label}
-              </Text>
-            </Box>
-          );
-        })}
-        {rows.length > VISIBLE_ROWS && (
-          <Box paddingX={spacing.indent}>
-            <Text dimColor>
-              {String(cursor + 1)} of {String(rows.length)}
-            </Text>
-          </Box>
-        )}
+        <PathPickerRows rows={rows} start={start} end={end} cursor={cursor} />
       </Box>
       {typing ? (
         <Box flexDirection="column" marginTop={1} paddingX={spacing.indent}>
@@ -235,7 +315,7 @@ export const PathPickerPrompt = ({
           <TextPrompt
             message="Path"
             initial={cwd}
-            onSubmit={(value) => void submitTyped(value)}
+            onSubmit={(value) => void submitTypedPath(value, { setError, setTyping, onSubmit })}
             onCancel={() => setTyping(false)}
           />
         </Box>

--- a/src/application/ui/tui/prompts/text-area-prompt.tsx
+++ b/src/application/ui/tui/prompts/text-area-prompt.tsx
@@ -28,8 +28,8 @@
  *   (pgup/pgdn jump roughly a screenful, scrolling the window at the edges)
  */
 
-import React, { useEffect, useRef, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React, { useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { Box, Text, useInput, type Key } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useTerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
 import { normalizePasteNewlines, stripPasteMarkers, usePaste } from '@src/application/ui/tui/prompts/use-paste.ts';
@@ -100,6 +100,362 @@ const isMouseReport = (input: string): boolean => {
   return /^\[<\d+;\d+;\d+[Mm]$/.test(stripped);
 };
 
+/** Move one line up/down (`dir` -1/+1), jumping to the buffer's start/end at either edge. */
+const verticalMoveOffset = (buf: string, line: number, targetCol: number, dir: -1 | 1): number => {
+  if (dir === -1) {
+    if (line === 0) return 0;
+    return lineColToOffset(buf, line - 1, targetCol);
+  }
+  const totalLines = buf.split('\n').length;
+  if (line >= totalLines - 1) return buf.length;
+  return lineColToOffset(buf, line + 1, targetCol);
+};
+
+/** Move roughly a screenful up/down (`dir` -1/+1), clamped to the buffer's first/last line. */
+const pageMoveOffset = (buf: string, line: number, targetCol: number, viewport: number, dir: -1 | 1): number => {
+  if (dir === -1) return lineColToOffset(buf, Math.max(0, line - viewport), targetCol);
+  const total = buf.split('\n').length;
+  return lineColToOffset(buf, Math.min(total - 1, line + viewport), targetCol);
+};
+
+/**
+ * Derive the window of buffer lines to render this render pass: which lines are visible, whether
+ * content is hidden above/below the window, and where the cursor sits within it. `firstVisible`
+ * is the persisted window offset (hysteresis); when the whole buffer fits, the window collapses
+ * to showing every line with no slicing and no cue — byte-for-byte the short-body behaviour.
+ */
+interface TextAreaViewportState {
+  readonly cursorLine: number;
+  readonly cursorCol: number;
+  readonly viewport: number;
+  readonly windowStart: number;
+  readonly visible: readonly string[];
+  readonly hasAbove: boolean;
+  readonly hasBelow: boolean;
+}
+
+const computeViewportState = (
+  buf: string,
+  cursor: number,
+  termRows: number,
+  firstVisible: number
+): TextAreaViewportState => {
+  const lines = buf.split('\n');
+  const { line: cursorLine, col: cursorCol } = offsetToLineCol(buf, cursor);
+  const viewport = Math.max(TEXT_AREA_MIN_VIEWPORT, termRows - TEXT_AREA_CHROME_ROWS);
+  const overflows = lines.length > viewport;
+  // Effective window offset for this render — always contains the cursor line, so the caret and
+  // the hint row below stay on screen no matter how the cursor moved (edit, arrow, paste, page).
+  const windowStart = overflows ? followCursorOffset(firstVisible, cursorLine, viewport, lines.length) : 0;
+  const visible = overflows ? lines.slice(windowStart, windowStart + viewport) : lines;
+  const hasAbove = overflows && windowStart > 0;
+  const hasBelow = overflows && windowStart + viewport < lines.length;
+  return { cursorLine, cursorCol, viewport, windowStart, visible, hasAbove, hasBelow };
+};
+
+/** Bundle of refs/callbacks the `useInput` key-dispatch groups below need to read or mutate. */
+interface TextAreaKeyCtx {
+  readonly bufRef: MutableRefObject<string>;
+  readonly cursorRef: MutableRefObject<number>;
+  readonly desiredColRef: MutableRefObject<number | null>;
+  readonly viewport: number;
+  readonly updateCursor: (next: (prev: number) => number) => void;
+  readonly updateBufAndCursor: (transform: (b: string, c: number) => [string, number]) => void;
+  readonly insertAtCursor: (text: string) => void;
+  readonly onSubmit: (value: string) => void;
+  readonly onCancel: () => void;
+}
+
+/**
+ * Resolve the cursor's current line + the "remembered" column for ↑/↓/PgUp/PgDn navigation.
+ * Seeds `desiredColRef` from the current column on first use so a run of vertical moves keeps
+ * tracking the original column through shorter lines, until a horizontal move or edit clears it.
+ */
+const resolveDesiredCol = (ctx: TextAreaKeyCtx): { line: number; targetCol: number } => {
+  const { line, col } = offsetToLineCol(ctx.bufRef.current, ctx.cursorRef.current);
+  const targetCol = ctx.desiredColRef.current ?? col;
+  if (ctx.desiredColRef.current === null) ctx.desiredColRef.current = col;
+  return { line, targetCol };
+};
+
+/**
+ * Escape / Enter chords — cancel, the \↵ newline-insert convention, and plain-Enter submit.
+ * Always handled (returns true) when reached — the caller has already consumed paste bytes.
+ */
+const handleControlKeys = (_input: string, key: Key, ctx: TextAreaKeyCtx): boolean => {
+  if (key.escape) {
+    ctx.onCancel();
+    return true;
+  }
+  if (key.return) {
+    const b = ctx.bufRef.current;
+    // \↵ chord — strip the trailing backslash and insert a real newline at cursor.
+    if (b.slice(0, ctx.cursorRef.current).endsWith('\\')) {
+      ctx.updateBufAndCursor((b2, c) => {
+        const newBuf = b2.slice(0, c - 1) + '\n' + b2.slice(c);
+        return [newBuf, c]; // cursor stays after the newline (now pointing after the \n)
+      });
+      ctx.desiredColRef.current = null;
+      return true;
+    }
+    ctx.onSubmit(b);
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Cursor-navigation chords: arrows, Home/End (+ ctrl+a/ctrl+e aliases), PgUp/PgDn. Vertical and
+ * page moves share desiredColumn tracking via {@link resolveDesiredCol} so both ↑/↓ and PgUp/PgDn
+ * remember the column through shorter lines.
+ */
+const handleCursorMovement = (input: string, key: Key, ctx: TextAreaKeyCtx): boolean => {
+  if (key.leftArrow) {
+    ctx.updateCursor((c) => Math.max(0, c - 1));
+    ctx.desiredColRef.current = null;
+    return true;
+  }
+  if (key.rightArrow) {
+    ctx.updateCursor((c) => Math.min(ctx.bufRef.current.length, c + 1));
+    ctx.desiredColRef.current = null;
+    return true;
+  }
+  if (key.upArrow) {
+    const { line, targetCol } = resolveDesiredCol(ctx);
+    ctx.updateCursor(() => verticalMoveOffset(ctx.bufRef.current, line, targetCol, -1));
+    return true;
+  }
+  if (key.downArrow) {
+    const { line, targetCol } = resolveDesiredCol(ctx);
+    ctx.updateCursor(() => verticalMoveOffset(ctx.bufRef.current, line, targetCol, 1));
+    return true;
+  }
+  // PgDn / PgUp — move the cursor roughly a screenful; the window follows so the net effect is
+  // a page scroll. Clamped to the buffer's first / last line, no wrap-around.
+  if (key.pageDown) {
+    const { line, targetCol } = resolveDesiredCol(ctx);
+    ctx.updateCursor(() => pageMoveOffset(ctx.bufRef.current, line, targetCol, ctx.viewport, 1));
+    return true;
+  }
+  if (key.pageUp) {
+    const { line, targetCol } = resolveDesiredCol(ctx);
+    ctx.updateCursor(() => pageMoveOffset(ctx.bufRef.current, line, targetCol, ctx.viewport, -1));
+    return true;
+  }
+  // Home / ctrl+a — jump to start of current line.
+  if (key.home || (key.ctrl && input === 'a')) {
+    const { line } = offsetToLineCol(ctx.bufRef.current, ctx.cursorRef.current);
+    ctx.updateCursor(() => lineColToOffset(ctx.bufRef.current, line, 0));
+    ctx.desiredColRef.current = 0;
+    return true;
+  }
+  // End / ctrl+e — jump to end of current line.
+  if (key.end || (key.ctrl && input === 'e')) {
+    const b = ctx.bufRef.current;
+    const { line } = offsetToLineCol(b, ctx.cursorRef.current);
+    const lineLen = b.split('\n')[line]?.length ?? 0;
+    ctx.updateCursor(() => lineColToOffset(b, line, lineLen));
+    ctx.desiredColRef.current = lineLen;
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Buffer-mutating chords: delete/backspace, ctrl+u (clear), ctrl+w (delete word), ctrl+j / literal
+ * `\n` (newline insert), and finally plain printable/pasted-text insertion at the cursor. Reached
+ * only once control keys and cursor movement have both declined the keystroke, so it dispatches
+ * unconditionally instead of returning a handled flag.
+ */
+const handleTextEditing = (input: string, key: Key, ctx: TextAreaKeyCtx): void => {
+  if (key.backspace || key.delete) {
+    ctx.updateBufAndCursor((b, c) => {
+      if (c === 0) return [b, c];
+      return [b.slice(0, c - 1) + b.slice(c), c - 1];
+    });
+    ctx.desiredColRef.current = null;
+    return;
+  }
+  if (key.ctrl && input === 'u') {
+    ctx.updateBufAndCursor(() => ['', 0]);
+    ctx.desiredColRef.current = null;
+    return;
+  }
+  if (key.ctrl && input === 'w') {
+    // Drop trailing whitespace (incl. newlines before cursor), then the preceding word.
+    ctx.updateBufAndCursor((b, c) => {
+      const before = b.slice(0, c);
+      const after = b.slice(c);
+      const trimmed = before.replace(/[\s\n]+$/u, '');
+      const lastBoundary = trimmed.search(/\S+$/u);
+      const newBefore = lastBoundary === -1 ? '' : trimmed.slice(0, lastBoundary);
+      return [newBefore + after, newBefore.length];
+    });
+    ctx.desiredColRef.current = null;
+    return;
+  }
+  // ctrl+j → newline at cursor. Some terminals send the LF byte instead of CR for this chord;
+  // others surface it via `input === '\n'` with no ctrl flag. Handle both.
+  if ((key.ctrl && input === 'j') || input === '\n') {
+    ctx.updateBufAndCursor((b, c) => {
+      const newBuf = b.slice(0, c) + '\n' + b.slice(c);
+      return [newBuf, c + 1];
+    });
+    ctx.desiredColRef.current = null;
+    return;
+  }
+  // Printable characters incl. pasted text. Mouse SGR reports are rejected — the field is
+  // keyboard-only and a leaked wheel event must not type stray bytes. Fallback for terminals
+  // that don't honour mode 2004: a single-chunk paste lands here, so strip any stray paste
+  // markers and normalize `\r\n`/`\r` → `\n` before inserting (kept multi-line, never submit).
+  if (input.length > 0 && !key.meta && !key.ctrl && !key.tab && !isMouseReport(input)) {
+    const ins = normalizePasteNewlines(stripPasteMarkers(input));
+    ctx.insertAtCursor(ins);
+  }
+};
+
+/** Blink the caret every 500ms for as long as the field is mounted. */
+const useCaretBlink = (setCaretOn: (next: (prev: boolean) => boolean) => void): void => {
+  useEffect(() => {
+    const id = setInterval(() => setCaretOn((v) => !v), 500);
+    return () => {
+      clearInterval(id);
+    };
+  }, [setCaretOn]);
+};
+
+/**
+ * Derive this render's viewport state and persist the followed window offset so the next
+ * interaction keeps the window where it settled. The persistence effect is idempotent once the
+ * cursor is inside the window, so it cannot loop.
+ */
+const useTextAreaViewport = (
+  buf: string,
+  cursor: number,
+  termRows: number,
+  firstVisible: number,
+  setFirstVisible: (next: number) => void
+): TextAreaViewportState => {
+  const state = computeViewportState(buf, cursor, termRows, firstVisible);
+  useEffect(() => {
+    if (firstVisible !== state.windowStart) setFirstVisible(state.windowStart);
+  }, [firstVisible, state.windowStart, setFirstVisible]);
+  return state;
+};
+
+/**
+ * Wire the three key-dispatch groups into Ink's `useInput`. Bracketed paste is consumed first so
+ * its bytes and embedded line breaks never reach the dispatch groups — no premature submit.
+ */
+const useTextAreaKeyHandler = (ctx: TextAreaKeyCtx, consumePaste: (input: string) => boolean): void => {
+  useInput((input, key) => {
+    if (consumePaste(input)) return;
+    if (handleControlKeys(input, key, ctx)) return;
+    if (handleCursorMovement(input, key, ctx)) return;
+    handleTextEditing(input, key, ctx);
+  });
+};
+
+interface TextAreaRowProps {
+  readonly line: string;
+  readonly absoluteIndex: number;
+  readonly isActiveLine: boolean;
+  readonly cursorCol: number;
+  readonly caretOn: boolean;
+}
+
+/** One rendered line of the text area — the leading marker/caret column plus the line's text. */
+const TextAreaRow = ({
+  line,
+  absoluteIndex,
+  isActiveLine,
+  cursorCol,
+  caretOn,
+}: TextAreaRowProps): React.JSX.Element => (
+  <Box>
+    <Text dimColor>{absoluteIndex === 0 ? `${glyphs.arrowRight} ` : '  '}</Text>
+    {isActiveLine ? (
+      <>
+        <Text>{line.slice(0, cursorCol)}</Text>
+        {caretOn ? (
+          <>
+            <Text color={inkColors.highlight}>█</Text>
+            <Text>{line.slice(cursorCol + 1)}</Text>
+          </>
+        ) : (
+          <>
+            <Text>{line.slice(cursorCol, cursorCol + 1).length > 0 ? line.slice(cursorCol, cursorCol + 1) : ' '}</Text>
+            <Text>{line.slice(cursorCol + 1)}</Text>
+          </>
+        )}
+      </>
+    ) : (
+      <Text>{line}</Text>
+    )}
+  </Box>
+);
+
+interface TextAreaFrameProps {
+  readonly message: string;
+  readonly escLabel: string;
+  readonly hasAbove: boolean;
+  readonly hasBelow: boolean;
+  readonly visible: readonly string[];
+  readonly windowStart: number;
+  readonly cursorLine: number;
+  readonly cursorCol: number;
+  readonly caretOn: boolean;
+}
+
+/** The header line, the bordered viewport (rows + hidden-content cues), and the hint row. */
+const TextAreaFrame = ({
+  message,
+  escLabel,
+  hasAbove,
+  hasBelow,
+  visible,
+  windowStart,
+  cursorLine,
+  cursorCol,
+  caretOn,
+}: TextAreaFrameProps): React.JSX.Element => (
+  <Box flexDirection="column" paddingX={spacing.indent}>
+    <Text color={inkColors.primary} bold>
+      {glyphs.actionCursor} {message}
+    </Text>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={inkColors.rule}
+      borderDimColor
+      paddingX={spacing.cardPadX}
+      paddingY={0}
+      marginTop={spacing.gutter}
+      marginBottom={spacing.gutter}
+    >
+      {hasAbove ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
+      {visible.map((line, i) => {
+        const absoluteIndex = windowStart + i;
+        const isActiveLine = absoluteIndex === cursorLine;
+        return (
+          <TextAreaRow
+            key={`row-${String(absoluteIndex)}`}
+            line={line}
+            absoluteIndex={absoluteIndex}
+            isActiveLine={isActiveLine}
+            cursorCol={cursorCol}
+            caretOn={caretOn}
+          />
+        );
+      })}
+      {hasBelow ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
+    </Box>
+    <Text dimColor>
+      ↵ submit · \↵ newline · ←/→/↑/↓ cursor · home/end edge · esc {escLabel} · ctrl+w word · ctrl+u clear
+    </Text>
+  </Box>
+);
+
 export const TextAreaPrompt = ({
   message,
   onSubmit,
@@ -156,223 +512,42 @@ export const TextAreaPrompt = ({
   // whole payload here once the closing marker arrives (markers stripped, newlines normalized).
   const paste = usePaste(insertAtCursor);
 
-  useEffect(() => {
-    const id = setInterval(() => setCaretOn((v) => !v), 500);
-    return () => {
-      clearInterval(id);
-    };
-  }, []);
+  useCaretBlink(setCaretOn);
 
-  const lines = buf.split('\n');
-  const { line: cursorLine, col: cursorCol } = offsetToLineCol(buf, cursor);
-  const viewport = Math.max(TEXT_AREA_MIN_VIEWPORT, term.rows - TEXT_AREA_CHROME_ROWS);
-  const overflows = lines.length > viewport;
-  // Effective window offset for this render — always contains the cursor line, so the caret and
-  // the hint row below stay on screen no matter how the cursor moved (edit, arrow, paste, page).
-  const windowStart = overflows ? followCursorOffset(firstVisible, cursorLine, viewport, lines.length) : 0;
+  const { cursorLine, cursorCol, viewport, windowStart, visible, hasAbove, hasBelow } = useTextAreaViewport(
+    buf,
+    cursor,
+    term.rows,
+    firstVisible,
+    setFirstVisible
+  );
 
-  // Persist the followed offset so the next interaction keeps the window where it settled. This
-  // is idempotent once the cursor is inside the window, so it cannot loop.
-  useEffect(() => {
-    if (firstVisible !== windowStart) setFirstVisible(windowStart);
-  }, [firstVisible, windowStart]);
-
-  useInput((input, key) => {
-    // Bracketed paste first: a start marker (or a chunk mid-paste) is consumed here so its bytes
-    // and embedded line breaks never reach the key-dispatch branches below — no premature submit.
-    if (paste.consume(input)) return;
-    if (key.escape) {
-      onCancel();
-      return;
-    }
-    if (key.return) {
-      const b = bufRef.current;
-      // \↵ chord — strip the trailing backslash and insert a real newline at cursor.
-      if (b.slice(0, cursorRef.current).endsWith('\\')) {
-        updateBufAndCursor((b2, c) => {
-          const newBuf = b2.slice(0, c - 1) + '\n' + b2.slice(c);
-          return [newBuf, c]; // cursor stays after the newline (now pointing after the \n)
-        });
-        desiredColRef.current = null;
-        return;
-      }
-      onSubmit(b);
-      return;
-    }
-    if (key.leftArrow) {
-      updateCursor((c) => Math.max(0, c - 1));
-      desiredColRef.current = null;
-      return;
-    }
-    if (key.rightArrow) {
-      updateCursor((c) => Math.min(bufRef.current.length, c + 1));
-      desiredColRef.current = null;
-      return;
-    }
-    if (key.upArrow) {
-      const b = bufRef.current;
-      const c = cursorRef.current;
-      const { line, col } = offsetToLineCol(b, c);
-      const targetCol = desiredColRef.current ?? col;
-      if (desiredColRef.current === null) desiredColRef.current = col;
-      if (line === 0) {
-        // Already on first line — jump to start.
-        updateCursor(() => 0);
-      } else {
-        updateCursor(() => lineColToOffset(b, line - 1, targetCol));
-      }
-      return;
-    }
-    if (key.downArrow) {
-      const b = bufRef.current;
-      const c = cursorRef.current;
-      const { line, col } = offsetToLineCol(b, c);
-      const bufLines = b.split('\n');
-      const targetCol = desiredColRef.current ?? col;
-      if (desiredColRef.current === null) desiredColRef.current = col;
-      if (line >= bufLines.length - 1) {
-        // Already on last line — jump to end.
-        updateCursor(() => b.length);
-      } else {
-        updateCursor(() => lineColToOffset(b, line + 1, targetCol));
-      }
-      return;
-    }
-    // PgDn / PgUp — move the cursor roughly a screenful; the window follows so the net effect is
-    // a page scroll. Clamped to the buffer's first / last line, no wrap-around.
-    if (key.pageDown) {
-      const b = bufRef.current;
-      const { line, col } = offsetToLineCol(b, cursorRef.current);
-      const total = b.split('\n').length;
-      const targetCol = desiredColRef.current ?? col;
-      if (desiredColRef.current === null) desiredColRef.current = col;
-      updateCursor(() => lineColToOffset(b, Math.min(total - 1, line + viewport), targetCol));
-      return;
-    }
-    if (key.pageUp) {
-      const b = bufRef.current;
-      const { line, col } = offsetToLineCol(b, cursorRef.current);
-      const targetCol = desiredColRef.current ?? col;
-      if (desiredColRef.current === null) desiredColRef.current = col;
-      updateCursor(() => lineColToOffset(b, Math.max(0, line - viewport), targetCol));
-      return;
-    }
-    // Home / ctrl+a — jump to start of current line.
-    if (key.home || (key.ctrl && input === 'a')) {
-      const { line } = offsetToLineCol(bufRef.current, cursorRef.current);
-      updateCursor(() => lineColToOffset(bufRef.current, line, 0));
-      desiredColRef.current = 0;
-      return;
-    }
-    // End / ctrl+e — jump to end of current line.
-    if (key.end || (key.ctrl && input === 'e')) {
-      const b = bufRef.current;
-      const { line } = offsetToLineCol(b, cursorRef.current);
-      const lineLen = b.split('\n')[line]?.length ?? 0;
-      updateCursor(() => lineColToOffset(b, line, lineLen));
-      desiredColRef.current = lineLen;
-      return;
-    }
-    if (key.backspace || key.delete) {
-      updateBufAndCursor((b, c) => {
-        if (c === 0) return [b, c];
-        return [b.slice(0, c - 1) + b.slice(c), c - 1];
-      });
-      desiredColRef.current = null;
-      return;
-    }
-    if (key.ctrl && input === 'u') {
-      updateBufAndCursor(() => ['', 0]);
-      desiredColRef.current = null;
-      return;
-    }
-    if (key.ctrl && input === 'w') {
-      // Drop trailing whitespace (incl. newlines before cursor), then the preceding word.
-      updateBufAndCursor((b, c) => {
-        const before = b.slice(0, c);
-        const after = b.slice(c);
-        const trimmed = before.replace(/[\s\n]+$/u, '');
-        const lastBoundary = trimmed.search(/\S+$/u);
-        const newBefore = lastBoundary === -1 ? '' : trimmed.slice(0, lastBoundary);
-        return [newBefore + after, newBefore.length];
-      });
-      desiredColRef.current = null;
-      return;
-    }
-    // ctrl+j → newline at cursor. Some terminals send the LF byte instead of CR for this chord;
-    // others surface it via `input === '\n'` with no ctrl flag. Handle both.
-    if ((key.ctrl && input === 'j') || input === '\n') {
-      updateBufAndCursor((b, c) => {
-        const newBuf = b.slice(0, c) + '\n' + b.slice(c);
-        return [newBuf, c + 1];
-      });
-      desiredColRef.current = null;
-      return;
-    }
-    // Printable characters incl. pasted text. Mouse SGR reports are rejected — the field is
-    // keyboard-only and a leaked wheel event must not type stray bytes. Fallback for terminals
-    // that don't honour mode 2004: a single-chunk paste lands here, so strip any stray paste
-    // markers and normalize `\r\n`/`\r` → `\n` before inserting (kept multi-line, never submit).
-    if (input.length > 0 && !key.meta && !key.ctrl && !key.tab && !isMouseReport(input)) {
-      const ins = normalizePasteNewlines(stripPasteMarkers(input));
-      insertAtCursor(ins);
-    }
-  });
-
-  const visible = overflows ? lines.slice(windowStart, windowStart + viewport) : lines;
-  const hasAbove = overflows && windowStart > 0;
-  const hasBelow = overflows && windowStart + viewport < lines.length;
+  useTextAreaKeyHandler(
+    {
+      bufRef,
+      cursorRef,
+      desiredColRef,
+      viewport,
+      updateCursor,
+      updateBufAndCursor,
+      insertAtCursor,
+      onSubmit,
+      onCancel,
+    },
+    paste.consume
+  );
 
   return (
-    <Box flexDirection="column" paddingX={spacing.indent}>
-      <Text color={inkColors.primary} bold>
-        {glyphs.actionCursor} {message}
-      </Text>
-      <Box
-        flexDirection="column"
-        borderStyle="round"
-        borderColor={inkColors.rule}
-        borderDimColor
-        paddingX={spacing.cardPadX}
-        paddingY={0}
-        marginTop={spacing.gutter}
-        marginBottom={spacing.gutter}
-      >
-        {hasAbove ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
-        {visible.map((line, i) => {
-          const absoluteIndex = windowStart + i;
-          const isActiveLine = absoluteIndex === cursorLine;
-          return (
-            <Box key={`row-${String(absoluteIndex)}`}>
-              <Text dimColor>{absoluteIndex === 0 ? `${glyphs.arrowRight} ` : '  '}</Text>
-              {isActiveLine ? (
-                <>
-                  <Text>{line.slice(0, cursorCol)}</Text>
-                  {caretOn ? (
-                    <>
-                      <Text color={inkColors.highlight}>█</Text>
-                      <Text>{line.slice(cursorCol + 1)}</Text>
-                    </>
-                  ) : (
-                    <>
-                      <Text>
-                        {line.slice(cursorCol, cursorCol + 1).length > 0 ? line.slice(cursorCol, cursorCol + 1) : ' '}
-                      </Text>
-                      <Text>{line.slice(cursorCol + 1)}</Text>
-                    </>
-                  )}
-                </>
-              ) : (
-                <Text>{line}</Text>
-              )}
-            </Box>
-          );
-        })}
-        {hasBelow ? <Text dimColor>{`  ${glyphs.clipEllipsis}`}</Text> : null}
-      </Box>
-      <Text dimColor>
-        ↵ submit · \↵ newline · ←/→/↑/↓ cursor · home/end edge · esc {escLabel} · ctrl+w word · ctrl+u clear
-      </Text>
-    </Box>
+    <TextAreaFrame
+      message={message}
+      escLabel={escLabel}
+      hasAbove={hasAbove}
+      hasBelow={hasBelow}
+      visible={visible}
+      windowStart={windowStart}
+      cursorLine={cursorLine}
+      cursorCol={cursorCol}
+      caretOn={caretOn}
+    />
   );
 };

--- a/src/application/ui/tui/prompts/text-prompt.tsx
+++ b/src/application/ui/tui/prompts/text-prompt.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, type Key } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { stripPasteMarkers, usePaste } from '@src/application/ui/tui/prompts/use-paste.ts';
 
@@ -21,6 +21,135 @@ import { stripPasteMarkers, usePaste } from '@src/application/ui/tui/prompts/use
  * single-line no matter what was on the clipboard.
  */
 const flattenToSingleLine = (text: string): string => text.replace(/\s+/gu, ' ').trim();
+
+type UpdateCursor = (next: (prev: number) => number) => void;
+type UpdateBufAndCursor = (transform: (b: string, c: number) => [string, number]) => void;
+type InsertAtCursor = (text: string) => void;
+
+interface LineBuffer {
+  readonly buf: string;
+  readonly cursor: number;
+  readonly bufRef: React.RefObject<string>;
+  readonly updateCursor: UpdateCursor;
+  readonly updateBufAndCursor: UpdateBufAndCursor;
+  readonly insertAtCursor: InsertAtCursor;
+}
+
+/**
+ * Buffer + cursor state for a single-line editable field, backed by refs so handlers always read
+ * the latest values even when multiple keystrokes arrive between renders (paste + Enter, ctrl+u +
+ * Enter, fast typing).
+ */
+const useLineBuffer = (initial: string): LineBuffer => {
+  const [buf, setBuf] = useState(initial);
+  const [cursor, setCursor] = useState(initial.length);
+
+  const bufRef = useRef<string>(initial);
+  const cursorRef = useRef<number>(initial.length);
+
+  const updateCursor: UpdateCursor = (next) => {
+    setCursor((prev) => {
+      const value = next(prev);
+      cursorRef.current = value;
+      return value;
+    });
+  };
+
+  // Atomically update both buf and cursor to avoid stale-closure races on rapid keystrokes.
+  // The transform receives (prevBuf, prevCursor) and returns [newBuf, newCursor] so both values
+  // are computed from a consistent snapshot without needing to read refs between calls.
+  const updateBufAndCursor: UpdateBufAndCursor = (transform) => {
+    setBuf((prevBuf) => {
+      const prevCursor = cursorRef.current;
+      const [newBuf, newCursor] = transform(prevBuf, prevCursor);
+      bufRef.current = newBuf;
+      cursorRef.current = newCursor;
+      setCursor(newCursor);
+      return newBuf;
+    });
+  };
+
+  // Insert text at the cursor. Routed through updateBufAndCursor so refs stay authoritative.
+  const insertAtCursor: InsertAtCursor = (text) => {
+    if (text.length === 0) return;
+    updateBufAndCursor((b, c) => [b.slice(0, c) + text + b.slice(c), c + text.length]);
+  };
+
+  return { buf, cursor, bufRef, updateCursor, updateBufAndCursor, insertAtCursor };
+};
+
+/** ←/→ and Home/End (+ ctrl+a/ctrl+e) cursor movement. Returns true when the key was handled. */
+const handleNavigationKey = (
+  key: Key,
+  input: string,
+  bufRef: React.RefObject<string>,
+  updateCursor: UpdateCursor
+): boolean => {
+  if (key.leftArrow) {
+    updateCursor((c) => Math.max(0, c - 1));
+    return true;
+  }
+  if (key.rightArrow) {
+    updateCursor((c) => Math.min(bufRef.current.length, c + 1));
+    return true;
+  }
+  // Home / ctrl+a — jump to start of buffer.
+  if (key.home || (key.ctrl && input === 'a')) {
+    updateCursor(() => 0);
+    return true;
+  }
+  // End / ctrl+e — jump to end of buffer.
+  if (key.end || (key.ctrl && input === 'e')) {
+    updateCursor(() => bufRef.current.length);
+    return true;
+  }
+  return false;
+};
+
+/** Backspace/delete, ctrl+u (clear), ctrl+w (delete word). Returns true when the key was handled. */
+const handleEditingKey = (key: Key, input: string, updateBufAndCursor: UpdateBufAndCursor): boolean => {
+  if (key.backspace || key.delete) {
+    updateBufAndCursor((b, c) => {
+      if (c === 0) return [b, c];
+      return [b.slice(0, c - 1) + b.slice(c), c - 1];
+    });
+    return true;
+  }
+  if (key.ctrl && input === 'u') {
+    updateBufAndCursor(() => ['', 0]);
+    return true;
+  }
+  if (key.ctrl && input === 'w') {
+    // Delete from cursor back to the start of the previous word.
+    updateBufAndCursor((b, c) => {
+      const before = b.slice(0, c);
+      const after = b.slice(c);
+      const trimmed = before.replace(/\s+$/u, '');
+      const lastBoundary = trimmed.search(/\S+$/u);
+      const newBefore = lastBoundary === -1 ? '' : trimmed.slice(0, lastBoundary);
+      return [newBefore + after, newBefore.length];
+    });
+    return true;
+  }
+  return false;
+};
+
+/** Printable-character insertion, including the shift+letter and pasted-chunk fallbacks. */
+const handleInsertionKey = (key: Key, input: string, insertAtCursor: InsertAtCursor): void => {
+  // Printable characters (including pasted multi-char input): insert at cursor. Fallback for
+  // terminals that don't honour mode 2004 — a single-chunk paste arrives here. Strip stray paste
+  // markers; if the result still carries newlines (a multi-line paste), flatten it to keep the
+  // field single-line. A plain keystroke (incl. a lone space) is inserted verbatim.
+  if (input.length > 0 && !key.meta && !key.ctrl && !key.tab) {
+    const stripped = stripPasteMarkers(input);
+    insertAtCursor(/[\r\n]/u.test(stripped) ? flattenToSingleLine(stripped) : stripped);
+    return;
+  }
+  if (input.length > 0 && key.shift) {
+    // shift+letter still produces a printable
+    insertAtCursor(stripPasteMarkers(input));
+  }
+};
 
 export interface TextPromptProps {
   readonly message: string;
@@ -41,42 +170,8 @@ export const TextPrompt = ({
   initial = '',
   escLabel = 'cancel',
 }: TextPromptProps): React.JSX.Element => {
-  const [buf, setBuf] = useState(initial);
-  const [cursor, setCursor] = useState(initial.length);
+  const { buf, cursor, bufRef, updateCursor, updateBufAndCursor, insertAtCursor } = useLineBuffer(initial);
   const [caretOn, setCaretOn] = useState(true);
-
-  // Track buffer and cursor in refs so onSubmit/handlers read the latest values even when
-  // multiple keystrokes arrive between renders (paste + Enter, ctrl+u + Enter, fast typing).
-  const bufRef = useRef<string>(initial);
-  const cursorRef = useRef<number>(initial.length);
-
-  const updateCursor = (next: (prev: number) => number): void => {
-    setCursor((prev) => {
-      const value = next(prev);
-      cursorRef.current = value;
-      return value;
-    });
-  };
-
-  // Atomically update both buf and cursor to avoid stale-closure races on rapid keystrokes.
-  // The transform receives (prevBuf, prevCursor) and returns [newBuf, newCursor] so both values
-  // are computed from a consistent snapshot without needing to read refs between calls.
-  const updateBufAndCursor = (transform: (b: string, c: number) => [string, number]): void => {
-    setBuf((prevBuf) => {
-      const prevCursor = cursorRef.current;
-      const [newBuf, newCursor] = transform(prevBuf, prevCursor);
-      bufRef.current = newBuf;
-      cursorRef.current = newCursor;
-      setCursor(newCursor);
-      return newBuf;
-    });
-  };
-
-  // Insert text at the cursor. Routed through updateBufAndCursor so refs stay authoritative.
-  const insertAtCursor = (text: string): void => {
-    if (text.length === 0) return;
-    updateBufAndCursor((b, c) => [b.slice(0, c) + text + b.slice(c), c + text.length]);
-  };
 
   // Bracketed-paste channel. A single-line field flattens the payload: runs of whitespace and the
   // newlines of a multi-line paste collapse to one space so the field stays single-line.
@@ -103,60 +198,9 @@ export const TextPrompt = ({
       onSubmit(bufRef.current);
       return;
     }
-    if (key.leftArrow) {
-      updateCursor((c) => Math.max(0, c - 1));
-      return;
-    }
-    if (key.rightArrow) {
-      updateCursor((c) => Math.min(bufRef.current.length, c + 1));
-      return;
-    }
-    // Home / ctrl+a — jump to start of buffer.
-    if (key.home || (key.ctrl && input === 'a')) {
-      updateCursor(() => 0);
-      return;
-    }
-    // End / ctrl+e — jump to end of buffer.
-    if (key.end || (key.ctrl && input === 'e')) {
-      updateCursor(() => bufRef.current.length);
-      return;
-    }
-    if (key.backspace || key.delete) {
-      updateBufAndCursor((b, c) => {
-        if (c === 0) return [b, c];
-        return [b.slice(0, c - 1) + b.slice(c), c - 1];
-      });
-      return;
-    }
-    if (key.ctrl && input === 'u') {
-      updateBufAndCursor(() => ['', 0]);
-      return;
-    }
-    if (key.ctrl && input === 'w') {
-      // Delete from cursor back to the start of the previous word.
-      updateBufAndCursor((b, c) => {
-        const before = b.slice(0, c);
-        const after = b.slice(c);
-        const trimmed = before.replace(/\s+$/u, '');
-        const lastBoundary = trimmed.search(/\S+$/u);
-        const newBefore = lastBoundary === -1 ? '' : trimmed.slice(0, lastBoundary);
-        return [newBefore + after, newBefore.length];
-      });
-      return;
-    }
-    // Printable characters (including pasted multi-char input): insert at cursor. Fallback for
-    // terminals that don't honour mode 2004 — a single-chunk paste arrives here. Strip stray paste
-    // markers; if the result still carries newlines (a multi-line paste), flatten it to keep the
-    // field single-line. A plain keystroke (incl. a lone space) is inserted verbatim.
-    if (input.length > 0 && !key.meta && !key.ctrl && !key.tab) {
-      const stripped = stripPasteMarkers(input);
-      insertAtCursor(/[\r\n]/u.test(stripped) ? flattenToSingleLine(stripped) : stripped);
-      return;
-    }
-    if (input.length > 0 && key.shift) {
-      // shift+letter still produces a printable
-      insertAtCursor(stripPasteMarkers(input));
-    }
+    if (handleNavigationKey(key, input, bufRef, updateCursor)) return;
+    if (handleEditingKey(key, input, updateBufAndCursor)) return;
+    handleInsertionKey(key, input, insertAtCursor);
   });
 
   // Render the single input line with the caret at the cursor position.

--- a/src/application/ui/tui/runtime/session-manager.ts
+++ b/src/application/ui/tui/runtime/session-manager.ts
@@ -41,6 +41,13 @@ const SESSION_RUNNING_CEILING = 200;
 const isTerminal = (status: RunnerStatus): boolean =>
   status === 'completed' || status === 'failed' || status === 'aborted';
 
+// Age key for ordering / TTL: prefer the descriptor's `finishedAt`. Terminal records registered
+// via the synthetic-replay path (runner reaches terminal before `register()` runs) will have
+// `finishedAt` populated during the sync replay — but if a future runner contract change drops
+// that guarantee, fall back to `startedAt` so the record is still LRU-eligible instead of
+// becoming an un-evictable leak.
+const ageKey = (rec: SessionRecord): number => rec.descriptor.finishedAt ?? rec.descriptor.startedAt;
+
 /**
  * Replace a terminal record's live {@link Runner} with a frozen stub that preserves the identity +
  * status + trace the UI reads, but drops the strong reference to the live runner closure — whose
@@ -166,6 +173,323 @@ export interface SessionRecord {
 
 export type SessionListener = () => void;
 
+/**
+ * The subset of {@link SessionDescriptor}'s optional fields that `register()` accepts directly
+ * from the caller (as opposed to `finishedAt` / `error`, which are only ever set internally by
+ * {@link update}). Named explicitly — rather than derived via `Omit` from the whole descriptor —
+ * so the whitelist stays a compile-time-checked, self-contained contract for
+ * {@link withDefinedFields}.
+ */
+type RegisterOptionalFields = Pick<
+  SessionDescriptor,
+  | 'taskNames'
+  | 'maxTurns'
+  | 'maxAttempts'
+  | 'plannedLeaves'
+  | 'planLabelByName'
+  | 'terminalSubstepName'
+  | 'taskRecovering'
+  | 'generatorModel'
+  | 'evaluatorModel'
+  | 'generatorProvider'
+  | 'evaluatorProvider'
+  | 'generatorEffort'
+  | 'evaluatorEffort'
+  | 'pinnedProjectId'
+  | 'pinnedProjectLabel'
+  | 'pinnedSprintId'
+  | 'pinnedSprintLabel'
+>;
+
+/**
+ * Mirrors {@link RegisterOptionalFields} but with every key REQUIRED (its value may still be
+ * `undefined`) — the shape of a destructured `{ taskNames, maxTurns, ... }` object literal, where
+ * every name is always present as a key even when its value is `undefined`. Distinct from the
+ * optional-key `RegisterOptionalFields` because of `exactOptionalPropertyTypes: true`.
+ */
+type RegisterOptionalFieldsInput = {
+  readonly [K in keyof RegisterOptionalFields]-?: RegisterOptionalFields[K] | undefined;
+};
+
+/**
+ * Copy only the DEFINED keys from `fields` onto a fresh object. Replaces 17 independent
+ * `...(x !== undefined ? {x} : {})` conditional spreads — the sole source of `register`'s former
+ * complexity/cognitive warnings — with one loop over an explicit whitelist. Keys are OMITTED
+ * (never set to `undefined`) per `exactOptionalPropertyTypes: true` and the "leaves pinned fields
+ * undefined when not supplied" contract.
+ *
+ * Callers MUST pass an explicit whitelist object literal (`{ taskNames, maxTurns, ... }`), never
+ * the raw `register()` input — the input also carries the always-defined `runner` / `flowId` /
+ * `title`, which this generic copy would otherwise reattach to the descriptor and pin the live
+ * runner's heavy ctx past terminal (the exact retention `terminalRunnerStub` exists to avoid).
+ */
+const withDefinedFields = (fields: RegisterOptionalFieldsInput): RegisterOptionalFields => {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out as RegisterOptionalFields;
+};
+
+/**
+ * Subscribe to `runner`'s lifecycle, auto-detaching once the run reaches terminal — mirrors the
+ * chain-runner-bridge pattern (see `observability/chain-runner-bridge.ts`) so every dead
+ * Implement run drops its listener instead of accumulating on `runner.subscribe`'s internal Set
+ * across a long multi-run TUI session, each closure otherwise pinning the runner's trace buffer
+ * for the harness lifetime.
+ */
+const attachRunnerLifecycle = (
+  runner: Runner<unknown>,
+  handlers: {
+    readonly onStarted: () => void;
+    readonly onStep: () => void;
+    readonly onCompleted: () => void;
+    readonly onFailed: (error: DomainError) => void;
+    readonly onAborted: () => void;
+  }
+): void => {
+  // `unsub` doubles as state: `null` before subscribe completes or after detach; a function while
+  // the subscription is live. The listener can fire synchronously during `runner.subscribe(...)`
+  // for an already-terminal runner (sync-replay); when that happens `unsub` is still null inside
+  // `detach()`, so we record `pendingDetach` and re-run detach once subscribe has returned.
+  let unsub: (() => void) | null = null;
+  let pendingDetach = false;
+  const detach = (): void => {
+    if (unsub === null) {
+      pendingDetach = true;
+      return;
+    }
+    const fn = unsub;
+    unsub = null;
+    fn();
+  };
+
+  unsub = runner.subscribe((event) => {
+    switch (event.type) {
+      case 'started':
+        handlers.onStarted();
+        return;
+      case 'step':
+        handlers.onStep(); // trace-only wakeup, no descriptor rebuild — see touchTrace
+        return;
+      case 'completed':
+        handlers.onCompleted();
+        detach();
+        return;
+      case 'failed':
+        handlers.onFailed(event.error);
+        detach();
+        return;
+      case 'aborted':
+        handlers.onAborted();
+        detach();
+    }
+  });
+  // Sync-replay case (already-terminal runner during register): the listener fired before
+  // `unsub` was assigned, so detach() recorded `pendingDetach` and returned. Re-run it now that
+  // the assignment has completed.
+  if (pendingDetach) detach();
+};
+
+const notify = (listeners: ReadonlySet<SessionListener>): void => {
+  for (const fn of [...listeners]) {
+    try {
+      fn();
+    } catch (err) {
+      console.warn('[session-manager] listener threw:', err);
+    }
+  }
+};
+
+// TTL pass: drop terminal records older than the window.
+const evictExpiredTerminals = (records: Map<string, SessionRecord>, now: number): boolean => {
+  let removed = false;
+  for (const [id, rec] of records) {
+    if (isTerminal(rec.descriptor.status) && now - ageKey(rec) > SESSION_RECORD_TTL_MS) {
+      records.delete(id);
+      removed = true;
+    }
+  }
+  return removed;
+};
+
+// While above `cap`, drop the oldest record matching `pick`, ordered ascending by `order`.
+const evictOldestWhileOverCap = (
+  records: Map<string, SessionRecord>,
+  cap: number,
+  pick: (rec: SessionRecord) => boolean,
+  order: (rec: SessionRecord) => number
+): boolean => {
+  if (records.size <= cap) return false;
+  let removed = false;
+  const candidates = [...records.values()].filter(pick).sort((a, b) => order(a) - order(b));
+  for (const rec of candidates) {
+    if (records.size <= cap) break;
+    records.delete(rec.descriptor.id);
+    removed = true;
+  }
+  return removed;
+};
+
+const evict = (records: Map<string, SessionRecord>, now: number): boolean => {
+  let removed = evictExpiredTerminals(records, now);
+  // Soft LRU: shed the oldest TERMINAL records (running / queued are protected).
+  removed =
+    evictOldestWhileOverCap(records, SESSION_LRU_CAP, (r) => isTerminal(r.descriptor.status), ageKey) || removed;
+  // Emergency relief: if STILL over the hard ceiling, terminal records are exhausted and the
+  // overflow is live runs (the leak pathology). Shed the oldest RUNNING records as last resort —
+  // a healthy session never reaches the ceiling; their runners keep running detached.
+  removed =
+    evictOldestWhileOverCap(
+      records,
+      SESSION_RUNNING_CEILING,
+      (r) => !isTerminal(r.descriptor.status),
+      (r) => r.descriptor.startedAt
+    ) || removed;
+  return removed;
+};
+
+const update = (
+  records: Map<string, SessionRecord>,
+  listeners: ReadonlySet<SessionListener>,
+  clock: () => number,
+  id: string,
+  patch: Partial<SessionDescriptor>
+): void => {
+  const cur = records.get(id);
+  if (!cur) return;
+  const descriptor = { ...cur.descriptor, ...patch };
+  const goingTerminal = patch.status !== undefined && isTerminal(patch.status);
+  // On the terminal transition, swap the live runner for a frozen stub that keeps id/status/trace
+  // but drops the strong reference to the heavy forked ctx (the implement worktree ctx). The
+  // descriptor already snapshots the trace; nothing reads `runner.ctx` after terminal. This frees
+  // the dominant retainer AT terminal instead of waiting for TTL / LRU eviction. The original
+  // runner is no longer needed — its `abort()` is a no-op once terminal.
+  const runner = goingTerminal
+    ? terminalRunnerStub(cur.runner.id, patch.status!, descriptor.trace, descriptor.error)
+    : cur.runner;
+  records.set(id, { descriptor, runner });
+  if (goingTerminal) evict(records, clock());
+  notify(listeners);
+};
+
+/**
+ * Trace-only "step" wakeup. The descriptor's `trace` field already points at the runner's
+ * shared-mutable trace array from `register()` (the runner never reassigns it — see runner.ts),
+ * so a `step` mutates that array IN PLACE and the descriptor needs NO rebuild. We therefore notify
+ * subscribers WITHOUT spreading a fresh descriptor / record. This kills the per-step amplifier:
+ * previously every `step` allocated a new descriptor object, which invalidated the execute view's
+ * `useBucketedTasks` memo (keyed on the descriptor reference) and re-ran `bucketTaskSignals` over
+ * the whole trace on every leaf step of every task. Status-gated consumers (`useSessions` /
+ * `useSession` / `use-sprint-bundle`) already ignore step notifies; the live flow-steps rail stays
+ * current via the shared-mutable trace array + the sibling chainEvents re-render, exactly as the
+ * sigOf comment in sessions-context.tsx documents.
+ */
+const touchTrace = (
+  records: ReadonlyMap<string, SessionRecord>,
+  listeners: ReadonlySet<SessionListener>,
+  id: string
+): void => {
+  if (!records.has(id)) return;
+  notify(listeners);
+};
+
+const shedTerminalRecords = (records: Map<string, SessionRecord>, listeners: ReadonlySet<SessionListener>): number => {
+  let dropped = 0;
+  for (const [id, rec] of records) {
+    if (isTerminal(rec.descriptor.status)) {
+      records.delete(id);
+      dropped += 1;
+    }
+  }
+  if (dropped > 0) notify(listeners);
+  return dropped;
+};
+
+const registerSession = (
+  records: Map<string, SessionRecord>,
+  listeners: ReadonlySet<SessionListener>,
+  clock: () => number,
+  input: Parameters<SessionManager['register']>[0]
+): SessionRecord => {
+  const {
+    runner,
+    flowId,
+    title,
+    taskNames,
+    maxTurns,
+    maxAttempts,
+    plannedLeaves,
+    planLabelByName,
+    terminalSubstepName,
+    taskRecovering,
+    generatorModel,
+    evaluatorModel,
+    generatorProvider,
+    evaluatorProvider,
+    generatorEffort,
+    evaluatorEffort,
+    pinnedProjectId,
+    pinnedProjectLabel,
+    pinnedSprintId,
+    pinnedSprintLabel,
+  } = input;
+
+  evict(records, clock());
+  const descriptor: SessionDescriptor = {
+    id: runner.id,
+    flowId,
+    title,
+    status: runner.status,
+    startedAt: clock(),
+    trace: runner.trace,
+    ...withDefinedFields({
+      taskNames,
+      maxTurns,
+      maxAttempts,
+      plannedLeaves,
+      planLabelByName,
+      terminalSubstepName,
+      taskRecovering,
+      generatorModel,
+      evaluatorModel,
+      generatorProvider,
+      evaluatorProvider,
+      generatorEffort,
+      evaluatorEffort,
+      pinnedProjectId,
+      pinnedProjectLabel,
+      pinnedSprintId,
+      pinnedSprintLabel,
+    }),
+  };
+  const record: SessionRecord = { descriptor, runner: runner as Runner<unknown> };
+  records.set(runner.id, record);
+  notify(listeners);
+
+  attachRunnerLifecycle(runner, {
+    onStarted: () => update(records, listeners, clock, runner.id, { status: 'running' }),
+    onStep: () => touchTrace(records, listeners, runner.id),
+    onCompleted: () =>
+      update(records, listeners, clock, runner.id, {
+        status: 'completed',
+        finishedAt: clock(),
+        trace: runner.trace,
+      }),
+    onFailed: (error) =>
+      update(records, listeners, clock, runner.id, {
+        status: 'failed',
+        finishedAt: clock(),
+        trace: runner.trace,
+        error,
+      }),
+    onAborted: () =>
+      update(records, listeners, clock, runner.id, { status: 'aborted', finishedAt: clock(), trace: runner.trace }),
+  });
+
+  return record;
+};
+
 export interface SessionManager {
   list(): readonly SessionRecord[];
   get(id: string): SessionRecord | undefined;
@@ -223,233 +547,18 @@ export const createSessionManager = (opts?: { readonly clock?: () => number }): 
   const records = new Map<string, SessionRecord>();
   const listeners = new Set<SessionListener>();
 
-  const notify = (): void => {
-    for (const fn of [...listeners]) {
-      try {
-        fn();
-      } catch (err) {
-        console.warn('[session-manager] listener threw:', err);
-      }
-    }
-  };
-
-  // Age key for ordering / TTL: prefer the descriptor's `finishedAt`. Terminal records
-  // registered via the synthetic-replay path (runner reaches terminal before `register()` runs)
-  // will have `finishedAt` populated during the sync replay — but if a future runner contract
-  // change drops that guarantee, fall back to `startedAt` so the record is still LRU-eligible
-  // instead of becoming an un-evictable leak.
-  const ageKey = (rec: SessionRecord): number => rec.descriptor.finishedAt ?? rec.descriptor.startedAt;
-
-  // TTL pass: drop terminal records older than the window.
-  const evictExpiredTerminals = (now: number): boolean => {
-    let removed = false;
-    for (const [id, rec] of records) {
-      if (isTerminal(rec.descriptor.status) && now - ageKey(rec) > SESSION_RECORD_TTL_MS) {
-        records.delete(id);
-        removed = true;
-      }
-    }
-    return removed;
-  };
-
-  // While above `cap`, drop the oldest record matching `pick`, ordered ascending by `order`.
-  const evictOldestWhileOverCap = (
-    cap: number,
-    pick: (rec: SessionRecord) => boolean,
-    order: (rec: SessionRecord) => number
-  ): boolean => {
-    if (records.size <= cap) return false;
-    let removed = false;
-    const candidates = [...records.values()].filter(pick).sort((a, b) => order(a) - order(b));
-    for (const rec of candidates) {
-      if (records.size <= cap) break;
-      records.delete(rec.descriptor.id);
-      removed = true;
-    }
-    return removed;
-  };
-
-  const evict = (now: number): boolean => {
-    let removed = evictExpiredTerminals(now);
-    // Soft LRU: shed the oldest TERMINAL records (running / queued are protected).
-    removed = evictOldestWhileOverCap(SESSION_LRU_CAP, (r) => isTerminal(r.descriptor.status), ageKey) || removed;
-    // Emergency relief: if STILL over the hard ceiling, terminal records are exhausted and the
-    // overflow is live runs (the leak pathology). Shed the oldest RUNNING records as last resort —
-    // a healthy session never reaches the ceiling; their runners keep running detached.
-    removed =
-      evictOldestWhileOverCap(
-        SESSION_RUNNING_CEILING,
-        (r) => !isTerminal(r.descriptor.status),
-        (r) => r.descriptor.startedAt
-      ) || removed;
-    return removed;
-  };
-
-  const update = (id: string, patch: Partial<SessionDescriptor>): void => {
-    const cur = records.get(id);
-    if (!cur) return;
-    const descriptor = { ...cur.descriptor, ...patch };
-    const goingTerminal = patch.status !== undefined && isTerminal(patch.status);
-    // On the terminal transition, swap the live runner for a frozen stub that keeps id/status/trace
-    // but drops the strong reference to the heavy forked ctx (the implement worktree ctx). The
-    // descriptor already snapshots the trace; nothing reads `runner.ctx` after terminal. This frees
-    // the dominant retainer AT terminal instead of waiting for TTL / LRU eviction. The original
-    // runner is no longer needed — its `abort()` is a no-op once terminal.
-    const runner = goingTerminal
-      ? terminalRunnerStub(cur.runner.id, patch.status!, descriptor.trace, descriptor.error)
-      : cur.runner;
-    records.set(id, { descriptor, runner });
-    if (goingTerminal) evict(clock());
-    notify();
-  };
-
-  /**
-   * Trace-only "step" wakeup. The descriptor's `trace` field already points at the runner's
-   * shared-mutable trace array from `register()` (the runner never reassigns it — see runner.ts),
-   * so a `step` mutates that array IN PLACE and the descriptor needs NO rebuild. We therefore notify
-   * subscribers WITHOUT spreading a fresh descriptor / record. This kills the per-step amplifier:
-   * previously every `step` allocated a new descriptor object, which invalidated the execute view's
-   * `useBucketedTasks` memo (keyed on the descriptor reference) and re-ran `bucketTaskSignals` over
-   * the whole trace on every leaf step of every task. Status-gated consumers (`useSessions` /
-   * `useSession` / `use-sprint-bundle`) already ignore step notifies; the live flow-steps rail stays
-   * current via the shared-mutable trace array + the sibling chainEvents re-render, exactly as the
-   * sigOf comment in sessions-context.tsx documents.
-   */
-  const touchTrace = (id: string): void => {
-    if (!records.has(id)) return;
-    notify();
-  };
-
   return {
-    list(): readonly SessionRecord[] {
-      return [...records.values()].sort((a, b) => a.descriptor.startedAt - b.descriptor.startedAt);
+    list: () => [...records.values()].sort((a, b) => a.descriptor.startedAt - b.descriptor.startedAt),
+    get: (id) => records.get(id),
+    register: (input) => registerSession(records, listeners, clock, input),
+    abort: (id) => records.get(id)?.runner.abort('user requested'),
+    remove: (id) => {
+      if (records.delete(id)) notify(listeners);
     },
-    get(id: string): SessionRecord | undefined {
-      return records.get(id);
-    },
-    register({
-      runner,
-      flowId,
-      title,
-      taskNames,
-      maxTurns,
-      maxAttempts,
-      plannedLeaves,
-      planLabelByName,
-      terminalSubstepName,
-      taskRecovering,
-      generatorModel,
-      evaluatorModel,
-      generatorProvider,
-      evaluatorProvider,
-      generatorEffort,
-      evaluatorEffort,
-      pinnedProjectId,
-      pinnedProjectLabel,
-      pinnedSprintId,
-      pinnedSprintLabel,
-    }): SessionRecord {
-      evict(clock());
-      const descriptor: SessionDescriptor = {
-        id: runner.id,
-        flowId,
-        title,
-        status: runner.status,
-        startedAt: clock(),
-        trace: runner.trace,
-        ...(taskNames !== undefined ? { taskNames } : {}),
-        ...(maxTurns !== undefined ? { maxTurns } : {}),
-        ...(maxAttempts !== undefined ? { maxAttempts } : {}),
-        ...(plannedLeaves !== undefined ? { plannedLeaves } : {}),
-        ...(planLabelByName !== undefined ? { planLabelByName } : {}),
-        ...(terminalSubstepName !== undefined ? { terminalSubstepName } : {}),
-        ...(taskRecovering !== undefined ? { taskRecovering } : {}),
-        ...(generatorModel !== undefined ? { generatorModel } : {}),
-        ...(evaluatorModel !== undefined ? { evaluatorModel } : {}),
-        ...(generatorProvider !== undefined ? { generatorProvider } : {}),
-        ...(evaluatorProvider !== undefined ? { evaluatorProvider } : {}),
-        ...(generatorEffort !== undefined ? { generatorEffort } : {}),
-        ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
-        ...(pinnedProjectId !== undefined ? { pinnedProjectId } : {}),
-        ...(pinnedProjectLabel !== undefined ? { pinnedProjectLabel } : {}),
-        ...(pinnedSprintId !== undefined ? { pinnedSprintId } : {}),
-        ...(pinnedSprintLabel !== undefined ? { pinnedSprintLabel } : {}),
-      };
-      const record: SessionRecord = { descriptor, runner: runner as Runner<unknown> };
-      records.set(runner.id, record);
-      notify();
-
-      // Mirror the chain-runner-bridge pattern: hold the unsubscribe in a 1-slot box so the
-      // listener can release itself on terminal. Without this, every dead Implement run leaves
-      // a permanent listener on `runner.subscribe`'s internal Set across a long multi-run TUI
-      // session — and each closure pins the runner's trace buffer for the harness lifetime.
-      let unsub: (() => void) | null = null;
-      let pendingDetach = false;
-      const detach = (): void => {
-        if (unsub === null) {
-          pendingDetach = true;
-          return;
-        }
-        const fn = unsub;
-        unsub = null;
-        fn();
-      };
-
-      unsub = runner.subscribe((event) => {
-        switch (event.type) {
-          case 'started':
-            update(runner.id, { status: 'running' });
-            return;
-          case 'step':
-            touchTrace(runner.id); // trace-only wakeup, no descriptor rebuild — see touchTrace
-            return;
-          case 'completed':
-            update(runner.id, { status: 'completed', finishedAt: clock(), trace: runner.trace });
-            detach();
-            return;
-          case 'failed':
-            update(runner.id, {
-              status: 'failed',
-              finishedAt: clock(),
-              trace: runner.trace,
-              error: event.error,
-            });
-            detach();
-            return;
-          case 'aborted':
-            update(runner.id, { status: 'aborted', finishedAt: clock(), trace: runner.trace });
-            detach();
-        }
-      });
-      // Sync-replay case (already-terminal runner during register): the listener fired before
-      // `unsub` was assigned, so detach() recorded `pendingDetach` and returned. Re-run it now
-      // that the assignment has completed.
-      if (pendingDetach) detach();
-
-      return record;
-    },
-    abort(id: string): void {
-      const rec = records.get(id);
-      rec?.runner.abort('user requested');
-    },
-    remove(id: string): void {
-      if (records.delete(id)) notify();
-    },
-    shedTerminal(): number {
-      let dropped = 0;
-      for (const [id, rec] of records) {
-        if (isTerminal(rec.descriptor.status)) {
-          records.delete(id);
-          dropped += 1;
-        }
-      }
-      if (dropped > 0) notify();
-      return dropped;
-    },
-    setPinnedSprint(runnerId: string, sprintId: SprintId, sprintLabel: string): void {
-      update(runnerId, { pinnedSprintId: sprintId, pinnedSprintLabel: sprintLabel });
-    },
-    subscribe(fn: SessionListener): () => void {
+    shedTerminal: () => shedTerminalRecords(records, listeners),
+    setPinnedSprint: (runnerId, sprintId, sprintLabel) =>
+      update(records, listeners, clock, runnerId, { pinnedSprintId: sprintId, pinnedSprintLabel: sprintLabel }),
+    subscribe: (fn) => {
       listeners.add(fn);
       return () => {
         listeners.delete(fn);

--- a/src/application/ui/tui/runtime/use-coalesced-map.ts
+++ b/src/application/ui/tui/runtime/use-coalesced-map.ts
@@ -1,0 +1,99 @@
+/**
+ * Keyed-Map sibling of {@link useCoalescedBuffer} — folds a hot AppEvent subscription into a
+ * `Map<key, V>` instead of a trailing array, at most once per flush window.
+ *
+ * Owns only the mechanical plumbing shared by every per-key AppEvent tracker: buffer
+ * construction, the lazy-clone fold-then-trim reducer, and unsub->flushNow->stop cleanup. The
+ * accept predicate, keying, per-event fold, and cap are all caller-supplied — retention rationale
+ * and audit docs stay in each caller's own hook file (`use-token-usage.ts`,
+ * `use-task-round-tracker.ts`, …).
+ *
+ * Within-batch threading: `existing` is looked up via `(next ?? prev).get(key)` BEFORE `fold`
+ * runs, so a later same-key event in the batch sees the value an earlier one in the same batch
+ * just folded — not the pre-batch state. Lazy-clone: `next` is only allocated once some event's
+ * `fold` returns non-`undefined`; if every event in a batch is skipped (fold returns `undefined`
+ * for all of them), `prev` is returned unchanged and no re-render happens.
+ */
+
+import { useEffect, useState } from 'react';
+import type { AppEvent } from '@src/business/observability/events.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import { createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+
+/** @public */
+export interface UseCoalescedMapOptions<E extends AppEvent, V> {
+  /** Hard cap on retained Map entries — also doubles as the coalescing buffer's per-window cap. */
+  readonly cap: number;
+  /** Flush cadence in ms. Test-only escape hatch; production callers use the coalescer default. */
+  readonly flushMs?: number;
+  /** Narrows the bus's `AppEvent` union to the events this tracker folds. */
+  readonly accept: (e: AppEvent) => e is E;
+  /** Derives the Map key for an accepted event. */
+  readonly keyOf: (e: E) => string;
+  /**
+   * Folds an accepted event into the Map value for its key. Return `undefined` to skip the event
+   * (e.g. a stale/out-of-order update) — the existing entry, if any, is left untouched.
+   */
+  readonly fold: (existing: V | undefined, e: E) => V | undefined;
+}
+
+/**
+ * Subscribe to `accept`-matching events on `bus` and fold them into a `Map<key, V>` via `fold`.
+ * Returns a fresh Map on every update so React's referential equality check triggers re-renders.
+ *
+ * Events feed a `createCoalescedBuffer` (delta semantics via `clearOnFlush`), so a burst of
+ * publishes folds into the Map in a single `setState` per flush window — decoupling the publish
+ * rate from React's commit rate.
+ */
+export const useCoalescedMap = <E extends AppEvent, V>(
+  bus: EventBus,
+  opts: UseCoalescedMapOptions<E, V>
+): ReadonlyMap<string, V> => {
+  const { cap, flushMs, accept, keyOf, fold } = opts;
+  const [state, setState] = useState<ReadonlyMap<string, V>>(() => new Map());
+
+  useEffect(() => {
+    const buf = createCoalescedBuffer<E>({
+      limit: cap,
+      clearOnFlush: true,
+      ...(flushMs !== undefined ? { flushMs } : {}),
+      onFlush: (batch) => {
+        setState((prev) => {
+          let next: Map<string, V> | undefined;
+          for (const event of batch) {
+            const key = keyOf(event);
+            const existing = (next ?? prev).get(key);
+            const folded = fold(existing, event);
+            if (folded === undefined) continue;
+            if (next === undefined) next = new Map(prev);
+            // Delete + re-set so an updated key jumps to the end of insertion order; the
+            // post-fold trim below then drops the actually-oldest entry, not whichever key
+            // hashed first in Map's insertion order.
+            next.delete(key);
+            next.set(key, folded);
+          }
+          if (next === undefined) return prev;
+          // Single LRU trim once the whole batch is folded (delete+set kept order hot per key).
+          while (next.size > cap) {
+            const oldest = next.keys().next().value;
+            if (oldest === undefined) break;
+            next.delete(oldest);
+          }
+          return next;
+        });
+      },
+    });
+    const unsub = bus.subscribe((event) => {
+      if (accept(event)) buf.push(event);
+    });
+    // Order matters: unsub first so no push can race the drain, flushNow to land in-flight events,
+    // stop last to tear down the timer (no flush-after-stop on single-threaded JS).
+    return () => {
+      unsub();
+      buf.flushNow();
+      buf.stop();
+    };
+  }, [bus, cap, flushMs, accept, keyOf, fold]);
+
+  return state;
+};

--- a/src/application/ui/tui/runtime/use-edit-field.ts
+++ b/src/application/ui/tui/runtime/use-edit-field.ts
@@ -16,13 +16,14 @@
  * consistent across every consumer.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Result } from '@src/domain/result.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { PendingPromptInput, PromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 
 export type EditFieldKind = 'short' | 'long';
 
@@ -75,19 +76,16 @@ export const useEditField = (): UseEditFieldState => {
   // Mounted-ref guard: `openEditPrompt` is async and the host view can unmount between the
   // initial keystroke and the prompt's resolution. Calling setState on an unmounted component
   // is a no-op in React 18+ but emits a dev warning and indicates a closure that survived
-  // teardown. The ref is set false on cleanup; every state mutation routes through
-  // `setFeedback` which checks it. `release()` in the finally block is unconditional — the
-  // claim counter must always decrement even if the view is gone.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
+  // teardown. Every state mutation routes through `setFeedback` which checks it. `release()` in
+  // the finally block is unconditional — the claim counter must always decrement even if the
+  // view is gone.
+  const mountedRef = useIsMounted();
+  const setFeedback = useCallback(
+    (value: string | undefined): void => {
+      if (mountedRef.current) setFeedbackState(value);
     },
-    []
+    [mountedRef]
   );
-  const setFeedback = useCallback((value: string | undefined): void => {
-    if (mountedRef.current) setFeedbackState(value);
-  }, []);
 
   const openEditPrompt = useCallback(
     async (input: OpenEditPromptInput): Promise<void> => {

--- a/src/application/ui/tui/runtime/use-global-keys.ts
+++ b/src/application/ui/tui/runtime/use-global-keys.ts
@@ -7,8 +7,8 @@
 
 import type { MutableRefObject } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
-import { useApp, useInput } from 'ink';
-import { useRouter, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+import { useApp, useInput, type Key } from 'ink';
+import { useRouter, type RouterApi, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
@@ -17,6 +17,9 @@ import type { SessionRecord } from '@src/application/ui/tui/runtime/session-mana
 import { type CopyToClipboard, createCopyToClipboard } from '@src/integration/io/clipboard.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
+
+type UiStateApi = ReturnType<typeof useUiState>;
+type SelectionApi = ReturnType<typeof useSelection>;
 
 /** Duration of the "Copied to clipboard" toast before the global handler auto-clears it. */
 const CLIPBOARD_TOAST_DURATION_MS = 2000;
@@ -54,134 +57,187 @@ export const useGlobalKeys = (opts: UseGlobalKeysOptions = {}): void => {
   );
 
   useInput((input, key) => {
-    // Quit always wins.
-    if ((key.ctrl && input === 'c') || (input === 'q' && router.current.id === 'home' && !opts.disabled)) {
-      exit();
-      return;
-    }
-
+    if (handleQuitChord(input, key, router, opts.disabled, exit)) return;
     if (opts.disabled) return;
-
-    // Help toggle is recognised even when the overlay is open — pressing `?` dismisses it.
-    if (input === '?') {
-      ui.toggleHelp();
-      return;
-    }
-    // Help mode swallows the rest of the keystrokes; only Esc dismisses.
-    if (ui.helpOpen) {
-      if (key.escape) ui.toggleHelp();
-      return;
-    }
-
-    // Progress overlay — same modal contract as help. `g` opens (only when a sprint is loaded);
-    // `g` also dismisses while open so the operator can mash the same key to toggle. `esc`
-    // dismisses. The open-gate mirrors the overlay's own sprint resolution
-    // (`focusedRunSprintId ?? selection.sprintId`): when an Execute view pins a run whose sprint
-    // is not the global selection, `g` must still open onto the pinned run instead of silently
-    // no-op'ing. Home — neither pinned nor selected — stays a no-op as the spec demands.
-    if (ui.progressOpen) {
-      if (key.escape || input === 'g') ui.toggleProgress();
-      return;
-    }
-    if (input === 'g' && (ui.focusedRunSprintId ?? selection.sprintId) !== undefined) {
-      ui.toggleProgress();
-      return;
-    }
-
-    // Multi-flow navigation. Tab / Shift+Tab cycle through the RUNNING sessions; Ctrl+1..9 jump
-    // to the Nth running session (1-indexed). Reaches this point only when no prompt is mounted
-    // (opts.disabled gate above) and no overlay is open (help / progress early-returned). Focusing
-    // a session reuses the Sessions view's mechanism — push / replace the `execute` route keyed on
-    // the session id. With zero running sessions every chord is a silent no-op.
-    if (key.tab) {
-      focusRunningSession(sessions, router, key.shift ? 'prev' : 'next');
-      return;
-    }
-    if (key.ctrl && /^[1-9]$/.test(input)) {
-      focusRunningSession(sessions, router, Number(input) - 1);
-      return;
-    }
+    if (handleHelpOverlay(ui, input, key)) return;
+    if (handleProgressOverlay(ui, selection, input, key)) return;
+    if (handleSessionNav(sessions, router, input, key)) return;
 
     if (key.escape && !ui.escapeClaimed) {
       router.pop();
       return;
     }
 
-    // `y` (yank) copies the currently-focused task's markdown summary. The execute view
-    // registers an `ActiveTaskSummaryProvider` on UiState while it is mounted with bucketed
-    // data; everywhere else the provider is undefined and the hotkey surfaces a "no active
-    // task" toast instead of silently dropping the keystroke (silent fail = mystery for the
-    // operator).
-    if (input === 'y') {
-      const summary = ui.getActiveTaskSummary();
-      if (summary === undefined) {
-        emitClipboardBanner(deps.eventBus, {
-          tier: 'info',
-          message: 'No active task to copy',
-        });
-        scheduleClear(deps.eventBus, clearTimerRef);
-        return;
-      }
-      void (async (): Promise<void> => {
-        const result = await copyToClipboard(summary);
-        if (result.ok) {
-          emitClipboardBanner(deps.eventBus, {
-            tier: 'info',
-            message: 'Copied to clipboard',
-          });
-        } else {
-          emitClipboardBanner(deps.eventBus, {
-            tier: 'warn',
-            message: 'Clipboard copy failed',
-            cause: result.error.message,
-          });
-        }
-        scheduleClear(deps.eventBus, clearTimerRef);
-      })();
-      return;
-    }
-
-    // Pressing the shortcut for the view you're already on is a no-op — otherwise the breadcrumb
-    // stack would balloon as the user mashes the same key.
-    const navigate = (id: string): void => {
-      if (router.current.id === id) return;
-      router.push({ id });
-    };
-
-    switch (input) {
-      case 'h':
-        if (router.current.id !== 'home') router.reset();
-        return;
-      case 'n':
-        navigate('flows');
-        return;
-      case 'x':
-        navigate('sessions');
-        return;
-      case 's':
-        navigate('settings');
-        return;
-      case '!':
-        navigate('doctor');
-        return;
-      case 'b':
-        // Banner full ↔ compact toggle. Overrides the view's `compactBanner` prop for the rest
-        // of the session — pressing `h` back to Home does not reset the toggle.
-        ui.toggleBanner();
-        return;
-      case 'P':
-        // Capital P opens the project picker from anywhere — lowercase `p` still routes to
-        // the read-only Projects view. The picker remembers the current selection as its
-        // default cursor so Enter is a one-keystroke confirm.
-        navigate('pick-project');
-        return;
-      case 'S':
-        // Mirror of `P` for sprints: capital S opens the sprint picker from anywhere;
-        // lowercase `s` still routes to Settings. Picker is project-scoped, so it relies
-        // on a project being loaded; otherwise it shows a "no project loaded" card.
-        navigate('pick-sprint');
-    }
+    if (handleYankCopy(ui, deps, copyToClipboard, clearTimerRef, input)) return;
+    handleViewShortcut(input, router, ui);
   });
+};
+
+/** Quitting (`Ctrl-C` anywhere, or `q` on Home) is the operator's escape hatch — it always wins. */
+const handleQuitChord = (
+  input: string,
+  key: Key,
+  router: { current: ViewEntry },
+  disabled: boolean | undefined,
+  exit: () => void
+): boolean => {
+  if ((key.ctrl && input === 'c') || (input === 'q' && router.current.id === 'home' && !disabled)) {
+    exit();
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Help toggle is recognised even when the overlay is open — pressing `?` dismisses it. Once open,
+ * help mode swallows the rest of the keystrokes; only Esc dismisses.
+ */
+const handleHelpOverlay = (ui: UiStateApi, input: string, key: Key): boolean => {
+  if (input === '?') {
+    ui.toggleHelp();
+    return true;
+  }
+  if (ui.helpOpen) {
+    if (key.escape) ui.toggleHelp();
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Progress overlay — same modal contract as help. `g` opens (only when a sprint is loaded);
+ * `g` also dismisses while open so the operator can mash the same key to toggle. `esc`
+ * dismisses. The open-gate mirrors the overlay's own sprint resolution
+ * (`focusedRunSprintId ?? selection.sprintId`): when an Execute view pins a run whose sprint
+ * is not the global selection, `g` must still open onto the pinned run instead of silently
+ * no-op'ing. Home — neither pinned nor selected — stays a no-op as the spec demands.
+ */
+const handleProgressOverlay = (ui: UiStateApi, selection: SelectionApi, input: string, key: Key): boolean => {
+  if (ui.progressOpen) {
+    if (key.escape || input === 'g') ui.toggleProgress();
+    return true;
+  }
+  if (input === 'g' && (ui.focusedRunSprintId ?? selection.sprintId) !== undefined) {
+    ui.toggleProgress();
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Multi-flow navigation. Tab / Shift+Tab cycle through the RUNNING sessions; Ctrl+1..9 jump
+ * to the Nth running session (1-indexed). Reaches this point only when no prompt is mounted
+ * (opts.disabled gate above) and no overlay is open (help / progress early-returned). Focusing
+ * a session reuses the Sessions view's mechanism — push / replace the `execute` route keyed on
+ * the session id. With zero running sessions every chord is a silent no-op.
+ */
+const handleSessionNav = (
+  sessions: { list(): readonly SessionRecord[] },
+  router: { current: ViewEntry; push(e: ViewEntry): void; replace(e: ViewEntry): void },
+  input: string,
+  key: Key
+): boolean => {
+  if (key.tab) {
+    focusRunningSession(sessions, router, key.shift ? 'prev' : 'next');
+    return true;
+  }
+  if (key.ctrl && /^[1-9]$/.test(input)) {
+    focusRunningSession(sessions, router, Number(input) - 1);
+    return true;
+  }
+  return false;
+};
+
+/**
+ * `y` (yank) copies the currently-focused task's markdown summary. The execute view
+ * registers an `ActiveTaskSummaryProvider` on UiState while it is mounted with bucketed
+ * data; everywhere else the provider is undefined and the hotkey surfaces a "no active
+ * task" toast instead of silently dropping the keystroke (silent fail = mystery for the
+ * operator).
+ */
+const handleYankCopy = (
+  ui: UiStateApi,
+  deps: { eventBus: EventBus },
+  copyToClipboard: CopyToClipboard,
+  clearTimerRef: MutableRefObject<NodeJS.Timeout | undefined>,
+  input: string
+): boolean => {
+  if (input !== 'y') return false;
+
+  const summary = ui.getActiveTaskSummary();
+  if (summary === undefined) {
+    emitClipboardBanner(deps.eventBus, {
+      tier: 'info',
+      message: 'No active task to copy',
+    });
+    scheduleClear(deps.eventBus, clearTimerRef);
+    return true;
+  }
+  void (async (): Promise<void> => {
+    const result = await copyToClipboard(summary);
+    if (result.ok) {
+      emitClipboardBanner(deps.eventBus, {
+        tier: 'info',
+        message: 'Copied to clipboard',
+      });
+    } else {
+      emitClipboardBanner(deps.eventBus, {
+        tier: 'warn',
+        message: 'Clipboard copy failed',
+        cause: result.error.message,
+      });
+    }
+    scheduleClear(deps.eventBus, clearTimerRef);
+  })();
+  return true;
+};
+
+/**
+ * The trailing single-letter view shortcuts. Pressing the shortcut for the view you're already
+ * on is a no-op — otherwise the breadcrumb stack would balloon as the user mashes the same key.
+ */
+const handleViewShortcut = (input: string, router: RouterApi, ui: UiStateApi): boolean => {
+  const navigate = (id: string): void => {
+    if (router.current.id === id) return;
+    router.push({ id });
+  };
+
+  switch (input) {
+    case 'h':
+      if (router.current.id !== 'home') router.reset();
+      return true;
+    case 'n':
+      navigate('flows');
+      return true;
+    case 'x':
+      navigate('sessions');
+      return true;
+    case 's':
+      navigate('settings');
+      return true;
+    case '!':
+      navigate('doctor');
+      return true;
+    case 'b':
+      // Banner full ↔ compact toggle. Overrides the view's `compactBanner` prop for the rest
+      // of the session — pressing `h` back to Home does not reset the toggle.
+      ui.toggleBanner();
+      return true;
+    case 'P':
+      // Capital P opens the project picker from anywhere — lowercase `p` still routes to
+      // the read-only Projects view. The picker remembers the current selection as its
+      // default cursor so Enter is a one-keystroke confirm.
+      navigate('pick-project');
+      return true;
+    case 'S':
+      // Mirror of `P` for sprints: capital S opens the sprint picker from anywhere;
+      // lowercase `s` still routes to Settings. Picker is project-scoped, so it relies
+      // on a project being loaded; otherwise it shows a "no project loaded" card.
+      navigate('pick-sprint');
+      return true;
+    default:
+      return false;
+  }
 };
 
 /**

--- a/src/application/ui/tui/runtime/use-is-mounted.ts
+++ b/src/application/ui/tui/runtime/use-is-mounted.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared mount-guard ref: `true` while the owning component is mounted, flipped to `false` on
+ * unmount. Callers gate post-await state writes on `mountedRef.current` so an async handler that
+ * resolves after the view unmounted doesn't fire `setState` into a dead tree.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+export const useIsMounted = (): RefObject<boolean> => {
+  const ref = useRef(true);
+  useEffect(
+    () => () => {
+      ref.current = false;
+    },
+    []
+  );
+  return ref;
+};

--- a/src/application/ui/tui/runtime/use-task-round-tracker.ts
+++ b/src/application/ui/tui/runtime/use-task-round-tracker.ts
@@ -5,11 +5,12 @@
 // first (no-op on stale events, so they never bump LRU order), and the eviction loop only fires
 // on net-new insertions past the cap — mirrors the `use-token-usage.ts` pattern.
 //
-// Commit-rate: the subscription feeds a `createCoalescedBuffer`, so a burst of `task-round-started`
-// events yields at most ONE `setRounds` (one React commit) per flush window rather than one
-// per publish — the same commit-storm guard `use-event-bus.ts` gained in d2208392. `TASK_ROUND_CAP`
-// doubles as the buffer's per-window event cap; because it equals the Map cap, the buffer can only
-// shed events the Map fold would itself evict via LRU, so the dual use never drops a live entry.
+// Commit-rate: the subscription feeds a `createCoalescedBuffer` (via `useCoalescedMap`), so a
+// burst of `task-round-started` events yields at most ONE `setRounds` (one React commit) per
+// flush window rather than one per publish — the same commit-storm guard `use-event-bus.ts`
+// gained in d2208392. `TASK_ROUND_CAP` doubles as the buffer's per-window event cap; because it
+// equals the Map cap, the buffer can only shed events the Map fold would itself evict via LRU, so
+// the dual use never drops a live entry.
 
 /**
  * Per-task gen-eval round tracker — subscribes to `task-round-started` AppEvents and folds
@@ -26,10 +27,9 @@
  * Each `task-round-started` event carries `taskId` directly, so we don't need windowing.
  */
 
-import { useEffect, useState } from 'react';
 import type { AppEvent, TaskRoundStartedEvent } from '@src/business/observability/events.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
-import { createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+import { useCoalescedMap } from '@src/application/ui/tui/runtime/use-coalesced-map.ts';
 
 /**
  * Hard cap on retained per-task round entries. A planner can legitimately emit dozens to low
@@ -47,6 +47,15 @@ export interface TaskRound {
 
 const isTaskRoundStarted = (e: AppEvent): e is TaskRoundStartedEvent => e.type === 'task-round-started';
 
+// Module-scoped so it stays referentially stable across renders — `useCoalescedMap`'s effect
+// deps include it, and a fresh arrow per render would churn the subscription.
+const keyOfTaskRound = (e: TaskRoundStartedEvent): string => e.taskId;
+
+// Monotonic guard — a late/older round must not regress the high-water mark. Returning
+// `undefined` tells `useCoalescedMap` to skip the event and leave `existing` untouched.
+const foldTaskRound = (existing: TaskRound | undefined, e: TaskRoundStartedEvent): TaskRound | undefined =>
+  existing && existing.roundN >= e.roundN ? undefined : { roundN: e.roundN, totalCap: e.totalCap };
+
 /** @public */
 export interface UseTaskRoundTrackerOptions {
   /** Flush cadence in ms. Test-only escape hatch; production callers use the coalescer default. */
@@ -63,60 +72,21 @@ export interface UseTaskRoundTrackerOptions {
  * sessions is structurally impossible. Components that drive multiple sessions still get a
  * single source of truth because the upstream filtering happens at the runner-bridge layer.
  *
- * Events feed a `createCoalescedBuffer` (delta semantics via `clearOnFlush`), so a burst of
- * publishes is folded into the Map in a single `setRounds` per flush window — decoupling the
- * publish rate from React's commit rate. The monotonic guard reads `next ?? prev` so same-taskId
- * events within one batch fold in arrival order; the lazy clone skips the allocation (and the
- * re-render) entirely when every event in a batch is stale.
+ * Events feed a `useCoalescedMap` (delta semantics via the shared buffer's `clearOnFlush`), so a
+ * burst of publishes is folded into the Map in a single `setState` per flush window —
+ * decoupling the publish rate from React's commit rate. The monotonic guard reads `existing`
+ * (looked up via `next ?? prev`) so same-taskId events within one batch fold in arrival order;
+ * the lazy clone skips the allocation (and the re-render) entirely when every event in a batch
+ * is stale.
  */
 export const useTaskRoundTracker = (
   bus: EventBus,
   opts: UseTaskRoundTrackerOptions = {}
-): ReadonlyMap<string, TaskRound> => {
-  const { flushMs } = opts;
-  const [rounds, setRounds] = useState<ReadonlyMap<string, TaskRound>>(() => new Map());
-
-  useEffect(() => {
-    const buf = createCoalescedBuffer<TaskRoundStartedEvent>({
-      limit: TASK_ROUND_CAP,
-      clearOnFlush: true,
-      ...(flushMs !== undefined ? { flushMs } : {}),
-      onFlush: (batch) => {
-        setRounds((prev) => {
-          let next: Map<string, TaskRound> | undefined;
-          for (const event of batch) {
-            const existing = (next ?? prev).get(event.taskId);
-            // Monotonic guard — a late/older round must not regress the high-water mark.
-            if (existing !== undefined && existing.roundN >= event.roundN) continue;
-            if (next === undefined) next = new Map(prev);
-            // Delete + re-set so an updated taskId jumps to the end of insertion order; the
-            // post-fold trim below then drops the actually-oldest entry, not whichever taskId
-            // hashed first in Map's insertion order.
-            next.delete(event.taskId);
-            next.set(event.taskId, { roundN: event.roundN, totalCap: event.totalCap });
-          }
-          if (next === undefined) return prev;
-          // Single LRU trim once the whole batch is folded (delete+set kept order hot per taskId).
-          while (next.size > TASK_ROUND_CAP) {
-            const oldest = next.keys().next().value;
-            if (oldest === undefined) break;
-            next.delete(oldest);
-          }
-          return next;
-        });
-      },
-    });
-    const unsub = bus.subscribe((event) => {
-      if (isTaskRoundStarted(event)) buf.push(event);
-    });
-    // Order matters: unsub first so no push can race the drain, flushNow to land in-flight events,
-    // stop last to tear down the timer (no flush-after-stop on single-threaded JS).
-    return () => {
-      unsub();
-      buf.flushNow();
-      buf.stop();
-    };
-  }, [bus, flushMs]);
-
-  return rounds;
-};
+): ReadonlyMap<string, TaskRound> =>
+  useCoalescedMap<TaskRoundStartedEvent, TaskRound>(bus, {
+    cap: TASK_ROUND_CAP,
+    ...(opts.flushMs !== undefined ? { flushMs: opts.flushMs } : {}),
+    accept: isTaskRoundStarted,
+    keyOf: keyOfTaskRound,
+    fold: foldTaskRound,
+  });

--- a/src/application/ui/tui/runtime/use-token-usage.ts
+++ b/src/application/ui/tui/runtime/use-token-usage.ts
@@ -4,11 +4,11 @@
 // because every insert path goes through the same delete-then-set-then-evict reducer, and the
 // TokenBudgetCard only ever reads the most recent session anyway — evicted entries are unread.
 //
-// Commit-rate: the subscription feeds a `createCoalescedBuffer`, so a burst of `token-usage`
-// events yields at most ONE `setUsage` (one React commit) per flush window rather than one
-// per publish — the same commit-storm guard `use-event-bus.ts` gained in d2208392. The cap
-// doubles as the buffer's per-window event cap; equal to the Map cap, it can only shed events
-// the Map fold would itself evict via LRU.
+// Commit-rate: the subscription feeds a `createCoalescedBuffer` (via `useCoalescedMap`), so a
+// burst of `token-usage` events yields at most ONE `setUsage` (one React commit) per flush window
+// rather than one per publish — the same commit-storm guard `use-event-bus.ts` gained in d2208392.
+// The cap doubles as the buffer's per-window event cap; equal to the Map cap, it can only shed
+// events the Map fold would itself evict via LRU.
 
 /**
  * Per-session token-usage tracker — subscribes to `TokenUsageEvent` on the EventBus and folds
@@ -28,10 +28,9 @@
  * many rounds × tasks × rate-limit retries could otherwise grow the Map unboundedly.
  */
 
-import { useEffect, useState } from 'react';
 import type { AppEvent, TokenUsageEvent } from '@src/business/observability/events.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
-import { createCoalescedBuffer } from '@src/application/ui/tui/runtime/coalesced-buffer.ts';
+import { useCoalescedMap } from '@src/application/ui/tui/runtime/use-coalesced-map.ts';
 
 /**
  * Hard cap on retained per-session token-usage entries. Each entry is small (~100 bytes) but
@@ -73,6 +72,17 @@ const toUsage = (e: TokenUsageEvent): TokenUsage => ({
   ...(e.contextWindow !== undefined ? { contextWindow: e.contextWindow } : {}),
 });
 
+// Key by the chain runner id when present — that is the id the execute view looks up by.
+// Provider adapters stamp `sessionId` with the AI CLI's own uuid (a disjoint id space), so keying
+// on it alone guarantees a miss. Legacy / one-shot events without a runner id fall back to
+// `sessionId` so they still resolve. Module-scoped so it stays referentially stable across
+// renders — `useCoalescedMap`'s effect deps include it, and a fresh arrow per render would churn
+// the subscription.
+const keyOfTokenUsage = (e: TokenUsageEvent): string => e.chainSessionId ?? e.sessionId;
+
+// Latest event always wins per key — no monotonic guard, so the fold ignores `existing`.
+const foldTokenUsage = (_existing: TokenUsage | undefined, e: TokenUsageEvent): TokenUsage => toUsage(e);
+
 /** @public */
 export interface UseTokenUsageOptions {
   /** Flush cadence in ms. Test-only escape hatch; production callers use the coalescer default. */
@@ -83,58 +93,16 @@ export interface UseTokenUsageOptions {
  * Subscribe to `token-usage` events on `bus` and return the latest usage per sessionId. Returns
  * a fresh Map on every update so React's referential equality check triggers re-renders.
  *
- * Events feed a `createCoalescedBuffer` (delta semantics via `clearOnFlush`), so a burst of
- * publishes folds into the Map in a single `setUsage` per flush window — decoupling the publish
- * rate from React's commit rate. Latest-wins per key, so a same-session event later in a batch
- * supersedes an earlier one via the delete + re-set.
+ * Events feed a `useCoalescedMap` (delta semantics via the shared buffer's `clearOnFlush`), so a
+ * burst of publishes folds into the Map in a single `setState` per flush window — decoupling the
+ * publish rate from React's commit rate. Latest-wins per key, so a same-session event later in a
+ * batch supersedes an earlier one.
  */
-export const useTokenUsage = (bus: EventBus, opts: UseTokenUsageOptions = {}): ReadonlyMap<string, TokenUsage> => {
-  const { flushMs } = opts;
-  const [usage, setUsage] = useState<ReadonlyMap<string, TokenUsage>>(() => new Map());
-
-  useEffect(() => {
-    const buf = createCoalescedBuffer<TokenUsageEvent>({
-      limit: TOKEN_USAGE_SESSION_CAP,
-      clearOnFlush: true,
-      ...(flushMs !== undefined ? { flushMs } : {}),
-      onFlush: (batch) => {
-        setUsage((prev) => {
-          let next: Map<string, TokenUsage> | undefined;
-          for (const event of batch) {
-            // Key by the chain runner id when present — that is the id the execute view looks up by.
-            // Provider adapters stamp `sessionId` with the AI CLI's own uuid (a disjoint id space), so
-            // keying on it alone guarantees a miss. Legacy / one-shot events without a runner id fall
-            // back to `sessionId` so they still resolve.
-            const key = event.chainSessionId ?? event.sessionId;
-            if (next === undefined) next = new Map(prev);
-            // Delete + re-set so an updated session jumps to the end of insertion order; the
-            // post-fold trim below then drops the actually-oldest entry, not whichever key hashed
-            // first in Map's insertion order.
-            next.delete(key);
-            next.set(key, toUsage(event));
-          }
-          if (next === undefined) return prev;
-          // Single LRU trim once the whole batch is folded (delete+set kept order hot per session).
-          while (next.size > TOKEN_USAGE_SESSION_CAP) {
-            const oldest = next.keys().next().value;
-            if (oldest === undefined) break;
-            next.delete(oldest);
-          }
-          return next;
-        });
-      },
-    });
-    const unsub = bus.subscribe((event) => {
-      if (isTokenUsage(event)) buf.push(event);
-    });
-    // Order matters: unsub first so no push can race the drain, flushNow to land in-flight events,
-    // stop last to tear down the timer (no flush-after-stop on single-threaded JS).
-    return () => {
-      unsub();
-      buf.flushNow();
-      buf.stop();
-    };
-  }, [bus, flushMs]);
-
-  return usage;
-};
+export const useTokenUsage = (bus: EventBus, opts: UseTokenUsageOptions = {}): ReadonlyMap<string, TokenUsage> =>
+  useCoalescedMap<TokenUsageEvent, TokenUsage>(bus, {
+    cap: TOKEN_USAGE_SESSION_CAP,
+    ...(opts.flushMs !== undefined ? { flushMs: opts.flushMs } : {}),
+    accept: isTokenUsage,
+    keyOf: keyOfTokenUsage,
+    fold: foldTokenUsage,
+  });

--- a/src/application/ui/tui/views/create-pr-view.tsx
+++ b/src/application/ui/tui/views/create-pr-view.tsx
@@ -25,6 +25,10 @@ import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 import { resolveSprintDir } from '@src/integration/persistence/storage.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { Result } from '@src/domain/result.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 
 const DEFAULT_BASE = 'main';
 const DEFAULT_DRAFT = false;
@@ -57,39 +61,15 @@ export const CreatePrView = (): React.JSX.Element => {
   // Resolve cwd (project's first repo path) and branch (sprint-execution.branch) up front,
   // so the confirm card can show concrete values rather than spinning twice.
   useEffect(() => {
-    // Guard every setPrep behind a `cancelled` flag: if the selection changes (a new load
-    // starts) or the view unmounts while the two findById awaits are in flight, the stale run
-    // must not write state — matches the cancelled-flag idiom used across the other async views.
+    // Guard the setPrep write behind a `cancelled` flag: if the selection changes (a new load
+    // starts) or the view unmounts while `resolvePrepState`'s awaits are in flight, the stale
+    // run must not write state — matches the cancelled-flag idiom used across the other async
+    // views. `resolvePrepState` itself runs to natural completion regardless (see its own doc
+    // comment); only the state write is gated here.
     let cancelled = false;
-    const load = async (): Promise<void> => {
-      if (selection.projectId === undefined || selection.sprintId === undefined) {
-        if (!cancelled) setPrep({ kind: 'error', message: 'No project or sprint selected.' });
-        return;
-      }
-      const project = await deps.projectRepo.findById(selection.projectId);
-      if (cancelled) return;
-      if (!project.ok) {
-        setPrep({ kind: 'error', message: project.error.message });
-        return;
-      }
-      const cwd = project.value.repositories[0]?.path;
-      if (cwd === undefined) {
-        setPrep({ kind: 'error', message: 'Project has no repositories — add one first.' });
-        return;
-      }
-      const execution = await deps.sprintExecutionRepo.findById(selection.sprintId);
-      if (cancelled) return;
-      if (!execution.ok) {
-        setPrep({ kind: 'error', message: execution.error.message });
-        return;
-      }
-      if (execution.value.branch === null) {
-        setPrep({ kind: 'error', message: 'Sprint has no branch — implement at least one task first.' });
-        return;
-      }
-      setPrep({ kind: 'ready', cwd, branch: execution.value.branch });
-    };
-    void load();
+    void resolvePrepState(deps, selection.projectId, selection.sprintId).then((next) => {
+      if (!cancelled) setPrep(next);
+    });
     return () => {
       cancelled = true;
     };
@@ -97,75 +77,21 @@ export const CreatePrView = (): React.JSX.Element => {
 
   const runCreate = useCallback(
     async (cwd: AbsolutePath): Promise<void> => {
-      if (selection.sprintId === undefined) {
-        setRun({ kind: 'error', message: 'No sprint selected.' });
-        return;
-      }
-      // PATH-gate the AI step FIRST: the create-pr AI session spawns the `createPr` row's provider
-      // CLI. Probe for it before any sprint I/O so a missing binary surfaces the same actionable
-      // "binary not found" message every other AI flow gives, instead of an opaque spawn failure
-      // mid-run. Only relevant when AI authoring is on — the template path spawns no AI.
-      if (useAi) {
-        const gate = await checkCli('create-pr', deps.settings);
-        if (gate !== undefined && !gate.ok) {
-          setRun({ kind: 'error', message: gate.reason });
-          return;
-        }
-      }
-      // Resolve the sprint dir via the tolerant id-prefix resolver (both `<id>--<slug>/` and the
-      // legacy bare `<id>/`); the view only holds the sprint id, not the entity.
-      const resolvedDir = await resolveSprintDir(deps.storage.dataRoot, selection.sprintId);
-      if (resolvedDir === undefined) {
-        setRun({ kind: 'error', message: 'sprint dir: not found on disk' });
-        return;
-      }
-      const sprintDir = AbsolutePath.parse(resolvedDir);
-      if (!sprintDir.ok) {
-        setRun({ kind: 'error', message: `sprint dir: ${sprintDir.error.message}` });
+      const inputs = await resolveCreatePrInputs(deps, selection.sprintId, useAi);
+      if (!inputs.ok) {
+        setRun(inputs.error);
         return;
       }
       setRun({ kind: 'running' });
-      // Rebuild the provider from the `createPr` settings row. `deps.provider` is the wire-time
-      // seed keyed on the `implement` row; in a mixed-provider config that hands the createPr
-      // model string to the implement provider's CLI — a provider/model mismatch. The model is
-      // already sourced from `ai.createPr.model`, so the provider must match it.
-      const provider = createAiProvider({
-        flow: 'createPr',
-        ai: deps.settings.ai,
-        harnessConfig: deps.settings.harness,
-        eventBus: deps.eventBus,
-      });
-      const flow = createCreatePrFlow(
-        {
-          sprintRepo: deps.sprintRepo,
-          sprintExecutionRepo: deps.sprintExecutionRepo,
-          taskRepo: deps.taskRepo,
-          pullRequestCreator: deps.pullRequestCreator,
-          gitRunner: deps.gitRunner,
-          eventBus: deps.eventBus,
-          clock: deps.clock,
-          provider,
-          templateLoader: deps.templateLoader,
-          writeFile: deps.writeFile,
-          logger: deps.logger,
-          model: deps.settings.ai.createPr.model,
-        },
-        { useAi }
-      );
-      const result = await flow.execute({
-        input: {
-          sprintId: selection.sprintId,
+      setRun(
+        await executeCreatePrFlow({
+          deps,
+          sprintId: selection.sprintId!,
+          sprintDir: inputs.value.sprintDir,
           cwd,
-          sprintDir: sprintDir.value,
-          base: DEFAULT_BASE,
-          draft: DEFAULT_DRAFT,
-        },
-      });
-      if (!result.ok) {
-        setRun({ kind: 'error', message: result.error.error.message });
-        return;
-      }
-      setRun({ kind: 'done', url: result.value.ctx.output!.url });
+          useAi,
+        })
+      );
     },
     [deps, selection.sprintId, useAi]
   );
@@ -189,54 +115,196 @@ export const CreatePrView = (): React.JSX.Element => {
 
   return (
     <ViewShell title="Create pull request" subtitle="open PR / MR for the sprint branch">
-      {ui.helpOpen ? (
-        <HelpOverlay />
-      ) : (
-        <Box flexDirection="column" paddingX={spacing.indent} marginTop={spacing.section}>
-          {prep.kind === 'loading' ? (
-            <Spinner label="Loading project + sprint execution…" />
-          ) : prep.kind === 'error' ? (
-            <Card title="Cannot open PR" tone="rule">
-              <Text color={inkColors.error}>
-                {glyphs.bullet} {prep.message}
-              </Text>
-            </Card>
-          ) : run.kind === 'idle' ? (
-            <Card title="Confirm" tone="rule">
-              <Text>
-                Branch <Text bold>{prep.branch}</Text> {glyphs.arrowRight} base <Text bold>{DEFAULT_BASE}</Text>{' '}
-                {glyphs.bullet} draft: <Text bold>{DEFAULT_DRAFT ? 'yes' : 'no'}</Text>
-              </Text>
-              <Text>
-                AI-authored: <Text bold>{useAi ? 'yes' : 'no'}</Text> {glyphs.bullet} press <Text bold>a</Text> to
-                toggle
-              </Text>
-              <Text dimColor>
-                press <Text bold>enter</Text> to open the PR · esc to back out · use the CLI for non-default base /
-                draft / title / body
-              </Text>
-            </Card>
-          ) : run.kind === 'running' ? (
-            <Spinner label="Opening pull request…" />
-          ) : run.kind === 'done' ? (
-            <Card title="Done" tone="rule">
-              <Text>
-                <Text color={inkColors.primary} bold>
-                  {glyphs.check}{' '}
-                </Text>
-                <Text bold>{run.url}</Text>
-              </Text>
-            </Card>
-          ) : (
-            <Card title="Failed" tone="rule">
-              <Text color={inkColors.error}>
-                {glyphs.bullet} {run.message}
-              </Text>
-              <Text dimColor>press r to retry</Text>
-            </Card>
-          )}
-        </Box>
-      )}
+      {ui.helpOpen ? <HelpOverlay /> : <Body prep={prep} run={run} useAi={useAi} />}
     </ViewShell>
+  );
+};
+
+/**
+ * Resolve the confirm card's inputs: the project's first repo path (`cwd`) and the sprint
+ * execution's branch. Pure I/O, no state writes — the caller's effect owns the cancelled-flag
+ * gate around the resulting `setPrep`, so (like `useAsyncLoad`'s untracked loaders) this runs
+ * to natural completion even if the caller ends up discarding the result.
+ */
+const resolvePrepState = async (
+  deps: AppDeps,
+  projectId: ProjectId | undefined,
+  sprintId: SprintId | undefined
+): Promise<PrepState> => {
+  if (projectId === undefined || sprintId === undefined) {
+    return { kind: 'error', message: 'No project or sprint selected.' };
+  }
+  const project = await deps.projectRepo.findById(projectId);
+  if (!project.ok) return { kind: 'error', message: project.error.message };
+  const cwd = project.value.repositories[0]?.path;
+  if (cwd === undefined) {
+    return { kind: 'error', message: 'Project has no repositories — add one first.' };
+  }
+  const execution = await deps.sprintExecutionRepo.findById(sprintId);
+  if (!execution.ok) return { kind: 'error', message: execution.error.message };
+  if (execution.value.branch === null) {
+    return { kind: 'error', message: 'Sprint has no branch — implement at least one task first.' };
+  }
+  return { kind: 'ready', cwd, branch: execution.value.branch };
+};
+
+/**
+ * Guard chain for the `runCreate` handler: sprint-selected check, then the PATH gate for the AI
+ * step, then the sprint-dir resolve + parse. PATH-gates the AI step FIRST: the create-pr AI
+ * session spawns the `createPr` row's provider CLI. Probe for it before any sprint I/O so a
+ * missing binary surfaces the same actionable "binary not found" message every other AI flow
+ * gives, instead of an opaque spawn failure mid-run. Only relevant when AI authoring is on — the
+ * template path spawns no AI. Resolves the sprint dir via the tolerant id-prefix resolver (both
+ * `<id>--<slug>/` and the legacy bare `<id>/`) — the view only holds the sprint id, not the
+ * entity. Returns the failure `RunState` on error so the caller can `setRun` it directly.
+ */
+const resolveCreatePrInputs = async (
+  deps: AppDeps,
+  sprintId: SprintId | undefined,
+  useAi: boolean
+): Promise<Result<{ readonly sprintDir: AbsolutePath }, RunState>> => {
+  if (sprintId === undefined) {
+    return Result.error({ kind: 'error', message: 'No sprint selected.' });
+  }
+  if (useAi) {
+    const gate = await checkCli('create-pr', deps.settings);
+    if (gate !== undefined && !gate.ok) {
+      return Result.error({ kind: 'error', message: gate.reason });
+    }
+  }
+  const resolvedDir = await resolveSprintDir(deps.storage.dataRoot, sprintId);
+  if (resolvedDir === undefined) {
+    return Result.error({ kind: 'error', message: 'sprint dir: not found on disk' });
+  }
+  const sprintDir = AbsolutePath.parse(resolvedDir);
+  if (!sprintDir.ok) {
+    return Result.error({ kind: 'error', message: `sprint dir: ${sprintDir.error.message}` });
+  }
+  return Result.ok({ sprintDir: sprintDir.value });
+};
+
+interface ExecuteCreatePrFlowArgs {
+  readonly deps: AppDeps;
+  readonly sprintId: SprintId;
+  readonly sprintDir: AbsolutePath;
+  readonly cwd: AbsolutePath;
+  readonly useAi: boolean;
+}
+
+/**
+ * Build the createPr provider + flow and run it. Rebuilds the provider from the `createPr`
+ * settings row rather than reusing `deps.provider` (the wire-time seed keyed on the `implement`
+ * row) — in a mixed-provider config that would hand the createPr model string to the implement
+ * provider's CLI, a provider/model mismatch. The model is already sourced from
+ * `ai.createPr.model`, so the provider must match it.
+ */
+const executeCreatePrFlow = async (args: ExecuteCreatePrFlowArgs): Promise<RunState> => {
+  const { deps, sprintId, sprintDir, cwd, useAi } = args;
+  const provider = createAiProvider({
+    flow: 'createPr',
+    ai: deps.settings.ai,
+    harnessConfig: deps.settings.harness,
+    eventBus: deps.eventBus,
+  });
+  const flow = createCreatePrFlow(
+    {
+      sprintRepo: deps.sprintRepo,
+      sprintExecutionRepo: deps.sprintExecutionRepo,
+      taskRepo: deps.taskRepo,
+      pullRequestCreator: deps.pullRequestCreator,
+      gitRunner: deps.gitRunner,
+      eventBus: deps.eventBus,
+      clock: deps.clock,
+      provider,
+      templateLoader: deps.templateLoader,
+      writeFile: deps.writeFile,
+      logger: deps.logger,
+      model: deps.settings.ai.createPr.model,
+    },
+    { useAi }
+  );
+  const result = await flow.execute({
+    input: {
+      sprintId,
+      cwd,
+      sprintDir,
+      base: DEFAULT_BASE,
+      draft: DEFAULT_DRAFT,
+    },
+  });
+  if (!result.ok) {
+    return { kind: 'error', message: result.error.error.message };
+  }
+  return { kind: 'done', url: result.value.ctx.output!.url };
+};
+
+interface BodyProps {
+  readonly prep: PrepState;
+  readonly run: RunState;
+  readonly useAi: boolean;
+}
+
+/**
+ * Flat if-returns instead of a nested ternary chain — same branch order and same JSX as before,
+ * just laid out as one branch per line (mirrors `SprintDetailContent` in sprint-detail-view.tsx,
+ * the established fix for this exact cognitive-complexity shape in this codebase).
+ */
+const Body = ({ prep, run, useAi }: BodyProps): React.JSX.Element => {
+  const content = renderBody(prep, run, useAi);
+  return (
+    <Box flexDirection="column" paddingX={spacing.indent} marginTop={spacing.section}>
+      {content}
+    </Box>
+  );
+};
+
+const renderBody = (prep: PrepState, run: RunState, useAi: boolean): React.JSX.Element => {
+  if (prep.kind === 'loading') return <Spinner label="Loading project + sprint execution…" />;
+  if (prep.kind === 'error') {
+    return (
+      <Card title="Cannot open PR" tone="rule">
+        <Text color={inkColors.error}>
+          {glyphs.bullet} {prep.message}
+        </Text>
+      </Card>
+    );
+  }
+  if (run.kind === 'idle') {
+    return (
+      <Card title="Confirm" tone="rule">
+        <Text>
+          Branch <Text bold>{prep.branch}</Text> {glyphs.arrowRight} base <Text bold>{DEFAULT_BASE}</Text>{' '}
+          {glyphs.bullet} draft: <Text bold>{DEFAULT_DRAFT ? 'yes' : 'no'}</Text>
+        </Text>
+        <Text>
+          AI-authored: <Text bold>{useAi ? 'yes' : 'no'}</Text> {glyphs.bullet} press <Text bold>a</Text> to toggle
+        </Text>
+        <Text dimColor>
+          press <Text bold>enter</Text> to open the PR · esc to back out · use the CLI for non-default base / draft /
+          title / body
+        </Text>
+      </Card>
+    );
+  }
+  if (run.kind === 'running') return <Spinner label="Opening pull request…" />;
+  if (run.kind === 'done') {
+    return (
+      <Card title="Done" tone="rule">
+        <Text>
+          <Text color={inkColors.primary} bold>
+            {glyphs.check}{' '}
+          </Text>
+          <Text bold>{run.url}</Text>
+        </Text>
+      </Card>
+    );
+  }
+  return (
+    <Card title="Failed" tone="rule">
+      <Text color={inkColors.error}>
+        {glyphs.bullet} {run.message}
+      </Text>
+      <Text dimColor>press r to retry</Text>
+    </Card>
   );
 };

--- a/src/application/ui/tui/views/execute-view.tsx
+++ b/src/application/ui/tui/views/execute-view.tsx
@@ -49,6 +49,23 @@ import type { AppEvent } from '@src/business/observability/events.ts';
 import { useUiState, type FocusedRunCtx } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { fmtElapsed } from '@src/application/ui/tui/theme/duration.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import type {
+  SessionDescriptor,
+  SessionManager,
+  SessionRecord,
+} from '@src/application/ui/tui/runtime/session-manager.ts';
+import type { RouterApi } from '@src/application/ui/tui/runtime/router.tsx';
+import type { TerminalSize } from '@src/application/ui/tui/runtime/use-terminal-size.ts';
+import type { TokenUsage } from '@src/application/ui/tui/runtime/use-token-usage.ts';
+import type { LogEvent } from '@src/business/observability/events.ts';
+import type { HarnessSignal } from '@src/domain/signal.ts';
+import type { SprintExecution } from '@src/domain/entity/sprint-execution.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { ResponsiveLayout } from '@src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts';
+import type { BucketedDerivation } from '@src/application/ui/tui/views/execute-view-internals/use-bucketed-tasks.ts';
+import type { CancelHandlers } from '@src/application/ui/tui/views/execute-view-internals/use-cancel-handlers.ts';
 
 import { ExecuteBody } from '@src/application/ui/tui/views/execute-view-internals/body.tsx';
 import { LOG_TAIL_LIMIT } from '@src/application/ui/tui/views/execute-view-internals/log-panel.tsx';
@@ -67,51 +84,35 @@ interface ExecuteProps extends Readonly<Record<string, unknown>> {
 }
 
 /**
- * Derive a human-readable section title from a flow id. Keeps the Execute view header
- * accurate for any flow that reuses this view (refine, plan, review, create-pr, …) instead
- * of always showing "Implement". Falls back to the raw flowId so a future flow never shows
- * a blank header.
+ * Human-readable section title per flow id. Keeps the Execute view header accurate for any
+ * flow that reuses this view (refine, plan, review, create-pr, …) instead of always showing
+ * "Implement".
  */
-const flowIdToTitle = (flowId: string): string => {
-  switch (flowId) {
-    case 'implement':
-      return 'Implement';
-    case 'refine':
-      return 'Refine';
-    case 'plan':
-      return 'Plan';
-    case 'ideate':
-      return 'Ideate';
-    case 'review':
-      return 'Review';
-    case 'create-pr':
-      return 'Create PR';
-    case 'readiness':
-      return 'Readiness';
-    case 'detect-scripts':
-      return 'Detect Scripts';
-    case 'detect-skills':
-      return 'Detect Skills';
-    case 'create-sprint':
-      return 'Create Sprint';
-    case 'close-sprint':
-      return 'Close Sprint';
-    case 'add-ticket':
-      return 'Add Ticket';
-    case 'remove-ticket':
-      return 'Remove Ticket';
-    case 'export-context':
-      return 'Export Context';
-    case 'export-requirements':
-      return 'Export Requirements';
-    case 'doctor':
-      return 'Doctor';
-    case 'settings':
-      return 'Settings';
-    default:
-      return flowId;
-  }
+const FLOW_TITLES: Record<string, string> = {
+  implement: 'Implement',
+  refine: 'Refine',
+  plan: 'Plan',
+  ideate: 'Ideate',
+  review: 'Review',
+  'create-pr': 'Create PR',
+  readiness: 'Readiness',
+  'detect-scripts': 'Detect Scripts',
+  'detect-skills': 'Detect Skills',
+  'create-sprint': 'Create Sprint',
+  'close-sprint': 'Close Sprint',
+  'add-ticket': 'Add Ticket',
+  'remove-ticket': 'Remove Ticket',
+  'export-context': 'Export Context',
+  'export-requirements': 'Export Requirements',
+  doctor: 'Doctor',
+  settings: 'Settings',
 };
+
+/**
+ * Derive a human-readable section title from a flow id. Falls back to the raw flowId so a
+ * future flow never shows a blank header.
+ */
+const flowIdToTitle = (flowId: string): string => FLOW_TITLES[flowId] ?? flowId;
 
 /**
  * Buffer sizing for long Implement runs:
@@ -125,8 +126,30 @@ const flowIdToTitle = (flowId: string): string => {
 const HARNESS_SIGNAL_LIMIT = 1000;
 const CHAIN_EVENT_LIMIT = 2000;
 
-export const ExecuteView = (): React.JSX.Element => {
-  const { sessionId } = useViewProps<ExecuteProps>();
+// `useUiState` doesn't export its return interface, so infer it locally.
+type UiStateApi = ReturnType<typeof useUiState>;
+
+interface ExecuteSessionData {
+  readonly session: SessionRecord | undefined;
+  readonly sessions: SessionManager;
+  readonly sessionList: readonly SessionRecord[];
+  readonly router: RouterApi;
+  readonly ui: UiStateApi;
+  readonly deps: AppDeps;
+  readonly eventBus: AppDeps['eventBus'];
+  readonly signals: readonly HarnessSignal[];
+  readonly logEntries: readonly LogEvent[];
+  readonly chainEvents: readonly AppEvent[];
+  readonly term: TerminalSize;
+}
+
+/**
+ * Every hook that just wires this view to shared runtime context (session registry, event
+ * buses, deps, terminal size, …) rather than deriving Execute-specific state. Grouped into one
+ * call so the component body reads as "get my wiring, then derive my state" instead of a long
+ * flat prelude — the individual hooks are unchanged, still called in the same relative order.
+ */
+const useExecuteSessionData = (sessionId: string): ExecuteSessionData => {
   const session = useSession(sessionId);
   const sessions = useSessionManager();
   // Live list of every session for the multi-flow strip (renders only when ≥2 are running).
@@ -143,22 +166,40 @@ export const ExecuteView = (): React.JSX.Element => {
     limit: CHAIN_EVENT_LIMIT,
   });
   const term = useTerminalSize();
+  return { session, sessions, sessionList, router, ui, deps, eventBus, signals, logEntries, chainEvents, term };
+};
 
-  // Each Execute view is scoped to its session's pinned sprint so concurrent runs remain
-  // independent of each other and of the mutable global selection.
-  const pinnedSprintId = session?.descriptor?.pinnedSprintId as SprintId | undefined;
-  const pinnedProjectLabel = session?.descriptor?.pinnedProjectLabel;
-  const pinnedSprintLabel = session?.descriptor?.pinnedSprintLabel;
+interface UsePinnedSprintContextInput {
+  readonly pinnedSprintId: SprintId | undefined;
+  readonly pinnedProjectLabel: string | undefined;
+  readonly pinnedSprintLabel: string | undefined;
+  readonly sprintRepo: AppDeps['sprintRepo'];
+  readonly setFocusedRunContext: (ctx: FocusedRunCtx | undefined) => void;
+}
 
-  // Best-effort probe: mark the sprint unavailable when it has been closed or removed so
-  // the Execute view can show an inline fallback instead of stale panel data.
+/**
+ * Two effects scoped to the session's pinned sprint, extracted together because they share
+ * the same trio of inputs (pinnedSprintId / pinnedProjectLabel / pinnedSprintLabel):
+ *  - probes `sprintRepo` to detect a closed/removed sprint, surfaced as `pinnedSprintAvailable`
+ *    so the caller can blank the panels that depend on it (see `deriveTasksPanel` below).
+ *  - registers this run's project/sprint as the focused-run context so the breadcrumb and
+ *    progress overlay reflect the run's own sprint while this view is mounted.
+ */
+const usePinnedSprintContext = ({
+  pinnedSprintId,
+  pinnedProjectLabel,
+  pinnedSprintLabel,
+  sprintRepo,
+  setFocusedRunContext,
+}: UsePinnedSprintContextInput): { pinnedSprintAvailable: boolean } => {
   const [pinnedSprintAvailable, setPinnedSprintAvailable] = React.useState(true);
+
   React.useEffect(() => {
     if (pinnedSprintId === undefined) return undefined;
     let cancelled = false;
     const check = async (): Promise<void> => {
       try {
-        const r = await deps.sprintRepo.findById(pinnedSprintId);
+        const r = await sprintRepo.findById(pinnedSprintId);
         if (cancelled) return;
         if (!r.ok || r.value.status === 'done') setPinnedSprintAvailable(false);
       } catch {
@@ -169,11 +210,8 @@ export const ExecuteView = (): React.JSX.Element => {
     return (): void => {
       cancelled = true;
     };
-  }, [pinnedSprintId, deps.sprintRepo]);
+  }, [pinnedSprintId, sprintRepo]);
 
-  // Register this run's pinned project/sprint as the focused-run context so breadcrumb and
-  // progress overlay reflect the run's own sprint while this view is mounted.
-  const setFocusedRunContext = ui.setFocusedRunContext;
   React.useEffect(() => {
     const ctx: FocusedRunCtx = {
       projectLabel: pinnedProjectLabel,
@@ -186,107 +224,44 @@ export const ExecuteView = (): React.JSX.Element => {
     };
   }, [pinnedProjectLabel, pinnedSprintId, pinnedSprintLabel, setFocusedRunContext]);
 
-  // NOTE deliberately NO selection convergence here: focusing a run (Tab / Ctrl+1..9 /
-  // Sessions-open) is a *browse*, exactly like opening a project or sprint detail — it must
-  // never mutate (or persist) the global project/sprint selection. The user's pick survives
-  // until they explicitly pick something else; the focused-run context above already scopes
-  // the breadcrumb / overlay to the run's own sprint while this view is mounted.
+  return { pinnedSprintAvailable };
+};
 
-  const baselineSprintId: SprintId | undefined = pinnedSprintId;
-  const { executionState, taskState } = useBaselineHealthData({
-    baselineSprintId,
-    sprintExecutionRepo: deps.sprintExecutionRepo,
-    taskRepo: deps.taskRepo,
-  });
+interface DeriveTasksPanelInput {
+  readonly pinnedSprintStale: boolean;
+  readonly bucketed: BucketedExecution | undefined;
+  readonly descriptor: SessionDescriptor;
+  readonly isRunning: boolean;
+  readonly layout: ResponsiveLayout;
+  readonly tasksInputActive: boolean;
+  readonly now: number;
+  readonly executionState: SprintExecution | undefined;
+  readonly taskState: readonly Task[] | undefined;
+}
 
-  const isRunning = session?.descriptor.status === 'running';
+interface DeriveTasksPanelResult {
+  readonly tasksPanel: React.JSX.Element;
+  // Named to match `ExecuteBodyProps` (`executionState` / `taskState`) so the caller can spread
+  // this result straight onto `<ExecuteBody>` — see `ExecuteViewFrame` below.
+  readonly executionState: SprintExecution | undefined;
+  readonly taskState: readonly Task[] | undefined;
+}
 
-  // Cancel-scope picker — `c` no longer aborts immediately; it opens an inline overlay that
-  // distinguishes "cancel current attempt" (keep task queued, retry next round) from "cancel
-  // whole flow" (mark current task blocked + exit chain). The overlay claims the keyboard
-  // while mounted so the picker's `1` / `2` / `esc` keystrokes don't fight this handler.
-  const [cancelScopeOpen, setCancelScopeOpen] = React.useState(false);
-
-  useExecuteInput({
-    isRunning,
-    cancelScopeOpen,
-    setCancelScopeOpen,
-    modalOpen: ui.modalOpen,
-    router,
-  });
-
-  const now = useLiveClock(isRunning);
-
-  const { bucketed, tasksDone, tasksTotal, currentTask, currentTaskIdx, currentTaskName, currentSubStep } =
-    useBucketedTasks({ descriptor: session?.descriptor, chainEvents, signals, eventBus });
-
-  // Per-session token usage — latest `TokenUsageEvent` per sessionId. The execute view is
-  // sessionId-scoped so we only look up the current runner's entry; absent ⇒ empty state.
-  const tokenUsageBySession = useTokenUsage(eventBus);
-  const tokenUsage = tokenUsageBySession.get(sessionId);
-
-  // Stash the stable setter so the active-task-summary effect doesn't fire on unrelated
-  // UI state toggles (helpOpen, claims, …).
-  const setActiveTaskSummaryProvider = ui.setActiveTaskSummaryProvider;
-  useActiveTaskSummary({ currentTask, currentTaskName, setActiveTaskSummaryProvider });
-
-  const { attemptStartedAt, remainingTaskCount } = useCancelScopeStats({
-    chainEvents,
-    currentTask,
-    bucketed,
-  });
-  // Elapsed is derived here (not inside the memo) so the O(chainEvents) scan that produces
-  // `attemptStartedAt` does not re-run on every 1 Hz `useLiveClock` tick — only this cheap
-  // subtraction does. Math.max guards the initial render: `now` (useLiveClock's Date.now() seed)
-  // can be fractionally behind an attempt timestamp parsed in the same tick, yielding a small
-  // negative delta we clamp to 0.
-  const attemptElapsedMs = attemptStartedAt !== undefined ? Math.max(0, now - attemptStartedAt) : undefined;
-
-  const {
-    onCancelAttempt,
-    onCancelFlow,
-    onDismiss: onDismissCancelScope,
-  } = useCancelHandlers({
-    sessions,
-    sessionId,
-    sprintId: pinnedSprintId,
-    currentTask,
-    taskRepo: deps.taskRepo,
-    logger: deps.logger,
-    setCancelScopeOpen,
-  });
-
-  const layout = useResponsiveLayout({ columns: term.columns, rows: term.rows, isRunning });
-
-  // Early-return for "no session in registry" must come AFTER every hook above so the Hook
-  // call order is identical across renders. Hooks below this line do not exist — every Hook
-  // the view needs has already run.
-  const descriptor = session?.descriptor;
-  if (!session || descriptor === undefined) {
-    return (
-      <ViewShell title="Implement" subtitle="(session not found)">
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>The session id was not found in the registry. It may have been removed.</Text>
-        </Box>
-      </ViewShell>
-    );
-  }
-
-  // Wall-clock elapsed since the run started — a display string for the header / footer.
-  const endedAt = descriptor.finishedAt ?? now;
-  const elapsed = fmtElapsed(descriptor.startedAt, endedAt);
-
-  // TasksPanel claims input for the signal-row cursor (j/k or ↑/↓ to move, Enter / Space to
-  // expand a commit-message row). Disabled while any modal owns the keyboard so the cursor
-  // can't fight the help overlay (`?`), the progress overlay (`g`), a prompt, or the
-  // cancel-scope picker (`c`) — the latter is rendered inline behind the modal, so without
-  // this gate esc/j/k/e would double-handle the hidden panel.
-  const tasksInputActive = !ui.modalOpen && !cancelScopeOpen;
-
-  // When the pinned sprint is no longer available (done or removed), blank the panels that
-  // depend on it and surface a pick-a-sprint prompt so the user knows what happened.
-  const pinnedSprintStale = pinnedSprintId !== undefined && !pinnedSprintAvailable;
-
+/**
+ * When the pinned sprint is no longer available (done or removed), blank the panels that
+ * depend on it and surface a pick-a-sprint prompt so the user knows what happened.
+ */
+const deriveTasksPanel = ({
+  pinnedSprintStale,
+  bucketed,
+  descriptor,
+  isRunning,
+  layout,
+  tasksInputActive,
+  now,
+  executionState,
+  taskState,
+}: DeriveTasksPanelInput): DeriveTasksPanelResult => {
   const tasksPanel = pinnedSprintStale ? (
     <Box paddingX={spacing.indent}>
       <Text dimColor>Sprint no longer available — pick a sprint to continue.</Text>
@@ -304,8 +279,109 @@ export const ExecuteView = (): React.JSX.Element => {
     />
   );
 
-  const effectiveExecutionState = pinnedSprintStale ? undefined : executionState;
-  const effectiveTaskState = pinnedSprintStale ? undefined : taskState;
+  return {
+    tasksPanel,
+    executionState: pinnedSprintStale ? undefined : executionState,
+    taskState: pinnedSprintStale ? undefined : taskState,
+  };
+};
+
+/** Rendered when `sessionId` has no matching entry in the registry (e.g. it was removed). */
+const SessionNotFoundNotice = (): React.JSX.Element => (
+  <ViewShell title="Implement" subtitle="(session not found)">
+    <Box paddingX={spacing.indent}>
+      <Text dimColor>The session id was not found in the registry. It may have been removed.</Text>
+    </Box>
+  </ViewShell>
+);
+
+/**
+ * Not derived inside `useCancelScopeStats` itself so the O(chainEvents) scan that produces
+ * `attemptStartedAt` does not re-run on every 1 Hz `useLiveClock` tick — only this cheap
+ * subtraction does. `Math.max` guards the initial render: `now` (`useLiveClock`'s `Date.now()`
+ * seed) can be fractionally behind an attempt timestamp parsed in the same tick, yielding a
+ * small negative delta we clamp to 0.
+ */
+const computeAttemptElapsedMs = (attemptStartedAt: number | undefined, now: number): number | undefined =>
+  attemptStartedAt !== undefined ? Math.max(0, now - attemptStartedAt) : undefined;
+
+interface UseExecuteRunControlsInput {
+  readonly descriptor: SessionDescriptor | undefined;
+  readonly modalOpen: boolean;
+  readonly router: RouterApi;
+}
+
+export interface ExecuteRunControls {
+  readonly isRunning: boolean;
+  readonly cancelScopeOpen: boolean;
+  readonly setCancelScopeOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly now: number;
+}
+
+/**
+ * Bundles the three pieces of state/derivation that only make sense together: whether the run
+ * is live, the cancel-scope picker's open/closed state (claimed by `useExecuteInput`'s `c` key),
+ * and the 1 Hz clock that only ticks while running.
+ */
+const useExecuteRunControls = ({ descriptor, modalOpen, router }: UseExecuteRunControlsInput): ExecuteRunControls => {
+  const isRunning = descriptor?.status === 'running';
+
+  // Cancel-scope picker — `c` no longer aborts immediately; it opens an inline overlay that
+  // distinguishes "cancel current attempt" (keep task queued, retry next round) from "cancel
+  // whole flow" (mark current task blocked + exit chain). The overlay claims the keyboard
+  // while mounted so the picker's `1` / `2` / `esc` keystrokes don't fight this handler.
+  const [cancelScopeOpen, setCancelScopeOpen] = React.useState(false);
+
+  useExecuteInput({ isRunning, cancelScopeOpen, setCancelScopeOpen, modalOpen, router });
+
+  const now = useLiveClock(isRunning);
+
+  return { isRunning, cancelScopeOpen, setCancelScopeOpen, now };
+};
+
+interface ExecuteViewFrameProps {
+  readonly ui: UiStateApi;
+  readonly descriptor: SessionDescriptor;
+  readonly sessionList: readonly SessionRecord[];
+  readonly sessionId: string;
+  readonly runControls: ExecuteRunControls;
+  readonly layout: ResponsiveLayout;
+  readonly term: TerminalSize;
+  readonly bucketedTasks: BucketedDerivation;
+  readonly tasksPanelDerivation: DeriveTasksPanelResult;
+  readonly tokenUsage: TokenUsage | undefined;
+  readonly logEntries: readonly LogEvent[];
+  readonly attemptElapsedMs: number | undefined;
+  readonly remainingTaskCount: number;
+  readonly cancelHandlers: CancelHandlers;
+  readonly pinnedSprintStale: boolean;
+}
+
+/**
+ * The settled render for a found session — header chip + either the help overlay or the full
+ * `ExecuteBody`. Takes the grouped hook results as-is (rather than 20+ flat props) so the
+ * caller reads as "assemble the frame from what I already computed".
+ */
+const ExecuteViewFrame = ({
+  ui,
+  descriptor,
+  sessionList,
+  sessionId,
+  runControls,
+  layout,
+  term,
+  bucketedTasks,
+  tasksPanelDerivation,
+  tokenUsage,
+  logEntries,
+  attemptElapsedMs,
+  remainingTaskCount,
+  cancelHandlers,
+  pinnedSprintStale,
+}: ExecuteViewFrameProps): React.JSX.Element => {
+  // Wall-clock elapsed since the run started — a display string for the header / footer.
+  const endedAt = descriptor.finishedAt ?? runControls.now;
+  const elapsed = fmtElapsed(descriptor.startedAt, endedAt);
 
   return (
     <ViewShell
@@ -321,33 +397,146 @@ export const ExecuteView = (): React.JSX.Element => {
           descriptor={descriptor}
           sessionList={sessionList}
           sessionId={sessionId}
-          isRunning={isRunning}
-          now={now}
+          isRunning={runControls.isRunning}
+          now={runControls.now}
           elapsed={elapsed}
           layout={layout}
           termColumns={term.columns}
           termRows={term.rows}
-          bucketed={bucketed}
-          executionState={effectiveExecutionState}
-          taskState={effectiveTaskState}
           tokenUsage={tokenUsage}
-          tasksDone={tasksDone}
-          tasksTotal={tasksTotal}
-          currentTask={currentTask}
-          currentTaskIdx={currentTaskIdx}
-          currentTaskName={currentTaskName}
-          currentSubStep={currentSubStep}
-          tasksPanel={tasksPanel}
           logEntries={logEntries}
-          cancelScopeOpen={cancelScopeOpen}
+          cancelScopeOpen={runControls.cancelScopeOpen}
           attemptElapsedMs={attemptElapsedMs}
           remainingTaskCount={remainingTaskCount}
-          onCancelAttempt={onCancelAttempt}
-          onCancelFlow={onCancelFlow}
-          onDismissCancelScope={onDismissCancelScope}
+          onCancelAttempt={cancelHandlers.onCancelAttempt}
+          onCancelFlow={cancelHandlers.onCancelFlow}
+          onDismissCancelScope={cancelHandlers.onDismiss}
           pinnedSprintStale={pinnedSprintStale}
+          {...bucketedTasks}
+          {...tasksPanelDerivation}
         />
       )}
     </ViewShell>
+  );
+};
+
+export const ExecuteView = (): React.JSX.Element => {
+  const { sessionId } = useViewProps<ExecuteProps>();
+  const { session, sessions, sessionList, router, ui, deps, eventBus, signals, logEntries, chainEvents, term } =
+    useExecuteSessionData(sessionId);
+
+  // Each Execute view is scoped to its session's pinned sprint so concurrent runs remain
+  // independent of each other and of the mutable global selection.
+  const descriptor = session?.descriptor;
+  const pinnedSprintId = descriptor?.pinnedSprintId as SprintId | undefined;
+  const pinnedProjectLabel = descriptor?.pinnedProjectLabel;
+  const pinnedSprintLabel = descriptor?.pinnedSprintLabel;
+
+  // Probes sprintRepo (best-effort — mark unavailable when closed/removed so the Execute
+  // view can show an inline fallback instead of stale panel data) and registers this run's
+  // pinned project/sprint as the focused-run context so breadcrumb and progress overlay
+  // reflect the run's own sprint while this view is mounted.
+  const { pinnedSprintAvailable } = usePinnedSprintContext({
+    pinnedSprintId,
+    pinnedProjectLabel,
+    pinnedSprintLabel,
+    sprintRepo: deps.sprintRepo,
+    setFocusedRunContext: ui.setFocusedRunContext,
+  });
+
+  // NOTE deliberately NO selection convergence here: focusing a run (Tab / Ctrl+1..9 /
+  // Sessions-open) is a *browse*, exactly like opening a project or sprint detail — it must
+  // never mutate (or persist) the global project/sprint selection. The user's pick survives
+  // until they explicitly pick something else; the focused-run context above already scopes
+  // the breadcrumb / overlay to the run's own sprint while this view is mounted.
+
+  const { executionState, taskState } = useBaselineHealthData({
+    baselineSprintId: pinnedSprintId,
+    sprintExecutionRepo: deps.sprintExecutionRepo,
+    taskRepo: deps.taskRepo,
+  });
+
+  const runControls = useExecuteRunControls({ descriptor, modalOpen: ui.modalOpen, router });
+
+  const bucketedTasks = useBucketedTasks({ descriptor, chainEvents, signals, eventBus });
+
+  // Per-session token usage — latest `TokenUsageEvent` per sessionId. The execute view is
+  // sessionId-scoped so we only look up the current runner's entry; absent ⇒ empty state.
+  const tokenUsageBySession = useTokenUsage(eventBus);
+  const tokenUsage = tokenUsageBySession.get(sessionId);
+
+  // Stash the stable setter so the active-task-summary effect doesn't fire on unrelated
+  // UI state toggles (helpOpen, claims, …).
+  const setActiveTaskSummaryProvider = ui.setActiveTaskSummaryProvider;
+  useActiveTaskSummary({
+    currentTask: bucketedTasks.currentTask,
+    currentTaskName: bucketedTasks.currentTaskName,
+    setActiveTaskSummaryProvider,
+  });
+
+  const cancelStats = useCancelScopeStats({
+    chainEvents,
+    currentTask: bucketedTasks.currentTask,
+    bucketed: bucketedTasks.bucketed,
+  });
+  const attemptElapsedMs = computeAttemptElapsedMs(cancelStats.attemptStartedAt, runControls.now);
+
+  const cancelHandlers = useCancelHandlers({
+    sessions,
+    sessionId,
+    sprintId: pinnedSprintId,
+    currentTask: bucketedTasks.currentTask,
+    taskRepo: deps.taskRepo,
+    logger: deps.logger,
+    setCancelScopeOpen: runControls.setCancelScopeOpen,
+  });
+
+  const layout = useResponsiveLayout({ columns: term.columns, rows: term.rows, isRunning: runControls.isRunning });
+
+  // Early-return for "no session in registry" must come AFTER every hook above so the Hook
+  // call order is identical across renders. Hooks below this line do not exist — every Hook
+  // the view needs has already run.
+  if (!session || descriptor === undefined) return <SessionNotFoundNotice />;
+
+  // TasksPanel claims input for the signal-row cursor (j/k or ↑/↓ to move, Enter / Space to
+  // expand a commit-message row). Disabled while any modal owns the keyboard so the cursor
+  // can't fight the help overlay (`?`), the progress overlay (`g`), a prompt, or the
+  // cancel-scope picker (`c`) — the latter is rendered inline behind the modal, so without
+  // this gate esc/j/k/e would double-handle the hidden panel.
+  const tasksInputActive = !ui.modalOpen && !runControls.cancelScopeOpen;
+
+  // The pinned sprint is stale once it's been closed or removed — see `deriveTasksPanel`.
+  const pinnedSprintStale = pinnedSprintId !== undefined && !pinnedSprintAvailable;
+
+  const tasksPanelDerivation = deriveTasksPanel({
+    pinnedSprintStale,
+    bucketed: bucketedTasks.bucketed,
+    descriptor,
+    isRunning: runControls.isRunning,
+    layout,
+    tasksInputActive,
+    now: runControls.now,
+    executionState,
+    taskState,
+  });
+
+  return (
+    <ExecuteViewFrame
+      ui={ui}
+      descriptor={descriptor}
+      sessionList={sessionList}
+      sessionId={sessionId}
+      runControls={runControls}
+      layout={layout}
+      term={term}
+      bucketedTasks={bucketedTasks}
+      tasksPanelDerivation={tasksPanelDerivation}
+      tokenUsage={tokenUsage}
+      logEntries={logEntries}
+      attemptElapsedMs={attemptElapsedMs}
+      remainingTaskCount={cancelStats.remainingTaskCount}
+      cancelHandlers={cancelHandlers}
+      pinnedSprintStale={pinnedSprintStale}
+    />
   );
 };

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -138,6 +138,147 @@ const formatRow = (row: AiFlowSettings, globalEffort: Settings['ai']['effort']):
   return `${row.provider} / ${row.model} / ${resolved ?? 'auto'}`;
 };
 
+/** Outcome of {@link pickProviderStep} — feeds the model + effort steps and the final override. */
+interface ProviderStepResult {
+  readonly providerValue: string;
+  readonly providerChanged: boolean;
+  readonly effectiveProvider: AiProvider;
+}
+
+/**
+ * Step 1 of {@link customizeRow} — provider. Keep default first, then every provider option
+ * (including the default's own provider; picking it explicitly is treated as "no change").
+ * Returns `undefined` when the user cancels.
+ */
+const pickProviderStep = async (
+  interactive: InteractivePrompt,
+  header: string,
+  defaultRow: AiFlowSettings
+): Promise<ProviderStepResult | undefined> => {
+  const providerOptions: ReadonlyArray<Choice<string>> = [
+    { label: labelKeepDefault(defaultRow.provider), value: KEEP },
+    ...AI_PROVIDERS.map((p) => ({ label: p, value: p })),
+  ];
+  const providerAns = await interactive.askChoice<string>(`${header}\nProvider:`, providerOptions);
+  if (!providerAns.ok) return undefined;
+  const providerChanged = providerAns.value !== KEEP && providerAns.value !== defaultRow.provider;
+  const effectiveProvider: AiProvider = providerChanged ? (providerAns.value as AiProvider) : defaultRow.provider;
+  return { providerValue: providerAns.value, providerChanged, effectiveProvider };
+};
+
+/**
+ * Step 2 of {@link customizeRow} — model. When the provider switched, the saved default model
+ * belongs to a different provider's catalog; omit `Keep default` so the user can't accidentally
+ * pick an incompatible model. Otherwise show `Keep default` first. Returns `undefined` when the
+ * user cancels.
+ */
+const pickModelStep = async (
+  interactive: InteractivePrompt,
+  header: string,
+  defaultRow: AiFlowSettings,
+  effectiveProvider: AiProvider,
+  providerChanged: boolean,
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+): Promise<string | undefined> => {
+  const modelCatalog = await resolveModelCatalog(effectiveProvider, availableModelsFor);
+  const modelOptions: ReadonlyArray<Choice<string>> = providerChanged
+    ? modelCatalog.map(modelChoice)
+    : [{ label: labelKeepDefault(defaultRow.model), value: KEEP }, ...modelCatalog.map(modelChoice)];
+  const modelAns = await interactive.askChoice<string>(`${header}\nModel:`, modelOptions);
+  if (!modelAns.ok) return undefined;
+  return modelAns.value;
+};
+
+/**
+ * Compute the `Keep default` label for the effort step. When the provider switched, the saved
+ * row's effort may not exist in the new provider's vocabulary; `Keep default` then means "let
+ * the launcher resolve" (the row carries no per-flow effort, so resolveEffort floors the global
+ * value to the new provider).
+ *
+ * When the provider stayed the same but the model changed, the saved row's effort would be
+ * silently inherited — which is the bug: sonnet @ xhigh (the worst wall-clock combination)
+ * appears when the user's intent was only "use a cheaper model". Make the inheritance visible by
+ * labelling the keep-default option with the concrete value it carries, flagging whether it
+ * comes from the saved row or the global default so the user can decide deliberately.
+ */
+const computeEffortDefaultLabel = (
+  defaultRow: AiFlowSettings,
+  globalEffort: Settings['ai']['effort'],
+  providerChanged: boolean,
+  modelChanged: boolean,
+  resolvedRowEffort: string | undefined
+): string => {
+  if (providerChanged) {
+    // Provider switched — the saved row's effort vocabulary may not apply; omit the concrete
+    // value so the user isn't misled into thinking it will carry over.
+    return 'Keep default';
+  }
+  if (modelChanged) {
+    // Model changed but provider stayed. Show the value the row would inherit AND flag that
+    // it comes from the saved row, so the user can make a deliberate choice.
+    const rowEffortSource = defaultRow.effort !== undefined ? 'saved row' : globalEffort !== undefined ? 'global' : '';
+    const effortDisplay = resolvedRowEffort ?? 'auto';
+    return rowEffortSource.length > 0
+      ? `Keep default (${effortDisplay} — ${rowEffortSource})`
+      : `Keep default (${effortDisplay})`;
+  }
+  // Neither provider nor model changed — show the resolved effort as-is (existing behaviour).
+  return labelKeepDefault(resolvedRowEffort ?? 'auto');
+};
+
+/**
+ * Step 3 of {@link customizeRow} — effort. See {@link computeEffortDefaultLabel} for how the
+ * model-changed case shifts the highlighted default to the global effort (or 'auto') rather
+ * than the per-row value, so the safest option leads. Returns `undefined` when the user cancels.
+ */
+const pickEffortStep = async (
+  interactive: InteractivePrompt,
+  header: string,
+  defaultRow: AiFlowSettings,
+  globalEffort: Settings['ai']['effort'],
+  effectiveProvider: AiProvider,
+  providerChanged: boolean,
+  modelChanged: boolean
+): Promise<string | undefined> => {
+  const effortCatalog = PROVIDER_EFFORT_LEVELS[effectiveProvider];
+  const resolvedRowEffort = resolveEffortForRow(defaultRow, globalEffort);
+  const effortDefaultLabel = computeEffortDefaultLabel(
+    defaultRow,
+    globalEffort,
+    providerChanged,
+    modelChanged,
+    resolvedRowEffort
+  );
+  const effortOptions: ReadonlyArray<Choice<string>> = [
+    { label: effortDefaultLabel, value: KEEP },
+    ...effortCatalog.map((e) => ({ label: e, value: e })),
+  ];
+  const effortAns = await interactive.askChoice<string>(`${header}\nEffort:`, effortOptions);
+  if (!effortAns.ok) return undefined;
+  return effortAns.value;
+};
+
+/**
+ * Assemble the per-field override from the three step answers. When the provider switched but
+ * model / effort were not chosen, we still need a model (the launcher can't merge a model from
+ * the old provider's catalog) — forced through when it was unset above (because it matched
+ * `defaultRow.model` on a single catalog overlap).
+ */
+const assembleRowOverride = (
+  defaultRow: AiFlowSettings,
+  providerChanged: boolean,
+  providerValue: string,
+  modelValue: string,
+  effortValue: string
+): NonNullable<LaunchExtras['override']> => {
+  const override: { provider?: AiProvider; model?: string; effort?: string } = {};
+  if (providerChanged) override.provider = providerValue as AiProvider;
+  if (modelValue !== KEEP && modelValue !== defaultRow.model) override.model = modelValue;
+  if (effortValue !== KEEP) override.effort = effortValue;
+  if (providerChanged && override.model === undefined) override.model = modelValue;
+  return override;
+};
+
 /**
  * Walk one row through the three sequential prompts — provider → model → effort. Returns the
  * per-field override (only fields the user changed) or `undefined` when the user cancels at
@@ -150,76 +291,33 @@ const customizeRow = async (
   globalEffort: Settings['ai']['effort'],
   availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
 ): Promise<NonNullable<LaunchExtras['override']> | undefined> => {
-  // Step 1 — provider. Keep default first, then every provider option (including the
-  // default's own provider; picking it explicitly is treated as "no change").
-  const providerOptions: ReadonlyArray<Choice<string>> = [
-    { label: labelKeepDefault(defaultRow.provider), value: KEEP },
-    ...AI_PROVIDERS.map((p) => ({ label: p, value: p })),
-  ];
-  const providerAns = await interactive.askChoice<string>(`${header}\nProvider:`, providerOptions);
-  if (!providerAns.ok) return undefined;
-  const providerChanged = providerAns.value !== KEEP && providerAns.value !== defaultRow.provider;
-  const effectiveProvider: AiProvider = providerChanged ? (providerAns.value as AiProvider) : defaultRow.provider;
+  const providerStep = await pickProviderStep(interactive, header, defaultRow);
+  if (providerStep === undefined) return undefined;
+  const { providerValue, providerChanged, effectiveProvider } = providerStep;
 
-  // Step 2 — model. When the provider switched, the saved default model belongs to a
-  // different provider's catalog; omit `Keep default` so the user can't accidentally pick an
-  // incompatible model. Otherwise show `Keep default` first.
-  const modelCatalog = await resolveModelCatalog(effectiveProvider, availableModelsFor);
-  const modelOptions: ReadonlyArray<Choice<string>> = providerChanged
-    ? modelCatalog.map(modelChoice)
-    : [{ label: labelKeepDefault(defaultRow.model), value: KEEP }, ...modelCatalog.map(modelChoice)];
-  const modelAns = await interactive.askChoice<string>(`${header}\nModel:`, modelOptions);
-  if (!modelAns.ok) return undefined;
+  const modelValue = await pickModelStep(
+    interactive,
+    header,
+    defaultRow,
+    effectiveProvider,
+    providerChanged,
+    availableModelsFor
+  );
+  if (modelValue === undefined) return undefined;
+  const modelChanged = modelValue !== KEEP && modelValue !== defaultRow.model;
 
-  // Step 3 — effort. When the provider switched, the saved row's effort may not exist in the
-  // new provider's vocabulary; `Keep default` then means "let the launcher resolve" (the row
-  // carries no per-flow effort, so resolveEffort floors the global value to the new provider).
-  //
-  // When the provider stayed the same but the model changed, the saved row's effort would be
-  // silently inherited — which is the bug: sonnet @ xhigh (the worst wall-clock combination)
-  // appears when the user's intent was only "use a cheaper model". Make the inheritance
-  // visible by labelling the keep-default option with the concrete value it carries, flagging
-  // whether it comes from the saved row or the global default so the user can decide
-  // deliberately. The model-changed case also shifts the highlighted default to the global
-  // effort (or 'auto') rather than the per-row value so the safest option leads.
-  const effortCatalog = PROVIDER_EFFORT_LEVELS[effectiveProvider];
-  const modelChanged = modelAns.value !== KEEP && modelAns.value !== defaultRow.model;
-  const resolvedRowEffort = resolveEffortForRow(defaultRow, globalEffort);
-  let effortDefaultLabel: string;
-  if (providerChanged) {
-    // Provider switched — the saved row's effort vocabulary may not apply; omit the concrete
-    // value so the user isn't misled into thinking it will carry over.
-    effortDefaultLabel = 'Keep default';
-  } else if (modelChanged) {
-    // Model changed but provider stayed. Show the value the row would inherit AND flag that
-    // it comes from the saved row, so the user can make a deliberate choice.
-    const rowEffortSource = defaultRow.effort !== undefined ? 'saved row' : globalEffort !== undefined ? 'global' : '';
-    const effortDisplay = resolvedRowEffort ?? 'auto';
-    effortDefaultLabel =
-      rowEffortSource.length > 0
-        ? `Keep default (${effortDisplay} — ${rowEffortSource})`
-        : `Keep default (${effortDisplay})`;
-  } else {
-    // Neither provider nor model changed — show the resolved effort as-is (existing behaviour).
-    effortDefaultLabel = labelKeepDefault(resolvedRowEffort ?? 'auto');
-  }
-  const effortOptions: ReadonlyArray<Choice<string>> = [
-    { label: effortDefaultLabel, value: KEEP },
-    ...effortCatalog.map((e) => ({ label: e, value: e })),
-  ];
-  const effortAns = await interactive.askChoice<string>(`${header}\nEffort:`, effortOptions);
-  if (!effortAns.ok) return undefined;
+  const effortValue = await pickEffortStep(
+    interactive,
+    header,
+    defaultRow,
+    globalEffort,
+    effectiveProvider,
+    providerChanged,
+    modelChanged
+  );
+  if (effortValue === undefined) return undefined;
 
-  const override: { provider?: AiProvider; model?: string; effort?: string } = {};
-  if (providerChanged) override.provider = providerAns.value as AiProvider;
-  if (modelAns.value !== KEEP && modelAns.value !== defaultRow.model) override.model = modelAns.value;
-  if (effortAns.value !== KEEP) override.effort = effortAns.value;
-  // When the provider switched but model / effort were not chosen, we still need a model
-  // (the launcher can't merge a model from the old provider's catalog). When provider
-  // changed and model was unset above (because it matched defaultRow.model on a single
-  // catalog overlap), force the picked value through.
-  if (providerChanged && override.model === undefined) override.model = modelAns.value;
-  return override;
+  return assembleRowOverride(defaultRow, providerChanged, providerValue, modelValue, effortValue);
 };
 
 export interface RunCustomizePickerArgs {
@@ -234,6 +332,69 @@ export interface RunCustomizePickerArgs {
    */
   readonly availableModelsFor?: (provider: AiProvider) => Promise<readonly string[]>;
 }
+
+/**
+ * Header context — shown at the top of every prompt frame so the user always knows what the
+ * current defaults are. For implement we render both gen and eval; for everything else we
+ * render the single resolved row.
+ */
+const buildPickerHeader = (flowId: string, flowTitle: string, settings: Settings): string =>
+  flowId === 'implement'
+    ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort)}`
+    : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort)}`;
+
+/**
+ * Customize path for the `implement` flow — walk generator first, then evaluator. Cancel at
+ * any step (including mid-evaluator) closes the picker without launching and discards any
+ * generator override already set — the launcher must not apply a half-completed customize
+ * session.
+ */
+const runImplementCustomize = async (
+  interactive: InteractivePrompt,
+  header: string,
+  settings: Settings,
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+): Promise<CustomizePickerResult> => {
+  const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
+  const collected: {
+    generator?: NonNullable<LaunchExtras['override']>;
+    evaluator?: NonNullable<LaunchExtras['override']>;
+  } = {};
+  for (const role of roles) {
+    const row = role === 'generator' ? settings.ai.implement.generator : settings.ai.implement.evaluator;
+    const roleHeader = `${header}\n\nRole: ${role}`;
+    const result = await customizeRow(interactive, roleHeader, row, settings.ai.effort, availableModelsFor);
+    if (result === undefined) return { kind: 'cancel' };
+    if (Object.keys(result).length > 0) collected[role] = result;
+  }
+  if (collected.generator === undefined && collected.evaluator === undefined) {
+    // Both roles kept all defaults — same outcome as picking Start.
+    return { kind: 'defaults' };
+  }
+  return {
+    kind: 'implement',
+    implementRoleOverrides: {
+      ...(collected.generator !== undefined ? { generator: collected.generator } : {}),
+      ...(collected.evaluator !== undefined ? { evaluator: collected.evaluator } : {}),
+    },
+  };
+};
+
+/** Customize path for every non-implement flow — a single row walk through {@link customizeRow}. */
+const runSingleRowCustomize = async (
+  interactive: InteractivePrompt,
+  header: string,
+  flowId: string,
+  settings: Settings,
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+): Promise<CustomizePickerResult> => {
+  const defaultRow = defaultRowFor(flowId, settings);
+  if (defaultRow === undefined) return { kind: 'defaults' };
+  const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor);
+  if (override === undefined) return { kind: 'cancel' };
+  if (Object.keys(override).length === 0) return { kind: 'defaults' };
+  return { kind: 'single', override };
+};
 
 /**
  * Drive the pre-launch picker for one click of an AI-driven flow row. Returns `kind: 'cancel'`
@@ -254,13 +415,7 @@ export const runCustomizePicker = async ({
   const aiFlow = aiFlowIdForPicker(flowId);
   if (aiFlow === undefined) return { kind: 'defaults' };
 
-  // Header context — shown at the top of every prompt frame so the user always knows what
-  // the current defaults are. For implement we render both gen and eval; for everything else
-  // we render the single resolved row.
-  const header =
-    flowId === 'implement'
-      ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort)}`
-      : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort)}`;
+  const header = buildPickerHeader(flowId, flowTitle, settings);
 
   const action = await interactive.askChoice<'start' | 'customize' | 'cancel'>(
     `${header}\n\nWhat would you like to do?`,
@@ -274,38 +429,8 @@ export const runCustomizePicker = async ({
   if (action.value === 'start') return { kind: 'defaults' };
 
   if (flowId === 'implement') {
-    // Walk generator first, then evaluator. Cancel at any step (including mid-evaluator)
-    // closes the picker without launching and discards any generator override already set —
-    // the launcher must not apply a half-completed customize session.
-    const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
-    const collected: {
-      generator?: NonNullable<LaunchExtras['override']>;
-      evaluator?: NonNullable<LaunchExtras['override']>;
-    } = {};
-    for (const role of roles) {
-      const row = role === 'generator' ? settings.ai.implement.generator : settings.ai.implement.evaluator;
-      const roleHeader = `${header}\n\nRole: ${role}`;
-      const result = await customizeRow(interactive, roleHeader, row, settings.ai.effort, availableModelsFor);
-      if (result === undefined) return { kind: 'cancel' };
-      if (Object.keys(result).length > 0) collected[role] = result;
-    }
-    if (collected.generator === undefined && collected.evaluator === undefined) {
-      // Both roles kept all defaults — same outcome as picking Start.
-      return { kind: 'defaults' };
-    }
-    return {
-      kind: 'implement',
-      implementRoleOverrides: {
-        ...(collected.generator !== undefined ? { generator: collected.generator } : {}),
-        ...(collected.evaluator !== undefined ? { evaluator: collected.evaluator } : {}),
-      },
-    };
+    return runImplementCustomize(interactive, header, settings, availableModelsFor);
   }
 
-  const defaultRow = defaultRowFor(flowId, settings);
-  if (defaultRow === undefined) return { kind: 'defaults' };
-  const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor);
-  if (override === undefined) return { kind: 'cancel' };
-  if (Object.keys(override).length === 0) return { kind: 'defaults' };
-  return { kind: 'single', override };
+  return runSingleRowCustomize(interactive, header, flowId, settings, availableModelsFor);
 };

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -15,23 +15,34 @@ import { ActionMenu, type MenuItem } from '@src/application/ui/tui/components/ac
 import { LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
 import { StatusChip, sprintStatusKind } from '@src/application/ui/tui/components/status-chip.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
-import { flowRegistry } from '@src/application/registry.ts';
+import { flowRegistry, type FlowEntry } from '@src/application/registry.ts';
 import { evaluateTriggers } from '@src/application/registry-triggers.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { useAppStateSnapshot } from '@src/application/ui/tui/runtime/use-app-state-snapshot.ts';
 import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
-import { useRouter, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+import { useRouter, type RouterApi, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSessionManager } from '@src/application/ui/tui/runtime/sessions-context.tsx';
+import type { SessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
+import type { PromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
 import { useStorage } from '@src/application/ui/tui/runtime/storage-context.tsx';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { openFlowSession } from '@src/application/ui/tui/runtime/open-flow-session.ts';
-import { launchFlow } from '@src/application/ui/shared/launcher.ts';
+import {
+  launchFlow,
+  type LaunchExtras,
+  type LauncherDeps,
+  type LaunchResult,
+} from '@src/application/ui/shared/launcher.ts';
 import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
-import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customize-picker.ts';
+import {
+  runCustomizePicker,
+  type CustomizePickerResult,
+} from '@src/application/ui/tui/views/flows-customize-picker.ts';
 import { runRepositorySelection } from '@src/application/ui/tui/views/flows-repository-picker.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
@@ -39,6 +50,9 @@ import { getImplementRoleOverrides } from '@src/application/ui/tui/runtime/imple
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { SprintPipeline, resolveSprintStage } from '@src/application/ui/tui/components/sprint-pipeline.tsx';
 import { sectionFor, sectionRank, visibleFlowsFor } from '@src/application/ui/tui/views/flows-visibility.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Runner } from '@src/application/chain/run/runner.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
 
 // Sprint-state-machine visibility lives in `flows-visibility.ts` so it can be unit-tested
 // without a React render. The view delegates section labelling, ordering, and the
@@ -160,6 +174,297 @@ const OrientationCard = ({ snapshot, showAll }: OrientationCardProps): React.JSX
   );
 };
 
+/**
+ * Assemble the per-launch {@link LaunchExtras} from the resolved repository id, the customize
+ * picker's outcome, and the fresh settings snapshot. Implement role overrides prefer the
+ * picker's per-role result; falling back to the CLI-derived module holder (parsed from
+ * `--implement-{generator,evaluator}-{provider,model}`) only for the `implement` flow when the
+ * picker ran in single-row mode (i.e. every AI flow other than implement).
+ */
+const buildLaunchExtras = (
+  picker: CustomizePickerResult,
+  entry: FlowEntry,
+  chosenRepositoryId: RepositoryId | undefined,
+  ui: ReturnType<typeof useUiState>,
+  settings: Settings
+): LaunchExtras => {
+  const implementRoleOverrides =
+    picker.kind === 'implement'
+      ? picker.implementRoleOverrides
+      : entry.manifest.id === 'implement'
+        ? getImplementRoleOverrides()
+        : undefined;
+  const override = picker.kind === 'single' ? picker.override : undefined;
+  // Thread the resolved repository id as a pre-selection. When the repo-selection step ran,
+  // `chosenRepositoryId` is the user's fresh pick; otherwise (single-repo / non-repo flows) it
+  // falls back to the session pin so the flow's own `pickRepositoryLeaf` still pre-selects the
+  // lone / previously-chosen repo.
+  const repositoryId = chosenRepositoryId ?? ui.sessionRepositoryId;
+  return {
+    ...(repositoryId !== undefined ? { repositoryId } : {}),
+    ...(override !== undefined ? { override } : {}),
+    ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
+    settingsSnapshot: settings,
+  };
+};
+
+interface RunFlowLaunchDeps {
+  readonly selection: ReturnType<typeof useSelection>;
+  readonly sessions: SessionManager;
+}
+
+/**
+ * Dispatch the flow launch. create-sprint and close-sprint change which sprint (or status) the
+ * user is "on" — route them through the sprint-bound wrapper so the post-completion selection
+ * reseat happens in one place instead of leaving the global selection stale. create-sprint
+ * additionally strips the launch-time sprint from the snapshot: the new sprint doesn't exist
+ * yet, so pinning the PREVIOUS sprint onto the run's descriptor would mislabel every panel;
+ * `onSprintResolved` pins the real one once known. Every other flow launches directly.
+ */
+const runFlowLaunch = async (
+  launcherDeps: LauncherDeps,
+  entry: FlowEntry,
+  snapshot: AppStateSnapshot,
+  launchExtras: LaunchExtras,
+  { selection, sessions }: RunFlowLaunchDeps
+): Promise<LaunchResult> => {
+  const sprintBound = entry.manifest.id === CREATE_SPRINT_FLOW_ID || entry.manifest.id === 'close-sprint';
+  if (!sprintBound) return launchFlow(launcherDeps, entry.manifest.id, snapshot, launchExtras);
+
+  const { sprint: _staleSprint, ...snapshotWithoutSprint } = snapshot;
+  void _staleSprint;
+  return launchSprintBoundFlow(
+    launcherDeps,
+    entry.manifest.id,
+    entry.manifest.id === CREATE_SPRINT_FLOW_ID ? snapshotWithoutSprint : snapshot,
+    {
+      ...launchExtras,
+      onReseat: ({ id, name, status }) => {
+        if (entry.manifest.id === CREATE_SPRINT_FLOW_ID) {
+          // A brand-new sprint can't collide with a mid-run switch — always reseat (and let
+          // the "✓ now on …" toast fire via lastSwitch).
+          selection.setSprint(id, name, status);
+          return;
+        }
+        // close-sprint: the sprint stays selected but its status flipped to done on disk —
+        // refresh the chip without replaying the switch toast. syncSprintStatus no-ops when
+        // the user moved to a different sprint mid-run, so a late completion never yanks them
+        // back.
+        if (status !== undefined) selection.syncSprintStatus(id, status);
+      },
+      onSprintResolved: (runnerId, { id, name }) => {
+        sessions.setPinnedSprint(runnerId, id, name);
+      },
+    }
+  );
+};
+
+/**
+ * Subscribe BEFORE `start()` so we don't miss the synchronous completion of a fast-path flow.
+ * Captures the chosen repository id from the final ctx for subsequent launches in this session.
+ * Self-unsubscribes on terminal events so every flow launch doesn't pin a dead listener (and its
+ * closure scope, incl. the `ui` ref + the event's `ctx` object) to the runner's listener Set
+ * across a long TUI session — historically a load-bearing OOM contributor.
+ */
+const attachRepositoryCapture = (runner: Runner<unknown>, ui: ReturnType<typeof useUiState>): void => {
+  const unsubRepoCapture: () => void = runner.subscribe((event) => {
+    if (event.type === 'failed' || event.type === 'aborted') {
+      unsubRepoCapture();
+      return;
+    }
+    if (event.type !== 'completed') return;
+    const ctx = event.ctx as { readonly repository?: { readonly id: RepositoryId } };
+    if (ctx.repository !== undefined) ui.setSessionRepositoryId(ctx.repository.id);
+    unsubRepoCapture();
+  });
+};
+
+/** Everything a flow row's click handler needs, threaded once from {@link useFlowMenuItems}. */
+interface FlowMenuItemHandlerCtx {
+  readonly deps: AppDeps;
+  readonly queue: PromptQueue;
+  readonly storage: StoragePaths;
+  readonly ui: ReturnType<typeof useUiState>;
+  readonly selection: ReturnType<typeof useSelection>;
+  readonly sessions: SessionManager;
+  readonly router: RouterApi;
+  readonly reload: () => void;
+  readonly setLaunchError: (message: string | undefined) => void;
+}
+
+/**
+ * Build the click handler for one flow row: route-check → interactive prompt → repository
+ * selection → customize picker → launch → session registration, in the order the flow menu has
+ * always used.
+ */
+const createFlowSelectHandler = (
+  entry: FlowEntry,
+  snapshot: AppStateSnapshot,
+  handlerCtx: FlowMenuItemHandlerCtx
+): (() => Promise<void>) => {
+  const { deps, queue, storage, ui, selection, sessions, router, reload, setLaunchError } = handlerCtx;
+  return async (): Promise<void> => {
+    setLaunchError(undefined);
+
+    // Use-case-shaped flows (doctor, settings-*, ticket-*) don't go through the chain
+    // launcher — they have dedicated views. Route there directly.
+    const route = viewRouteFor(entry.manifest.id, snapshot);
+    if (route !== undefined) {
+      router.push(route);
+      return;
+    }
+
+    const interactive = createInkInteractivePrompt(queue);
+
+    // Re-read settings from disk now so provider/model changes made via the Settings
+    // view propagate. `deps.settings` is the boot-time snapshot and goes stale across
+    // any settings write; the on-disk repo is the source of truth.
+    const freshSettings = await deps.settingsRepo.load();
+    const settings = freshSettings.ok ? freshSettings.value : deps.settings;
+
+    // Pre-launch repository selection — for repo-selecting flows (detect-scripts /
+    // detect-skills / readiness) against a multi-repo project, ask which repository the
+    // run targets BEFORE the provider picker (the sequence reads "pick repo, then
+    // customize provider"). The session-pinned repo (`ui.sessionRepositoryId`) is offered
+    // first as a SOFT default — re-pickable every launch — rather than a HARD lock that
+    // would make `pickRepositoryLeaf` skip its prompt forever. Single-repo projects and
+    // non-repo flows return `kind: 'skip'` (no prompt); the chain's own `pickRepositoryLeaf`
+    // auto-selects the lone repo / handles the empty-project error.
+    const repoSelection = await runRepositorySelection({
+      interactive,
+      flowId: entry.manifest.id,
+      flowTitle: entry.manifest.title,
+      project: snapshot.project,
+      pinnedRepositoryId: ui.sessionRepositoryId,
+    });
+    if (repoSelection.kind === 'cancel') return;
+    const chosenRepositoryId = repoSelection.kind === 'selected' ? repoSelection.repositoryId : undefined;
+    // Re-pin immediately so the new choice is the default on the next launch and the
+    // post-completion capture below just re-affirms it (no conflict / double-prompt).
+    if (chosenRepositoryId !== undefined) ui.setSessionRepositoryId(chosenRepositoryId);
+
+    // Pre-launch customize picker — for AI-driven flows the user gets Start /
+    // Customize / Cancel. Customize walks provider → model → effort for each row
+    // (implement walks generator then evaluator). Settings are never mutated; per-launch
+    // overrides are passed through {@link LaunchExtras}. Non-AI flows return
+    // `kind: 'defaults'` without prompting.
+    const picker = await runCustomizePicker({
+      interactive,
+      flowId: entry.manifest.id,
+      flowTitle: entry.manifest.title,
+      settings,
+      // exactOptionalPropertyTypes: only pass the key when defined — the picker arg is
+      // `?`-optional (absent), not `| undefined`. Absent ⇒ picker falls back to modelCatalogFor.
+      ...(deps.availableModelsFor !== undefined ? { availableModelsFor: deps.availableModelsFor } : {}),
+    });
+    if (picker.kind === 'cancel') return;
+
+    const launchExtras = buildLaunchExtras(picker, entry, chosenRepositoryId, ui, settings);
+    const launcherDeps = { app: deps, interactive, storage, runInTerminal: getRunInTerminal() };
+    const result = await runFlowLaunch(launcherDeps, entry, snapshot, launchExtras, { selection, sessions });
+    if (!result.ok) {
+      setLaunchError(`${entry.manifest.title}: ${result.reason}`);
+      return;
+    }
+    attachRepositoryCapture(result.runner, ui);
+    // Register + start + route via the shared tail. `replace` (not push) so the flow menu
+    // isn't left on the stack behind the run; the trailing reload refreshes this menu's
+    // enabled/disabled state for when the user pops back.
+    openFlowSession({ sessions, router }, result, entry.manifest.id, { mode: 'replace' });
+    reload();
+  };
+};
+
+/**
+ * Build one flow row's {@link MenuItem} — section, label, description, cost hint, and the
+ * disabled state derived from the current snapshot's trigger inputs — wiring `onSelect` to the
+ * click handler built by {@link createFlowSelectHandler}.
+ */
+const buildFlowMenuItem = (
+  entry: FlowEntry,
+  snapshot: AppStateSnapshot,
+  handlerCtx: FlowMenuItemHandlerCtx
+): MenuItem => {
+  const triggerEval = evaluateTriggers(entry.manifest.triggers, snapshot.triggerInputs);
+  const item: MenuItem = {
+    id: entry.manifest.id,
+    section: sectionFor(entry.manifest.id),
+    label: entry.manifest.title,
+    description: entry.manifest.description,
+    ...(entry.manifest.costHint !== undefined ? { costHint: entry.manifest.costHint } : {}),
+    onSelect: createFlowSelectHandler(entry, snapshot, handlerCtx),
+  };
+  if (!triggerEval.enabled) return { ...item, disabledReason: triggerEval.reason };
+  return item;
+};
+
+interface UseFlowMenuItemsArgs {
+  readonly state: ReturnType<typeof useAppStateSnapshot>['state'];
+  readonly deps: AppDeps;
+  readonly queue: PromptQueue;
+  readonly storage: StoragePaths;
+  readonly sessions: SessionManager;
+  readonly router: RouterApi;
+  readonly reload: () => void;
+  readonly showAll: boolean;
+  readonly ui: ReturnType<typeof useUiState>;
+  readonly selection: ReturnType<typeof useSelection>;
+  readonly setLaunchError: (message: string | undefined) => void;
+}
+
+/**
+ * Build the flow menu's items from the latest snapshot — filtered by state-machine visibility,
+ * mapped to {@link MenuItem}s via {@link buildFlowMenuItem}, and sorted so the action menu's
+ * section headers stay sticky (items in the same category render consecutively even when
+ * registry order interleaves them).
+ */
+const useFlowMenuItems = ({
+  state,
+  deps,
+  queue,
+  storage,
+  sessions,
+  router,
+  reload,
+  showAll,
+  ui,
+  selection,
+  setLaunchError,
+}: UseFlowMenuItemsArgs): readonly MenuItem[] =>
+  useMemo<readonly MenuItem[]>(() => {
+    if (state.kind !== 'ok') return [];
+    const snapshot = state.value;
+    // State-machine visibility: hide sprint-scoped flows that don't apply to the current
+    // sprint status (or hide them all when no sprint is selected). `showAll` toggles every
+    // flow back into view so the user can see what's reachable in other states — those
+    // rows stay dimmed via `evaluateTriggers`.
+    const visible = visibleFlowsFor({
+      hasProject: snapshot.project !== undefined,
+      ...(snapshot.sprint !== undefined ? { sprintStatus: snapshot.sprint.status } : {}),
+      showAll,
+    });
+    const filteredRegistry = flowRegistry.filter((entry) => visible.has(entry.manifest.id));
+    const handlerCtx: FlowMenuItemHandlerCtx = {
+      deps,
+      queue,
+      storage,
+      ui,
+      selection,
+      sessions,
+      router,
+      reload,
+      setLaunchError,
+    };
+    const built = filteredRegistry.map((entry) => buildFlowMenuItem(entry, snapshot, handlerCtx));
+    // Sort by section so the action menu's section headers stay sticky (items in the same
+    // category render consecutively even when registry order interleaves them).
+    return [...built].sort((a, b) => sectionRank(a.section ?? 'other') - sectionRank(b.section ?? 'other'));
+    // setLaunchError is a useState setter (stable identity across renders); the linter can't see
+    // that through the hook boundary once it's threaded in as a plain parameter instead of a
+    // same-scope closure reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, deps, queue, storage, sessions, router, reload, showAll, ui, selection]);
+
 export const FlowsView = (): React.JSX.Element => {
   const ui = useUiState();
   const deps = useDeps();
@@ -179,179 +484,19 @@ export const FlowsView = (): React.JSX.Element => {
 
   const { state, reload } = useAppStateSnapshot();
 
-  const items = useMemo<readonly MenuItem[]>(() => {
-    if (state.kind !== 'ok') return [];
-    const snapshot = state.value;
-    // State-machine visibility: hide sprint-scoped flows that don't apply to the current
-    // sprint status (or hide them all when no sprint is selected). `showAll` toggles every
-    // flow back into view so the user can see what's reachable in other states — those
-    // rows stay dimmed via `evaluateTriggers`.
-    const visible = visibleFlowsFor({
-      hasProject: snapshot.project !== undefined,
-      ...(snapshot.sprint !== undefined ? { sprintStatus: snapshot.sprint.status } : {}),
-      showAll,
-    });
-    const filteredRegistry = flowRegistry.filter((entry) => visible.has(entry.manifest.id));
-    const built = filteredRegistry.map((entry): MenuItem => {
-      const triggerEval = evaluateTriggers(entry.manifest.triggers, snapshot.triggerInputs);
-      const item: MenuItem = {
-        id: entry.manifest.id,
-        section: sectionFor(entry.manifest.id),
-        label: entry.manifest.title,
-        description: entry.manifest.description,
-        ...(entry.manifest.costHint !== undefined ? { costHint: entry.manifest.costHint } : {}),
-        onSelect: async (): Promise<void> => {
-          setLaunchError(undefined);
-
-          // Use-case-shaped flows (doctor, settings-*, ticket-*) don't go through the chain
-          // launcher — they have dedicated views. Route there directly.
-          const route = viewRouteFor(entry.manifest.id, snapshot);
-          if (route !== undefined) {
-            router.push(route);
-            return;
-          }
-
-          const interactive = createInkInteractivePrompt(queue);
-
-          // Re-read settings from disk now so provider/model changes made via the Settings
-          // view propagate. `deps.settings` is the boot-time snapshot and goes stale across
-          // any settings write; the on-disk repo is the source of truth.
-          const freshSettings = await deps.settingsRepo.load();
-          const settings = freshSettings.ok ? freshSettings.value : deps.settings;
-
-          // Pre-launch repository selection — for repo-selecting flows (detect-scripts /
-          // detect-skills / readiness) against a multi-repo project, ask which repository the
-          // run targets BEFORE the provider picker (the sequence reads "pick repo, then
-          // customize provider"). The session-pinned repo (`ui.sessionRepositoryId`) is offered
-          // first as a SOFT default — re-pickable every launch — rather than a HARD lock that
-          // would make `pickRepositoryLeaf` skip its prompt forever. Single-repo projects and
-          // non-repo flows return `kind: 'skip'` (no prompt); the chain's own `pickRepositoryLeaf`
-          // auto-selects the lone repo / handles the empty-project error.
-          const repoSelection = await runRepositorySelection({
-            interactive,
-            flowId: entry.manifest.id,
-            flowTitle: entry.manifest.title,
-            project: snapshot.project,
-            pinnedRepositoryId: ui.sessionRepositoryId,
-          });
-          if (repoSelection.kind === 'cancel') return;
-          const chosenRepositoryId = repoSelection.kind === 'selected' ? repoSelection.repositoryId : undefined;
-          // Re-pin immediately so the new choice is the default on the next launch and the
-          // post-completion capture below just re-affirms it (no conflict / double-prompt).
-          if (chosenRepositoryId !== undefined) ui.setSessionRepositoryId(chosenRepositoryId);
-
-          // Pre-launch customize picker — for AI-driven flows the user gets Start /
-          // Customize / Cancel. Customize walks provider → model → effort for each row
-          // (implement walks generator then evaluator). Settings are never mutated; per-launch
-          // overrides are passed through {@link LaunchExtras}. Non-AI flows return
-          // `kind: 'defaults'` without prompting.
-          const picker = await runCustomizePicker({
-            interactive,
-            flowId: entry.manifest.id,
-            flowTitle: entry.manifest.title,
-            settings,
-            // exactOptionalPropertyTypes: only pass the key when defined — the picker arg is
-            // `?`-optional (absent), not `| undefined`. Absent ⇒ picker falls back to modelCatalogFor.
-            ...(deps.availableModelsFor !== undefined ? { availableModelsFor: deps.availableModelsFor } : {}),
-          });
-          if (picker.kind === 'cancel') return;
-
-          // Thread the resolved repository id as a pre-selection. When the repo-selection step
-          // above ran, `chosenRepositoryId` is the user's fresh pick; otherwise (single-repo /
-          // non-repo flows) it falls back to the session pin so the flow's own
-          // `pickRepositoryLeaf` still pre-selects the lone / previously-chosen repo. The runner
-          // emits `completed` with the chosen `ctx.repository` and we re-affirm the pin below.
-          // Implement role overrides come from the picker when the user customized; otherwise
-          // they fall back to the CLI-derived module holder (parsed from
-          // `--implement-{generator,evaluator}-{provider,model}` on the bare `ralphctl`
-          // invocation).
-          const implementRoleOverrides =
-            picker.kind === 'implement'
-              ? picker.implementRoleOverrides
-              : entry.manifest.id === 'implement'
-                ? getImplementRoleOverrides()
-                : undefined;
-          const override = picker.kind === 'single' ? picker.override : undefined;
-          const launcherDeps = { app: deps, interactive, storage, runInTerminal: getRunInTerminal() };
-          const repositoryId = chosenRepositoryId ?? ui.sessionRepositoryId;
-          const launchExtras = {
-            ...(repositoryId !== undefined ? { repositoryId } : {}),
-            ...(override !== undefined ? { override } : {}),
-            ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
-            settingsSnapshot: settings,
-          };
-          // create-sprint and close-sprint change which sprint (or status) the user is "on" —
-          // route them through the sprint-bound wrapper so the post-completion selection reseat
-          // happens in one place instead of leaving the global selection stale. create-sprint
-          // additionally strips the launch-time sprint from the snapshot: the new sprint doesn't
-          // exist yet, so pinning the PREVIOUS sprint onto the run's descriptor would mislabel
-          // every panel; onSprintResolved pins the real one once known.
-          const sprintBound = entry.manifest.id === CREATE_SPRINT_FLOW_ID || entry.manifest.id === 'close-sprint';
-          let result;
-          if (sprintBound) {
-            const { sprint: _staleSprint, ...snapshotWithoutSprint } = snapshot;
-            void _staleSprint;
-            result = await launchSprintBoundFlow(
-              launcherDeps,
-              entry.manifest.id,
-              entry.manifest.id === CREATE_SPRINT_FLOW_ID ? snapshotWithoutSprint : snapshot,
-              {
-                ...launchExtras,
-                onReseat: ({ id, name, status }) => {
-                  if (entry.manifest.id === CREATE_SPRINT_FLOW_ID) {
-                    // A brand-new sprint can't collide with a mid-run switch — always reseat
-                    // (and let the "✓ now on …" toast fire via lastSwitch).
-                    selection.setSprint(id, name, status);
-                    return;
-                  }
-                  // close-sprint: the sprint stays selected but its status flipped to done on
-                  // disk — refresh the chip without replaying the switch toast. syncSprintStatus
-                  // no-ops when the user moved to a different sprint mid-run, so a late
-                  // completion never yanks them back.
-                  if (status !== undefined) selection.syncSprintStatus(id, status);
-                },
-                onSprintResolved: (runnerId, { id, name }) => {
-                  sessions.setPinnedSprint(runnerId, id, name);
-                },
-              }
-            );
-          } else {
-            result = await launchFlow(launcherDeps, entry.manifest.id, snapshot, launchExtras);
-          }
-          if (!result.ok) {
-            setLaunchError(`${entry.manifest.title}: ${result.reason}`);
-            return;
-          }
-          // Subscribe BEFORE start() so we don't miss the synchronous completion of a
-          // fast-path flow. Capture the chosen repository id from the final ctx for
-          // subsequent launches in this session. Self-unsubscribe on terminal events so
-          // every flow launch doesn't pin a dead listener (and its closure scope, incl.
-          // the `ui` ref + the event's `ctx` object) to the runner's listener Set across
-          // a long TUI session — historically a load-bearing OOM contributor.
-          const unsubRepoCapture: () => void = result.runner.subscribe((event) => {
-            if (event.type === 'failed' || event.type === 'aborted') {
-              unsubRepoCapture();
-              return;
-            }
-            if (event.type !== 'completed') return;
-            const ctx = event.ctx as { readonly repository?: { readonly id: RepositoryId } };
-            if (ctx.repository !== undefined) ui.setSessionRepositoryId(ctx.repository.id);
-            unsubRepoCapture();
-          });
-          // Register + start + route via the shared tail. `replace` (not push) so the flow menu
-          // isn't left on the stack behind the run; the trailing reload refreshes this menu's
-          // enabled/disabled state for when the user pops back.
-          openFlowSession({ sessions, router }, result, entry.manifest.id, { mode: 'replace' });
-          reload();
-        },
-      };
-      if (!triggerEval.enabled) return { ...item, disabledReason: triggerEval.reason };
-      return item;
-    });
-    // Sort by section so the action menu's section headers stay sticky (items in the same
-    // category render consecutively even when registry order interleaves them).
-    return [...built].sort((a, b) => sectionRank(a.section ?? 'other') - sectionRank(b.section ?? 'other'));
-  }, [state, deps, queue, storage, sessions, router, reload, showAll, ui, selection]);
+  const items = useFlowMenuItems({
+    state,
+    deps,
+    queue,
+    storage,
+    sessions,
+    router,
+    reload,
+    showAll,
+    ui,
+    selection,
+    setLaunchError,
+  });
 
   // Refresh the cached breadcrumb status chip from every fresh snapshot load — flow chains
   // transition the sprint's status on disk (plan → planned, implement → review, close-sprint →

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -16,23 +16,25 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, type Key } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
-import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
+import { useAsyncLoad, type AsyncLoadState } from '@src/application/ui/tui/runtime/use-async-load.ts';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { useLaunchCreateSprint } from '@src/application/ui/tui/runtime/use-launch-create-sprint.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
-import type { PickerData } from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { FlatRow, PickerData } from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
 import {
   buildGroups,
   cursorableNear,
@@ -47,33 +49,50 @@ import {
 } from '@src/application/ui/tui/views/pick-sprint-internals/window.ts';
 import { RowWindowView } from '@src/application/ui/tui/views/pick-sprint-internals/row-views.tsx';
 
-/**
- * Re-export of the windowing helper. Kept at this canonical path so the existing unit-test
- * import (`@src/application/ui/tui/views/pick-sprint-view.tsx`) continues to resolve without
- * churn after the split.
- *
- * @public
- */
-export { computeWindow };
+type Selection = ReturnType<typeof useSelection>;
 
-export const PickSprintView = (): React.JSX.Element => {
-  const deps = useDeps();
-  const router = useRouter();
-  const selection = useSelection();
-  const ui = useUiState();
-  const [feedback, setFeedback] = useState<string | undefined>(undefined);
+/**
+ * Preferred cursor index within `rows`: the row for `preferredSprintId` if present, else the
+ * first sprint row, else the first cursorable row (the synthetic create row), else 0. Shared by
+ * the initial-mount seed and the scope-toggle reseat — both want the same "best landing spot"
+ * rule, just against a (possibly different) row list.
+ */
+const preferredCursorIndex = (rows: readonly FlatRow[], preferredSprintId: SprintId | undefined): number => {
+  if (preferredSprintId !== undefined) {
+    const i = rows.findIndex((r) => r.kind === 'sprint' && r.sprint.id === preferredSprintId);
+    if (i !== -1) return i;
+  }
+  const firstSprint = rows.findIndex((r) => r.kind === 'sprint');
+  if (firstSprint !== -1) return firstSprint;
+  return cursorableRowIndices(rows)[0] ?? 0;
+};
+
+interface UsePickerRowsResult {
+  readonly state: AsyncLoadState<PickerData, unknown>;
+  readonly reload: () => void;
+  readonly data: PickerData;
+  readonly rows: readonly FlatRow[];
+  readonly sprintCount: number;
+  readonly hiddenByDoneFilter: boolean;
+  readonly scopeAll: boolean;
+  readonly hideDone: boolean;
+  readonly setHideDone: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly toggleScope: () => void;
+  readonly cursor: number;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+}
+
+/**
+ * Load the raw sprint/project snapshot, derive the filtered + grouped + flattened row list, and
+ * own the cursor's position within it (including reseating on scope/filter toggles and on data
+ * reload). Kept as one hook so the picker's data pipeline and cursor bookkeeping — which must
+ * always agree on the same `rows` — can't drift apart across separate `useMemo` call sites.
+ */
+const usePickerRows = (deps: AppDeps, selection: Selection): UsePickerRowsResult => {
   const [scopeAll, setScopeAll] = useState<boolean>(true);
   // Default OFF — closed sprints stay reachable here by contract (the Home shortcut list
   // already filters them; this picker is the documented way back to a done sprint).
   const [hideDone, setHideDone] = useState<boolean>(false);
-  useViewHints([
-    { keys: '↑/↓/j/k', label: 'move' },
-    { keys: '↵', label: 'use sprint' },
-    { keys: 't', label: 'toggle scope' },
-    { keys: 'f', label: hideDone ? 'show done' : 'hide done' },
-    { keys: 'c/+', label: 'create new' },
-    { keys: 'r', label: 'reload' },
-  ]);
 
   const { state, reload } = useAsyncLoad<PickerData>(
     async (signal) => {
@@ -126,27 +145,13 @@ export const PickSprintView = (): React.JSX.Element => {
     return flatten(buildGroups(data, selection.projectId, scopeAll), false).some((r) => r.kind === 'sprint');
   }, [hideDone, sprintCount, data, selection.projectId, scopeAll]);
 
-  // Window the rendered slice so a user with hundreds of sprints across many projects doesn't
-  // pay an Ink reconciliation cost proportional to the full row list. Capacity tracks terminal
-  // height so the visible slice always fills the viewport without overflowing it.
-  const bp = useBreakpoint();
-  const visibleRows = Math.max(MIN_VISIBLE_ROWS, bp.rows - VERTICAL_CHROME_ROWS);
-
   // Pre-seed the cursor to the already-selected sprint so Enter is a one-keystroke confirm.
   // Otherwise, prefer the first sprint row over the synthetic `+ create` row so users with
   // existing sprints can still press Enter to pick the topmost one — the create row sits at
   // the very top but is intentionally NOT the initial focus (the common case is "switch", not
   // "create"). When the picker is completely empty (no sprints anywhere), the create row IS
   // first cursorable, so the fallback still lands on it.
-  const initialIdx = useMemo(() => {
-    if (selection.sprintId !== undefined) {
-      const i = rows.findIndex((r) => r.kind === 'sprint' && r.sprint.id === selection.sprintId);
-      if (i !== -1) return i;
-    }
-    const firstSprint = rows.findIndex((r) => r.kind === 'sprint');
-    if (firstSprint !== -1) return firstSprint;
-    return cursorableRowIndices(rows)[0] ?? 0;
-  }, [rows, selection.sprintId]);
+  const initialIdx = useMemo(() => preferredCursorIndex(rows, selection.sprintId), [rows, selection.sprintId]);
 
   const [cursor, setCursor] = useState<number>(initialIdx);
   useEffect(() => {
@@ -164,6 +169,249 @@ export const PickSprintView = (): React.JSX.Element => {
   useEffect(() => {
     setCursor(initialIdx);
   }, [initialIdx]);
+
+  const toggleScope = (): void => {
+    const next = !scopeAll;
+    setScopeAll(next);
+    // Recompute the cursor: prefer the already-selected sprint, then the first sprint row,
+    // then the create row (only relevant on a totally empty picker).
+    const nextRows = flatten(buildGroups(visibleData, selection.projectId, next), includeCreate);
+    setCursor(preferredCursorIndex(nextRows, selection.sprintId));
+  };
+
+  return {
+    state,
+    reload,
+    data,
+    rows,
+    sprintCount,
+    hiddenByDoneFilter,
+    scopeAll,
+    hideDone,
+    setHideDone,
+    toggleScope,
+    cursor,
+    setCursor,
+  };
+};
+
+/** Whether `input`/`key` is one of the six cursor-navigation keys (arrows, j/k, page, home/end). */
+const isNavigationInput = (input: string, key: Key): boolean =>
+  key.upArrow || key.downArrow || key.pageUp || key.pageDown || key.home || key.end || input === 'j' || input === 'k';
+
+/**
+ * Resolve the cursor's next index for the six pure-navigation keys (arrows, j/k, page up/down,
+ * home/end); `undefined` for any other key. Called from inside the `setCursor` updater (see
+ * {@link usePickerInput}) so `cursor` is always the truly-latest committed state, not whatever
+ * value the `useInput` closure captured at its last render.
+ */
+const resolveArrowMove = (
+  rows: readonly FlatRow[],
+  cursor: number,
+  visibleRows: number,
+  input: string,
+  key: Key
+): number | undefined => {
+  if (key.upArrow || input === 'k') return nextCursorableIndex(rows, cursor, -1);
+  if (key.downArrow || input === 'j') return nextCursorableIndex(rows, cursor, 1);
+  if (key.pageUp) return cursorableNear(rows, Math.max(0, cursor - visibleRows), -1);
+  if (key.pageDown) return cursorableNear(rows, Math.min(rows.length - 1, cursor + visibleRows), 1);
+  if (key.home) return cursorableRowIndices(rows)[0] ?? 0;
+  if (key.end) {
+    const candidates = cursorableRowIndices(rows);
+    return candidates[candidates.length - 1] ?? cursor;
+  }
+  return undefined;
+};
+
+interface PickerBodyProps {
+  readonly helpOpen: boolean;
+  readonly state: AsyncLoadState<PickerData, unknown>;
+  readonly sprintCount: number;
+  readonly hiddenByDoneFilter: boolean;
+  readonly scopeAll: boolean;
+  readonly hideDone: boolean;
+  readonly rows: readonly FlatRow[];
+  readonly cursor: number;
+  readonly visibleRows: number;
+  readonly currentSprintId: SprintId | undefined;
+  readonly currentSprintLabel: string | undefined;
+  readonly feedback: string | undefined;
+}
+
+/** Loading / error / empty / list-of-rows presentation — pure props in, no state of its own. */
+const PickerBody = ({
+  helpOpen,
+  state,
+  sprintCount,
+  hiddenByDoneFilter,
+  scopeAll,
+  hideDone,
+  rows,
+  cursor,
+  visibleRows,
+  currentSprintId,
+  currentSprintLabel,
+  feedback,
+}: PickerBodyProps): React.JSX.Element =>
+  helpOpen ? (
+    <HelpOverlay />
+  ) : state.kind === 'loading' || state.kind === 'idle' ? (
+    <LoadingRow label="Loading sprints…" />
+  ) : state.kind === 'error' ? (
+    <LoadErrorRow message="Failed to load sprints." color={inkColors.error} />
+  ) : sprintCount === 0 ? (
+    <Box flexDirection="column" paddingX={spacing.indent}>
+      {hiddenByDoneFilter ? (
+        <>
+          <Text>All sprints here are done (hidden).</Text>
+          <Text dimColor>Press f to show them, or + to create a new one.</Text>
+        </>
+      ) : (
+        <>
+          <Text>No sprints yet.</Text>
+          <Text dimColor>
+            {scopeAll ? 'Press + to create one.' : 'Press t to show all projects, or + to create one.'}
+          </Text>
+        </>
+      )}
+    </Box>
+  ) : (
+    <Box flexDirection="column">
+      <Box paddingX={spacing.indent} marginBottom={spacing.section}>
+        <Text dimColor>
+          {String(sprintCount)} sprint{sprintCount === 1 ? '' : 's'} {glyphs.bullet}{' '}
+          {scopeAll ? 'all projects' : 'current project only'} {glyphs.bullet}{' '}
+          {currentSprintLabel !== undefined ? (
+            <Text>
+              current:{' '}
+              <Text color={inkColors.primary} bold>
+                {currentSprintLabel}
+              </Text>
+            </Text>
+          ) : (
+            <Text>press ↵ to confirm</Text>
+          )}
+        </Text>
+      </Box>
+      <RowWindowView rows={rows} cursor={cursor} visibleRows={visibleRows} currentSprintId={currentSprintId} />
+      <Box marginTop={spacing.section} paddingX={spacing.indent}>
+        <Text dimColor>
+          {glyphs.bullet} ↵ use the highlighted sprint {glyphs.bullet} t toggle scope {glyphs.bullet} f{' '}
+          {hideDone ? 'show' : 'hide'} done {glyphs.bullet} + create a new one
+        </Text>
+      </Box>
+      {feedback !== undefined && (
+        <Box paddingX={spacing.indent} marginTop={1}>
+          <Text color={inkColors.error}>{feedback}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+
+interface UsePickerInputArgs {
+  readonly modalOpen: boolean;
+  readonly rows: readonly FlatRow[];
+  readonly cursor: number;
+  readonly visibleRows: number;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+  readonly pick: (sprint: Sprint) => void;
+  readonly launchCreateSprint: () => Promise<void>;
+  readonly toggleScope: () => void;
+  readonly setHideDone: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly reload: () => void;
+}
+
+/**
+ * Sole `useInput` registration for the picker — the six navigation keys resolve through
+ * {@link resolveArrowMove}; everything else (confirm / scope toggle / done filter / create /
+ * reload) is a flat one-branch-each dispatch.
+ */
+const usePickerInput = ({
+  modalOpen,
+  rows,
+  cursor,
+  visibleRows,
+  setCursor,
+  pick,
+  launchCreateSprint,
+  toggleScope,
+  setHideDone,
+  reload,
+}: UsePickerInputArgs): void => {
+  useInput((input, key) => {
+    if (modalOpen) return;
+    if (isNavigationInput(input, key)) {
+      setCursor((c) => resolveArrowMove(rows, c, visibleRows, input, key) ?? c);
+      return;
+    }
+    if (key.return) {
+      const row = rows[cursor];
+      if (row?.kind === 'sprint') pick(row.sprint);
+      else if (row?.kind === 'create') void launchCreateSprint();
+      return;
+    }
+    if (input === 't') {
+      toggleScope();
+      return;
+    }
+    if (input === 'f') {
+      setHideDone((v) => !v);
+      return;
+    }
+    if (input === '+' || input === 'c') {
+      void launchCreateSprint();
+      return;
+    }
+    if (input === 'r') reload();
+  });
+};
+
+/**
+ * Re-export of the windowing helper. Kept at this canonical path so the existing unit-test
+ * import (`@src/application/ui/tui/views/pick-sprint-view.tsx`) continues to resolve without
+ * churn after the split.
+ *
+ * @public
+ */
+export { computeWindow };
+
+export const PickSprintView = (): React.JSX.Element => {
+  const deps = useDeps();
+  const router = useRouter();
+  const selection = useSelection();
+  const ui = useUiState();
+  const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  const {
+    state,
+    reload,
+    data,
+    rows,
+    sprintCount,
+    hiddenByDoneFilter,
+    scopeAll,
+    hideDone,
+    setHideDone,
+    toggleScope,
+    cursor,
+    setCursor,
+  } = usePickerRows(deps, selection);
+
+  useViewHints([
+    { keys: '↑/↓/j/k', label: 'move' },
+    { keys: '↵', label: 'use sprint' },
+    { keys: 't', label: 'toggle scope' },
+    { keys: 'f', label: hideDone ? 'show done' : 'hide done' },
+    { keys: 'c/+', label: 'create new' },
+    { keys: 'r', label: 'reload' },
+  ]);
+
+  // Window the rendered slice so a user with hundreds of sprints across many projects doesn't
+  // pay an Ink reconciliation cost proportional to the full row list. Capacity tracks terminal
+  // height so the visible slice always fills the viewport without overflowing it.
+  const bp = useBreakpoint();
+  const visibleRows = Math.max(MIN_VISIBLE_ROWS, bp.rows - VERTICAL_CHROME_ROWS);
 
   const pick = (sprint: Sprint): void => {
     if (sprint.projectId !== selection.projectId) {
@@ -188,127 +436,35 @@ export const PickSprintView = (): React.JSX.Element => {
     noProjectMessage: `${glyphs.cross} select a project first`,
   });
 
-  const toggleScope = (): void => {
-    const next = !scopeAll;
-    setScopeAll(next);
-    // Recompute the cursor: prefer the already-selected sprint, then the first sprint row,
-    // then the create row (only relevant on a totally empty picker).
-    const nextRows = flatten(buildGroups(visibleData, selection.projectId, next), includeCreate);
-    let idx = -1;
-    if (selection.sprintId !== undefined) {
-      idx = nextRows.findIndex((r) => r.kind === 'sprint' && r.sprint.id === selection.sprintId);
-    }
-    if (idx === -1) idx = nextRows.findIndex((r) => r.kind === 'sprint');
-    if (idx === -1) idx = cursorableRowIndices(nextRows)[0] ?? 0;
-    setCursor(idx);
-  };
-
-  useInput((input, key) => {
-    if (ui.modalOpen) return;
-    if (key.upArrow || input === 'k') {
-      setCursor((c) => nextCursorableIndex(rows, c, -1));
-      return;
-    }
-    if (key.downArrow || input === 'j') {
-      setCursor((c) => nextCursorableIndex(rows, c, 1));
-      return;
-    }
-    if (key.pageUp) {
-      setCursor((c) => cursorableNear(rows, Math.max(0, c - visibleRows), -1));
-      return;
-    }
-    if (key.pageDown) {
-      setCursor((c) => cursorableNear(rows, Math.min(rows.length - 1, c + visibleRows), 1));
-      return;
-    }
-    if (key.home) {
-      setCursor(() => cursorableRowIndices(rows)[0] ?? 0);
-      return;
-    }
-    if (key.end) {
-      setCursor((c) => {
-        const candidates = cursorableRowIndices(rows);
-        return candidates[candidates.length - 1] ?? c;
-      });
-      return;
-    }
-    if (key.return) {
-      const row = rows[cursor];
-      if (row?.kind === 'sprint') pick(row.sprint);
-      else if (row?.kind === 'create') void launchCreateSprint();
-      return;
-    }
-    if (input === 't') {
-      toggleScope();
-      return;
-    }
-    if (input === 'f') {
-      setHideDone((v) => !v);
-      return;
-    }
-    if (input === '+' || input === 'c') {
-      void launchCreateSprint();
-      return;
-    }
-    if (input === 'r') reload();
+  usePickerInput({
+    modalOpen: ui.modalOpen,
+    rows,
+    cursor,
+    visibleRows,
+    setCursor,
+    pick,
+    launchCreateSprint,
+    toggleScope,
+    setHideDone,
+    reload,
   });
 
   return (
     <ViewShell title="Pick a sprint" subtitle="Switch sprint (and project) in one step" suppressScrollArrows>
-      {ui.helpOpen ? (
-        <HelpOverlay />
-      ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <LoadingRow label="Loading sprints…" />
-      ) : state.kind === 'error' ? (
-        <LoadErrorRow message="Failed to load sprints." color={inkColors.error} />
-      ) : sprintCount === 0 ? (
-        <Box flexDirection="column" paddingX={spacing.indent}>
-          {hiddenByDoneFilter ? (
-            <>
-              <Text>All sprints here are done (hidden).</Text>
-              <Text dimColor>Press f to show them, or + to create a new one.</Text>
-            </>
-          ) : (
-            <>
-              <Text>No sprints yet.</Text>
-              <Text dimColor>
-                {scopeAll ? 'Press + to create one.' : 'Press t to show all projects, or + to create one.'}
-              </Text>
-            </>
-          )}
-        </Box>
-      ) : (
-        <Box flexDirection="column">
-          <Box paddingX={spacing.indent} marginBottom={spacing.section}>
-            <Text dimColor>
-              {String(sprintCount)} sprint{sprintCount === 1 ? '' : 's'} {glyphs.bullet}{' '}
-              {scopeAll ? 'all projects' : 'current project only'} {glyphs.bullet}{' '}
-              {selection.sprintLabel !== undefined ? (
-                <Text>
-                  current:{' '}
-                  <Text color={inkColors.primary} bold>
-                    {selection.sprintLabel}
-                  </Text>
-                </Text>
-              ) : (
-                <Text>press ↵ to confirm</Text>
-              )}
-            </Text>
-          </Box>
-          <RowWindowView rows={rows} cursor={cursor} visibleRows={visibleRows} currentSprintId={selection.sprintId} />
-          <Box marginTop={spacing.section} paddingX={spacing.indent}>
-            <Text dimColor>
-              {glyphs.bullet} ↵ use the highlighted sprint {glyphs.bullet} t toggle scope {glyphs.bullet} f{' '}
-              {hideDone ? 'show' : 'hide'} done {glyphs.bullet} + create a new one
-            </Text>
-          </Box>
-          {feedback !== undefined && (
-            <Box paddingX={spacing.indent} marginTop={1}>
-              <Text color={inkColors.error}>{feedback}</Text>
-            </Box>
-          )}
-        </Box>
-      )}
+      <PickerBody
+        helpOpen={ui.helpOpen}
+        state={state}
+        sprintCount={sprintCount}
+        hiddenByDoneFilter={hiddenByDoneFilter}
+        scopeAll={scopeAll}
+        hideDone={hideDone}
+        rows={rows}
+        cursor={cursor}
+        visibleRows={visibleRows}
+        currentSprintId={selection.sprintId}
+        currentSprintLabel={selection.sprintLabel}
+        feedback={feedback}
+      />
     </ViewShell>
   );
 };

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -8,7 +8,7 @@
  * project's sprints.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
@@ -24,6 +24,7 @@ import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { Result } from '@src/domain/result.ts';
 import { type OpenEditPromptInput, useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
@@ -92,14 +93,8 @@ export const ProjectDetailView = (): React.JSX.Element => {
   // Mounted-ref guard for the async remove-repo handler: dismissing the confirm overlay unblocks the
   // router, so the operator can navigate away (unmounting this view) before the awaited save resolves.
   // The guard skips the post-await view-local writes (setFeedback / reload) so they never fire into an
-  // unmounted tree. Mirrors the guard in `useEditField`.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-    },
-    []
-  );
+  // unmounted tree.
+  const mountedRef = useIsMounted();
 
   const project = state.kind === 'ok' ? state.value : undefined;
 

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -27,6 +27,7 @@ import { type OpenEditPromptInput, useEditField } from '@src/application/ui/tui/
 import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useAsyncLoad } from '@src/application/ui/tui/runtime/use-async-load.ts';
+import type { AsyncLoadState } from '@src/application/ui/tui/runtime/use-async-load.ts';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
@@ -53,6 +54,191 @@ type Field =
 type EditTarget =
   { readonly kind: 'project' } | { readonly kind: 'repo'; readonly field: RepoFieldKey; readonly repo: Repository };
 
+/**
+ * Once the project loads, refresh the display-name label in the selection cache so the status
+ * bar can show "proj: <name>" without re-loading the aggregate — but ONLY for the project that
+ * is already current. Re-stamping a *different* project here would switch the selection (and
+ * clear the sprint cursor) as a side effect of merely browsing its detail; the explicit `m`
+ * chord is the only path that switches.
+ */
+const useSyncCurrentProjectLabel = (
+  state: AsyncLoadState<Project, unknown>,
+  selection: ReturnType<typeof useSelection>
+): void => {
+  const setProjectRef = React.useRef(selection.setProject);
+  setProjectRef.current = selection.setProject;
+  const selectionProjectIdRef = React.useRef(selection.projectId);
+  selectionProjectIdRef.current = selection.projectId;
+  React.useEffect(() => {
+    if (state.kind !== 'ok') return;
+    if (selectionProjectIdRef.current === state.value.id) {
+      setProjectRef.current(state.value.id, state.value.displayName);
+    }
+  }, [state]);
+};
+
+interface BuildFieldEditArgs {
+  readonly target: EditTarget;
+  readonly project: Project;
+  readonly projectRepo: ReturnType<typeof useDeps>['projectRepo'];
+  readonly reload: () => void;
+}
+
+/** Build the edit-prompt config for the focused row — the project's displayName or one repo
+ *  field. Takes the entity + repo port as explicit args instead of closing over them so it can
+ *  live outside the component's render scope. */
+const buildFieldEdit = (args: BuildFieldEditArgs): OpenEditPromptInput => {
+  const { target, project, projectRepo, reload } = args;
+  if (target.kind === 'project') {
+    return {
+      title: `Rename project "${project.displayName}"`,
+      kind: 'short',
+      currentValue: project.displayName,
+      onSave: async (value) => {
+        const renamed = setProjectDisplayName(project, value);
+        if (!renamed.ok) return Result.error(renamed.error);
+        const saved = await projectRepo.save(renamed.value);
+        if (!saved.ok) return Result.error(saved.error);
+        reload();
+        return Result.ok(undefined);
+      },
+      successLabel: `✓ renamed project`,
+    };
+  }
+  const { repo, field } = target;
+  const label = field === 'name' ? `Rename repository "${repo.name}"` : `Edit ${field} for "${repo.name}"`;
+  const current =
+    field === 'name' ? repo.name : field === 'setupScript' ? (repo.setupScript ?? '') : (repo.verifyScript ?? '');
+  return {
+    title: label,
+    kind: field === 'name' ? 'short' : 'long',
+    currentValue: current,
+    onSave: async (value) => {
+      // For optional script fields, route through the setter directly so `value === ''`
+      // explicitly *clears* the field (the entity setter accepts `undefined` for clear).
+      // `updateRepository`'s partial type — with exactOptionalPropertyTypes — disallows
+      // direct undefined assignment, so we update the repo and persist the parent project.
+      if (field === 'name') {
+        const next = updateRepository(project, repo.id, { name: value });
+        if (!next.ok) return Result.error(next.error);
+        const saved = await projectRepo.save(next.value);
+        if (!saved.ok) return Result.error(saved.error);
+        reload();
+        return Result.ok(undefined);
+      }
+      const updatedRepo =
+        field === 'setupScript'
+          ? setRepositorySetupScript(repo, value.length === 0 ? undefined : value)
+          : setRepositoryVerifyScript(repo, value.length === 0 ? undefined : value);
+      if (!updatedRepo.ok) return Result.error(updatedRepo.error);
+      const nextRepos = project.repositories.map((r) => (r.id === repo.id ? updatedRepo.value : r));
+      const saved = await projectRepo.save({ ...project, repositories: nextRepos });
+      if (!saved.ok) return Result.error(saved.error);
+      reload();
+      return Result.ok(undefined);
+    },
+    successLabel: `✓ updated ${field}`,
+  };
+};
+
+interface LaunchPerRepoFlowCtx {
+  readonly deps: ReturnType<typeof useDeps>;
+  readonly queue: ReturnType<typeof usePromptQueue>;
+  readonly storage: ReturnType<typeof useStorage>;
+  readonly sessions: ReturnType<typeof useSessionManager>;
+  readonly router: ReturnType<typeof useRouter>;
+  readonly mountedRef: ReturnType<typeof useIsMounted>;
+  readonly setFeedback: (message: string | undefined) => void;
+}
+
+/**
+ * Launch the `detect-scripts` / `detect-skills` one-shot flow scoped to a single repository.
+ * `c`/`S` don't claim the global key-mute, so the operator can navigate away (unmounting this
+ * view) while the launcher resolves — the mounted-ref guard skips the post-await view-local
+ * writes (setFeedback / session open) so neither fires into an unmounted tree.
+ */
+const launchPerRepoFlow = async (
+  ctx: LaunchPerRepoFlowCtx,
+  project: Project | undefined,
+  flowId: 'detect-scripts' | 'detect-skills',
+  target: Repository
+): Promise<void> => {
+  if (project === undefined) return;
+  const { deps, queue, storage, sessions, router, mountedRef, setFeedback } = ctx;
+  setFeedback(undefined);
+  const snapshot = await loadAppStateSnapshot(deps, { projectId: project.id });
+  const interactive = createInkInteractivePrompt(queue);
+  const result = await launchFlow(
+    { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
+    flowId,
+    snapshot,
+    { repositoryId: target.id }
+  );
+  if (!mountedRef.current) return;
+  if (!result.ok) {
+    setFeedback(`✗ ${result.reason}`);
+    return;
+  }
+  openFlowSession({ sessions, router }, result, flowId);
+};
+
+interface ProjectDetailShortcutArgs {
+  readonly modalOpen: boolean;
+  readonly confirmRemoveActive: boolean;
+  readonly project: Project | undefined;
+  readonly focused: Field | undefined;
+  readonly fieldsLength: number;
+  readonly setCursorIdx: React.Dispatch<React.SetStateAction<number>>;
+  readonly handleEdit: () => void;
+  // One lookup per action group instead of a separate callback field per chord — keeps both the
+  // interface and the dispatch below flat. `rootActions` covers the two project-scoped chords
+  // (add repo / mark current); `repoActions` covers the three repo-scoped ones.
+  readonly rootActions: Readonly<Record<'a' | 'm', (project: Project) => void>>;
+  readonly repoActions: Readonly<Record<'d' | 'c' | 'S', (repo: Repository) => void>>;
+  readonly pushSprints: () => void;
+}
+
+/**
+ * Keymap hook for the project-detail view — encapsulates every `useInput` chord (add repo, mark
+ * current, edit field, flat-cursor navigation, per-repo CRUD + detect flows, sprints shortcut)
+ * so the orchestrator only has to wire state and handler callbacks. Mirrors
+ * `useSprintDetailShortcuts` on the sibling sprint-detail view.
+ */
+const useProjectDetailShortcuts = (args: ProjectDetailShortcutArgs): void => {
+  useInput((input, key) => {
+    if (args.modalOpen || args.confirmRemoveActive || args.project === undefined) return;
+    const project = args.project;
+    if (input in args.rootActions) {
+      args.rootActions[input as 'a' | 'm'](project);
+      return;
+    }
+    if (input === 'e' || key.return) {
+      args.handleEdit();
+      return;
+    }
+    if (key.downArrow || input === 'j') {
+      args.setCursorIdx((c) => Math.min(Math.max(0, args.fieldsLength - 1), c + 1));
+      return;
+    }
+    if (key.upArrow || input === 'k') {
+      args.setCursorIdx((c) => Math.max(0, c - 1));
+      return;
+    }
+    // Repo-scoped chords look up their handler in `repoActions` instead of repeating the "is a
+    // repo row focused" guard for each chord.
+    if (args.focused?.kind === 'repo' && input in args.repoActions) {
+      args.repoActions[input as 'd' | 'c' | 'S'](args.focused.repo);
+      return;
+    }
+    if (input === 'r') {
+      // The hint has advertised `r — sprints` since this view shipped, but no handler ever
+      // existed. Plain navigation: the Sprints list scopes to the current selection (press
+      // `m` first to scope it to the viewed project).
+      args.pushSprints();
+    }
+  });
+};
+
 export const ProjectDetailView = (): React.JSX.Element => {
   const deps = useDeps();
   const router = useRouter();
@@ -69,22 +255,8 @@ export const ProjectDetailView = (): React.JSX.Element => {
     return r.value;
   }, [projectId]);
 
-  // Once the project loads, refresh the display-name label in the selection cache so the
-  // status bar can show "proj: <name>" without re-loading the aggregate — but ONLY for the
-  // project that is already current. Re-stamping a *different* project here would switch the
-  // selection (and clear the sprint cursor) as a side effect of merely browsing its detail;
-  // the explicit `m` chord below is the only path that switches.
   const selection = useSelection();
-  const setProjectRef = React.useRef(selection.setProject);
-  setProjectRef.current = selection.setProject;
-  const selectionProjectIdRef = React.useRef(selection.projectId);
-  selectionProjectIdRef.current = selection.projectId;
-  React.useEffect(() => {
-    if (state.kind !== 'ok') return;
-    if (selectionProjectIdRef.current === state.value.id) {
-      setProjectRef.current(state.value.id, state.value.displayName);
-    }
-  }, [state]);
+  useSyncCurrentProjectLabel(state, selection);
 
   const [cursorIdx, setCursorIdx] = useState(0);
   const [confirmRemove, setConfirmRemove] = useState<Repository | undefined>(undefined);
@@ -145,137 +317,43 @@ export const ProjectDetailView = (): React.JSX.Element => {
     if (state.kind === 'ok') setCursorIdx(0);
   }, [state.kind, projectId]);
 
-  const launchPerRepoFlow = async (flowId: 'detect-scripts' | 'detect-skills', target: Repository): Promise<void> => {
-    if (project === undefined) return;
-    setFeedback(undefined);
-    const snapshot = await loadAppStateSnapshot(deps, { projectId: project.id });
-    const interactive = createInkInteractivePrompt(queue);
-    const result = await launchFlow(
-      { app: deps, interactive, storage, runInTerminal: getRunInTerminal() },
-      flowId,
-      snapshot,
-      { repositoryId: target.id }
-    );
-    // `c`/`S` don't claim the global key-mute, so the operator can navigate away (unmounting this
-    // view) while the launcher resolves. Skip consuming the result once unmounted — both the
-    // view-local `setFeedback` and the session/router open — so neither fires into an unmounted
-    // tree. Mirrors `handleRemoveConfirmed`.
-    if (!mountedRef.current) return;
-    if (!result.ok) {
-      setFeedback(`✗ ${result.reason}`);
-      return;
-    }
-    openFlowSession({ sessions, router }, result, flowId);
-  };
-
-  const renderEditPrompt = (target: EditTarget): OpenEditPromptInput | undefined => {
-    if (project === undefined) return undefined;
-    if (target.kind === 'project') {
-      return {
-        title: `Rename project "${project.displayName}"`,
-        kind: 'short',
-        currentValue: project.displayName,
-        onSave: async (value) => {
-          const renamed = setProjectDisplayName(project, value);
-          if (!renamed.ok) return Result.error(renamed.error);
-          const saved = await deps.projectRepo.save(renamed.value);
-          if (!saved.ok) return Result.error(saved.error);
-          reload();
-          return Result.ok(undefined);
-        },
-        successLabel: `✓ renamed project`,
-      };
-    }
-    const { repo, field } = target;
-    const label = field === 'name' ? `Rename repository "${repo.name}"` : `Edit ${field} for "${repo.name}"`;
-    const current =
-      field === 'name' ? repo.name : field === 'setupScript' ? (repo.setupScript ?? '') : (repo.verifyScript ?? '');
-    return {
-      title: label,
-      kind: field === 'name' ? 'short' : 'long',
-      currentValue: current,
-      onSave: async (value) => {
-        // For optional script fields, route through the setter directly so `value === ''`
-        // explicitly *clears* the field (the entity setter accepts `undefined` for clear).
-        // `updateRepository`'s partial type — with exactOptionalPropertyTypes — disallows
-        // direct undefined assignment, so we update the repo and persist the parent project.
-        if (field === 'name') {
-          const next = updateRepository(project, repo.id, { name: value });
-          if (!next.ok) return Result.error(next.error);
-          const saved = await deps.projectRepo.save(next.value);
-          if (!saved.ok) return Result.error(saved.error);
-          reload();
-          return Result.ok(undefined);
-        }
-        const updatedRepo =
-          field === 'setupScript'
-            ? setRepositorySetupScript(repo, value.length === 0 ? undefined : value)
-            : setRepositoryVerifyScript(repo, value.length === 0 ? undefined : value);
-        if (!updatedRepo.ok) return Result.error(updatedRepo.error);
-        const nextRepos = project.repositories.map((r) => (r.id === repo.id ? updatedRepo.value : r));
-        const saved = await deps.projectRepo.save({ ...project, repositories: nextRepos });
-        if (!saved.ok) return Result.error(saved.error);
-        reload();
-        return Result.ok(undefined);
-      },
-      successLabel: `✓ updated ${field}`,
-    };
-  };
-
   const handleEdit = (): void => {
     if (project === undefined || focused === undefined) return;
     setFeedback(undefined);
     const target: EditTarget =
       focused.kind === 'project' ? { kind: 'project' } : { kind: 'repo', field: focused.field, repo: focused.repo };
-    const cfg = renderEditPrompt(target);
-    if (cfg !== undefined) void edit.openEditPrompt(cfg);
+    const cfg = buildFieldEdit({ target, project, projectRepo: deps.projectRepo, reload });
+    void edit.openEditPrompt(cfg);
   };
 
-  useInput((input, key) => {
-    if (ui.modalOpen || confirmRemove !== undefined || project === undefined) return;
-    if (input === 'a') {
-      router.push({ id: 'add-repository', props: { projectId: project.id } });
-      return;
-    }
-    if (input === 'm') {
-      // Explicit "make this project current" — the deliberate counterpart to the browse-only
-      // open. No-op if already current so re-pressing doesn't churn feedback.
-      if (selection.projectId !== project.id) {
-        selection.setProject(project.id, project.displayName);
-        setFeedback(`✓ now on ${project.displayName}`);
-      }
-      return;
-    }
-    if (input === 'e' || key.return) {
-      handleEdit();
-      return;
-    }
-    if (key.downArrow || input === 'j') {
-      setCursorIdx((c) => Math.min(Math.max(0, fields.length - 1), c + 1));
-      return;
-    }
-    if (key.upArrow || input === 'k') {
-      setCursorIdx((c) => Math.max(0, c - 1));
-      return;
-    }
-    if (input === 'd' && focused?.kind === 'repo') {
-      setConfirmRemove(focused.repo);
-      return;
-    }
-    if (input === 'c' && focused?.kind === 'repo') {
-      void launchPerRepoFlow('detect-scripts', focused.repo);
-      return;
-    }
-    if (input === 'S' && focused?.kind === 'repo') {
-      void launchPerRepoFlow('detect-skills', focused.repo);
-      return;
-    }
-    if (input === 'r') {
-      // The hint has advertised `r — sprints` since this view shipped, but no handler ever
-      // existed. Plain navigation: the Sprints list scopes to the current selection (press
-      // `m` first to scope it to the viewed project).
-      router.push({ id: 'sprints' });
-    }
+  // Explicit "make this project current" — the deliberate counterpart to the browse-only open.
+  // No-op if already current so re-pressing doesn't churn feedback.
+  const markCurrent = (target: Project): void => {
+    if (selection.projectId === target.id) return;
+    selection.setProject(target.id, target.displayName);
+    setFeedback(`✓ now on ${target.displayName}`);
+  };
+
+  const launchPerRepoFlowCtx = { deps, queue, storage, sessions, router, mountedRef, setFeedback };
+
+  useProjectDetailShortcuts({
+    modalOpen: ui.modalOpen,
+    confirmRemoveActive: confirmRemove !== undefined,
+    project,
+    focused,
+    fieldsLength: fields.length,
+    setCursorIdx,
+    handleEdit,
+    rootActions: {
+      a: (p) => router.push({ id: 'add-repository', props: { projectId: p.id } }),
+      m: markCurrent,
+    },
+    repoActions: {
+      d: (repo) => setConfirmRemove(repo),
+      c: (repo) => void launchPerRepoFlow(launchPerRepoFlowCtx, project, 'detect-scripts', repo),
+      S: (repo) => void launchPerRepoFlow(launchPerRepoFlowCtx, project, 'detect-skills', repo),
+    },
+    pushSprints: () => router.push({ id: 'sprints' }),
   });
 
   const handleRemoveConfirmed = async (target: Repository, confirmed: boolean): Promise<void> => {

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -6,7 +6,7 @@
  * mirroring the sprint-detail view's explicit opt-in.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -28,12 +28,115 @@ import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 
-export const ProjectsView = (): React.JSX.Element => {
+/** Private hook for rename action. */
+const useRenameProjectAction = (
+  edit: ReturnType<typeof useEditField>,
+  selection: ReturnType<typeof useSelection>,
+  setFeedback: (msg: string | undefined) => void,
+  reload: () => void
+): ((target: Project) => void) => {
   const deps = useDeps();
+  return useCallback(
+    (target: Project) => {
+      setFeedback(undefined);
+      void edit.openEditPrompt({
+        title: `Rename project "${target.displayName}"`,
+        kind: 'short',
+        currentValue: target.displayName,
+        onSave: async (value) => {
+          const renamed = setProjectDisplayName(target, value);
+          if (!renamed.ok) return Result.error(renamed.error);
+          const saved = await deps.projectRepo.save(renamed.value);
+          if (!saved.ok) return Result.error(saved.error);
+          if (selection.projectId === target.id) selection.setProject(target.id, renamed.value.displayName);
+          reload();
+          return Result.ok(undefined);
+        },
+        successLabel: `✓ renamed "${target.displayName}"`,
+      });
+    },
+    [edit, selection, deps, reload, setFeedback]
+  );
+};
+
+/** Private hook for delete action. */
+const useDeleteProjectAction = (
+  selection: ReturnType<typeof useSelection>,
+  mountedRef: ReturnType<typeof useIsMounted>,
+  setFeedback: (msg: string | undefined) => void,
+  reload: () => void
+): {
+  handleDeleteConfirmed: (target: Project, confirmed: boolean) => Promise<void>;
+} => {
+  const deps = useDeps();
+  const handleDeleteConfirmed = useCallback(
+    async (target: Project, confirmed: boolean) => {
+      if (!confirmed) return;
+      const r = await deps.projectRepo.remove(target.id);
+      if (!r.ok) {
+        if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
+        return;
+      }
+      // Clearing the deleted project's selection targets the always-mounted SelectionProvider, so it
+      // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
+      if (selection.projectId === target.id) selection.setProject(undefined);
+      if (!mountedRef.current) return;
+      setFeedback(`${glyphs.check} removed ${target.displayName}`);
+      reload();
+    },
+    [deps, mountedRef, selection, setFeedback, reload]
+  );
+  return { handleDeleteConfirmed };
+};
+
+/** Private presentational component for a single project row. */
+const ProjectRow = ({ project, focused }: { project: Project; focused: boolean }): React.JSX.Element => (
+  <Box key={project.id} flexDirection="column" marginBottom={1}>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={focused ? inkColors.primary : inkColors.rule}
+      borderDimColor={!focused}
+      paddingX={spacing.cardPadX}
+    >
+      <Box justifyContent="space-between">
+        <Text bold {...(focused ? { color: inkColors.primary } : {})}>
+          {project.displayName}
+        </Text>
+        <Text dimColor>
+          {String(project.repositories.length)} repo{project.repositories.length === 1 ? '' : 's'}
+        </Text>
+      </Box>
+      <Text dimColor>
+        {project.slug}
+        {project.description !== undefined && project.description.length > 0
+          ? ` ${glyphs.bullet} ${project.description}`
+          : ''}
+      </Text>
+      {project.repositories.slice(0, 2).map((r) => (
+        <Text key={r.id} dimColor>
+          {glyphs.activityArrow} {r.name} <Text dimColor>{r.path}</Text>
+        </Text>
+      ))}
+      {project.repositories.length > 2 && (
+        <Text dimColor italic>
+          +{String(project.repositories.length - 2)} more{' '}
+          {project.repositories.length - 2 === 1 ? 'repository' : 'repositories'}
+        </Text>
+      )}
+    </Box>
+  </Box>
+);
+
+export const ProjectsView = (): React.JSX.Element => {
   const router = useRouter();
   const selection = useSelection();
   const ui = useUiState();
   const { rows } = useBreakpoint();
+  const edit = useEditField();
+  const deps = useDeps();
+  const mountedRef = useIsMounted();
+
   useViewHints([
     { keys: '↑/↓/j/k', label: 'move' },
     { keys: '↵', label: 'open' },
@@ -43,16 +146,9 @@ export const ProjectsView = (): React.JSX.Element => {
     { keys: 'd', label: 'delete' },
     { keys: 'r', label: 'reload' },
   ]);
-  const edit = useEditField();
 
   const [confirmDelete, setConfirmDelete] = useState<Project | undefined>(undefined);
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
-
-  // Mounted-ref guard for the async delete handler: dismissing the confirm overlay unblocks the
-  // router, so the operator can navigate away (unmounting this view) before `projectRepo.remove`
-  // resolves. The guard skips the post-await view-local writes (setFeedback / reload) so they never
-  // fire into an unmounted tree.
-  const mountedRef = useIsMounted();
 
   const { state, reload } = useAsyncLoad<readonly Project[]>(async () => {
     const r = await deps.projectRepo.list();
@@ -61,12 +157,9 @@ export const ProjectsView = (): React.JSX.Element => {
   }, []);
 
   const items = state.kind === 'ok' ? state.value : [];
-
-  // The windowed-list owns the single cursor (id-keyed on project id) and the keyboard nav
-  // (↑/↓ + j/k + PgUp/PgDn + Home/End). Disabled whenever a prompt / overlay / confirm is up so
-  // it doesn't compete for keys; Enter pushes the detail route and stamps the selection.
   const listActive = !ui.modalOpen && confirmDelete === undefined;
   const visibleRows = Math.max(4, Math.min(12, Math.floor(rows / 5)));
+
   const { window, visibleItems, focusedItem } = useListWindow<Project>({
     items,
     getId: (p) => p.id,
@@ -79,24 +172,8 @@ export const ProjectsView = (): React.JSX.Element => {
     },
   });
 
-  const handleRename = (target: Project): void => {
-    setFeedback(undefined);
-    void edit.openEditPrompt({
-      title: `Rename project "${target.displayName}"`,
-      kind: 'short',
-      currentValue: target.displayName,
-      onSave: async (value) => {
-        const renamed = setProjectDisplayName(target, value);
-        if (!renamed.ok) return Result.error(renamed.error);
-        const saved = await deps.projectRepo.save(renamed.value);
-        if (!saved.ok) return Result.error(saved.error);
-        if (selection.projectId === target.id) selection.setProject(target.id, renamed.value.displayName);
-        reload();
-        return Result.ok(undefined);
-      },
-      successLabel: `✓ renamed "${target.displayName}"`,
-    });
-  };
+  const handleRename = useRenameProjectAction(edit, selection, setFeedback, reload);
+  const { handleDeleteConfirmed } = useDeleteProjectAction(selection, mountedRef, setFeedback, reload);
 
   useInput((input) => {
     if (ui.modalOpen || confirmDelete !== undefined) return;
@@ -130,22 +207,6 @@ export const ProjectsView = (): React.JSX.Element => {
     }
   });
 
-  const handleDeleteConfirmed = async (target: Project, confirmed: boolean): Promise<void> => {
-    setConfirmDelete(undefined);
-    if (!confirmed) return;
-    const r = await deps.projectRepo.remove(target.id);
-    if (!r.ok) {
-      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
-      return;
-    }
-    // Clearing the deleted project's selection targets the always-mounted SelectionProvider, so it
-    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
-    if (selection.projectId === target.id) selection.setProject(undefined);
-    if (!mountedRef.current) return;
-    setFeedback(`${glyphs.check} removed ${target.displayName}`);
-    reload();
-  };
-
   return (
     <ViewShell title="Projects" subtitle="Browse projects — press m to make one current" suppressScrollArrows>
       {ui.helpOpen ? (
@@ -163,7 +224,11 @@ export const ProjectsView = (): React.JSX.Element => {
           }
           body={<Text dimColor>Sprints and repository contents are not touched.</Text>}
           message="Delete?"
-          onSubmit={(value) => void handleDeleteConfirmed(confirmDelete, value)}
+          onSubmit={(value) => {
+            const target = confirmDelete;
+            setConfirmDelete(undefined);
+            void handleDeleteConfirmed(target, value);
+          }}
           onCancel={() => setConfirmDelete(undefined)}
         />
       ) : state.value.length === 0 ? (
@@ -175,46 +240,9 @@ export const ProjectsView = (): React.JSX.Element => {
       ) : (
         <Box flexDirection="column">
           <OverflowRow direction="above" count={window.start} />
-          {visibleItems.map((p) => {
-            const focused = focusedItem?.id === p.id;
-            return (
-              <Box key={p.id} flexDirection="column" marginBottom={1}>
-                <Box
-                  flexDirection="column"
-                  borderStyle="round"
-                  borderColor={focused ? inkColors.primary : inkColors.rule}
-                  borderDimColor={!focused}
-                  paddingX={spacing.cardPadX}
-                >
-                  <Box justifyContent="space-between">
-                    <Text bold {...(focused ? { color: inkColors.primary } : {})}>
-                      {p.displayName}
-                    </Text>
-                    <Text dimColor>
-                      {String(p.repositories.length)} repo{p.repositories.length === 1 ? '' : 's'}
-                    </Text>
-                  </Box>
-                  <Text dimColor>
-                    {p.slug}
-                    {p.description !== undefined && p.description.length > 0
-                      ? ` ${glyphs.bullet} ${p.description}`
-                      : ''}
-                  </Text>
-                  {p.repositories.slice(0, 2).map((r) => (
-                    <Text key={r.id} dimColor>
-                      {glyphs.activityArrow} {r.name} <Text dimColor>{r.path}</Text>
-                    </Text>
-                  ))}
-                  {p.repositories.length > 2 && (
-                    <Text dimColor italic>
-                      +{String(p.repositories.length - 2)} more{' '}
-                      {p.repositories.length - 2 === 1 ? 'repository' : 'repositories'}
-                    </Text>
-                  )}
-                </Box>
-              </Box>
-            );
-          })}
+          {visibleItems.map((p) => (
+            <ProjectRow key={p.id} project={p} focused={focusedItem?.id === p.id} />
+          ))}
           <OverflowRow direction="below" count={state.value.length - window.end} />
           <Box paddingX={spacing.indent} marginTop={spacing.section}>
             <Text dimColor>

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -6,7 +6,7 @@
  * mirroring the sprint-detail view's explicit opt-in.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -16,6 +16,7 @@ import { FeedbackLine } from '@src/application/ui/tui/components/feedback-line.t
 import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { type Project, setProjectDisplayName } from '@src/domain/entity/project.ts';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { Result } from '@src/domain/result.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
@@ -50,14 +51,8 @@ export const ProjectsView = (): React.JSX.Element => {
   // Mounted-ref guard for the async delete handler: dismissing the confirm overlay unblocks the
   // router, so the operator can navigate away (unmounting this view) before `projectRepo.remove`
   // resolves. The guard skips the post-await view-local writes (setFeedback / reload) so they never
-  // fire into an unmounted tree. Mirrors the guard in `useEditField`.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-    },
-    []
-  );
+  // fire into an unmounted tree.
+  const mountedRef = useIsMounted();
 
   const { state, reload } = useAsyncLoad<readonly Project[]>(async () => {
     const r = await deps.projectRepo.list();

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -23,10 +23,15 @@
  * row's `{ provider, model }` from the new provider's defaults so the persistence schema stays
  * satisfied). Off-catalog persisted model values stay visible on read; the catalog gate only
  * constrains the editor surface.
+ *
+ * `SettingsView` itself is a short composition of local hooks (`useSettingsData`,
+ * `useInstalledProviders`, `useAvailableModelsMap`, `useSectionNavigation`,
+ * `useSettingsKeyHandler`) plus the `SettingsViewBody` display-state subcomponent — each owns one
+ * cohesive slice of the view's state/effects so the orchestrator itself stays a thin wire-up.
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, type Key } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
 import { ConfirmPrompt } from '@src/application/ui/tui/prompts/confirm-prompt.tsx';
@@ -42,6 +47,7 @@ import type { PresetName } from '@src/business/settings/presets.ts';
 import type { PresetWarning } from '@src/application/flows/settings-apply-preset/ctx.ts';
 import { type AiProvider, type Settings, uniqueProvidersFromAi } from '@src/domain/entity/settings.ts';
 import type { LogLevel } from '@src/domain/value/log-level.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { detectInstalledProviders } from '@src/integration/system/detect-cli.ts';
 import { SettingsEditor } from '@src/application/ui/tui/views/settings-editor.tsx';
 import { applyPreset, submitField } from '@src/application/ui/tui/views/settings-mutations.ts';
@@ -52,58 +58,144 @@ import {
   type SettingsSection,
 } from '@src/application/ui/tui/views/settings-view-model.ts';
 
-export const SettingsView = (): React.JSX.Element => {
-  const deps = useDeps();
-  const storage = useStorage();
-  const ui = useUiState();
-  const logLevel = useLogLevel();
+/** Feedback banner rendered under the active section — `undefined` clears it. */
+type SettingsFeedback = { readonly tone: 'ok' | 'error'; readonly text: string } | undefined;
+
+/** `-1` (previous) / `1` (next) section-switch delta for `←`/`[` and `→`/`]`; `undefined` otherwise. */
+const sectionKeyDelta = (input: string, key: Pick<Key, 'leftArrow' | 'rightArrow'>): -1 | 1 | undefined => {
+  if (key.leftArrow || input === '[') return -1;
+  if (key.rightArrow || input === ']') return 1;
+  return undefined;
+};
+
+/**
+ * Next cursor index for `↑/↓`/j/k (clamped ±1) and PageUp/PageDown/Home/End (snap to an end);
+ * `undefined` when `input`/`key` isn't a cursor-movement key.
+ */
+const cursorKeyIndex = (
+  input: string,
+  key: Pick<Key, 'upArrow' | 'downArrow' | 'pageUp' | 'pageDown' | 'home' | 'end'>,
+  cursor: number,
+  length: number
+): number | undefined => {
+  if (key.upArrow || input === 'k') return Math.max(0, cursor - 1);
+  if (key.downArrow || input === 'j') return Math.min(length - 1, cursor + 1);
+  if (key.pageUp || key.home) return 0;
+  if (key.pageDown || key.end) return length - 1;
+  return undefined;
+};
+
+/** Renders the current value + active-cursor glyph for `key` inside the active section's field list. */
+const renderFieldValue = (activeFields: readonly EditableField[], cursor: number, key: string): React.ReactNode => {
+  const focused = activeFields[cursor]?.key === key;
+  const field = activeFields.find((f) => f.key === key);
+  const value = field?.current ?? '';
+  return (
+    <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
+      {focused ? `${glyphs.actionCursor} ` : '  '}
+      {value}
+    </Text>
+  );
+};
+
+interface FieldActivationSetters {
+  readonly setFeedback: (feedback: SettingsFeedback) => void;
+  readonly setPresetWarnings: (warnings: readonly PresetWarning[]) => void;
+  readonly setPendingPreset: (preset: PresetName) => void;
+  readonly setEditingField: (field: EditableField) => void;
+}
+
+/** `↵/e` activation for the focused field — opens the preset-confirm prompt or the field editor. */
+const activateField = (field: EditableField, setters: FieldActivationSetters): void => {
+  setters.setFeedback(undefined);
+  if (field.kind === 'preset') {
+    setters.setPresetWarnings([]);
+    setters.setPendingPreset(field.preset);
+    return;
+  }
+  setters.setPresetWarnings([]);
+  setters.setEditingField(field);
+};
+
+interface SettingsDataParams {
+  readonly settingsRepo: SettingsRepository;
+  readonly setLogLevel: (level: LogLevel) => void;
+  readonly setFeedback: (feedback: SettingsFeedback) => void;
+  readonly setPresetWarnings: (warnings: readonly PresetWarning[]) => void;
+  readonly closeEditor: () => void;
+}
+
+interface SettingsDataResult {
+  readonly settings: Settings | undefined;
+  readonly loadError: string | undefined;
+  readonly handlePreset: (preset: PresetName) => Promise<void>;
+  readonly handleSubmit: (raw: string, field: EditableField) => Promise<void>;
+}
+
+/**
+ * Owns the loaded `Settings` record and its load/mutate lifecycle: initial load, preset apply,
+ * and per-field submit. Every mutation re-runs `refresh` on success so the view always reflects
+ * the persisted record rather than an optimistic local patch.
+ */
+const useSettingsData = (params: SettingsDataParams): SettingsDataResult => {
+  const { settingsRepo, setLogLevel, setFeedback, setPresetWarnings, closeEditor } = params;
   const [settings, setSettings] = useState<Settings | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | undefined>(undefined);
-  /**
-   * Set of providers whose CLI binary resolved on PATH at mount time. Probed once per Settings
-   * session — the per-row Settings editor never re-probes; the user has to leave and re-enter
-   * Settings to refresh the gate (matches the apply-preset / launch-time probe sites). Stays
-   * `undefined` while the probe is in flight; the provider picker treats `undefined` as "all
-   * enabled" so the picker is usable in the rare frame between mount and probe-completion.
-   */
-  const [installedProviders, setInstalledProviders] = useState<ReadonlySet<AiProvider> | undefined>(undefined);
-  /**
-   * Per-provider account-available model subset, resolved lazily after the settings load. Keyed by
-   * provider; absent entries fall back to the full catalog inside {@link buildSections}. Empty
-   * while the availability probes are in flight — the full catalog renders, then re-renders
-   * filtered once each provider resolves. Never blocks the view.
-   */
-  const [availableModels, setAvailableModels] = useState<ReadonlyMap<AiProvider, readonly string[]>>(new Map());
-  const [sectionIdx, setSectionIdx] = useState(0);
-  const [cursor, setCursor] = useState(0);
-  const [editingField, setEditingField] = useState<EditableField | undefined>(undefined);
-  /** Pending preset confirmation — populated when the user activates a preset button. */
-  const [pendingPreset, setPendingPreset] = useState<PresetName | undefined>(undefined);
-  const [feedback, setFeedback] = useState<{ readonly tone: 'ok' | 'error'; readonly text: string } | undefined>(
-    undefined
-  );
-  /**
-   * Warnings from the most recent apply-preset. Rendered as a dimmed multi-line note below the
-   * preset action group; cleared when the user activates a new preset or edits any other row.
-   */
-  const [presetWarnings, setPresetWarnings] = useState<readonly PresetWarning[]>([]);
-  useViewHints([
-    { keys: '←/→', label: 'section' },
-    { keys: '↑/↓', label: 'navigate' },
-    { keys: '↵/e', label: 'edit' },
-  ]);
 
   const refresh = React.useCallback(async (): Promise<void> => {
-    const flow = createSettingsShowFlow({ settingsRepo: deps.settingsRepo });
+    const flow = createSettingsShowFlow({ settingsRepo });
     const result = await flow.execute({ input: undefined });
     if (result.ok) setSettings(result.value.ctx.output!);
     else setLoadError(result.error.error.message);
-  }, [deps]);
+  }, [settingsRepo]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
+  const handlePreset = async (preset: PresetName): Promise<void> => {
+    const outcome = await applyPreset(preset, settingsRepo);
+    if (outcome.kind === 'error') {
+      setFeedback({ tone: 'error', text: outcome.text });
+      return;
+    }
+    setFeedback({ tone: 'ok', text: outcome.text });
+    setPresetWarnings(outcome.warnings);
+    await refresh();
+  };
+
+  const handleSubmit = async (raw: string, field: EditableField): Promise<void> => {
+    if (settings === undefined) {
+      setFeedback({ tone: 'error', text: 'settings not loaded yet' });
+      closeEditor();
+      return;
+    }
+    const outcome = await submitField(settings, field, raw, settingsRepo);
+    if (outcome.kind === 'error') {
+      setFeedback({ tone: 'error', text: outcome.text });
+      closeEditor();
+      return;
+    }
+    if (outcome.next !== undefined && field.key === 'logging.level') {
+      setLogLevel(outcome.next.logging.level satisfies LogLevel);
+    }
+    setFeedback({ tone: 'ok', text: outcome.text });
+    closeEditor();
+    await refresh();
+  };
+
+  return { settings, loadError, handlePreset, handleSubmit };
+};
+
+/**
+ * Set of providers whose CLI binary resolved on PATH at mount time. Probed once per Settings
+ * session — the per-row Settings editor never re-probes; the user has to leave and re-enter
+ * Settings to refresh the gate (matches the apply-preset / launch-time probe sites). Resolves to
+ * `undefined` while the probe is in flight; the provider picker treats `undefined` as "all
+ * enabled" so the picker is usable in the rare frame between mount and probe-completion.
+ */
+const useInstalledProviders = (): ReadonlySet<AiProvider> | undefined => {
+  const [installedProviders, setInstalledProviders] = useState<ReadonlySet<AiProvider> | undefined>(undefined);
   useEffect(() => {
     let cancelled = false;
     void detectInstalledProviders().then((installed) => {
@@ -113,11 +205,21 @@ export const SettingsView = (): React.JSX.Element => {
       cancelled = true;
     };
   }, []);
+  return installedProviders;
+};
 
-  // Resolve account-available models once settings load — one probe per distinct provider in the
-  // loaded config. Non-blocking: each result folds into the map as it arrives, re-rendering the
-  // affected provider's model options filtered. The probe never throws (fail open).
-  const availableModelsFor = deps.availableModelsFor;
+/**
+ * Per-provider account-available model subset, resolved lazily after settings load — one probe
+ * per distinct provider in the loaded config. Keyed by provider; absent entries fall back to the
+ * full catalog inside {@link buildSections}. Empty while the availability probes are in flight —
+ * the full catalog renders, then re-renders filtered once each provider resolves. The probe never
+ * throws (fail open); never blocks the view.
+ */
+const useAvailableModelsMap = (
+  settings: Settings | undefined,
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+): ReadonlyMap<AiProvider, readonly string[]> => {
+  const [availableModels, setAvailableModels] = useState<ReadonlyMap<AiProvider, readonly string[]>>(new Map());
   useEffect(() => {
     if (settings === undefined || availableModelsFor === undefined) return;
     let cancelled = false;
@@ -131,12 +233,35 @@ export const SettingsView = (): React.JSX.Element => {
       cancelled = true;
     };
   }, [settings, availableModelsFor]);
+  return availableModels;
+};
 
+interface SectionNavigationResult {
+  readonly sections: readonly SettingsSection[];
+  readonly sectionIdx: number;
+  readonly setSectionIdx: React.Dispatch<React.SetStateAction<number>>;
+  readonly cursor: number;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+  readonly activeSection: SettingsSection | undefined;
+  readonly activeFields: readonly EditableField[];
+}
+
+/**
+ * Builds the section list from the loaded settings + resolved model catalog, and owns the
+ * section/cursor pointers into it — including the two clamp effects that keep both pointers in
+ * bounds when the underlying field set shrinks (e.g. a provider switch resets a section's model
+ * options, or the section list itself changes shape).
+ */
+const useSectionNavigation = (
+  settings: Settings | undefined,
+  availableModels: ReadonlyMap<AiProvider, readonly string[]>
+): SectionNavigationResult => {
   const sections = useMemo<readonly SettingsSection[]>(
     () => (settings === undefined ? [] : buildSections(settings, availableModels)),
     [settings, availableModels]
   );
-
+  const [sectionIdx, setSectionIdx] = useState(0);
+  const [cursor, setCursor] = useState(0);
   const activeSection = sections[sectionIdx];
   /**
    * `useMemo` keeps the same array reference across renders while the section's field set is
@@ -156,59 +281,218 @@ export const SettingsView = (): React.JSX.Element => {
     if (sectionIdx >= sections.length && sections.length > 0) setSectionIdx(sections.length - 1);
   }, [sections, sectionIdx]);
 
+  return { sections, sectionIdx, setSectionIdx, cursor, setCursor, activeSection, activeFields };
+};
+
+interface SettingsKeyHandlerParams {
+  readonly modalOpen: boolean;
+  readonly editingField: EditableField | undefined;
+  readonly pendingPreset: PresetName | undefined;
+  readonly sections: readonly SettingsSection[];
+  readonly activeFields: readonly EditableField[];
+  readonly cursor: number;
+  readonly setSectionIdx: React.Dispatch<React.SetStateAction<number>>;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+  readonly setFeedback: (feedback: SettingsFeedback) => void;
+  readonly onActivate: (field: EditableField) => void;
+}
+
+/**
+ * Owns the Settings view's global keyboard routing: `←/→`/`[`/`]` switch sections, `↑/↓`/j/k
+ * (plus PageUp/PageDown/Home/End) move the cursor within the active section's fields, `↵`/`e`
+ * activates the focused field. Muted while a modal overlay, editor, or preset confirmation is
+ * active — those own their own `useInput` handlers.
+ */
+const useSettingsKeyHandler = (params: SettingsKeyHandlerParams): void => {
+  const {
+    modalOpen,
+    editingField,
+    pendingPreset,
+    sections,
+    activeFields,
+    cursor,
+    setSectionIdx,
+    setCursor,
+    setFeedback,
+    onActivate,
+  } = params;
+
   useInput((input, key) => {
-    if (ui.modalOpen || editingField !== undefined || pendingPreset !== undefined) return;
+    if (modalOpen || editingField !== undefined || pendingPreset !== undefined) return;
     if (sections.length === 0) return;
-    if (key.leftArrow || input === '[') {
-      setSectionIdx((i) => (i - 1 + sections.length) % sections.length);
-      setCursor(0);
-      setFeedback(undefined);
-      return;
-    }
-    if (key.rightArrow || input === ']') {
-      setSectionIdx((i) => (i + 1) % sections.length);
+    const sectionDelta = sectionKeyDelta(input, key);
+    if (sectionDelta !== undefined) {
+      setSectionIdx((i) => (i + sectionDelta + sections.length) % sections.length);
       setCursor(0);
       setFeedback(undefined);
       return;
     }
     if (activeFields.length === 0) return;
-    if (key.upArrow || input === 'k') {
-      setCursor((c) => Math.max(0, c - 1));
-      return;
-    }
-    if (key.downArrow || input === 'j') {
-      setCursor((c) => Math.min(activeFields.length - 1, c + 1));
-      return;
-    }
-    if (key.pageUp) {
-      // Per-section row count is small (≤ 8) so PgUp snaps to the first field.
-      setCursor(0);
-      return;
-    }
-    if (key.pageDown) {
-      setCursor(activeFields.length - 1);
-      return;
-    }
-    if (key.home) {
-      setCursor(0);
-      return;
-    }
-    if (key.end) {
-      setCursor(activeFields.length - 1);
+    const nextCursor = cursorKeyIndex(input, key, cursor, activeFields.length);
+    if (nextCursor !== undefined) {
+      setCursor(nextCursor);
       return;
     }
     if (key.return || input === 'e') {
       const field = activeFields[cursor];
-      if (field === undefined) return;
-      setFeedback(undefined);
-      if (field.kind === 'preset') {
-        setPresetWarnings([]);
-        setPendingPreset(field.preset);
-        return;
-      }
-      setPresetWarnings([]);
-      setEditingField(field);
+      if (field !== undefined) onActivate(field);
     }
+  });
+};
+
+interface SettingsViewBodyProps {
+  readonly helpOpen: boolean;
+  readonly pendingPreset: PresetName | undefined;
+  readonly onApplyPreset: (preset: PresetName) => Promise<void>;
+  readonly onCancelPreset: () => void;
+  readonly editingField: EditableField | undefined;
+  readonly installedProviders: ReadonlySet<AiProvider> | undefined;
+  readonly onSubmitField: (raw: string, field: EditableField) => Promise<void>;
+  readonly onCancelField: () => void;
+  readonly loadError: string | undefined;
+  readonly settings: Settings | undefined;
+  readonly activeSection: SettingsSection | undefined;
+  readonly sections: readonly SettingsSection[];
+  readonly sectionIdx: number;
+  readonly valueFor: (key: string) => React.ReactNode;
+  readonly storage: ReturnType<typeof useStorage>;
+  readonly presetWarnings: readonly PresetWarning[];
+  readonly feedback: SettingsFeedback;
+}
+
+/**
+ * The Settings view's mutually-exclusive display states, in priority order: help overlay, preset
+ * confirmation, field editor, load error, loading spinner, then the section strip + active-section
+ * body. Isolated from `SettingsView` so the hook-heavy orchestrator stays a short composition.
+ */
+const SettingsViewBody = ({
+  helpOpen,
+  pendingPreset,
+  onApplyPreset,
+  onCancelPreset,
+  editingField,
+  installedProviders,
+  onSubmitField,
+  onCancelField,
+  loadError,
+  settings,
+  activeSection,
+  sections,
+  sectionIdx,
+  valueFor,
+  storage,
+  presetWarnings,
+  feedback,
+}: SettingsViewBodyProps): React.JSX.Element => {
+  if (helpOpen) return <HelpOverlay />;
+
+  if (pendingPreset !== undefined) {
+    return (
+      <ConfirmPrompt
+        message={`Apply preset ${pendingPreset}? This overwrites all AI rows.`}
+        defaultYes={false}
+        onSubmit={(yes) => {
+          onCancelPreset();
+          if (yes) void onApplyPreset(pendingPreset);
+        }}
+        onCancel={onCancelPreset}
+      />
+    );
+  }
+
+  if (editingField !== undefined) {
+    return (
+      <SettingsEditor
+        field={editingField}
+        installedProviders={installedProviders}
+        onSubmit={(value) => void onSubmitField(value, editingField)}
+        onCancel={onCancelField}
+      />
+    );
+  }
+
+  if (loadError !== undefined) {
+    return (
+      <Box paddingX={spacing.indent}>
+        <Text color={inkColors.error}>Failed to load settings: {loadError}</Text>
+      </Box>
+    );
+  }
+
+  if (settings === undefined || activeSection === undefined) {
+    return (
+      <Box paddingX={spacing.indent}>
+        <Spinner label="Loading…" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <SectionStrip sections={sections} activeIdx={sectionIdx} />
+      <Box marginTop={spacing.section}>
+        <SectionBody section={activeSection} valueFor={valueFor} storage={storage} presetWarnings={presetWarnings} />
+      </Box>
+      {feedback !== undefined && (
+        <Box paddingX={spacing.indent} marginTop={spacing.section}>
+          <Text color={feedback.tone === 'ok' ? inkColors.primary : inkColors.error}>
+            {feedback.tone === 'ok' ? glyphs.check : glyphs.cross} {feedback.text}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export const SettingsView = (): React.JSX.Element => {
+  const deps = useDeps();
+  const storage = useStorage();
+  const ui = useUiState();
+  const logLevel = useLogLevel();
+
+  const [editingField, setEditingField] = useState<EditableField | undefined>(undefined);
+  /** Pending preset confirmation — populated when the user activates a preset button. */
+  const [pendingPreset, setPendingPreset] = useState<PresetName | undefined>(undefined);
+  const [feedback, setFeedback] = useState<SettingsFeedback>(undefined);
+  /**
+   * Warnings from the most recent apply-preset. Rendered as a dimmed multi-line note below the
+   * preset action group; cleared when the user activates a new preset or edits any other row.
+   */
+  const [presetWarnings, setPresetWarnings] = useState<readonly PresetWarning[]>([]);
+
+  useViewHints([
+    { keys: '←/→', label: 'section' },
+    { keys: '↑/↓', label: 'navigate' },
+    { keys: '↵/e', label: 'edit' },
+  ]);
+
+  const closeEditor = (): void => setEditingField(undefined);
+
+  const { settings, loadError, handlePreset, handleSubmit } = useSettingsData({
+    settingsRepo: deps.settingsRepo,
+    setLogLevel: logLevel.setLevel,
+    setFeedback,
+    setPresetWarnings,
+    closeEditor,
+  });
+  const installedProviders = useInstalledProviders();
+  const availableModels = useAvailableModelsMap(settings, deps.availableModelsFor);
+  const { sections, sectionIdx, setSectionIdx, cursor, setCursor, activeSection, activeFields } = useSectionNavigation(
+    settings,
+    availableModels
+  );
+
+  useSettingsKeyHandler({
+    modalOpen: ui.modalOpen,
+    editingField,
+    pendingPreset,
+    sections,
+    activeFields,
+    cursor,
+    setSectionIdx,
+    setCursor,
+    setFeedback,
+    onActivate: (field) => activateField(field, { setFeedback, setPresetWarnings, setPendingPreset, setEditingField }),
   });
 
   // Tie the prompt-active claim to the editing-field state so React's effect cleanup matches
@@ -220,104 +504,30 @@ export const SettingsView = (): React.JSX.Element => {
     [editingField, pendingPreset, claimPrompt]
   );
 
-  const closeEditor = (): void => {
-    setEditingField(undefined);
-  };
-
-  const handlePreset = async (preset: PresetName): Promise<void> => {
-    const outcome = await applyPreset(preset, deps.settingsRepo);
-    if (outcome.kind === 'error') {
-      setFeedback({ tone: 'error', text: outcome.text });
-      return;
-    }
-    setFeedback({ tone: 'ok', text: outcome.text });
-    setPresetWarnings(outcome.warnings);
-    await refresh();
-  };
-
-  const handleSubmit = async (raw: string, field: EditableField): Promise<void> => {
-    if (settings === undefined) {
-      setFeedback({ tone: 'error', text: 'settings not loaded yet' });
-      closeEditor();
-      return;
-    }
-    const outcome = await submitField(settings, field, raw, deps.settingsRepo);
-    if (outcome.kind === 'error') {
-      setFeedback({ tone: 'error', text: outcome.text });
-      closeEditor();
-      return;
-    }
-    if (outcome.next !== undefined && field.key === 'logging.level') {
-      logLevel.setLevel(outcome.next.logging.level satisfies LogLevel);
-    }
-    setFeedback({ tone: 'ok', text: outcome.text });
-    closeEditor();
-    await refresh();
-  };
-
-  const valueFor = (key: string): React.ReactNode => {
-    if (settings === undefined) return null;
-    const focused = activeFields[cursor]?.key === key;
-    const field = activeFields.find((f) => f.key === key);
-    const value = field?.current ?? '';
-    return (
-      <Text {...(focused ? { color: inkColors.primary } : {})} bold={focused}>
-        {focused ? `${glyphs.actionCursor} ` : '  '}
-        {value}
-      </Text>
-    );
-  };
+  const valueFor = (key: string): React.ReactNode =>
+    settings === undefined ? null : renderFieldValue(activeFields, cursor, key);
 
   return (
     <ViewShell title="Settings" subtitle="←/→ section · ↑/↓ navigate · ↵ edit · esc cancel">
-      {ui.helpOpen ? (
-        <HelpOverlay />
-      ) : pendingPreset !== undefined ? (
-        <ConfirmPrompt
-          message={`Apply preset ${pendingPreset}? This overwrites all AI rows.`}
-          defaultYes={false}
-          onSubmit={(yes) => {
-            const preset = pendingPreset;
-            setPendingPreset(undefined);
-            if (yes) void handlePreset(preset);
-          }}
-          onCancel={() => setPendingPreset(undefined)}
-        />
-      ) : editingField !== undefined ? (
-        <SettingsEditor
-          field={editingField}
-          installedProviders={installedProviders}
-          onSubmit={(value) => void handleSubmit(value, editingField)}
-          onCancel={closeEditor}
-        />
-      ) : loadError !== undefined ? (
-        <Box paddingX={spacing.indent}>
-          <Text color={inkColors.error}>Failed to load settings: {loadError}</Text>
-        </Box>
-      ) : settings === undefined || activeSection === undefined ? (
-        <Box paddingX={spacing.indent}>
-          <Spinner label="Loading…" />
-        </Box>
-      ) : (
-        <Box flexDirection="column">
-          <SectionStrip sections={sections} activeIdx={sectionIdx} />
-          <Box marginTop={spacing.section}>
-            <SectionBody
-              section={activeSection}
-              valueFor={valueFor}
-              storage={storage}
-              presetWarnings={presetWarnings}
-            />
-          </Box>
-          {feedback !== undefined && (
-            <Box paddingX={spacing.indent} marginTop={spacing.section}>
-              <Text color={feedback.tone === 'ok' ? inkColors.primary : inkColors.error}>
-                {feedback.tone === 'ok' ? glyphs.check : glyphs.cross} {feedback.text}
-              </Text>
-            </Box>
-          )}
-        </Box>
-      )}
+      <SettingsViewBody
+        helpOpen={ui.helpOpen}
+        pendingPreset={pendingPreset}
+        onApplyPreset={handlePreset}
+        onCancelPreset={() => setPendingPreset(undefined)}
+        editingField={editingField}
+        installedProviders={installedProviders}
+        onSubmitField={handleSubmit}
+        onCancelField={closeEditor}
+        loadError={loadError}
+        settings={settings}
+        activeSection={activeSection}
+        sections={sections}
+        sectionIdx={sectionIdx}
+        valueFor={valueFor}
+        storage={storage}
+        presetWarnings={presetWarnings}
+        feedback={feedback}
+      />
     </ViewShell>
   );
 };

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -30,6 +30,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
+import type { RefObject } from 'react';
 import { Box, Text } from 'ink';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
@@ -39,17 +40,19 @@ import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/asy
 import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { Project } from '@src/domain/entity/project.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import type { Ticket } from '@src/domain/entity/ticket.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { useRouter, useViewProps } from '@src/application/ui/tui/runtime/router.tsx';
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
-import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
+import { useViewHints, type ViewHint } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { createTicketRemoveFlow } from '@src/application/flows/remove-ticket/flow.ts';
-import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
+import type { TicketRemoveDeps } from '@src/application/flows/remove-ticket/deps.ts';
+import { type UnblockTaskProps, unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 import { NextPhaseCard, SprintHeader } from '@src/application/ui/tui/views/sprint-detail-internals/header-card.tsx';
 import { TicketsSection } from '@src/application/ui/tui/views/sprint-detail-internals/ticket-list.tsx';
 import { TasksSection } from '@src/application/ui/tui/views/sprint-detail-internals/task-summary.tsx';
@@ -63,6 +66,7 @@ import {
 import { useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { runEdit } from '@src/application/ui/tui/views/sprint-detail-internals/field-editors.ts';
+import type { AsyncLoadState } from '@src/application/ui/tui/runtime/use-async-load.ts';
 import {
   type SprintBundle,
   useSprintBundle,
@@ -71,6 +75,120 @@ import {
 interface SprintDetailProps extends Readonly<Record<string, unknown>> {
   readonly sprintId: SprintId;
 }
+
+interface FocusedSelection {
+  readonly focusedTicket: Ticket | undefined;
+  readonly focusedTodoTask: Task | undefined;
+  readonly focusedStuckTask: Task | undefined;
+  readonly canEdit: boolean;
+}
+
+/**
+ * Derive the "what's under the cursor" selection from the flat focus list. Feeds the `e` edit
+ * gate, the `u` unblock gate, and the hint row — all three read off this one pass. Pure: same
+ * `focusList` + `cursorIdx` + `ticketsEditable` always yields the same selection, so it lives
+ * outside the component body as a plain helper rather than a hook.
+ */
+const deriveFocusedSelection = (
+  focusList: readonly FocusItem[],
+  cursorIdx: number,
+  ticketsEditable: boolean
+): FocusedSelection => {
+  const focusedNow = focusList[Math.min(cursorIdx, Math.max(0, focusList.length - 1))];
+  // "Stuck" covers both `blocked` (maxAttempts exhausted / verify failed) and `in_progress`
+  // with a settled last attempt (crash recovery after Ctrl-C / watchdog kill). Both map to the
+  // same operator action: press `u` to reset to `todo` and retry on the next implement run.
+  const focusedStuckTask =
+    focusedNow?.kind === 'task' && (focusedNow.task.status === 'blocked' || focusedNow.task.status === 'in_progress')
+      ? focusedNow.task
+      : undefined;
+  const focusedTicket = focusedNow?.kind === 'ticket' && ticketsEditable ? focusedNow.ticket : undefined;
+  const focusedTodoTask =
+    focusedNow?.kind === 'task' && focusedNow.task.status === 'todo' ? focusedNow.task : undefined;
+  const canEdit = focusedTicket !== undefined || focusedTodoTask !== undefined;
+  return { focusedTicket, focusedTodoTask, focusedStuckTask, canEdit };
+};
+
+/** Stable identity for the flat focus list — see the `useMemo` call site for why it matters. */
+const focusItemId = (item: FocusItem): string =>
+  item.kind === 'ticket' ? `ticket:${String(item.ticket.id)}` : `task:${String(item.task.id)}`;
+
+interface BuildDetailHintsArgs {
+  readonly inDetail: boolean;
+  readonly ticketsEditable: boolean;
+  readonly canEdit: boolean;
+  readonly sprint: Sprint | undefined;
+  readonly currentSprintId: SprintId | undefined;
+  readonly focusedStuckTask: Task | undefined;
+}
+
+/**
+ * Build the local footer-hint list. Every hint shares one source of truth with its handler via
+ * `enabledWhen`: the `a`/`d` ticket-CRUD chords are gated on `ticketsEditable` (draft only), so
+ * the hints must hide on a non-draft sprint or the footer would advertise keys that do nothing.
+ * `m` (mark-current) and `u` (unblock) follow the same declarative gate rather than conditional
+ * spreads. Pure — lives outside the component so `useViewHints` keeps a plain call site.
+ */
+const buildDetailHints = (args: BuildDetailHintsArgs): readonly ViewHint[] => {
+  const { inDetail, ticketsEditable, canEdit, sprint, currentSprintId, focusedStuckTask } = args;
+  return [
+    { keys: '↑/↓/j/k', label: 'move' },
+    { keys: 'n', label: 'flows' },
+    { keys: '↵/o', label: inDetail ? 'expand/collapse' : 'expand' },
+    // `esc/q` collapses all expanded cards; only shown while in detail mode so the hint
+    // doesn't compete with the global `esc → back` behavior when nothing is expanded.
+    { keys: 'esc/q', label: 'collapse all', enabledWhen: inDetail },
+    { keys: 'a', label: 'add ticket', enabledWhen: ticketsEditable },
+    { keys: 'e', label: 'edit field', enabledWhen: canEdit },
+    { keys: 'd', label: 'remove ticket', enabledWhen: ticketsEditable },
+    // Surface the `m` chord only when this sprint is not already the current one — once
+    // they match, the action is a no-op and the hint adds noise. Suppressed while a
+    // stuck task is focused so the `u unblock` hint (a more urgent operator action)
+    // stays prominent in the footer without competing for horizontal space.
+    {
+      keys: 'm',
+      label: 'current',
+      enabledWhen: sprint !== undefined && currentSprintId !== sprint.id && focusedStuckTask === undefined,
+    },
+    { keys: 'u', label: 'unblock', enabledWhen: focusedStuckTask !== undefined },
+  ];
+};
+
+interface BuildShortcutsActionsArgs {
+  readonly selection: ReturnType<typeof useSelection>;
+  readonly router: ReturnType<typeof useRouter>;
+  readonly setOpenIds: React.Dispatch<React.SetStateAction<ReadonlySet<string>>>;
+  readonly setConfirmRemove: (ticket: Ticket | undefined) => void;
+  readonly setFeedback: (message: string) => void;
+  readonly onUnblock: (task: Task) => Promise<void>;
+}
+
+/**
+ * Build the `useSprintDetailShortcuts` action closures (`a`/`m`/↵/`d`/`u`) — spread into the
+ * hook's config alongside the plain gate fields so the call site stays a flat list.
+ */
+const buildShortcutsActions = (args: BuildShortcutsActionsArgs) => {
+  const { selection, router, setOpenIds, setConfirmRemove, setFeedback, onUnblock } = args;
+  return {
+    closeAllExpanded: () => setOpenIds(new Set()),
+    openAddTicket: (id: SprintId) => router.push({ id: 'add-ticket', props: { sprintId: id } }),
+    toggleExpand: (id: string) =>
+      setOpenIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }),
+    beginRemove: (ticket: Ticket) => setConfirmRemove(ticket),
+    markCurrent: (s: Sprint) => {
+      selection.setSprint(s.id, s.name, s.status);
+      setFeedback(`${glyphs.check} now on ${s.name}`);
+    },
+    handleUnblock: (task: Task) => {
+      void onUnblock(task);
+    },
+  };
+};
 
 export const SprintDetailView = (): React.JSX.Element => {
   const deps = useDeps();
@@ -102,12 +220,7 @@ export const SprintDetailView = (): React.JSX.Element => {
   // Id-stable cursor over the flat focus list. Items are keyed as `ticket:<id>` / `task:<id>`
   // matching the entity's stable domain id, so a task-list refresh or reorder keeps focus on
   // the same logical item instead of teleporting to whatever sits at the old index.
-  const getFocusItemId = useMemo(
-    () =>
-      (item: FocusItem): string =>
-        item.kind === 'ticket' ? `ticket:${String(item.ticket.id)}` : `task:${String(item.task.id)}`,
-    []
-  );
+  const getFocusItemId = useMemo(() => focusItemId, []);
   const listActive = !ui.modalOpen;
   const { focusedIndex: cursorIdx } = useListWindow<FocusItem>({
     items: focusList,
@@ -131,48 +244,25 @@ export const SprintDetailView = (): React.JSX.Element => {
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';
   const inDetail = openIds.size > 0;
-  const focusedNow = focusList[Math.min(cursorIdx, Math.max(0, focusList.length - 1))];
-  // "Stuck" covers both `blocked` (maxAttempts exhausted / verify failed) and `in_progress`
-  // with a settled last attempt (crash recovery after Ctrl-C / watchdog kill). Both map to the
-  // same operator action: press `u` to reset to `todo` and retry on the next implement run.
-  const focusedStuckTask =
-    focusedNow?.kind === 'task' && (focusedNow.task.status === 'blocked' || focusedNow.task.status === 'in_progress')
-      ? focusedNow.task
-      : undefined;
+  const { focusedTicket, focusedTodoTask, focusedStuckTask, canEdit } = deriveFocusedSelection(
+    focusList,
+    cursorIdx,
+    ticketsEditable
+  );
 
   const edit = useEditField();
   const queue = usePromptQueue();
 
-  const focusedTicket = focusedNow?.kind === 'ticket' && ticketsEditable ? focusedNow.ticket : undefined;
-  const focusedTodoTask =
-    focusedNow?.kind === 'task' && focusedNow.task.status === 'todo' ? focusedNow.task : undefined;
-  const canEdit = focusedTicket !== undefined || focusedTodoTask !== undefined;
-
-  // Every hint shares one source of truth with its handler via `enabledWhen`: the `a`/`d`
-  // ticket-CRUD chords are gated on `ticketsEditable` (draft only), so the hints must hide on a
-  // non-draft sprint or the footer would advertise keys that do nothing. `m` (mark-current) and
-  // `u` (unblock) follow the same declarative gate rather than conditional spreads.
-  useViewHints([
-    { keys: '↑/↓/j/k', label: 'move' },
-    { keys: 'n', label: 'flows' },
-    { keys: '↵/o', label: inDetail ? 'expand/collapse' : 'expand' },
-    // `esc/q` collapses all expanded cards; only shown while in detail mode so the hint
-    // doesn't compete with the global `esc → back` behavior when nothing is expanded.
-    { keys: 'esc/q', label: 'collapse all', enabledWhen: inDetail },
-    { keys: 'a', label: 'add ticket', enabledWhen: ticketsEditable === true },
-    { keys: 'e', label: 'edit field', enabledWhen: canEdit },
-    { keys: 'd', label: 'remove ticket', enabledWhen: ticketsEditable === true },
-    // Surface the `m` chord only when this sprint is not already the current one — once
-    // they match, the action is a no-op and the hint adds noise. Suppressed while a
-    // stuck task is focused so the `u unblock` hint (a more urgent operator action)
-    // stays prominent in the footer without competing for horizontal space.
-    {
-      keys: 'm',
-      label: 'current',
-      enabledWhen: sprint !== undefined && selection.sprintId !== sprint.id && focusedStuckTask === undefined,
-    },
-    { keys: 'u', label: 'unblock', enabledWhen: focusedStuckTask !== undefined },
-  ]);
+  useViewHints(
+    buildDetailHints({
+      inDetail,
+      ticketsEditable: ticketsEditable === true,
+      canEdit,
+      sprint,
+      currentSprintId: selection.sprintId,
+      focusedStuckTask,
+    })
+  );
 
   const handleEdit = (): void => {
     if (sprint === undefined) return;
@@ -190,21 +280,17 @@ export const SprintDetailView = (): React.JSX.Element => {
 
   const handleUnblock = async (target: Task): Promise<void> => {
     if (sprint === undefined) return;
-    const r = await unblockTaskUseCase({
-      task: target,
+    await runUnblock({
+      target,
       sprintId: sprint.id,
       taskRepo: deps.taskRepo,
       sprintRepo: deps.sprintRepo,
       clock: deps.clock,
       logger: deps.logger,
+      mountedRef,
+      setFeedback,
+      reload,
     });
-    if (!r.ok) {
-      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
-      return;
-    }
-    if (!mountedRef.current) return;
-    setFeedback(`${glyphs.check} unblocked "${target.name}"`);
-    reload();
   };
 
   useSprintDetailShortcuts({
@@ -218,24 +304,15 @@ export const SprintDetailView = (): React.JSX.Element => {
     focusList,
     cursorIdx,
     focusedStuckTask,
-    closeAllExpanded: () => setOpenIds(new Set()),
-    openAddTicket: (id) => router.push({ id: 'add-ticket', props: { sprintId: id } }),
-    toggleExpand: (id) =>
-      setOpenIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      }),
-    beginRemove: (ticket) => setConfirmRemove(ticket),
-    markCurrent: (s) => {
-      selection.setSprint(s.id, s.name, s.status);
-      setFeedback(`${glyphs.check} now on ${s.name}`);
-    },
+    ...buildShortcutsActions({
+      selection,
+      router,
+      setOpenIds,
+      setConfirmRemove,
+      setFeedback,
+      onUnblock: handleUnblock,
+    }),
     handleEdit,
-    handleUnblock: (task) => {
-      void handleUnblock(task);
-    },
   });
 
   // Claim `esc` while the detail card is open so the local handler can close the card without
@@ -247,15 +324,14 @@ export const SprintDetailView = (): React.JSX.Element => {
   const handleRemoveConfirmed = async (target: Ticket, confirmed: boolean): Promise<void> => {
     setConfirmRemove(undefined);
     if (!confirmed || sprint === undefined) return;
-    const flow = createTicketRemoveFlow({ sprintRepo: deps.sprintRepo });
-    const r = await flow.execute({ input: { sprintId: sprint.id, ticketId: target.id } });
-    if (!r.ok) {
-      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.error.message}`);
-      return;
-    }
-    if (!mountedRef.current) return;
-    setFeedback(`${glyphs.check} removed "${target.title}"`);
-    reload();
+    await runRemoveTicket({
+      target,
+      sprintId: sprint.id,
+      sprintRepo: deps.sprintRepo,
+      mountedRef,
+      setFeedback,
+      reload,
+    });
   };
 
   return (
@@ -268,36 +344,143 @@ export const SprintDetailView = (): React.JSX.Element => {
       // page scroll keeps its arrows there.
       suppressScrollArrows={state.kind === 'ok'}
     >
-      {ui.helpOpen ? (
-        <HelpOverlay />
-      ) : state.kind === 'loading' || state.kind === 'idle' ? (
-        <LoadingRow label="Loading…" />
-      ) : state.kind === 'error' ? (
-        <LoadErrorRow message="Failed to load sprint." />
-      ) : confirmRemove !== undefined ? (
-        <ConfirmCard
-          title={
-            <Text>
-              Remove ticket <Text bold>{confirmRemove.title}</Text> from this sprint?
-            </Text>
-          }
-          message="Remove?"
-          onSubmit={(value) => void handleRemoveConfirmed(confirmRemove, value)}
-          onCancel={() => setConfirmRemove(undefined)}
-        />
-      ) : (
-        <Body
-          bundle={state.value}
-          project={project}
-          focusList={focusList}
-          cursorIdx={Math.min(cursorIdx, Math.max(0, focusList.length - 1))}
-          openIds={openIds}
-          ticketsEditable={ticketsEditable === true}
-          feedback={feedback ?? edit.feedback}
-          isCurrent={selection.sprintId === state.value.sprint.id}
-        />
-      )}
+      <SprintDetailContent
+        helpOpen={ui.helpOpen}
+        state={state}
+        confirmRemove={confirmRemove}
+        onCancelRemove={() => setConfirmRemove(undefined)}
+        onRemoveConfirmed={(target, confirmed) => void handleRemoveConfirmed(target, confirmed)}
+        project={project}
+        focusList={focusList}
+        cursorIdx={cursorIdx}
+        openIds={openIds}
+        ticketsEditable={ticketsEditable === true}
+        feedback={feedback ?? edit.feedback}
+        currentSprintId={selection.sprintId}
+      />
     </ViewShell>
+  );
+};
+
+interface RunUnblockArgs {
+  readonly target: Task;
+  readonly sprintId: SprintId;
+  readonly taskRepo: UnblockTaskProps['taskRepo'];
+  readonly sprintRepo: UnblockTaskProps['sprintRepo'];
+  readonly clock: UnblockTaskProps['clock'];
+  readonly logger: UnblockTaskProps['logger'];
+  readonly mountedRef: RefObject<boolean>;
+  readonly setFeedback: (message: string) => void;
+  readonly reload: () => void;
+}
+
+/**
+ * Run the unblock use case for one stuck task (the `u` chord) and thread the result to
+ * feedback + reload. `mountedRef` guards the post-await writes — see the comment on the
+ * component's own `mountedRef` declaration for why they can otherwise fire into an unmounted
+ * tree.
+ */
+const runUnblock = async (args: RunUnblockArgs): Promise<void> => {
+  const { target, sprintId, taskRepo, sprintRepo, clock, logger, mountedRef, setFeedback, reload } = args;
+  const r = await unblockTaskUseCase({ task: target, sprintId, taskRepo, sprintRepo, clock, logger });
+  if (!r.ok) {
+    if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
+    return;
+  }
+  if (!mountedRef.current) return;
+  setFeedback(`${glyphs.check} unblocked "${target.name}"`);
+  reload();
+};
+
+interface RunRemoveTicketArgs {
+  readonly target: Ticket;
+  readonly sprintId: SprintId;
+  readonly sprintRepo: TicketRemoveDeps['sprintRepo'];
+  readonly mountedRef: RefObject<boolean>;
+  readonly setFeedback: (message: string) => void;
+  readonly reload: () => void;
+}
+
+/**
+ * Run the ticket-remove flow for one confirmed removal and thread the result to feedback +
+ * reload. Same `mountedRef` guard as {@link runUnblock} — the confirm overlay dismisses before
+ * the flow resolves, so the view can already be unmounted by the time it settles.
+ */
+const runRemoveTicket = async (args: RunRemoveTicketArgs): Promise<void> => {
+  const { target, sprintId, sprintRepo, mountedRef, setFeedback, reload } = args;
+  const flow = createTicketRemoveFlow({ sprintRepo });
+  const r = await flow.execute({ input: { sprintId, ticketId: target.id } });
+  if (!r.ok) {
+    if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.error.message}`);
+    return;
+  }
+  if (!mountedRef.current) return;
+  setFeedback(`${glyphs.check} removed "${target.title}"`);
+  reload();
+};
+
+interface SprintDetailContentProps {
+  readonly helpOpen: boolean;
+  readonly state: AsyncLoadState<SprintBundle, unknown>;
+  readonly confirmRemove: Ticket | undefined;
+  readonly onCancelRemove: () => void;
+  readonly onRemoveConfirmed: (target: Ticket, confirmed: boolean) => void;
+  readonly project: Project | undefined;
+  readonly focusList: readonly FocusItem[];
+  readonly cursorIdx: number;
+  readonly openIds: ReadonlySet<string>;
+  readonly ticketsEditable: boolean;
+  readonly feedback: string | undefined;
+  readonly currentSprintId: SprintId | undefined;
+}
+
+/**
+ * Top-level render branch: help overlay > load/error states > remove confirm > the loaded
+ * body. Flat if-returns instead of a nested ternary chain — same branch order and same props
+ * as before, just laid out as one branch per line.
+ */
+const SprintDetailContent = ({
+  helpOpen,
+  state,
+  confirmRemove,
+  onCancelRemove,
+  onRemoveConfirmed,
+  project,
+  focusList,
+  cursorIdx,
+  openIds,
+  ticketsEditable,
+  feedback,
+  currentSprintId,
+}: SprintDetailContentProps): React.JSX.Element => {
+  if (helpOpen) return <HelpOverlay />;
+  if (state.kind === 'loading' || state.kind === 'idle') return <LoadingRow label="Loading…" />;
+  if (state.kind === 'error') return <LoadErrorRow message="Failed to load sprint." />;
+  if (confirmRemove !== undefined) {
+    return (
+      <ConfirmCard
+        title={
+          <Text>
+            Remove ticket <Text bold>{confirmRemove.title}</Text> from this sprint?
+          </Text>
+        }
+        message="Remove?"
+        onSubmit={(value) => onRemoveConfirmed(confirmRemove, value)}
+        onCancel={onCancelRemove}
+      />
+    );
+  }
+  return (
+    <Body
+      bundle={state.value}
+      project={project}
+      focusList={focusList}
+      cursorIdx={Math.min(cursorIdx, Math.max(0, focusList.length - 1))}
+      openIds={openIds}
+      ticketsEditable={ticketsEditable}
+      feedback={feedback}
+      isCurrent={currentSprintId === state.value.sprint.id}
+    />
   );
 };
 

--- a/src/application/ui/tui/views/sprint-detail-view.tsx
+++ b/src/application/ui/tui/views/sprint-detail-view.tsx
@@ -29,9 +29,10 @@
  * helpers, footer hints, keymap) live in `sprint-detail-internals/`.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { usePromptQueue } from '@src/application/ui/tui/prompts/prompt-context.tsx';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
@@ -124,14 +125,8 @@ export const SprintDetailView = (): React.JSX.Element => {
   // Mounted-ref guard for the async unblock / remove-ticket handlers: dismissing the confirm overlay
   // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
   // before the awaited use-case / flow resolves. The guard skips the post-await view-local writes
-  // (setFeedback / reload) so they never fire into an unmounted tree. Mirrors the guard in `useEditField`.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-    },
-    []
-  );
+  // (setFeedback / reload) so they never fire into an unmounted tree.
+  const mountedRef = useIsMounted();
 
   // Ticket CRUD is only meaningful in draft. Detail-mode disables hot keys other than esc.
   const ticketsEditable = sprint?.status === 'draft';

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -8,7 +8,7 @@
  *   ↵   open the sprint's detail view.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { OverflowRow, useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -19,6 +19,7 @@ import { sprintStatusKind, StatusChip } from '@src/application/ui/tui/components
 import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { renameSprint, type Sprint } from '@src/domain/entity/sprint.ts';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { Result } from '@src/domain/result.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
@@ -61,14 +62,7 @@ export const SprintsView = (): React.JSX.Element => {
   // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
   // before the awaited repo writes resolve. The guard skips the post-await view-local writes
   // (setFeedback / reload / setFocusedSprintTasks) so they never fire into an unmounted tree.
-  // Mirrors the guard in `useEditField`.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-    },
-    []
-  );
+  const mountedRef = useIsMounted();
 
   // Windowed cursor — owns ↑/↓ + j/k + PgUp/PgDn + Home/End + Enter; the cursor is the sprint id,
   // so a reload/reorder keeps focus on the same sprint. Enter selects (sets current + drills in).

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -19,6 +19,7 @@ import { sprintStatusKind, StatusChip } from '@src/application/ui/tui/components
 import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
 import { renameSprint, type Sprint } from '@src/domain/entity/sprint.ts';
 import { useEditField } from '@src/application/ui/tui/runtime/use-edit-field.ts';
+import type { UseEditFieldState } from '@src/application/ui/tui/runtime/use-edit-field.ts';
 import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 import { Result } from '@src/domain/result.ts';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
@@ -33,6 +34,204 @@ import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { unblockTaskUseCase } from '@src/business/task/unblock-task.ts';
 import type { Task } from '@src/domain/entity/task.ts';
+
+/** Pure `succeeded`/`total`/`lastError` → toast-message formatter for a bulk-unblock run. */
+const formatUnblockFeedback = (
+  succeeded: number,
+  total: number,
+  lastError: string | undefined,
+  sprintName: string
+): string =>
+  succeeded === total
+    ? `${glyphs.check} unblocked ${String(succeeded)} task${succeeded === 1 ? '' : 's'} in "${sprintName}"`
+    : `${succeeded > 0 ? glyphs.check : glyphs.cross} unblocked ${String(succeeded)} of ${String(total)}${lastError !== undefined ? ` — ${lastError}` : ''}`;
+
+interface UseStuckSprintTasksResult {
+  readonly stuckTasks: readonly Task[];
+  readonly stuckCount: number;
+  readonly unblockAll: (sprint: Sprint | undefined, setFeedback: (text: string | undefined) => void) => Promise<void>;
+}
+
+/**
+ * Loads the focused sprint's tasks (cancel-safe on sprint change / unmount) and derives the
+ * blocked + in_progress subset that `u` can bulk-unblock. `unblockAll` mirrors the original
+ * inline handler's mounted-ref-gated ordering: the unblock loop runs unconditionally, a mount
+ * check gates the feedback write, and a second mount check (after the further awaited refresh)
+ * gates the task-list write — mount state can change between the two awaits.
+ */
+const useStuckSprintTasks = (sprintId: Sprint['id'] | undefined): UseStuckSprintTasksResult => {
+  const deps = useDeps();
+  const mountedRef = useIsMounted();
+  const [tasks, setTasks] = useState<readonly Task[]>([]);
+
+  useEffect(() => {
+    if (sprintId === undefined) {
+      setTasks([]);
+      return undefined;
+    }
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      const r = await deps.taskRepo.findBySprintId(sprintId);
+      if (cancelled) return;
+      if (r.ok) setTasks(r.value);
+    };
+    load().catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [sprintId, deps.taskRepo]);
+
+  const stuckTasks = tasks.filter((t) => t.status === 'blocked' || t.status === 'in_progress');
+
+  const unblockAll = async (
+    sprint: Sprint | undefined,
+    setFeedback: (text: string | undefined) => void
+  ): Promise<void> => {
+    if (sprint === undefined || stuckTasks.length === 0) return;
+    setFeedback(undefined);
+    let succeeded = 0;
+    let lastError: string | undefined;
+    for (const task of stuckTasks) {
+      const r = await unblockTaskUseCase({
+        task,
+        sprintId: sprint.id,
+        taskRepo: deps.taskRepo,
+        sprintRepo: deps.sprintRepo,
+        clock: deps.clock,
+        logger: deps.logger,
+      });
+      if (r.ok) {
+        succeeded += 1;
+      } else {
+        lastError = r.error.message;
+      }
+    }
+    const total = stuckTasks.length;
+    if (!mountedRef.current) return;
+    setFeedback(formatUnblockFeedback(succeeded, total, lastError, sprint.name));
+    // Refresh task list so the hint and count update immediately.
+    const refreshed = await deps.taskRepo.findBySprintId(sprint.id);
+    if (mountedRef.current && refreshed.ok) setTasks(refreshed.value);
+  };
+
+  return { stuckTasks, stuckCount: stuckTasks.length, unblockAll };
+};
+
+interface SprintRowProps {
+  readonly sprint: Sprint;
+  readonly focused: boolean;
+}
+
+/** One sprint card: name + status chip, slug, ticket count with pending/approved sub-counts. */
+const SprintRow = ({ sprint, focused }: SprintRowProps): React.JSX.Element => {
+  const pending = sprint.tickets.filter((t) => t.status === 'pending').length;
+  const approved = sprint.tickets.filter((t) => t.status === 'approved').length;
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={focused ? inkColors.primary : inkColors.rule}
+        borderDimColor={!focused}
+        paddingX={spacing.cardPadX}
+      >
+        <Box justifyContent="space-between">
+          <Text bold {...(focused ? { color: inkColors.primary } : {})}>
+            {sprint.name}
+          </Text>
+          <StatusChip label={sprint.status} kind={sprintStatusKind(sprint.status)} />
+        </Box>
+        <Text dimColor>{sprint.slug}</Text>
+        <Text>
+          <Text bold>{String(sprint.tickets.length)}</Text>
+          <Text dimColor> tickets</Text>
+          {pending > 0 && (
+            <Text>
+              <Text dimColor> {glyphs.bullet} </Text>
+              <Text bold color={inkColors.warning}>
+                {String(pending)}
+              </Text>
+              <Text dimColor> pending</Text>
+            </Text>
+          )}
+          {approved > 0 && (
+            <Text>
+              <Text dimColor> {glyphs.bullet} </Text>
+              <Text bold color={inkColors.success}>
+                {String(approved)}
+              </Text>
+              <Text dimColor> approved</Text>
+            </Text>
+          )}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+interface UseSprintRowActionsResult {
+  readonly confirmDelete: Sprint | undefined;
+  readonly setConfirmDelete: (sprint: Sprint | undefined) => void;
+  readonly feedback: string | undefined;
+  readonly setFeedback: (text: string | undefined) => void;
+  readonly handleRename: (target: Sprint) => void;
+  readonly handleDeleteConfirmed: (target: Sprint, confirmed: boolean) => Promise<void>;
+}
+
+/**
+ * Rename + delete-confirm state and handlers for the focused sprint row, shaped like
+ * {@link useLaunchCreateSprint} — the caller (the render + `useInput` dispatcher) supplies the
+ * `edit` field-prompt hook and `reload` callback it already owns rather than this hook
+ * instantiating its own competing instances.
+ */
+const useSprintRowActions = (edit: UseEditFieldState, reload: () => void): UseSprintRowActionsResult => {
+  const deps = useDeps();
+  const selection = useSelection();
+  // Mounted-ref guard: dismissing the confirm overlay unblocks the router, so the operator can
+  // navigate away (unmounting this view) before the awaited repo write resolves. The guard skips
+  // the post-await view-local writes (setFeedback / reload) so they never fire into an unmounted
+  // tree.
+  const mountedRef = useIsMounted();
+  const [confirmDelete, setConfirmDelete] = useState<Sprint | undefined>(undefined);
+  const [feedback, setFeedback] = useState<string | undefined>(undefined);
+
+  const handleRename = (target: Sprint): void => {
+    setFeedback(undefined);
+    void edit.openEditPrompt({
+      title: `Rename sprint "${target.name}"`,
+      kind: 'short',
+      currentValue: target.name,
+      onSave: async (value) => {
+        const renamed = renameSprint(target, value);
+        if (!renamed.ok) return Result.error(renamed.error);
+        const saved = await deps.sprintRepo.save(renamed.value);
+        if (!saved.ok) return Result.error(saved.error);
+        if (selection.sprintId === target.id) selection.setSprint(target.id, value.trim(), target.status);
+        reload();
+        return Result.ok(undefined);
+      },
+      successLabel: `${glyphs.check} renamed "${target.name}"`,
+    });
+  };
+
+  const handleDeleteConfirmed = async (target: Sprint, confirmed: boolean): Promise<void> => {
+    setConfirmDelete(undefined);
+    if (!confirmed) return;
+    const r = await deps.sprintRepo.remove(target.id);
+    if (!r.ok) {
+      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
+      return;
+    }
+    // Clearing the deleted sprint's selection targets the always-mounted SelectionProvider, so it
+    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
+    if (selection.sprintId === target.id) selection.setSprint(undefined);
+    if (!mountedRef.current) return;
+    setFeedback(`${glyphs.check} removed ${target.name}`);
+    reload();
+  };
+
+  return { confirmDelete, setConfirmDelete, feedback, setFeedback, handleRename, handleDeleteConfirmed };
+};
 
 export const SprintsView = (): React.JSX.Element => {
   const deps = useDeps();
@@ -55,14 +254,8 @@ export const SprintsView = (): React.JSX.Element => {
 
   const items = state.kind === 'ok' ? state.value : [];
 
-  const [confirmDelete, setConfirmDelete] = useState<Sprint | undefined>(undefined);
-  const [feedback, setFeedback] = useState<string | undefined>(undefined);
-
-  // Mounted-ref guard for the async bulk-unblock / delete handlers: dismissing the confirm overlay
-  // (or firing `u`) unblocks the router, so the operator can navigate away (unmounting this view)
-  // before the awaited repo writes resolve. The guard skips the post-await view-local writes
-  // (setFeedback / reload / setFocusedSprintTasks) so they never fire into an unmounted tree.
-  const mountedRef = useIsMounted();
+  const { confirmDelete, setConfirmDelete, feedback, setFeedback, handleRename, handleDeleteConfirmed } =
+    useSprintRowActions(edit, reload);
 
   // Windowed cursor — owns ↑/↓ + j/k + PgUp/PgDn + Home/End + Enter; the cursor is the sprint id,
   // so a reload/reorder keeps focus on the same sprint. Enter selects (sets current + drills in).
@@ -80,32 +273,10 @@ export const SprintsView = (): React.JSX.Element => {
     },
   });
 
-  // Load tasks for the focused sprint so we can count stuck ones (blocked + in_progress) and
-  // offer `u` to bulk-unblock them. Keyed by sprint id so cursor moves re-trigger the fetch.
-  const [focusedSprintTasks, setFocusedSprintTasks] = useState<readonly Task[]>([]);
   const focusedSprint = focusedItem ?? items[0];
-  useEffect(() => {
-    if (focusedSprint === undefined) {
-      setFocusedSprintTasks([]);
-      return undefined;
-    }
-    let cancelled = false;
-    const load = async (): Promise<void> => {
-      const r = await deps.taskRepo.findBySprintId(focusedSprint.id);
-      if (cancelled) return;
-      if (r.ok) setFocusedSprintTasks(r.value);
-    };
-    load().catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-    // `focusedSprint?.id` is the only piece of focusedSprint we read; depending on the full
-    // object would re-fire whenever the sprint list reloads with semantically-identical data.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- id is the load axis
-  }, [focusedSprint?.id, deps.taskRepo]);
-
-  const stuckTasks = focusedSprintTasks.filter((t) => t.status === 'blocked' || t.status === 'in_progress');
-  const stuckCount = stuckTasks.length;
+  // Keyed by sprint id (not the full object) so a reload with semantically-identical data doesn't
+  // re-trigger the fetch.
+  const { stuckCount, unblockAll } = useStuckSprintTasks(focusedSprint?.id);
 
   // `e rename` shares one source of truth with its handler: the rename chord guards
   // `status !== 'done'` (a done sprint is immutable), so the hint must hide on a done sprint
@@ -128,24 +299,7 @@ export const SprintsView = (): React.JSX.Element => {
     noProjectMessage: `${glyphs.cross} pick a project first (Projects ${glyphs.arrowRight} open one)`,
   });
 
-  const handleRename = (target: Sprint): void => {
-    setFeedback(undefined);
-    void edit.openEditPrompt({
-      title: `Rename sprint "${target.name}"`,
-      kind: 'short',
-      currentValue: target.name,
-      onSave: async (value) => {
-        const renamed = renameSprint(target, value);
-        if (!renamed.ok) return Result.error(renamed.error);
-        const saved = await deps.sprintRepo.save(renamed.value);
-        if (!saved.ok) return Result.error(saved.error);
-        if (selection.sprintId === target.id) selection.setSprint(target.id, value.trim(), target.status);
-        reload();
-        return Result.ok(undefined);
-      },
-      successLabel: `${glyphs.check} renamed "${target.name}"`,
-    });
-  };
+  const handleBulkUnblock = (): Promise<void> => unblockAll(focusedSprint, setFeedback);
 
   useInput((input) => {
     if (ui.modalOpen || confirmDelete !== undefined) return;
@@ -179,58 +333,6 @@ export const SprintsView = (): React.JSX.Element => {
       void handleBulkUnblock();
     }
   });
-
-  const handleBulkUnblock = async (): Promise<void> => {
-    if (focusedSprint === undefined || stuckTasks.length === 0) return;
-    setFeedback(undefined);
-    let succeeded = 0;
-    let lastError: string | undefined;
-    for (const task of stuckTasks) {
-      const r = await unblockTaskUseCase({
-        task,
-        sprintId: focusedSprint.id,
-        taskRepo: deps.taskRepo,
-        sprintRepo: deps.sprintRepo,
-        clock: deps.clock,
-        logger: deps.logger,
-      });
-      if (r.ok) {
-        succeeded += 1;
-      } else {
-        lastError = r.error.message;
-      }
-    }
-    const total = stuckTasks.length;
-    if (!mountedRef.current) return;
-    if (succeeded === total) {
-      setFeedback(
-        `${glyphs.check} unblocked ${String(succeeded)} task${succeeded === 1 ? '' : 's'} in "${focusedSprint.name}"`
-      );
-    } else {
-      setFeedback(
-        `${succeeded > 0 ? glyphs.check : glyphs.cross} unblocked ${String(succeeded)} of ${String(total)}${lastError !== undefined ? ` — ${lastError}` : ''}`
-      );
-    }
-    // Refresh task list so the hint and count update immediately.
-    const refreshed = await deps.taskRepo.findBySprintId(focusedSprint.id);
-    if (mountedRef.current && refreshed.ok) setFocusedSprintTasks(refreshed.value);
-  };
-
-  const handleDeleteConfirmed = async (target: Sprint, confirmed: boolean): Promise<void> => {
-    setConfirmDelete(undefined);
-    if (!confirmed) return;
-    const r = await deps.sprintRepo.remove(target.id);
-    if (!r.ok) {
-      if (mountedRef.current) setFeedback(`${glyphs.cross} ${r.error.message}`);
-      return;
-    }
-    // Clearing the deleted sprint's selection targets the always-mounted SelectionProvider, so it
-    // runs unconditionally — the stale cursor must drop even if the operator navigated away mid-delete.
-    if (selection.sprintId === target.id) selection.setSprint(undefined);
-    if (!mountedRef.current) return;
-    setFeedback(`${glyphs.check} removed ${target.name}`);
-    reload();
-  };
 
   return (
     <ViewShell
@@ -276,49 +378,7 @@ export const SprintsView = (): React.JSX.Element => {
             <OverflowRow direction="above" count={window.start} />
             {visibleItems.map((s, localIdx) => {
               const focused = window.start + localIdx === focusedIndex;
-              const pending = s.tickets.filter((t) => t.status === 'pending').length;
-              const approved = s.tickets.filter((t) => t.status === 'approved').length;
-              return (
-                <Box key={s.id} flexDirection="column" marginBottom={1}>
-                  <Box
-                    flexDirection="column"
-                    borderStyle="round"
-                    borderColor={focused ? inkColors.primary : inkColors.rule}
-                    borderDimColor={!focused}
-                    paddingX={spacing.cardPadX}
-                  >
-                    <Box justifyContent="space-between">
-                      <Text bold {...(focused ? { color: inkColors.primary } : {})}>
-                        {s.name}
-                      </Text>
-                      <StatusChip label={s.status} kind={sprintStatusKind(s.status)} />
-                    </Box>
-                    <Text dimColor>{s.slug}</Text>
-                    <Text>
-                      <Text bold>{String(s.tickets.length)}</Text>
-                      <Text dimColor> tickets</Text>
-                      {pending > 0 && (
-                        <Text>
-                          <Text dimColor> {glyphs.bullet} </Text>
-                          <Text bold color={inkColors.warning}>
-                            {String(pending)}
-                          </Text>
-                          <Text dimColor> pending</Text>
-                        </Text>
-                      )}
-                      {approved > 0 && (
-                        <Text>
-                          <Text dimColor> {glyphs.bullet} </Text>
-                          <Text bold color={inkColors.success}>
-                            {String(approved)}
-                          </Text>
-                          <Text dimColor> approved</Text>
-                        </Text>
-                      )}
-                    </Text>
-                  </Box>
-                </Box>
-              );
+              return <SprintRow key={s.id} sprint={s} focused={focused} />;
             })}
             <OverflowRow direction="below" count={state.value.length - window.end} />
           </Box>

--- a/src/business/settings/apply-key.ts
+++ b/src/business/settings/apply-key.ts
@@ -96,163 +96,178 @@ const setAiImplementRoleField = (
   return Result.ok({ ...current, ai: nextAi });
 };
 
-export const applySettingsKey = (current: Settings, key: string, raw: string): Result<Settings, ValidationError> => {
-  // Per-flow AI keys: ai.<flow>.{provider,model,effort} — implement is split into roles and
-  // rejects the flat shape; every other flow accepts the 3-part path.
-  if (key.startsWith('ai.')) {
-    const parts = key.split('.');
-    if (parts.length === 3 && parts[0] === 'ai') {
-      const maybeFlow = parts[1] ?? '';
-      const maybeField = parts[2] ?? '';
-      if (
-        isFlowId(maybeFlow) &&
-        maybeFlow !== 'implement' &&
-        (maybeField === 'provider' || maybeField === 'model' || maybeField === 'effort')
-      ) {
-        return setAiFlowField(current, maybeFlow, maybeField, raw);
-      }
-      // Flat `ai.implement.<field>` is no longer addressable — the row split into
-      // generator / evaluator. Surface a focused error that names the correct keys.
-      if (
-        maybeFlow === 'implement' &&
-        (maybeField === 'provider' || maybeField === 'model' || maybeField === 'effort')
-      ) {
-        return Result.error(
-          new ValidationError({
-            field: key,
-            value: raw,
-            message: `'${key}' is no longer addressable — implement splits into generator and evaluator roles`,
-            hint: `use ai.implement.generator.${maybeField} or ai.implement.evaluator.${maybeField}`,
-          })
-        );
-      }
-    }
-    // Per-role implement keys: ai.implement.{generator,evaluator}.{provider,model,effort}
-    if (parts.length === 4 && parts[0] === 'ai' && parts[1] === 'implement') {
-      const maybeRole = parts[2] ?? '';
-      const maybeField = parts[3] ?? '';
-      if (
-        isImplementRole(maybeRole) &&
-        (maybeField === 'provider' || maybeField === 'model' || maybeField === 'effort')
-      ) {
-        return setAiImplementRoleField(current, maybeRole, maybeField, raw);
-      }
-    }
-    if (key === 'ai.effort') {
-      const trimmed = raw.trim();
-      if (trimmed.length === 0) {
-        const { effort: _drop, ...aiWithoutEffort } = current.ai;
-        void _drop;
-        return Result.ok({ ...current, ai: aiWithoutEffort as AiSettings });
-      }
-      return Result.ok({ ...current, ai: { ...current.ai, effort: trimmed } as AiSettings });
-    }
+const isAiFlowField = (raw: string): raw is 'provider' | 'model' | 'effort' =>
+  raw === 'provider' || raw === 'model' || raw === 'effort';
+
+/** `ai.<flow>.<field>` — every flow except `implement`, which splits into roles below. */
+const tryApplyAiFlowKey = (
+  current: Settings,
+  key: string,
+  raw: string
+): Result<Settings, ValidationError> | undefined => {
+  const parts = key.split('.');
+  if (parts.length !== 3 || parts[0] !== 'ai') return undefined;
+  const maybeFlow = parts[1] ?? '';
+  const maybeField = parts[2] ?? '';
+  if (isFlowId(maybeFlow) && maybeFlow !== 'implement' && isAiFlowField(maybeField)) {
+    return setAiFlowField(current, maybeFlow, maybeField, raw);
   }
-  // Per-entry escalation-map setter: `harness.escalationMap.<fromModel>` takes the upgraded
-  // model id; empty input clears the entry (mirrors per-flow effort clearing).
-  if (key.startsWith('harness.escalationMap.')) {
-    const fromModel = key.slice('harness.escalationMap.'.length);
-    if (fromModel.length === 0) {
-      return Result.error(
-        new ValidationError({
-          field: 'key',
-          value: key,
-          message: `'${key}' is missing the source model id`,
-          hint: 'use harness.escalationMap.<fromModel>',
-        })
-      );
-    }
-    const nextMap = { ...current.harness.escalationMap };
-    if (raw.trim().length === 0) {
-      delete nextMap[fromModel];
-    } else {
-      nextMap[fromModel] = raw;
-    }
-    return Result.ok({ ...current, harness: { ...current.harness, escalationMap: nextMap } });
+  return undefined;
+};
+
+/**
+ * Flat `ai.implement.<field>` is no longer addressable — the row split into generator /
+ * evaluator. Surface a focused error that names the correct keys.
+ */
+const tryRejectFlatImplementKey = (key: string, raw: string): Result<Settings, ValidationError> | undefined => {
+  const parts = key.split('.');
+  if (parts.length !== 3 || parts[0] !== 'ai') return undefined;
+  const maybeFlow = parts[1] ?? '';
+  const maybeField = parts[2] ?? '';
+  if (maybeFlow !== 'implement' || !isAiFlowField(maybeField)) return undefined;
+  return Result.error(
+    new ValidationError({
+      field: key,
+      value: raw,
+      message: `'${key}' is no longer addressable — implement splits into generator and evaluator roles`,
+      hint: `use ai.implement.generator.${maybeField} or ai.implement.evaluator.${maybeField}`,
+    })
+  );
+};
+
+/** Per-role implement keys: `ai.implement.{generator,evaluator}.{provider,model,effort}`. */
+const tryApplyAiImplementRoleKey = (
+  current: Settings,
+  key: string,
+  raw: string
+): Result<Settings, ValidationError> | undefined => {
+  const parts = key.split('.');
+  if (parts.length !== 4 || parts[0] !== 'ai' || parts[1] !== 'implement') return undefined;
+  const maybeRole = parts[2] ?? '';
+  const maybeField = parts[3] ?? '';
+  if (isImplementRole(maybeRole) && isAiFlowField(maybeField)) {
+    return setAiImplementRoleField(current, maybeRole, maybeField, raw);
   }
+  return undefined;
+};
+
+/** `ai.effort` — global fallback effort; empty input clears it. */
+const tryApplyAiEffortKey = (
+  current: Settings,
+  key: string,
+  raw: string
+): Result<Settings, ValidationError> | undefined => {
+  if (key !== 'ai.effort') return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    const { effort: _drop, ...aiWithoutEffort } = current.ai;
+    void _drop;
+    return Result.ok({ ...current, ai: aiWithoutEffort as AiSettings });
+  }
+  return Result.ok({ ...current, ai: { ...current.ai, effort: trimmed } as AiSettings });
+};
+
+/**
+ * Dispatch every `ai.*` key shape. Returns `undefined` when `key` starts with `ai.` but
+ * matches none of the known sub-grammars, so the caller falls through to the unknown-key error.
+ */
+const applyAiKey = (current: Settings, key: string, raw: string): Result<Settings, ValidationError> | undefined =>
+  tryApplyAiFlowKey(current, key, raw) ??
+  tryRejectFlatImplementKey(key, raw) ??
+  tryApplyAiImplementRoleKey(current, key, raw) ??
+  tryApplyAiEffortKey(current, key, raw);
+
+/**
+ * Per-entry escalation-map setter: `harness.escalationMap.<fromModel>` takes the upgraded
+ * model id; empty input clears the entry (mirrors per-flow effort clearing).
+ */
+const applyEscalationMapKey = (current: Settings, key: string, raw: string): Result<Settings, ValidationError> => {
+  const fromModel = key.slice('harness.escalationMap.'.length);
+  if (fromModel.length === 0) {
+    return Result.error(
+      new ValidationError({
+        field: 'key',
+        value: key,
+        message: `'${key}' is missing the source model id`,
+        hint: 'use harness.escalationMap.<fromModel>',
+      })
+    );
+  }
+  const nextMap = { ...current.harness.escalationMap };
+  if (raw.trim().length === 0) {
+    delete nextMap[fromModel];
+  } else {
+    nextMap[fromModel] = raw;
+  }
+  return Result.ok({ ...current, harness: { ...current.harness, escalationMap: nextMap } });
+};
+
+/** Shared shape for the four numeric `harness.*` keys — same parse-and-error, different field. */
+const applyNumberField = (
+  current: Settings,
+  key: string,
+  raw: string,
+  apply: (current: Settings, n: number) => Settings
+): Result<Settings, ValidationError> => {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    return Result.error(new ValidationError({ field: key, value: raw, message: `'${raw}' is not a number` }));
+  }
+  return Result.ok(apply(current, n));
+};
+
+/** Shared shape for the boolean settings keys — same parse-and-error, different field. */
+const applyBooleanField = (
+  current: Settings,
+  key: string,
+  raw: string,
+  apply: (current: Settings, b: boolean) => Settings
+): Result<Settings, ValidationError> => {
+  const b = parseBool(raw);
+  if (b === undefined) {
+    return Result.error(
+      new ValidationError({ field: key, value: raw, message: `'${raw}' is not a boolean`, hint: BOOLEAN_VALUE_HINT })
+    );
+  }
+  return Result.ok(apply(current, b));
+};
+
+/** Fixed, non-templated settings keys — everything outside the `ai.*` / escalation-map grammars. */
+const applyFixedSettingsKey = (current: Settings, key: string, raw: string): Result<Settings, ValidationError> => {
   switch (key) {
     case 'harness.maxTurns':
     case 'harness.maxAttempts':
     case 'harness.rateLimitRetries':
     case 'harness.idleWatchdogMs':
     case 'harness.plateauThreshold': {
-      const n = Number(raw);
-      if (!Number.isFinite(n)) {
-        return Result.error(new ValidationError({ field: key, value: raw, message: `'${raw}' is not a number` }));
-      }
       const which = key.split('.')[1] as
         'maxTurns' | 'maxAttempts' | 'rateLimitRetries' | 'idleWatchdogMs' | 'plateauThreshold';
-      return Result.ok({ ...current, harness: { ...current.harness, [which]: n } });
+      return applyNumberField(current, key, raw, (c, n) => ({ ...c, harness: { ...c.harness, [which]: n } }));
     }
-    case 'harness.escalateOnPlateau': {
-      const b = parseBool(raw);
-      if (b === undefined) {
-        return Result.error(
-          new ValidationError({
-            field: key,
-            value: raw,
-            message: `'${raw}' is not a boolean`,
-            hint: BOOLEAN_VALUE_HINT,
-          })
-        );
-      }
-      return Result.ok({ ...current, harness: { ...current.harness, escalateOnPlateau: b } });
-    }
-    case 'harness.skipPreVerifyOnFreshSetup': {
-      const b = parseBool(raw);
-      if (b === undefined) {
-        return Result.error(
-          new ValidationError({
-            field: key,
-            value: raw,
-            message: `'${raw}' is not a boolean`,
-            hint: BOOLEAN_VALUE_HINT,
-          })
-        );
-      }
-      return Result.ok({ ...current, harness: { ...current.harness, skipPreVerifyOnFreshSetup: b } });
-    }
-    case 'logging.level': {
+    case 'harness.escalateOnPlateau':
+      return applyBooleanField(current, key, raw, (c, b) => ({
+        ...c,
+        harness: { ...c.harness, escalateOnPlateau: b },
+      }));
+    case 'harness.skipPreVerifyOnFreshSetup':
+      return applyBooleanField(current, key, raw, (c, b) => ({
+        ...c,
+        harness: { ...c.harness, skipPreVerifyOnFreshSetup: b },
+      }));
+    case 'logging.level':
       return Result.ok({ ...current, logging: { level: raw as Settings['logging']['level'] } });
-    }
-    case 'concurrency.maxParallelTasks': {
-      const n = Number(raw);
-      if (!Number.isFinite(n)) {
-        return Result.error(new ValidationError({ field: key, value: raw, message: `'${raw}' is not a number` }));
-      }
-      return Result.ok({ ...current, concurrency: { maxParallelTasks: n } });
-    }
-    case 'scm.postRefinementComment': {
-      const b = parseBool(raw);
-      if (b === undefined) {
-        return Result.error(
-          new ValidationError({
-            field: key,
-            value: raw,
-            message: `'${raw}' is not a boolean`,
-            hint: BOOLEAN_VALUE_HINT,
-          })
-        );
-      }
-      return Result.ok({ ...current, scm: { ...current.scm, postRefinementComment: b } });
-    }
-    case 'ui.notifications.enabled': {
-      const b = parseBool(raw);
-      if (b === undefined) {
-        return Result.error(
-          new ValidationError({
-            field: key,
-            value: raw,
-            message: `'${raw}' is not a boolean`,
-            hint: BOOLEAN_VALUE_HINT,
-          })
-        );
-      }
-      return Result.ok({
-        ...current,
-        ui: { ...current.ui, notifications: { ...current.ui.notifications, enabled: b } },
-      });
-    }
+    case 'concurrency.maxParallelTasks':
+      return applyNumberField(current, key, raw, (c, n) => ({ ...c, concurrency: { maxParallelTasks: n } }));
+    case 'scm.postRefinementComment':
+      return applyBooleanField(current, key, raw, (c, b) => ({
+        ...c,
+        scm: { ...c.scm, postRefinementComment: b },
+      }));
+    case 'ui.notifications.enabled':
+      return applyBooleanField(current, key, raw, (c, b) => ({
+        ...c,
+        ui: { ...c.ui, notifications: { ...c.ui.notifications, enabled: b } },
+      }));
     default:
       return Result.error(
         new ValidationError({
@@ -263,6 +278,16 @@ export const applySettingsKey = (current: Settings, key: string, raw: string): R
         })
       );
   }
+};
+
+export const applySettingsKey = (current: Settings, key: string, raw: string): Result<Settings, ValidationError> => {
+  if (key.startsWith('ai.')) {
+    const applied = applyAiKey(current, key, raw);
+    if (applied !== undefined) return applied;
+  } else if (key.startsWith('harness.escalationMap.')) {
+    return applyEscalationMapKey(current, key, raw);
+  }
+  return applyFixedSettingsKey(current, key, raw);
 };
 
 /**

--- a/src/business/sprint/views/context-md.ts
+++ b/src/business/sprint/views/context-md.ts
@@ -1,6 +1,7 @@
 import type { Project } from '@src/domain/entity/project.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { Task } from '@src/domain/entity/task.ts';
+import type { Ticket } from '@src/domain/entity/ticket.ts';
 
 export interface RenderSprintContextInput {
   readonly sprint: Sprint;
@@ -21,14 +22,29 @@ export const renderSprintContextMarkdown = (input: RenderSprintContextInput): st
   const { sprint, project, tasks } = input;
   const lines: string[] = [];
 
-  lines.push(`# Harness Context — ${sprint.name}`);
-  lines.push('');
-  lines.push(`- Sprint id: \`${String(sprint.id)}\``);
-  lines.push(`- Slug: \`${String(sprint.slug)}\``);
-  lines.push(`- Status: ${sprint.status}`);
-  lines.push(`- Tickets: ${String(sprint.tickets.length)}`);
-  lines.push(`- Tasks: ${String(tasks.length)}`);
-  lines.push('');
+  lines.push(...renderHeaderLines(sprint, tasks));
+  lines.push(...renderProjectLines(project));
+  lines.push(...renderTicketsLines(sprint.tickets));
+  lines.push(...renderTasksLines(tasks));
+
+  return lines.join('\n');
+};
+
+const renderHeaderLines = (sprint: Sprint, tasks: readonly Task[]): string[] => {
+  return [
+    `# Harness Context — ${sprint.name}`,
+    '',
+    `- Sprint id: \`${String(sprint.id)}\``,
+    `- Slug: \`${String(sprint.slug)}\``,
+    `- Status: ${sprint.status}`,
+    `- Tickets: ${String(sprint.tickets.length)}`,
+    `- Tasks: ${String(tasks.length)}`,
+    '',
+  ];
+};
+
+const renderProjectLines = (project: Project): string[] => {
+  const lines: string[] = [];
 
   lines.push('## Project');
   lines.push('');
@@ -49,13 +65,19 @@ export const renderSprintContextMarkdown = (input: RenderSprintContextInput): st
   }
   lines.push('');
 
+  return lines;
+};
+
+const renderTicketsLines = (tickets: readonly Ticket[]): string[] => {
+  const lines: string[] = [];
+
   lines.push('## Tickets');
   lines.push('');
-  if (sprint.tickets.length === 0) {
+  if (tickets.length === 0) {
     lines.push('_(no tickets)_');
     lines.push('');
   } else {
-    for (const ticket of sprint.tickets) {
+    for (const ticket of tickets) {
       lines.push(`### ${ticket.title}`);
       lines.push('');
       lines.push(`- ID: \`${String(ticket.id)}\``);
@@ -75,46 +97,60 @@ export const renderSprintContextMarkdown = (input: RenderSprintContextInput): st
     }
   }
 
+  return lines;
+};
+
+const renderTaskLines = (task: Task): string[] => {
+  const lines: string[] = [];
+
+  lines.push(`### ${String(task.order)}. ${task.name}`);
+  lines.push('');
+  lines.push(`- ID: \`${String(task.id)}\``);
+  lines.push(`- Status: ${task.status}`);
+  lines.push(`- Ticket: \`${String(task.ticketId)}\``);
+  if (task.dependsOn.length > 0) {
+    lines.push(`- Depends on: ${task.dependsOn.map((id) => `\`${String(id)}\``).join(', ')}`);
+  }
+  if (task.description !== undefined) {
+    lines.push('');
+    lines.push(task.description);
+  }
+  if (task.steps.length > 0) {
+    lines.push('');
+    lines.push('**Steps:**');
+    for (const step of task.steps) lines.push(`- ${step}`);
+  }
+  if (task.verificationCriteria.length > 0) {
+    lines.push('');
+    lines.push('**Verification:**');
+    for (const vc of task.verificationCriteria) {
+      if (vc.check === 'auto' && vc.command !== undefined) {
+        lines.push(`- [${vc.id}] auto \`${vc.command}\` — ${vc.assertion}`);
+      } else {
+        lines.push(`- [${vc.id}] manual — ${vc.assertion}`);
+      }
+    }
+  }
+  lines.push('');
+
+  return lines;
+};
+
+const renderTasksLines = (tasks: readonly Task[]): string[] => {
+  const lines: string[] = [];
+
   lines.push('## Tasks');
   lines.push('');
   if (tasks.length === 0) {
     lines.push('_(no tasks generated yet — run `ralphctl sprint plan`)_');
     lines.push('');
-    return lines.join('\n');
+    return lines;
   }
 
   const sortedTasks = [...tasks].sort((a, b) => a.order - b.order);
   for (const task of sortedTasks) {
-    lines.push(`### ${String(task.order)}. ${task.name}`);
-    lines.push('');
-    lines.push(`- ID: \`${String(task.id)}\``);
-    lines.push(`- Status: ${task.status}`);
-    lines.push(`- Ticket: \`${String(task.ticketId)}\``);
-    if (task.dependsOn.length > 0) {
-      lines.push(`- Depends on: ${task.dependsOn.map((id) => `\`${String(id)}\``).join(', ')}`);
-    }
-    if (task.description !== undefined) {
-      lines.push('');
-      lines.push(task.description);
-    }
-    if (task.steps.length > 0) {
-      lines.push('');
-      lines.push('**Steps:**');
-      for (const step of task.steps) lines.push(`- ${step}`);
-    }
-    if (task.verificationCriteria.length > 0) {
-      lines.push('');
-      lines.push('**Verification:**');
-      for (const vc of task.verificationCriteria) {
-        if (vc.check === 'auto' && vc.command !== undefined) {
-          lines.push(`- [${vc.id}] auto \`${vc.command}\` — ${vc.assertion}`);
-        } else {
-          lines.push(`- [${vc.id}] manual — ${vc.assertion}`);
-        }
-      }
-    }
-    lines.push('');
+    lines.push(...renderTaskLines(task));
   }
 
-  return lines.join('\n');
+  return lines;
 };

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -214,6 +214,25 @@ const resolveMalformedRemedy = (
   return { task: props.task, shouldFailAttempt };
 };
 
+/**
+ * A process crash (watchdog kill / spawn crash) is not a quality plateau — retry regardless of
+ * `escalateOnPlateau`, and WITHOUT stamping the escalation model fields (no ladder rung).
+ * `failCurrentAttempt` transitions the task to `blocked` on its own once attempts hit the cap — but
+ * ONLY when `task.maxAttempts` is set. Legacy tasks (`maxAttempts` undefined) have no cap enforced
+ * downstream, so a persistent crash would retry forever across launches; once such a task's recorded
+ * attempts reach the configured fallback budget (`cfg.maxAttempts`), block here directly instead.
+ */
+const resolveCrashedRemedy = (props: FinalizeGenEvalProps, cfg: { readonly maxAttempts: number }): Remedy => {
+  const legacyBudgetExhausted = props.task.maxAttempts === undefined && props.task.attempts.length >= cfg.maxAttempts;
+  return legacyBudgetExhausted
+    ? {
+        task: props.task,
+        shouldFailAttempt: false,
+        blockedReason: 'AI process repeatedly crashed; attempt budget exhausted',
+      }
+    : { task: props.task, shouldFailAttempt: true };
+};
+
 export const finalizeGenEvalUseCase = async (
   props: FinalizeGenEvalProps
 ): Promise<Result<FinalizeGenEvalOutput, InvalidStateError | NotFoundError | StorageError | ValidationError>> => {
@@ -249,12 +268,7 @@ export const finalizeGenEvalUseCase = async (
   } else if (exit.kind === 'malformed') {
     remedy = resolveMalformedRemedy(props, cfg, log);
   } else if (exit.kind === 'crashed') {
-    // A process crash (watchdog kill / spawn crash) is not a quality plateau — retry
-    // UNCONDITIONALLY, regardless of `escalateOnPlateau`, and WITHOUT stamping the escalation
-    // model fields (no ladder rung). `failCurrentAttempt` transitions the task to `blocked` on its
-    // own once attempts hit the cap, so `shouldFailAttempt: true` is correct even on the final
-    // attempt — the retry budget itself decides when to stop.
-    remedy = { task: props.task, shouldFailAttempt: true };
+    remedy = resolveCrashedRemedy(props, cfg);
   }
 
   const taskForPersist: InProgressTask = remedy.task;

--- a/src/business/task/run-evaluator-turn.ts
+++ b/src/business/task/run-evaluator-turn.ts
@@ -8,7 +8,11 @@ import {
 } from '@src/domain/entity/task-attempts.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
-import { computePlateauVerdict, type PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
+import {
+  computePlateauVerdict,
+  type PlateauTurnRecord,
+  type PlateauVerdict,
+} from '@src/business/task/plateau-detection.ts';
 import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts';
 
 /**
@@ -135,32 +139,141 @@ const resolveCritique = (evaluation: EvaluationSignal): string | undefined => {
   return synthesized.length > 0 ? synthesized : undefined;
 };
 
-export const runEvaluatorTurnUseCase = async (
-  props: RunEvaluatorTurnProps
-): Promise<Result<RunEvaluatorTurnOutput, DomainError>> => {
+type TurnResult = Result<RunEvaluatorTurnOutput, DomainError>;
+
+/**
+ * Handle a `callEvaluate` failure. Fatal errors (user abort, rate-limit-after-retries) must
+ * abort the whole run — propagate. Everything else is a recoverable signals-contract failure:
+ * self-block THIS task so it settles as `blocked` (the generator's work is NOT committed/
+ * marked-done ungraded — commit is gated on no block reason). Routing to `malformed` instead
+ * would mark the change done.
+ */
+const handleEvaluateFailure = (err: DomainError, task: InProgressTask, log: Logger): TurnResult => {
+  if (!isRecoverableTurnError(err)) {
+    log.error('evaluate call failed (fatal — propagating)', { taskId: task.id, error: err.message });
+    return Result.error(err);
+  }
+  log.warn('evaluator did not produce a valid signals.json — blocking task', {
+    taskId: task.id,
+    error: err.message,
+  });
+  return Result.ok({
+    task,
+    exit: { kind: 'self-blocked', reason: `evaluator did not produce a valid signals.json: ${err.message}` },
+  });
+};
+
+/** `passed`/`malformed` are terminal exits recorded as-is; `undefined` means the loop continues. */
+const handleTerminalStatus = (
+  evaluation: EvaluationSignal,
+  task: InProgressTask,
+  log: Logger
+): TurnResult | undefined => {
+  if (evaluation.status === 'passed') {
+    log.info('evaluator passed the attempt', { taskId: task.id });
+    return Result.ok({ task, evaluation, exit: { kind: 'passed' } });
+  }
+
+  if (evaluation.status === 'malformed') {
+    log.warn('evaluator emitted dimension scores but no terminal verdict', { taskId: task.id });
+    return Result.ok({
+      task,
+      evaluation,
+      exit: { kind: 'malformed', detail: 'evaluator emitted dimension scores but no terminal verdict' },
+    });
+  }
+
+  return undefined;
+};
+
+/**
+ * Build the current turn's plateau record from what we know NOW — the just-recorded
+ * evaluation, the critique we're about to feed forward, and the generator's proposed
+ * commit subject for this round.
+ */
+const buildTurnRecord = (
+  evaluation: EvaluationSignal,
+  critique: string | undefined,
+  props: Pick<RunEvaluatorTurnProps, 'currentCommitSubject' | 'changedFilesHash'>
+): PlateauTurnRecord => ({
+  evaluation,
+  ...(critique !== undefined && critique.trim().length > 0 ? { critique } : {}),
+  ...(props.currentCommitSubject !== undefined && props.currentCommitSubject.trim().length > 0
+    ? { commitSubject: props.currentCommitSubject }
+    : {}),
+  ...(props.changedFilesHash !== undefined && props.changedFilesHash.length > 0
+    ? { changedFilesHash: props.changedFilesHash }
+    : {}),
+});
+
+/**
+ * `failed`, fresh dimensions or exemption applies → continue: record the critique on the
+ * running attempt so the next generator turn's prompt incorporates it. `announce` gates the
+ * trailing debug logs — the warning-softened caller (which already logged an `info` for the
+ * softening) passes `false` to avoid double narration; the plain-continue path passes `true`.
+ */
+const finishContinuing = (
+  task: InProgressTask,
+  evaluation: EvaluationSignal,
+  critique: string | undefined,
+  turnRecord: PlateauTurnRecord,
+  log: Logger,
+  announce: boolean
+): TurnResult => {
+  if (critique !== undefined && critique.trim().length > 0) {
+    const recordedCritique = recordRunningAttemptCritique(task, critique);
+    if (!recordedCritique.ok) {
+      log.error('cannot record critique on attempt', {
+        taskId: task.id,
+        error: recordedCritique.error.message,
+      });
+      return Result.error(recordedCritique.error);
+    }
+    if (announce) {
+      log.debug('evaluator failed; recorded critique for next turn', { taskId: recordedCritique.value.id });
+    }
+    return Result.ok({ task: recordedCritique.value, evaluation, turnRecord });
+  }
+
+  if (announce) {
+    log.debug('evaluator failed without critique; continuing', { taskId: task.id });
+  }
+  return Result.ok({ task, evaluation, turnRecord });
+};
+
+/**
+ * Net stall, but the work-product fingerprint changed (real code edits) — record a `plateau`
+ * warning so the attempt audit reflects the soft signal, then keep looping. Capped at
+ * WARNING_SOFTEN_CAP consecutive softenings inside the predicate.
+ */
+const handleWarningVerdict = (
+  verdict: Extract<PlateauVerdict, { kind: 'warning' }>,
+  task: InProgressTask,
+  critique: string | undefined,
+  turnRecord: PlateauTurnRecord,
+  evaluation: EvaluationSignal,
+  log: Logger
+): TurnResult => {
+  const warned = recordRunningAttemptWarning(task, { kind: 'plateau', dimensions: verdict.dimensions });
+  if (!warned.ok) {
+    log.error('cannot record plateau warning on attempt', { taskId: task.id, error: warned.error.message });
+    return Result.error(warned.error);
+  }
+  log.info('plateau softened to warning — work product changed; continuing', {
+    taskId: warned.value.id,
+    dimensions: verdict.dimensions,
+    reason: verdict.reason,
+  });
+  // Continue: also record the critique so the next generator turn picks it up.
+  return finishContinuing(warned.value, evaluation, critique, turnRecord, log, false);
+};
+
+export const runEvaluatorTurnUseCase = async (props: RunEvaluatorTurnProps): Promise<TurnResult> => {
   const log = props.logger.named('task.evaluator-turn');
   log.debug('running evaluator turn', { taskId: props.task.id });
 
   const signalsResult = await props.callEvaluate(props.task);
-  if (!signalsResult.ok) {
-    const err = signalsResult.error;
-    // Fatal errors (user abort, rate-limit-after-retries) must abort the whole run — propagate.
-    // Everything else is a recoverable signals-contract failure: self-block THIS task so it
-    // settles as `blocked` (the generator's work is NOT committed/marked-done ungraded — commit
-    // is gated on no block reason). Routing to `malformed` instead would mark the change done.
-    if (!isRecoverableTurnError(err)) {
-      log.error('evaluate call failed (fatal — propagating)', { taskId: props.task.id, error: err.message });
-      return Result.error(err);
-    }
-    log.warn('evaluator did not produce a valid signals.json — blocking task', {
-      taskId: props.task.id,
-      error: err.message,
-    });
-    return Result.ok({
-      task: props.task,
-      exit: { kind: 'self-blocked', reason: `evaluator did not produce a valid signals.json: ${err.message}` },
-    });
-  }
+  if (!signalsResult.ok) return handleEvaluateFailure(signalsResult.error, props.task, log);
   const signals = signalsResult.value;
 
   const evaluation = findEvaluation(signals);
@@ -183,37 +296,15 @@ export const runEvaluatorTurnUseCase = async (
     return Result.error(recorded.error);
   }
 
-  if (evaluation.status === 'passed') {
-    log.info('evaluator passed the attempt', { taskId: recorded.value.id });
-    return Result.ok({ task: recorded.value, evaluation, exit: { kind: 'passed' } });
-  }
+  const terminal = handleTerminalStatus(evaluation, recorded.value, log);
+  if (terminal !== undefined) return terminal;
 
-  if (evaluation.status === 'malformed') {
-    log.warn('evaluator emitted dimension scores but no terminal verdict', { taskId: recorded.value.id });
-    return Result.ok({
-      task: recorded.value,
-      evaluation,
-      exit: { kind: 'malformed', detail: 'evaluator emitted dimension scores but no terminal verdict' },
-    });
-  }
-
-  // Build the current turn's plateau record from what we know NOW — the just-recorded
-  // evaluation, the critique we're about to feed forward, and the generator's proposed
-  // commit subject for this round. When the reviewer left `critique` empty on a FAIL we
-  // synthesize one from the per-dimension findings so the wire to the next generator turn
-  // never goes silent (and so the plateau predicate's critique-shift exemption has real text
-  // to compare instead of always falling through on a missing critique).
+  // When the reviewer left `critique` empty on a FAIL we synthesize one from the per-dimension
+  // findings so the wire to the next generator turn never goes silent (and so the plateau
+  // predicate's critique-shift exemption has real text to compare instead of always falling
+  // through on a missing critique).
   const critique = resolveCritique(evaluation);
-  const baseRecord: PlateauTurnRecord = {
-    evaluation,
-    ...(critique !== undefined && critique.trim().length > 0 ? { critique } : {}),
-    ...(props.currentCommitSubject !== undefined && props.currentCommitSubject.trim().length > 0
-      ? { commitSubject: props.currentCommitSubject }
-      : {}),
-    ...(props.changedFilesHash !== undefined && props.changedFilesHash.length > 0
-      ? { changedFilesHash: props.changedFilesHash }
-      : {}),
-  };
+  const baseRecord = buildTurnRecord(evaluation, critique, props);
 
   const verdict = computePlateauVerdict(props.priorTurns ?? [], baseRecord, {
     threshold: props.plateauThreshold,
@@ -238,38 +329,7 @@ export const runEvaluatorTurnUseCase = async (
   }
 
   if (verdict.kind === 'warning') {
-    // Net stall, but the work-product fingerprint changed (real code edits) — record a `plateau`
-    // warning so the attempt audit reflects the soft signal, then keep looping. Capped at
-    // WARNING_SOFTEN_CAP consecutive softenings inside the predicate.
-    const warned = recordRunningAttemptWarning(recorded.value, {
-      kind: 'plateau',
-      dimensions: verdict.dimensions,
-    });
-    if (!warned.ok) {
-      log.error('cannot record plateau warning on attempt', {
-        taskId: recorded.value.id,
-        error: warned.error.message,
-      });
-      return Result.error(warned.error);
-    }
-    log.info('plateau softened to warning — work product changed; continuing', {
-      taskId: warned.value.id,
-      dimensions: verdict.dimensions,
-      reason: verdict.reason,
-    });
-    // Continue: also record the critique so the next generator turn picks it up.
-    if (critique !== undefined && critique.trim().length > 0) {
-      const recordedCritique = recordRunningAttemptCritique(warned.value, critique);
-      if (!recordedCritique.ok) {
-        log.error('cannot record critique on attempt', {
-          taskId: warned.value.id,
-          error: recordedCritique.error.message,
-        });
-        return Result.error(recordedCritique.error);
-      }
-      return Result.ok({ task: recordedCritique.value, evaluation, turnRecord: currentRecord });
-    }
-    return Result.ok({ task: warned.value, evaluation, turnRecord: currentRecord });
+    return handleWarningVerdict(verdict, recorded.value, critique, currentRecord, evaluation, log);
   }
 
   if (verdict.kind === 'progress') {
@@ -279,19 +339,5 @@ export const runEvaluatorTurnUseCase = async (
     });
   }
 
-  if (critique !== undefined && critique.trim().length > 0) {
-    const recordedCritique = recordRunningAttemptCritique(recorded.value, critique);
-    if (!recordedCritique.ok) {
-      log.error('cannot record critique on attempt', {
-        taskId: recorded.value.id,
-        error: recordedCritique.error.message,
-      });
-      return Result.error(recordedCritique.error);
-    }
-    log.debug('evaluator failed; recorded critique for next turn', { taskId: recordedCritique.value.id });
-    return Result.ok({ task: recordedCritique.value, evaluation, turnRecord: currentRecord });
-  }
-
-  log.debug('evaluator failed without critique; continuing', { taskId: recorded.value.id });
-  return Result.ok({ task: recorded.value, evaluation, turnRecord: currentRecord });
+  return finishContinuing(recorded.value, evaluation, critique, currentRecord, log, true);
 };

--- a/src/domain/entity/project.ts
+++ b/src/domain/entity/project.ts
@@ -259,36 +259,11 @@ export const updateRepository = (
   if (partial.path !== undefined) {
     updated = setRepositoryPath(updated, partial.path);
   }
-  if ('verifyScript' in partial) {
-    const r = setRepositoryVerifyScript(updated, partial.verifyScript);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
-  if ('verifyGates' in partial) {
-    const r = setRepositoryVerifyGates(updated, partial.verifyGates);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
-  if ('verifyTimeout' in partial) {
-    const r = setRepositoryVerifyTimeout(updated, partial.verifyTimeout);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
-  if ('setupScript' in partial) {
-    const r = setRepositorySetupScript(updated, partial.setupScript);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
-  if ('setupSkill' in partial) {
-    const r = setRepositorySetupSkill(updated, partial.setupSkill);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
-  if ('verifySkill' in partial) {
-    const r = setRepositoryVerifySkill(updated, partial.verifySkill);
-    if (!r.ok) return Result.error(r.error);
-    updated = r.value;
-  }
+
+  const validated = applyValidatedRepositoryFields(updated, partial);
+  if (!validated.ok) return Result.error(validated.error);
+  updated = validated.value;
+
   if ('suggestedSkills' in partial) {
     updated = setRepositorySuggestedSkills(updated, partial.suggestedSkills);
   }
@@ -296,6 +271,58 @@ export const updateRepository = (
   const next = [...project.repositories];
   next[idx] = updated;
   return Result.ok({ ...project, repositories: next });
+};
+
+/** The subset of {@link RepositoryUpdate} keys handled uniformly by {@link applyValidatedRepositoryFields}. */
+type ValidatedRepositoryField =
+  'verifyScript' | 'verifyGates' | 'verifyTimeout' | 'setupScript' | 'setupSkill' | 'verifySkill';
+
+/**
+ * Builds one `(repo, partial) => Result<Repository, ValidationError>` step for a single
+ * validated field. `key`/`setter` are correlated at the call site (this generic invocation),
+ * so the returned closure is safe to store alongside the other fields' closures in a plain,
+ * uniformly-typed array — see {@link VALIDATED_FIELD_STEPS}.
+ */
+const validatedFieldStep = <K extends ValidatedRepositoryField>(
+  key: K,
+  setter: (repo: Repository, value: RepositoryUpdate[K]) => Result<Repository, ValidationError>
+): ((repo: Repository, partial: RepositoryUpdate) => Result<Repository, ValidationError>) => {
+  return (repo, partial) => {
+    if (!(key in partial)) return Result.ok(repo);
+    return setter(repo, partial[key]);
+  };
+};
+
+/**
+ * The six `RepositoryUpdate` fields that share the exact same "guarded validating setter"
+ * shape (`'field' in partial` → call a `(repo, value) => Result<Repository, ValidationError>`
+ * setter → thread the error or the updated repo). Order matters — it is applied in declaration
+ * order by {@link applyValidatedRepositoryFields}, matching the field order `updateRepository`
+ * has always used.
+ */
+const VALIDATED_FIELD_STEPS: ReadonlyArray<
+  (repo: Repository, partial: RepositoryUpdate) => Result<Repository, ValidationError>
+> = [
+  validatedFieldStep('verifyScript', setRepositoryVerifyScript),
+  validatedFieldStep('verifyGates', setRepositoryVerifyGates),
+  validatedFieldStep('verifyTimeout', setRepositoryVerifyTimeout),
+  validatedFieldStep('setupScript', setRepositorySetupScript),
+  validatedFieldStep('setupSkill', setRepositorySetupSkill),
+  validatedFieldStep('verifySkill', setRepositoryVerifySkill),
+];
+
+/** Applies every {@link ValidatedRepositoryField} present on `partial`, in order, short-circuiting on error. */
+const applyValidatedRepositoryFields = (
+  repo: Repository,
+  partial: RepositoryUpdate
+): Result<Repository, ValidationError> => {
+  let updated = repo;
+  for (const step of VALIDATED_FIELD_STEPS) {
+    const r = step(updated, partial);
+    if (!r.ok) return Result.error(r.error);
+    updated = r.value;
+  }
+  return Result.ok(updated);
 };
 
 const resolveSlug = (

--- a/src/domain/entity/repository.ts
+++ b/src/domain/entity/repository.ts
@@ -100,27 +100,23 @@ export const createRepository = (input: RepositoryCreateInput): Result<Repositor
   const slugResult = resolveSlug(input.slug, nameResult.value);
   if (!slugResult.ok) return Result.error(slugResult.error);
 
-  const verifyScript = parseOptionalString('repository.verifyScript', input.verifyScript);
-  if (!verifyScript.ok) return Result.error(verifyScript.error);
-
-  const setupScript = parseOptionalString('repository.setupScript', input.setupScript);
-  if (!setupScript.ok) return Result.error(setupScript.error);
-
-  const setupSkill = parseOptionalString('repository.setupSkill', input.setupSkill);
-  if (!setupSkill.ok) return Result.error(setupSkill.error);
-
-  const verifySkill = parseOptionalString('repository.verifySkill', input.verifySkill);
-  if (!verifySkill.ok) return Result.error(verifySkill.error);
+  const scriptFieldsResult = resolveOptionalScriptFields(input);
+  if (!scriptFieldsResult.ok) return Result.error(scriptFieldsResult.error);
 
   const verifyGates = verifyGatesPart(input.verifyGates);
   if (!verifyGates.ok) return Result.error(verifyGates.error);
 
-  let verifyTimeout: number | undefined;
-  if (input.verifyTimeout !== undefined) {
-    const parsed = parsePositiveInt('repository.verifyTimeout', input.verifyTimeout);
-    if (!parsed.ok) return Result.error(parsed.error);
-    verifyTimeout = parsed.value;
-  }
+  const verifyTimeoutResult = resolveVerifyTimeout(input.verifyTimeout);
+  if (!verifyTimeoutResult.ok) return Result.error(verifyTimeoutResult.error);
+
+  const optionalFields = optionalFieldsPart({
+    verifyScript: scriptFieldsResult.value.verifyScript,
+    setupScript: scriptFieldsResult.value.setupScript,
+    setupSkill: scriptFieldsResult.value.setupSkill,
+    verifySkill: scriptFieldsResult.value.verifySkill,
+    verifyGates: verifyGates.value.verifyGates,
+    verifyTimeout: verifyTimeoutResult.value,
+  });
 
   return Result.ok({
     id: input.id ?? RepositoryId.generate(),
@@ -128,12 +124,7 @@ export const createRepository = (input: RepositoryCreateInput): Result<Repositor
     name: nameResult.value,
     path: input.path,
     ...suggestedSkillsPart(input.suggestedSkills),
-    ...(verifyScript.value !== undefined ? { verifyScript: verifyScript.value } : {}),
-    ...(verifyGates.value.verifyGates !== undefined ? { verifyGates: verifyGates.value.verifyGates } : {}),
-    ...(verifyTimeout !== undefined ? { verifyTimeout } : {}),
-    ...(setupScript.value !== undefined ? { setupScript: setupScript.value } : {}),
-    ...(setupSkill.value !== undefined ? { setupSkill: setupSkill.value } : {}),
-    ...(verifySkill.value !== undefined ? { verifySkill: verifySkill.value } : {}),
+    ...optionalFields,
   });
 };
 
@@ -264,6 +255,73 @@ export const setRepositorySuggestedSkills = (repo: Repository, names: readonly s
 };
 
 /**
+ * Parse the four optional string fields (verifyScript, setupScript, setupSkill, verifySkill)
+ * from the input, validating each in sequence. Returns a Result containing all four parsed
+ * values (which may be undefined). Short-circuits on the first parse error.
+ */
+const resolveOptionalScriptFields = (
+  input: RepositoryCreateInput
+): Result<
+  {
+    readonly verifyScript: string | undefined;
+    readonly setupScript: string | undefined;
+    readonly setupSkill: string | undefined;
+    readonly verifySkill: string | undefined;
+  },
+  ValidationError
+> => {
+  const verifyScript = parseOptionalString('repository.verifyScript', input.verifyScript);
+  if (!verifyScript.ok) return Result.error(verifyScript.error);
+
+  const setupScript = parseOptionalString('repository.setupScript', input.setupScript);
+  if (!setupScript.ok) return Result.error(setupScript.error);
+
+  const setupSkill = parseOptionalString('repository.setupSkill', input.setupSkill);
+  if (!setupSkill.ok) return Result.error(setupSkill.error);
+
+  const verifySkill = parseOptionalString('repository.verifySkill', input.verifySkill);
+  if (!verifySkill.ok) return Result.error(verifySkill.error);
+
+  return Result.ok({
+    verifyScript: verifyScript.value,
+    setupScript: setupScript.value,
+    setupSkill: setupSkill.value,
+    verifySkill: verifySkill.value,
+  });
+};
+
+/**
+ * Parse an optional verifyTimeout. When the input is undefined, returns Ok(undefined).
+ * Otherwise validates that it is a positive integer.
+ */
+const resolveVerifyTimeout = (timeout: number | undefined): Result<number | undefined, ValidationError> => {
+  if (timeout === undefined) return Result.ok(undefined);
+  const parsed = parsePositiveInt('repository.verifyTimeout', timeout);
+  if (!parsed.ok) return Result.error(parsed.error);
+  return Result.ok(parsed.value);
+};
+
+/**
+ * Construct the partial object containing all optional Repository fields from their parsed
+ * values. Returns an object ready to spread into the final Repository.
+ */
+const optionalFieldsPart = (fields: {
+  readonly verifyScript: string | undefined;
+  readonly setupScript: string | undefined;
+  readonly setupSkill: string | undefined;
+  readonly verifySkill: string | undefined;
+  readonly verifyGates: readonly VerifyGate[] | undefined;
+  readonly verifyTimeout: number | undefined;
+}): Partial<Repository> => ({
+  ...(fields.verifyScript !== undefined ? { verifyScript: fields.verifyScript } : {}),
+  ...(fields.verifyGates !== undefined ? { verifyGates: fields.verifyGates } : {}),
+  ...(fields.verifyTimeout !== undefined ? { verifyTimeout: fields.verifyTimeout } : {}),
+  ...(fields.setupScript !== undefined ? { setupScript: fields.setupScript } : {}),
+  ...(fields.setupSkill !== undefined ? { setupSkill: fields.setupSkill } : {}),
+  ...(fields.verifySkill !== undefined ? { verifySkill: fields.verifySkill } : {}),
+});
+
+/**
  * Trim each suggested skill name, drop blanks, de-duplicate. Returns `{ suggestedSkills }` only
  * when at least one name survives so the factory omits the field entirely otherwise (a clean
  * repo round-trips without an empty array on disk).
@@ -277,13 +335,35 @@ const suggestedSkillsPart = (
 };
 
 /**
- * Normalise a `verifyGates` input. Trims each gate's `command`, drops gates whose command is
- * blank, trims the `pathPrefix` is NOT done — a prefix is matched verbatim against POSIX paths,
- * so leading/trailing whitespace in a prefix would be a deliberate (if unusual) author choice;
- * we only validate the load-bearing `command` and the optional `timeoutMs`. Returns
- * `{ verifyGates }` only when at least one gate survives so the factory omits the field entirely
- * otherwise (a repo with no gates round-trips without an empty array on disk). A surviving gate
- * with a non-positive `timeoutMs` fails the whole parse.
+ * Normalise a single verify gate: trim the command, validate the optional timeoutMs.
+ * Returns undefined when the command is blank (the gate is skipped). Returns an error
+ * if the gate has a non-positive timeoutMs. The pathPrefix is NOT trimmed — prefixes
+ * are matched verbatim against POSIX paths, so whitespace is significant.
+ */
+const normalizeVerifyGate = (gate: VerifyGate): Result<VerifyGate | undefined, ValidationError> => {
+  const command = typeof gate.command === 'string' ? gate.command.trim() : '';
+  if (command.length === 0) return Result.ok(undefined);
+
+  let timeoutMs: number | undefined;
+  if (gate.timeoutMs !== undefined) {
+    const parsed = parsePositiveInt('repository.verifyGates[].timeoutMs', gate.timeoutMs);
+    if (!parsed.ok) return Result.error(parsed.error);
+    timeoutMs = parsed.value;
+  }
+
+  return Result.ok({
+    pathPrefix: typeof gate.pathPrefix === 'string' ? gate.pathPrefix : '',
+    command,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  });
+};
+
+/**
+ * Normalise a `verifyGates` input. Validates each gate via {@link normalizeVerifyGate},
+ * drops gates whose command is blank, and validates optional per-gate timeoutMs values.
+ * Returns `{ verifyGates }` only when at least one gate survives so the factory omits the
+ * field entirely otherwise (a repo with no gates round-trips without an empty array on
+ * disk). Short-circuits on the first validation error.
  */
 const verifyGatesPart = (
   input: readonly VerifyGate[] | undefined
@@ -291,19 +371,9 @@ const verifyGatesPart = (
   if (input === undefined) return Result.ok({});
   const gates: VerifyGate[] = [];
   for (const gate of input) {
-    const command = typeof gate.command === 'string' ? gate.command.trim() : '';
-    if (command.length === 0) continue;
-    let timeoutMs: number | undefined;
-    if (gate.timeoutMs !== undefined) {
-      const parsed = parsePositiveInt('repository.verifyGates[].timeoutMs', gate.timeoutMs);
-      if (!parsed.ok) return Result.error(parsed.error);
-      timeoutMs = parsed.value;
-    }
-    gates.push({
-      pathPrefix: typeof gate.pathPrefix === 'string' ? gate.pathPrefix : '',
-      command,
-      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-    });
+    const result = normalizeVerifyGate(gate);
+    if (!result.ok) return Result.error(result.error);
+    if (result.value !== undefined) gates.push(result.value);
   }
   return Result.ok(gates.length > 0 ? { verifyGates: gates } : {});
 };

--- a/src/domain/value/settings-models/context-window.ts
+++ b/src/domain/value/settings-models/context-window.ts
@@ -8,10 +8,9 @@
  *  2. The TUI (`application/`) cannot import the integration-layer adapter
  *     (`providers/_engine/context-window.ts`) without violating the four-module layer rule.
  *
- * This intentionally duplicates the map that also lives in
- * `src/integration/ai/providers/_engine/context-window.ts`. Once ticket #226 lands and the
- * provider-engine is refactored, the integration copy should delegate here rather than maintaining
- * its own table. Until then keep both in sync when adding a new model entry.
+ * `src/integration/ai/providers/_engine/context-window.ts` re-exports {@link contextWindowFor}
+ * from here rather than keeping its own table — this module is the single source of truth for
+ * the model → window map.
  *
  * Scope discipline: only entries we are confident about. A guess here surfaces as a wrong label or
  * a wrong % bar in the TUI; an omission surfaces as "no label rendered". Prefer the latter — add a

--- a/src/integration/ai/prompts/_engine/parse-task-list.ts
+++ b/src/integration/ai/prompts/_engine/parse-task-list.ts
@@ -101,6 +101,48 @@ export const parseTaskList = (
   }
 
   // Pass 1: resolve user-supplied task ids → minted TaskIds (for blockedBy resolution).
+  const idMapResult = buildIdMap(specs);
+  if (!idMapResult.ok) return Result.error(idMapResult.error);
+  const idMap = idMapResult.value;
+
+  // Pass 2: domain-aware validation (path → repo, ticketRef → ticketId, blockedBy → TaskId)
+  // and TodoTask construction.
+  const tasks: TodoTask[] = [];
+  for (let i = 0; i < specs.length; i++) {
+    const t = specs[i];
+    if (t === undefined) continue;
+
+    const built = buildTask(t, i, {
+      repoByPath,
+      idMap,
+      mode: input.mode,
+      ...(input.defaultMaxAttempts !== undefined ? { defaultMaxAttempts: input.defaultMaxAttempts } : {}),
+    });
+    if (!built.ok) return Result.error(built.error);
+    tasks.push(built.value);
+  }
+
+  // Pass 3: dependency-wave schedule via the shared domain scheduler.
+  // `scheduleIntoWaves` validates the graph (unknown dep / self-edge / cycle) then runs
+  // Kahn-by-level so every dependency lands in an earlier wave than its dependent. We flatten
+  // the waves into a single sequence and renumber `order` to the 1-based array position.
+  const scheduled = scheduleAndFlatten(tasks);
+  if (!scheduled.ok) return Result.error(scheduled.error);
+  if (scheduled.value.changed) {
+    input.logger?.info(
+      `[parseTaskList] reordered ${String(scheduled.value.tasks.length)} of ${String(tasks.length)} tasks to satisfy blockedBy graph`
+    );
+  }
+
+  return Result.ok(scheduled.value.tasks);
+};
+
+/**
+ * Pass 1 helper — mint a `TaskId` for every user-supplied `id` so Pass 2's `blockedBy`
+ * resolution can look tasks up by their spec-authored id before the domain entity exists.
+ * Rejects duplicate ids outright (the AI must not emit the same id twice within one call).
+ */
+const buildIdMap = (specs: readonly TaskImportSpec[]): Result<Map<string, TaskId>, ParseError> => {
   const idMap = new Map<string, TaskId>();
   for (let i = 0; i < specs.length; i++) {
     const t = specs[i];
@@ -117,97 +159,110 @@ export const parseTaskList = (
       idMap.set(t.id, TaskId.generate());
     }
   }
+  return Result.ok(idMap);
+};
 
-  // Pass 2: domain-aware validation (path → repo, ticketRef → ticketId, blockedBy → TaskId)
-  // and TodoTask construction.
-  const tasks: TodoTask[] = [];
-  for (let i = 0; i < specs.length; i++) {
-    const t = specs[i];
-    if (t === undefined) continue;
-
-    const ticketResolution = resolveTicketRef(t, i, input.mode);
-    if (!ticketResolution.ok) return Result.error(ticketResolution.error);
-    const { ticketId, externalRefs } = ticketResolution.value;
-
-    const repoId = repoByPath.get(t.projectPath);
-    if (repoId === undefined) {
+/** Resolve a task's `blockedBy` spec-ids onto the minted `TaskId`s from {@link buildIdMap}. */
+const resolveDependsOn = (
+  blockedBy: readonly string[] | undefined,
+  idMap: Map<string, TaskId>,
+  i: number
+): Result<TaskId[], ParseError> => {
+  const dependsOn: TaskId[] = [];
+  for (const ref of blockedBy ?? []) {
+    const resolved = idMap.get(ref);
+    if (resolved === undefined) {
       return Result.error(
         new ParseError({
           subCode: SCHEMA_MISMATCH,
-          message: `task-list: tasks[${String(i)}].projectPath '${t.projectPath}' is not in the project's repositories`,
-          hint: `available paths: ${Array.from(repoByPath.keys()).join(', ')}`,
+          message: `task-list: tasks[${String(i)}].blockedBy references unknown task id '${ref}'`,
         })
       );
     }
-    const dependsOn: TaskId[] = [];
-    for (const ref of t.blockedBy ?? []) {
-      const resolved = idMap.get(ref);
-      if (resolved === undefined) {
-        return Result.error(
-          new ParseError({
-            subCode: SCHEMA_MISMATCH,
-            message: `task-list: tasks[${String(i)}].blockedBy references unknown task id '${ref}'`,
-          })
-        );
-      }
-      dependsOn.push(resolved);
-    }
-    const mappedId = t.id !== undefined ? idMap.get(t.id) : undefined;
-    // Normalise extras: trim, lowercase, drop empties so the prompt + parser stay stable
-    // regardless of casing or stray whitespace the planner emits.
-    const normalisedExtras =
-      t.extraDimensions !== undefined
-        ? t.extraDimensions.map((d) => d.trim().toLowerCase()).filter((d) => d.length > 0)
-        : undefined;
-    // `t.verificationCriteria` is the AI-emitted structured shape; pass it straight through —
-    // `createTask` re-validates the auto / manual command invariant and clones defensively.
-    const created = createTask({
-      ...(mappedId !== undefined ? { id: mappedId } : {}),
-      // Single-line names everywhere: the name is interpolated into the journal's structural
-      // `## Task: <name> — Attempt <N>` header line that cap-progress splits and attributes on —
-      // a planner-emitted newline would break the task's own section boundary.
-      name: t.name.replace(/[\r\n\t\v\f]+/g, ' ').trim(),
-      ...(t.description !== undefined && t.description.trim().length > 0 ? { description: t.description } : {}),
-      steps: t.steps,
-      verificationCriteria: t.verificationCriteria.map((c) => ({
-        id: c.id,
-        assertion: c.assertion,
-        check: c.check,
-        ...(c.command !== undefined ? { command: c.command } : {}),
-      })),
-      order: i + 1,
-      ticketId,
-      repositoryId: repoId,
-      ...(dependsOn.length > 0 ? { dependsOn } : {}),
-      ...(normalisedExtras !== undefined && normalisedExtras.length > 0 ? { extraDimensions: normalisedExtras } : {}),
-      ...(externalRefs !== undefined ? { externalRefs } : {}),
-      ...(input.defaultMaxAttempts !== undefined ? { maxAttempts: input.defaultMaxAttempts } : {}),
-    });
-    if (!created.ok) {
-      return Result.error(
-        new ParseError({
-          subCode: SCHEMA_MISMATCH,
-          message: `task-list: tasks[${String(i)}] failed validation: ${created.error.message}`,
-          cause: created.error,
-        })
-      );
-    }
-    tasks.push(created.value);
+    dependsOn.push(resolved);
   }
+  return Result.ok(dependsOn);
+};
 
-  // Pass 3: dependency-wave schedule via the shared domain scheduler.
-  // `scheduleIntoWaves` validates the graph (unknown dep / self-edge / cycle) then runs
-  // Kahn-by-level so every dependency lands in an earlier wave than its dependent. We flatten
-  // the waves into a single sequence and renumber `order` to the 1-based array position.
-  const scheduled = scheduleAndFlatten(tasks);
-  if (!scheduled.ok) return Result.error(scheduled.error);
-  if (scheduled.value.changed) {
-    input.logger?.info(
-      `[parseTaskList] reordered ${String(scheduled.value.tasks.length)} of ${String(tasks.length)} tasks to satisfy blockedBy graph`
+/**
+ * Normalise extras: trim, lowercase, drop empties so the prompt + parser stay stable regardless
+ * of casing or stray whitespace the planner emits.
+ */
+const normalizeExtraDimensions = (extraDimensions?: readonly string[]): readonly string[] | undefined =>
+  extraDimensions !== undefined
+    ? extraDimensions.map((d) => d.trim().toLowerCase()).filter((d) => d.length > 0)
+    : undefined;
+
+/**
+ * Pass 2 helper — resolve one task spec's cross-references (ticketRef → ticketId, projectPath →
+ * repo, blockedBy → TaskId) and construct the `TodoTask` entity via `createTask`.
+ * `t.verificationCriteria` is the AI-emitted structured shape; it is passed straight through —
+ * `createTask` re-validates the auto / manual command invariant and clones defensively.
+ */
+const buildTask = (
+  t: TaskImportSpec,
+  i: number,
+  ctx: {
+    readonly repoByPath: Map<string, RepositoryId>;
+    readonly idMap: Map<string, TaskId>;
+    readonly mode: ParseTaskListMode;
+    readonly defaultMaxAttempts?: number;
+  }
+): Result<TodoTask, ParseError> => {
+  const ticketResolution = resolveTicketRef(t, i, ctx.mode);
+  if (!ticketResolution.ok) return Result.error(ticketResolution.error);
+  const { ticketId, externalRefs } = ticketResolution.value;
+
+  const repoId = ctx.repoByPath.get(t.projectPath);
+  if (repoId === undefined) {
+    return Result.error(
+      new ParseError({
+        subCode: SCHEMA_MISMATCH,
+        message: `task-list: tasks[${String(i)}].projectPath '${t.projectPath}' is not in the project's repositories`,
+        hint: `available paths: ${Array.from(ctx.repoByPath.keys()).join(', ')}`,
+      })
     );
   }
 
-  return Result.ok(scheduled.value.tasks);
+  const dependsOnResult = resolveDependsOn(t.blockedBy, ctx.idMap, i);
+  if (!dependsOnResult.ok) return Result.error(dependsOnResult.error);
+  const dependsOn = dependsOnResult.value;
+
+  const mappedId = t.id !== undefined ? ctx.idMap.get(t.id) : undefined;
+  const normalisedExtras = normalizeExtraDimensions(t.extraDimensions);
+
+  const created = createTask({
+    ...(mappedId !== undefined ? { id: mappedId } : {}),
+    // Single-line names everywhere: the name is interpolated into the journal's structural
+    // `## Task: <name> — Attempt <N>` header line that cap-progress splits and attributes on —
+    // a planner-emitted newline would break the task's own section boundary.
+    name: t.name.replace(/[\r\n\t\v\f]+/g, ' ').trim(),
+    ...(t.description !== undefined && t.description.trim().length > 0 ? { description: t.description } : {}),
+    steps: t.steps,
+    verificationCriteria: t.verificationCriteria.map((c) => ({
+      id: c.id,
+      assertion: c.assertion,
+      check: c.check,
+      ...(c.command !== undefined ? { command: c.command } : {}),
+    })),
+    order: i + 1,
+    ticketId,
+    repositoryId: repoId,
+    ...(dependsOn.length > 0 ? { dependsOn } : {}),
+    ...(normalisedExtras !== undefined && normalisedExtras.length > 0 ? { extraDimensions: normalisedExtras } : {}),
+    ...(externalRefs !== undefined ? { externalRefs } : {}),
+    ...(ctx.defaultMaxAttempts !== undefined ? { maxAttempts: ctx.defaultMaxAttempts } : {}),
+  });
+  if (!created.ok) {
+    return Result.error(
+      new ParseError({
+        subCode: SCHEMA_MISMATCH,
+        message: `task-list: tasks[${String(i)}] failed validation: ${created.error.message}`,
+        cause: created.error,
+      })
+    );
+  }
+  return Result.ok(created.value);
 };
 
 interface ScheduledTasks {

--- a/src/integration/ai/prompts/_engine/substitute.ts
+++ b/src/integration/ai/prompts/_engine/substitute.ts
@@ -36,12 +36,17 @@ const PLACEHOLDER_PATTERN = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
 
 /**
  * Keys whose substituted values are tail-compressed when they exceed {@link SECTION_CHAR_CAP}.
- * These are large dynamic sections (progress journals, learning ledgers, episode history) that
- * grow unboundedly over a long sprint. Keeping the tail (most recent content) follows the
- * "Lost in the Middle" guidance — older entries are less useful and pushing them into the middle
- * of the context degrades model attention on the task-critical sections that follow.
+ * These are large dynamic sections (progress journals, learning ledgers) that grow unboundedly
+ * over a long sprint. Keeping the tail (most recent content) follows the "Lost in the Middle"
+ * guidance — older entries are less useful and pushing them into the middle of the context
+ * degrades model attention on the task-critical sections that follow.
+ *
+ * Episode summaries are deliberately excluded: they are hard-bounded to a handful of short items
+ * well under the cap, and their substituted value self-wraps in an opening/closing tag (unlike
+ * the wrappers for the keys below, which live in template.md). Tail-slicing would drop the
+ * leading open tag, leaving a dangling close tag outside any tag — malformed.
  */
-const COMPRESSIBLE_KEYS = new Set(['PRIOR_PROGRESS', 'PRIOR_LEARNINGS', 'PRIOR_EPISODES']);
+const COMPRESSIBLE_KEYS = new Set(['PRIOR_PROGRESS', 'PRIOR_LEARNINGS']);
 
 export const substitute = (template: string, values: Readonly<Record<string, string>>): string =>
   template.replace(PLACEHOLDER_PATTERN, (match, key: string) => {

--- a/src/integration/ai/providers/_engine/context-window.ts
+++ b/src/integration/ai/providers/_engine/context-window.ts
@@ -26,24 +26,4 @@
  * the provider reports, since the model-side wrapping (system prompts, tool definitions, …)
  * differs per route.
  */
-const CONTEXT_WINDOW: Readonly<Record<string, number>> = {
-  // Claude (claude-code adapter — direct from Anthropic)
-  'claude-haiku-4-5': 200_000,
-  'claude-sonnet-4-6': 200_000,
-  'claude-opus-4-8': 200_000,
-  // Sonnet 5 has no `[1m]` variant — it always runs at its native 1M window on the Anthropic API.
-  'claude-sonnet-5': 1_000_000,
-  // `[1m]` is Claude Code's 1M-token long-context selector — the window is part of the id.
-  'claude-opus-4-8[1m]': 1_000_000,
-  'claude-fable-5[1m]': 1_000_000,
-};
-
-/**
- * Look up the canonical context window for a provider-reported model id. Returns `undefined`
- * for unknown / unset models — emit the {@link TokenUsageEvent} without `contextWindow`, the
- * subscriber renders the raw counts.
- */
-export const contextWindowFor = (model: string | undefined): number | undefined => {
-  if (model === undefined) return undefined;
-  return CONTEXT_WINDOW[model];
-};
+export { contextWindowFor } from '@src/domain/value/settings-models/context-window.ts';

--- a/src/integration/ai/providers/_engine/run-provider-attempt.ts
+++ b/src/integration/ai/providers/_engine/run-provider-attempt.ts
@@ -111,8 +111,10 @@ export interface ProviderAttemptInput {
   readonly getStdoutTail: () => string | undefined;
   /**
    * Returns the assistant body for `bodyFile` mirroring. Only called when `session.bodyFile`
-   * is set. For providers that read from a tempfile (codex), may return a failure Result that
-   * surfaces as a hard error from `onSuccess`.
+   * is set. Forensic capture is best-effort across all providers — an unreadable body resolves to
+   * an empty string rather than a failure Result, so it never discards an otherwise-recovered
+   * success (`signals.json` is the authoritative gate). A non-`AbortError` failure Result here
+   * would still surface as a hard error from `onSuccess`.
    */
   readonly getBody: () => Promise<Result<string, DomainError>>;
   /**

--- a/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
+++ b/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
@@ -98,6 +98,129 @@ const withoutResume = (session: AiSession): AiSession => {
   return cold;
 };
 
+interface HandleRateLimitOutcomeParams {
+  readonly eventBus: EventBus;
+  readonly providerSlug: RunWithRateLimitRetryOptions['providerSlug'];
+  readonly providerName: string;
+  readonly session: AiSession;
+  readonly attemptIdx: number;
+  readonly maxAttempts: number;
+  readonly schedule: readonly number[];
+  readonly error: RateLimitError;
+}
+
+/**
+ * Result of one rate-limit-outcome handling pass: either an abort surfaced during the backoff
+ * sleep (caller must stop and return it), or the rebuilt session the loop should retry with.
+ */
+type RateLimitOutcomeResult =
+  { readonly type: 'aborted'; readonly error: AbortError } | { readonly type: 'continue'; readonly session: AiSession };
+
+/**
+ * Handle one `rate-limit` attempt outcome: warn-log, rebuild the session with the captured
+ * resume id (if any), and — unless this was the last allotted attempt — wait out the backoff
+ * schedule behind a show/clear banner pair, short-circuiting on abort. Pulled out of the main
+ * loop body purely to keep that loop under the complexity/line thresholds; same publishes, same
+ * ordering, same abort semantics as before.
+ */
+const handleRateLimitOutcome = async ({
+  eventBus,
+  providerSlug,
+  providerName,
+  session,
+  attemptIdx,
+  maxAttempts,
+  schedule,
+  error,
+}: HandleRateLimitOutcomeParams): Promise<RateLimitOutcomeResult> => {
+  const bannerId = `rate-limit-${providerSlug}-${error.sessionId ?? String(attemptIdx + 1)}`;
+  eventBus.publish({
+    type: 'log',
+    level: 'warn',
+    message: `${providerName}: rate-limit on attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
+    meta: { attempt: attemptIdx + 1, maxAttempts, subCode: error.subCode },
+    at: IsoTimestamp.now(),
+  });
+  // Carry the interrupted session forward so the retry resumes it instead of cold-starting.
+  // Only when the provider captured an id — a 429 before any session id leaves nothing to
+  // resume, so the next attempt is necessarily cold.
+  const nextSession = error.sessionId !== undefined ? withResume(session, error.sessionId) : session;
+
+  // Wait before retrying — gives a daily-quota throttle a chance to reset on a fresh window.
+  // Only between attempts, not after the last one. Abort short-circuits the sleep so a
+  // user-initiated cancel doesn't have to wait through a multi-hour backoff.
+  if (attemptIdx >= maxAttempts - 1) {
+    return { type: 'continue', session: nextSession };
+  }
+  const delayMs = delayForRetry(attemptIdx + 1, schedule);
+  if (delayMs <= 0) {
+    return { type: 'continue', session: nextSession };
+  }
+
+  eventBus.publish({
+    type: 'log',
+    level: 'info',
+    message: `${providerName}: waiting ${String(delayMs)}ms before retry`,
+    meta: { delayMs, nextAttempt: attemptIdx + 2, maxAttempts },
+    at: IsoTimestamp.now(),
+  });
+  eventBus.publish({
+    type: 'banner-show',
+    id: bannerId,
+    tier: 'info',
+    message: `Rate limit (${providerSlug}) — waiting ${Math.round(delayMs / 1000).toString()}s before retry`,
+    cause: `attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
+    at: IsoTimestamp.now(),
+  });
+  await sleepCancellable(delayMs, nextSession.abortSignal);
+  // Clear once the wait completes (either elapsed or abort fired); the next attempt
+  // re-publishes if it also hits the rate-limit.
+  eventBus.publish({ type: 'banner-clear', id: bannerId, at: IsoTimestamp.now() });
+  if (nextSession.abortSignal?.aborted === true) {
+    // User cancel during the backoff sleep must surface as AbortError — the one error
+    // chains propagate transparently (CLAUDE.md §AbortError). InvalidStateError is
+    // classified as a recoverable turn error and would wrongly self-block the task.
+    // Mirrors the abort-on-exit shape in classify-spawn-exit.ts.
+    return {
+      type: 'aborted',
+      error: new AbortError({
+        elementName: providerName,
+        reason: `${providerName}: aborted by caller during rate-limit backoff`,
+      }),
+    };
+  }
+  return { type: 'continue', session: nextSession };
+};
+
+/**
+ * Stale-resume cold fallback predicate (FINDING 4 — shared, was codex-only). A `resume` spawn
+ * that failed because the provider no longer has the session/thread would otherwise block the
+ * task; the caller falls back to a COLD spawn (no resume) exactly once when this returns `true`.
+ * An aborted run is exempt: a user cancel must tear the run down, not spawn fresh work a
+ * competitor may now own.
+ */
+const shouldColdRetry = (
+  outcome: Extract<AttemptOutcome, { readonly kind: 'error' }>,
+  session: AiSession,
+  resumeStaleRe: RegExp | undefined,
+  coldRetried: boolean
+): boolean =>
+  resumeStaleRe !== undefined &&
+  !coldRetried &&
+  session.abortSignal?.aborted !== true &&
+  session.resume !== undefined &&
+  resumeStaleRe.test(outcome.error.message);
+
+const logColdRetry = (eventBus: EventBus, providerName: string, session: AiSession): void => {
+  eventBus.publish({
+    type: 'log',
+    level: 'warn',
+    message: `${providerName}: resume thread not found — retrying cold (dropping --resume)`,
+    meta: { resume: String(session.resume) },
+    at: IsoTimestamp.now(),
+  });
+};
+
 export const runWithRateLimitRetry = async (
   opts: RunWithRateLimitRetryOptions
 ): Promise<Result<ProviderOutput, DomainError>> => {
@@ -121,83 +244,28 @@ export const runWithRateLimitRetry = async (
 
     if (outcome.kind === 'rate-limit') {
       lastRateLimit = outcome.error;
-      const bannerId = `rate-limit-${providerSlug}-${outcome.error.sessionId ?? String(attemptIdx + 1)}`;
-      eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `${providerName}: rate-limit on attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
-        meta: { attempt: attemptIdx + 1, maxAttempts, subCode: outcome.error.subCode },
-        at: IsoTimestamp.now(),
+      const result = await handleRateLimitOutcome({
+        eventBus,
+        providerSlug,
+        providerName,
+        session,
+        attemptIdx,
+        maxAttempts,
+        schedule,
+        error: outcome.error,
       });
-      // Carry the interrupted session forward so the retry resumes it instead of cold-starting.
-      // Only when the provider captured an id — a 429 before any session id leaves nothing to
-      // resume, so the next attempt is necessarily cold.
-      if (outcome.error.sessionId !== undefined) {
-        session = withResume(session, outcome.error.sessionId);
+      if (result.type === 'aborted') {
+        return Result.error(result.error) as Result<ProviderOutput, DomainError>;
       }
-      // Wait before retrying — gives a daily-quota throttle a chance to reset on a fresh window.
-      // Only between attempts, not after the last one. Abort short-circuits the sleep so a
-      // user-initiated cancel doesn't have to wait through a multi-hour backoff.
-      if (attemptIdx < maxAttempts - 1) {
-        const delayMs = delayForRetry(attemptIdx + 1, schedule);
-        if (delayMs > 0) {
-          eventBus.publish({
-            type: 'log',
-            level: 'info',
-            message: `${providerName}: waiting ${String(delayMs)}ms before retry`,
-            meta: { delayMs, nextAttempt: attemptIdx + 2, maxAttempts },
-            at: IsoTimestamp.now(),
-          });
-          eventBus.publish({
-            type: 'banner-show',
-            id: bannerId,
-            tier: 'info',
-            message: `Rate limit (${providerSlug}) — waiting ${Math.round(delayMs / 1000).toString()}s before retry`,
-            cause: `attempt ${String(attemptIdx + 1)}/${String(maxAttempts)}`,
-            at: IsoTimestamp.now(),
-          });
-          await sleepCancellable(delayMs, session.abortSignal);
-          // Clear once the wait completes (either elapsed or abort fired); the next attempt
-          // re-publishes if it also hits the rate-limit.
-          eventBus.publish({ type: 'banner-clear', id: bannerId, at: IsoTimestamp.now() });
-          if (session.abortSignal?.aborted === true) {
-            // User cancel during the backoff sleep must surface as AbortError — the one error
-            // chains propagate transparently (CLAUDE.md §AbortError). InvalidStateError is
-            // classified as a recoverable turn error and would wrongly self-block the task.
-            // Mirrors the abort-on-exit shape in classify-spawn-exit.ts.
-            return Result.error(
-              new AbortError({
-                elementName: providerName,
-                reason: `${providerName}: aborted by caller during rate-limit backoff`,
-              })
-            ) as Result<ProviderOutput, DomainError>;
-          }
-        }
-      }
+      session = result.session;
       continue;
     }
 
-    // Stale-resume cold fallback (FINDING 4 — shared, was codex-only). A `resume` spawn that
-    // failed because the provider no longer has the session/thread would otherwise block the
-    // task. Fall back to a COLD spawn (no resume) exactly once. Re-running the SAME attempt
-    // index keeps the fallback from consuming a rate-limit slot; the `coldRetried` latch bounds
-    // it. An aborted run is exempt: a user cancel must tear the run down, not spawn fresh work a
-    // competitor may now own.
-    if (
-      resumeStaleRe !== undefined &&
-      !coldRetried &&
-      session.abortSignal?.aborted !== true &&
-      session.resume !== undefined &&
-      resumeStaleRe.test(outcome.error.message)
-    ) {
+    // Re-running the SAME attempt index keeps the cold fallback from consuming a rate-limit
+    // slot; see `shouldColdRetry` for the full rationale.
+    if (shouldColdRetry(outcome, session, resumeStaleRe, coldRetried)) {
       coldRetried = true;
-      eventBus.publish({
-        type: 'log',
-        level: 'warn',
-        message: `${providerName}: resume thread not found — retrying cold (dropping --resume)`,
-        meta: { resume: String(session.resume) },
-        at: IsoTimestamp.now(),
-      });
+      logColdRetry(eventBus, providerName, session);
       session = withoutResume(session);
       attemptIdx--;
       continue;

--- a/src/integration/ai/providers/claude/parse-stream.ts
+++ b/src/integration/ai/providers/claude/parse-stream.ts
@@ -32,6 +32,54 @@ import type {
 import { STDOUT_LINE_PARSE_CAP } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import { isRecord, numberField, stringField } from '@src/integration/ai/providers/_engine/json-field.ts';
 
+// Module-level (no closure over parser state) — safe to hoist out of the factory.
+//
+// Why: stdout-stream records arrive at high volume — a Zod schema per record is overkill.
+// `ingest()` downstream extracts known fields with narrow `stringField` / `numberField` helpers;
+// unknown keys are ignored.
+const emitLine = (raw: string, onLine: (line: ClaudeStreamLine) => void): void => {
+  if (raw.length === 0) return;
+  if (raw.startsWith('{') && raw.endsWith('}')) {
+    try {
+      const json = JSON.parse(raw) as Record<string, unknown>;
+      onLine({ raw, json });
+      return;
+    } catch {
+      // fall through — non-JSON or malformed: emit as plain text and let `ingest` skip it.
+    }
+  }
+  onLine({ raw });
+};
+
+// Per-turn usage lives on `message.usage` (same nested field names the result path uses).
+const extractLiveUsage = (u: Record<string, unknown>): ClaudeLiveUsage => {
+  const i = numberField(u, 'input_tokens', 'inputTokens');
+  const cr = numberField(u, 'cache_read_input_tokens', 'cacheReadInputTokens');
+  const cc = numberField(u, 'cache_creation_input_tokens', 'cacheCreationInputTokens');
+  return {
+    ...(i !== undefined ? { inputTokens: i } : {}),
+    ...(cr !== undefined ? { cacheReadTokens: cr } : {}),
+    ...(cc !== undefined ? { cacheCreationTokens: cc } : {}),
+  };
+};
+
+// Token usage on the result event: `usage: { input_tokens, output_tokens,
+// cache_read_input_tokens, cache_creation_input_tokens }`. Cumulative — already the spawn
+// total. Stream-json never streams partial counts on intermediate events for `-p` mode, so a
+// single read here is the authoritative figure.
+const extractResultUsage = (u: Record<string, unknown>): ClaudeUsage => {
+  const i = numberField(u, 'input_tokens', 'inputTokens');
+  const o = numberField(u, 'output_tokens', 'outputTokens');
+  const cr = numberField(u, 'cache_read_input_tokens', 'cacheReadInputTokens');
+  const cc = numberField(u, 'cache_creation_input_tokens', 'cacheCreationInputTokens');
+  return {
+    ...(i !== undefined ? { inputTokens: i } : {}),
+    ...(o !== undefined ? { outputTokens: o } : {}),
+    ...(cr !== undefined ? { cacheReadTokens: cr } : {}),
+    ...(cc !== undefined ? { cacheCreationTokens: cc } : {}),
+  };
+};
+
 export const createClaudeStreamParser = (): ClaudeStreamParser => {
   let buffer = '';
   // One-shot latch: warn exactly once per parser so a child that streams a pathologically long
@@ -68,77 +116,46 @@ export const createClaudeStreamParser = (): ClaudeStreamParser => {
   // unlike the cumulative `result.usage` above. Stays `{}` if no assistant carried usage.
   let liveUsage: ClaudeLiveUsage = {};
 
-  const emit = (raw: string, onLine: (line: ClaudeStreamLine) => void): void => {
-    if (raw.length === 0) return;
-    if (raw.startsWith('{') && raw.endsWith('}')) {
-      try {
-        // Why: stdout-stream records arrive at high volume — a Zod schema per record
-        // is overkill. `ingest()` downstream extracts known fields with narrow
-        // `stringField` / `numberField` helpers; unknown keys are ignored.
-        const json = JSON.parse(raw) as Record<string, unknown>;
-        onLine({ raw, json });
-        return;
-      } catch {
-        // fall through — non-JSON or malformed: emit as plain text and let `ingest` skip it.
-      }
-    }
-    onLine({ raw });
+  // Earliest session_id wins. The system/init event normally arrives first and carries it, but
+  // every event after that re-states it; clamping to "first seen" makes the value stable.
+  const applySessionId = (json: Record<string, unknown>): void => {
+    if (sessionId !== undefined) return;
+    const seen = stringField(json, 'session_id', 'sessionId');
+    if (seen !== undefined) sessionId = seen;
+  };
+
+  const applyModel = (type: string | undefined, json: Record<string, unknown>): void => {
+    if (type !== 'system' || model !== undefined) return;
+    const m = stringField(json, 'model');
+    if (m !== undefined) model = m;
+  };
+
+  // Defensive: content-only assistant deltas carry no usage — only update when a usage record
+  // is present, so a usage-less delta never clobbers a captured live snapshot.
+  const applyLiveUsage = (type: string | undefined, json: Record<string, unknown>): void => {
+    if (type !== 'assistant') return;
+    const message = json['message'];
+    if (!isRecord(message)) return;
+    const u = message['usage'];
+    if (isRecord(u)) liveUsage = extractLiveUsage(u);
+  };
+
+  const applyResultFields = (type: string | undefined, json: Record<string, unknown>): void => {
+    if (type !== 'result') return;
+    const r = stringField(json, 'result');
+    if (r !== undefined) body = r;
+    const u = json['usage'];
+    if (isRecord(u)) usage = extractResultUsage(u);
   };
 
   const ingest = (line: ClaudeStreamLine): void => {
     const json = line.json;
     if (json === undefined) return;
-    // Earliest session_id wins. The system/init event normally arrives first and carries it,
-    // but every event after that re-states it; clamping to "first seen" makes the value stable.
-    if (sessionId === undefined) {
-      const seen = stringField(json, 'session_id', 'sessionId');
-      if (seen !== undefined) sessionId = seen;
-    }
+    applySessionId(json);
     const type = stringField(json, 'type');
-    if (type === 'system' && model === undefined) {
-      const m = stringField(json, 'model');
-      if (m !== undefined) model = m;
-    }
-    if (type === 'assistant') {
-      // Per-turn usage lives on `message.usage` (same nested field names the result path uses).
-      // Defensive: content-only assistant deltas carry no usage — only update when a usage record
-      // is present, so a usage-less delta never clobbers a captured live snapshot.
-      const message = json['message'];
-      if (isRecord(message)) {
-        const u = message['usage'];
-        if (isRecord(u)) {
-          const i = numberField(u, 'input_tokens', 'inputTokens');
-          const cr = numberField(u, 'cache_read_input_tokens', 'cacheReadInputTokens');
-          const cc = numberField(u, 'cache_creation_input_tokens', 'cacheCreationInputTokens');
-          liveUsage = {
-            ...(i !== undefined ? { inputTokens: i } : {}),
-            ...(cr !== undefined ? { cacheReadTokens: cr } : {}),
-            ...(cc !== undefined ? { cacheCreationTokens: cc } : {}),
-          };
-        }
-      }
-    }
-    if (type === 'result') {
-      const r = stringField(json, 'result');
-      if (r !== undefined) body = r;
-      // Token usage on the result event: `usage: { input_tokens, output_tokens,
-      // cache_read_input_tokens, cache_creation_input_tokens }`. Cumulative — already the
-      // spawn total. Stream-json never streams partial counts on intermediate events for `-p`
-      // mode, so a single read here is the authoritative figure.
-      const u = json['usage'];
-      if (isRecord(u)) {
-        const i = numberField(u, 'input_tokens', 'inputTokens');
-        const o = numberField(u, 'output_tokens', 'outputTokens');
-        const cr = numberField(u, 'cache_read_input_tokens', 'cacheReadInputTokens');
-        const cc = numberField(u, 'cache_creation_input_tokens', 'cacheCreationInputTokens');
-        usage = {
-          ...(i !== undefined ? { inputTokens: i } : {}),
-          ...(o !== undefined ? { outputTokens: o } : {}),
-          ...(cr !== undefined ? { cacheReadTokens: cr } : {}),
-          ...(cc !== undefined ? { cacheCreationTokens: cc } : {}),
-        };
-      }
-    }
+    applyModel(type, json);
+    applyLiveUsage(type, json);
+    applyResultFields(type, json);
   };
 
   return {
@@ -148,13 +165,13 @@ export const createClaudeStreamParser = (): ClaudeStreamParser => {
       while (nl !== -1) {
         const line = buffer.slice(0, nl);
         buffer = buffer.slice(nl + 1);
-        emit(line, onLine);
+        emitLine(line, onLine);
         nl = buffer.indexOf('\n');
       }
     },
     flush(onLine) {
       if (buffer.length > 0) {
-        emit(buffer, onLine);
+        emitLine(buffer, onLine);
         buffer = '';
       }
     },

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -16,6 +16,7 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { DEFAULT_RATE_LIMIT_RE } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import {
   createHeadlessProvider,
@@ -209,6 +210,47 @@ interface CodexMetaUpdate {
 }
 
 /**
+ * Trim + JSON.parse a single stdout line. Returns `undefined` for blank lines, non-JSON-looking
+ * lines, and lines that fail to parse — codex occasionally prints banner text alongside json
+ * records, so a parse failure is an expected, silently-skipped case rather than a caller error.
+ */
+const parseCodexJsonLine = (line: string): Record<string, unknown> | undefined => {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || !trimmed.startsWith('{')) return undefined;
+  try {
+    // Why: codex stream records arrive line-by-line at high volume; downstream `stringField` /
+    // `numberField` helpers narrowly type-check the fields we care about (`thread_id`,
+    // `session_id`, `model`, `usage.*`). Unknown shapes are skipped.
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Pull the session-id / `model` / token-usage fields out of one already-parsed stdout record.
+ * Returns `undefined` when the record carries none of them (caller skips the `onMeta` call).
+ */
+const extractCodexMetaUpdate = (obj: Record<string, unknown>): CodexMetaUpdate | undefined => {
+  // `thread_id` is the 0.130.x field (on the `thread.started` record); `session_id` /
+  // `sessionId` cover legacy / forward-compat builds. First non-empty id wins (deduped by
+  // the caller), so listing `thread_id` first matches the stream order.
+  const id = stringField(obj, 'thread_id', 'session_id', 'sessionId');
+  const model = stringField(obj, 'model');
+  const usageObj = obj['usage'];
+  const source = isRecord(usageObj) ? usageObj : obj;
+  const i = numberField(source, 'input_tokens', 'inputTokens', 'prompt_tokens');
+  const o = numberField(source, 'output_tokens', 'outputTokens', 'completion_tokens');
+  if (id === undefined && model === undefined && i === undefined && o === undefined) return undefined;
+  return {
+    ...(id !== undefined ? { sessionId: id } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(i !== undefined ? { inputTokens: i } : {}),
+    ...(o !== undefined ? { outputTokens: o } : {}),
+  };
+};
+
+/**
  * Line-extract session-id / `model` / token-usage fields from codex's JSONL stdout. Returns
  * the residual tail (unterminated trailing chars). `onMeta` is invoked once per recognised
  * line carrying any of the fields; the caller dedupes (sessionId / model = first wins; usage
@@ -236,39 +278,79 @@ const consumeMetaLines = (
     if (nl === -1) return remaining;
     const line = remaining.slice(0, nl);
     remaining = remaining.slice(nl + 1);
-    const trimmed = line.trim();
-    if (trimmed.length === 0 || !trimmed.startsWith('{')) continue;
-    let obj: Record<string, unknown>;
-    try {
-      // Why: codex stream records arrive line-by-line at high volume; downstream
-      // `stringField` / `numberField` helpers narrowly type-check the fields we care
-      // about (`thread_id`, `session_id`, `model`, `usage.*`). Unknown shapes are skipped.
-      obj = JSON.parse(trimmed) as Record<string, unknown>;
-    } catch {
-      // non-JSON line — codex occasionally prints banner text alongside json records; skip
-      continue;
-    }
+    const obj = parseCodexJsonLine(line);
+    if (obj === undefined) continue;
     // Per-line debug fan-out (assistant / tool_use / tool_result) BEFORE the meta extractors,
     // so a single `item.completed` record both updates meta accumulators (when applicable)
     // and surfaces as one debug event in chain.log.
     if (onLine !== undefined) onLine(obj);
-    // `thread_id` is the 0.130.x field (on the `thread.started` record); `session_id` /
-    // `sessionId` cover legacy / forward-compat builds. First non-empty id wins (deduped by
-    // the caller), so listing `thread_id` first matches the stream order.
-    const id = stringField(obj, 'thread_id', 'session_id', 'sessionId');
-    const model = stringField(obj, 'model');
-    const usageObj = obj['usage'];
-    const source = isRecord(usageObj) ? usageObj : obj;
-    const i = numberField(source, 'input_tokens', 'inputTokens', 'prompt_tokens');
-    const o = numberField(source, 'output_tokens', 'outputTokens', 'completion_tokens');
-    if (id === undefined && model === undefined && i === undefined && o === undefined) continue;
-    onMeta({
-      ...(id !== undefined ? { sessionId: id } : {}),
-      ...(model !== undefined ? { model } : {}),
-      ...(i !== undefined ? { inputTokens: i } : {}),
-      ...(o !== undefined ? { outputTokens: o } : {}),
-    });
+    const update = extractCodexMetaUpdate(obj);
+    if (update !== undefined) onMeta(update);
   }
+};
+
+/** `item.completed` / `item.type === 'agent_message'` → one `assistant` debug event. */
+const publishAgentMessageEvent = (eventBus: EventBus, item: Record<string, unknown>): void => {
+  const text = truncateField(stringField(item, 'text'));
+  if (text === undefined) return;
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'codex-provider: assistant',
+    meta: { text },
+    at: IsoTimestamp.now(),
+  });
+};
+
+/** `item.completed` / `item.type === 'command_execution'` → one `tool_use` debug event. */
+const publishCommandExecutionEvent = (eventBus: EventBus, item: Record<string, unknown>): void => {
+  const args = truncateField(stringField(item, 'command'));
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'codex-provider: tool_use',
+    meta: {
+      tool: 'command_execution',
+      ...(args !== undefined ? { args } : {}),
+    },
+    at: IsoTimestamp.now(),
+  });
+};
+
+/** `item.completed` / `item.type === 'function_call'` → one `tool_use` debug event. */
+const publishFunctionCallEvent = (eventBus: EventBus, item: Record<string, unknown>): void => {
+  const tool = stringField(item, 'name') ?? '';
+  const rawArgs = item['arguments'];
+  const argsPreview = typeof rawArgs === 'string' ? rawArgs : safeJson(rawArgs);
+  const args = truncateField(argsPreview);
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'codex-provider: tool_use',
+    meta: {
+      tool,
+      ...(args !== undefined ? { args } : {}),
+    },
+    at: IsoTimestamp.now(),
+  });
+};
+
+/** `item.completed` / `item.type === 'function_call_output'` → one `tool_result` debug event. */
+const publishFunctionCallOutputEvent = (eventBus: EventBus, item: Record<string, unknown>): void => {
+  const tool = stringField(item, 'name') ?? stringField(item, 'call_id') ?? '';
+  const status = item['is_error'] === true || stringField(item, 'status') === 'error' ? 'error' : 'ok';
+  const preview = truncateField(stringField(item, 'output'));
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'codex-provider: tool_result',
+    meta: {
+      tool,
+      status,
+      ...(preview !== undefined ? { preview } : {}),
+    },
+    at: IsoTimestamp.now(),
+  });
 };
 
 /**
@@ -283,66 +365,10 @@ const publishCodexStreamLineEvents = (eventBus: EventBus, obj: Record<string, un
   const item = obj['item'];
   if (!isRecord(item)) return;
   const itemType = stringField(item, 'type');
-  if (itemType === 'agent_message') {
-    const text = truncateField(stringField(item, 'text'));
-    if (text !== undefined) {
-      eventBus.publish({
-        type: 'log',
-        level: 'debug',
-        message: 'codex-provider: assistant',
-        meta: { text },
-        at: IsoTimestamp.now(),
-      });
-    }
-    return;
-  }
-  if (itemType === 'command_execution') {
-    const args = truncateField(stringField(item, 'command'));
-    eventBus.publish({
-      type: 'log',
-      level: 'debug',
-      message: 'codex-provider: tool_use',
-      meta: {
-        tool: 'command_execution',
-        ...(args !== undefined ? { args } : {}),
-      },
-      at: IsoTimestamp.now(),
-    });
-    return;
-  }
-  if (itemType === 'function_call') {
-    const tool = stringField(item, 'name') ?? '';
-    const rawArgs = item['arguments'];
-    const argsPreview = typeof rawArgs === 'string' ? rawArgs : safeJson(rawArgs);
-    const args = truncateField(argsPreview);
-    eventBus.publish({
-      type: 'log',
-      level: 'debug',
-      message: 'codex-provider: tool_use',
-      meta: {
-        tool,
-        ...(args !== undefined ? { args } : {}),
-      },
-      at: IsoTimestamp.now(),
-    });
-    return;
-  }
-  if (itemType === 'function_call_output') {
-    const tool = stringField(item, 'name') ?? stringField(item, 'call_id') ?? '';
-    const status = item['is_error'] === true || stringField(item, 'status') === 'error' ? 'error' : 'ok';
-    const preview = truncateField(stringField(item, 'output'));
-    eventBus.publish({
-      type: 'log',
-      level: 'debug',
-      message: 'codex-provider: tool_result',
-      meta: {
-        tool,
-        status,
-        ...(preview !== undefined ? { preview } : {}),
-      },
-      at: IsoTimestamp.now(),
-    });
-  }
+  if (itemType === 'agent_message') return publishAgentMessageEvent(eventBus, item);
+  if (itemType === 'command_execution') return publishCommandExecutionEvent(eventBus, item);
+  if (itemType === 'function_call') return publishFunctionCallEvent(eventBus, item);
+  if (itemType === 'function_call_output') return publishFunctionCallOutputEvent(eventBus, item);
 };
 
 /** Best-effort debug log when the codex forensic body tempfile can't be read (audit-[09]). */
@@ -378,6 +404,153 @@ const agentMessageText = (obj: Record<string, unknown>): string | undefined => {
   return stringField(item, 'text');
 };
 
+/**
+ * Mutable per-attempt accumulator for codex's JSONL stdout stream: session id / model / token
+ * usage (dedup rules per {@link consumeMetaLines}'s `onMeta` contract — first-wins for id/model,
+ * last-wins for usage) plus the bounded `agent_message` tail used as the rate-limit haystack.
+ * One fresh instance per `attempt()` call — mirrors the sibling `createClaudeStreamParser`
+ * pattern in claude/headless.ts, kept file-local since codex's JSONL-meta-line shape has no
+ * natural shared port with Claude's `result`-envelope shape.
+ */
+interface CodexAttemptTracker {
+  /** Feed one raw stdout chunk through {@link consumeMetaLines}. */
+  readonly consumeChunk: (chunk: string) => void;
+  /** Flush any partial trailing line once the child has exited (no trailing newline). */
+  readonly flush: () => void;
+  readonly getSessionId: () => string | undefined;
+  readonly getModel: () => string | undefined;
+  readonly getInputTokens: () => number | undefined;
+  readonly getOutputTokens: () => number | undefined;
+  /** Bounded `agent_message` tail for the rate-limit classifier's haystack. */
+  readonly getStdoutTail: () => string | undefined;
+}
+
+const createCodexAttemptTracker = (eventBus: EventBus): CodexAttemptTracker => {
+  let sessionId: string | undefined;
+  let model: string | undefined;
+  let inputTokens: number | undefined;
+  let outputTokens: number | undefined;
+  // Accumulate codex's `agent_message` text so the rate-limit classifier can scan it
+  // alongside stderr — codex surfaces a quota throttle in the agent_message body,
+  // not always on stderr. Capped to bound memory on a long session.
+  let agentMessageTail = '';
+  let stdoutLineBuf = '';
+
+  const onMeta = (update: CodexMetaUpdate): void => {
+    if (update.sessionId !== undefined && sessionId === undefined) {
+      sessionId = update.sessionId;
+    }
+    if (update.model !== undefined && model === undefined) {
+      model = update.model;
+    }
+    // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
+    // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
+    if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
+    if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
+  };
+  const onLine = (obj: Record<string, unknown>): void => {
+    publishCodexStreamLineEvents(eventBus, obj);
+    const text = agentMessageText(obj);
+    if (text !== undefined) {
+      agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
+        -RATE_LIMIT_SCAN_TAIL_CAP
+      );
+    }
+  };
+
+  return {
+    consumeChunk: (chunk) => {
+      stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
+    },
+    // Flush any partial line remaining in the buffer — codex may terminate without a
+    // trailing newline. Appending a synthetic '\n' forces the partial through the parser.
+    flush: () => {
+      if (stdoutLineBuf.length > 0) {
+        consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
+      }
+    },
+    getSessionId: () => sessionId,
+    getModel: () => model,
+    getInputTokens: () => inputTokens,
+    getOutputTokens: () => outputTokens,
+    getStdoutTail: () => (agentMessageTail.length > 0 ? agentMessageTail : undefined),
+  };
+};
+
+interface RunCodexAttemptOpts {
+  readonly outputFile: string;
+  readonly spawnFn: ProviderSpawn;
+  readonly command: string;
+  readonly deps: CodexProviderDeps;
+  readonly readFile: (path: string) => Promise<string>;
+}
+
+/**
+ * Run one codex spawn attempt: validates argv, wires a fresh {@link CodexAttemptTracker} into
+ * `runProviderAttempt`'s stdout hooks, and reads back the forensic body tempfile. `outputFile` is
+ * shared across every retry attempt within one `generate()` call (see `createGenerateContext`
+ * below, which owns its lifetime); the tracker's mutable state is fresh per `attempt()` call.
+ */
+const runCodexAttempt = (
+  attemptSession: AiSession,
+  { outputFile, spawnFn, command, deps, readFile }: RunCodexAttemptOpts
+): Promise<AttemptOutcome> => {
+  const built = buildCodexArgs(attemptSession, { outputFile });
+  if (!built.ok) return Promise.resolve({ kind: 'error', error: built.error });
+
+  const tracker = createCodexAttemptTracker(deps.eventBus);
+
+  return runProviderAttempt({
+    spawnFn,
+    command,
+    args: built.value,
+    session: attemptSession,
+    resolveOn: 'exit',
+    // `cwd` is set in addition to codex's argv `-C` so context-file autoload works on
+    // `exec resume` (which does not accept `-C`) and is consistent with the other adapters.
+    // See CLAUDE.md §Security.
+    stdin: attemptSession.prompt,
+    rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+    onStdoutChunk: (chunk) => tracker.consumeChunk(chunk),
+    flush: () => tracker.flush(),
+    getSessionId: () => tracker.getSessionId(),
+    // Codex reports a quota throttle in the agent_message body, not always on stderr.
+    // Feed the accumulated tail into the rate-limit haystack so it trips the backoff.
+    getStdoutTail: () => tracker.getStdoutTail(),
+    // Single-shot read of the codex output tempfile (may be partial/empty on SIGTERM
+    // recovery). audit-[09]: a missing/unreadable tempfile must NOT hard-error — `onSuccess`
+    // also runs on the recovery branch (non-zero exit + signals.json present), and
+    // signals.json is the authoritative gate. Best-effort, like claude/copilot's getBody.
+    getBody: async () => {
+      try {
+        return Result.ok(await readFile(outputFile));
+      } catch (err) {
+        if (err instanceof AbortError) throw err;
+        publishUnreadableBody(deps.eventBus, err);
+        return Result.ok('');
+      }
+    },
+    emitProviderTokenUsage: (sessionId_) => {
+      // Codex commonly omits token counts from the JSONL records on v0.130.x; the event
+      // still fires so subscribers can correlate sessionId → provider without inferring
+      // success from token-field absence.
+      const model = tracker.getModel();
+      const inputTokens = tracker.getInputTokens();
+      const outputTokens = tracker.getOutputTokens();
+      emitTokenUsage(deps.eventBus, attemptSession, sessionId_, {
+        provider: 'openai-codex',
+        ...(model !== undefined ? { model } : {}),
+        ...(inputTokens !== undefined ? { inputTokens } : {}),
+        ...(outputTokens !== undefined ? { outputTokens } : {}),
+      });
+    },
+    providerName: PROVIDER_NAME,
+    providerSlug: 'codex',
+    eventBus: deps.eventBus,
+    ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
+  });
+};
+
 export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider => {
   const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
   const command = deps.command ?? 'codex';
@@ -403,97 +576,7 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
       // retry reuses the same -o path without leaving orphan files. Cleaned up in cleanup().
       const outputFile = mkTempPath();
       return {
-        attempt: async (attemptSession) => {
-          const built = buildCodexArgs(attemptSession, { outputFile });
-          if (!built.ok) return { kind: 'error', error: built.error };
-
-          let sessionId: string | undefined;
-          let model: string | undefined;
-          let inputTokens: number | undefined;
-          let outputTokens: number | undefined;
-          // Accumulate codex's `agent_message` text so the rate-limit classifier can scan it
-          // alongside stderr — codex surfaces a quota throttle in the agent_message body,
-          // not always on stderr. Capped to bound memory on a long session.
-          let agentMessageTail = '';
-          let stdoutLineBuf = '';
-
-          const onMeta = (update: CodexMetaUpdate): void => {
-            if (update.sessionId !== undefined && sessionId === undefined) {
-              sessionId = update.sessionId;
-            }
-            if (update.model !== undefined && model === undefined) {
-              model = update.model;
-            }
-            // Last-write-wins on usage — codex's `turn.completed` record carries the cumulative
-            // figure; earlier records (thread.started / streaming chunks) report partials or nothing.
-            if (update.inputTokens !== undefined) inputTokens = update.inputTokens;
-            if (update.outputTokens !== undefined) outputTokens = update.outputTokens;
-          };
-          const onLine = (obj: Record<string, unknown>): void => {
-            publishCodexStreamLineEvents(deps.eventBus, obj);
-            const text = agentMessageText(obj);
-            if (text !== undefined) {
-              agentMessageTail = `${agentMessageTail}${agentMessageTail.length > 0 ? '\n' : ''}${text}`.slice(
-                -RATE_LIMIT_SCAN_TAIL_CAP
-              );
-            }
-          };
-
-          return runProviderAttempt({
-            spawnFn,
-            command,
-            args: built.value,
-            session: attemptSession,
-            resolveOn: 'exit',
-            // `cwd` is set in addition to codex's argv `-C` so context-file autoload works on
-            // `exec resume` (which does not accept `-C`) and is consistent with the other adapters.
-            // See CLAUDE.md §Security.
-            stdin: attemptSession.prompt,
-            rateLimitRe: DEFAULT_RATE_LIMIT_RE,
-            onStdoutChunk: (chunk) => {
-              stdoutLineBuf = consumeMetaLines(stdoutLineBuf + chunk, onMeta, onLine);
-            },
-            // Flush any partial line remaining in the buffer — codex may terminate without a
-            // trailing newline. Appending a synthetic '\n' forces the partial through the parser.
-            flush: () => {
-              if (stdoutLineBuf.length > 0) {
-                consumeMetaLines(stdoutLineBuf + '\n', onMeta, onLine);
-              }
-            },
-            getSessionId: () => sessionId,
-            // Codex reports a quota throttle in the agent_message body, not always on stderr.
-            // Feed the accumulated tail into the rate-limit haystack so it trips the backoff.
-            getStdoutTail: () => (agentMessageTail.length > 0 ? agentMessageTail : undefined),
-            // Single-shot read of the codex output tempfile (may be partial/empty on SIGTERM
-            // recovery). audit-[09]: a missing/unreadable tempfile must NOT hard-error — `onSuccess`
-            // also runs on the recovery branch (non-zero exit + signals.json present), and
-            // signals.json is the authoritative gate. Best-effort, like claude/copilot's getBody.
-            getBody: async () => {
-              try {
-                return Result.ok(await readFile(outputFile));
-              } catch (err) {
-                if (err instanceof AbortError) throw err;
-                publishUnreadableBody(deps.eventBus, err);
-                return Result.ok('');
-              }
-            },
-            emitProviderTokenUsage: (sessionId_) => {
-              // Codex commonly omits token counts from the JSONL records on v0.130.x; the event
-              // still fires so subscribers can correlate sessionId → provider without inferring
-              // success from token-field absence.
-              emitTokenUsage(deps.eventBus, attemptSession, sessionId_, {
-                provider: 'openai-codex',
-                ...(model !== undefined ? { model } : {}),
-                ...(inputTokens !== undefined ? { inputTokens } : {}),
-                ...(outputTokens !== undefined ? { outputTokens } : {}),
-              });
-            },
-            providerName: PROVIDER_NAME,
-            providerSlug: 'codex',
-            eventBus: deps.eventBus,
-            ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
-          });
-        },
+        attempt: (attemptSession) => runCodexAttempt(attemptSession, { outputFile, spawnFn, command, deps, readFile }),
         cleanup: () => unlink(outputFile),
       };
     },

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -9,6 +9,7 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
 import type { CodexProviderDeps } from '@src/integration/ai/providers/_engine/codex-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
@@ -344,6 +345,17 @@ const publishCodexStreamLineEvents = (eventBus: EventBus, obj: Record<string, un
   }
 };
 
+/** Best-effort debug log when the codex forensic body tempfile can't be read (audit-[09]). */
+const publishUnreadableBody = (eventBus: EventBus, err: unknown): void => {
+  eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'codex-provider: forensic body tempfile unreadable',
+    meta: { error: err instanceof Error ? err.message : String(err) },
+    at: IsoTimestamp.now(),
+  });
+};
+
 const safeJson = (v: unknown): string | undefined => {
   if (v === undefined || v === null) return undefined;
   try {
@@ -452,20 +464,17 @@ export const createCodexProvider = (deps: CodexProviderDeps): HeadlessAiProvider
             // Codex reports a quota throttle in the agent_message body, not always on stderr.
             // Feed the accumulated tail into the rate-limit haystack so it trips the backoff.
             getStdoutTail: () => (agentMessageTail.length > 0 ? agentMessageTail : undefined),
-            // Single-shot read of the codex output tempfile — no per-line in-process accumulation.
-            // On SIGTERM-recovery the tempfile may be partial or empty.
+            // Single-shot read of the codex output tempfile (may be partial/empty on SIGTERM
+            // recovery). audit-[09]: a missing/unreadable tempfile must NOT hard-error — `onSuccess`
+            // also runs on the recovery branch (non-zero exit + signals.json present), and
+            // signals.json is the authoritative gate. Best-effort, like claude/copilot's getBody.
             getBody: async () => {
               try {
                 return Result.ok(await readFile(outputFile));
               } catch (err) {
-                return Result.error(
-                  new InvalidStateError({
-                    entity: PROVIDER_NAME,
-                    currentState: 'output-capture',
-                    attemptedAction: 'read tempfile',
-                    message: `codex-provider: failed to read output tempfile: ${err instanceof Error ? err.message : String(err)}`,
-                  })
-                );
+                if (err instanceof AbortError) throw err;
+                publishUnreadableBody(deps.eventBus, err);
+                return Result.ok('');
               }
             },
             emitProviderTokenUsage: (sessionId_) => {

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -169,6 +169,173 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
   return Result.ok(args);
 };
 
+/** Handle returned by {@link createBoundedTail} — aliased so helpers below don't need a type import. */
+type BoundedTailHandle = ReturnType<typeof createBoundedTail>;
+
+/**
+ * Mutable per-attempt state captured while parsing one Copilot stdout stream. A single plain
+ * object (rather than three separate closured `let`s) so the `onLine` helpers below can read and
+ * mutate it by reference without each capturing its own slice of the attempt closure.
+ */
+interface CopilotAttemptState {
+  sessionId: string | undefined;
+  model: string | undefined;
+  usage: CopilotUsage;
+}
+
+const createCopilotAttemptState = (): CopilotAttemptState => ({
+  sessionId: undefined,
+  model: undefined,
+  usage: {},
+});
+
+/**
+ * Appends one line to both bounded tails in stream order — the forensic tail backs body.txt and
+ * the rate-limit tail is the classifier's scan haystack. Both drop their oldest bytes once full,
+ * so per-spawn stdout footprint is pinned regardless of child verbosity.
+ */
+const createLineRecorder =
+  (forensicTail: BoundedTailHandle, rateLimitTail: BoundedTailHandle) =>
+  (text: string): void => {
+    forensicTail.append(`${text}\n`);
+    rateLimitTail.append(`${text}\n`);
+  };
+
+/** Captures session id / model / usage off one JSON stream line into the shared attempt state. */
+const applyLineMeta = (state: CopilotAttemptState, line: CopilotStreamLine): void => {
+  if (line.sessionId !== undefined && state.sessionId === undefined) {
+    state.sessionId = line.sessionId;
+  }
+  if (line.model !== undefined && state.model === undefined) {
+    state.model = line.model;
+  }
+  // Last-write-wins on usage. Copilot occasionally emits multiple meta lines through a
+  // spawn; whichever lands last is the most current cumulative count.
+  if (line.usage !== undefined) {
+    state.usage = line.usage;
+  }
+};
+
+/** Per-line assistant debug event, driven off the parser's extracted `bodyText`. */
+const publishAssistantLine = (deps: CopilotProviderDeps, bodyText: string): void => {
+  const text = truncateField(bodyText);
+  if (text === undefined) return;
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'copilot-provider: assistant',
+    meta: { text },
+    at: IsoTimestamp.now(),
+  });
+};
+
+/** Per-line raw-stdout debug event, published for every recognised JSON stream line. */
+const publishStdoutJsonLine = (deps: CopilotProviderDeps, line: CopilotStreamLine): void => {
+  // Truncate the raw line like every other stream-originated debug field (see truncateField):
+  // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
+  // each capped log-bus entry. The full raw stream is still captured in bodyFile when set.
+  const rawLine = truncateField(line.raw);
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'debug',
+    message: 'copilot-provider: stdout json line',
+    ...(rawLine !== undefined ? { meta: { raw: rawLine } } : {}),
+    at: IsoTimestamp.now(),
+  });
+};
+
+/** Handles one JSON stream line: meta capture, body/raw recording, then the stdout debug event. */
+const handleJsonLine = (
+  deps: CopilotProviderDeps,
+  state: CopilotAttemptState,
+  recordLine: (text: string) => void,
+  line: CopilotStreamLine
+): void => {
+  applyLineMeta(state, line);
+  if (line.bodyText !== undefined && line.bodyText.length > 0) {
+    recordLine(line.bodyText);
+    publishAssistantLine(deps, line.bodyText);
+  } else if (line.sessionId === undefined && line.model === undefined && line.usage === undefined) {
+    // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
+    // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
+    // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
+    recordLine(line.raw);
+  }
+  publishStdoutJsonLine(deps, line);
+};
+
+/** Builds the parser's per-line callback: non-JSON lines record raw, JSON lines fan out via {@link handleJsonLine}. */
+const createOnLine =
+  (deps: CopilotProviderDeps, state: CopilotAttemptState, recordLine: (text: string) => void) =>
+  (line: CopilotStreamLine): void =>
+    // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
+    line.json === undefined ? recordLine(line.raw) : handleJsonLine(deps, state, recordLine, line);
+
+/**
+ * Builds the per-attempt function passed to `runProviderAttempt` via `createGenerateContext`.
+ * Wires the argv build, stream parser, bounded tails, attempt state, and the resulting
+ * `onLine` callback, then delegates the actual spawn/exit/retry-classification handling to
+ * the shared `runProviderAttempt` scaffold.
+ */
+const createCopilotAttempt = (deps: CopilotProviderDeps, spawnFn: ProviderSpawn, command: string) => {
+  return async (attemptSession: AiSession) => {
+    const built = buildCopilotArgs(attemptSession);
+    if (!built.ok) return { kind: 'error' as const, error: built.error };
+
+    const parser = createCopilotStreamParser();
+    // Two bounded tails fed in stream order — the forensic tail backs body.txt and the
+    // rate-limit tail is the classifier's scan haystack. Both drop their oldest bytes once
+    // full, so per-spawn stdout footprint is pinned regardless of child verbosity.
+    const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
+    const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
+    const recordLine = createLineRecorder(forensicTail, rateLimitTail);
+    const state = createCopilotAttemptState();
+    const onLine = createOnLine(deps, state, recordLine);
+
+    return runProviderAttempt({
+      spawnFn,
+      command,
+      args: built.value,
+      session: attemptSession,
+      resolveOn: 'exit',
+      // Copilot reads the prompt from -p argv (no stdin payload); omitting `stdin` causes
+      // runProviderAttempt to close the child's stdin immediately.
+      rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+      onStdoutChunk: (chunk) => {
+        parser.feed(chunk, onLine);
+      },
+      // Flush any partial line remaining in the buffer — Copilot may terminate without a
+      // trailing newline. The parser drains inline so flush is a no-op in the normal case.
+      flush: () => {
+        parser.flush(onLine);
+      },
+      getSessionId: () => state.sessionId,
+      // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota
+      // throttle in its result-record text, not on stderr. rateLimitTail is already bounded
+      // to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
+      getStdoutTail: () => {
+        const tail = rateLimitTail.value();
+        return tail.length > 0 ? tail : undefined;
+      },
+      // forensicTail is the accumulated body buffer; operators inspect it when a proposal
+      // comes back empty to decide whether the prompt, the AI, or the validator is at fault.
+      getBody: () => Promise.resolve(Result.ok(forensicTail.value())),
+      emitProviderTokenUsage: (sid) => {
+        emitTokenUsage(deps.eventBus, attemptSession, sid, {
+          provider: 'github-copilot',
+          ...(state.model !== undefined ? { model: state.model } : {}),
+          ...(state.usage.inputTokens !== undefined ? { inputTokens: state.usage.inputTokens } : {}),
+          ...(state.usage.outputTokens !== undefined ? { outputTokens: state.usage.outputTokens } : {}),
+        });
+      },
+      providerName: PROVIDER_NAME,
+      providerSlug: 'copilot',
+      eventBus: deps.eventBus,
+      ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
+    });
+  };
+};
+
 export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProvider => {
   const spawnFn: ProviderSpawn = deps.spawn ?? defaultProviderSpawn;
   const command = deps.command ?? 'copilot';
@@ -180,116 +347,6 @@ export const createCopilotProvider = (deps: CopilotProviderDeps): HeadlessAiProv
     rateLimitRetries: deps.rateLimitRetries,
     eventBus: deps.eventBus,
     ...(deps.backoffSchedule !== undefined ? { backoffSchedule: deps.backoffSchedule } : {}),
-    createGenerateContext: () => ({
-      attempt: async (attemptSession) => {
-        const built = buildCopilotArgs(attemptSession);
-        if (!built.ok) return { kind: 'error', error: built.error };
-
-        const parser = createCopilotStreamParser();
-        // Two bounded tails fed in stream order — the forensic tail backs body.txt and the
-        // rate-limit tail is the classifier's scan haystack. Both drop their oldest bytes once
-        // full, so per-spawn stdout footprint is pinned regardless of child verbosity.
-        const forensicTail = createBoundedTail(FORENSIC_BODY_TAIL_CAP);
-        const rateLimitTail = createBoundedTail(RATE_LIMIT_SCAN_TAIL_CAP);
-        const recordLine = (text: string): void => {
-          forensicTail.append(`${text}\n`);
-          rateLimitTail.append(`${text}\n`);
-        };
-        let sessionId: string | undefined;
-        let model: string | undefined;
-        let usage: CopilotUsage = {};
-
-        const onLine = (line: CopilotStreamLine): void => {
-          if (line.json !== undefined) {
-            if (line.sessionId !== undefined && sessionId === undefined) {
-              sessionId = line.sessionId;
-            }
-            if (line.model !== undefined && model === undefined) {
-              model = line.model;
-            }
-            // Last-write-wins on usage. Copilot occasionally emits multiple meta lines through a
-            // spawn; whichever lands last is the most current cumulative count.
-            if (line.usage !== undefined) {
-              usage = line.usage;
-            }
-            if (line.bodyText !== undefined && line.bodyText.length > 0) {
-              recordLine(line.bodyText);
-              // Per-line assistant debug event.
-              const text = truncateField(line.bodyText);
-              if (text !== undefined) {
-                deps.eventBus.publish({
-                  type: 'log',
-                  level: 'debug',
-                  message: 'copilot-provider: assistant',
-                  meta: { text },
-                  at: IsoTimestamp.now(),
-                });
-              }
-            } else if (line.sessionId === undefined && line.model === undefined && line.usage === undefined) {
-              // Unrecognised JSON event — keep the raw form so `body.txt` (when bodyFile is set)
-              // captures Copilot's actual stream shapes. NEVER feed this to the signal parser:
-              // Copilot echoes the prompt as `user.message`, which carries literal harness tags.
-              recordLine(line.raw);
-            }
-            // Truncate the raw line like every other stream-originated debug field (see truncateField):
-            // at the debug floor this fires per stdout line, so an untruncated raw envelope would bloat
-            // each capped log-bus entry. The full raw stream is still captured in bodyFile when set.
-            const rawLine = truncateField(line.raw);
-            deps.eventBus.publish({
-              type: 'log',
-              level: 'debug',
-              message: 'copilot-provider: stdout json line',
-              ...(rawLine !== undefined ? { meta: { raw: rawLine } } : {}),
-              at: IsoTimestamp.now(),
-            });
-            return;
-          }
-          // Non-JSON lines (banner/status); preserve in body.txt but keep out of signal parsing.
-          recordLine(line.raw);
-        };
-
-        return runProviderAttempt({
-          spawnFn,
-          command,
-          args: built.value,
-          session: attemptSession,
-          resolveOn: 'exit',
-          // Copilot reads the prompt from -p argv (no stdin payload); omitting `stdin` causes
-          // runProviderAttempt to close the child's stdin immediately.
-          rateLimitRe: DEFAULT_RATE_LIMIT_RE,
-          onStdoutChunk: (chunk) => {
-            parser.feed(chunk, onLine);
-          },
-          // Flush any partial line remaining in the buffer — Copilot may terminate without a
-          // trailing newline. The parser drains inline so flush is a no-op in the normal case.
-          flush: () => {
-            parser.flush(onLine);
-          },
-          getSessionId: () => sessionId,
-          // Feed the stream body tail into the rate-limit haystack — Copilot reports a quota
-          // throttle in its result-record text, not on stderr. rateLimitTail is already bounded
-          // to RATE_LIMIT_SCAN_TAIL_CAP, so a long session can't build a multi-MB scan string.
-          getStdoutTail: () => {
-            const tail = rateLimitTail.value();
-            return tail.length > 0 ? tail : undefined;
-          },
-          // forensicTail is the accumulated body buffer; operators inspect it when a proposal
-          // comes back empty to decide whether the prompt, the AI, or the validator is at fault.
-          getBody: () => Promise.resolve(Result.ok(forensicTail.value())),
-          emitProviderTokenUsage: (sid) => {
-            emitTokenUsage(deps.eventBus, attemptSession, sid, {
-              provider: 'github-copilot',
-              ...(model !== undefined ? { model } : {}),
-              ...(usage.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
-              ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
-            });
-          },
-          providerName: PROVIDER_NAME,
-          providerSlug: 'copilot',
-          eventBus: deps.eventBus,
-          ...(deps.idleMs !== undefined ? { idleMs: deps.idleMs } : {}),
-        });
-      },
-    }),
+    createGenerateContext: () => ({ attempt: createCopilotAttempt(deps, spawnFn, command) }),
   });
 };

--- a/src/integration/ai/readiness/claude/probe.ts
+++ b/src/integration/ai/readiness/claude/probe.ts
@@ -4,7 +4,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { ProbeError } from '@src/domain/value/error/probe-error.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
-import type { ArtifactRef, HookRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
+import type { ArtifactRef, HookRef, NamedArtifactRef } from '@src/integration/ai/readiness/_engine/artifact-ref.ts';
 import {
   probeFile,
   probeNamedDirCollection,
@@ -35,49 +35,84 @@ export const claudeProbe: ReadinessProbe<ClaudeArtifacts> = {
   async evaluate(repository: Repository, now: IsoTimestamp): Promise<Result<ReadinessState, ProbeError>> {
     const root = repository.path;
 
-    const claudeMd = await probeFile(join(root, 'CLAUDE.md'));
-    if (!claudeMd.ok) return Result.error(claudeMd.error);
+    const coreFiles = await probeCoreFiles(root);
+    if (!coreFiles.ok) return Result.error(coreFiles.error);
 
-    const agentsMd = await probeFile(join(root, 'AGENTS.md'));
-    if (!agentsMd.ok) return Result.error(agentsMd.error);
+    const namedArtifacts = await probeNamedArtifacts(root);
+    if (!namedArtifacts.ok) return Result.error(namedArtifacts.error);
 
-    const settings = await probeFile(join(root, '.claude/settings.json'));
-    if (!settings.ok) return Result.error(settings.error);
-
-    const settingsLocal = await probeFile(join(root, '.claude/settings.local.json'));
-    if (!settingsLocal.ok) return Result.error(settingsLocal.error);
-
-    const mcpConfig = await probeFile(join(root, '.mcp.json'));
-    if (!mcpConfig.ok) return Result.error(mcpConfig.error);
-
-    const skills = await probeNamedDirCollection(join(root, '.claude/skills'), 'SKILL.md');
-    if (!skills.ok) return Result.error(skills.error);
-
-    const commands = await probeNamedFileCollection(join(root, '.claude/commands'));
-    if (!commands.ok) return Result.error(commands.error);
-
-    const agents = await probeNamedFileCollection(join(root, '.claude/agents'));
-    if (!agents.ok) return Result.error(agents.error);
-
-    const hooks = await readHooks([settings.value, settingsLocal.value]);
+    const hooks = await readHooks([coreFiles.value.settings, coreFiles.value.settingsLocal]);
     if (!hooks.ok) return Result.error(hooks.error);
 
-    const artifacts: ClaudeArtifacts = {
-      tool: 'claude-code',
-      ...(claudeMd.value !== undefined ? { claudeMd: claudeMd.value } : {}),
-      ...(agentsMd.value !== undefined ? { agentsMd: agentsMd.value } : {}),
-      ...(settings.value !== undefined ? { settings: settings.value } : {}),
-      ...(settingsLocal.value !== undefined ? { settingsLocal: settingsLocal.value } : {}),
-      ...(mcpConfig.value !== undefined ? { mcpConfig: mcpConfig.value } : {}),
-      skills: skills.value,
-      commands: commands.value,
-      agents: agents.value,
-      hooks: hooks.value,
-    };
+    const artifacts = buildClaudeArtifacts(coreFiles.value, namedArtifacts.value, hooks.value);
 
     return Result.ok(hasAnyClaudeArtifact(artifacts) ? presentState(now, artifacts) : absentState(now));
   },
 };
+
+const CORE_FILE_SPECS = [
+  ['claudeMd', 'CLAUDE.md'],
+  ['agentsMd', 'AGENTS.md'],
+  ['settings', '.claude/settings.json'],
+  ['settingsLocal', '.claude/settings.local.json'],
+  ['mcpConfig', '.mcp.json'],
+] as const;
+
+type CoreFiles = Record<(typeof CORE_FILE_SPECS)[number][0], ArtifactRef | undefined>;
+
+/**
+ * Probes the flat, single-file artifacts (root memory files + project config) that live
+ * directly under `root`. Short-circuits on the first read error.
+ */
+const probeCoreFiles = async (root: string): Promise<Result<CoreFiles, ProbeError>> => {
+  const files = {} as CoreFiles;
+  for (const [key, relPath] of CORE_FILE_SPECS) {
+    const probed = await probeFile(join(root, relPath));
+    if (!probed.ok) return Result.error(probed.error);
+    files[key] = probed.value;
+  }
+  return Result.ok(files);
+};
+
+interface NamedArtifacts {
+  readonly skills: readonly NamedArtifactRef[];
+  readonly commands: readonly NamedArtifactRef[];
+  readonly agents: readonly NamedArtifactRef[];
+}
+
+/**
+ * Probes the named-collection artifacts (skills, commands, subagents) that live under
+ * `.claude/<collection>/`.
+ */
+const probeNamedArtifacts = async (root: string): Promise<Result<NamedArtifacts, ProbeError>> => {
+  const skills = await probeNamedDirCollection(join(root, '.claude/skills'), 'SKILL.md');
+  if (!skills.ok) return Result.error(skills.error);
+
+  const commands = await probeNamedFileCollection(join(root, '.claude/commands'));
+  if (!commands.ok) return Result.error(commands.error);
+
+  const agents = await probeNamedFileCollection(join(root, '.claude/agents'));
+  if (!agents.ok) return Result.error(agents.error);
+
+  return Result.ok({ skills: skills.value, commands: commands.value, agents: agents.value });
+};
+
+const buildClaudeArtifacts = (
+  coreFiles: CoreFiles,
+  namedArtifacts: NamedArtifacts,
+  hooks: readonly HookRef[]
+): ClaudeArtifacts => ({
+  tool: 'claude-code',
+  ...(coreFiles.claudeMd !== undefined ? { claudeMd: coreFiles.claudeMd } : {}),
+  ...(coreFiles.agentsMd !== undefined ? { agentsMd: coreFiles.agentsMd } : {}),
+  ...(coreFiles.settings !== undefined ? { settings: coreFiles.settings } : {}),
+  ...(coreFiles.settingsLocal !== undefined ? { settingsLocal: coreFiles.settingsLocal } : {}),
+  ...(coreFiles.mcpConfig !== undefined ? { mcpConfig: coreFiles.mcpConfig } : {}),
+  skills: namedArtifacts.skills,
+  commands: namedArtifacts.commands,
+  agents: namedArtifacts.agents,
+  hooks,
+});
 
 const readHooks = async (
   settingsRefs: ReadonlyArray<ArtifactRef | undefined>
@@ -111,18 +146,33 @@ const extractHooks = (settings: unknown, sink: HookRef[]): void => {
   const hooks = (settings as Record<string, unknown>).hooks;
   if (typeof hooks !== 'object' || hooks === null) return;
   for (const [event, matchers] of Object.entries(hooks as Record<string, unknown>)) {
-    if (!Array.isArray(matchers)) continue;
-    for (const matcher of matchers) {
-      if (typeof matcher !== 'object' || matcher === null) continue;
-      const inner = (matcher as Record<string, unknown>).hooks;
-      if (!Array.isArray(inner)) continue;
-      for (const entry of inner) {
-        if (typeof entry !== 'object' || entry === null) continue;
-        const command = (entry as Record<string, unknown>).command;
-        if (typeof command === 'string' && command.startsWith('/')) {
-          sink.push({ event, script: command as AbsolutePath });
-        }
-      }
-    }
+    extractHookEvent(matchers, event, sink);
+  }
+};
+
+/** Second nesting level: `<Event>`'s matcher array — each matcher carries its own `hooks` list. */
+const extractHookEvent = (matchers: unknown, event: string, sink: HookRef[]): void => {
+  if (!Array.isArray(matchers)) return;
+  for (const matcher of matchers) {
+    extractHookMatcher(matcher, event, sink);
+  }
+};
+
+/** Third nesting level: a single matcher's inner `hooks` list of `{ type, command }` entries. */
+const extractHookMatcher = (matcher: unknown, event: string, sink: HookRef[]): void => {
+  if (typeof matcher !== 'object' || matcher === null) return;
+  const inner = (matcher as Record<string, unknown>).hooks;
+  if (!Array.isArray(inner)) return;
+  for (const entry of inner) {
+    pushHookCommand(entry, event, sink);
+  }
+};
+
+/** Leaf: pushes `entry.command` onto `sink` iff it's an absolute-path string command. */
+const pushHookCommand = (entry: unknown, event: string, sink: HookRef[]): void => {
+  if (typeof entry !== 'object' || entry === null) return;
+  const command = (entry as Record<string, unknown>).command;
+  if (typeof command === 'string' && command.startsWith('/')) {
+    sink.push({ event, script: command as AbsolutePath });
   }
 };

--- a/src/integration/io/git-runner.ts
+++ b/src/integration/io/git-runner.ts
@@ -1,3 +1,4 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
@@ -65,138 +66,191 @@ export const createGitRunner = (deps: GitRunnerDeps = {}): GitRunner => {
     args: readonly string[],
     opts: GitRunOptions = {}
   ): Promise<Result<GitRunResult, StorageError>> =>
-    new Promise((resolve) => {
-      const timeoutMs = opts.timeoutMs ?? defaultTimeoutMs;
-      let child;
-      try {
-        child = spawn('git', args, {
-          stdio: ['pipe', 'pipe', 'pipe'],
-          cwd: String(cwd),
-        });
-      } catch (cause) {
-        resolve(
-          Result.error(
-            new StorageError({
-              subCode: 'io',
-              message: `failed to spawn git: ${stringifyError(cause)}`,
-              cause,
-            })
-          )
-        );
-        return;
-      }
-
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
-      let stdoutBytes = 0;
-      let stderrBytes = 0;
-      let timedOut = false;
-      // Cap-truncation is tracked separately from `timedOut`: the SIGTERM we issue for the cap
-      // also fires the child's `close`, and that close must surface ok+marker, NOT the timeout
-      // StorageError. A shared flag would let cap-kills masquerade as timeouts.
-      let truncated = false;
-      let settled = false;
-
-      const killChild = (): void => {
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // already dead
-        }
-      };
-
-      // Drop further chunks once the cap is hit and kill the child so git stops producing more
-      // (mirrors shell-script-runner). The kill drives `close`, which the handler below reports
-      // as cap-truncation rather than a timeout.
-      const appendStdout = (chunk: Buffer): void => {
-        if (truncated) return;
-        stdoutBytes += chunk.length;
-        if (stdoutBytes > maxOutputBytes) {
-          truncated = true;
-          killChild();
-          return;
-        }
-        stdoutChunks.push(chunk);
-      };
-      // stderr is tiny in practice; cap it too for consistency. No marker is emitted for stderr.
-      const appendStderr = (chunk: Buffer): void => {
-        if (stderrBytes > maxOutputBytes) return;
-        stderrBytes += chunk.length;
-        if (stderrBytes > maxOutputBytes) return;
-        stderrChunks.push(chunk);
-      };
-
-      child.stdout.on('data', (c: Buffer) => appendStdout(c));
-      child.stderr.on('data', (c: Buffer) => appendStderr(c));
-
-      const timer = setTimeout(() => {
-        timedOut = true;
-        killChild();
-      }, timeoutMs);
-
-      const finish = (result: Result<GitRunResult, StorageError>): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(result);
-      };
-
-      child.on('error', (err) => {
-        finish(
-          Result.error(
-            new StorageError({
-              subCode: 'io',
-              message: `git spawn error: ${err.message}`,
-              cause: err,
-            })
-          )
-        );
-      });
-
-      child.on('close', (code) => {
-        if (timedOut) {
-          finish(
-            Result.error(
-              new StorageError({
-                subCode: 'io',
-                message: `git timed out after ${String(timeoutMs)}ms: git ${args.join(' ')}`,
-              })
-            )
-          );
-          return;
-        }
-        // Materializing stdout can throw ERR_STRING_TOO_LONG when output exceeds V8's max string
-        // length (~512MiB — e.g. a `git diff HEAD` over enormous generated artifacts). This close
-        // handler runs outside any caller try/catch, so an uncaught throw here would kill the
-        // whole process instead of surfacing through the Result envelope. Catch and map to
-        // StorageError — consumers like the work-product fingerprint degrade gracefully.
-        try {
-          const base = Buffer.concat(stdoutChunks).toString('utf8');
-          const stdout = truncated
-            ? `${base}\n[git output exceeded ${String(maxOutputBytes)} byte cap — truncated]`
-            : base;
-          finish(
-            Result.ok({
-              stdout,
-              stderr: Buffer.concat(stderrChunks).toString('utf8'),
-              exitCode: code ?? -1,
-            })
-          );
-        } catch (cause) {
-          finish(
-            Result.error(
-              new StorageError({
-                subCode: 'io',
-                message: `git output too large to materialize: git ${args.join(' ')} — ${stringifyError(cause)}`,
-              })
-            )
-          );
-        }
-      });
-    });
+    runGitOnce(spawn, cwd, args, opts.timeoutMs ?? defaultTimeoutMs, maxOutputBytes);
 
   return { run };
 };
+
+/** Spawns the `git` child, mapping a synchronous spawn throw to a `StorageError`. */
+const spawnGitChild = (
+  spawn: Spawn,
+  cwd: AbsolutePath,
+  args: readonly string[]
+): Result<ChildProcessWithoutNullStreams, StorageError> => {
+  try {
+    return Result.ok(
+      spawn('git', args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: String(cwd),
+      })
+    );
+  } catch (cause) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `failed to spawn git: ${stringifyError(cause)}`,
+        cause,
+      })
+    );
+  }
+};
+
+interface OutputCollector {
+  /** Buffers a stdout chunk. Returns `true` the instant the cap trips, so the caller — which
+   * owns the child process — can kill it; further chunks are dropped once truncated. */
+  readonly appendStdout: (chunk: Buffer) => boolean;
+  readonly appendStderr: (chunk: Buffer) => void;
+  readonly isTruncated: () => boolean;
+  readonly stdoutText: () => string;
+  readonly stderrText: () => string;
+}
+
+/**
+ * Buffers stdout/stderr up to `maxOutputBytes`. Mirrors shell-script-runner's byte-cap
+ * bookkeeping so a huge AI-generated diff can't OOM the heap.
+ */
+const createOutputCollector = (maxOutputBytes: number): OutputCollector => {
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let truncated = false;
+
+  const appendStdout = (chunk: Buffer): boolean => {
+    if (truncated) return false;
+    stdoutBytes += chunk.length;
+    if (stdoutBytes > maxOutputBytes) {
+      truncated = true;
+      return true;
+    }
+    stdoutChunks.push(chunk);
+    return false;
+  };
+
+  // stderr is tiny in practice; cap it too for consistency. No marker is emitted for stderr.
+  const appendStderr = (chunk: Buffer): void => {
+    if (stderrBytes > maxOutputBytes) return;
+    stderrBytes += chunk.length;
+    if (stderrBytes > maxOutputBytes) return;
+    stderrChunks.push(chunk);
+  };
+
+  return {
+    appendStdout,
+    appendStderr,
+    isTruncated: () => truncated,
+    stdoutText: () => Buffer.concat(stdoutChunks).toString('utf8'),
+    stderrText: () => Buffer.concat(stderrChunks).toString('utf8'),
+  };
+};
+
+/**
+ * Translates a `close` event into the final `Result`. Timeout takes precedence (cap-kills are
+ * tracked separately via `collector.isTruncated()` so they never masquerade as a timeout).
+ * Materializing stdout can throw `ERR_STRING_TOO_LONG` when output exceeds V8's max string
+ * length (~512MiB — e.g. a `git diff HEAD` over enormous generated artifacts); this runs outside
+ * any caller try/catch, so the throw is caught here and mapped to a `StorageError` instead of
+ * killing the process.
+ */
+const buildCloseResult = (
+  collector: OutputCollector,
+  timedOut: boolean,
+  code: number | null,
+  timeoutMs: number,
+  args: readonly string[],
+  maxOutputBytes: number
+): Result<GitRunResult, StorageError> => {
+  if (timedOut) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git timed out after ${String(timeoutMs)}ms: git ${args.join(' ')}`,
+      })
+    );
+  }
+  try {
+    const base = collector.stdoutText();
+    const stdout = collector.isTruncated()
+      ? `${base}\n[git output exceeded ${String(maxOutputBytes)} byte cap — truncated]`
+      : base;
+    return Result.ok({
+      stdout,
+      stderr: collector.stderrText(),
+      exitCode: code ?? -1,
+    });
+  } catch (cause) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `git output too large to materialize: git ${args.join(' ')} — ${stringifyError(cause)}`,
+      })
+    );
+  }
+};
+
+const runGitOnce = (
+  spawn: Spawn,
+  cwd: AbsolutePath,
+  args: readonly string[],
+  timeoutMs: number,
+  maxOutputBytes: number
+): Promise<Result<GitRunResult, StorageError>> =>
+  new Promise((resolve) => {
+    const spawnResult = spawnGitChild(spawn, cwd, args);
+    if (!spawnResult.ok) {
+      resolve(Result.error(spawnResult.error));
+      return;
+    }
+    const child = spawnResult.value;
+
+    const collector = createOutputCollector(maxOutputBytes);
+    let timedOut = false;
+    let settled = false;
+
+    const killChild = (): void => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead
+      }
+    };
+
+    // Drop further chunks once the cap is hit and kill the child so git stops producing more
+    // (mirrors shell-script-runner). The kill drives `close`, which the handler below reports
+    // as cap-truncation rather than a timeout.
+    child.stdout.on('data', (c: Buffer) => {
+      if (collector.appendStdout(c)) killChild();
+    });
+    child.stderr.on('data', (c: Buffer) => collector.appendStderr(c));
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killChild();
+    }, timeoutMs);
+
+    const finish = (result: Result<GitRunResult, StorageError>): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    child.on('error', (err) => {
+      finish(
+        Result.error(
+          new StorageError({
+            subCode: 'io',
+            message: `git spawn error: ${err.message}`,
+            cause: err,
+          })
+        )
+      );
+    });
+
+    child.on('close', (code) => {
+      finish(buildCloseResult(collector, timedOut, code, timeoutMs, args, maxOutputBytes));
+    });
+  });
 
 const defaultSpawn: Spawn = (command, args, options) =>
   crossPlatformSpawn(command, args, { ...options, stdio: [...options.stdio] }) as ReturnType<Spawn>;

--- a/src/integration/io/shell-script-runner.ts
+++ b/src/integration/io/shell-script-runner.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn } from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
@@ -89,11 +90,281 @@ export interface ShellScriptRunnerDeps {
   readonly abortKillGraceMs?: number;
 }
 
+const abortResult = (): Result<ShellScriptResult, StorageError | AbortError> =>
+  Result.error(new AbortError({ elementName: 'shell-script-runner', reason: 'shell script aborted' }));
+
+/**
+ * Kill the child's process group (or the child itself as a fallback). Detached children get
+ * their own process group (`detached: process.platform !== 'win32'` at spawn time) so a negative
+ * pid signal reaches the whole tree a shell script may have spawned, not just the shell.
+ */
+const killProcessTree = (child: ChildProcessWithoutNullStreams, sig: NodeJS.Signals): void => {
+  if (process.platform !== 'win32' && typeof child.pid === 'number') {
+    try {
+      process.kill(-child.pid, sig);
+      return;
+    } catch {
+      // group already gone — fall through to per-process kill.
+    }
+  }
+  try {
+    child.kill(sig);
+  } catch {
+    // already dead.
+  }
+};
+
+/**
+ * Non-interactive defaults for the spawned setup/verify child. These live on the CHILD env
+ * only — ralphctl's own process env is untouched, so they never alter how the harness itself
+ * detects CI / colour.
+ *
+ *   CI=true   — setup/verify scripts run headless (no TTY). pnpm 11 hardened its
+ *     `node_modules` purge to ABORT without a TTY instead of re-creating it silently
+ *     (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, pnpm/pnpm#9966 / #11562). On
+ *     pnpm 11 EVERY `confirm-modules-purge=false` form is ignored at the abort site —
+ *     verified against 11.1.3: the `npm_config_*` env, the `PNPM_CONFIG_*` env, and a
+ *     local `.npmrc` all still abort; only `CI=true` (env) or
+ *     `--config.confirm-modules-purge=false` (a CLI flag) suppress it. We run the
+ *     user's script as an opaque shell string and cannot inject a flag into their
+ *     `pnpm` invocation, so `CI=true` is the one lever available. It is also the honest
+ *     signal — this IS an automated, non-interactive context. Set on BOTH setup and
+ *     verify (both flow through this runner), so the two phases share one env and never
+ *     drift on baseline. Caveat: JVM tests gated on
+ *     `@DisabledIfEnvironmentVariable("CI")` skip — by design for automation, and
+ *     symmetric across setup/verify. (This deliberately reverses the earlier
+ *     "do NOT reach for CI=true" policy, which assumed a narrow pnpm flag would work —
+ *     it does not on pnpm 11.)
+ *
+ *   PNPM_CONFIG_FROZEN_LOCKFILE=false   — `CI=true` also flips pnpm's `frozen-lockfile`
+ *     default to true, which would fail a bare `pnpm install` on a drifted lockfile
+ *     (`ERR_PNPM_OUTDATED_LOCKFILE`) — trading one abort for another. The pnpm-native
+ *     `PNPM_CONFIG_` prefix IS honoured here (unlike the broken `npm_config_` form),
+ *     so this restores the pre-CI install semantics: non-frozen, exactly as before.
+ *
+ *   NO_COLOR=1   — the cross-tool convention (https://no-color.org). Persisted
+ *     setup/verify logs are plain text; without this they fill with `^[[1m…` escape
+ *     sequences that render as garbage in editors. Honoured by Node / Python / Rust /
+ *     Go / Ruby and modern CLIs; unknown to JVM tools (Maven / Gradle / sbt) — those
+ *     are handled at script-authoring time via `mvn -B`, `gradle --console=plain`.
+ *
+ * Defaults sit BEFORE `...process.env` so a user can override any of them (e.g. export
+ * `CI=` to opt out, `NO_COLOR=` / `FORCE_COLOR=1` for colour); `opts.env` wins last.
+ */
+const buildChildEnv = (overrideEnv: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv => ({
+  CI: 'true',
+  PNPM_CONFIG_FROZEN_LOCKFILE: 'false',
+  NO_COLOR: '1',
+  ...process.env,
+  ...overrideEnv,
+});
+
+type SpawnAttempt =
+  | { readonly ok: true; readonly child: ChildProcessWithoutNullStreams }
+  | { readonly ok: false; readonly error: StorageError };
+
+const trySpawnChild = (spawn: Spawn, cwd: AbsolutePath, script: string, env: NodeJS.ProcessEnv): SpawnAttempt => {
+  try {
+    const child = spawn(script, [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: String(cwd),
+      shell: true,
+      detached: process.platform !== 'win32',
+      env,
+    });
+    return { ok: true, child };
+  } catch (cause) {
+    return {
+      ok: false,
+      error: new StorageError({
+        subCode: 'io',
+        message: `failed to spawn shell script: ${stringifyError(cause)}`,
+        cause,
+      }),
+    };
+  }
+};
+
+interface OutputSink {
+  append(chunk: Buffer): void;
+  isCapExceeded(): boolean;
+  toBufferString(): string;
+}
+
+/**
+ * Combined stdout+stderr buffer with the {@link MAX_OUTPUT_BYTES} hard cap. Once the cap is
+ * exceeded, further chunks are dropped and `onCapExceeded` fires once (to trigger the kill) —
+ * subsequent chunks are silently ignored rather than re-triggering the kill.
+ */
+const createOutputSink = (onCapExceeded: () => void): OutputSink => {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let capExceeded = false;
+  return {
+    append(chunk) {
+      if (capExceeded) return;
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_OUTPUT_BYTES) {
+        capExceeded = true;
+        onCapExceeded();
+        return;
+      }
+      chunks.push(chunk);
+    },
+    isCapExceeded: () => capExceeded,
+    toBufferString: () => Buffer.concat(chunks).toString('utf8').trim(),
+  };
+};
+
+interface RunChildProcessDeps {
+  readonly spawn: Spawn;
+  readonly defaultTimeoutMs: number;
+  readonly now: () => number;
+  readonly abortKillGraceMs: number;
+}
+
+interface AbortLadder {
+  isAborted(): boolean;
+  teardown(): void;
+}
+
+/**
+ * Cancellation: when the chain's signal fires mid-run, kill the child tree (SIGTERM, same
+ * ladder as the timeout / cap kills) and remember we aborted so `finish()` resolves an
+ * `AbortError` rather than a `passed: false` gate failure. `{ once: true }` so a settle that
+ * races the abort doesn't leak the listener; `teardown()` also removes it explicitly on settle.
+ *
+ * SIGTERM → SIGKILL escalation: a setup/verify script that traps SIGTERM would otherwise
+ * outlive the abort and strand the run. After `abortKillGraceMs` we send a hard SIGKILL;
+ * `teardown()` clears this timer so a child that exits cleanly within the window never gets a
+ * stray kill. Mirrors the idle-watchdog's grace ladder.
+ */
+const wireAbortLadder = (
+  child: ChildProcessWithoutNullStreams,
+  signal: AbortSignal | undefined,
+  abortKillGraceMs: number,
+  isSettled: () => boolean
+): AbortLadder => {
+  let aborted = false;
+  let killGraceTimer: NodeJS.Timeout | null = null;
+  const onAbort = (): void => {
+    if (isSettled()) return;
+    aborted = true;
+    killProcessTree(child, 'SIGTERM');
+    killGraceTimer = setTimeout(() => {
+      killProcessTree(child, 'SIGKILL');
+    }, abortKillGraceMs);
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
+  return {
+    isAborted: () => aborted,
+    teardown: () => {
+      if (killGraceTimer !== null) {
+        clearTimeout(killGraceTimer);
+        killGraceTimer = null;
+      }
+      signal?.removeEventListener('abort', onAbort);
+    },
+  };
+};
+
+/**
+ * Spawns the child and wires abort / timeout / output-cap / close handling through to a single
+ * `finish()` settle point. Pulled out of the `run()` Promise executor as a named function (rather
+ * than the executor callback itself) so nesting depth stops accruing to `run`.
+ */
+const runChildProcess = (
+  cwd: AbsolutePath,
+  script: string,
+  opts: ShellRunOptions,
+  deps: RunChildProcessDeps,
+  resolve: (result: Result<ShellScriptResult, StorageError | AbortError>) => void
+): void => {
+  const { spawn, defaultTimeoutMs, now, abortKillGraceMs } = deps;
+  const start = now();
+  const timeoutMs = opts.timeoutMs ?? defaultTimeoutMs;
+
+  // Already-aborted on entry: nothing spawned, resolve immediately as an abort so the caller
+  // doesn't pay the spawn + timeout cost for a cancel that already happened.
+  if (opts.signal?.aborted === true) {
+    resolve(abortResult());
+    return;
+  }
+
+  const spawnAttempt = trySpawnChild(spawn, cwd, script, buildChildEnv(opts.env));
+  if (!spawnAttempt.ok) {
+    resolve(Result.error(spawnAttempt.error));
+    return;
+  }
+  const { child } = spawnAttempt;
+
+  let timedOut = false;
+  let settled = false;
+  const abortLadder = wireAbortLadder(child, opts.signal, abortKillGraceMs, () => settled);
+
+  const sink = createOutputSink(() => killProcessTree(child, 'SIGTERM'));
+  child.stdout.on('data', (c: Buffer) => {
+    sink.append(c);
+  });
+  child.stderr.on('data', (c: Buffer) => {
+    sink.append(c);
+  });
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    killProcessTree(child, 'SIGTERM');
+  }, timeoutMs);
+
+  const finish = (exitCode: number | null, marker?: string): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    abortLadder.teardown();
+    // Abort wins over every other settle reason: a cancelled run is a user-initiated abort,
+    // not a clean gate failure. Surface the codebase's transparently-propagated AbortError so
+    // the chain tears down rather than treating the kill as a `passed: false` verify failure.
+    if (abortLadder.isAborted()) {
+      resolve(abortResult());
+      return;
+    }
+    const base = sink.toBufferString();
+    const output = marker !== undefined ? (base.length > 0 ? `${base}\n${marker}` : marker) : base;
+    resolve(
+      Result.ok({
+        passed: exitCode === 0 && !timedOut && !sink.isCapExceeded(),
+        exitCode,
+        output,
+        durationMs: now() - start,
+      })
+    );
+  };
+
+  child.on('error', (err) => {
+    // Spawn-time error after the spawn() call returned (e.g. shell binary disappeared).
+    // Surface as passed:false with a marker; callers treat this the same as exit 127.
+    finish(null, `[spawn error: ${err.message}]`);
+  });
+
+  child.on('close', (code) => {
+    if (timedOut) {
+      finish(code, `[timeout exceeded after ${String(timeoutMs)}ms]`);
+      return;
+    }
+    if (sink.isCapExceeded()) {
+      finish(code, `[output exceeded ${String(MAX_OUTPUT_BYTES)} byte cap — truncated]`);
+      return;
+    }
+    finish(code);
+  });
+};
+
 export const createShellScriptRunner = (deps: ShellScriptRunnerDeps = {}): ShellScriptRunner => {
-  const spawn = deps.spawn ?? defaultSpawn;
-  const defaultTimeoutMs = deps.defaultTimeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS;
-  const now = deps.now ?? Date.now;
-  const abortKillGraceMs = deps.abortKillGraceMs ?? ABORT_KILL_GRACE_MS;
+  const runDeps: RunChildProcessDeps = {
+    spawn: deps.spawn ?? defaultSpawn,
+    defaultTimeoutMs: deps.defaultTimeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS,
+    now: deps.now ?? Date.now,
+    abortKillGraceMs: deps.abortKillGraceMs ?? ABORT_KILL_GRACE_MS,
+  };
 
   const run = (
     cwd: AbsolutePath,
@@ -101,192 +372,7 @@ export const createShellScriptRunner = (deps: ShellScriptRunnerDeps = {}): Shell
     opts: ShellRunOptions = {}
   ): Promise<Result<ShellScriptResult, StorageError | AbortError>> =>
     new Promise((resolve) => {
-      const start = now();
-      const timeoutMs = opts.timeoutMs ?? defaultTimeoutMs;
-
-      // Already-aborted on entry: nothing spawned, resolve immediately as an abort so the
-      // caller doesn't pay the spawn + timeout cost for a cancel that already happened.
-      if (opts.signal?.aborted === true) {
-        resolve(Result.error(new AbortError({ elementName: 'shell-script-runner', reason: 'shell script aborted' })));
-        return;
-      }
-
-      let child;
-      try {
-        child = spawn(script, [], {
-          stdio: ['pipe', 'pipe', 'pipe'],
-          cwd: String(cwd),
-          shell: true,
-          detached: process.platform !== 'win32',
-          // Non-interactive defaults for the spawned setup/verify child. These live on the CHILD
-          // env only — ralphctl's own process env is untouched, so they never alter how the
-          // harness itself detects CI / colour.
-          //
-          //   CI=true   — setup/verify scripts run headless (no TTY). pnpm 11 hardened its
-          //     `node_modules` purge to ABORT without a TTY instead of re-creating it silently
-          //     (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, pnpm/pnpm#9966 / #11562). On
-          //     pnpm 11 EVERY `confirm-modules-purge=false` form is ignored at the abort site —
-          //     verified against 11.1.3: the `npm_config_*` env, the `PNPM_CONFIG_*` env, and a
-          //     local `.npmrc` all still abort; only `CI=true` (env) or
-          //     `--config.confirm-modules-purge=false` (a CLI flag) suppress it. We run the
-          //     user's script as an opaque shell string and cannot inject a flag into their
-          //     `pnpm` invocation, so `CI=true` is the one lever available. It is also the honest
-          //     signal — this IS an automated, non-interactive context. Set on BOTH setup and
-          //     verify (both flow through this runner), so the two phases share one env and never
-          //     drift on baseline. Caveat: JVM tests gated on
-          //     `@DisabledIfEnvironmentVariable("CI")` skip — by design for automation, and
-          //     symmetric across setup/verify. (This deliberately reverses the earlier
-          //     "do NOT reach for CI=true" policy, which assumed a narrow pnpm flag would work —
-          //     it does not on pnpm 11.)
-          //
-          //   PNPM_CONFIG_FROZEN_LOCKFILE=false   — `CI=true` also flips pnpm's `frozen-lockfile`
-          //     default to true, which would fail a bare `pnpm install` on a drifted lockfile
-          //     (`ERR_PNPM_OUTDATED_LOCKFILE`) — trading one abort for another. The pnpm-native
-          //     `PNPM_CONFIG_` prefix IS honoured here (unlike the broken `npm_config_` form),
-          //     so this restores the pre-CI install semantics: non-frozen, exactly as before.
-          //
-          //   NO_COLOR=1   — the cross-tool convention (https://no-color.org). Persisted
-          //     setup/verify logs are plain text; without this they fill with `^[[1m…` escape
-          //     sequences that render as garbage in editors. Honoured by Node / Python / Rust /
-          //     Go / Ruby and modern CLIs; unknown to JVM tools (Maven / Gradle / sbt) — those
-          //     are handled at script-authoring time via `mvn -B`, `gradle --console=plain`.
-          //
-          // Defaults sit BEFORE `...process.env` so a user can override any of them (e.g. export
-          // `CI=` to opt out, `NO_COLOR=` / `FORCE_COLOR=1` for colour); `opts.env` wins last.
-          env: {
-            CI: 'true',
-            PNPM_CONFIG_FROZEN_LOCKFILE: 'false',
-            NO_COLOR: '1',
-            ...process.env,
-            ...opts.env,
-          },
-        });
-      } catch (cause) {
-        resolve(
-          Result.error(
-            new StorageError({
-              subCode: 'io',
-              message: `failed to spawn shell script: ${stringifyError(cause)}`,
-              cause,
-            })
-          )
-        );
-        return;
-      }
-
-      const killTree = (sig: NodeJS.Signals): void => {
-        if (process.platform !== 'win32' && typeof child.pid === 'number') {
-          try {
-            process.kill(-child.pid, sig);
-            return;
-          } catch {
-            // group already gone — fall through to per-process kill.
-          }
-        }
-        try {
-          child.kill(sig);
-        } catch {
-          // already dead.
-        }
-      };
-
-      const chunks: Buffer[] = [];
-      let totalBytes = 0;
-      let timedOut = false;
-      let capExceeded = false;
-      let aborted = false;
-      let settled = false;
-      let killGraceTimer: NodeJS.Timeout | null = null;
-
-      // Cancellation: when the chain's signal fires mid-run, kill the child tree (SIGTERM, same
-      // ladder as the timeout / cap kills) and remember we aborted so the `close` handler resolves
-      // an `AbortError` rather than a `passed: false` gate failure. `{ once: true }` so a settle
-      // that races the abort doesn't leak the listener; we also remove it explicitly on settle.
-      //
-      // SIGTERM → SIGKILL escalation: a setup/verify script that traps SIGTERM would otherwise
-      // outlive the abort and strand the run. After `ABORT_KILL_GRACE_MS` we send a hard SIGKILL;
-      // `finish()` clears this timer so a child that exits cleanly within the window never gets a
-      // stray kill. Mirrors the idle-watchdog's grace ladder.
-      const onAbort = (): void => {
-        if (settled) return;
-        aborted = true;
-        killTree('SIGTERM');
-        killGraceTimer = setTimeout(() => {
-          killTree('SIGKILL');
-        }, abortKillGraceMs);
-      };
-      opts.signal?.addEventListener('abort', onAbort, { once: true });
-
-      const appendChunk = (chunk: Buffer): void => {
-        if (capExceeded) return;
-        totalBytes += chunk.length;
-        if (totalBytes > MAX_OUTPUT_BYTES) {
-          capExceeded = true;
-          killTree('SIGTERM');
-          return;
-        }
-        chunks.push(chunk);
-      };
-
-      child.stdout.on('data', (c: Buffer) => {
-        appendChunk(c);
-      });
-      child.stderr.on('data', (c: Buffer) => {
-        appendChunk(c);
-      });
-
-      const timer = setTimeout(() => {
-        timedOut = true;
-        killTree('SIGTERM');
-      }, timeoutMs);
-
-      const finish = (exitCode: number | null, marker?: string): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        // Clear the abort grace timer so a child that exited cleanly within the window doesn't
-        // fire a stray SIGKILL at a recycled pid after we've resolved.
-        if (killGraceTimer !== null) {
-          clearTimeout(killGraceTimer);
-          killGraceTimer = null;
-        }
-        opts.signal?.removeEventListener('abort', onAbort);
-        // Abort wins over every other settle reason: a cancelled run is a user-initiated abort,
-        // not a clean gate failure. Surface the codebase's transparently-propagated AbortError so
-        // the chain tears down rather than treating the kill as a `passed: false` verify failure.
-        if (aborted) {
-          resolve(Result.error(new AbortError({ elementName: 'shell-script-runner', reason: 'shell script aborted' })));
-          return;
-        }
-        const base = Buffer.concat(chunks).toString('utf8').trim();
-        const output = marker !== undefined ? (base.length > 0 ? `${base}\n${marker}` : marker) : base;
-        resolve(
-          Result.ok({
-            passed: exitCode === 0 && !timedOut && !capExceeded,
-            exitCode,
-            output,
-            durationMs: now() - start,
-          })
-        );
-      };
-
-      child.on('error', (err) => {
-        // Spawn-time error after the spawn() call returned (e.g. shell binary disappeared).
-        // Surface as passed:false with a marker; callers treat this the same as exit 127.
-        finish(null, `[spawn error: ${err.message}]`);
-      });
-
-      child.on('close', (code) => {
-        if (timedOut) {
-          finish(code, `[timeout exceeded after ${String(timeoutMs)}ms]`);
-          return;
-        }
-        if (capExceeded) {
-          finish(code, `[output exceeded ${String(MAX_OUTPUT_BYTES)} byte cap — truncated]`);
-          return;
-        }
-        finish(code);
-      });
+      runChildProcess(cwd, script, opts, runDeps, resolve);
     });
 
   return { run };

--- a/tests/e2e/flows/implement-parallel-realgit.test.ts
+++ b/tests/e2e/flows/implement-parallel-realgit.test.ts
@@ -380,6 +380,7 @@ function runTests(): void {
       },
       writeFile: createAtomicWriteFile(),
       appendFile: createAppendFile(),
+      journalMutex: createFoldQueue(),
     };
   };
 

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -43,6 +43,7 @@ import { createFileLocker } from '@src/integration/io/file-locker.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 import { createFakeAiProvider } from '@tests/fixtures/fake-ai-provider.ts';
 import { createImplementFlow } from '@src/application/flows/implement/flow.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
@@ -352,6 +353,7 @@ const buildDeps = (
   interactive: unusedInteractive,
   writeFile: createAtomicWriteFile(),
   appendFile: createAppendFile(),
+  journalMutex: createFoldQueue(),
 });
 
 const unusedInteractive: InteractivePrompt = {

--- a/tests/e2e/full-stack/implement-review-close.test.ts
+++ b/tests/e2e/full-stack/implement-review-close.test.ts
@@ -44,6 +44,7 @@ import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts'
 import { createAppendFile } from '@src/integration/io/append-file-adapter.ts';
 
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { createImplementFlow } from '@src/application/flows/implement/flow.ts';
 
@@ -240,6 +241,7 @@ function runTests(): void {
     interactive: unusedInteractive,
     writeFile: createAtomicWriteFile(),
     appendFile: createAppendFile(),
+    journalMutex: createFoldQueue(),
   });
 
   // ─── Fixture setup helpers ─────────────────────────────────────────────────

--- a/tests/e2e/full-stack/sprint-lifecycle.test.ts
+++ b/tests/e2e/full-stack/sprint-lifecycle.test.ts
@@ -35,6 +35,7 @@ import { createAppendFile } from '@src/integration/io/append-file-adapter.ts';
 import type { AppEvent, LogEvent } from '@src/business/observability/events.ts';
 
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { createImplementFlow } from '@src/application/flows/implement/flow.ts';
 import { createRunner } from '@src/application/chain/run/runner.ts';
@@ -218,6 +219,7 @@ function runTests(): void {
     interactive: unusedInteractive,
     writeFile: createAtomicWriteFile(),
     appendFile: createAppendFile(),
+    journalMutex: createFoldQueue(),
   });
 
   // ─── Fixture builder ─────────────────────────────────────────────────────────

--- a/tests/integration/application/flows/implement/leaves/append-learnings.test.ts
+++ b/tests/integration/application/flows/implement/leaves/append-learnings.test.ts
@@ -25,6 +25,7 @@ import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { recordingAppendFile } from '@tests/fixtures/recording-append-file.ts';
 import { recordingWriteFile } from '@tests/fixtures/recording-write-file.ts';
 import { appendLearningsLeaf } from '@src/application/flows/implement/leaves/append-learnings.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import { progressJournalLeaf } from '@src/application/flows/implement/leaves/progress-journal.ts';
 import { loadLearningsLeaf } from '@src/application/flows/_shared/memory/load-learnings.ts';
 import { LEARNINGS_LEDGER_FILE } from '@src/application/flows/_shared/memory/ledger-path.ts';
@@ -292,7 +293,7 @@ describe('appendLearningsLeaf', () => {
       task.id
     );
     const journalLeaf = progressJournalLeaf(
-      { writeFile: journalWrite.fn, clock: () => FIXED_NOW, logger: noopLogger },
+      { writeFile: journalWrite.fn, clock: () => FIXED_NOW, logger: noopLogger, journalMutex: createFoldQueue() },
       { progressFile: PROGRESS_FILE, totalRounds: 5 },
       task.id
     );

--- a/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
+++ b/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
@@ -30,6 +30,7 @@ import {
 import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import type { WriteFile } from '@src/business/io/write-file.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { progressJournalLeaf } from '@src/application/flows/implement/leaves/progress-journal.ts';
@@ -77,7 +78,12 @@ const ctxFor = (tasks: ImplementCtx['tasks'], extra: Partial<ImplementCtx> = {})
   ...extra,
 });
 
-const journalDeps = (writeFile: WriteFile, clock = () => FIXED_LATER) => ({ writeFile, clock, logger: noopLogger });
+const journalDeps = (writeFile: WriteFile, clock = () => FIXED_LATER) => ({
+  writeFile,
+  clock,
+  logger: noopLogger,
+  journalMutex: createFoldQueue(),
+});
 
 describe('progressJournalLeaf', () => {
   it('writes a task-attempt section with the stable id token + verdict=pass for a settled done task', async () => {

--- a/tests/unit/application/flows/implement/leaves/_shared/dedupe-texts.test.ts
+++ b/tests/unit/application/flows/implement/leaves/_shared/dedupe-texts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeTexts } from '@src/application/flows/implement/leaves/_shared/dedupe-texts.ts';
+
+/**
+ * `dedupeTexts` folds a per-attempt signal-text accumulator (changes / decisions / notes) into a
+ * trimmed, deduped, first-seen-order list. Shared by the progress-journal and append-learnings
+ * leaves.
+ */
+
+describe('dedupeTexts', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(dedupeTexts(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(dedupeTexts([])).toEqual([]);
+  });
+
+  it('trims whitespace around each entry', () => {
+    expect(dedupeTexts(['  added X  ', '\trenamed Y to Z\n'])).toEqual(['added X', 'renamed Y to Z']);
+  });
+
+  it('drops empty / whitespace-only entries', () => {
+    expect(dedupeTexts(['added X', '', '   ', 'renamed Y'])).toEqual(['added X', 'renamed Y']);
+  });
+
+  it('dedupes on the trimmed text, keeping first-seen order', () => {
+    expect(dedupeTexts(['added X', 'renamed Y', '  added X  ', 'added X', 'renamed Y'])).toEqual([
+      'added X',
+      'renamed Y',
+    ]);
+  });
+});

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -711,6 +711,37 @@ describe('finalizeGenEvalUseCase', () => {
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
   });
 
+  it('legacy task (no maxAttempts) crashed at fallback budget cap: blocks instead of granting another retry', async () => {
+    // Legacy task (task.maxAttempts undefined): `failCurrentAttempt` never applies a cap for
+    // these, so an unconditional retry here would crash-loop the task forever across launches.
+    // Once recorded attempts reach the fallback budget, finalize must block directly.
+    const task = makeInProgressTaskWithRunningAttempt();
+    const bus = newBus();
+    const events: Array<{ type: string }> = [];
+    bus.subscribe((e) => events.push(e));
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'crashed', reason: 'AI process was killed before producing signals.json: exit 143 (SIGTERM)' },
+      turnsUsed: 1,
+      // Fallback budget 1 === 1 attempt already recorded → exhausted.
+      readConfig: cfg({ escalateOnPlateau: false, maxAttempts: 1 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: bus,
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.verdict).toBe('failed');
+    expect(result.value.warning?.kind).toBe('crashed');
+    expect(result.value.shouldFailAttempt).toBeFalsy();
+    expect(result.value.blockedReason).toBe('AI process repeatedly crashed; attempt budget exhausted');
+    expect(result.value.task.escalatedToModel).toBeUndefined();
+    expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
+  });
+
   it('forwards a StorageError from the repo', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const failing: UpdateTask = {


### PR DESCRIPTION
Two-part code-quality pass over everything since v0.13.0, produced via a multi-agent review (haiku overview → opus adversarial-verify → sonnet/opus implement) and verified end-to-end.

## 1. Quality sweep (`fa9239e3`) — 12 adversarially-verified findings
**Reliability**
- **progress.md journal lost-update race**: the v0.14.0 append-only→read-modify-write change let parallel wave branches silently drop each other's attempt sections. The whole read→regenerate→write is now serialized behind one per-run `journalMutex` on `ImplementDeps` (inherited by all branches; serial path is a single-caller no-op).
- **legacy crash-loop**: `finalize-gen-eval` now bounds crash retries for pre-field (`maxAttempts` undefined) tasks at the fallback budget.

**Correctness / dead config**
- codex `getBody` is now best-effort (won't discard a SIGTERM-recovered success with `signals.json` present).
- removed `PRIOR_EPISODES` from `COMPRESSIBLE_KEYS` (dead config + latent self-wrapped-tag truncation).

**Dedup / readability** — shared `dedupe-texts`, ledger `serializeLedgerBody`, `readCappedSprintProgress`, integration `context-window` now delegates to domain (single source of truth), `useCoalescedMap`, `useIsMounted`, shared `fmtTokens`, pr-content logger bind-once. Net −108 LOC.

## 2. Lint-warning reduction (`a9197fdf`) — 253 → 115
Behavior-preserving extraction of ~45 oversized / over-complex functions into cohesive file-local helpers & subcomponents (tiered fan-out: sonnet triage → refactor model chosen by complexity). No public signature or logic changes. Lint cap ratcheted 254 → 115.

## Verification (prod gate)
typecheck clean · lint 115/0 · **4271 tests pass** · format:check clean · knip clean · build success.