### PR TITLE
feat(evaluator): robustness floor + single-sourced floor rubric (#218)

### DIFF
--- a/src/application/flows/implement/leaves/evaluator.contract.ts
+++ b/src/application/flows/implement/leaves/evaluator.contract.ts
@@ -125,6 +125,7 @@ const evaluatorExampleSignals: readonly EvaluatorSignal[] = [
       { dimension: 'completeness', passed: true, finding: 'all declared steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated at the request boundary' },
       { dimension: 'consistency', passed: true, finding: 'matches sibling code at src/bar.ts' },
+      { dimension: 'robustness', passed: true, finding: 'error path retries the write once before surfacing' },
     ],
     criteria: [
       { id: 'C1', passed: false, evidence: 'npm test exited 1 — empty-input case failed at src/foo.ts:23' },

--- a/src/business/task/plateau-detection.ts
+++ b/src/business/task/plateau-detection.ts
@@ -116,12 +116,14 @@ export interface PlateauOptions {
 
 /**
  * Extract the set of failed dimension names from a parsed evaluation. Names are lowercased
- * and trimmed so `Correctness` / ` correctness ` / `CORRECTNESS` collapse to one entry.
+ * and trimmed so `Correctness` / ` correctness ` / `CORRECTNESS` collapse to one entry. A
+ * dimension marked `applicable: false` (explicit not-applicable, with the reason in `finding`)
+ * is never counted as failed regardless of its `passed` value — N/A is neither pass nor fail.
  */
 export const failedDimensions = (signal: EvaluationSignal): ReadonlySet<string> => {
   const names = new Set<string>();
   for (const d of signal.dimensions) {
-    if (!d.passed) {
+    if (d.applicable !== false && !d.passed) {
       names.add(d.dimension.trim().toLowerCase());
     }
   }

--- a/src/domain/signal.ts
+++ b/src/domain/signal.ts
@@ -27,33 +27,26 @@ export type EvaluationDimension = string;
  * stdout/stderr so an operator can audit the verdict without re-running the spawn. Optional at
  * the schema layer (the auto/manual partitioning lives on the task contract, not the signal),
  * prompt-enforced for auto criteria.
+ *
+ * `applicable` marks whether the dimension could be meaningfully graded at all. Absent or `true`
+ * means the ordinary graded pass/fail on `passed` applies; `false` means the dimension does not
+ * apply to this change (e.g. a robustness grade on a change that touches no error path) and
+ * `passed` is not a graded verdict — `finding` carries the stated reason instead. The five floor
+ * dimensions living in `floor-dimensions.ts` (integration layer) are the single canonical source
+ * of the always-present rubric; this domain type only shapes the per-dimension verdict.
  */
 export interface DimensionScore {
   readonly dimension: EvaluationDimension;
   readonly passed: boolean;
   readonly finding: string;
   readonly executionEvidence?: string;
+  readonly applicable?: boolean;
 }
-
-/**
- * The four floor dimensions every terminal evaluator verdict MUST grade. They are the
- * always-present rubric pinned in the evaluate prompt (`prompts/evaluate/template.md`); the
- * planner may append task-specific dimensions on top, but these four are mandatory on every
- * `passed` / `failed` verdict so a vacuous "passed with zero dimensions" can never validate.
- *
- * Names are compared case-/whitespace-insensitively (lowercased, trimmed) by the signal-schema
- * refinement and by `failedDimensions` in the plateau predicate, so the canonical lowercase
- * spelling here is the single source of truth the integration schema imports (domain → integration
- * is the allowed direction).
- *
- * @public
- */
-export const FLOOR_DIMENSIONS = ['correctness', 'completeness', 'safety', 'consistency'] as const;
 
 /**
  * One structured per-criterion verdict the evaluator emits, keyed by {@link VerificationCriterion.id}
  * (`C1`, `C2`, …). Orthogonal to {@link DimensionScore}: dimensions grade the always-present floor
- * rubric (correctness / completeness / safety / consistency), whereas `criteria` records the
+ * rubric (correctness / completeness / safety / consistency / robustness), whereas `criteria` records the
  * machine-readable PASS / FAIL of each task-specific acceptance criterion the planner authored — the
  * grading the evaluator already does in prose (`Phase 2 — Per-criterion assessment`), now carried as
  * data so the harness can persist a durable k-of-N checklist instead of collapsing many criteria to

--- a/src/integration/ai/contract/_engine/corrective-retry.ts
+++ b/src/integration/ai/contract/_engine/corrective-retry.ts
@@ -104,8 +104,8 @@ const correctiveBody = (err: DomainError, signalsPath: string, selfContainedCont
       );
     }
     lines.push('');
-    lines.push('Common cause: a terminal `evaluation` verdict (`passed` / `failed`) MUST grade all four');
-    lines.push('floor dimensions — correctness, completeness, safety, consistency — each with a finding.');
+    lines.push('Common cause: a terminal `evaluation` verdict (`passed` / `failed`) MUST grade all five');
+    lines.push('floor dimensions — correctness, completeness, safety, consistency, robustness — each with a finding.');
   } else if (err instanceof ParseError && err.subCode === 'invalid-json') {
     lines.push(`The file at \`${signalsPath}\` existed but was not valid JSON. Re-write it as a single`);
     lines.push('valid JSON object matching the `{ schemaVersion, signals }` shape. Check for trailing');

--- a/src/integration/ai/contract/_engine/render-evaluation-markdown.ts
+++ b/src/integration/ai/contract/_engine/render-evaluation-markdown.ts
@@ -12,7 +12,7 @@ import type { EvaluationSignal } from '@src/domain/signal.ts';
  *
  *     ## Dimensions
  *
- *     ### <dimension name> — <passed | failed>
+ *     ### <dimension name> — <passed | failed | n/a>
  *     <finding>
  *
  *     ```
@@ -28,6 +28,12 @@ import type { EvaluationSignal } from '@src/domain/signal.ts';
  * Empty sections are omitted entirely. The output has a trailing newline so editors line-
  * count cleanly.
  */
+/** `n/a` for an explicit not-applicable dimension, otherwise the ordinary passed/failed verdict. */
+const dimensionVerdict = (d: EvaluationSignal['dimensions'][number]): string => {
+  if (d.applicable === false) return 'n/a';
+  return d.passed ? 'passed' : 'failed';
+};
+
 export const renderEvaluationMarkdown = (signal: EvaluationSignal): string => {
   const lines: string[] = [];
   lines.push(`# Evaluation — ${signal.status}`);
@@ -46,7 +52,7 @@ export const renderEvaluationMarkdown = (signal: EvaluationSignal): string => {
     lines.push('## Dimensions');
     lines.push('');
     for (const d of signal.dimensions) {
-      lines.push(`### ${d.dimension} — ${d.passed ? 'passed' : 'failed'}`);
+      lines.push(`### ${d.dimension} — ${dimensionVerdict(d)}`);
       if (d.finding.trim().length > 0) {
         lines.push('');
         lines.push(d.finding.trim());

--- a/src/integration/ai/contract/_engine/signals/evaluation/schema.ts
+++ b/src/integration/ai/contract/_engine/signals/evaluation/schema.ts
@@ -1,20 +1,22 @@
 import { z } from 'zod';
-import {
-  FLOOR_DIMENSIONS,
-  type CriterionVerdict,
-  type DimensionScore,
-  type EvaluationSignal,
-} from '@src/domain/signal.ts';
+import type { CriterionVerdict, DimensionScore, EvaluationSignal } from '@src/domain/signal.ts';
+import { FLOOR_DIMENSION_NAMES } from '@src/integration/ai/evaluation/_engine/floor-dimensions.ts';
 import { IsoTimestampSchema } from '@src/integration/persistence/shared/value-schemas.ts';
 import type { Compatible } from '@src/integration/persistence/shared/codec-internal.ts';
 
+/** Sorted floor-dimension name list, derived from the canonical rubric — one source, no drift. */
+const FLOOR_DIMENSIONS = [...FLOOR_DIMENSION_NAMES].sort();
+
 /**
  * Per-dimension PASS / FAIL verdict the evaluator emits. The redesign dropped the numeric
- * `score` field — `passed` is the only verdict per dimension. Two refinements protect
- * downstream consumers:
+ * `score` field — `passed` is the only verdict per dimension. Refinements protect downstream
+ * consumers:
  *
  *  - `passed === false` REQUIRES `finding` to be non-empty so the operator (and the next
  *    generator turn's prompt) always has a concrete reason for the FAIL.
+ *  - `applicable === false` (explicit not-applicable, e.g. a robustness grade on a change that
+ *    touches no error path) also REQUIRES `finding` to be non-empty — the operator needs the
+ *    stated reason even though there is no pass/fail verdict to explain.
  *  - `executionEvidence` is schema-optional. Auto criteria are prompt-enforced to fill it;
  *    making it Zod-required would require cross-referencing `tasks.json` from the signal
  *    schema (ugly cross-aggregate coupling). The anti-rubber-stamp guard in the evaluator
@@ -26,12 +28,20 @@ const dimensionScoreSchema = z
     passed: z.boolean(),
     finding: z.string(),
     executionEvidence: z.string().optional(),
+    applicable: z.boolean().optional(),
   })
   .superRefine((d, ctx) => {
-    if (!d.passed && d.finding.trim().length === 0) {
+    if (!d.passed && d.applicable !== false && d.finding.trim().length === 0) {
       ctx.addIssue({
         code: 'custom',
         message: `dimension '${d.dimension}' failed but carries no finding`,
+        path: ['finding'],
+      });
+    }
+    if (d.applicable === false && d.finding.trim().length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `dimension '${d.dimension}' is marked not-applicable but carries no finding`,
         path: ['finding'],
       });
     }
@@ -61,12 +71,15 @@ void _criterionTypeCheck;
  *
  * The signal-level refinement enforces verdict / dimension consistency AND the floor-dimension
  * coverage the prompt prose mandates:
- *  - `status: 'passed'`  → every dimension MUST be `passed: true` AND all four
- *     {@link FLOOR_DIMENSIONS} (correctness / completeness / safety / consistency) MUST be
- *     present. A "passed with zero dimensions" (or a partial floor set) is rejected here — the
- *     hole that previously let a vacuous PASS validate while the rubric lived in prompt-prose only.
- *  - `status: 'failed'`  → at least one dimension MUST be `passed: false` AND all four floor
- *     dimensions MUST be present (so the critique can name a concrete failing floor item).
+ *  - `status: 'passed'`  → every dimension with `applicable !== false` MUST be `passed: true`
+ *     AND all five {@link FLOOR_DIMENSIONS} (correctness / completeness / safety / consistency /
+ *     robustness) MUST be present. A "passed with zero dimensions" (or a partial floor set) is
+ *     rejected here — the hole that previously let a vacuous PASS validate while the rubric
+ *     lived in prompt-prose only. A dimension marked `applicable: false` is neither a pass nor a
+ *     fail, so it never blocks a `passed` status.
+ *  - `status: 'failed'`  → at least one `applicable !== false` dimension MUST be `passed: false`
+ *     AND all five floor dimensions MUST be present (so the critique can name a concrete failing
+ *     floor item).
  *  - `status: 'malformed'` is the escape hatch the harness uses when the AI emits dimension
  *     rows but no terminal verdict; no consistency or coverage check applies — the harness
  *     retries the attempt (see `prompts/evaluate/template.md`).
@@ -110,13 +123,13 @@ export const evaluationSignalSchema = z
     if (missing.length > 0) {
       ctx.addIssue({
         code: 'custom',
-        message: `status is "${s.status}" but the required floor dimension(s) ${missing.join(', ')} are missing — every terminal verdict must grade correctness, completeness, safety, and consistency`,
+        message: `status is "${s.status}" but the required floor dimension(s) ${missing.join(', ')} are missing — every terminal verdict must grade correctness, completeness, safety, consistency, and robustness`,
         path: ['dimensions'],
       });
     }
 
     if (s.status === 'passed') {
-      const failedIndex = s.dimensions.findIndex((d) => !d.passed);
+      const failedIndex = s.dimensions.findIndex((d) => d.applicable !== false && !d.passed);
       if (failedIndex !== -1) {
         ctx.addIssue({
           code: 'custom',
@@ -125,7 +138,7 @@ export const evaluationSignalSchema = z
         });
       }
     } else {
-      const anyFailed = s.dimensions.some((d) => !d.passed);
+      const anyFailed = s.dimensions.some((d) => d.applicable !== false && !d.passed);
       if (!anyFailed) {
         ctx.addIssue({
           code: 'custom',

--- a/src/integration/ai/evaluation/_engine/floor-dimensions.ts
+++ b/src/integration/ai/evaluation/_engine/floor-dimensions.ts
@@ -1,5 +1,5 @@
 /**
- * Floor evaluation dimensions — the four universal axes every task is graded on, regardless
+ * Floor evaluation dimensions — the five universal axes every task is graded on, regardless
  * of whether the planner emitted any per-task `extraDimensions`. The names are stable and
  * lowercased for plateau-detection use; the descriptions are mirrored into the evaluate prompt
  * template so the AI sees one consistent rubric.
@@ -36,6 +36,11 @@ export const FLOOR_DIMENSIONS: readonly FloorDimension[] = [
     name: 'Consistency',
     description:
       'Does the implementation fit the codebase? Check for: follows existing patterns and conventions (naming, structure, error handling); uses existing utilities instead of reinventing them; no unnecessary changes outside the task scope (spec drift); test patterns match the project existing test style.',
+  },
+  {
+    name: 'Robustness',
+    description:
+      'Does the change handle error and failure paths gracefully? Check for: unhandled exceptions, missing error propagation, ungraceful degradation under partial failure, and recovery from transient faults (retries, cleanup, rollback). When the change touches no error path, grade this dimension `applicable: false` and state why in `finding` rather than fabricating a pass or fail.',
   },
 ];
 

--- a/src/integration/ai/prompts/_engine/renderers/floor-rubric.ts
+++ b/src/integration/ai/prompts/_engine/renderers/floor-rubric.ts
@@ -1,0 +1,30 @@
+import { FLOOR_DIMENSIONS } from '@src/integration/ai/evaluation/_engine/floor-dimensions.ts';
+
+/**
+ * Render the `{{FLOOR_RUBRIC_SECTION}}` markdown block shared by the evaluate and
+ * evaluate-continuation templates. Single-sourced from {@link FLOOR_DIMENSIONS} — the same list
+ * the evaluation schema (`signals/evaluation/schema.ts`) reads for its floor-coverage check — so
+ * the rubric the evaluator is shown and the rule the harness validates against can never drift
+ * apart.
+ *
+ * Each floor renders as one self-contained numbered block: the dimension's canonical rationale
+ * (why the floor matters and what to check, verbatim from `FloorDimension.description`) followed
+ * by its PASS / FAIL verdict rule — rationale before verdict, every floor. A shared preamble
+ * anchors the verdict to the task's acceptance criteria in `<task_specification>` and the
+ * check/verify output gathered in Phase 1, and tells the evaluator to note — never fabricate —
+ * reference material that is missing or empty.
+ */
+export const renderFloorRubricSection = (): string => {
+  const preamble = [
+    `Every evaluation grades ${String(FLOOR_DIMENSIONS.length)} floor dimensions. Each dimension is independent; a FAIL on any one forces \`status: "failed"\` regardless of how other dimensions score.`,
+    '',
+    'Ground every verdict in the acceptance criteria listed in `<task_specification>` and the check/verify command output you gather in Phase 1 — cite them directly rather than asserting from memory. When `<task_specification>` or the check/verify output is missing or empty for this task, say so explicitly in the finding; never fabricate criteria or results that were not provided.',
+  ].join('\n');
+
+  const blocks = FLOOR_DIMENSIONS.map(
+    (dimension, index) =>
+      `${String(index + 1)}. **${dimension.name}** — ${dimension.description}\n\n   **Verdict:** PASS when every check above holds, each backed by a concrete observation (file path, line, function, tool output, or quoted snippet); FAIL when any check fails, or a PASS claim lacks evidence.`
+  );
+
+  return [preamble, '', blocks.join('\n\n')].join('\n');
+};

--- a/src/integration/ai/prompts/_engine/renderers/task.ts
+++ b/src/integration/ai/prompts/_engine/renderers/task.ts
@@ -1,4 +1,5 @@
 import type { Task } from '@src/domain/entity/task.ts';
+import { FLOOR_DIMENSIONS } from '@src/integration/ai/evaluation/_engine/floor-dimensions.ts';
 import { normalizeRefs } from '@src/domain/value/external-ref.ts';
 
 /**
@@ -132,9 +133,13 @@ export const renderProjectToolingSection = (projectTooling: string | undefined):
  *
  * Empty / absent → empty string so the template placeholder collapses without leaving an
  * orphan heading. `floorCount` is the number of floor dimensions already listed above the
- * placeholder; defaults to 4 to match the canonical rubric.
+ * placeholder; defaults to `FLOOR_DIMENSIONS.length` (the canonical rubric size) so the
+ * numbering never drifts from the rendered `{{FLOOR_RUBRIC_SECTION}}` block.
  */
-export const renderExtraDimensionsSection = (extras: readonly string[] | undefined, floorCount = 4): string => {
+export const renderExtraDimensionsSection = (
+  extras: readonly string[] | undefined,
+  floorCount = FLOOR_DIMENSIONS.length
+): string => {
   if (extras === undefined || extras.length === 0) return '';
   const lines = extras.map(
     (name, i) =>

--- a/src/integration/ai/prompts/_engine/task-import-schema.ts
+++ b/src/integration/ai/prompts/_engine/task-import-schema.ts
@@ -68,10 +68,10 @@ export const TaskImportSpecSchema = z
     verificationCriteria: z.array(VerificationCriterionImportSchema).min(1, 'verificationCriteria missing or empty'),
     blockedBy: z.array(z.string()).optional(),
     /**
-     * Per-task evaluator dimensions to score in ADDITION to the four floor dimensions
-     * (correctness, completeness, safety, consistency). Optional; the planner omits the field
-     * when the floor dimensions already capture what matters. Capped at 6 to keep the rubric
-     * focused — past that, dimensions tend to overlap and dilute the per-axis verdict.
+     * Per-task evaluator dimensions to score in ADDITION to the five floor dimensions
+     * (correctness, completeness, safety, consistency, robustness). Optional; the planner omits
+     * the field when the floor dimensions already capture what matters. Capped at 6 to keep the
+     * rubric focused — past that, dimensions tend to overlap and dilute the per-axis verdict.
      */
     extraDimensions: z.array(z.string().min(1)).max(6).optional(),
   })

--- a/src/integration/ai/prompts/evaluate-continuation/definition.ts
+++ b/src/integration/ai/prompts/evaluate-continuation/definition.ts
@@ -3,6 +3,7 @@ import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts'
 import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/_engine/build-prompt.ts';
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
+import { renderFloorRubricSection } from '@src/integration/ai/prompts/_engine/renderers/floor-rubric.ts';
 import { renderGeneratorHintsSection } from '@src/integration/ai/prompts/_engine/renderers/task.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 
@@ -45,6 +46,13 @@ export interface EvaluateContinuationPromptParams {
    */
   readonly priorProgress: string;
   /**
+   * Rendered `{{FLOOR_RUBRIC_SECTION}}` markdown block — the five floor dimensions, each with a
+   * rationale-before-verdict block, single-sourced from `FLOOR_DIMENSIONS` via
+   * {@link renderFloorRubricSection}. Kept consistent with `evaluate/template.md` so the
+   * reviewer never drifts on the rubric across rounds. Always non-empty.
+   */
+  readonly floorRubricSection: string;
+  /**
    * Audit-[09] output contract section rendered from the evaluator contract for THIS round's
    * output directory (`rounds/<N>/evaluator/`). Because the leaf re-renders it per round, the
    * embedded `signals.json` path always names the current round — `{{OUTPUT_CONTRACT_SECTION}}`.
@@ -86,6 +94,15 @@ export const evaluateContinuationPromptDef: PromptDefinition<EvaluateContinuatio
     priorProgress: {
       placeholder: 'PRIOR_PROGRESS',
       description: 'Capped recent slice of progress.md inlined into the prior-progress block — empty when none yet.',
+    },
+    floorRubricSection: {
+      placeholder: 'FLOOR_RUBRIC_SECTION',
+      description:
+        'The five floor dimensions, each rendered as a rationale-before-verdict block, single-sourced from FLOOR_DIMENSIONS.',
+      validate: requireNonEmpty(
+        'floorRubricSection',
+        'floor-rubric section must not be empty (renderFloorRubricSection always emits a body)'
+      ),
     },
     outputContractSection: {
       placeholder: 'OUTPUT_CONTRACT_SECTION',
@@ -141,6 +158,7 @@ export const buildEvaluateContinuationPrompt = async (
     contractPath: input.contractPath,
     progressFile: input.progressFile,
     priorProgress: input.priorProgress,
+    floorRubricSection: renderFloorRubricSection(),
     outputContractSection: input.outputContractSection,
     generatorHintsSection: renderGeneratorHintsSection(input.generatorHints),
   });

--- a/src/integration/ai/prompts/evaluate-continuation/template.md
+++ b/src/integration/ai/prompts/evaluate-continuation/template.md
@@ -11,12 +11,15 @@ fixed. Investigate the current working tree again.
 You do not write code. You do not fix bugs. You do not edit tests. You read, run verification
 tooling, and render a verdict.
 
-**Grading rubric (unchanged every round):** grade the four floor dimensions (correctness, completeness, safety, consistency)
-plus any task-specific dimensions the planner attached. Each dimension is independent; a FAIL on
-any one forces `status: "failed"`. Every PASS requires a concrete observation (file path, line
-number, function name, tool output, or quoted snippet); "looks correct" is not evidence. A terminal
-`passed` or `failed` verdict MUST grade all four floor dimensions, each with a finding — a verdict
-missing a floor dimension is rejected and re-requested.
+**Grading rubric (unchanged every round):**
+
+{{FLOOR_RUBRIC_SECTION}}
+
+Grade any task-specific dimensions the planner attached with the same binary pass/fail logic. Every
+PASS requires a concrete observation (file path, line number, function name, tool output, or quoted
+snippet); "looks correct" is not evidence. A terminal `passed` or `failed` verdict MUST grade all
+five floor dimensions, each with a finding — a verdict missing a floor dimension is rejected and
+re-requested.
 
 **Verdict values — `passed`, `failed`, `malformed`:** reach for `malformed` ONLY when a tooling or
 environment problem blocks you from reaching a terminal verdict this round — never to dodge a clear
@@ -74,7 +77,7 @@ end. The final `signals.json` is the only machine-readable output and must come 
 **Checkpoint write — do this first, before re-grading**
 
 If you have not already written a checkpoint `signals.json` for this round, write an `evaluation`
-signal now before continuing. Use `status: "failed"`, all four floor dimensions present, each set
+signal now before continuing. Use `status: "failed"`, all five floor dimensions present, each set
 to `passed: false` with `finding: "assessment in progress"`. Use the path named in the output
 contract section at the bottom of this prompt. This placeholder is valid against the schema the
 harness validates — it ensures a recoverable file exists on disk if this session exhausts its
@@ -92,13 +95,18 @@ below.
         { "dimension": "correctness", "passed": false, "finding": "assessment in progress" },
         { "dimension": "completeness", "passed": false, "finding": "assessment in progress" },
         { "dimension": "safety", "passed": false, "finding": "assessment in progress" },
-        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" }
+        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "robustness", "passed": false, "applicable": false, "finding": "assessment in progress" }
       ],
       "timestamp": "<ISO-8601 timestamp>"
     }
   ]
 }
 ```
+
+Robustness carries the optional `applicable` field shown above — set it to `false` only if
+re-grading determines the change touches no error/failure path (with the real reason in
+`finding`), or omit it (default `true`) once you record an actual pass/fail.
 
 Re-grade this round the same way you graded the first:
 

--- a/src/integration/ai/prompts/evaluate/definition.ts
+++ b/src/integration/ai/prompts/evaluate/definition.ts
@@ -4,6 +4,7 @@ import type { Task } from '@src/domain/entity/task.ts';
 import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/_engine/build-prompt.ts';
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
+import { renderFloorRubricSection } from '@src/integration/ai/prompts/_engine/renderers/floor-rubric.ts';
 import {
   renderExtraDimensionsSection,
   renderGeneratorHintsSection,
@@ -24,9 +25,9 @@ import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/templat
  *
  * The evaluate template runs an independent reviewer agent: it reads the task description /
  * steps / verification criteria, runs the verify script as authoritative ground truth, scores
- * four floor dimensions (correctness, completeness, safety, consistency), and writes exactly
- * one `evaluation` signal to `signals.json` carrying the PASS / FAIL verdict + per-dimension
- * findings.
+ * five floor dimensions (correctness, completeness, safety, consistency, robustness), and writes
+ * exactly one `evaluation` signal to `signals.json` carrying the PASS / FAIL verdict +
+ * per-dimension findings.
  */
 export interface EvaluatePromptParams {
   /** Task display name — `{{TASK_NAME}}` (referenced both as the page title and inside the spec block). */
@@ -53,7 +54,13 @@ export interface EvaluatePromptParams {
   /** Detected subagents / skills / MCP servers the reviewer can route to, or fallback. */
   readonly projectTooling: string;
   /**
-   * Optional "Task-specific dimensions" block appended after the four floor dimensions. Empty
+   * Rendered `{{FLOOR_RUBRIC_SECTION}}` markdown block — the five floor dimensions, each with a
+   * rationale-before-verdict block, single-sourced from `FLOOR_DIMENSIONS` via
+   * {@link renderFloorRubricSection}. Always non-empty.
+   */
+  readonly floorRubricSection: string;
+  /**
+   * Optional "Task-specific dimensions" block appended after the five floor dimensions. Empty
    * string when the planner didn't attach extras to this task — keeps the template stable.
    */
   readonly extraDimensionsSection: string;
@@ -87,7 +94,7 @@ const requireNonEmpty =
 export const evaluatePromptDef: PromptDefinition<EvaluatePromptParams> = {
   templateName: 'evaluate',
   description:
-    'Independent code review of a completed task. The agent runs deterministic checks, scores four floor dimensions, and emits one verdict signal.',
+    'Independent code review of a completed task. The agent runs deterministic checks, scores five floor dimensions, and emits one verdict signal.',
   parameters: {
     taskName: {
       placeholder: 'TASK_NAME',
@@ -128,6 +135,15 @@ export const evaluatePromptDef: PromptDefinition<EvaluatePromptParams> = {
     projectTooling: {
       placeholder: 'PROJECT_TOOLING',
       description: 'Detected subagents, skills, MCP servers, or "(none detected)".',
+    },
+    floorRubricSection: {
+      placeholder: 'FLOOR_RUBRIC_SECTION',
+      description:
+        'The five floor dimensions, each rendered as a rationale-before-verdict block, single-sourced from FLOOR_DIMENSIONS.',
+      validate: requireNonEmpty(
+        'floorRubricSection',
+        'floor-rubric section must not be empty (renderFloorRubricSection always emits a body)'
+      ),
     },
     extraDimensionsSection: {
       placeholder: 'EXTRA_DIMENSIONS_SECTION',
@@ -201,9 +217,10 @@ export interface BuildEvaluatePromptInput {
  * grades every criterion and records each verdict structurally in the `evaluation` signal's `criteria`
  * array (id + passed boolean + one-line evidence citation) in addition to prose assessment. Phase 3
  * applies inferential investigation to what deterministic checks cannot catch, including end-to-end
- * product exercise when a run-path is declared in `<project_tooling>`. Phase 4 assesses the four
- * floor dimensions (correctness, completeness, safety, consistency) plus any task-specific extras
- * injected via `{{EXTRA_DIMENSIONS_SECTION}}`. An `<evaluation_discipline>` block instructs the
+ * product exercise when a run-path is declared in `<project_tooling>`. Phase 4 assesses the five
+ * floor dimensions (correctness, completeness, safety, consistency, robustness) rendered via
+ * `{{FLOOR_RUBRIC_SECTION}}`, plus any task-specific extras injected via
+ * `{{EXTRA_DIMENSIONS_SECTION}}`. An `<evaluation_discipline>` block instructs the
  * evaluator to work through each criterion and floor dimension explicitly — recording a preliminary
  * verdict per criterion before moving to the next — to reduce premature verdict commitment.
  */
@@ -220,6 +237,7 @@ export const buildEvaluatePrompt = async (
     verificationCriteriaSection: renderVerificationCriteriaSection(input.task),
     verifyScriptSection: renderVerifyScriptSection(input.verifyScript),
     projectTooling: renderProjectToolingSection(input.projectTooling),
+    floorRubricSection: renderFloorRubricSection(),
     extraDimensionsSection: renderExtraDimensionsSection(input.task.extraDimensions),
     outputContractSection: input.outputContractSection,
     priorProgress: input.priorProgress ?? '',

--- a/src/integration/ai/prompts/evaluate/template.md
+++ b/src/integration/ai/prompts/evaluate/template.md
@@ -8,15 +8,7 @@ render a verdict.
 
 **Grading rubric (pinned here — applies every round regardless of context):**
 
-Every evaluation grades four floor dimensions. Each dimension is independent; a FAIL on any one forces
-`status: "failed"` on the signal regardless of how other dimensions score.
-
-| Dimension    | PASS when                                                                                                                | FAIL when                                                                             |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| Correctness  | Every verification criterion in `<task_specification>` is met, with evidence                                             | Any criterion unmet, or evidence is missing for a PASS claim                          |
-| Completeness | All declared steps present; all criteria addressed; no criterion silently skipped                                        | A step or criterion has no evidence in the findings                                   |
-| Safety       | No error paths that crash, swallow, or silently corrupt; no unvalidated inputs at trust boundaries; no leaked resources  | A concrete safety defect is observable in the diff                                    |
-| Consistency  | Change follows the project's existing patterns — naming, file organisation, error handling, test structure, import style | A sibling file or function shows a materially different pattern the generator ignored |
+{{FLOOR_RUBRIC_SECTION}}
 
 Additional dimensions appended by the planner (when present) are evaluated with the same binary pass/fail
 logic. The rubric from `<task_specification>` is the authority — grade against it, not against your own
@@ -51,9 +43,9 @@ forcing a `passed` you cannot support — a false `passed` ships a bug; a `malfo
 Conversely, do not reach for `malformed` to dodge a clear `failed`: if you can name a concrete failing
 criterion, the verdict is `failed` with a critique, never `malformed`.
 
-A terminal `passed` or `failed` verdict MUST grade all four floor dimensions (correctness, completeness,
-safety, consistency), each with a finding — a verdict missing a floor dimension is rejected by the harness and
-re-requested. `malformed` is exempt from that coverage requirement.
+A terminal `passed` or `failed` verdict MUST grade all five floor dimensions (correctness, completeness,
+safety, consistency, robustness), each with a finding — a verdict missing a floor dimension is rejected by the
+harness and re-requested. `malformed` is exempt from that coverage requirement.
 </role>
 
 {{HARNESS_CONTEXT}}
@@ -143,7 +135,7 @@ may write is `signals.json` under the harness output directory.
 
 ### Phase 0 — Checkpoint write (do this first, before any verification)
 
-Write `signals.json` now with placeholder verdicts — `status: "failed"`, all four floor dimensions
+Write `signals.json` now with placeholder verdicts — `status: "failed"`, all five floor dimensions
 present, each set to `passed: false` with `finding: "assessment in progress"`. Use the schema and
 path shown in the output contract section at the bottom of this prompt.
 
@@ -164,13 +156,18 @@ rather than restarting from scratch.
         { "dimension": "correctness", "passed": false, "finding": "assessment in progress" },
         { "dimension": "completeness", "passed": false, "finding": "assessment in progress" },
         { "dimension": "safety", "passed": false, "finding": "assessment in progress" },
-        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" }
+        { "dimension": "consistency", "passed": false, "finding": "assessment in progress" },
+        { "dimension": "robustness", "passed": false, "applicable": false, "finding": "assessment in progress" }
       ],
       "timestamp": "<ISO-8601 timestamp>"
     }
   ]
 }
 ```
+
+Robustness carries the optional `applicable` field shown above — leave it as a placeholder here and
+set it to `false` only if Phase 4 determines the change touches no error/failure path (with the real
+reason in `finding`), or omit it (default `true`) once you grade an actual pass/fail.
 
 Write this file, then proceed to Phase 1.
 
@@ -246,8 +243,9 @@ observation — file path, line number, function name, tool output, or quoted sn
 
 ### Phase 4 — Dimension assessment
 
-Evaluate across the four floor dimensions. Write per-dimension findings as one PASS/FAIL verdict and 1–3
-specific observations each.
+Evaluate across the five floor dimensions rendered in `{{FLOOR_RUBRIC_SECTION}}` above. Write per-dimension
+findings as one PASS/FAIL verdict (or `applicable: false` for robustness, when justified) and 1–3 specific
+observations each, anchored to the acceptance criteria and check/verify output you gathered in Phases 1–3.
 
 1. **Correctness** — does the implementation do what the specification says, across every verification
    criterion? Cite the criterion and the code that satisfies (or fails to satisfy) it.
@@ -258,6 +256,10 @@ specific observations each.
 4. **Consistency** — does the change follow the project's existing patterns and conventions (naming, file
    organisation, error handling, test structure, import style)? Cite a specific sibling file or function
    when the comparison matters.
+5. **Robustness** — does the change handle error and failure paths gracefully — unhandled exceptions,
+   missing error propagation, ungraceful degradation, recovery from transient faults? When the change
+   touches no error/failure path, grade this dimension `applicable: false` and state the concrete reason in
+   `finding` rather than fabricating a pass or fail.
 
 {{EXTRA_DIMENSIONS_SECTION}}
 
@@ -303,6 +305,8 @@ Phase 4 dimensions:
   to this task's criteria.
 - Safety — PASS — input validated via shared Zod schema at `src/routes/exports.ts:12` before DB access.
 - Consistency — PASS — follows existing endpoint patterns in `src/routes/`; uses the shared error format.
+- Robustness — N/A — the change only adds input validation with a standard 400 response; it introduces no
+  error/failure-recovery path (retries, rollback, degradation) beyond what Correctness already covers.
 
 Verdict: `status: "passed"`, no critique.
 
@@ -336,6 +340,12 @@ Signals:
           "dimension": "consistency",
           "passed": true,
           "finding": "follows existing endpoint patterns in src/routes/; uses the shared error format from src/lib/errors.ts"
+        },
+        {
+          "dimension": "robustness",
+          "passed": false,
+          "applicable": false,
+          "finding": "input-validation change only; no error/failure-recovery path beyond the 400 response Correctness already covers"
         }
       ],
       "criteria": [
@@ -379,6 +389,9 @@ Phase 4 dimensions:
 - Safety — FAIL — `src/repositories/users.ts:23`: SQL injection via unparameterised template literal.
   Sibling `src/repositories/posts.ts:15` shows the correct pattern.
 - Consistency — PASS — controller structure follows existing patterns; pagination helper used correctly.
+- Robustness — FAIL — `src/controllers/users.ts:47` lets the `NaN` from `parseInt(page)` propagate
+  uncaught into the query layer instead of degrading gracefully (e.g. rejecting with a 400 before the
+  query runs); the same defect that breaks Correctness also breaks graceful error handling here.
 
 Verdict: `status: "failed"`, critique:
 
@@ -388,6 +401,9 @@ Verdict: `status: "failed"`, critique:
 - "[Safety] (a) safety, (b) `WHERE name LIKE '%${query}%'` at `src/repositories/users.ts:23` interpolates
   user input into SQL, (c) use a parameterised query with `$1` placeholder, (d)
   `src/repositories/users.ts:23`."
+- "[Robustness] (a) robustness, (b) `src/controllers/users.ts:47` lets an invalid `page` value propagate
+  as an uncaught exception instead of a handled 400, (c) validate `page` before use and return a graceful
+  400 on failure, (d) `src/controllers/users.ts:47`."
 
 Signals:
 
@@ -419,6 +435,11 @@ Signals:
           "dimension": "consistency",
           "passed": true,
           "finding": "controller structure follows existing patterns; pagination helper used correctly"
+        },
+        {
+          "dimension": "robustness",
+          "passed": false,
+          "finding": "src/controllers/users.ts:47 lets an invalid page value propagate as an uncaught exception instead of a handled 400"
         }
       ],
       "criteria": [
@@ -429,7 +450,7 @@ Signals:
           "evidence": "src/controllers/users.ts:47 returns 500 on non-numeric page (expected 400)"
         }
       ],
-      "critique": "[Correctness · C2] (a) correctness, (b) parseInt(page) at src/controllers/users.ts:47 returns NaN for non-numeric input causing 500, (c) validate page before use so invalid input returns 400, (d) src/controllers/users.ts:47. [Safety] (a) safety, (b) WHERE name LIKE '%${query}%' at src/repositories/users.ts:23 interpolates user input into SQL, (c) use a parameterised query, (d) src/repositories/users.ts:23.",
+      "critique": "[Correctness · C2] (a) correctness, (b) parseInt(page) at src/controllers/users.ts:47 returns NaN for non-numeric input causing 500, (c) validate page before use so invalid input returns 400, (d) src/controllers/users.ts:47. [Safety] (a) safety, (b) WHERE name LIKE '%${query}%' at src/repositories/users.ts:23 interpolates user input into SQL, (c) use a parameterised query, (d) src/repositories/users.ts:23. [Robustness] (a) robustness, (b) src/controllers/users.ts:47 lets an invalid page value propagate as an uncaught exception, (c) validate page before use and return a graceful 400, (d) src/controllers/users.ts:47.",
       "timestamp": "2026-01-01T00:00:00.000Z"
     }
   ]
@@ -469,6 +490,9 @@ Phase 4 dimensions:
 - Safety — PASS — new session store uses the project's standard signing key from `src/config/secrets.ts`.
 - Consistency — PASS — middleware structure matches `src/middleware/csrf.ts`; config access follows the
   pattern in `src/middleware/rate-limit.ts`.
+- Robustness — PASS — `src/middleware/session.ts:31` catches store-lookup failures and falls back to
+  issuing a fresh anonymous session, matching the retry/fallback pattern already used in
+  `src/middleware/csrf.ts`.
 
 Note: the verify script passed. This round still fails because C3 is unimplemented. The verify suite does
 not test TTL configurability.

--- a/src/integration/ai/prompts/plan/template.md
+++ b/src/integration/ai/prompts/plan/template.md
@@ -100,12 +100,12 @@ Each task entry uses these fields:
     `check === "manual"`. Use the project's own commands — read the project's AI context
     file or manifest for the exact verification command this repository expects.
 - **`blockedBy`** — `id`s of earlier tasks that must complete first.
-- **`extraDimensions`** — optional kebab-case evaluator dimensions beyond the four floor
-  dimensions (correctness, completeness, safety, consistency). Attach an extra dimension
-  ONLY when an acceptance criterion explicitly demands a measurable property that no floor
-  dimension covers AND no manual criterion already encodes it. When in doubt, omit — the
+- **`extraDimensions`** — optional kebab-case evaluator dimensions beyond the five floor
+  dimensions (correctness, completeness, safety, consistency, robustness). Attach an extra
+  dimension ONLY when an acceptance criterion explicitly demands a measurable property that no
+  floor dimension covers AND no manual criterion already encodes it. When in doubt, omit — the
   floor dimensions are almost always sufficient. Example of a justified attachment:
-  `migration-safety` when the ticket requires a zero-downtime schema change that the four
+  `migration-safety` when the ticket requires a zero-downtime schema change that the five
   floor dimensions cannot score on their own. Cap: 2–3 per task; hard max 6.
 
 If you cannot produce a sound plan, emit the `task-plan` signal with `tasksJson` set to:

--- a/tests/e2e/flows/implement-parallel-realgit.test.ts
+++ b/tests/e2e/flows/implement-parallel-realgit.test.ts
@@ -189,12 +189,13 @@ function runTests(): void {
   const evaluationPassed = (): HarnessSignal => ({
     type: 'evaluation',
     status: 'passed',
-    // Full floor set — a terminal PASS must grade all four floor dimensions per the signal schema.
+    // Full floor set — a terminal PASS must grade all five floor dimensions per the signal schema.
     dimensions: [
       { dimension: 'correctness', passed: true, finding: 'all good' },
       { dimension: 'completeness', passed: true, finding: 'steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated' },
       { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+      { dimension: 'robustness', passed: true, finding: 'error paths handled' },
     ],
     timestamp: FIXED_NOW,
   });

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -396,13 +396,14 @@ const commitMessage = (subject: string, body?: string): HarnessSignal => ({
 });
 
 /**
- * The three floor dimensions other than `correctness`, all passing — appended so terminal
+ * The four floor dimensions other than `correctness`, all passing — appended so terminal
  * verdicts carry the full floor set the signal schema now requires.
  */
 const floorPasses = [
   { dimension: 'completeness', passed: true, finding: 'steps shipped' },
   { dimension: 'safety', passed: true, finding: 'inputs validated' },
   { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+  { dimension: 'robustness', passed: true, finding: 'error paths handled' },
 ];
 
 /**

--- a/tests/e2e/full-stack/implement-review-close.test.ts
+++ b/tests/e2e/full-stack/implement-review-close.test.ts
@@ -101,6 +101,7 @@ function runTests(): void {
       { dimension: 'completeness', passed: true, finding: 'steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated' },
       { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+      { dimension: 'robustness', passed: true, finding: 'error paths handled' },
     ],
     timestamp: FIXED_NOW,
   });
@@ -112,6 +113,7 @@ function runTests(): void {
       { dimension: 'completeness', passed: true, finding: 'steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated' },
       { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+      { dimension: 'robustness', passed: true, finding: 'error paths handled' },
     ],
     critique,
     timestamp: FIXED_NOW,

--- a/tests/e2e/full-stack/sprint-lifecycle.test.ts
+++ b/tests/e2e/full-stack/sprint-lifecycle.test.ts
@@ -89,6 +89,7 @@ function runTests(): void {
       { dimension: 'completeness', passed: true, finding: 'steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated' },
       { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+      { dimension: 'robustness', passed: true, finding: 'error paths handled' },
     ],
     timestamp: FIXED_NOW,
   });
@@ -100,6 +101,7 @@ function runTests(): void {
       { dimension: 'completeness', passed: true, finding: 'steps shipped' },
       { dimension: 'safety', passed: true, finding: 'inputs validated' },
       { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+      { dimension: 'robustness', passed: true, finding: 'error paths handled' },
     ],
     critique,
     timestamp: FIXED_NOW,

--- a/tests/integration/ai/prompts/evaluate-continuation/definition.test.ts
+++ b/tests/integration/ai/prompts/evaluate-continuation/definition.test.ts
@@ -13,6 +13,7 @@ const deps = createFsTemplateLoader(defaultTemplatesDir());
 const TEMPLATE_PATH = `${String(defaultTemplatesDir())}/evaluate-continuation/template.md`;
 const CONTRACT_PATH = '/tmp/ralph/main-repo/contract.md';
 const PROGRESS_FILE = '/tmp/ralph/sprint-1/progress.md';
+const SAMPLE_FLOOR_RUBRIC_SECTION = '1. **Correctness** — rationale.\n\n   **Verdict:** PASS when ...; FAIL when ...';
 const SAMPLE_CONTRACT_SECTION =
   '## Output contract\n\nWrite /tmp/ralph/sandbox/rounds/3/evaluator/signals.json. (test fixture body.)';
 
@@ -51,6 +52,11 @@ describe('evaluateContinuationPromptDef — completeness', () => {
   it('declares the single evaluation-verdict signal the full evaluate prompt does', () => {
     expect(evaluateContinuationPromptDef.expectedSignals).toEqual(['evaluation']);
   });
+
+  it('declares the FLOOR_RUBRIC_SECTION placeholder for the single-sourced floor rubric', () => {
+    const placeholders = Object.values(evaluateContinuationPromptDef.parameters).map((p) => p.placeholder);
+    expect(placeholders).toContain('FLOOR_RUBRIC_SECTION');
+  });
 });
 
 describe('buildEvaluateContinuationPrompt — end-to-end against the real template', () => {
@@ -68,9 +74,16 @@ describe('buildEvaluateContinuationPrompt — end-to-end against the real templa
     expect(result.value).toContain('# Re-evaluate — Round 4');
     expect(result.value).toContain(CONTRACT_PATH);
     expect(result.value).toContain(PROGRESS_FILE);
-    // The verdict-format reminder must ride so the reviewer stays consistent on the floor
+    // The rendered floor rubric must ride so the reviewer stays consistent on the floor
     // dimensions and malformed semantics across rounds (kept in sync with evaluate/template.md).
-    expect(result.value).toContain('correctness, completeness, safety, consistency');
+    for (const name of ['**Correctness**', '**Completeness**', '**Safety**', '**Consistency**', '**Robustness**']) {
+      expect(result.value).toContain(name);
+    }
+    // Rationale-before-verdict: the floor's name/description precedes its "Verdict:" line.
+    const robustnessIdx = result.value.indexOf('**Robustness**');
+    const robustnessVerdictIdx = result.value.indexOf('**Verdict:**', robustnessIdx);
+    expect(robustnessIdx).toBeGreaterThan(-1);
+    expect(robustnessVerdictIdx).toBeGreaterThan(robustnessIdx);
     expect(result.value).toContain('malformed');
     // The cold-resume hedge tells a context-free thread where to re-read the specification.
     expect(result.value).toContain('re-read these on-disk files');
@@ -143,6 +156,7 @@ describe('evaluateContinuationPromptDef — validate-rejected paths', () => {
       contractPath: CONTRACT_PATH,
       progressFile: PROGRESS_FILE,
       priorProgress: '',
+      floorRubricSection: SAMPLE_FLOOR_RUBRIC_SECTION,
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       generatorHintsSection: '',
     });
@@ -157,6 +171,7 @@ describe('evaluateContinuationPromptDef — validate-rejected paths', () => {
       contractPath: CONTRACT_PATH,
       progressFile: PROGRESS_FILE,
       priorProgress: '',
+      floorRubricSection: SAMPLE_FLOOR_RUBRIC_SECTION,
       outputContractSection: '   ',
       generatorHintsSection: '',
     });

--- a/tests/integration/ai/prompts/evaluate/definition.test.ts
+++ b/tests/integration/ai/prompts/evaluate/definition.test.ts
@@ -103,9 +103,15 @@ describe('evaluatePromptDef — completeness', () => {
     const placeholders = Object.values(evaluatePromptDef.parameters).map((p) => p.placeholder);
     expect(placeholders).toContain('PRIOR_PROGRESS');
   });
+
+  it('declares the FLOOR_RUBRIC_SECTION placeholder for the single-sourced floor rubric', () => {
+    const placeholders = Object.values(evaluatePromptDef.parameters).map((p) => p.placeholder);
+    expect(placeholders).toContain('FLOOR_RUBRIC_SECTION');
+  });
 });
 
 const SAMPLE_CONTRACT_SECTION = '## Output contract\n\nWrite signals.json. (test fixture body.)';
+const SAMPLE_FLOOR_RUBRIC_SECTION = '1. **Correctness** — rationale.\n\n   **Verdict:** PASS when ...; FAIL when ...';
 
 describe('buildEvaluatePrompt — end-to-end against the real template', () => {
   it('produces a fully-substituted prompt with title, task name, project path, and no leftover placeholders', async () => {
@@ -222,6 +228,29 @@ describe('buildEvaluatePrompt — end-to-end against the real template', () => {
     expect(result.value).toContain('## Task: shipped-earlier — Attempt 1');
   });
 
+  it('renders all five floor dimensions including robustness, rationale before verdict', async () => {
+    const task = makeTaskWith({ name: 'five-floor rubric' });
+    const result = await buildEvaluatePrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    for (const name of ['**Correctness**', '**Completeness**', '**Safety**', '**Consistency**', '**Robustness**']) {
+      expect(result.value).toContain(name);
+    }
+    // Rationale-before-verdict: each floor's name/description precedes its "Verdict:" line.
+    const robustnessIdx = result.value.indexOf('**Robustness**');
+    const robustnessVerdictIdx = result.value.indexOf('**Verdict:**', robustnessIdx);
+    expect(robustnessIdx).toBeGreaterThan(-1);
+    expect(robustnessVerdictIdx).toBeGreaterThan(robustnessIdx);
+    // Robustness carries its explicit not-applicable-with-reason guidance.
+    expect(result.value).toContain('applicable: false');
+  });
+
   it('renders extra dimensions after the floor dimensions when planner attached them', async () => {
     const ticket = makeApprovedTicket();
     const task = unwrap(
@@ -244,10 +273,10 @@ describe('buildEvaluatePrompt — end-to-end against the real template', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value).toContain('Task-specific dimensions');
-    expect(result.value).toContain('5. **accessibility**');
-    expect(result.value).toContain('6. **performance**');
-    // Extras must come after the four floor dimensions.
-    const floorIdx = result.value.indexOf('**Consistency**');
+    expect(result.value).toContain('6. **accessibility**');
+    expect(result.value).toContain('7. **performance**');
+    // Extras must come after the five floor dimensions.
+    const floorIdx = result.value.indexOf('**Robustness**');
     const extrasIdx = result.value.indexOf('Task-specific dimensions');
     expect(floorIdx).toBeGreaterThan(-1);
     expect(extrasIdx).toBeGreaterThan(floorIdx);
@@ -266,6 +295,7 @@ describe('evaluatePromptDef — validate-rejected paths', () => {
       verificationCriteriaSection: '',
       verifyScriptSection: 'No verify script configured for this repo.',
       projectTooling: '_(none detected)_',
+      floorRubricSection: SAMPLE_FLOOR_RUBRIC_SECTION,
       extraDimensionsSection: '',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       priorProgress: '',
@@ -286,6 +316,7 @@ describe('evaluatePromptDef — validate-rejected paths', () => {
       verificationCriteriaSection: '',
       verifyScriptSection: 'No verify script configured for this repo.',
       projectTooling: '_(none detected)_',
+      floorRubricSection: SAMPLE_FLOOR_RUBRIC_SECTION,
       extraDimensionsSection: '',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       priorProgress: '',
@@ -306,6 +337,7 @@ describe('evaluatePromptDef — validate-rejected paths', () => {
       verificationCriteriaSection: '',
       verifyScriptSection: 'No verify script configured for this repo.',
       projectTooling: '_(none detected)_',
+      floorRubricSection: SAMPLE_FLOOR_RUBRIC_SECTION,
       extraDimensionsSection: '',
       outputContractSection: SAMPLE_CONTRACT_SECTION,
       priorProgress: '',

--- a/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
@@ -112,12 +112,13 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     return { events, eventBus };
   };
 
-  // Terminal verdicts now MUST grade all four floor dimensions (correctness / completeness /
-  // safety / consistency), so every fixture below carries the full floor set.
+  // Terminal verdicts now MUST grade all five floor dimensions (correctness / completeness /
+  // safety / consistency / robustness), so every fixture below carries the full floor set.
   const floorPasses = [
     { dimension: 'completeness', passed: true, finding: 'all steps shipped' },
     { dimension: 'safety', passed: true, finding: 'inputs validated' },
     { dimension: 'consistency', passed: true, finding: 'matches siblings' },
+    { dimension: 'robustness', passed: true, finding: 'error paths handled' },
   ];
 
   const passedEvaluation: EvaluationSignal = {

--- a/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
+++ b/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
@@ -361,7 +361,7 @@ describe('createGenEvalLoop — entropy-check (R2) live behavior', () => {
   const change = (text: string): HarnessSignal => ({ type: 'change', text, timestamp: ts });
   const learning = (text: string): HarnessSignal => ({ type: 'learning', text, timestamp: ts });
 
-  const FLOOR = ['correctness', 'completeness', 'safety', 'consistency'] as const;
+  const FLOOR = ['correctness', 'completeness', 'safety', 'consistency', 'robustness'] as const;
   // Pairwise-dissimilar critiques (trigram-Jaccard < 0.5) so the evaluator's critique-shift
   // exemption keeps returning `progress` and its count-based plateau never fires.
   const CRITIQUES = [

--- a/tests/unit/business/task/dimension-trajectory.test.ts
+++ b/tests/unit/business/task/dimension-trajectory.test.ts
@@ -6,18 +6,27 @@ import { composeDimensionTrajectory } from '@src/business/task/dimension-traject
 
 const TS = '2026-06-12T00:00:00.000Z' as IsoTimestamp;
 
-const evalWith = (failed: readonly string[], passed: readonly string[] = []): EvaluationSignal => ({
+const evalWith = (
+  failed: readonly string[],
+  passed: readonly string[] = [],
+  notApplicable: readonly string[] = []
+): EvaluationSignal => ({
   type: 'evaluation',
   status: failed.length === 0 ? 'passed' : 'failed',
   dimensions: [
     ...failed.map((d) => ({ dimension: d, passed: false, finding: 'x' })),
     ...passed.map((d) => ({ dimension: d, passed: true, finding: 'ok' })),
+    ...notApplicable.map((d) => ({ dimension: d, passed: false, applicable: false, finding: 'not applicable' })),
   ],
   timestamp: TS,
 });
 
-const turn = (failed: readonly string[], passed: readonly string[] = []): PlateauTurnRecord => ({
-  evaluation: evalWith(failed, passed),
+const turn = (
+  failed: readonly string[],
+  passed: readonly string[] = [],
+  notApplicable: readonly string[] = []
+): PlateauTurnRecord => ({
+  evaluation: evalWith(failed, passed, notApplicable),
 });
 
 describe('composeDimensionTrajectory', () => {
@@ -57,6 +66,16 @@ describe('composeDimensionTrajectory', () => {
       maxTurns: 8,
     });
     expect(out).toContain('completeness: newly failing this round');
+  });
+
+  it('treats an applicable:false dimension as never failing, not newly failing', () => {
+    const out = composeDimensionTrajectory({
+      history: [turn(['correctness']), turn(['correctness'], [], ['robustness'])],
+      plateauThreshold: 5,
+      roundNum: 2,
+      maxTurns: 8,
+    });
+    expect(out).not.toContain('robustness');
   });
 
   it('fires the budget-pressure line one round before the plateau threshold', () => {

--- a/tests/unit/business/task/plateau-detection-branches.test.ts
+++ b/tests/unit/business/task/plateau-detection-branches.test.ts
@@ -22,10 +22,11 @@ import {
 
 const NOW = isoTimestamp('2026-05-26T10:00:00.000Z');
 
-const dim = (name: string, passed: boolean): DimensionScore => ({
+const dim = (name: string, passed: boolean, applicable?: boolean): DimensionScore => ({
   dimension: name,
   passed,
   finding: passed ? '' : 'placeholder failure finding',
+  ...(applicable !== undefined ? { applicable } : {}),
 });
 
 const evalFrom = (...dims: DimensionScore[]): EvaluationSignal => ({

--- a/tests/unit/business/task/plateau-detection.test.ts
+++ b/tests/unit/business/task/plateau-detection.test.ts
@@ -11,10 +11,11 @@ import {
 
 const NOW = isoTimestamp('2026-05-09T10:00:00.000Z');
 
-const dim = (name: string, passed: boolean): DimensionScore => ({
+const dim = (name: string, passed: boolean, applicable?: boolean): DimensionScore => ({
   dimension: name,
   passed,
   finding: passed ? '' : 'placeholder failure finding',
+  ...(applicable !== undefined ? { applicable } : {}),
 });
 
 const evalFrom = (...dims: DimensionScore[]): EvaluationSignal => ({
@@ -48,6 +49,11 @@ describe('failedDimensions', () => {
   it('returns lowercased trimmed names of failed dimensions only', () => {
     const sig = evalFrom(dim(' Correctness ', false), dim('Completeness', true), dim('SAFETY', false));
     expect(failedDimensions(sig)).toEqual(new Set(['correctness', 'safety']));
+  });
+
+  it('excludes an applicable:false dimension even when passed is false', () => {
+    const sig = evalFrom(dim('correctness', false), dim('robustness', false, false));
+    expect(failedDimensions(sig)).toEqual(new Set(['correctness']));
   });
 });
 

--- a/tests/unit/integration/ai/contract/_engine/render-evaluation-markdown.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/render-evaluation-markdown.test.ts
@@ -39,6 +39,27 @@ describe('renderEvaluationMarkdown', () => {
     expect(md).toContain('```\nnpm test\n  12 passing\n```');
   });
 
+  it('renders an applicable:false dimension as n/a, not passed/failed', () => {
+    const signal: EvaluationSignal = {
+      type: 'evaluation',
+      status: 'passed',
+      dimensions: [
+        {
+          dimension: 'robustness',
+          passed: false,
+          applicable: false,
+          finding: 'change touches no error path',
+        },
+      ],
+      timestamp: ts(),
+    };
+    const md = renderEvaluationMarkdown(signal);
+    expect(md).toContain('### robustness — n/a');
+    expect(md).not.toContain('### robustness — passed');
+    expect(md).not.toContain('### robustness — failed');
+    expect(md).toContain('change touches no error path');
+  });
+
   it('omits the critique section when critique is absent', () => {
     const signal: EvaluationSignal = {
       type: 'evaluation',

--- a/tests/unit/integration/ai/contract/_engine/signal-schemas.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/signal-schemas.test.ts
@@ -20,7 +20,7 @@ import { prContentSignalSchema } from '@src/integration/ai/contract/_engine/sign
 const ts = '2026-05-22T10:00:00.000Z';
 
 /**
- * The three floor dimensions other than `correctness` — appended so a terminal verdict carries
+ * The four floor dimensions other than `correctness` — appended so a terminal verdict carries
  * the full floor set the signal schema now requires. Individual tests vary the `correctness`
  * row to drive the case under test.
  */
@@ -28,6 +28,7 @@ const floorRest = [
   { dimension: 'completeness', passed: true, finding: '' },
   { dimension: 'safety', passed: true, finding: '' },
   { dimension: 'consistency', passed: true, finding: '' },
+  { dimension: 'robustness', passed: true, finding: '' },
 ];
 
 /**
@@ -235,6 +236,31 @@ describe('signal schemas (happy-path parses)', () => {
     });
     expect(r.success).toBe(false);
   });
+
+  it('evaluation: a PASS verdict whose robustness dimension is applicable:false (with a finding) validates', () => {
+    const dimensions = [
+      { dimension: 'correctness', passed: true, finding: '' },
+      { dimension: 'completeness', passed: true, finding: '' },
+      { dimension: 'safety', passed: true, finding: '' },
+      { dimension: 'consistency', passed: true, finding: '' },
+      { dimension: 'robustness', passed: false, applicable: false, finding: 'change touches no error path' },
+    ];
+    const r = evaluationSignalSchema.safeParse({ type: 'evaluation', status: 'passed', dimensions, timestamp: ts });
+    expect(r.success).toBe(true);
+  });
+
+  it('evaluation: rejects an applicable:false dimension with an empty finding', () => {
+    const dimensions = [
+      { dimension: 'correctness', passed: true, finding: '' },
+      { dimension: 'completeness', passed: true, finding: '' },
+      { dimension: 'safety', passed: true, finding: '' },
+      { dimension: 'consistency', passed: true, finding: '' },
+      { dimension: 'robustness', passed: false, applicable: false, finding: '' },
+    ];
+    const r = evaluationSignalSchema.safeParse({ type: 'evaluation', status: 'passed', dimensions, timestamp: ts });
+    expect(r.success).toBe(false);
+  });
+
   it('commit-message', () => {
     expect(
       commitMessageSignalSchema.safeParse({ type: 'commit-message', subject: 'feat: x', timestamp: ts }).success

--- a/tests/unit/integration/ai/evaluation/floor-dimensions.test.ts
+++ b/tests/unit/integration/ai/evaluation/floor-dimensions.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { FLOOR_DIMENSION_NAMES, FLOOR_DIMENSIONS } from '@src/integration/ai/evaluation/_engine/floor-dimensions.ts';
 
 describe('FLOOR_DIMENSIONS', () => {
-  it('lists exactly four dimensions in canonical order', () => {
-    expect(FLOOR_DIMENSIONS.map((d) => d.name)).toEqual(['Correctness', 'Completeness', 'Safety', 'Consistency']);
+  it('lists exactly five dimensions in canonical order', () => {
+    expect(FLOOR_DIMENSIONS.map((d) => d.name)).toEqual([
+      'Correctness',
+      'Completeness',
+      'Safety',
+      'Consistency',
+      'Robustness',
+    ]);
   });
 
   it('every dimension has a non-empty description', () => {
@@ -13,6 +19,12 @@ describe('FLOOR_DIMENSIONS', () => {
   });
 
   it('FLOOR_DIMENSION_NAMES contains lowercased names matching FLOOR_DIMENSIONS', () => {
-    expect([...FLOOR_DIMENSION_NAMES].sort()).toEqual(['completeness', 'consistency', 'correctness', 'safety']);
+    expect([...FLOOR_DIMENSION_NAMES].sort()).toEqual([
+      'completeness',
+      'consistency',
+      'correctness',
+      'robustness',
+      'safety',
+    ]);
   });
 });


### PR DESCRIPTION
Sprint branch for the evaluator floor work from #218:

- add a robustness floor and an explicit N/A dimension outcome
- single-source the floor rubric, rationale-before-verdict ordering, five floors

29 files, +367/−105 — evaluator contract, floor dimensions, plateau detection, prompt templates, and their tests.

https://claude.ai/code/session_01LcQaVCVMqszKyS6kDi2rwU