### PR TITLE
feat(skills): opt-in / selective skill loading per flow & run (#216)

### DIFF
--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -78,6 +78,9 @@
 - [project_loop_diversity_budget_precedence.md](project_loop_diversity_budget_precedence.md) — gen-eval loop-diversity
   guard must not pre-empt the final budgeted turn; budget-exhausted wins over plateau when turnsUsed >= maxTurns (reads
   readConfig budget, not a captured const)
+- [project_skill_selection_resolution_seam.md](project_skill_selection_resolution_seam.md) — #216 T4: ONE skill
+  resolution point (createResolvedSkillSource decorator in launcher buildComposedSkillSource); compose order
+  bundled→project→operator→phase (LAST-wins dedupe), disabled subtraction, getByName unfiltered, aiFlowIdFor aliasing
 - [project_plateau_predicate_count_based.md](project_plateau_predicate_count_based.md) — plateau predicate is
   failed-dim-COUNT based (not identical-set); critique-shift (Jaccard<0.5) is the lever to keep a multi-turn loop test
   running; R2 entropy guard reads ctx.lastTurnActionCounts (signal-kind proxy) stamped by generator every turn

--- a/.claude/agent-memory/implementer/project_skill_selection_resolution_seam.md
+++ b/.claude/agent-memory/implementer/project_skill_selection_resolution_seam.md
@@ -1,0 +1,34 @@
+---
+name: skill-selection-resolution-seam
+description: The ONE skill-selection resolution point — createResolvedSkillSource decorator wraps the composed
+  SkillSource in the launcher; dedupe last-wins + disabled subtraction; getByName passes through unfiltered
+metadata:
+  type: project
+---
+
+Opt-in/opt-out skill loading (#216 T4) resolves at exactly ONE point: `createResolvedSkillSource`
+(`src/integration/ai/skills/_engine/resolve-selection.ts`), a pure `SkillSource` decorator wired inside
+`buildComposedSkillSource` in `src/application/ui/shared/launcher.ts`. No leaf/adapter filters skills.
+
+**Why:** the plan required a single seam that a future v2 relevance recommender can replace behind the same
+`SkillSource` contract without touching install-skills leaves or adapters.
+
+**How to apply:**
+
+- Composition ORDER is load-bearing: `composeSkillSources(bundled, project, operator, phase)` — phase LAST.
+  The decorator's `getForFlow` dedupes by install `name` keeping the LAST occurrence, so a phase-folder copy
+  (catalog copy-on-enable) shadows the bundled default. Dedupe is a no-op when names are unique (zero-config
+  byte-identical to pre-decorator behaviour — fenced by `launcher-composition.test.ts`).
+- `getForFlow` = dedupe THEN subtract `flowDisabled(flowId)`. `getByName` passes through UNFILTERED/un-deduped:
+  it's a name-RESOLUTION seam (readiness `offer-skill-suggestions` uses it to tell known-bundled from unknown),
+  NOT an install seam. Filtering it would mislabel an opted-out skill as "unknown" and scaffold a wrong stub.
+- `flowDisabled` is run-scoped in the launcher: saved `settings.ai.skills[flow].disabled` unioned with per-run
+  `LaunchExtras.skillsOverride.disabled` (new field, applies to ANY skill name). Duplicates collapse in a Set.
+- ALIASED-FLOW RULE (one everywhere): the saved-preference key is resolved from the DISPATCHED orchestration id
+  via the existing `aiFlowIdFor` (kebab→camel): `create-pr`→`createPr`, `review`→`implement`,
+  `detect-scripts`/`detect-skills`→`readiness`. So a review launch inherits implement's disabled row.
+- Only refine/plan/implement/readiness/ideate actually mount skills via `ctx.skillSource`. review/detect-*
+  don't pass `skillSource` to their flow, so their `getForFlow` is never called (aliasing still resolves the key
+  harmlessly). create-pr has NO launch case in `launchFlow`'s dispatch switch today.
+- `buildComposedSkillSource` is exported (@public) so the composition fence test drives the REAL wiring rather
+  than a reconstruction that could drift.

--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -29,6 +29,24 @@ with effort unset escalates to `max`, not `high`), while Copilot/Codex escalate 
 at a different one; the launcher rebuilds the provider / interactive-AI / skills-adapter trio per launch
 keyed on the dispatched flow's row, so mixed and uniform configs traverse the same code path.
 
+**Per-flow skill opt-out — `settings.ai.skills`.** An optional, durable preference of shape
+`Partial<Record<FlowId, { disabled: string[] }>>`. Every flow key is optional; an absent key — or an absent
+`ai.skills` altogether — means the flow's registry defaults apply. Each flow's `disabled` array lists skill
+names (`ralphctl-*`) to SUBTRACT from that flow's bundled defaults at launch. Names are not validated against
+the bundled catalog at parse time, so an unknown name is a harmless no-op. This is opt-OUT only — adding a
+skill beyond the defaults is filesystem-based (`<appRoot>/skills/<flow>/` folders), never settings.
+
+```json
+"skills": {
+  "implement": { "disabled": ["ralphctl-ponytail"] },
+  "refine": { "disabled": [] }
+}
+```
+
+Precedence at launch: per-run override > this saved preference > registry default. The per-run override is
+the customize picker's checklist; the saved preference is this key; the registry default is the flow's
+bundled skill set.
+
 **Twenty presets across five families** stamp the entire `ai` section plus `harness.escalateOnPlateau`
 in one shot — all equally first-class (none is marked default). Each family carries four variants:
 `mixed` (best-fit provider per flow), `claude-only`, `copilot-only`, `codex-only`. The families:

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -226,8 +226,8 @@ Four `SkillSource` implementations compose into one union at launch time (`build
 `createResolvedSkillSource` (`_engine/resolve-selection.ts`) wraps the composed union as the single skill-
 selection resolution seam: `getForFlow` dedupes by install name keeping the LAST occurrence (so a phase-
 folder copy of a bundled name shadows the bundled default — composition order is load-bearing), then
-subtracts a per-flow disabled-name set — the union of the durable `settings.ai.skills[flow].disabled`
-preference and the customize picker's per-run `skillsOverride` (a run override REPLACES the saved
+subtracts a per-flow disabled-name set — the customize picker's per-run `skillsOverride` when present,
+otherwise the durable `settings.ai.skills[flow].disabled` preference (a run override REPLACES the saved
 preference outright, so it can also re-enable a remembered-off skill for one run). `getByName` passes
 through unfiltered — it is a name-_resolution_ seam for the readiness flow's `offer-skill-suggestions`
 leaf, not an install seam, so opt-out never hides a name from being recognised.

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -179,20 +179,21 @@ business/
 Service ports live under `business/<module>/` (one folder per cross-cutting concern). Repository interfaces live
 in `domain/repository/<aggregate>/`.
 
-| Port                                                  | Folder                              | Concrete adapter                                                                                                                                                            |
-| ----------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Logger` + `Sink`                                     | `business/observability/`           | `createEventBusLogger` (re-published as `LogEvent`)                                                                                                                         |
-| `EventBus`                                            | `business/observability/`           | `InMemoryEventBus` (`integration/observability/`)                                                                                                                           |
-| `HeadlessAiProvider`                                  | `integration/ai/providers/_engine/` | `claude` / `copilot` / `codex` adapters under `providers/<tool>/`                                                                                                           |
-| `InteractiveAiProvider`                               | `integration/ai/providers/_engine/` | same per-tool adapters (interactive entrypoint)                                                                                                                             |
-| `PublishSignal` (fn type)                             | `application/flows/_shared/`        | `createPublishSignal(eventBus, source, taskId?)` — the ONE harness-signal channel (`ai-signal` AppEvent)                                                                    |
-| `TemplateLoader`                                      | `integration/ai/prompts/_engine/`   | `FsTemplateLoader` — dev: src tree, bundled: `dist/`                                                                                                                        |
-| `ReadinessProbe`                                      | `integration/ai/readiness/_engine/` | per-tool probes under `readiness/<tool>/`                                                                                                                                   |
-| `SkillsAdapter` + `SkillSource`                       | `integration/ai/skills/_engine/`    | per-tool adapter + bundled / operator / project source; `parseSkill` extracts a `Skill` from a `SKILL.md`; `checkSkillContract` validates against six harness rules (S1–S6) |
-| `GitRunner` / `ShellScriptRunner`                     | `integration/io/`                   | `createGitRunner` / `createShellScriptRunner`                                                                                                                               |
-| `WriteFile` (port) + `FileLocker` (adapter)           | `business/io/` / `integration/io/`  | atomic write helper / `createFileLocker`                                                                                                                                    |
-| `IssueFetcher` / `IssuePusher` / `PullRequestCreator` | `business/scm/`                     | `gh` / `glab` shell wrappers under `integration/scm/`                                                                                                                       |
-| `VersionChecker`                                      | `business/version/`                 | `createNpmVersionChecker` (`integration/version/`)                                                                                                                          |
+| Port                                                  | Folder                              | Concrete adapter                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Logger` + `Sink`                                     | `business/observability/`           | `createEventBusLogger` (re-published as `LogEvent`)                                                                                                                                                                                                                       |
+| `EventBus`                                            | `business/observability/`           | `InMemoryEventBus` (`integration/observability/`)                                                                                                                                                                                                                         |
+| `HeadlessAiProvider`                                  | `integration/ai/providers/_engine/` | `claude` / `copilot` / `codex` adapters under `providers/<tool>/`                                                                                                                                                                                                         |
+| `InteractiveAiProvider`                               | `integration/ai/providers/_engine/` | same per-tool adapters (interactive entrypoint)                                                                                                                                                                                                                           |
+| `PublishSignal` (fn type)                             | `application/flows/_shared/`        | `createPublishSignal(eventBus, source, taskId?)` — the ONE harness-signal channel (`ai-signal` AppEvent)                                                                                                                                                                  |
+| `TemplateLoader`                                      | `integration/ai/prompts/_engine/`   | `FsTemplateLoader` — dev: src tree, bundled: `dist/`                                                                                                                                                                                                                      |
+| `ReadinessProbe`                                      | `integration/ai/readiness/_engine/` | per-tool probes under `readiness/<tool>/`                                                                                                                                                                                                                                 |
+| `SkillsAdapter` + `SkillSource`                       | `integration/ai/skills/_engine/`    | per-tool adapter + bundled / project / operator / phase-folder source, composed and resolved by `createResolvedSkillSource`; `parseSkill` extracts a `Skill` from a `SKILL.md`; `checkSkillContract` validates against six harness rules (S1–S6) — see § Skills subsystem |
+| `SkillCatalogPort`                                    | `integration/ai/skills/_engine/`    | `createSkillCatalog` (`skills/phase/catalog.ts`) — list / enable / disable / update / updateAll over the phase folders, provenance-stamped                                                                                                                                |
+| `GitRunner` / `ShellScriptRunner`                     | `integration/io/`                   | `createGitRunner` / `createShellScriptRunner`                                                                                                                                                                                                                             |
+| `WriteFile` (port) + `FileLocker` (adapter)           | `business/io/` / `integration/io/`  | atomic write helper / `createFileLocker`                                                                                                                                                                                                                                  |
+| `IssueFetcher` / `IssuePusher` / `PullRequestCreator` | `business/scm/`                     | `gh` / `glab` shell wrappers under `integration/scm/`                                                                                                                                                                                                                     |
+| `VersionChecker`                                      | `business/version/`                 | `createNpmVersionChecker` (`integration/version/`)                                                                                                                                                                                                                        |
 
 Shared engine-level helpers (not ports — no interface boundary, but architecturally significant):
 
@@ -209,6 +210,39 @@ Shared engine-level helpers (not ports — no interface boundary, but architectu
 - **`compressSection`** (`prompts/_engine/compress-section.ts`) — tail-compresses oversized prompt
   sections (`PRIOR_PROGRESS` / `PRIOR_LEARNINGS` / `PRIOR_EPISODES`) to at most `SECTION_CHAR_CAP`
   (4,000) characters, keeping the most-recent tail and prepending a truncation notice.
+
+## Skills subsystem (`integration/ai/skills/`)
+
+Four `SkillSource` implementations compose into one union at launch time (`buildComposedSkillSource` in
+`application/ui/shared/launcher.ts`), in a fixed order — bundled → project → operator → phase:
+
+| Source     | Folder                            | Scope                                                                                                                                                |
+| ---------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bundled`  | `integration/ai/skills/bundled/`  | Committed `ralphctl-*` skills; per-skill `defaultFor` phases (`_engine/registry.ts`'s `BUNDLED_SKILLS`)                                              |
+| `project`  | `integration/ai/skills/project/`  | Per-repo `setup`/`verify` guidance materialised from `Repository.setupSkill`/`verifySkill`                                                           |
+| `operator` | `integration/ai/skills/operator/` | Global, per-provider drop-ins under `<appRoot>/skills/<claude,copilot,codex>/<name>/SKILL.md`                                                        |
+| `phase`    | `integration/ai/skills/phase/`    | Global, per-flow opt-in folders under `<appRoot>/skills/<flow>/<name>/SKILL.md` — provider-agnostic; the Skills-catalog view's copy-on-enable target |
+
+`createResolvedSkillSource` (`_engine/resolve-selection.ts`) wraps the composed union as the single skill-
+selection resolution seam: `getForFlow` dedupes by install name keeping the LAST occurrence (so a phase-
+folder copy of a bundled name shadows the bundled default — composition order is load-bearing), then
+subtracts a per-flow disabled-name set — the union of the durable `settings.ai.skills[flow].disabled`
+preference and the customize picker's per-run `skillsOverride` (a run override REPLACES the saved
+preference outright, so it can also re-enable a remembered-off skill for one run). `getByName` passes
+through unfiltered — it is a name-_resolution_ seam for the readiness flow's `offer-skill-suggestions`
+leaf, not an install seam, so opt-out never hides a name from being recognised.
+
+`SkillCatalogPort` (`_engine/skill-catalog-port.ts`, implemented by `createSkillCatalog` in
+`phase/catalog.ts`) drives the TUI Skills catalog view (`views/skills-view.tsx`, Home hotkey `K`). The
+phase folder IS the enabled/disabled state: `enable` copies a bundled skill's raw `SKILL.md` bytes
+(via the narrow `BundledSkillRawReader` port — never round-tripped through `parseSkill`) into
+`<appRoot>/skills/<flow>/<name>/` and writes a `.provenance.json` sidecar (`phase/provenance.ts`: sha256
+of the copied bytes, `ralphctlVersion`, `copiedAt`); `disable` removes the folder. The sidecar lets
+`list()` classify each install as `manual` (no stamp — hand-dropped), `in-sync`, `update-available` (the
+bundle moved on upstream), or `locally-modified` (the operator edited the copy — checked first, so it
+always wins over `update-available` and `update`/`updateAll` never silently discard an edit). The
+sidecar is catalog-only bookkeeping — no `SkillSource` ever emits or installs it into a session; a
+`Skill` is always `{ name, description, content }` derived from `SKILL.md` alone.
 
 ## Repository interfaces (`src/domain/repository/`)
 
@@ -373,10 +407,17 @@ of the stack — the leaf or use-case wrapping them catches and converts to `Res
 ~/.ralphctl/                      ← override with RALPHCTL_HOME
 ├── config/
 │   └── settings.json                ← user-configurable settings (per-flow models, provider, log level, …)
-├── skills/                          ← operator drop-in skills root (operatorSkillsRoot); operator-authored,
-│   ├── claude/<name>/SKILL.md          not created by ensureStorageRoots; missing dir = no operator skills
+├── skills/                          ← operatorSkillsRoot; operator-authored, not created by
+│   │                                    ensureStorageRoots; a missing dir = no skills of that kind
+│   ├── claude/<name>/SKILL.md          per-provider operator drop-ins (operator/source.ts)
 │   ├── copilot/<name>/SKILL.md
-│   └── codex/<name>/SKILL.md
+│   ├── codex/<name>/SKILL.md
+│   ├── refine/<name>/SKILL.md          per-flow opt-in folders (phase/source.ts) — provider-agnostic;
+│   ├── plan/<name>/SKILL.md              the Skills-catalog view's copy-on-enable target; kebab dir
+│   ├── implement/<name>/SKILL.md         names via PHASE_FLOW_DIR (createPr → create-pr); a copy
+│   ├── readiness/<name>/SKILL.md         carries a `.provenance.json` sidecar when catalog-managed
+│   ├── ideate/<name>/SKILL.md
+│   └── create-pr/<name>/SKILL.md
 ├── data/
 │   ├── .ralphctl-data-version.json  ← version stamp written after auto-migration; compared on launch to detect pending migrations
 │   ├── projects/
@@ -477,7 +518,9 @@ and the non-obvious mutators.
   `ai.effort` plus one row per flow — `ai.{refine, plan, readiness, ideate, createPr}`, each
   `{ provider, model, effort? }`, and `ai.implement`, a nested `{ generator, evaluator }` pair
   where each role is its own `{ provider, model, effort? }` row. `provider` is one of
-  `'claude-code' | 'github-copilot' | 'openai-codex'`.
+  `'claude-code' | 'github-copilot' | 'openai-codex'`. Optional `ai.skills` is the durable per-flow
+  skill opt-out map (`Partial<Record<FlowId, { disabled: readonly string[] }>>`) — see
+  `AI-SETTINGS.md` § skill opt-out and § Skills subsystem above.
 
 ## Harness Signals
 
@@ -566,7 +609,7 @@ application/ui/
     ├── theme/                       ← tokens.ts (single source of visual truth)
     ├── components/                  ← ViewShell, SectionStamp, ResultCard, FieldList, Spinner, …
     ├── prompts/                     ← InkInteractivePrompt + per-kind components
-    └── views/                       ← Home, Sprints, Sprint detail, Projects, Settings, Doctor,
+    └── views/                       ← Home, Sprints, Sprint detail, Projects, Settings, Skills, Doctor,
                                        Sessions, Execute, Welcome, browse/, crud/
 ```
 

--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -58,7 +58,7 @@ Canonical set. If a view needs a symbol not in this list, **add it to `glyphs` f
 | Phase / status  | `phaseDone ■`, `phaseActive ◆`, `phasePending ◇`, `phaseDisabled ◌`                   |
 | Cursors         | `actionCursor ▸`, `selectMarker ›`                                                    |
 | Section markers | `badge ▣`, `sectionRule ━`                                                            |
-| State           | `check ✓`, `cross ✗`, `warningGlyph ⚠`, `infoGlyph i`                                 |
+| State           | `check ✓`, `cross ✗`, `warningGlyph ⚠`, `infoGlyph i`, `modified ✎`                   |
 | Bullets         | `bullet ·`, `inlineDot ·`, `emDash —`, `arrowRight →`, `activityArrow ↳`, `refresh ↻` |
 | Separators      | `pipe │`                                                                              |
 | Motion          | `spinner` (braille frames `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`)                                               |
@@ -222,8 +222,19 @@ Specialised components owned by `ExecuteView`. Don't import them from other view
 
 ### 4.4 Prompt family (`src/application/ui/tui/prompts/`)
 
-Never build a new prompt component. Always call the injected `InteractivePrompt` port and let
-`createInkInteractivePrompt` queue it onto the `PromptQueue` rendered by `PromptHost`.
+Two legitimate integration modes — pick by who's asking:
+
+- **Business-flow prompts** (a chain leaf / use case needs to ask the user something,
+  provider-agnostic). Never build a new prompt component for this — call the injected
+  `InteractivePrompt` port and let `createInkInteractivePrompt` queue it onto the `PromptQueue`
+  rendered by `PromptHost`.
+- **View-local ephemeral prompts** (a browse/action view needs a quick confirm or multi-select
+  before an in-view mutation — no chain involved). Mount the prompt **component** directly in the
+  view's own conditional render, driven by local React state, exactly like `<ConfirmCard>` /
+  `<ConfirmPrompt>` in `sprints-view.tsx` / `sessions-view.tsx`, or `<MultiSelectPrompt>` in
+  `skills-view.tsx`'s enable/disable flow picker. The view must `ui.claimPrompt()` for as long as
+  the component is mounted (`ConfirmCard` does this internally; a raw `MultiSelectPrompt` mount
+  does not — claim it yourself in a `useEffect`) so global hotkeys stay muted underneath it.
 
 | Method           | Returns                             | Cancel behavior                            |
 | ---------------- | ----------------------------------- | ------------------------------------------ |
@@ -238,6 +249,12 @@ renderer components selected by prompt `kind` (`text` / `textarea` / `confirm` /
 
 `askTextArea` is the Claude-style multi-line inline editor (↵ submits; `\↵` or ctrl+j inserts a newline; Esc
 cancels). No external editor spawn.
+
+`<MultiSelectPrompt>` (used both by `askMultiChoice`'s queue path and view-local mounts) supports
+`Choice.disabled` (dims the row, skips it on cursor movement and `a` select-all, rejects a direct
+toggle — same contract as `<SelectPrompt>`'s single-select cursor) and an optional
+`initialSelectedValues` prop to pre-check a starting selection (e.g. a skill's `recommendedFor`
+list) instead of forcing every choice from scratch.
 
 ## 5. State surfaces — one visual per kind
 

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -207,12 +207,24 @@ Status flow: `draft → planned → active → review → done`.
 - [x] **Bundled skills** — `installSkillsLeaf` / `uninstallSkillsLeaf` bracket every AI session that benefits
       from defaults. Skills are copied into `<repo>/<parentDir>/skills/ralphctl-<name>/` and git-excluded via a
       single `ralphctl-*` wildcard appended to `.git/info/exclude`. Project skills always win over bundled ones.
-      Eight bundled skills ship (`ralphctl-abstraction-first`, `ralphctl-alignment`, `ralphctl-iterative-review`,
+      Thirteen bundled skills ship (`ralphctl-abstraction-first`, `ralphctl-alignment`, `ralphctl-iterative-review`,
       `ralphctl-minimal-scaffolding`, `ralphctl-debugging-and-error-recovery`, `ralphctl-code-review-and-quality`,
-      `ralphctl-test-driven-development`, `ralphctl-surgical-simplicity`). Each is validated by
-      `skill-contract-checker.ts` (hard-fail on contract violation) before it can ship.
-      Operator drop-in skills (`~/.ralphctl/skills/{claude,copilot,codex}/…`) install through the same path;
-      violations are warnings only.
+      `ralphctl-test-driven-development`, `ralphctl-surgical-simplicity`, `ralphctl-ponytail`,
+      `ralphctl-karpathy-guidelines`, `ralphctl-cherny-workflow`, `ralphctl-idea-refinement`,
+      `ralphctl-domain-driven-design` — per-skill default/recommended phases in `_engine/registry.ts`'s
+      `BUNDLED_SKILLS`). Each is validated by `skill-contract-checker.ts` (hard-fail on contract violation)
+      before it can ship. Operator drop-in skills (`~/.ralphctl/skills/{claude,copilot,codex}/…`) install
+      through the same path; violations are warnings only.
+- [x] **Opt-in phase-folder skills (#216)** — a provider-agnostic, per-flow opt-in source under
+      `<appRoot>/skills/<flow>/<name>/SKILL.md` (`createPhaseSkillSource`), composed with the bundled /
+      project / operator sources and resolved by one seam (`createResolvedSkillSource`): a phase-folder
+      copy shadows a same-named bundled default (dedupe, last wins), then the per-flow disabled set —
+      the durable `settings.ai.skills[flow].disabled` preference, or the customize picker's per-run
+      override, which replaces rather than unions with the saved preference — is subtracted. The Skills
+      catalog view (`SkillCatalogPort` / `createSkillCatalog`) drives enable (copy + `.provenance.json`
+      stamp) / disable (remove) / update / update-all, and classifies each install `manual` / `in-sync` /
+      `update-available` / `locally-modified` from that stamp. See `ARCHITECTURE.md` § Skills subsystem
+      and `AI-SETTINGS.md` § skill opt-out for the full contract.
 - [x] **Provider-native context file** — the `readiness` flow fans out across every uniquely referenced
       provider in `settings.ai`, writing one native context file per distinct provider: `CLAUDE.md`
       (claude-code), `.github/copilot-instructions.md` (github-copilot), `AGENTS.md` (openai-codex). A
@@ -315,6 +327,12 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
 - [x] **Idle-state ticker** — tasks panel shows last-note signals when no task is `in_progress`.
 - [x] **ETA estimate** — attempt header shows a median-round-duration ETA derived from past settled
       attempts for the same task.
+- [x] **Skills catalog view (#216)** — `SkillsView` (Home menu, hotkey `K`) lists every bundled skill
+      with its per-flow install status; `e`/`d`/`u`/`U`/`r` enable / disable / update / update-all /
+      reload. A destructive `update` on a `locally-modified` install confirms first via `ConfirmCard`;
+      `updateAll` never touches `locally-modified` or `manual` installs. The pre-launch customize
+      picker's skills step (checklist, run-only vs remember) is the per-run counterpart — see
+      `WORKFLOWS.md` for the navigation walk-through.
 
 ## Build & Distribution
 

--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -87,7 +87,7 @@ non-interactive runs. The earlier "approve & update" / "approve & create" review
 `defaultIssueOrigin`-driven create path were removed — `Project.defaultIssueOrigin` survives as a
 persisted field but refine no longer consults it.
 
-**Bundled skills (8 total) always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already
+**Bundled skills (13 total) always lose to project skills.** When `<cwd>/.claude/skills/<name>/` already
 exists, the bundled copy is skipped and the project copy is left untouched. The skills adapter
 (`src/integration/ai/skills/adapter-factory.ts`) tracks only what it installed; uninstall removes only
 those entries. Every bundled `SKILL.md` is validated by `skill-contract-checker.ts` against six harness
@@ -99,6 +99,20 @@ are discovered by `createOperatorSkillSource` and installed through the same `ra
 `.git/info/exclude` wildcard as bundled skills. `StoragePaths.operatorSkillsRoot` = `<appRoot>/skills`.
 The compat checker runs as a warning for operator skills — a violation logs and skips, never aborts the
 flow. There is no per-project operator location.
+
+**Phase-folder opt-in skills.** Global, per-FLOW (not per-provider) opt-in skills under
+`<appRoot>/skills/<flow>/<name>/SKILL.md` — the provider-agnostic sibling of the operator drop-in above.
+Discovered by `createPhaseSkillSource` and installed through the same `ralphctl-` namespace and
+`.git/info/exclude` wildcard as bundled/operator skills. The TUI's Skills-catalog view (`K` from Home) is
+the intended writer: enabling a bundled skill copies its raw `SKILL.md` bytes into the flow's phase dir
+and drops a `.provenance.json` sidecar next to it (sha256 of the copied bytes, `ralphctlVersion`,
+`copiedAt`) so a later `list()` can tell in-sync / update-available / locally-modified apart; disabling
+removes the folder. The sidecar is catalog-only bookkeeping — no `SkillSource` (bundled, project,
+operator, or phase) ever reads it or installs it into an AI session; only `SKILL.md` reaches the model.
+A hand-dropped folder with no sidecar is a valid `manual` entry and loads exactly like a catalog-managed
+one. Selection is resolved once, at launch, by `createResolvedSkillSource`: a phase-folder copy shadows
+a same-named bundled default, and either can be subtracted per-flow via `settings.ai.skills[flow].disabled`
+or the customize picker's per-run override (see `AI-SETTINGS.md`).
 
 **`pnpm skills:update` (maintainers only).** Re-vendors upstream `SKILL.md` files from URLs in
 `scripts/skills-sources.json` into `scripts/vendor/skills/` for human review; adapted committed copies live

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -106,8 +106,10 @@ terminals it is an inert no-op (the help overlay labels it accordingly), while `
 **Customize picker's skills step + Skills catalog view.** The pre-launch customize picker (per AI flow:
 `Start` / `Customize for this run…` / `Cancel`) gained a skills step after the provider/model/effort row
 walk(s) — a checklist pre-checked to what would currently load, then `Apply for this run only` vs `Apply
-and remember for <flow>` (remember persists into `settings.ai.skills[flow].disabled`; see
-`AI-SETTINGS.md`). Skipped entirely for a flow with no AI row or no skill candidates to offer. The Home
+and remember for <flow>` (remember persists only the flow's registry-default names into
+`settings.ai.skills[flow].disabled`, merge-preserving hand-added entries — project / operator /
+phase-folder unchecks stay run-scoped; see `AI-SETTINGS.md`). Skipped entirely for a flow with no AI
+row, no skill candidates to offer, or a degraded (partially failed) candidate listing. The Home
 menu's `Skills catalog` view (hotkey `K`) is the enable / disable / update surface across every flow's
 opt-in phase folder: `e` enable, `d` disable, `u` update one, `U` update every out-of-date copy, `r`
 reload — the filesystem under `<appRoot>/skills/<flow>/` is the source of truth (see `ARCHITECTURE.md`

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -103,6 +103,16 @@ mounted; `SessionsView` lists every runner. `Ctrl+1..9` only fires under a kitty
 terminals it is an inert no-op (the help overlay labels it accordingly), while `Tab` cycling works everywhere.
 `?` opens the centralised help overlay generated from `keyboard-map.ts`.
 
+**Customize picker's skills step + Skills catalog view.** The pre-launch customize picker (per AI flow:
+`Start` / `Customize for this run…` / `Cancel`) gained a skills step after the provider/model/effort row
+walk(s) — a checklist pre-checked to what would currently load, then `Apply for this run only` vs `Apply
+and remember for <flow>` (remember persists into `settings.ai.skills[flow].disabled`; see
+`AI-SETTINGS.md`). Skipped entirely for a flow with no AI row or no skill candidates to offer. The Home
+menu's `Skills catalog` view (hotkey `K`) is the enable / disable / update surface across every flow's
+opt-in phase folder: `e` enable, `d` disable, `u` update one, `U` update every out-of-date copy, `r`
+reload — the filesystem under `<appRoot>/skills/<flow>/` is the source of truth (see `ARCHITECTURE.md`
+§ Skills subsystem).
+
 Execute view: three-column at `xl` (≥180), two-column at `lg` (≥140), compact-rail at `md` (100–139),
 single-column below `md`. Rail grows fluidly 36→56 cols at `xl`+ via `resolveRailWidth`. Named breakpoints
 (`sm 80 / md 100 / lg 140 / xl 180 / xxl 220`) are canonical — use `breakpointFor`, `fluid`, `responsive`

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 pnpm-lock.yaml
 node_modules/
 dist/
+scripts/vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ to [Semantic Versioning](https://semver.org/).
 - **Destructive CLI removes require confirmation.** The `sprint`, `project`, and `ticket` remove
   commands now prompt for confirmation on a TTY and refuse to proceed on a non-TTY unless
   `-y`/`--yes` is passed, matching the existing `runs prune` behavior.
+- **Opt-in skills per flow, with a browsable catalog and a customize-picker step (#216).** Beyond
+  the bundled defaults, dropping a skill into `<appRoot>/skills/<flow>/<name>/` now makes it load
+  for that flow only — provider-agnostic and independent of the existing per-provider drop-in
+  folders. The new "Skills catalog" view (Home menu, hotkey `K`) browses every bundled skill, shows
+  where each is currently enabled and whether that copy is in sync with the bundle, and lets you
+  enable / disable / update it — or update every out-of-date copy at once — without leaving the
+  TUI. The pre-launch customize picker gained a matching skills step: pick what loads for this run
+  only, or save the choice as the flow's new default. Five new curated skills ship with the
+  catalog: `ralphctl-ponytail` (anti-over-engineering), `ralphctl-domain-driven-design`,
+  `ralphctl-idea-refinement`, `ralphctl-karpathy-guidelines`, and `ralphctl-cherny-workflow`.
 
 ### Fixed
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,92 @@
+# Third-party notices
+
+ralphctl bundles skill content adapted from the following MIT-licensed upstream projects. The
+adapted copies live under `src/integration/ai/skills/bundled/` (shipped as `dist/skills/`);
+verbatim upstream snapshots used for drift review live under `scripts/vendor/skills/`. Each
+upstream's license and copyright notice is reproduced in full below, as the MIT license requires.
+
+- `ralphctl-debugging-and-error-recovery`, `ralphctl-code-review-and-quality`,
+  `ralphctl-test-driven-development`, `ralphctl-idea-refinement` — from
+  [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills)
+- `ralphctl-ponytail` — from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail)
+- `ralphctl-domain-driven-design` — from [wondelai/skills](https://github.com/wondelai/skills)
+
+---
+
+## addyosmani/agent-skills
+
+```
+MIT License
+
+Copyright (c) 2025 Addy Osmani
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## DietrichGebert/ponytail
+
+```
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## wondelai/skills
+
+```
+MIT License
+
+Copyright (c) 2025 Wondel.ai sp. z o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -200,7 +200,7 @@ const READINESS_PROVIDERS = ['claude', 'codex', 'copilot'] as const;
  * Cross-sibling reach goes through `skills/_engine/`; the composition switch over the per-tool
  * adapters lives at `skills/adapter-factory.ts`, which is not itself a sibling.
  */
-const SKILLS = ['bundled', 'claude', 'codex', 'copilot', 'operator', 'project'] as const;
+const SKILLS = ['bundled', 'claude', 'codex', 'copilot', 'operator', 'phase', 'project'] as const;
 
 /**
  * Domain layer rule. Pure entities + value objects + errors + Result + observability interfaces.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "ralphctl": "./dist/cli.mjs"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "THIRD-PARTY-NOTICES.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/scripts/skills-sources.json
+++ b/scripts/skills-sources.json
@@ -27,6 +27,30 @@
       "ref": "main",
       "license": "MIT",
       "upstreamUrl": "https://github.com/addyosmani/agent-skills"
+    },
+    {
+      "name": "ralphctl-ponytail",
+      "repo": "DietrichGebert/ponytail",
+      "path": "skills/ponytail/SKILL.md",
+      "ref": "main",
+      "license": "MIT",
+      "upstreamUrl": "https://github.com/DietrichGebert/ponytail"
+    },
+    {
+      "name": "ralphctl-idea-refinement",
+      "repo": "addyosmani/agent-skills",
+      "path": "skills/idea-refine/SKILL.md",
+      "ref": "main",
+      "license": "MIT",
+      "upstreamUrl": "https://github.com/addyosmani/agent-skills"
+    },
+    {
+      "name": "ralphctl-domain-driven-design",
+      "repo": "wondelai/skills",
+      "path": "domain-driven-design/SKILL.md",
+      "ref": "main",
+      "license": "MIT",
+      "upstreamUrl": "https://github.com/wondelai/skills"
     }
   ]
 }

--- a/scripts/skills-sources.json
+++ b/scripts/skills-sources.json
@@ -1,7 +1,9 @@
 {
-  "$comment": "Maintainer-only manifest mapping each UPSTREAM-DERIVED bundled skill to its upstream source. Drives `pnpm skills:update` (scripts/sync-skills.ts), which refreshes the raw-upstream cache under scripts/vendor/skills/ so `git diff scripts/vendor/` shows what changed upstream since the last sync. The maintainer then hand-re-applies the de-JS / compat adaptation to the live bundled SKILL.md under src/integration/ai/skills/bundled/<name>/. Bundled skills are FROZEN committed source — this tooling never touches src/.",
+  "$comment": "Maintainer-only manifest mapping each UPSTREAM-DERIVED bundled skill to its upstream source. Drives `pnpm skills:update` (scripts/sync-skills.ts), which refreshes the raw-upstream cache under scripts/vendor/skills/ so `git diff scripts/vendor/` shows what changed upstream since the last sync. The maintainer then hand-re-applies the de-JS / compat adaptation to the live bundled SKILL.md under src/integration/ai/skills/bundled/<name>/. Bundled skills are FROZEN committed source \u2014 this tooling never touches src/.",
   "$cleanRoom": [
-    "ralphctl-surgical-simplicity is clean-room (authored in-repo, no upstream) — intentionally omitted from `skills` below; `pnpm skills:update` does not manage it."
+    "ralphctl-surgical-simplicity is clean-room (authored in-repo, no upstream) \u2014 intentionally omitted from `skills` below; `pnpm skills:update` does not manage it.",
+    "ralphctl-karpathy-guidelines is clean-room (distilled from Andrej Karpathy's public X post https://x.com/karpathy/status/2015883857489522876 \u2014 concepts only, no upstream SKILL.md) \u2014 not sync-managed.",
+    "ralphctl-cherny-workflow is clean-room (distilled from Boris Cherny's public X thread https://x.com/bcherny/status/2007179832300581177 \u2014 concepts only, no upstream SKILL.md) \u2014 not sync-managed."
   ],
   "skills": [
     {

--- a/scripts/vendor/skills/ralphctl-domain-driven-design/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-domain-driven-design/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: domain-driven-design
+description: 'Model software around the business domain using bounded contexts, aggregates, and ubiquitous language. Use when the user mentions "domain modeling", "bounded context", "aggregate root", "ubiquitous language", "anti-corruption layer", "context mapping", "domain events", "strategic design", "the code doesnt match the business", or "how do we split this big system". Also trigger when breaking a monolith into services, defining service boundaries, or aligning code structure with business processes. Covers entities vs value objects, domain events, and context mapping strategies. For architecture layers, see clean-architecture. For complexity, see software-design-philosophy.'
+license: MIT
+metadata:
+  author: wondelai
+  version: '1.4.0'
+---
+
+# Domain-Driven Design Framework
+
+Framework for tackling software complexity by modeling code around the business domain. The greatest risk in software is not technical failure -- it is building a model that does not reflect how the business actually works.
+
+## Core Principle
+
+**The model is the code; the code is the model.** Software should embody a deep, shared understanding of the business domain. When domain experts and developers speak the same language and that language is directly expressed in the codebase, complexity becomes manageable and the system evolves gracefully as the business changes.
+
+## Scoring
+
+**Goal: 10/10.** Score a domain model by awarding **1 point per satisfied row of the Quick Diagnostic** (7 rows) plus up to 3 points for depth: +1 if the Core Domain has a genuinely rich model (not just CRUD), +1 if invariants live inside aggregates rather than in services, +1 if the ubiquitous language is consistent across conversation, code, and tests. Bands: **9-10** = expert-readable names, explicit context boundaries with ACLs, small aggregates, behavior-rich entities, events for cross-aggregate flow, an identified Core Domain; **5-6** = some domain language but leaky boundaries or anemic objects; **<=3** = technical naming, one model for everything, logic scattered in services. Report the score and the specific diagnostic rows failing.
+
+## Framework
+
+### 1. Ubiquitous Language
+
+**Core concept:** A shared, rigorous language between developers and domain experts, used consistently in conversation, documentation, and code. When the language changes, the code changes -- and awkward naming in code feeds back into refining the language.
+
+**Why it works:** Ambiguity is the root cause of most modeling failures. When a developer says "order" and an expert means "purchase request," bugs are inevitable; a ubiquitous language forces every name in code to map to a concept the business recognizes and validates.
+
+**Key insights:**
+
+- The language emerges from deep collaboration, not a glossary bolted on after the fact
+- If a concept is hard to name, the model is likely wrong -- naming difficulty is a design signal
+- Technical jargon (`DataProcessor` vs. `ClaimAdjudicator`) hides domain logic from the experts who could correct it
+- Different bounded contexts may use the same word with different meanings -- and that is fine
+
+**Code applications:**
+
+| Context             | Pattern                              | Example                                                                       |
+| ------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| Class/method naming | Name after domain concepts and verbs | `LoanApplication`, `policy.underwrite()` -- not `RequestHandler`, `process()` |
+| Module structure    | Organize by domain concept           | `shipping/`, `billing/` -- not `controllers/`, `services/`                    |
+| Code review         | Reject technical-only names          | Flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells               |
+
+See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when running modeling sessions or maintaining a glossary -- covers how the language evolves and feeds back into code.
+
+### 2. Bounded Contexts and Context Mapping
+
+**Core concept:** A bounded context is an explicit boundary within which a particular domain model applies. The same word ("Customer") can mean different things in different contexts; context maps define the relationships and translation strategies between them.
+
+**Why it works:** Large systems that try to maintain a single unified model inevitably collapse into inconsistency. Bounded contexts accept that different parts of the business need different models; context maps manage the integration between them.
+
+**Key insights:**
+
+- A bounded context is not a microservice -- it is a linguistic and model boundary that may contain multiple services
+- Context boundaries often align with team boundaries (Conway's Law)
+- The nine context mapping patterns describe political and technical relationships between teams
+- Anti-Corruption Layer is the most important defensive pattern -- never let a foreign model leak into your core domain
+- Shared Kernel couples two teams; keep it small and explicitly governed
+- Start by mapping what exists (Big Ball of Mud), then define target boundaries
+
+**Code applications:**
+
+| Context             | Pattern                                | Example                                                                   |
+| ------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| Service integration | Anti-Corruption Layer                  | Translate external API responses into your domain objects at the boundary |
+| Legacy migration    | Conformist / ACL                       | Wrap the legacy system behind an adapter that speaks your domain language |
+| API design          | Open Host Service + Published Language | Expose a well-documented REST API with a canonical schema                 |
+
+See: [references/bounded-contexts.md](references/bounded-contexts.md) for the nine mapping patterns and integration strategies.
+
+### 3. Entities, Value Objects, and Aggregates
+
+**Core concept:** Entities have identity that persists across state changes. Value Objects are defined entirely by their attributes and are immutable. Aggregates are clusters of entities and value objects with a single root that enforces consistency boundaries.
+
+**Why it works:** Without these distinctions, everything becomes a mutable, identity-bearing object -- tangled state, inconsistent updates, fragile concurrency. Aggregates draw the line: everything inside is guaranteed consistent; everything outside is eventually consistent.
+
+**Key insights:**
+
+- Entity test: "Am I the same thing even if all my attributes change?" (a person changes name and address -- still the same person)
+- Value Object test: "Am I defined only by my attributes?" (any $10 bill is interchangeable with another)
+- Most things should be Value Objects, not Entities -- prefer immutability
+- Keep aggregates small (one root plus a minimal cluster); reference other aggregates by ID, not object reference
+- Immediate consistency only within an aggregate; design for eventual consistency between aggregates
+
+**Code applications:**
+
+| Context              | Pattern                    | Example                                                  |
+| -------------------- | -------------------------- | -------------------------------------------------------- |
+| Identity tracking    | Entity with ID             | `Order` identified by `orderId`, survives state changes  |
+| Immutable attributes | Value Object               | `Address(street, city, zip)` -- replace, never mutate    |
+| Consistency boundary | Aggregate Root             | `Order` is root; `OrderLine` items exist only through it |
+| Concurrency control  | Optimistic locking on root | Version field on `Order`; conflict if two edits race     |
+
+See: [references/building-blocks.md](references/building-blocks.md) for aggregate design rules and consistency boundaries.
+
+### 4. Domain Events
+
+**Core concept:** A domain event captures something that happened in the domain that experts care about, named in past tense (`OrderPlaced`, `PaymentReceived`) -- a fact that has already occurred.
+
+**Why it works:** Domain events decouple cause from effect. When `OrderPlaced` is published, shipping, billing, and notifications each react independently without the ordering context knowing about them -- less coupling, eventual consistency, a natural audit trail.
+
+**Key insights:**
+
+- Events are immutable facts -- once published, they cannot be changed or retracted
+- Domain events are internal to a bounded context; integration events cross boundaries
+- Events enable temporal decoupling: the producer does not wait for the consumer
+- Event sourcing stores the full event history as the source of truth, deriving current state by replay
+- Not every state change deserves an event -- only publish what the domain cares about
+
+**Code applications:**
+
+| Context                   | Pattern                      | Example                                                             |
+| ------------------------- | ---------------------------- | ------------------------------------------------------------------- |
+| State transitions         | Raise event on domain action | `order.place()` raises `OrderPlaced`                                |
+| Cross-context integration | Publish integration event    | `OrderPlaced` triggers `ShippingLabelRequested` in shipping context |
+| Eventual consistency      | Async event handlers         | Inventory handler updates stock asynchronously after `OrderPlaced`  |
+
+See: [references/domain-events.md](references/domain-events.md) for event naming, event sourcing, and integration events.
+
+### 5. Repositories and Factories
+
+**Core concept:** Repositories provide the illusion of an in-memory collection of domain objects, hiding persistence. Factories encapsulate complex creation logic so aggregates are always born in a valid state.
+
+**Why it works:** When persistence and assembly details leak into domain code, every storage change ripples through business rules and aggregates can be constructed in half-valid states. Repositories confine SQL/ORM concerns to infrastructure so the domain stays testable in memory; factories make the only path to an aggregate one that enforces its invariants, so an invalid instance is unrepresentable.
+
+**Key insights:**
+
+- The Repository interface belongs in the domain layer; its implementation belongs in infrastructure
+- Repository methods speak the ubiquitous language: `findPendingOrders()`, not `getByStatusCode(3)`
+- Collection-oriented repositories mimic `add`/`remove`; persistence-oriented ones use `save`
+- Factories are warranted for complex rules or multi-part assembly; a two-field Value Object just needs a constructor
+- The Specification pattern encapsulates query criteria as domain objects: `OverdueInvoiceSpecification`
+
+**Code applications:**
+
+| Context                 | Pattern              | Example                                                                                             |
+| ----------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| Data access abstraction | Repository interface | `OrderRepository.findByCustomer(customerId)` in domain; `PostgresOrderRepository` in infrastructure |
+| Complex creation        | Factory method       | `Order.createFromQuote(quote)` validates and assembles from a `Quote` aggregate                     |
+| Query encapsulation     | Specification        | `spec = OverdueBy(days=30); repo.findMatching(spec)`                                                |
+
+See: [references/repositories-factories.md](references/repositories-factories.md) for Repository, Factory, and Specification patterns.
+
+### 6. Strategic Design and Distillation
+
+**Core concept:** Not all parts of a system are equally important. Strategic design identifies the Core Domain -- where competitive advantage lives -- and distinguishes it from Supporting Subdomains (necessary, not differentiating) and Generic Subdomains (commodity).
+
+**Why it works:** Applying the same rigor everywhere spreads your best talent thin and over-engineers commodity functionality. Identifying the Core Domain concentrates the best developers and deepest modeling where they matter most.
+
+**Key insights:**
+
+- Core Domain: invest your best people and deepest modeling; Supporting: build, but don't over-engineer; Generic (auth, email, payments): buy or use open-source
+- Distillation extracts and highlights the Core Domain from surrounding complexity
+- A Domain Vision Statement is a one-page description of the Core Domain's value proposition
+- Revisit what is "core" as the business evolves -- today's differentiator may become tomorrow's commodity
+
+**Code applications:**
+
+| Context           | Pattern                        | Example                                                                   |
+| ----------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| Build vs. buy     | Classify subdomain type        | Build custom pricing engine (core); use Stripe for payments (generic)     |
+| Team allocation   | Best developers on Core Domain | Seniors model underwriting rules; juniors integrate the email service     |
+| Code organization | Separate core from generic     | `domain/pricing/` (deep model) vs. `infrastructure/email/` (thin adapter) |
+
+See: [references/strategic-design.md](references/strategic-design.md) when deciding where to invest engineering effort -- subdomain classification and distillation techniques.
+
+## Common Mistakes
+
+| Mistake                                    | Why It Fails                                                                                     | Fix                                                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Technical names instead of domain language | Logic hidden behind `DataManager`; experts can't validate the model                              | Rename to domain terms (`ClaimAdjudicator`); if no domain term exists, the concept may be wrong |
+| One model to rule them all                 | A single `Customer` class for billing, shipping, and marketing becomes bloated and contradictory | Bounded contexts: each gets its own `Customer` with only the attributes it needs                |
+| Giant aggregates                           | Concurrency conflicts, slow loads, transactional bottlenecks                                     | Keep aggregates small; reference by ID; eventual consistency between them                       |
+| Anemic domain model                        | Objects are data bags; rules scatter across services and duplicate                               | Move behavior into entities and value objects; services orchestrate only                        |
+| No Anti-Corruption Layer                   | Foreign models leak in; code couples to external schemas                                         | Wrap every external system behind a translation layer                                           |
+| Bounded context = microservice             | Premature extraction; distributed complexity without benefit                                     | A context is a model boundary, not a deployment unit; start with modules in a monolith          |
+| Skipping domain experts                    | Developers invent a model that doesn't match reality; expensive rework                           | Regular modeling sessions until experts say "yes, that is how it works"                         |
+
+## Quick Diagnostic
+
+| Question                                                         | If No                                          | Action                                                         |
+| ---------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| Can a domain expert read your class names and understand them?   | Technical jargon hides the model               | Rename classes, methods, events to ubiquitous language         |
+| Are bounded context boundaries explicitly defined?               | Models bleed; same term means different things | Draw a context map; define boundaries and translations         |
+| Are aggregates small (one root + minimal cluster)?               | Slow loads, concurrency issues                 | Split aggregates; reference by ID; accept eventual consistency |
+| Do domain objects contain behavior, not just data?               | Anemic model; logic scattered in services      | Move business rules into entities and value objects            |
+| Are domain events used for cross-aggregate communication?        | Tight coupling, synchronous chains             | Introduce events; let aggregates react asynchronously          |
+| Is there an Anti-Corruption Layer at every external integration? | Foreign models pollute your domain             | Add a translation layer at each boundary                       |
+| Have you identified which subdomain is core?                     | Best talent spread thin                        | Classify subdomains; focus deep modeling on the Core Domain    |
+
+## Further Reading
+
+For the complete methodology, patterns, and deeper insights:
+
+- [_"Domain-Driven Design: Tackling Complexity in the Heart of Software"_](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215?tag=wondelai00-20) by Eric Evans
+
+## About the Author
+
+**Eric Evans** is a software design consultant and the originator of Domain-Driven Design, developed through work on large-scale systems in finance, insurance, and logistics. His 2003 book _Domain-Driven Design: Tackling Complexity in the Heart of Software_ is one of the most influential software architecture books ever written, and he continues to evolve DDD through his consultancy, Domain Language.

--- a/scripts/vendor/skills/ralphctl-domain-driven-design/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-domain-driven-design/SKILL.md
@@ -4,7 +4,7 @@ description: 'Model software around the business domain using bounded contexts, 
 license: MIT
 metadata:
   author: wondelai
-  version: '1.4.0'
+  version: "1.4.0"
 ---
 
 # Domain-Driven Design Framework
@@ -28,7 +28,6 @@ Framework for tackling software complexity by modeling code around the business 
 **Why it works:** Ambiguity is the root cause of most modeling failures. When a developer says "order" and an expert means "purchase request," bugs are inevitable; a ubiquitous language forces every name in code to map to a concept the business recognizes and validates.
 
 **Key insights:**
-
 - The language emerges from deep collaboration, not a glossary bolted on after the fact
 - If a concept is hard to name, the model is likely wrong -- naming difficulty is a design signal
 - Technical jargon (`DataProcessor` vs. `ClaimAdjudicator`) hides domain logic from the experts who could correct it
@@ -36,11 +35,11 @@ Framework for tackling software complexity by modeling code around the business 
 
 **Code applications:**
 
-| Context             | Pattern                              | Example                                                                       |
-| ------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| Context | Pattern | Example |
+|---------|---------|---------|
 | Class/method naming | Name after domain concepts and verbs | `LoanApplication`, `policy.underwrite()` -- not `RequestHandler`, `process()` |
-| Module structure    | Organize by domain concept           | `shipping/`, `billing/` -- not `controllers/`, `services/`                    |
-| Code review         | Reject technical-only names          | Flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells               |
+| Module structure | Organize by domain concept | `shipping/`, `billing/` -- not `controllers/`, `services/` |
+| Code review | Reject technical-only names | Flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells |
 
 See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when running modeling sessions or maintaining a glossary -- covers how the language evolves and feeds back into code.
 
@@ -51,7 +50,6 @@ See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when
 **Why it works:** Large systems that try to maintain a single unified model inevitably collapse into inconsistency. Bounded contexts accept that different parts of the business need different models; context maps manage the integration between them.
 
 **Key insights:**
-
 - A bounded context is not a microservice -- it is a linguistic and model boundary that may contain multiple services
 - Context boundaries often align with team boundaries (Conway's Law)
 - The nine context mapping patterns describe political and technical relationships between teams
@@ -61,11 +59,11 @@ See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when
 
 **Code applications:**
 
-| Context             | Pattern                                | Example                                                                   |
-| ------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
-| Service integration | Anti-Corruption Layer                  | Translate external API responses into your domain objects at the boundary |
-| Legacy migration    | Conformist / ACL                       | Wrap the legacy system behind an adapter that speaks your domain language |
-| API design          | Open Host Service + Published Language | Expose a well-documented REST API with a canonical schema                 |
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Service integration | Anti-Corruption Layer | Translate external API responses into your domain objects at the boundary |
+| Legacy migration | Conformist / ACL | Wrap the legacy system behind an adapter that speaks your domain language |
+| API design | Open Host Service + Published Language | Expose a well-documented REST API with a canonical schema |
 
 See: [references/bounded-contexts.md](references/bounded-contexts.md) for the nine mapping patterns and integration strategies.
 
@@ -76,7 +74,6 @@ See: [references/bounded-contexts.md](references/bounded-contexts.md) for the ni
 **Why it works:** Without these distinctions, everything becomes a mutable, identity-bearing object -- tangled state, inconsistent updates, fragile concurrency. Aggregates draw the line: everything inside is guaranteed consistent; everything outside is eventually consistent.
 
 **Key insights:**
-
 - Entity test: "Am I the same thing even if all my attributes change?" (a person changes name and address -- still the same person)
 - Value Object test: "Am I defined only by my attributes?" (any $10 bill is interchangeable with another)
 - Most things should be Value Objects, not Entities -- prefer immutability
@@ -85,12 +82,12 @@ See: [references/bounded-contexts.md](references/bounded-contexts.md) for the ni
 
 **Code applications:**
 
-| Context              | Pattern                    | Example                                                  |
-| -------------------- | -------------------------- | -------------------------------------------------------- |
-| Identity tracking    | Entity with ID             | `Order` identified by `orderId`, survives state changes  |
-| Immutable attributes | Value Object               | `Address(street, city, zip)` -- replace, never mutate    |
-| Consistency boundary | Aggregate Root             | `Order` is root; `OrderLine` items exist only through it |
-| Concurrency control  | Optimistic locking on root | Version field on `Order`; conflict if two edits race     |
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Identity tracking | Entity with ID | `Order` identified by `orderId`, survives state changes |
+| Immutable attributes | Value Object | `Address(street, city, zip)` -- replace, never mutate |
+| Consistency boundary | Aggregate Root | `Order` is root; `OrderLine` items exist only through it |
+| Concurrency control | Optimistic locking on root | Version field on `Order`; conflict if two edits race |
 
 See: [references/building-blocks.md](references/building-blocks.md) for aggregate design rules and consistency boundaries.
 
@@ -101,7 +98,6 @@ See: [references/building-blocks.md](references/building-blocks.md) for aggregat
 **Why it works:** Domain events decouple cause from effect. When `OrderPlaced` is published, shipping, billing, and notifications each react independently without the ordering context knowing about them -- less coupling, eventual consistency, a natural audit trail.
 
 **Key insights:**
-
 - Events are immutable facts -- once published, they cannot be changed or retracted
 - Domain events are internal to a bounded context; integration events cross boundaries
 - Events enable temporal decoupling: the producer does not wait for the consumer
@@ -110,11 +106,11 @@ See: [references/building-blocks.md](references/building-blocks.md) for aggregat
 
 **Code applications:**
 
-| Context                   | Pattern                      | Example                                                             |
-| ------------------------- | ---------------------------- | ------------------------------------------------------------------- |
-| State transitions         | Raise event on domain action | `order.place()` raises `OrderPlaced`                                |
-| Cross-context integration | Publish integration event    | `OrderPlaced` triggers `ShippingLabelRequested` in shipping context |
-| Eventual consistency      | Async event handlers         | Inventory handler updates stock asynchronously after `OrderPlaced`  |
+| Context | Pattern | Example |
+|---------|---------|---------|
+| State transitions | Raise event on domain action | `order.place()` raises `OrderPlaced` |
+| Cross-context integration | Publish integration event | `OrderPlaced` triggers `ShippingLabelRequested` in shipping context |
+| Eventual consistency | Async event handlers | Inventory handler updates stock asynchronously after `OrderPlaced` |
 
 See: [references/domain-events.md](references/domain-events.md) for event naming, event sourcing, and integration events.
 
@@ -125,7 +121,6 @@ See: [references/domain-events.md](references/domain-events.md) for event naming
 **Why it works:** When persistence and assembly details leak into domain code, every storage change ripples through business rules and aggregates can be constructed in half-valid states. Repositories confine SQL/ORM concerns to infrastructure so the domain stays testable in memory; factories make the only path to an aggregate one that enforces its invariants, so an invalid instance is unrepresentable.
 
 **Key insights:**
-
 - The Repository interface belongs in the domain layer; its implementation belongs in infrastructure
 - Repository methods speak the ubiquitous language: `findPendingOrders()`, not `getByStatusCode(3)`
 - Collection-oriented repositories mimic `add`/`remove`; persistence-oriented ones use `save`
@@ -134,11 +129,11 @@ See: [references/domain-events.md](references/domain-events.md) for event naming
 
 **Code applications:**
 
-| Context                 | Pattern              | Example                                                                                             |
-| ----------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| Context | Pattern | Example |
+|---------|---------|---------|
 | Data access abstraction | Repository interface | `OrderRepository.findByCustomer(customerId)` in domain; `PostgresOrderRepository` in infrastructure |
-| Complex creation        | Factory method       | `Order.createFromQuote(quote)` validates and assembles from a `Quote` aggregate                     |
-| Query encapsulation     | Specification        | `spec = OverdueBy(days=30); repo.findMatching(spec)`                                                |
+| Complex creation | Factory method | `Order.createFromQuote(quote)` validates and assembles from a `Quote` aggregate |
+| Query encapsulation | Specification | `spec = OverdueBy(days=30); repo.findMatching(spec)` |
 
 See: [references/repositories-factories.md](references/repositories-factories.md) for Repository, Factory, and Specification patterns.
 
@@ -149,7 +144,6 @@ See: [references/repositories-factories.md](references/repositories-factories.md
 **Why it works:** Applying the same rigor everywhere spreads your best talent thin and over-engineers commodity functionality. Identifying the Core Domain concentrates the best developers and deepest modeling where they matter most.
 
 **Key insights:**
-
 - Core Domain: invest your best people and deepest modeling; Supporting: build, but don't over-engineer; Generic (auth, email, payments): buy or use open-source
 - Distillation extracts and highlights the Core Domain from surrounding complexity
 - A Domain Vision Statement is a one-page description of the Core Domain's value proposition
@@ -157,44 +151,44 @@ See: [references/repositories-factories.md](references/repositories-factories.md
 
 **Code applications:**
 
-| Context           | Pattern                        | Example                                                                   |
-| ----------------- | ------------------------------ | ------------------------------------------------------------------------- |
-| Build vs. buy     | Classify subdomain type        | Build custom pricing engine (core); use Stripe for payments (generic)     |
-| Team allocation   | Best developers on Core Domain | Seniors model underwriting rules; juniors integrate the email service     |
-| Code organization | Separate core from generic     | `domain/pricing/` (deep model) vs. `infrastructure/email/` (thin adapter) |
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Build vs. buy | Classify subdomain type | Build custom pricing engine (core); use Stripe for payments (generic) |
+| Team allocation | Best developers on Core Domain | Seniors model underwriting rules; juniors integrate the email service |
+| Code organization | Separate core from generic | `domain/pricing/` (deep model) vs. `infrastructure/email/` (thin adapter) |
 
 See: [references/strategic-design.md](references/strategic-design.md) when deciding where to invest engineering effort -- subdomain classification and distillation techniques.
 
 ## Common Mistakes
 
-| Mistake                                    | Why It Fails                                                                                     | Fix                                                                                             |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| Technical names instead of domain language | Logic hidden behind `DataManager`; experts can't validate the model                              | Rename to domain terms (`ClaimAdjudicator`); if no domain term exists, the concept may be wrong |
-| One model to rule them all                 | A single `Customer` class for billing, shipping, and marketing becomes bloated and contradictory | Bounded contexts: each gets its own `Customer` with only the attributes it needs                |
-| Giant aggregates                           | Concurrency conflicts, slow loads, transactional bottlenecks                                     | Keep aggregates small; reference by ID; eventual consistency between them                       |
-| Anemic domain model                        | Objects are data bags; rules scatter across services and duplicate                               | Move behavior into entities and value objects; services orchestrate only                        |
-| No Anti-Corruption Layer                   | Foreign models leak in; code couples to external schemas                                         | Wrap every external system behind a translation layer                                           |
-| Bounded context = microservice             | Premature extraction; distributed complexity without benefit                                     | A context is a model boundary, not a deployment unit; start with modules in a monolith          |
-| Skipping domain experts                    | Developers invent a model that doesn't match reality; expensive rework                           | Regular modeling sessions until experts say "yes, that is how it works"                         |
+| Mistake | Why It Fails | Fix |
+|---------|-------------|-----|
+| Technical names instead of domain language | Logic hidden behind `DataManager`; experts can't validate the model | Rename to domain terms (`ClaimAdjudicator`); if no domain term exists, the concept may be wrong |
+| One model to rule them all | A single `Customer` class for billing, shipping, and marketing becomes bloated and contradictory | Bounded contexts: each gets its own `Customer` with only the attributes it needs |
+| Giant aggregates | Concurrency conflicts, slow loads, transactional bottlenecks | Keep aggregates small; reference by ID; eventual consistency between them |
+| Anemic domain model | Objects are data bags; rules scatter across services and duplicate | Move behavior into entities and value objects; services orchestrate only |
+| No Anti-Corruption Layer | Foreign models leak in; code couples to external schemas | Wrap every external system behind a translation layer |
+| Bounded context = microservice | Premature extraction; distributed complexity without benefit | A context is a model boundary, not a deployment unit; start with modules in a monolith |
+| Skipping domain experts | Developers invent a model that doesn't match reality; expensive rework | Regular modeling sessions until experts say "yes, that is how it works" |
 
 ## Quick Diagnostic
 
-| Question                                                         | If No                                          | Action                                                         |
-| ---------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| Can a domain expert read your class names and understand them?   | Technical jargon hides the model               | Rename classes, methods, events to ubiquitous language         |
-| Are bounded context boundaries explicitly defined?               | Models bleed; same term means different things | Draw a context map; define boundaries and translations         |
-| Are aggregates small (one root + minimal cluster)?               | Slow loads, concurrency issues                 | Split aggregates; reference by ID; accept eventual consistency |
-| Do domain objects contain behavior, not just data?               | Anemic model; logic scattered in services      | Move business rules into entities and value objects            |
-| Are domain events used for cross-aggregate communication?        | Tight coupling, synchronous chains             | Introduce events; let aggregates react asynchronously          |
-| Is there an Anti-Corruption Layer at every external integration? | Foreign models pollute your domain             | Add a translation layer at each boundary                       |
-| Have you identified which subdomain is core?                     | Best talent spread thin                        | Classify subdomains; focus deep modeling on the Core Domain    |
+| Question | If No | Action |
+|----------|-------|--------|
+| Can a domain expert read your class names and understand them? | Technical jargon hides the model | Rename classes, methods, events to ubiquitous language |
+| Are bounded context boundaries explicitly defined? | Models bleed; same term means different things | Draw a context map; define boundaries and translations |
+| Are aggregates small (one root + minimal cluster)? | Slow loads, concurrency issues | Split aggregates; reference by ID; accept eventual consistency |
+| Do domain objects contain behavior, not just data? | Anemic model; logic scattered in services | Move business rules into entities and value objects |
+| Are domain events used for cross-aggregate communication? | Tight coupling, synchronous chains | Introduce events; let aggregates react asynchronously |
+| Is there an Anti-Corruption Layer at every external integration? | Foreign models pollute your domain | Add a translation layer at each boundary |
+| Have you identified which subdomain is core? | Best talent spread thin | Classify subdomains; focus deep modeling on the Core Domain |
 
 ## Further Reading
 
 For the complete methodology, patterns, and deeper insights:
 
-- [_"Domain-Driven Design: Tackling Complexity in the Heart of Software"_](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215?tag=wondelai00-20) by Eric Evans
+- [*"Domain-Driven Design: Tackling Complexity in the Heart of Software"*](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215?tag=wondelai00-20) by Eric Evans
 
 ## About the Author
 
-**Eric Evans** is a software design consultant and the originator of Domain-Driven Design, developed through work on large-scale systems in finance, insurance, and logistics. His 2003 book _Domain-Driven Design: Tackling Complexity in the Heart of Software_ is one of the most influential software architecture books ever written, and he continues to evolve DDD through his consultancy, Domain Language.
+**Eric Evans** is a software design consultant and the originator of Domain-Driven Design, developed through work on large-scale systems in finance, insurance, and logistics. His 2003 book *Domain-Driven Design: Tackling Complexity in the Heart of Software* is one of the most influential software architecture books ever written, and he continues to evolve DDD through his consultancy, Domain Language.

--- a/scripts/vendor/skills/ralphctl-idea-refinement/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-idea-refinement/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: idea-refine
+description: Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
+---
+
+# Idea Refine
+
+Refines raw ideas into sharp, actionable concepts worth building through structured divergent and convergent thinking.
+
+## How It Works
+
+1.  **Understand & Expand (Divergent):** Restate the idea, ask sharpening questions, and generate variations.
+2.  **Evaluate & Converge:** Cluster ideas, stress-test them, and surface hidden assumptions.
+3.  **Sharpen & Ship:** Produce a concrete markdown one-pager moving work forward.
+
+## Usage
+
+This skill is primarily an interactive dialogue. Invoke it with an idea, and the agent will guide you through the process.
+
+```bash
+# Optional: Initialize the ideas directory
+bash skills/idea-refine/scripts/idea-refine.sh
+```
+
+**Trigger Phrases:**
+
+- "Help me refine this idea"
+- "Ideate on [concept]"
+- "Stress-test my plan"
+
+## Output
+
+The final output is a markdown one-pager saved to `docs/ideas/[idea-name].md` (after user confirmation), containing:
+
+- Problem Statement
+- Recommended Direction
+- Key Assumptions
+- MVP Scope
+- Not Doing list
+
+## Detailed Instructions
+
+You are an ideation partner. Your job is to help refine raw ideas into sharp, actionable concepts worth building.
+
+### Philosophy
+
+- Simplicity is the ultimate sophistication. Push toward the simplest version that still solves the real problem.
+- Start with the user experience, work backwards to technology.
+- Say no to 1,000 things. Focus beats breadth.
+- Challenge every assumption. "How it's usually done" is not a reason.
+- Show people the future — don't just give them better horses.
+- The parts you can't see should be as beautiful as the parts you can.
+
+### Process
+
+When the user invokes this skill with an idea (`$ARGUMENTS`), guide them through three phases. Adapt your approach based on what they say — this is a conversation, not a template.
+
+#### Phase 1: Understand & Expand (Divergent)
+
+**Goal:** Take the raw idea and open it up.
+
+1. **Restate the idea** as a crisp "How Might We" problem statement. This forces clarity on what's actually being solved.
+
+2. **Ask 3-5 sharpening questions** — no more. Focus on:
+   - Who is this for, specifically?
+   - What does success look like?
+   - What are the real constraints (time, tech, resources)?
+   - What's been tried before?
+   - Why now?
+
+   Use the `AskUserQuestion` tool to gather this input. Do NOT proceed until you understand who this is for and what success looks like.
+
+3. **Generate 5-8 idea variations** using these lenses:
+   - **Inversion:** "What if we did the opposite?"
+   - **Constraint removal:** "What if budget/time/tech weren't factors?"
+   - **Audience shift:** "What if this were for [different user]?"
+   - **Combination:** "What if we merged this with [adjacent idea]?"
+   - **Simplification:** "What's the version that's 10x simpler?"
+   - **10x version:** "What would this look like at massive scale?"
+   - **Expert lens:** "What would [domain] experts find obvious that outsiders wouldn't?"
+
+   Push beyond what the user initially asked for. Create products people don't know they need yet.
+
+**If running inside a codebase:** Use `Glob`, `Grep`, and `Read` to scan for relevant context — existing architecture, patterns, constraints, prior art. Ground your variations in what actually exists. Reference specific files and patterns when relevant.
+
+Read `frameworks.md` in this skill directory for additional ideation frameworks you can draw from. Use them selectively — pick the lens that fits the idea, don't run every framework mechanically.
+
+#### Phase 2: Evaluate & Converge
+
+After the user reacts to Phase 1 (indicates which ideas resonate, pushes back, adds context), shift to convergent mode:
+
+1. **Cluster** the ideas that resonated into 2-3 distinct directions. Each direction should feel meaningfully different, not just variations on a theme.
+
+2. **Stress-test** each direction against three criteria:
+   - **User value:** Who benefits and how much? Is this a painkiller or a vitamin?
+   - **Feasibility:** What's the technical and resource cost? What's the hardest part?
+   - **Differentiation:** What makes this genuinely different? Would someone switch from their current solution?
+
+   Read `refinement-criteria.md` in this skill directory for the full evaluation rubric.
+
+3. **Surface hidden assumptions.** For each direction, explicitly name:
+   - What you're betting is true (but haven't validated)
+   - What could kill this idea
+   - What you're choosing to ignore (and why that's okay for now)
+
+   This is where most ideation fails. Don't skip it.
+
+**Be honest, not supportive.** If an idea is weak, say so with kindness. A good ideation partner is not a yes-machine. Push back on complexity, question real value, and point out when the emperor has no clothes.
+
+#### Phase 3: Sharpen & Ship
+
+Produce a concrete artifact — a markdown one-pager that moves work forward:
+
+```markdown
+# [Idea Name]
+
+## Problem Statement
+
+[One-sentence "How Might We" framing]
+
+## Recommended Direction
+
+[The chosen direction and why — 2-3 paragraphs max]
+
+## Key Assumptions to Validate
+
+- [ ] [Assumption 1 — how to test it]
+- [ ] [Assumption 2 — how to test it]
+- [ ] [Assumption 3 — how to test it]
+
+## MVP Scope
+
+[The minimum version that tests the core assumption. What's in, what's out.]
+
+## Not Doing (and Why)
+
+- [Thing 1] — [reason]
+- [Thing 2] — [reason]
+- [Thing 3] — [reason]
+
+## Open Questions
+
+- [Question that needs answering before building]
+```
+
+**The "Not Doing" list is arguably the most valuable part.** Focus is about saying no to good ideas. Make the trade-offs explicit.
+
+Ask the user if they'd like to save this to `docs/ideas/[idea-name].md` (or a location of their choosing). Only save if they confirm.
+
+### Anti-patterns to Avoid
+
+- **Don't generate 20+ ideas.** Quality over quantity. 5-8 well-considered variations beat 20 shallow ones.
+- **Don't be a yes-machine.** Push back on weak ideas with specificity and kindness.
+- **Don't skip "who is this for."** Every good idea starts with a person and their problem.
+- **Don't produce a plan without surfacing assumptions.** Untested assumptions are the #1 killer of good ideas.
+- **Don't over-engineer the process.** Three phases, each doing one thing well. Resist adding steps.
+- **Don't just list ideas — tell a story.** Each variation should have a reason it exists, not just be a bullet point.
+- **Don't ignore the codebase.** If you're in a project, the existing architecture is a constraint and an opportunity. Use it.
+
+### Tone
+
+Direct, thoughtful, slightly provocative. You're a sharp thinking partner, not a facilitator reading from a script. Channel the energy of "that's interesting, but what if..." -- always pushing one step further without being exhausting.
+
+Read `examples.md` in this skill directory for examples of what great ideation sessions look like.
+
+## Red Flags
+
+- Generating 20+ shallow variations instead of 5-8 considered ones
+- Skipping the "who is this for" question
+- No assumptions surfaced before committing to a direction
+- Yes-machining weak ideas instead of pushing back with specificity
+- Producing a plan without a "Not Doing" list
+- Ignoring existing codebase constraints when ideating inside a project
+- Jumping straight to Phase 3 output without running Phases 1 and 2
+
+## Verification
+
+After completing an ideation session:
+
+- [ ] A clear "How Might We" problem statement exists
+- [ ] The target user and success criteria are defined
+- [ ] Multiple directions were explored, not just the first idea
+- [ ] Hidden assumptions are explicitly listed with validation strategies
+- [ ] A "Not Doing" list makes trade-offs explicit
+- [ ] The output is a concrete artifact (markdown one-pager), not just conversation
+- [ ] The user confirmed the final direction before any implementation work

--- a/scripts/vendor/skills/ralphctl-idea-refinement/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-idea-refinement/SKILL.md
@@ -23,7 +23,6 @@ bash skills/idea-refine/scripts/idea-refine.sh
 ```
 
 **Trigger Phrases:**
-
 - "Help me refine this idea"
 - "Ideate on [concept]"
 - "Stress-test my plan"
@@ -31,7 +30,6 @@ bash skills/idea-refine/scripts/idea-refine.sh
 ## Output
 
 The final output is a markdown one-pager saved to `docs/ideas/[idea-name].md` (after user confirmation), containing:
-
 - Problem Statement
 - Recommended Direction
 - Key Assumptions
@@ -115,31 +113,25 @@ Produce a concrete artifact — a markdown one-pager that moves work forward:
 # [Idea Name]
 
 ## Problem Statement
-
 [One-sentence "How Might We" framing]
 
 ## Recommended Direction
-
 [The chosen direction and why — 2-3 paragraphs max]
 
 ## Key Assumptions to Validate
-
 - [ ] [Assumption 1 — how to test it]
 - [ ] [Assumption 2 — how to test it]
 - [ ] [Assumption 3 — how to test it]
 
 ## MVP Scope
-
 [The minimum version that tests the core assumption. What's in, what's out.]
 
 ## Not Doing (and Why)
-
 - [Thing 1] — [reason]
 - [Thing 2] — [reason]
 - [Thing 3] — [reason]
 
 ## Open Questions
-
 - [Question that needs answering before building]
 ```
 

--- a/scripts/vendor/skills/ralphctl-ponytail/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-ponytail/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: '[lite|full|ultra]'
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs _after_ you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level     | What change                                                                                                                 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **lite**  | Build what's asked, but name the lazier alternative in one line. User picks.                                                |
+| **full**  | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.                                 |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/scripts/vendor/skills/ralphctl-ponytail/SKILL.md
+++ b/scripts/vendor/skills/ralphctl-ponytail/SKILL.md
@@ -13,7 +13,7 @@ description: >
   over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
   use for non-coding requests (general knowledge, prose, translation,
   summaries, recipes).
-argument-hint: '[lite|full|ultra]'
+argument-hint: "[lite|full|ultra]"
 license: MIT
 ---
 
@@ -41,7 +41,7 @@ Stop at the first rung that holds:
 6. **Can it be one line?** One line.
 7. **Only then:** the minimum code that works.
 
-The ladder is a reflex, not a research project — but it runs _after_ you
+The ladder is a reflex, not a research project — but it runs *after* you
 understand the problem, not instead of it. Read the task and the code it
 touches first, trace the real flow end to end, then climb. Two rungs work →
 take the higher one and move on. The first lazy solution that works is the
@@ -76,14 +76,13 @@ Pattern: `[code] → skipped: [X], add when [Y].`
 
 ## Intensity
 
-| Level     | What change                                                                                                                 |
-| --------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **lite**  | Build what's asked, but name the lazier alternative in one line. User picks.                                                |
-| **full**  | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.                                 |
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
 | **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
 
 Example: "Add a cache for these API responses."
-
 - lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
 - full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
 - ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -58,7 +58,9 @@ import { warnEscalationMapSelfLoops } from '@src/business/task/escalation-map.ts
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import { createSkillsAdapter } from '@src/integration/ai/skills/adapter-factory.ts';
-import { createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import { createBundledSkillRawReader, createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import type { SkillCatalogPort } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { createSkillCatalog } from '@src/integration/ai/skills/phase/catalog.ts';
 import type { NotificationDispatcher } from '@src/business/observability/notification-dispatcher.ts';
 import { startFileLogSink } from '@src/integration/observability/sinks/file-log-sink.ts';
 import type { FileLogSink, FileLogSinkDeps } from '@src/integration/observability/_engine/file-log-sink.ts';
@@ -214,6 +216,12 @@ export interface AppDeps {
    * `composeSkillSources` in `ui/shared/launcher.ts`.
    */
   readonly skillSource: SkillSource;
+  /**
+   * TUI skill-catalog port — backs the browsable Skills view (enable / disable / update /
+   * update-all the opt-in phase-scoped skills). Built once per `wire()` call over the same
+   * `operatorSkillsRoot` and `writeFile` seam as the rest of the skills stack.
+   */
+  readonly skillCatalog: SkillCatalogPort;
   /**
    * OS-attention notifier. Hooked onto the EventBus by {@link startNotificationSubscriber} at
    * `wire()` time; exposed on `AppDeps` so flows / tests that want to surface a one-shot
@@ -401,6 +409,9 @@ export const wire = (opts: WireOptions): AppDeps => {
     availableModelsInFlight.set(provider, pending);
     return pending;
   };
+  // Hoisted so the skill catalog's provenance-stamp writes share the exact same atomic-write
+  // seam as `AppDeps.writeFile` (one factory call, two consumers).
+  const atomicWriteFile = createAtomicWriteFile();
   return {
     storage: opts.storage,
     projectRepo: createFsProjectRepository({ root: opts.storage.dataRoot }),
@@ -422,7 +433,7 @@ export const wire = (opts: WireOptions): AppDeps => {
     gitRunner: createGitRunner(),
     shellScriptRunner: createShellScriptRunner(),
     fileLocker,
-    writeFile: createAtomicWriteFile(),
+    writeFile: atomicWriteFile,
     appendFile,
     interactiveAi: createInteractiveAiProvider({ flow: 'refine', ai: opts.settings.ai, eventBus }),
     interactiveAiFor: (provider) => createInteractiveAiProviderFor(provider, eventBus),
@@ -445,6 +456,12 @@ export const wire = (opts: WireOptions): AppDeps => {
     // flow launches get the implement row's provider as the default.
     skillsAdapter: createSkillsAdapter({ provider: opts.settings.ai.implement.generator.provider, logger }),
     skillSource: createBundledSkillSource(),
+    skillCatalog: createSkillCatalog({
+      operatorSkillsRoot: opts.storage.operatorSkillsRoot,
+      writeFile: atomicWriteFile,
+      bundledRawReader: createBundledSkillRawReader(),
+      logger,
+    }),
     notificationDispatcher,
     chainLogSink,
   };

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -527,6 +527,13 @@ export interface SkillCandidatesResult {
   readonly candidates: readonly SkillCandidate[];
   /** Names in the durable `settings.ai.skills[flow].disabled` row, before any per-run change. */
   readonly savedDisabled: readonly string[];
+  /**
+   * At least one source's listing FAILED, so `candidates` is incomplete. The caller must not
+   * show a checklist built from it (an unchecked-set complement over a partial list reads as
+   * "disable everything missing") and must never persist a "remember" choice computed from it —
+   * `flows-view.tsx` skips the skills step outright when this is set.
+   */
+  readonly degraded: boolean;
 }
 
 /**
@@ -547,17 +554,30 @@ export const buildSkillCandidates = async (
   deps: LauncherDeps,
   snapshot: AppStateSnapshot,
   flowId: string,
-  settings: Settings
+  settings: Settings,
+  providerOverride?: AiProvider
 ): Promise<SkillCandidatesResult> => {
   const aiFlow = aiFlowIdFor(flowId);
-  if (aiFlow === undefined || !flowMountsSkills(flowId)) return { candidates: [], savedDisabled: [] };
+  if (aiFlow === undefined || !flowMountsSkills(flowId)) {
+    return { candidates: [], savedDisabled: [], degraded: false };
+  }
 
-  const resolvedProvider = primaryFlowRow(settings.ai, aiFlow).provider;
+  // Operator skills are provider-scoped; the picker re-fetches with the row walk's overridden
+  // provider so the checklist matches what the run would actually install.
+  const resolvedProvider = providerOverride ?? primaryFlowRow(settings.ai, aiFlow).provider;
   const { bundled, project, operator, phase } = buildSkillSourceQuad(deps, snapshot, resolvedProvider);
 
+  // A failed listing degrades the whole result instead of silently narrowing it: the bundled
+  // source hard-fails on one unreadable SKILL.md, and a checklist missing every bundled default
+  // would let a "remember" save erase the operator's saved opt-outs over a transient read error.
+  let degraded = false;
   const tagged = async (source: SkillSource, origin: SkillCandidate['origin']): Promise<readonly SkillCandidate[]> => {
     const r = await source.getForFlow(aiFlow);
-    if (!r.ok) return [];
+    if (!r.ok) {
+      degraded = true;
+      deps.app.logger.warn(`skills checklist: ${origin} listing failed — ${r.error.message}`);
+      return [];
+    }
     return r.value.map((skill) => ({ name: skill.name, description: skill.description, origin }));
   };
 
@@ -574,20 +594,8 @@ export const buildSkillCandidates = async (
   const candidates = merged.filter((c, i) => lastIndexByName.get(c.name) === i);
 
   const savedDisabled = settings.ai.skills?.[aiFlow]?.disabled ?? [];
-  return { settingsFlow: aiFlow, candidates, savedDisabled };
+  return { settingsFlow: aiFlow, candidates, savedDisabled, degraded };
 };
-
-/**
- * Names in `candidates` whose origin is `bundled-default` — the only names the customize
- * picker's "remember" save writes into `settings.ai.skills[flow].disabled`. Project / operator /
- * phase-folder skill unchecks stay run-scoped: those sources are runtime-dependent (per-repo,
- * per-provider, per-catalog-enable) so persisting an opt-out for one would be scoped confusingly
- * against the next run's actual source contents.
- *
- * @public
- */
-export const bundledDefaultSkillNames = (candidates: readonly SkillCandidate[]): ReadonlySet<string> =>
-  new Set(candidates.filter((c) => c.origin === 'bundled-default').map((c) => c.name));
 
 /**
  * Pin the launch snapshot's project / sprint onto a successful dispatch result. create-sprint

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -26,6 +26,10 @@ import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { composeSkillSources, createProjectSkillSource } from '@src/integration/ai/skills/project/source.ts';
 import { createOperatorSkillSource } from '@src/integration/ai/skills/operator/source.ts';
+import { createPhaseSkillSource } from '@src/integration/ai/skills/phase/source.ts';
+import { createResolvedSkillSource } from '@src/integration/ai/skills/_engine/resolve-selection.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import { warnIfContractViolated as checkContract } from '@src/integration/ai/skills/_engine/skill-contract-checker.ts';
 import { type AiFlowSettings, type AiProvider, primaryFlowRow, type Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
@@ -172,6 +176,17 @@ export interface LaunchExtras {
       readonly effort?: string;
     };
   };
+  /**
+   * Per-run skill opt-out, supplied by the TUI customize picker's skills step. When present its
+   * `disabled` names REPLACE the durable `settings.ai.skills[flow].disabled` preference for this
+   * launch — a run override wins outright rather than unioning with the saved list, so a per-run
+   * RE-ENABLE of a remembered-off skill is possible (pick nothing to disable this run and every
+   * saved opt-out is lifted for the duration of the run). Subtraction is by exact install name,
+   * so it applies to ANY skill — bundled, project, operator, or phase-folder. Absent = no run
+   * override; the launcher then resolves against the saved preference alone. Consumed only at the
+   * single resolution seam in `buildComposedSkillSource` ({@link createResolvedSkillSource}).
+   */
+  readonly skillsOverride?: { readonly disabled: readonly string[] };
 }
 
 export interface LauncherDeps {
@@ -266,6 +281,20 @@ const aiFlowIdFor = (flowId: string): FlowId | undefined => {
       return undefined;
   }
 };
+
+/**
+ * Flows whose launch context actually threads `ctx.skillSource` into the dispatched use case
+ * (see each `launch/<flow>.ts`) — the only flows where a per-run skills customization has any
+ * effect. `review` / `detect-scripts` / `detect-skills` reuse another flow's AI row via
+ * {@link aiFlowIdFor} but their own launchers never read `ctx.skillSource`, so a skills override
+ * for them would silently no-op; `create-pr` never reaches the chain launcher at all (routed to
+ * its own view). The customize picker's skills step is skipped entirely for a flow this returns
+ * `false` for, rather than presenting a checklist that wouldn't do anything.
+ *
+ * @public
+ */
+export const flowMountsSkills = (flowId: string): boolean =>
+  flowId === 'refine' || flowId === 'plan' || flowId === 'implement' || flowId === 'readiness' || flowId === 'ideate';
 
 /**
  * Per-field merge of `override` onto an `AiFlowSettings` row. Each field of the override is
@@ -382,31 +411,183 @@ const buildLaunchAdapters = (deps: LauncherDeps, flowId: string, settings: Setti
 };
 
 /**
- * Compose the static bundled skill source with a project-scoped source that emits per-repo
- * setup / verify skills authored via the detect-skills flow, plus the global, provider-specific
- * operator drop-in skills under `<appRoot>/skills/<providerDir>/`. The project source's closure
- * reads through `snapshot.project` so every install-skills leaf during this chain run sees the
- * latest skills as of launch time; flows that run without a project (none today) fall back
- * cleanly to bundled-only. The operator source is keyed on `resolvedProvider` so a mixed config
- * installs each flow's operator skills for that flow's provider only — installed through the
- * same adapter as bundled (same `ralphctl-` namespace + `.git/info/exclude` wildcard + tracked
- * uninstall); a missing dir yields an empty source.
+ * Build the four skill sources composed at launch — the app-wired bundled source, a
+ * project-scoped source that emits per-repo setup / verify skills authored via the detect-skills
+ * flow, the global provider-specific operator drop-in source under
+ * `<appRoot>/skills/<providerDir>/`, and the provider-agnostic phase (opt-in) source under
+ * `<appRoot>/skills/<flowDir>/`. Returned as a tuple, NOT composed — {@link buildComposedSkillSource}
+ * unions them for a real launch; {@link buildSkillCandidates} tags each one's contribution with
+ * its origin for the customize picker's skills step, which needs to know WHICH source a
+ * candidate came from rather than a flattened union.
+ *
+ * The project source's closure reads through `snapshot.project` so every caller sees the latest
+ * skills as of call time; a project-less snapshot falls back cleanly to an empty project source.
+ * The operator source is keyed on `resolvedProvider` so a mixed config only sees that flow's
+ * provider's drop-in folder; a missing dir yields an empty source. The phase source is
+ * provider-agnostic and shares the SAME `operatorSkillsRoot` + logger as the operator source; a
+ * missing flow dir is likewise an empty source.
+ *
+ * `warnIfContractViolated` is optional and shared across the operator + phase sources — the real
+ * launch composition wires the WARNING-only contract check; the read-only candidate listing
+ * passes nothing (listing a skill isn't installing it, so the check stays reserved for the
+ * source that actually gets installed).
  */
-const buildComposedSkillSource = (deps: LauncherDeps, snapshot: AppStateSnapshot, resolvedProvider: AiProvider) => {
+const buildSkillSourceQuad = (
+  deps: LauncherDeps,
+  snapshot: AppStateSnapshot,
+  resolvedProvider: AiProvider,
+  warnIfContractViolated?: (skill: Skill) => void
+): {
+  readonly bundled: SkillSource;
+  readonly project: SkillSource;
+  readonly operator: SkillSource;
+  readonly phase: SkillSource;
+} => {
   const projectSource = createProjectSkillSource({ getProject: () => snapshot.project });
   const operatorSource = createOperatorSkillSource({
     operatorSkillsRoot: deps.storage.operatorSkillsRoot,
     provider: resolvedProvider,
     logger: deps.app.logger,
-    // Operator skills run the harness-compatibility scanner as a WARNING only — a violating
-    // skill is logged and still installed (the operator owns their skills). Adapt the checker's
-    // (logger, name, content) signature to the source's `(skill) => void` warner shape.
-    warnIfContractViolated: (skill) => {
-      checkContract(deps.app.logger, skill.name, skill.content);
-    },
+    ...(warnIfContractViolated !== undefined ? { warnIfContractViolated } : {}),
   });
-  return composeSkillSources(deps.app.skillSource, projectSource, operatorSource);
+  const phaseSource = createPhaseSkillSource({
+    operatorSkillsRoot: deps.storage.operatorSkillsRoot,
+    logger: deps.app.logger,
+    ...(warnIfContractViolated !== undefined ? { warnIfContractViolated } : {}),
+  });
+  return { bundled: deps.app.skillSource, project: projectSource, operator: operatorSource, phase: phaseSource };
 };
+
+/**
+ * Compose the four {@link buildSkillSourceQuad} sources into one union, then wrap it in the
+ * single skill-selection resolution seam ({@link createResolvedSkillSource}).
+ *
+ * Composition ORDER is load-bearing: bundled → project → operator → phase, because the resolving
+ * decorator's dedupe keeps the LAST occurrence of a name, so a phase-folder copy of a bundled
+ * skill (the catalog's copy-on-enable path) shadows the bundled default.
+ *
+ * The resolving decorator is the ONE place skill selection is filtered — no leaf / adapter
+ * filters. `flowDisabled` is run-scoped: when the per-run `extras.skillsOverride` is present, its
+ * `disabled` names REPLACE the durable opt-out preference outright — a run override wins over the
+ * saved preference rather than unioning with it, so picking nothing to disable for a run
+ * RE-ENABLES every remembered-off skill for that run's duration. Absent an override, the durable
+ * row applies: the dispatched flow's settings id via {@link aiFlowIdFor} (createPr camel; review
+ * → implement; detect-* → readiness — the single aliasing rule everywhere). With no saved row, no
+ * override, and empty phase folders the decorator is a byte-for-byte no-op, preserving today's
+ * skill set and order.
+ *
+ * Exported for the launcher composition fence test (zero-config no-op + opt-out subtraction +
+ * aliased-flow row inheritance) — it is the one place skill selection is resolved, so testing it
+ * directly beats reconstructing the wiring, which could drift from the real launcher.
+ *
+ * @public
+ */
+export const buildComposedSkillSource = (
+  deps: LauncherDeps,
+  snapshot: AppStateSnapshot,
+  resolvedProvider: AiProvider,
+  flowId: string,
+  settings: Settings,
+  extras: LaunchExtras
+): SkillSource => {
+  const warnIfContractViolated = (skill: Skill): void => {
+    // Contract scanner runs as a WARNING only — a violating skill is logged and still installed
+    // (the operator owns their skills). Adapt the checker's (logger, name, content) signature to
+    // the source's `(skill) => void` warner shape. Shared by the operator + phase sources.
+    checkContract(deps.app.logger, skill.name, skill.content);
+  };
+  const { bundled, project, operator, phase } = buildSkillSourceQuad(
+    deps,
+    snapshot,
+    resolvedProvider,
+    warnIfContractViolated
+  );
+  const composed = composeSkillSources(bundled, project, operator, phase);
+
+  // Run-scoped disabled set, resolved ONCE: the per-run override REPLACES the durable row when
+  // present (run wins over remembered); otherwise the dispatched flow's durable settings row
+  // applies (via the shared aiFlowIdFor aliasing). Flows with no AI row contribute no saved names.
+  const settingsFlow = aiFlowIdFor(flowId);
+  const savedDisabled = settingsFlow !== undefined ? (settings.ai.skills?.[settingsFlow]?.disabled ?? []) : [];
+  const runDisabled = extras.skillsOverride !== undefined ? extras.skillsOverride.disabled : savedDisabled;
+  return createResolvedSkillSource({ inner: composed, flowDisabled: () => runDisabled });
+};
+
+/** One skill the customize picker's skills step can offer to disable, tagged with where it comes from. */
+export interface SkillCandidate {
+  readonly name: string;
+  readonly description: string;
+  readonly origin: 'bundled-default' | 'phase-folder' | 'project' | 'operator';
+}
+
+/** Result of {@link buildSkillCandidates} — the picker's skills-step input. */
+export interface SkillCandidatesResult {
+  /** The settings-row `FlowId` a "remember" save would target — absent when the step is skipped. */
+  readonly settingsFlow?: FlowId;
+  readonly candidates: readonly SkillCandidate[];
+  /** Names in the durable `settings.ai.skills[flow].disabled` row, before any per-run change. */
+  readonly savedDisabled: readonly string[];
+}
+
+/**
+ * Pre-subtraction candidate list for a flow's skills customize step — the same four-source union
+ * {@link buildComposedSkillSource} composes (bundled → project → operator → phase, LAST wins on a
+ * name collision), each entry tagged with its origin so the picker can show why it's there. Unlike
+ * the real launch composition, nothing is subtracted here — the caller (the picker) decides
+ * checked/unchecked from `savedDisabled`.
+ *
+ * Returns `{ candidates: [], savedDisabled: [] }` for a flow with no AI row ({@link aiFlowIdFor}
+ * `undefined`) or one that doesn't actually mount a `skillSource` ({@link flowMountsSkills}
+ * `false`) — the caller uses this to skip the skills step entirely rather than show a checklist
+ * that would have no effect on the launch.
+ *
+ * @public
+ */
+export const buildSkillCandidates = async (
+  deps: LauncherDeps,
+  snapshot: AppStateSnapshot,
+  flowId: string,
+  settings: Settings
+): Promise<SkillCandidatesResult> => {
+  const aiFlow = aiFlowIdFor(flowId);
+  if (aiFlow === undefined || !flowMountsSkills(flowId)) return { candidates: [], savedDisabled: [] };
+
+  const resolvedProvider = primaryFlowRow(settings.ai, aiFlow).provider;
+  const { bundled, project, operator, phase } = buildSkillSourceQuad(deps, snapshot, resolvedProvider);
+
+  const tagged = async (source: SkillSource, origin: SkillCandidate['origin']): Promise<readonly SkillCandidate[]> => {
+    const r = await source.getForFlow(aiFlow);
+    if (!r.ok) return [];
+    return r.value.map((skill) => ({ name: skill.name, description: skill.description, origin }));
+  };
+
+  const merged = [
+    ...(await tagged(bundled, 'bundled-default')),
+    ...(await tagged(project, 'project')),
+    ...(await tagged(operator, 'operator')),
+    ...(await tagged(phase, 'phase-folder')),
+  ];
+  // Last-wins by name, mirroring the resolution seam's dedupe (`resolve-selection.ts`) so a
+  // phase-folder / operator copy of a bundled name shows its ACTUAL shadowing origin.
+  const lastIndexByName = new Map<string, number>();
+  merged.forEach((c, i) => lastIndexByName.set(c.name, i));
+  const candidates = merged.filter((c, i) => lastIndexByName.get(c.name) === i);
+
+  const savedDisabled = settings.ai.skills?.[aiFlow]?.disabled ?? [];
+  return { settingsFlow: aiFlow, candidates, savedDisabled };
+};
+
+/**
+ * Names in `candidates` whose origin is `bundled-default` — the only names the customize
+ * picker's "remember" save writes into `settings.ai.skills[flow].disabled`. Project / operator /
+ * phase-folder skill unchecks stay run-scoped: those sources are runtime-dependent (per-repo,
+ * per-provider, per-catalog-enable) so persisting an opt-out for one would be scoped confusingly
+ * against the next run's actual source contents.
+ *
+ * @public
+ */
+export const bundledDefaultSkillNames = (candidates: readonly SkillCandidate[]): ReadonlySet<string> =>
+  new Set(candidates.filter((c) => c.origin === 'bundled-default').map((c) => c.name));
 
 /**
  * Pin the launch snapshot's project / sprint onto a successful dispatch result. create-sprint
@@ -440,7 +621,7 @@ export const launchFlow = async (
     flowId,
     settings
   );
-  const composedSkillSource = buildComposedSkillSource(deps, snapshot, resolvedProvider);
+  const composedSkillSource = buildComposedSkillSource(deps, snapshot, resolvedProvider, flowId, settings, extras);
 
   // Every launched runner gets bridged to the event bus so subscribers (TUI panels,
   // progress files, future webhooks) see chain progress without per-flow emission wiring. The

--- a/src/application/ui/tui/prompts/ink-interactive-prompt.ts
+++ b/src/application/ui/tui/prompts/ink-interactive-prompt.ts
@@ -76,7 +76,8 @@ export const createInkInteractivePrompt = (queue: PromptQueue): InteractivePromp
 
   async askMultiChoice<T>(
     prompt: string,
-    options: ReadonlyArray<Choice<T>>
+    options: ReadonlyArray<Choice<T>>,
+    opts?: { readonly initial?: readonly T[] }
   ): Promise<Result<readonly T[], DomainError>> {
     if (options.length === 0) return Result.ok([]) as Result<readonly T[], DomainError>;
     try {
@@ -85,6 +86,7 @@ export const createInkInteractivePrompt = (queue: PromptQueue): InteractivePromp
           kind: 'multi-choice',
           message: prompt,
           options: options as ReadonlyArray<Choice<unknown>>,
+          ...(opts?.initial !== undefined ? { initial: opts.initial as readonly unknown[] } : {}),
           resolve: (v: readonly unknown[]) => resolve(v as readonly T[]),
           reject,
         });

--- a/src/application/ui/tui/prompts/multi-select-prompt.tsx
+++ b/src/application/ui/tui/prompts/multi-select-prompt.tsx
@@ -1,8 +1,12 @@
 /**
  * Multi-select prompt. Space toggles the focused option; Enter submits the current selection;
- * `a` selects all; `n` clears selection. Esc cancels with empty. Long option lists scroll
- * within a fixed window so the prompt frame stays predictable; `picked` keeps original-index
- * references so toggling survives scrolling.
+ * `a` selects all (enabled options only); `n` clears selection. Esc cancels with empty. Long
+ * option lists scroll within a fixed window so the prompt frame stays predictable; `picked`
+ * keeps original-index references so toggling survives scrolling.
+ *
+ * Disabled options (`Choice.disabled`) render dim, are skipped by cursor movement, and reject
+ * both a direct toggle and `a` select-all — same gating contract as {@link SelectPrompt}'s
+ * single-select cursor, extended here to the toggle set.
  */
 
 import React, { useState } from 'react';
@@ -12,31 +16,56 @@ import { glyphs, inkColors, PROMPT_VISIBLE_ROWS, spacing } from '@src/applicatio
 
 const clamp = (n: number, min: number, max: number): number => Math.max(min, Math.min(max, n));
 
-export interface MultiSelectPromptProps {
-  readonly message: string;
+const isEnabled = (opt: Choice<unknown> | undefined): boolean => opt !== undefined && opt.disabled !== true;
+
+/** Walk from `from` (exclusive) in `direction`, returning the first enabled index (or `from`). */
+const nextEnabledIndex = (options: ReadonlyArray<Choice<unknown>>, from: number, direction: -1 | 1): number => {
+  for (let i = from + direction; i >= 0 && i < options.length; i += direction) {
+    if (isEnabled(options[i])) return i;
+  }
+  return from;
+};
+
+const firstEnabledIndex = (options: ReadonlyArray<Choice<unknown>>): number => {
+  for (let i = 0; i < options.length; i += 1) {
+    if (isEnabled(options[i])) return i;
+  }
+  return 0;
+};
+
+/** Pure: the initial `picked` index set from `initialSelectedValues` (disabled rows excluded). */
+const computeInitialPicked = (
+  options: ReadonlyArray<Choice<unknown>>,
+  initialSelectedValues: readonly unknown[] | undefined
+): ReadonlySet<number> => {
+  if (initialSelectedValues === undefined || initialSelectedValues.length === 0) return new Set();
+  const preselected = new Set<number>();
+  options.forEach((opt, i) => {
+    if (isEnabled(opt) && initialSelectedValues.includes(opt.value)) preselected.add(i);
+  });
+  return preselected;
+};
+
+interface UseMultiSelectKeysArgs {
   readonly options: ReadonlyArray<Choice<unknown>>;
+  readonly cursor: number;
+  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
+  readonly picked: ReadonlySet<number>;
+  readonly setPicked: React.Dispatch<React.SetStateAction<ReadonlySet<number>>>;
   readonly onSubmit: (values: readonly unknown[]) => void;
   readonly onCancel: () => void;
 }
 
-export const MultiSelectPrompt = ({
-  message,
+/** Sole `useInput` registration for the prompt — cursor move, toggle, select-all/clear, submit/cancel. */
+const useMultiSelectKeys = ({
   options,
+  cursor,
+  setCursor,
+  picked,
+  setPicked,
   onSubmit,
   onCancel,
-}: MultiSelectPromptProps): React.JSX.Element => {
-  const [cursor, setCursor] = useState(0);
-  const [picked, setPicked] = useState<ReadonlySet<number>>(new Set());
-
-  const toggle = (idx: number): void => {
-    setPicked((prev) => {
-      const next = new Set(prev);
-      if (next.has(idx)) next.delete(idx);
-      else next.add(idx);
-      return next;
-    });
-  };
-
+}: UseMultiSelectKeysArgs): void => {
   useInput((input, key) => {
     if (key.escape) {
       onCancel();
@@ -51,12 +80,20 @@ export const MultiSelectPrompt = ({
       return;
     }
     if (input === ' ') {
-      toggle(cursor);
+      if (!isEnabled(options[cursor])) return;
+      setPicked((prev) => {
+        const next = new Set(prev);
+        if (next.has(cursor)) next.delete(cursor);
+        else next.add(cursor);
+        return next;
+      });
       return;
     }
     if (input === 'a') {
       const all = new Set<number>();
-      for (let i = 0; i < options.length; i++) all.add(i);
+      options.forEach((opt, i) => {
+        if (isEnabled(opt)) all.add(i);
+      });
       setPicked(all);
       return;
     }
@@ -64,9 +101,66 @@ export const MultiSelectPrompt = ({
       setPicked(new Set());
       return;
     }
-    if (key.upArrow || input === 'k') setCursor((c) => clamp(c - 1, 0, options.length - 1));
-    else if (key.downArrow || input === 'j') setCursor((c) => clamp(c + 1, 0, options.length - 1));
+    if (key.upArrow || input === 'k') setCursor((c) => clamp(nextEnabledIndex(options, c, -1), 0, options.length - 1));
+    else if (key.downArrow || input === 'j')
+      setCursor((c) => clamp(nextEnabledIndex(options, c, 1), 0, options.length - 1));
   });
+};
+
+interface OptionRowProps {
+  readonly opt: Choice<unknown>;
+  readonly focused: boolean;
+  readonly checked: boolean;
+}
+
+/** One option row: cursor glyph, checkbox, label, optional description — dimmed when disabled. */
+const OptionRow = ({ opt, focused, checked }: OptionRowProps): React.JSX.Element => {
+  const disabled = opt.disabled === true;
+  return (
+    <Box>
+      <Text color={focused ? inkColors.primary : inkColors.muted}>{focused ? glyphs.actionCursor : ' '} </Text>
+      <Text color={checked ? inkColors.success : inkColors.muted} bold={!disabled}>
+        [{checked ? glyphs.check : ' '}]
+      </Text>
+      <Text bold={focused} dimColor={disabled}>
+        {' '}
+        {opt.label}
+      </Text>
+      {opt.description !== undefined && (
+        <Text dimColor>
+          {' '}
+          {glyphs.emDash} {opt.description}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+export interface MultiSelectPromptProps {
+  readonly message: string;
+  readonly options: ReadonlyArray<Choice<unknown>>;
+  readonly onSubmit: (values: readonly unknown[]) => void;
+  readonly onCancel: () => void;
+  /**
+   * Pre-check every option whose `value` appears here (`===` match). Enabled callers pass
+   * e.g. a skill's `recommendedFor` list so the picker opens with a sensible starting selection
+   * instead of forcing every choice to be made from scratch. Values matching a `disabled`
+   * option are ignored — a disabled row can never be pre-selected.
+   */
+  readonly initialSelectedValues?: readonly unknown[];
+}
+
+export const MultiSelectPrompt = ({
+  message,
+  options,
+  onSubmit,
+  onCancel,
+  initialSelectedValues,
+}: MultiSelectPromptProps): React.JSX.Element => {
+  const [cursor, setCursor] = useState(() => firstEnabledIndex(options));
+  const [picked, setPicked] = useState<ReadonlySet<number>>(() => computeInitialPicked(options, initialSelectedValues));
+
+  useMultiSelectKeys({ options, cursor, setCursor, picked, setPicked, onSubmit, onCancel });
 
   const half = Math.floor(PROMPT_VISIBLE_ROWS / 2);
   const start = clamp(cursor - half, 0, Math.max(0, options.length - PROMPT_VISIBLE_ROWS));
@@ -80,23 +174,8 @@ export const MultiSelectPrompt = ({
       <Box flexDirection="column" marginTop={1}>
         {options.slice(start, end).map((opt, localIdx) => {
           const i = start + localIdx;
-          const focused = i === cursor;
-          const checked = picked.has(i);
-          return (
-            <Box key={`opt-${String(i)}`}>
-              <Text color={focused ? inkColors.primary : inkColors.muted}>{focused ? glyphs.actionCursor : ' '} </Text>
-              <Text color={checked ? inkColors.success : inkColors.muted} bold>
-                [{checked ? glyphs.check : ' '}]
-              </Text>
-              <Text bold={focused}> {opt.label}</Text>
-              {opt.description !== undefined && (
-                <Text dimColor>
-                  {' '}
-                  {glyphs.emDash} {opt.description}
-                </Text>
-              )}
-            </Box>
-          );
+          const focused = i === cursor && opt.disabled !== true;
+          return <OptionRow key={`opt-${String(i)}`} opt={opt} focused={focused} checked={picked.has(i)} />;
         })}
       </Box>
       {options.length > PROMPT_VISIBLE_ROWS && (

--- a/src/application/ui/tui/prompts/prompt-host.tsx
+++ b/src/application/ui/tui/prompts/prompt-host.tsx
@@ -110,6 +110,7 @@ const renderPrompt = (prompt: PendingPrompt, queue: PromptQueue): React.JSX.Elem
         <MultiSelectPrompt
           message={prompt.message}
           options={prompt.options}
+          {...(prompt.initial !== undefined ? { initialSelectedValues: prompt.initial } : {})}
           onSubmit={(values): void => queue.resolveHead(values)}
           onCancel={cancel}
         />

--- a/src/application/ui/tui/prompts/prompt-queue.ts
+++ b/src/application/ui/tui/prompts/prompt-queue.ts
@@ -53,6 +53,8 @@ export interface ChoicePrompt<T = unknown> extends BasePrompt {
 export interface MultiChoicePrompt<T = unknown> extends BasePrompt {
   readonly kind: 'multi-choice';
   readonly options: ReadonlyArray<Choice<T>>;
+  /** Values to pre-check on open — surfaced to the renderer as `initialSelectedValues`. */
+  readonly initial?: readonly T[];
   resolve(value: readonly T[]): void;
   reject(err: Error): void;
 }

--- a/src/application/ui/tui/runtime/keyboard-map.ts
+++ b/src/application/ui/tui/runtime/keyboard-map.ts
@@ -98,6 +98,11 @@ export const pickerKeys = {
  * opened sprint as the current selection — replaces the prior silent auto-sync on detail mount.
  * The same chord on the projects list / project detail marks the focused (or viewed) project
  * current — opening a project detail is a browse and never switches the selection.
+ *
+ * The Skills catalog view reuses `e` / `d` / `u` for enable / disable / update — another
+ * deliberate overlap (see the `e` note above): these only fire on the Skills screen, which has
+ * no Project/Sprint/Ticket field to edit and no stuck task to unblock, so the two meanings never
+ * collide at runtime. `U` (update-all) is unique to that view.
  */
 export const contextualKeys = {
   editField: { keys: ['e'], label: 'edit focused field' },
@@ -106,6 +111,10 @@ export const contextualKeys = {
   createSprint: { keys: ['+'], label: 'create a new sprint' },
   makeSprintCurrent: { keys: ['m'], label: 'make focused sprint current' },
   makeProjectCurrent: { keys: ['m'], label: 'make focused project current' },
+  enableSkill: { keys: ['e'], label: 'enable skill for picked flows' },
+  disableSkill: { keys: ['d'], label: 'disable skill for picked flows' },
+  updateSkill: { keys: ['u'], label: 'update skill from bundle' },
+  updateAllSkills: { keys: ['U'], label: 'update every out-of-date skill' },
 } as const satisfies Record<string, KeyBinding>;
 
 /**

--- a/src/application/ui/tui/theme/tokens.ts
+++ b/src/application/ui/tui/theme/tokens.ts
@@ -48,6 +48,10 @@ export const glyphs = {
   cross: '✗',
   warningGlyph: '⚠',
   infoGlyph: 'i',
+  // Skill-catalog "locally edited" marker — distinct shape from `warningGlyph` (an upstream
+  // update is available) and `cross` (removed/broken) so the three states read apart even
+  // without colour (NO_COLOR / accessibility).
+  modified: '✎',
   // Health marker — footer doctor indicator. Monochrome medical cross, tinted by probe status;
   // renders without color so it survives NO_COLOR (no emoji).
   stethoscope: '✚',

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -3,8 +3,11 @@
  * three choices on the entry prompt — `Start (use defaults)`, `Customize for this run…`, or
  * `Cancel`. Customize walks the user through provider → model → effort, with `Keep default`
  * as the first option on each step; implement walks generator (three steps) then evaluator
- * (three steps). The picker only ever reads {@link Settings}; it never calls `save()`, so
- * the on-disk file is byte-identical before and after any picker session.
+ * (three steps). A skills step follows the row walk(s) — once, flow-level, never per role — when
+ * the caller supplies {@link SkillCandidatesResult}; see {@link runSkillsStep}. The picker only
+ * ever reads {@link Settings}; it never calls `save()`, so the on-disk file is byte-identical
+ * before and after any picker session — a "remember" choice on the skills step is surfaced on the
+ * result for `flows-view.tsx` to persist, not written here.
  *
  * Extracted from the view into a standalone module so tests can drive it with a scripted
  * {@link InteractivePrompt} fake without mounting Ink. The view's `onSelect` calls
@@ -29,7 +32,7 @@ import { contextWindowLabel } from '@src/domain/value/settings-models/context-wi
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
-import type { LaunchExtras } from '@src/application/ui/shared/launcher.ts';
+import type { LaunchExtras, SkillCandidate, SkillCandidatesResult } from '@src/application/ui/shared/launcher.ts';
 
 /**
  * Catalog lookup for the customize picker — imported from the same domain modules
@@ -80,9 +83,24 @@ const modelChoice = (m: string): Choice<string> => {
 };
 
 /**
+ * Outcome of the skills step (see {@link runSkillsStep}) — carried on every non-cancel
+ * {@link CustomizePickerResult} variant. `disabled` is the full per-run disable set (any origin);
+ * `saveAsDefault` tells `flows-view.tsx` whether to persist the bundled-default subset of
+ * `disabled` into `settings.ai.skills[flow].disabled` (see `bundledDefaultSkillNames` in
+ * `launcher.ts`). Absent `skills` on a result means the user kept the current skill set (either
+ * the picker had no candidates to offer, or the user picked "Keep skills").
+ */
+export interface SkillsCustomizeResult {
+  readonly disabled: readonly string[];
+  readonly saveAsDefault: boolean;
+}
+
+/**
  * Outcome of one picker session. `kind` discriminates:
  *   - `cancel`: user pressed Esc / picked Cancel at any step — launcher should NOT launch
- *   - `defaults`: user picked Start — launcher should launch with no override
+ *   - `defaults`: user picked Start, OR customized and kept every row default — launcher should
+ *     launch with no row override (`skills` may still be set — the skills step runs independently
+ *     of whether the row walk changed anything)
  *   - `single`: customize completed for a single-row flow; `override` is the per-field diff
  *   - `implement`: customize completed for implement; `implementRoleOverrides` carries both
  *     roles (each independently optional)
@@ -92,11 +110,16 @@ const modelChoice = (m: string): Choice<string> => {
  */
 export type CustomizePickerResult =
   | { readonly kind: 'cancel' }
-  | { readonly kind: 'defaults' }
-  | { readonly kind: 'single'; readonly override: NonNullable<LaunchExtras['override']> }
+  | { readonly kind: 'defaults'; readonly skills?: SkillsCustomizeResult }
+  | {
+      readonly kind: 'single';
+      readonly override: NonNullable<LaunchExtras['override']>;
+      readonly skills?: SkillsCustomizeResult;
+    }
   | {
       readonly kind: 'implement';
       readonly implementRoleOverrides: NonNullable<LaunchExtras['implementRoleOverrides']>;
+      readonly skills?: SkillsCustomizeResult;
     };
 
 /**
@@ -331,6 +354,12 @@ export interface RunCustomizePickerArgs {
    * step falls back to the full {@link modelCatalogFor} catalog (the test / no-deps path).
    */
   readonly availableModelsFor?: (provider: AiProvider) => Promise<readonly string[]>;
+  /**
+   * Pre-fetched skill candidates for this flow, built by `launcher.ts`'s `buildSkillCandidates`
+   * BEFORE the picker runs (it needs `AppDeps` the picker itself is never given). Absent or empty
+   * skips the skills step entirely — see {@link runSkillsStep}.
+   */
+  readonly skillCandidates?: SkillCandidatesResult;
 }
 
 /**
@@ -343,17 +372,98 @@ const buildPickerHeader = (flowId: string, flowTitle: string, settings: Settings
     ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort)}`
     : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort)}`;
 
+/** Human label for a skill candidate's origin, shown next to its name in the skills checklist. */
+const originLabel = (origin: SkillCandidate['origin']): string => {
+  switch (origin) {
+    case 'bundled-default':
+      return 'default';
+    case 'phase-folder':
+      return 'opt-in folder';
+    case 'project':
+      return 'project';
+    case 'operator':
+      return 'operator';
+  }
+};
+
+/** Outcome of {@link runSkillsStep}. */
+interface SkillsStepResult {
+  readonly cancelled: boolean;
+  readonly skills?: SkillsCustomizeResult;
+}
+
 /**
- * Customize path for the `implement` flow — walk generator first, then evaluator. Cancel at
- * any step (including mid-evaluator) closes the picker without launching and discards any
- * generator override already set — the launcher must not apply a half-completed customize
- * session.
+ * Skills step — appended once, after the row walk(s) complete (implement: after BOTH generator
+ * and evaluator, never per-role). Entry prompt mirrors the top-level Start/Customize split:
+ * `Keep skills (N active)` is the zero-friction default; only `Customize skills for this run…`
+ * opens the checklist. Skipped ENTIRELY (no prompt at all) when `skillCandidates` is `undefined`
+ * or carries no candidates — `flows-view.tsx` only supplies it for a flow whose launch context
+ * actually threads a `skillSource` ({@link flowMountsSkills} in `launcher.ts`).
+ *
+ * The checklist opens PRE-CHECKED to today's effective state — checked = would currently load
+ * (default and not saved-disabled), unchecked = saved-disabled — via `askMultiChoice`'s `initial`
+ * seeding (`business/interactive/prompt.ts`). The result the user submits IS the enabled set;
+ * `disabled` is its complement over `candidates`, so unchecking a row is exactly "disable this".
+ */
+const runSkillsStep = async (
+  interactive: InteractivePrompt,
+  flowTitle: string,
+  skillCandidates: SkillCandidatesResult | undefined
+): Promise<SkillsStepResult> => {
+  if (skillCandidates === undefined || skillCandidates.candidates.length === 0) return { cancelled: false };
+
+  const { candidates, savedDisabled } = skillCandidates;
+  const disabledByDefault = new Set(savedDisabled);
+  const enabledByDefault = candidates.filter((c) => !disabledByDefault.has(c.name)).map((c) => c.name);
+
+  const entry = await interactive.askChoice<'keep' | 'customize'>('Skills:', [
+    { label: `Keep skills (${String(enabledByDefault.length)} active)`, value: 'keep' },
+    { label: 'Customize skills for this run…', value: 'customize' },
+  ]);
+  if (!entry.ok) return { cancelled: true };
+  if (entry.value === 'keep') return { cancelled: false };
+
+  const options: ReadonlyArray<Choice<string>> = candidates.map((c) => ({
+    label: `${c.name} (${originLabel(c.origin)})`,
+    value: c.name,
+    description: c.description,
+  }));
+  const enabledAns = await interactive.askMultiChoice<string>(
+    'Skills for this run — uncheck any to disable:',
+    options,
+    {
+      initial: enabledByDefault,
+    }
+  );
+  if (!enabledAns.ok) return { cancelled: true };
+  const enabledNames = new Set(enabledAns.value);
+  const disabled = candidates.filter((c) => !enabledNames.has(c.name)).map((c) => c.name);
+
+  const saveAns = await interactive.askChoice<'run-only' | 'remember'>('Remember this choice?', [
+    { label: 'Apply for this run only', value: 'run-only' },
+    { label: `Apply and remember for ${flowTitle}`, value: 'remember' },
+  ]);
+  if (!saveAns.ok) return { cancelled: true };
+
+  return {
+    cancelled: false,
+    skills: { disabled, saveAsDefault: saveAns.value === 'remember' },
+  };
+};
+
+/**
+ * Customize path for the `implement` flow — walk generator first, then evaluator, then (once,
+ * flow-level) the skills step. Cancel at any step (including mid-evaluator or mid-skills) closes
+ * the picker without launching and discards any override already collected — the launcher must
+ * not apply a half-completed customize session.
  */
 const runImplementCustomize = async (
   interactive: InteractivePrompt,
   header: string,
+  flowTitle: string,
   settings: Settings,
-  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
+  skillCandidates: SkillCandidatesResult | undefined
 ): Promise<CustomizePickerResult> => {
   const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
   const collected: {
@@ -367,9 +477,14 @@ const runImplementCustomize = async (
     if (result === undefined) return { kind: 'cancel' };
     if (Object.keys(result).length > 0) collected[role] = result;
   }
+
+  const skillsStep = await runSkillsStep(interactive, flowTitle, skillCandidates);
+  if (skillsStep.cancelled) return { kind: 'cancel' };
+  const skills = skillsStep.skills;
+
   if (collected.generator === undefined && collected.evaluator === undefined) {
-    // Both roles kept all defaults — same outcome as picking Start.
-    return { kind: 'defaults' };
+    // Both roles kept all defaults — same outcome as picking Start, modulo a skills change.
+    return skills !== undefined ? { kind: 'defaults', skills } : { kind: 'defaults' };
   }
   return {
     kind: 'implement',
@@ -377,23 +492,36 @@ const runImplementCustomize = async (
       ...(collected.generator !== undefined ? { generator: collected.generator } : {}),
       ...(collected.evaluator !== undefined ? { evaluator: collected.evaluator } : {}),
     },
+    ...(skills !== undefined ? { skills } : {}),
   };
 };
 
-/** Customize path for every non-implement flow — a single row walk through {@link customizeRow}. */
+/**
+ * Customize path for every non-implement flow — a single row walk through {@link customizeRow},
+ * then the skills step.
+ */
 const runSingleRowCustomize = async (
   interactive: InteractivePrompt,
   header: string,
   flowId: string,
+  flowTitle: string,
   settings: Settings,
-  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
+  skillCandidates: SkillCandidatesResult | undefined
 ): Promise<CustomizePickerResult> => {
   const defaultRow = defaultRowFor(flowId, settings);
   if (defaultRow === undefined) return { kind: 'defaults' };
   const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor);
   if (override === undefined) return { kind: 'cancel' };
-  if (Object.keys(override).length === 0) return { kind: 'defaults' };
-  return { kind: 'single', override };
+
+  const skillsStep = await runSkillsStep(interactive, flowTitle, skillCandidates);
+  if (skillsStep.cancelled) return { kind: 'cancel' };
+  const skills = skillsStep.skills;
+
+  if (Object.keys(override).length === 0) {
+    return skills !== undefined ? { kind: 'defaults', skills } : { kind: 'defaults' };
+  }
+  return skills !== undefined ? { kind: 'single', override, skills } : { kind: 'single', override };
 };
 
 /**
@@ -411,6 +539,7 @@ export const runCustomizePicker = async ({
   flowTitle,
   settings,
   availableModelsFor,
+  skillCandidates,
 }: RunCustomizePickerArgs): Promise<CustomizePickerResult> => {
   const aiFlow = aiFlowIdForPicker(flowId);
   if (aiFlow === undefined) return { kind: 'defaults' };
@@ -429,8 +558,8 @@ export const runCustomizePicker = async ({
   if (action.value === 'start') return { kind: 'defaults' };
 
   if (flowId === 'implement') {
-    return runImplementCustomize(interactive, header, settings, availableModelsFor);
+    return runImplementCustomize(interactive, header, flowTitle, settings, availableModelsFor, skillCandidates);
   }
 
-  return runSingleRowCustomize(interactive, header, flowId, settings, availableModelsFor);
+  return runSingleRowCustomize(interactive, header, flowId, flowTitle, settings, availableModelsFor, skillCandidates);
 };

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -85,9 +85,11 @@ const modelChoice = (m: string): Choice<string> => {
 /**
  * Outcome of the skills step (see {@link runSkillsStep}) — carried on every non-cancel
  * {@link CustomizePickerResult} variant. `disabled` is the full per-run disable set (any origin);
- * `saveAsDefault` tells `flows-view.tsx` whether to persist the bundled-default subset of
- * `disabled` into `settings.ai.skills[flow].disabled` (see `bundledDefaultSkillNames` in
- * `launcher.ts`). Absent `skills` on a result means the user kept the current skill set (either
+ * `saveAsDefault` tells `flows-view.tsx` whether to persist the registry-default subset of
+ * `disabled` into `settings.ai.skills[flow].disabled` (see `applySkillsRememberChoice` in
+ * `flows-launch-extras.ts` — names are matched against `skillsForFlow`, so a phase-folder copy
+ * shadowing a bundled default still persists). Absent `skills` on a result means the user kept
+ * the current skill set (either
  * the picker had no candidates to offer, or the user picked "Keep skills").
  */
 export interface SkillsCustomizeResult {
@@ -360,6 +362,14 @@ export interface RunCustomizePickerArgs {
    * skips the skills step entirely — see {@link runSkillsStep}.
    */
   readonly skillCandidates?: SkillCandidatesResult;
+  /**
+   * Re-fetch candidates for a provider the row walk just picked. The prefetched snapshot was
+   * built with the SAVED provider, but operator drop-in skills are provider-scoped — a per-run
+   * provider override changes what would actually install. When present and the walk overrode
+   * the provider, the skills step lists the rebuilt set; a failed/degraded rebuild falls back to
+   * the prefetched snapshot rather than dropping the step.
+   */
+  readonly rebuildSkillCandidates?: (provider: AiProvider) => Promise<SkillCandidatesResult | undefined>;
 }
 
 /**
@@ -384,6 +394,30 @@ const originLabel = (origin: SkillCandidate['origin']): string => {
     case 'operator':
       return 'operator';
   }
+};
+
+type RebuildSkillCandidates = (provider: AiProvider) => Promise<SkillCandidatesResult | undefined>;
+
+/** Skills-step inputs bundled so the two customize paths thread one bag, not two params. */
+interface SkillsStepInput {
+  readonly candidates?: SkillCandidatesResult;
+  readonly rebuild?: RebuildSkillCandidates;
+}
+
+/**
+ * Candidates the skills step should actually list, given the provider the row walk just chose.
+ * No override / no rebuild hook / nothing prefetched → the prefetched snapshot as-is. A rebuild
+ * that fails or comes back degraded keeps the prefetched snapshot — a stale-but-complete list
+ * beats silently dropping the step.
+ */
+const effectiveSkillCandidates = async (
+  prefetched: SkillCandidatesResult | undefined,
+  rebuild: RebuildSkillCandidates | undefined,
+  overriddenProvider: AiProvider | undefined
+): Promise<SkillCandidatesResult | undefined> => {
+  if (prefetched === undefined || rebuild === undefined || overriddenProvider === undefined) return prefetched;
+  const rebuilt = await rebuild(overriddenProvider);
+  return rebuilt !== undefined && rebuilt.degraded !== true ? rebuilt : prefetched;
 };
 
 /** Outcome of {@link runSkillsStep}. */
@@ -441,7 +475,11 @@ const runSkillsStep = async (
 
   const saveAns = await interactive.askChoice<'run-only' | 'remember'>('Remember this choice?', [
     { label: 'Apply for this run only', value: 'run-only' },
-    { label: `Apply and remember for ${flowTitle}`, value: 'remember' },
+    {
+      label: `Apply and remember for ${flowTitle}`,
+      value: 'remember',
+      description: 'Remembers bundled defaults only — other unchecks apply to this run',
+    },
   ]);
   if (!saveAns.ok) return { cancelled: true };
 
@@ -463,7 +501,7 @@ const runImplementCustomize = async (
   flowTitle: string,
   settings: Settings,
   availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
-  skillCandidates: SkillCandidatesResult | undefined
+  skillsStepInput: SkillsStepInput
 ): Promise<CustomizePickerResult> => {
   const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
   const collected: {
@@ -478,7 +516,14 @@ const runImplementCustomize = async (
     if (Object.keys(result).length > 0) collected[role] = result;
   }
 
-  const skillsStep = await runSkillsStep(interactive, flowTitle, skillCandidates);
+  // Skills install under the GENERATOR's resolved provider (the flow row `buildLaunchAdapters`
+  // reads for implement), so a generator provider override re-lists the candidates.
+  const candidates = await effectiveSkillCandidates(
+    skillsStepInput.candidates,
+    skillsStepInput.rebuild,
+    collected.generator?.provider
+  );
+  const skillsStep = await runSkillsStep(interactive, flowTitle, candidates);
   if (skillsStep.cancelled) return { kind: 'cancel' };
   const skills = skillsStep.skills;
 
@@ -507,14 +552,19 @@ const runSingleRowCustomize = async (
   flowTitle: string,
   settings: Settings,
   availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
-  skillCandidates: SkillCandidatesResult | undefined
+  skillsStepInput: SkillsStepInput
 ): Promise<CustomizePickerResult> => {
   const defaultRow = defaultRowFor(flowId, settings);
   if (defaultRow === undefined) return { kind: 'defaults' };
   const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor);
   if (override === undefined) return { kind: 'cancel' };
 
-  const skillsStep = await runSkillsStep(interactive, flowTitle, skillCandidates);
+  const candidates = await effectiveSkillCandidates(
+    skillsStepInput.candidates,
+    skillsStepInput.rebuild,
+    override.provider
+  );
+  const skillsStep = await runSkillsStep(interactive, flowTitle, candidates);
   if (skillsStep.cancelled) return { kind: 'cancel' };
   const skills = skillsStep.skills;
 
@@ -540,6 +590,7 @@ export const runCustomizePicker = async ({
   settings,
   availableModelsFor,
   skillCandidates,
+  rebuildSkillCandidates,
 }: RunCustomizePickerArgs): Promise<CustomizePickerResult> => {
   const aiFlow = aiFlowIdForPicker(flowId);
   if (aiFlow === undefined) return { kind: 'defaults' };
@@ -557,9 +608,13 @@ export const runCustomizePicker = async ({
   if (!action.ok || action.value === 'cancel') return { kind: 'cancel' };
   if (action.value === 'start') return { kind: 'defaults' };
 
+  const skillsStepInput: SkillsStepInput = {
+    ...(skillCandidates !== undefined ? { candidates: skillCandidates } : {}),
+    ...(rebuildSkillCandidates !== undefined ? { rebuild: rebuildSkillCandidates } : {}),
+  };
   if (flowId === 'implement') {
-    return runImplementCustomize(interactive, header, flowTitle, settings, availableModelsFor, skillCandidates);
+    return runImplementCustomize(interactive, header, flowTitle, settings, availableModelsFor, skillsStepInput);
   }
 
-  return runSingleRowCustomize(interactive, header, flowId, flowTitle, settings, availableModelsFor, skillCandidates);
+  return runSingleRowCustomize(interactive, header, flowId, flowTitle, settings, availableModelsFor, skillsStepInput);
 };

--- a/src/application/ui/tui/views/flows-launch-extras.ts
+++ b/src/application/ui/tui/views/flows-launch-extras.ts
@@ -14,17 +14,17 @@ import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.
 import type { FlowEntry } from '@src/application/registry.ts';
 import {
   buildSkillCandidates,
-  bundledDefaultSkillNames,
   flowMountsSkills,
   type LaunchExtras,
   type LauncherDeps,
   type SkillCandidatesResult,
 } from '@src/application/ui/shared/launcher.ts';
+import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
 import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
 import { getImplementRoleOverrides } from '@src/application/ui/tui/runtime/implement-role-overrides.ts';
 import type { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import type { CustomizePickerResult } from '@src/application/ui/tui/views/flows-customize-picker.ts';
-import type { Settings } from '@src/domain/entity/settings.ts';
+import type { AiProvider, AiSkillsSettings, Settings } from '@src/domain/entity/settings.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 
@@ -42,6 +42,16 @@ export const prefetchSkillCandidates = (
   flowMountsSkills(flowId)
     ? buildSkillCandidates(launcherDeps, snapshot, flowId, settings)
     : Promise.resolve(undefined);
+
+/**
+ * Closure the picker calls to re-list candidates for a provider its row walk just picked —
+ * operator drop-ins are provider-scoped, so the prefetched (saved-provider) snapshot can be
+ * stale the moment the user overrides the provider for the run.
+ */
+export const makeRebuildSkillCandidates =
+  (launcherDeps: LauncherDeps, snapshot: AppStateSnapshot, flowId: string, settings: Settings) =>
+  (provider: AiProvider): Promise<SkillCandidatesResult | undefined> =>
+    buildSkillCandidates(launcherDeps, snapshot, flowId, settings, provider);
 
 /**
  * Assemble the per-launch {@link LaunchExtras} from the resolved repository id, the customize
@@ -86,10 +96,9 @@ export const buildLaunchExtras = (
 };
 
 /**
- * Persist the "remember" half of the skills step: only the bundled-default subset of the picker's
- * disabled names (project / operator / phase-folder unchecks stay run-scoped — see
- * `bundledDefaultSkillNames`). A full read-modify-write of the already-loaded `settings` via the
- * same `settings-set` seam every other TUI mutation uses (`settings-mutations.ts`'s `persistKey`).
+ * Persist the "remember" half of the skills step. A full read-modify-write of the already-loaded
+ * `settings` via the same `settings-set` seam every other TUI mutation uses
+ * (`settings-mutations.ts`'s `persistKey`).
  */
 const persistSkillsDefault = async (
   settingsRepo: AppDeps['settingsRepo'],
@@ -97,12 +106,10 @@ const persistSkillsDefault = async (
   settingsFlow: FlowId,
   disabled: readonly string[]
 ): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }> => {
+  const skills: AiSkillsSettings = { ...settings.ai.skills, [settingsFlow]: { disabled } };
   const nextSettings: Settings = {
     ...settings,
-    ai: {
-      ...settings.ai,
-      skills: { ...settings.ai.skills, [settingsFlow]: { disabled } },
-    } as Settings['ai'],
+    ai: { ...settings.ai, skills } as Settings['ai'],
   };
   const saved = await createSettingsSetFlow({ settingsRepo }).execute({ input: { next: nextSettings } });
   if (!saved.ok) return { ok: false, message: saved.error.error.message };
@@ -111,10 +118,19 @@ const persistSkillsDefault = async (
 
 /**
  * Drive the picker's "remember" choice, if any. No-op (returns `undefined`) when the user kept
- * skills at default, picked "run only", or the flow never surfaced candidates in the first place.
- * Non-fatal on failure — the run itself already carries the full override via
- * {@link buildLaunchExtras}'s `skillsOverride`, independent of whether this save succeeds; the
- * caller surfaces the returned message as a soft warning and proceeds with the launch regardless.
+ * skills at default, picked "run only", the flow never surfaced candidates in the first place, or
+ * the candidate listing came back degraded (a complement computed over a partial list must never
+ * overwrite the saved row). Non-fatal on failure — the run itself already carries the full
+ * override via {@link buildLaunchExtras}'s `skillsOverride`, independent of whether this save
+ * succeeds; the caller surfaces the returned message as a soft warning and proceeds regardless.
+ *
+ * What persists is decided by NAME against the registry (`skillsForFlow`), not by candidate
+ * origin — a phase-folder copy shadowing a bundled default still counts as that default. The
+ * saved row is merged, not replaced: previously saved names OUTSIDE the flow's registry defaults
+ * (hand-added entries) survive; registry-default names the user re-checked drop out; only
+ * registry-default names the user unchecked are (re)added. Project / operator / phase-folder
+ * unchecks stay run-scoped — those sources are runtime-dependent (per-repo, per-provider,
+ * per-catalog-enable), so a durable opt-out for them would be scoped confusingly.
  */
 export const applySkillsRememberChoice = async (
   settingsRepo: AppDeps['settingsRepo'],
@@ -124,10 +140,17 @@ export const applySkillsRememberChoice = async (
 ): Promise<string | undefined> => {
   if (picker.kind === 'cancel' || picker.skills?.saveAsDefault !== true) return undefined;
   if (skillCandidates?.settingsFlow === undefined) return undefined;
+  if (skillCandidates.degraded) {
+    return "Skills listing was incomplete — preference not saved (this run's choice still applies).";
+  }
 
-  const bundledOnly = picker.skills.disabled.filter((name) =>
-    bundledDefaultSkillNames(skillCandidates.candidates).has(name)
-  );
-  const persisted = await persistSkillsDefault(settingsRepo, settings, skillCandidates.settingsFlow, bundledOnly);
+  const settingsFlow = skillCandidates.settingsFlow;
+  const registryDefaults = new Set(skillsForFlow(settingsFlow));
+  const previouslySaved = settings.ai.skills?.[settingsFlow]?.disabled ?? [];
+  const handAdded = previouslySaved.filter((name) => !registryDefaults.has(name));
+  const uncheckedDefaults = picker.skills.disabled.filter((name) => registryDefaults.has(name));
+  const disabled = [...new Set([...handAdded, ...uncheckedDefaults])];
+
+  const persisted = await persistSkillsDefault(settingsRepo, settings, settingsFlow, disabled);
   return persisted.ok ? undefined : `Couldn't remember skills preference: ${persisted.message}`;
 };

--- a/src/application/ui/tui/views/flows-launch-extras.ts
+++ b/src/application/ui/tui/views/flows-launch-extras.ts
@@ -1,0 +1,133 @@
+/**
+ * `flows-view.tsx`'s post-picker tail: assemble {@link LaunchExtras} from the customize picker's
+ * outcome, and persist the skills step's "remember" choice. Split out of the view so the click
+ * handler's cyclomatic complexity and the file's line budget both stay under the lint ratchet —
+ * mirrors the existing `flows-repository-picker.ts` pattern of a small, view-scoped helper module
+ * the view imports rather than inlining.
+ *
+ * The picker never writes settings itself (see `flows-customize-picker.ts`'s module doc); this is
+ * where a `saveAsDefault: true` skills choice actually persists.
+ */
+
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.ts';
+import type { FlowEntry } from '@src/application/registry.ts';
+import {
+  buildSkillCandidates,
+  bundledDefaultSkillNames,
+  flowMountsSkills,
+  type LaunchExtras,
+  type LauncherDeps,
+  type SkillCandidatesResult,
+} from '@src/application/ui/shared/launcher.ts';
+import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import { getImplementRoleOverrides } from '@src/application/ui/tui/runtime/implement-role-overrides.ts';
+import type { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import type { CustomizePickerResult } from '@src/application/ui/tui/views/flows-customize-picker.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
+
+/**
+ * Pre-fetch skill candidates BEFORE the picker runs — only for a flow whose launch context
+ * actually threads a `skillSource` ({@link flowMountsSkills}); every other flow skips the async
+ * directory-listing round-trip entirely (the picker's skills step is a no-op without it).
+ */
+export const prefetchSkillCandidates = (
+  launcherDeps: LauncherDeps,
+  snapshot: AppStateSnapshot,
+  flowId: string,
+  settings: Settings
+): Promise<SkillCandidatesResult | undefined> =>
+  flowMountsSkills(flowId)
+    ? buildSkillCandidates(launcherDeps, snapshot, flowId, settings)
+    : Promise.resolve(undefined);
+
+/**
+ * Assemble the per-launch {@link LaunchExtras} from the resolved repository id, the customize
+ * picker's outcome, and the fresh settings snapshot. Implement role overrides prefer the picker's
+ * per-role result; falling back to the CLI-derived module holder (parsed from
+ * `--implement-{generator,evaluator}-{provider,model}`) only for the `implement` flow when the
+ * picker ran in single-row mode (i.e. every AI flow other than implement).
+ *
+ * `skillsOverride` maps 1:1 from the picker's `skills.disabled` — present whenever the skills step
+ * ran and the user didn't just keep the default, REGARDLESS of whether `saveAsDefault` is also
+ * true. The run must not depend on the save round-trip: even when the caller persists a
+ * "remember" choice, this run still gets its override directly from the picker result.
+ */
+export const buildLaunchExtras = (
+  picker: CustomizePickerResult,
+  entry: FlowEntry,
+  chosenRepositoryId: RepositoryId | undefined,
+  ui: ReturnType<typeof useUiState>,
+  settings: Settings
+): LaunchExtras => {
+  const implementRoleOverrides =
+    picker.kind === 'implement'
+      ? picker.implementRoleOverrides
+      : entry.manifest.id === 'implement'
+        ? getImplementRoleOverrides()
+        : undefined;
+  const override = picker.kind === 'single' ? picker.override : undefined;
+  const skills = picker.kind !== 'cancel' ? picker.skills : undefined;
+  const skillsOverride = skills !== undefined ? { disabled: skills.disabled } : undefined;
+  // Thread the resolved repository id as a pre-selection. When the repo-selection step ran,
+  // `chosenRepositoryId` is the user's fresh pick; otherwise (single-repo / non-repo flows) it
+  // falls back to the session pin so the flow's own `pickRepositoryLeaf` still pre-selects the
+  // lone / previously-chosen repo.
+  const repositoryId = chosenRepositoryId ?? ui.sessionRepositoryId;
+  return {
+    ...(repositoryId !== undefined ? { repositoryId } : {}),
+    ...(override !== undefined ? { override } : {}),
+    ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
+    ...(skillsOverride !== undefined ? { skillsOverride } : {}),
+    settingsSnapshot: settings,
+  };
+};
+
+/**
+ * Persist the "remember" half of the skills step: only the bundled-default subset of the picker's
+ * disabled names (project / operator / phase-folder unchecks stay run-scoped — see
+ * `bundledDefaultSkillNames`). A full read-modify-write of the already-loaded `settings` via the
+ * same `settings-set` seam every other TUI mutation uses (`settings-mutations.ts`'s `persistKey`).
+ */
+const persistSkillsDefault = async (
+  settingsRepo: AppDeps['settingsRepo'],
+  settings: Settings,
+  settingsFlow: FlowId,
+  disabled: readonly string[]
+): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }> => {
+  const nextSettings: Settings = {
+    ...settings,
+    ai: {
+      ...settings.ai,
+      skills: { ...settings.ai.skills, [settingsFlow]: { disabled } },
+    } as Settings['ai'],
+  };
+  const saved = await createSettingsSetFlow({ settingsRepo }).execute({ input: { next: nextSettings } });
+  if (!saved.ok) return { ok: false, message: saved.error.error.message };
+  return { ok: true };
+};
+
+/**
+ * Drive the picker's "remember" choice, if any. No-op (returns `undefined`) when the user kept
+ * skills at default, picked "run only", or the flow never surfaced candidates in the first place.
+ * Non-fatal on failure — the run itself already carries the full override via
+ * {@link buildLaunchExtras}'s `skillsOverride`, independent of whether this save succeeds; the
+ * caller surfaces the returned message as a soft warning and proceeds with the launch regardless.
+ */
+export const applySkillsRememberChoice = async (
+  settingsRepo: AppDeps['settingsRepo'],
+  settings: Settings,
+  skillCandidates: SkillCandidatesResult | undefined,
+  picker: CustomizePickerResult
+): Promise<string | undefined> => {
+  if (picker.kind === 'cancel' || picker.skills?.saveAsDefault !== true) return undefined;
+  if (skillCandidates?.settingsFlow === undefined) return undefined;
+
+  const bundledOnly = picker.skills.disabled.filter((name) =>
+    bundledDefaultSkillNames(skillCandidates.candidates).has(name)
+  );
+  const persisted = await persistSkillsDefault(settingsRepo, settings, skillCandidates.settingsFlow, bundledOnly);
+  return persisted.ok ? undefined : `Couldn't remember skills preference: ${persisted.message}`;
+};

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -39,20 +39,20 @@ import {
   type LaunchResult,
 } from '@src/application/ui/shared/launcher.ts';
 import { launchSprintBoundFlow } from '@src/application/ui/shared/launch/sprint-bound.ts';
+import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customize-picker.ts';
 import {
-  runCustomizePicker,
-  type CustomizePickerResult,
-} from '@src/application/ui/tui/views/flows-customize-picker.ts';
+  applySkillsRememberChoice,
+  buildLaunchExtras,
+  prefetchSkillCandidates,
+} from '@src/application/ui/tui/views/flows-launch-extras.ts';
 import { runRepositorySelection } from '@src/application/ui/tui/views/flows-repository-picker.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { getRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
-import { getImplementRoleOverrides } from '@src/application/ui/tui/runtime/implement-role-overrides.ts';
 import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
 import { SprintPipeline, resolveSprintStage } from '@src/application/ui/tui/components/sprint-pipeline.tsx';
 import { sectionFor, sectionRank, visibleFlowsFor } from '@src/application/ui/tui/views/flows-visibility.ts';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
-import type { Settings } from '@src/domain/entity/settings.ts';
 
 // Sprint-state-machine visibility lives in `flows-visibility.ts` so it can be unit-tested
 // without a React render. The view delegates section labelling, ordering, and the
@@ -174,40 +174,6 @@ const OrientationCard = ({ snapshot, showAll }: OrientationCardProps): React.JSX
   );
 };
 
-/**
- * Assemble the per-launch {@link LaunchExtras} from the resolved repository id, the customize
- * picker's outcome, and the fresh settings snapshot. Implement role overrides prefer the
- * picker's per-role result; falling back to the CLI-derived module holder (parsed from
- * `--implement-{generator,evaluator}-{provider,model}`) only for the `implement` flow when the
- * picker ran in single-row mode (i.e. every AI flow other than implement).
- */
-const buildLaunchExtras = (
-  picker: CustomizePickerResult,
-  entry: FlowEntry,
-  chosenRepositoryId: RepositoryId | undefined,
-  ui: ReturnType<typeof useUiState>,
-  settings: Settings
-): LaunchExtras => {
-  const implementRoleOverrides =
-    picker.kind === 'implement'
-      ? picker.implementRoleOverrides
-      : entry.manifest.id === 'implement'
-        ? getImplementRoleOverrides()
-        : undefined;
-  const override = picker.kind === 'single' ? picker.override : undefined;
-  // Thread the resolved repository id as a pre-selection. When the repo-selection step ran,
-  // `chosenRepositoryId` is the user's fresh pick; otherwise (single-repo / non-repo flows) it
-  // falls back to the session pin so the flow's own `pickRepositoryLeaf` still pre-selects the
-  // lone / previously-chosen repo.
-  const repositoryId = chosenRepositoryId ?? ui.sessionRepositoryId;
-  return {
-    ...(repositoryId !== undefined ? { repositoryId } : {}),
-    ...(override !== undefined ? { override } : {}),
-    ...(implementRoleOverrides !== undefined ? { implementRoleOverrides } : {}),
-    settingsSnapshot: settings,
-  };
-};
-
 interface RunFlowLaunchDeps {
   readonly selection: ReturnType<typeof useSelection>;
   readonly sessions: SessionManager;
@@ -315,6 +281,9 @@ const createFlowSelectHandler = (
     }
 
     const interactive = createInkInteractivePrompt(queue);
+    // Built once, up-front, so both the skills-candidate lookup below and the eventual launch
+    // share the same `LauncherDeps` — no reason to reconstruct it after the picker runs.
+    const launcherDeps: LauncherDeps = { app: deps, interactive, storage, runInTerminal: getRunInTerminal() };
 
     // Re-read settings from disk now so provider/model changes made via the Settings
     // view propagate. `deps.settings` is the boot-time snapshot and goes stale across
@@ -343,11 +312,16 @@ const createFlowSelectHandler = (
     // post-completion capture below just re-affirms it (no conflict / double-prompt).
     if (chosenRepositoryId !== undefined) ui.setSessionRepositoryId(chosenRepositoryId);
 
+    // Pre-fetch skill candidates BEFORE the picker runs (no-op for a flow that doesn't mount a
+    // skillSource — see `prefetchSkillCandidates`).
+    const skillCandidates = await prefetchSkillCandidates(launcherDeps, snapshot, entry.manifest.id, settings);
+
     // Pre-launch customize picker — for AI-driven flows the user gets Start /
     // Customize / Cancel. Customize walks provider → model → effort for each row
-    // (implement walks generator then evaluator). Settings are never mutated; per-launch
-    // overrides are passed through {@link LaunchExtras}. Non-AI flows return
-    // `kind: 'defaults'` without prompting.
+    // (implement walks generator then evaluator), then (when `skillCandidates` is present) a
+    // skills step. Settings are never mutated by the picker itself; per-launch overrides are
+    // passed through {@link LaunchExtras} and a "remember" skills choice is persisted below.
+    // Non-AI flows return `kind: 'defaults'` without prompting.
     const picker = await runCustomizePicker({
       interactive,
       flowId: entry.manifest.id,
@@ -356,11 +330,17 @@ const createFlowSelectHandler = (
       // exactOptionalPropertyTypes: only pass the key when defined — the picker arg is
       // `?`-optional (absent), not `| undefined`. Absent ⇒ picker falls back to modelCatalogFor.
       ...(deps.availableModelsFor !== undefined ? { availableModelsFor: deps.availableModelsFor } : {}),
+      ...(skillCandidates !== undefined ? { skillCandidates } : {}),
     });
     if (picker.kind === 'cancel') return;
 
+    // "Remember for <flow>" — non-fatal on failure: the run itself already carries the full
+    // override via `buildLaunchExtras`'s `skillsOverride`, so a save failure only means the
+    // preference didn't stick for next time.
+    const rememberError = await applySkillsRememberChoice(deps.settingsRepo, settings, skillCandidates, picker);
+    if (rememberError !== undefined) setLaunchError(rememberError);
+
     const launchExtras = buildLaunchExtras(picker, entry, chosenRepositoryId, ui, settings);
-    const launcherDeps = { app: deps, interactive, storage, runInTerminal: getRunInTerminal() };
     const result = await runFlowLaunch(launcherDeps, entry, snapshot, launchExtras, { selection, sessions });
     if (!result.ok) {
       setLaunchError(`${entry.manifest.title}: ${result.reason}`);

--- a/src/application/ui/tui/views/flows-view.tsx
+++ b/src/application/ui/tui/views/flows-view.tsx
@@ -43,6 +43,7 @@ import { runCustomizePicker } from '@src/application/ui/tui/views/flows-customiz
 import {
   applySkillsRememberChoice,
   buildLaunchExtras,
+  makeRebuildSkillCandidates,
   prefetchSkillCandidates,
 } from '@src/application/ui/tui/views/flows-launch-extras.ts';
 import { runRepositorySelection } from '@src/application/ui/tui/views/flows-repository-picker.ts';
@@ -330,7 +331,10 @@ const createFlowSelectHandler = (
       // exactOptionalPropertyTypes: only pass the key when defined — the picker arg is
       // `?`-optional (absent), not `| undefined`. Absent ⇒ picker falls back to modelCatalogFor.
       ...(deps.availableModelsFor !== undefined ? { availableModelsFor: deps.availableModelsFor } : {}),
-      ...(skillCandidates !== undefined ? { skillCandidates } : {}),
+      // A degraded listing (some source failed) is withheld entirely: a checklist over a partial
+      // candidate set misreads as "disable everything missing" — the failure is already logged.
+      ...(skillCandidates !== undefined && !skillCandidates.degraded ? { skillCandidates } : {}),
+      rebuildSkillCandidates: makeRebuildSkillCandidates(launcherDeps, snapshot, entry.manifest.id, settings),
     });
     if (picker.kind === 'cancel') return;
 
@@ -338,7 +342,12 @@ const createFlowSelectHandler = (
     // override via `buildLaunchExtras`'s `skillsOverride`, so a save failure only means the
     // preference didn't stick for next time.
     const rememberError = await applySkillsRememberChoice(deps.settingsRepo, settings, skillCandidates, picker);
-    if (rememberError !== undefined) setLaunchError(rememberError);
+    if (rememberError !== undefined) {
+      // Also log it: on a successful launch this view is replaced immediately, destroying the
+      // local error state before the user can read it — the session log keeps the trace.
+      launcherDeps.app.logger.warn(rememberError);
+      setLaunchError(rememberError);
+    }
 
     const launchExtras = buildLaunchExtras(picker, entry, chosenRepositoryId, ui, settings);
     const result = await runFlowLaunch(launcherDeps, entry, snapshot, launchExtras, { selection, sessions });

--- a/src/application/ui/tui/views/home-internals/menu-items.ts
+++ b/src/application/ui/tui/views/home-internals/menu-items.ts
@@ -39,6 +39,7 @@ export interface BuildMenuItemsInput {
       | 'projects'
       | 'sessions'
       | 'settings'
+      | 'skills'
       | 'doctor'
   ) => void;
   readonly onPushAddTicket: (sprintId: SprintId) => void;
@@ -189,6 +190,14 @@ export const buildMenuItems = (input: BuildMenuItemsInput): readonly MenuItem[] 
       hotkey: 's',
       globalHotkey: true,
       onSelect: (): void => input.onPushHome('settings'),
+    },
+    {
+      id: 'skills',
+      section: 'system',
+      label: 'Skills catalog',
+      description: 'Browse, enable, disable, and update opt-in skills.',
+      hotkey: 'K',
+      onSelect: (): void => input.onPushHome('skills'),
     },
     {
       id: 'doctor',

--- a/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
+++ b/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure display-mapping helpers for the Skills catalog view. Kept separate from `skills-view.tsx`
+ * so the glyph/colour/label decisions are unit-testable without mounting Ink.
+ */
+
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+import type { SkillCatalogEntry, SkillInstallStatus } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
+
+/** Full flow name — used in picker option labels. */
+export const FLOW_LABEL: Record<FlowId, string> = {
+  refine: 'Refine',
+  plan: 'Plan',
+  implement: 'Implement',
+  readiness: 'Readiness',
+  ideate: 'Ideate',
+  createPr: 'Create PR',
+};
+
+/** Three-letter abbreviation — used in the compact per-row flow-chip strip. */
+export const FLOW_ABBR: Record<FlowId, string> = {
+  refine: 'ref',
+  plan: 'pln',
+  implement: 'imp',
+  readiness: 'rdy',
+  ideate: 'ide',
+  createPr: 'pr ',
+};
+
+export interface FlowChipVisual {
+  readonly glyph: string;
+  readonly color: string;
+  readonly bold: boolean;
+  /** One-word state description reused by both the row chip and the enable/disable picker. */
+  readonly label: string;
+}
+
+/** Glyph/colour/label for one {@link SkillInstallStatus}. */
+export const statusVisual = (status: SkillInstallStatus): FlowChipVisual => {
+  switch (status) {
+    case 'in-sync':
+      return { glyph: glyphs.check, color: inkColors.success, bold: false, label: 'in sync' };
+    case 'update-available':
+      return { glyph: glyphs.warningGlyph, color: inkColors.warning, bold: false, label: 'update available' };
+    case 'locally-modified':
+      return { glyph: glyphs.modified, color: inkColors.error, bold: false, label: 'locally modified' };
+    case 'manual':
+      return { glyph: glyphs.infoGlyph, color: inkColors.muted, bold: false, label: 'manual' };
+  }
+};
+
+/**
+ * Resolve one flow's chip glyph/colour/label for a catalog entry row. `defaultFor` always wins
+ * over any install status — a default-on skill loads regardless of a phase-folder copy (see the
+ * registry's module doc), so the display must say so even when a redundant opt-in copy exists
+ * (decision: overlap is tolerated, never hidden).
+ */
+export const flowChipVisual = (flowId: FlowId, entry: SkillCatalogEntry): FlowChipVisual => {
+  if (entry.defaultFor.includes(flowId)) {
+    return { glyph: glyphs.phaseDone, color: inkColors.highlight, bold: true, label: 'always on (default)' };
+  }
+  const install = entry.installs.find((i) => i.flow === flowId);
+  if (install === undefined) {
+    return { glyph: glyphs.phaseDisabled, color: inkColors.muted, bold: false, label: 'not enabled' };
+  }
+  return statusVisual(install.status);
+};

--- a/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
+++ b/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
@@ -3,9 +3,33 @@
  * so the glyph/colour/label decisions are unit-testable without mounting Ink.
  */
 
-import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
 import type { SkillCatalogEntry, SkillInstallStatus } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
+import { flowMountsSkills } from '@src/application/ui/shared/launcher.ts';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
+
+/**
+ * Flows whose launch context actually mounts a skill source — derived from the launcher's
+ * `flowMountsSkills` (the single source of truth), keyed back to `FlowId` via the phase-dir
+ * mapping (dir names equal the orchestration dispatch ids). The catalog offers, preselects, and
+ * renders chips ONLY for these: advertising an enable target no launch ever consumes (createPr
+ * today — its flow has no skill-mounting dispatch) would misrepresent effect.
+ */
+export const SKILL_MOUNTING_FLOW_IDS: readonly FlowId[] = FLOW_IDS.filter((flowId) =>
+  flowMountsSkills(PHASE_FLOW_DIR[flowId])
+);
+
+/**
+ * Flows a row renders chips for: every mounting flow, plus any NON-mounting flow that already
+ * holds an install (a leftover copy must stay visible so it can be disabled — it renders as
+ * `inactive`, never as a live status).
+ */
+export const chipFlowsFor = (entry: SkillCatalogEntry): readonly FlowId[] => {
+  const mounting = new Set(SKILL_MOUNTING_FLOW_IDS);
+  const leftovers = entry.installs.map((i) => i.flow).filter((f) => !mounting.has(f));
+  return [...SKILL_MOUNTING_FLOW_IDS, ...leftovers];
+};
 
 /** Full flow name — used in picker option labels. */
 export const FLOW_LABEL: Record<FlowId, string> = {
@@ -46,17 +70,36 @@ export const statusVisual = (status: SkillInstallStatus): FlowChipVisual => {
       return { glyph: glyphs.modified, color: inkColors.error, bold: false, label: 'locally modified' };
     case 'manual':
       return { glyph: glyphs.infoGlyph, color: inkColors.muted, bold: false, label: 'manual' };
+    case 'broken':
+      return { glyph: glyphs.cross, color: inkColors.error, bold: false, label: 'broken (no SKILL.md)' };
   }
 };
 
 /**
- * Resolve one flow's chip glyph/colour/label for a catalog entry row. `defaultFor` always wins
- * over any install status — a default-on skill loads regardless of a phase-folder copy (see the
- * registry's module doc), so the display must say so even when a redundant opt-in copy exists
- * (decision: overlap is tolerated, never hidden).
+ * Resolve one flow's chip glyph/colour/label for a catalog entry row. `defaultFor` wins over any
+ * install status — a default-on skill loads regardless of a phase-folder copy (see the registry's
+ * module doc), so the display must say so even when a redundant opt-in copy exists (decision:
+ * overlap is tolerated, never hidden) — UNLESS the flow's saved `settings.ai.skills` row durably
+ * opts the skill out, in which case the chip must not claim "always on". A leftover install on a
+ * non-mounting flow renders `inactive` — that flow loads no skills at all.
  */
-export const flowChipVisual = (flowId: FlowId, entry: SkillCatalogEntry): FlowChipVisual => {
+export const flowChipVisual = (
+  flowId: FlowId,
+  entry: SkillCatalogEntry,
+  savedDisabled?: (flowId: FlowId) => ReadonlySet<string>
+): FlowChipVisual => {
+  if (!SKILL_MOUNTING_FLOW_IDS.includes(flowId)) {
+    return {
+      glyph: glyphs.phaseDisabled,
+      color: inkColors.muted,
+      bold: false,
+      label: 'inactive (flow loads no skills)',
+    };
+  }
   if (entry.defaultFor.includes(flowId)) {
+    if (savedDisabled?.(flowId).has(entry.name) === true) {
+      return { glyph: glyphs.phaseDisabled, color: inkColors.muted, bold: false, label: 'default, off (saved)' };
+    }
     return { glyph: glyphs.phaseDone, color: inkColors.highlight, bold: true, label: 'always on (default)' };
   }
   const install = entry.installs.find((i) => i.flow === flowId);

--- a/src/application/ui/tui/views/skills-view-internals/picker-options.ts
+++ b/src/application/ui/tui/views/skills-view-internals/picker-options.ts
@@ -1,0 +1,39 @@
+/**
+ * Flow-picker option builders for the enable / disable multi-select prompts. Pure — kept
+ * separate from `skills-view.tsx` so the gating rules (what's disabled, what's offered at all)
+ * are unit-testable without mounting Ink.
+ */
+
+import type { Choice } from '@src/business/interactive/prompt.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { FLOW_LABEL, statusVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+
+/**
+ * Every flow is offered; a flow the skill is already default-ON for is disabled (opting it in
+ * would be a no-op — it loads regardless, see `flowChipVisual`'s doc comment) but still shown so
+ * the operator understands why it's greyed out.
+ */
+export const enableOptions = (entry: SkillCatalogEntry): ReadonlyArray<Choice<FlowId>> =>
+  FLOW_IDS.map((flowId) => {
+    const isDefault = entry.defaultFor.includes(flowId);
+    const install = entry.installs.find((i) => i.flow === flowId);
+    return {
+      label: FLOW_LABEL[flowId],
+      value: flowId,
+      disabled: isDefault,
+      ...(isDefault
+        ? { description: 'already default-on' }
+        : install !== undefined
+          ? { description: statusVisual(install.status).label }
+          : {}),
+    };
+  });
+
+/** Only the flows currently installed — disabling a flow with no phase-folder copy is a no-op. */
+export const disableOptions = (entry: SkillCatalogEntry): ReadonlyArray<Choice<FlowId>> =>
+  entry.installs.map((install) => ({
+    label: FLOW_LABEL[install.flow],
+    value: install.flow,
+    description: statusVisual(install.status).label,
+  }));

--- a/src/application/ui/tui/views/skills-view-internals/picker-options.ts
+++ b/src/application/ui/tui/views/skills-view-internals/picker-options.ts
@@ -5,30 +5,55 @@
  */
 
 import type { Choice } from '@src/business/interactive/prompt.ts';
-import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
-import { FLOW_LABEL, statusVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+import {
+  FLOW_LABEL,
+  SKILL_MOUNTING_FLOW_IDS,
+  statusVisual,
+} from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 
 /**
- * Every flow is offered; a flow the skill is already default-ON for is disabled (opting it in
- * would be a no-op — it loads regardless, see `flowChipVisual`'s doc comment) but still shown so
- * the operator understands why it's greyed out.
+ * Every skill-MOUNTING flow is offered (a flow whose launch never mounts a skill source —
+ * createPr today — is not listed at all: enabling there would advertise an effect that never
+ * happens). A flow the skill is already default-ON for is disabled (opting it in would be a
+ * no-op — it loads regardless, see `flowChipVisual`'s doc comment) but still shown so the
+ * operator understands why it's greyed out; likewise an edit-protected copy (`locally-modified`
+ * / `manual`) is shown disabled — `enable` deliberately skips those, `u` (update, with confirm)
+ * is the overwrite path.
  */
 export const enableOptions = (entry: SkillCatalogEntry): ReadonlyArray<Choice<FlowId>> =>
-  FLOW_IDS.map((flowId) => {
+  SKILL_MOUNTING_FLOW_IDS.map((flowId) => {
     const isDefault = entry.defaultFor.includes(flowId);
     const install = entry.installs.find((i) => i.flow === flowId);
+    const editProtected = install?.status === 'locally-modified' || install?.status === 'manual';
     return {
       label: FLOW_LABEL[flowId],
       value: flowId,
-      disabled: isDefault,
+      disabled: isDefault || editProtected,
       ...(isDefault
         ? { description: 'already default-on' }
-        : install !== undefined
-          ? { description: statusVisual(install.status).label }
-          : {}),
+        : editProtected
+          ? { description: `${statusVisual(install.status).label} — u overwrites` }
+          : install !== undefined
+            ? { description: statusVisual(install.status).label }
+            : {}),
     };
   });
+
+/**
+ * Preselection for the enable picker: `recommendedFor`, narrowed to rows that are actually
+ * selectable (mounting flows, not default-on, not edit-protected) — seeding a disabled row
+ * checked would misstate what submit will do.
+ */
+export const enablePreselect = (entry: SkillCatalogEntry): readonly FlowId[] => {
+  const selectable = new Set(
+    enableOptions(entry)
+      .filter((o) => o.disabled !== true)
+      .map((o) => o.value)
+  );
+  return entry.recommendedFor.filter((f) => selectable.has(f));
+};
 
 /** Only the flows currently installed — disabling a flow with no phase-folder copy is a no-op. */
 export const disableOptions = (entry: SkillCatalogEntry): ReadonlyArray<Choice<FlowId>> =>

--- a/src/application/ui/tui/views/skills-view-internals/skill-row.tsx
+++ b/src/application/ui/tui/views/skills-view-internals/skill-row.tsx
@@ -1,0 +1,62 @@
+/**
+ * One catalog row: name (+ "(manual)" tag for a non-bundled entry), one-line description,
+ * per-flow status chips, and a dim "recommended:" line when the registry suggests extra phases.
+ * Presentational only — `skills-view.tsx` owns the cursor + action wiring.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { StatusChip } from '@src/application/ui/tui/components/status-chip.tsx';
+import { inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { FLOW_ABBR, flowChipVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+
+export interface SkillRowProps {
+  readonly entry: SkillCatalogEntry;
+  readonly focused: boolean;
+  /** `false` for a hand-dropped phase-folder entry with no matching `BUNDLED_SKILLS` row. */
+  readonly isBundled: boolean;
+}
+
+export const SkillRow = ({ entry, focused, isBundled }: SkillRowProps): React.JSX.Element => {
+  const updateCount = entry.installs.filter((i) => i.status === 'update-available').length;
+  return (
+    <Box flexDirection="column" marginBottom={spacing.section}>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={focused ? inkColors.primary : inkColors.rule}
+        borderDimColor={!focused}
+        paddingX={spacing.cardPadX}
+      >
+        <Box justifyContent="space-between">
+          <Text bold {...(focused ? { color: inkColors.primary } : {})}>
+            {entry.name}
+            {!isBundled && <Text dimColor> (manual)</Text>}
+          </Text>
+          {updateCount > 0 && (
+            <StatusChip label={`${String(updateCount)} update${updateCount === 1 ? '' : 's'}`} kind="warning" />
+          )}
+        </Box>
+        <Text dimColor wrap="truncate-end">
+          {entry.description.length > 0 ? entry.description : '(no description)'}
+        </Text>
+        <Box>
+          {FLOW_IDS.map((flowId) => {
+            const visual = flowChipVisual(flowId, entry);
+            return (
+              <Text key={flowId} color={visual.color} bold={visual.bold}>
+                {visual.glyph} {FLOW_ABBR[flowId]}
+                {'  '}
+              </Text>
+            );
+          })}
+        </Box>
+        {entry.recommendedFor.length > 0 && (
+          <Text dimColor>recommended: {entry.recommendedFor.map((f) => FLOW_ABBR[f]).join(', ')}</Text>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/application/ui/tui/views/skills-view-internals/skill-row.tsx
+++ b/src/application/ui/tui/views/skills-view-internals/skill-row.tsx
@@ -6,20 +6,26 @@
 
 import React from 'react';
 import { Box, Text } from 'ink';
-import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { StatusChip } from '@src/application/ui/tui/components/status-chip.tsx';
 import { inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
-import { FLOW_ABBR, flowChipVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+import {
+  chipFlowsFor,
+  FLOW_ABBR,
+  flowChipVisual,
+} from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 
 export interface SkillRowProps {
   readonly entry: SkillCatalogEntry;
   readonly focused: boolean;
   /** `false` for a hand-dropped phase-folder entry with no matching `BUNDLED_SKILLS` row. */
   readonly isBundled: boolean;
+  /** Per-flow saved opt-outs (`settings.ai.skills`) — a durably-disabled default must not chip as "always on". */
+  readonly savedDisabled: (flowId: FlowId) => ReadonlySet<string>;
 }
 
-export const SkillRow = ({ entry, focused, isBundled }: SkillRowProps): React.JSX.Element => {
+export const SkillRow = ({ entry, focused, isBundled, savedDisabled }: SkillRowProps): React.JSX.Element => {
   const updateCount = entry.installs.filter((i) => i.status === 'update-available').length;
   return (
     <Box flexDirection="column" marginBottom={spacing.section}>
@@ -43,8 +49,8 @@ export const SkillRow = ({ entry, focused, isBundled }: SkillRowProps): React.JS
           {entry.description.length > 0 ? entry.description : '(no description)'}
         </Text>
         <Box>
-          {FLOW_IDS.map((flowId) => {
-            const visual = flowChipVisual(flowId, entry);
+          {chipFlowsFor(entry).map((flowId) => {
+            const visual = flowChipVisual(flowId, entry, savedDisabled);
             return (
               <Text key={flowId} color={visual.color} bold={visual.bold}>
                 {visual.glyph} {FLOW_ABBR[flowId]}

--- a/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
+++ b/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
@@ -1,0 +1,220 @@
+/**
+ * Action state + handlers for the Skills catalog view — enable / disable / update / update-all,
+ * plus the enable/disable flow-picker and destructive-confirm state they drive. Extracted from
+ * `skills-view.tsx` so the view stays a thin render + key-dispatch layer; the sequencing rules
+ * (when a confirm is required, what "up to date" means) live here where they're one hook away
+ * from a unit test.
+ *
+ * Handlers are module-level functions taking an explicit {@link ActionCtx} rather than closures
+ * inside the hook — keeps `useSkillCatalogActions` itself a thin dispatch table and each rule
+ * independently readable.
+ */
+
+import { useMemo, useState } from 'react';
+import type { RefObject } from 'react';
+import type { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
+import type {
+  SkillCatalogEntry,
+  SkillCatalogPort,
+  SkillInstallStatus,
+} from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { feedback, type StructuredFeedback } from '@src/application/ui/tui/components/feedback-line.tsx';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
+import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
+
+const LOCALLY_MODIFIED: SkillInstallStatus = 'locally-modified';
+
+export interface PickerState {
+  readonly kind: 'enable' | 'disable';
+  readonly entry: SkillCatalogEntry;
+}
+
+export interface ConfirmState {
+  readonly kind: 'disable' | 'update';
+  readonly entry: SkillCatalogEntry;
+  readonly flows: readonly FlowId[];
+}
+
+/** `true` when disabling any of `flows` would discard operator-owned content. */
+const isDestructiveDisable = (entry: SkillCatalogEntry, flows: readonly FlowId[]): boolean =>
+  flows.some((f) => {
+    const status = entry.installs.find((i) => i.flow === f)?.status;
+    return status === LOCALLY_MODIFIED || status === 'manual';
+  });
+
+/** Flows worth updating for `entry`: already-stale copies, plus edited ones (confirm-gated). */
+const updateTargets = (entry: SkillCatalogEntry): readonly FlowId[] =>
+  entry.installs.filter((i) => i.status === 'update-available' || i.status === LOCALLY_MODIFIED).map((i) => i.flow);
+
+/** Human title for the destructive-confirm card. */
+export const confirmTitle = (cs: ConfirmState): string =>
+  cs.kind === 'disable'
+    ? `Remove "${cs.entry.name}" for ${String(cs.flows.length)} flow(s)?`
+    : `Update "${cs.entry.name}" for ${String(cs.flows.length)} flow(s)?`;
+
+/** Threaded through every module-level handler below — one bag, one signature per handler. */
+interface ActionCtx {
+  readonly skillCatalog: SkillCatalogPort;
+  readonly mountedRef: RefObject<boolean>;
+  readonly reload: () => void;
+  readonly setBusy: (busy: boolean) => void;
+  readonly setActionFeedback: (value: StructuredFeedback | undefined) => void;
+  readonly setPicker: (value: PickerState | undefined) => void;
+  readonly setConfirmState: (value: ConfirmState | undefined) => void;
+}
+
+/** Run one catalog mutation, translate the Result into feedback, and reload the list on success. */
+const runCatalogOp = async <T>(
+  ctx: ActionCtx,
+  op: () => Promise<Result<T, StorageError>>,
+  successLabel: (value: T) => string
+): Promise<void> => {
+  ctx.setBusy(true);
+  const r = await op();
+  if (!ctx.mountedRef.current) return;
+  ctx.setBusy(false);
+  if (!r.ok) {
+    ctx.setActionFeedback(feedback('error', `${glyphs.cross} ${r.error.message}`));
+    return;
+  }
+  // `r.value`'s static type is a deferred conditional (`typescript-result`'s `ValueOr`) that TS
+  // can't collapse for a generic `T` bound only at the call site — same shape as the cast in
+  // `integration/io/file-locker.ts`'s `withLock`.
+  ctx.setActionFeedback(feedback('success', successLabel(r.value as T)));
+  ctx.reload();
+};
+
+const doStartEnable = (ctx: ActionCtx, bundledNames: ReadonlySet<string>, entry: SkillCatalogEntry): void => {
+  if (!bundledNames.has(entry.name)) {
+    ctx.setActionFeedback(feedback('error', `${glyphs.cross} "${entry.name}" is a manual entry — nothing to enable`));
+    return;
+  }
+  ctx.setPicker({ kind: 'enable', entry });
+};
+
+const doStartDisable = (ctx: ActionCtx, entry: SkillCatalogEntry): void => {
+  if (entry.installs.length === 0) {
+    ctx.setActionFeedback(feedback('info', `"${entry.name}" isn't enabled anywhere`));
+    return;
+  }
+  ctx.setPicker({ kind: 'disable', entry });
+};
+
+const doSubmitPicker = (ctx: ActionCtx, picker: PickerState | undefined, flows: readonly FlowId[]): void => {
+  ctx.setPicker(undefined);
+  if (picker === undefined || flows.length === 0) return;
+  const { kind, entry } = picker;
+  if (kind === 'enable') {
+    void runCatalogOp(
+      ctx,
+      () => ctx.skillCatalog.enable(entry.name, flows),
+      () => `${glyphs.check} enabled "${entry.name}" for ${String(flows.length)} flow(s)`
+    );
+    return;
+  }
+  if (isDestructiveDisable(entry, flows)) {
+    ctx.setConfirmState({ kind: 'disable', entry, flows });
+    return;
+  }
+  void runCatalogOp(
+    ctx,
+    () => ctx.skillCatalog.disable(entry.name, flows),
+    () => `${glyphs.check} disabled "${entry.name}" for ${String(flows.length)} flow(s)`
+  );
+};
+
+const doRunUpdate = (ctx: ActionCtx, bundledNames: ReadonlySet<string>, entry: SkillCatalogEntry): void => {
+  if (!bundledNames.has(entry.name)) {
+    ctx.setActionFeedback(feedback('error', `${glyphs.cross} "${entry.name}" is a manual entry — nothing to update`));
+    return;
+  }
+  const targets = updateTargets(entry);
+  if (targets.length === 0) {
+    ctx.setActionFeedback(feedback('info', `"${entry.name}" is already up to date`));
+    return;
+  }
+  if (targets.some((f) => entry.installs.find((i) => i.flow === f)?.status === LOCALLY_MODIFIED)) {
+    ctx.setConfirmState({ kind: 'update', entry, flows: targets });
+    return;
+  }
+  void runCatalogOp(
+    ctx,
+    () => ctx.skillCatalog.update(entry.name, targets),
+    () => `${glyphs.check} updated "${entry.name}" (${String(targets.length)} flow(s))`
+  );
+};
+
+const doSubmitConfirm = (ctx: ActionCtx, confirmState: ConfirmState | undefined, confirmed: boolean): void => {
+  ctx.setConfirmState(undefined);
+  if (confirmState === undefined || !confirmed) return;
+  const label = (n: number): string =>
+    `${glyphs.check} ${confirmState.kind === 'disable' ? 'disabled' : 'updated'} "${confirmState.entry.name}" (${String(n)} flow(s))`;
+  const op = confirmState.kind === 'disable' ? ctx.skillCatalog.disable : ctx.skillCatalog.update;
+  void runCatalogOp(
+    ctx,
+    () => op(confirmState.entry.name, confirmState.flows),
+    () => label(confirmState.flows.length)
+  );
+};
+
+const doRunUpdateAll = (ctx: ActionCtx): void => {
+  void runCatalogOp(
+    ctx,
+    () => ctx.skillCatalog.updateAll(),
+    (v) =>
+      v.updated.length === 0
+        ? `${glyphs.refresh} everything is already up to date`
+        : `${glyphs.check} updated ${String(v.updated.length)} skill(s): ${v.updated.join(', ')}`
+  );
+};
+
+export interface UseSkillCatalogActionsResult {
+  readonly picker: PickerState | undefined;
+  readonly confirmState: ConfirmState | undefined;
+  readonly actionFeedback: StructuredFeedback | undefined;
+  readonly busy: boolean;
+  /** Every `BUNDLED_SKILLS` name — an entry outside this set is a manual (non-bundled) row. */
+  readonly bundledNames: ReadonlySet<string>;
+  readonly startEnable: (entry: SkillCatalogEntry) => void;
+  readonly startDisable: (entry: SkillCatalogEntry) => void;
+  readonly runUpdate: (entry: SkillCatalogEntry) => void;
+  readonly runUpdateAll: () => void;
+  readonly cancelPicker: () => void;
+  readonly submitPicker: (flows: readonly FlowId[]) => void;
+  readonly submitConfirm: (confirmed: boolean) => void;
+  readonly flashInfo: (text: string) => void;
+}
+
+export const useSkillCatalogActions = (
+  skillCatalog: SkillCatalogPort,
+  reload: () => void
+): UseSkillCatalogActionsResult => {
+  const mountedRef = useIsMounted();
+  const bundledNames = useMemo(() => new Set(BUNDLED_SKILLS.map((e) => e.name)), []);
+
+  const [picker, setPicker] = useState<PickerState | undefined>(undefined);
+  const [confirmState, setConfirmState] = useState<ConfirmState | undefined>(undefined);
+  const [actionFeedback, setActionFeedback] = useState<StructuredFeedback | undefined>(undefined);
+  const [busy, setBusy] = useState(false);
+
+  const ctx: ActionCtx = { skillCatalog, mountedRef, reload, setBusy, setActionFeedback, setPicker, setConfirmState };
+
+  return {
+    picker,
+    confirmState,
+    actionFeedback,
+    busy,
+    bundledNames,
+    startEnable: (entry) => doStartEnable(ctx, bundledNames, entry),
+    startDisable: (entry) => doStartDisable(ctx, entry),
+    runUpdate: (entry) => doRunUpdate(ctx, bundledNames, entry),
+    runUpdateAll: () => doRunUpdateAll(ctx),
+    cancelPicker: () => setPicker(undefined),
+    submitPicker: (flows) => doSubmitPicker(ctx, picker, flows),
+    submitConfirm: (confirmed) => doSubmitConfirm(ctx, confirmState, confirmed),
+    flashInfo: (text) => setActionFeedback(feedback('info', text)),
+  };
+};

--- a/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
+++ b/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
@@ -45,9 +45,14 @@ const isDestructiveDisable = (entry: SkillCatalogEntry, flows: readonly FlowId[]
     return status === LOCALLY_MODIFIED || status === 'manual';
   });
 
-/** Flows worth updating for `entry`: already-stale copies, plus edited ones (confirm-gated). */
+/**
+ * Flows worth updating for `entry`: already-stale copies, edited ones (confirm-gated), and
+ * `broken` folders (no SKILL.md — update rewrites them, which is a pure repair).
+ */
 const updateTargets = (entry: SkillCatalogEntry): readonly FlowId[] =>
-  entry.installs.filter((i) => i.status === 'update-available' || i.status === LOCALLY_MODIFIED).map((i) => i.flow);
+  entry.installs
+    .filter((i) => i.status === 'update-available' || i.status === LOCALLY_MODIFIED || i.status === 'broken')
+    .map((i) => i.flow);
 
 /** Human title for the destructive-confirm card. */
 export const confirmTitle = (cs: ConfirmState): string =>
@@ -111,7 +116,12 @@ const doSubmitPicker = (ctx: ActionCtx, picker: PickerState | undefined, flows: 
     void runCatalogOp(
       ctx,
       () => ctx.skillCatalog.enable(entry.name, flows),
-      () => `${glyphs.check} enabled "${entry.name}" for ${String(flows.length)} flow(s)`
+      // Honest outcome: `enable` deliberately skips edit-protected copies — never report a
+      // flow as enabled when the port left it untouched.
+      (outcome) =>
+        outcome.skipped.length === 0
+          ? `${glyphs.check} enabled "${entry.name}" for ${String(outcome.copied.length)} flow(s)`
+          : `${glyphs.check} enabled "${entry.name}" for ${String(outcome.copied.length)} flow(s); skipped ${String(outcome.skipped.length)} (edit-protected — u overwrites)`
     );
     return;
   }

--- a/src/application/ui/tui/views/skills-view.tsx
+++ b/src/application/ui/tui/views/skills-view.tsx
@@ -1,0 +1,232 @@
+/**
+ * Skills catalog view — browse every bundled skill, see where it's currently enabled (per flow)
+ * and whether that copy is in sync, and enable / disable / update it. The filesystem under
+ * `<appRoot>/skills/<flow>/<name>/` is the single source of truth (see
+ * `integration/ai/skills/phase/catalog.ts`); this view is a thin driver over
+ * `AppDeps.skillCatalog`. Action sequencing (enable/disable/update/update-all, confirm gating)
+ * lives in `skills-view-internals/use-skill-catalog-actions.ts`; the per-row layout lives in
+ * `skills-view-internals/skill-row.tsx`.
+ *
+ * Local keys:
+ *   ↑/↓/j/k   move the focus cursor (windowed list)
+ *   e         enable the focused skill for picked flows (multi-select, recommendedFor preselected)
+ *   d         disable the focused skill for picked flows (multi-select over currently-installed flows)
+ *   u         update the focused skill from the bundle (confirms first if it would overwrite a
+ *             locally-modified copy)
+ *   U         update every install whose status is update-available, catalog-wide (never touches
+ *             locally-modified or manual installs — no confirm needed)
+ *   r         reload
+ *
+ * A `defaultFor` flow always renders "always on (default)" regardless of any phase-folder copy —
+ * default loading doesn't go through the phase folder at all (see `flowChipVisual`'s doc comment).
+ */
+
+import React, { useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
+import { useListWindow, type ListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
+import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
+import { EmptyState } from '@src/application/ui/tui/components/empty-state.tsx';
+import { ConfirmCard } from '@src/application/ui/tui/components/confirm-card.tsx';
+import { FeedbackLine, type StructuredFeedback } from '@src/application/ui/tui/components/feedback-line.tsx';
+import { MultiSelectPrompt } from '@src/application/ui/tui/prompts/multi-select-prompt.tsx';
+import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx';
+import { glyphs, spacing } from '@src/application/ui/tui/theme/tokens.ts';
+import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { useAsyncLoad, type AsyncLoadState } from '@src/application/ui/tui/runtime/use-async-load.ts';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
+import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { SkillRow } from '@src/application/ui/tui/views/skills-view-internals/skill-row.tsx';
+import { disableOptions, enableOptions } from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
+import {
+  confirmTitle,
+  type ConfirmState,
+  type PickerState,
+  useSkillCatalogActions,
+} from '@src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts';
+
+/** Non-list rows consumed by ViewShell chrome + summary line + overflow rows + feedback. */
+const CHROME_ROWS = 8;
+/** Approximate rendered height (rows) of one `SkillRow` card. */
+const ROW_HEIGHT = 6;
+
+interface SkillsBodyProps {
+  readonly helpOpen: boolean;
+  readonly state: AsyncLoadState<readonly SkillCatalogEntry[], unknown>;
+  readonly picker: PickerState | undefined;
+  readonly confirmState: ConfirmState | undefined;
+  readonly entries: readonly SkillCatalogEntry[];
+  readonly window: ListWindow;
+  readonly visibleItems: readonly SkillCatalogEntry[];
+  readonly focusedIndex: number;
+  readonly bundledNames: ReadonlySet<string>;
+  readonly operatorSkillsRoot: string;
+  readonly actionFeedback: StructuredFeedback | undefined;
+  readonly onSubmitPicker: (flows: readonly FlowId[]) => void;
+  readonly onCancelPicker: () => void;
+  readonly onSubmitConfirm: (confirmed: boolean) => void;
+}
+
+/** Loading / error / picker / confirm / empty / list-of-rows presentation — pure props in. */
+const SkillsBody = ({
+  helpOpen,
+  state,
+  picker,
+  confirmState,
+  entries,
+  window,
+  visibleItems,
+  focusedIndex,
+  bundledNames,
+  operatorSkillsRoot,
+  actionFeedback,
+  onSubmitPicker,
+  onCancelPicker,
+  onSubmitConfirm,
+}: SkillsBodyProps): React.JSX.Element => {
+  if (helpOpen) return <HelpOverlay />;
+  if (state.kind === 'loading' || state.kind === 'idle') return <LoadingRow label="Loading skill catalog…" />;
+  if (state.kind === 'error') return <LoadErrorRow message="Failed to load the skill catalog." />;
+
+  if (picker !== undefined) {
+    return (
+      <Box flexDirection="column" paddingX={spacing.indent}>
+        <Text bold>
+          {picker.kind === 'enable' ? 'Enable' : 'Disable'} &quot;{picker.entry.name}&quot; for:
+        </Text>
+        <MultiSelectPrompt
+          message="space toggle · a select-all · ↵ confirm"
+          options={picker.kind === 'enable' ? enableOptions(picker.entry) : disableOptions(picker.entry)}
+          initialSelectedValues={picker.kind === 'enable' ? picker.entry.recommendedFor : []}
+          onSubmit={(values) => onSubmitPicker(values as readonly FlowId[])}
+          onCancel={onCancelPicker}
+        />
+      </Box>
+    );
+  }
+
+  if (confirmState !== undefined) {
+    return (
+      <ConfirmCard
+        title={<Text bold>{confirmTitle(confirmState)}</Text>}
+        body={<Text dimColor>Local edits in the selected flow(s) will be permanently lost.</Text>}
+        message={confirmState.kind === 'disable' ? 'Remove?' : 'Overwrite?'}
+        onSubmit={onSubmitConfirm}
+        onCancel={() => onSubmitConfirm(false)}
+      />
+    );
+  }
+
+  if (entries.length === 0) {
+    return <EmptyState title="No skills bundled" hint="Nothing to browse — this build ships no skills." />;
+  }
+
+  const updateAvailableCount = entries.reduce(
+    (acc, e) => acc + e.installs.filter((i) => i.status === 'update-available').length,
+    0
+  );
+  const anyOptIn = entries.some((e) => e.installs.length > 0);
+
+  return (
+    <Box flexDirection="column">
+      <Box paddingX={spacing.indent} marginBottom={spacing.section}>
+        <Text dimColor>
+          {String(entries.length)} skill(s) {glyphs.bullet} {String(updateAvailableCount)} update
+          {updateAvailableCount === 1 ? '' : 's'} available
+          {!anyOptIn &&
+            ` ${glyphs.bullet} no opt-in copies yet — press e to enable one (folder: ${operatorSkillsRoot}/<flow>/<skill>)`}
+        </Text>
+      </Box>
+      <OverflowRow direction="above" count={window.start} />
+      {visibleItems.map((entry, localIdx) => (
+        <SkillRow
+          key={entry.name}
+          entry={entry}
+          focused={window.start + localIdx === focusedIndex}
+          isBundled={bundledNames.has(entry.name)}
+        />
+      ))}
+      <OverflowRow direction="below" count={entries.length - window.end} />
+      <FeedbackLine text={actionFeedback} />
+    </Box>
+  );
+};
+
+export const SkillsView = (): React.JSX.Element => {
+  const deps = useDeps();
+  const ui = useUiState();
+  const bp = useBreakpoint();
+
+  const { state, reload } = useAsyncLoad<readonly SkillCatalogEntry[]>(async () => {
+    const r = await deps.skillCatalog.list();
+    if (!r.ok) throw new Error(r.error.message);
+    return r.value;
+  }, [deps.skillCatalog]);
+  const entries = state.kind === 'ok' ? state.value : [];
+
+  const actions = useSkillCatalogActions(deps.skillCatalog, reload);
+  const { picker, confirmState, bundledNames } = actions;
+
+  const claimPrompt = ui.claimPrompt;
+  useEffect(() => (picker !== undefined ? claimPrompt() : undefined), [picker, claimPrompt]);
+
+  const listActive = !ui.modalOpen && picker === undefined && confirmState === undefined;
+  const visibleRows = Math.max(2, Math.min(6, Math.floor((bp.rows - CHROME_ROWS) / ROW_HEIGHT)));
+  const { window, visibleItems, focusedIndex, focusedItem } = useListWindow<SkillCatalogEntry>({
+    items: entries,
+    getId: (e) => e.name,
+    visibleRows,
+    active: listActive,
+  });
+
+  useViewHints([
+    { keys: '↑/↓/j/k', label: 'move' },
+    { keys: 'e', label: 'enable' },
+    { keys: 'd', label: 'disable' },
+    { keys: 'u', label: 'update' },
+    { keys: 'U', label: 'update all' },
+    { keys: 'r', label: 'reload' },
+  ]);
+
+  useInput((input) => {
+    if (!listActive || actions.busy) return;
+    if (input === 'U') {
+      actions.runUpdateAll();
+      return;
+    }
+    if (input === 'r') {
+      actions.flashInfo(`${glyphs.refresh} reloading…`);
+      reload();
+      return;
+    }
+    const target = focusedItem;
+    if (target === undefined) return;
+    if (input === 'e') actions.startEnable(target);
+    else if (input === 'd') actions.startDisable(target);
+    else if (input === 'u') actions.runUpdate(target);
+  });
+
+  return (
+    <ViewShell title="Skills" subtitle="Browse, enable, disable, and update opt-in skills" suppressScrollArrows>
+      <SkillsBody
+        helpOpen={ui.helpOpen}
+        state={state}
+        picker={picker}
+        confirmState={confirmState}
+        entries={entries}
+        window={window}
+        visibleItems={visibleItems}
+        focusedIndex={focusedIndex}
+        bundledNames={bundledNames}
+        operatorSkillsRoot={String(deps.storage.operatorSkillsRoot)}
+        actionFeedback={actions.actionFeedback}
+        onSubmitPicker={(flows) => actions.submitPicker(flows)}
+        onCancelPicker={actions.cancelPicker}
+        onSubmitConfirm={actions.submitConfirm}
+      />
+    </ViewShell>
+  );
+};

--- a/src/application/ui/tui/views/skills-view.tsx
+++ b/src/application/ui/tui/views/skills-view.tsx
@@ -21,7 +21,7 @@
  * default loading doesn't go through the phase folder at all (see `flowChipVisual`'s doc comment).
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { useListWindow, type ListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
@@ -37,10 +37,15 @@ import { useAsyncLoad, type AsyncLoadState } from '@src/application/ui/tui/runti
 import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
-import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { AiSkillsSettings } from '@src/domain/entity/settings.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { SkillRow } from '@src/application/ui/tui/views/skills-view-internals/skill-row.tsx';
-import { disableOptions, enableOptions } from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
+import {
+  disableOptions,
+  enableOptions,
+  enablePreselect,
+} from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
 import {
   confirmTitle,
   type ConfirmState,
@@ -50,12 +55,18 @@ import {
 
 /** Non-list rows consumed by ViewShell chrome + summary line + overflow rows + feedback. */
 const CHROME_ROWS = 8;
-/** Approximate rendered height (rows) of one `SkillRow` card. */
-const ROW_HEIGHT = 6;
+/**
+ * Rendered height (rows) of one `SkillRow` card at its tallest: border top, name, description,
+ * chip strip, "recommended:" line, border bottom, plus the section margin below the card.
+ */
+const ROW_HEIGHT = 7;
 
 interface SkillsBodyProps {
   readonly helpOpen: boolean;
-  readonly state: AsyncLoadState<readonly SkillCatalogEntry[], unknown>;
+  readonly state: AsyncLoadState<
+    { readonly entries: readonly SkillCatalogEntry[]; readonly skills: AiSkillsSettings | undefined },
+    unknown
+  >;
   readonly picker: PickerState | undefined;
   readonly confirmState: ConfirmState | undefined;
   readonly entries: readonly SkillCatalogEntry[];
@@ -63,6 +74,7 @@ interface SkillsBodyProps {
   readonly visibleItems: readonly SkillCatalogEntry[];
   readonly focusedIndex: number;
   readonly bundledNames: ReadonlySet<string>;
+  readonly savedDisabled: (flowId: FlowId) => ReadonlySet<string>;
   readonly operatorSkillsRoot: string;
   readonly actionFeedback: StructuredFeedback | undefined;
   readonly onSubmitPicker: (flows: readonly FlowId[]) => void;
@@ -81,6 +93,7 @@ const SkillsBody = ({
   visibleItems,
   focusedIndex,
   bundledNames,
+  savedDisabled,
   operatorSkillsRoot,
   actionFeedback,
   onSubmitPicker,
@@ -100,7 +113,7 @@ const SkillsBody = ({
         <MultiSelectPrompt
           message="space toggle · a select-all · ↵ confirm"
           options={picker.kind === 'enable' ? enableOptions(picker.entry) : disableOptions(picker.entry)}
-          initialSelectedValues={picker.kind === 'enable' ? picker.entry.recommendedFor : []}
+          initialSelectedValues={picker.kind === 'enable' ? enablePreselect(picker.entry) : []}
           onSubmit={(values) => onSubmitPicker(values as readonly FlowId[])}
           onCancel={onCancelPicker}
         />
@@ -147,6 +160,7 @@ const SkillsBody = ({
           entry={entry}
           focused={window.start + localIdx === focusedIndex}
           isBundled={bundledNames.has(entry.name)}
+          savedDisabled={savedDisabled}
         />
       ))}
       <OverflowRow direction="below" count={entries.length - window.end} />
@@ -160,12 +174,26 @@ export const SkillsView = (): React.JSX.Element => {
   const ui = useUiState();
   const bp = useBreakpoint();
 
-  const { state, reload } = useAsyncLoad<readonly SkillCatalogEntry[]>(async () => {
+  const { state, reload } = useAsyncLoad<{
+    readonly entries: readonly SkillCatalogEntry[];
+    readonly skills: AiSkillsSettings | undefined;
+  }>(async () => {
     const r = await deps.skillCatalog.list();
     if (!r.ok) throw new Error(r.error.message);
-    return r.value;
-  }, [deps.skillCatalog]);
-  const entries = state.kind === 'ok' ? state.value : [];
+    // Saved per-flow opt-outs make a "default" chip honest ("default, off (saved)"). A settings
+    // read failure is non-fatal here — the catalog still renders, chips just lose that nuance.
+    const settingsR = await deps.settingsRepo.load();
+    return { entries: r.value, skills: settingsR.ok ? settingsR.value.ai.skills : undefined };
+  }, [deps.skillCatalog, deps.settingsRepo]);
+  const entries = state.kind === 'ok' ? state.value.entries : [];
+  const skills = state.kind === 'ok' ? state.value.skills : undefined;
+
+  const EMPTY_NAMES: ReadonlySet<string> = useMemo(() => new Set(), []);
+  const savedDisabled = useMemo(() => {
+    const byFlow = new Map<FlowId, ReadonlySet<string>>();
+    for (const flowId of FLOW_IDS) byFlow.set(flowId, new Set(skills?.[flowId]?.disabled ?? []));
+    return (flowId: FlowId): ReadonlySet<string> => byFlow.get(flowId) ?? EMPTY_NAMES;
+  }, [skills, EMPTY_NAMES]);
 
   const actions = useSkillCatalogActions(deps.skillCatalog, reload);
   const { picker, confirmState, bundledNames } = actions;
@@ -221,6 +249,7 @@ export const SkillsView = (): React.JSX.Element => {
         visibleItems={visibleItems}
         focusedIndex={focusedIndex}
         bundledNames={bundledNames}
+        savedDisabled={savedDisabled}
         operatorSkillsRoot={String(deps.storage.operatorSkillsRoot)}
         actionFeedback={actions.actionFeedback}
         onSubmitPicker={(flows) => actions.submitPicker(flows)}

--- a/src/application/ui/tui/views/view-registry.tsx
+++ b/src/application/ui/tui/views/view-registry.tsx
@@ -14,6 +14,7 @@ import { SprintDetailView } from '@src/application/ui/tui/views/sprint-detail-vi
 import { ExecuteView } from '@src/application/ui/tui/views/execute-view.tsx';
 import { SessionsView } from '@src/application/ui/tui/views/sessions-view.tsx';
 import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
+import { SkillsView } from '@src/application/ui/tui/views/skills-view.tsx';
 import { DoctorView } from '@src/application/ui/tui/views/doctor-view.tsx';
 import { ExportContextView } from '@src/application/ui/tui/views/export-context-view.tsx';
 import { ExportRequirementsView } from '@src/application/ui/tui/views/export-requirements-view.tsx';
@@ -45,6 +46,8 @@ export const renderView = (entry: ViewEntry): React.JSX.Element => {
       return <SessionsView />;
     case 'settings':
       return <SettingsView />;
+    case 'skills':
+      return <SkillsView />;
     case 'doctor':
       return <DoctorView />;
     case 'export-context':

--- a/src/business/interactive/prompt.ts
+++ b/src/business/interactive/prompt.ts
@@ -52,8 +52,17 @@ export interface InteractivePrompt {
   askTextArea(prompt: string, opts?: { readonly initial?: string }): Promise<Result<string, DomainError>>;
   /** Single-select from a fixed option list. Returns the selected option's `value`. */
   askChoice<T>(prompt: string, options: ReadonlyArray<Choice<T>>): Promise<Result<T, DomainError>>;
-  /** Multi-select from a fixed option list. Returns the selected options' `value`s, order preserved. */
-  askMultiChoice<T>(prompt: string, options: ReadonlyArray<Choice<T>>): Promise<Result<readonly T[], DomainError>>;
+  /**
+   * Multi-select from a fixed option list. Returns the selected options' `value`s, order
+   * preserved. `opts.initial` pre-checks every option whose `value` appears in the list (`===`
+   * match) so callers can open the checklist reflecting an existing state — e.g. "currently
+   * enabled" — instead of forcing the user to rebuild a selection from an empty set.
+   */
+  askMultiChoice<T>(
+    prompt: string,
+    options: ReadonlyArray<Choice<T>>,
+    opts?: { readonly initial?: readonly T[] }
+  ): Promise<Result<readonly T[], DomainError>>;
   /**
    * Yes/no confirmation. Returns the user's boolean answer. Adapters define what counts as
    * yes/no (the console adapter accepts `y`/`yes` / `n`/`no`, case-insensitive); empty input

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -232,6 +232,41 @@ const healHarnessCrossKnobs = (harness: unknown): unknown => {
 };
 
 /**
+ * One flow's skills opt-out row. `disabled` lists skill names (`ralphctl-*`) to SUBTRACT from
+ * that flow's bundled default skill set at launch. Names are free trimmed non-empty strings —
+ * the domain cannot import the integration-side skill registry, so a name's validity against
+ * the bundled catalog is checked at launch (unknown names are harmless no-ops), never here. An
+ * empty list is valid and means "nothing disabled" (equivalent to an absent row).
+ */
+const FlowSkillsRowSchema = z.object({
+  disabled: z.array(z.string().trim().min(1, 'skill name must be a non-empty trimmed string')).readonly(),
+});
+
+/**
+ * Durable, per-flow skills opt-OUT preference — the saved counterpart of the per-run customize
+ * checklist. Structurally `Partial<Record<FlowId, { disabled: readonly string[] }>>`: every flow
+ * key is optional and an absent key (or an absent `ai.skills` altogether) means "the flow's
+ * registry defaults apply", resolved in the launcher, not here.
+ *
+ * Semantics — opt-OUT ONLY. Names under a flow's `disabled` are SUBTRACTED from that flow's
+ * bundled defaults at launch. Opt-IN (adding skills beyond the defaults) is filesystem-based —
+ * `<appRoot>/skills/<flow>/` folders — and deliberately never lives in settings.
+ *
+ * Precedence at launch: per-run override > this saved preference > registry default.
+ *
+ * Flow keys are enumerated explicitly (mirroring the `ai` rows above) so a stray/renamed flow
+ * key is tolerantly stripped by the surrounding `z.object` rather than failing the whole parse.
+ */
+const AiSkillsSchema = z.object({
+  refine: FlowSkillsRowSchema.optional(),
+  plan: FlowSkillsRowSchema.optional(),
+  implement: FlowSkillsRowSchema.optional(),
+  readiness: FlowSkillsRowSchema.optional(),
+  ideate: FlowSkillsRowSchema.optional(),
+  createPr: FlowSkillsRowSchema.optional(),
+});
+
+/**
  * Per-flow AI settings:
  *
  *   ai.effort?            // global default, used when a row omits its own effort
@@ -241,6 +276,7 @@ const healHarnessCrossKnobs = (harness: unknown): unknown => {
  *   ai.readiness          // { provider, model, effort? }
  *   ai.ideate             // { provider, model, effort? }
  *   ai.createPr           // { provider, model, effort? }
+ *   ai.skills?            // opt-OUT only: Partial<Record<FlowId, { disabled: readonly string[] }>>
  *
  * Rows are independent — refine can run on Claude while implement.evaluator runs on Codex.
  * The discriminated union on each row keeps `model` enforced against the row's provider
@@ -250,6 +286,9 @@ const healHarnessCrossKnobs = (harness: unknown): unknown => {
  * The `createPr` row was added after the original five — settings files written by
  * ralphctl ≤ 0.8.x are missing it. The preprocess seeds it from `refine` at parse time so
  * legacy files load without manual editing; the next `save()` rewrites the canonical shape.
+ *
+ * `ai.skills` is the durable opt-OUT preference — see {@link AiSkillsSchema}. Absent means
+ * "registry defaults apply"; that fallback lives in the launcher, not here.
  */
 const AiSettingsSchema = z.preprocess(
   promoteLegacyAiRows,
@@ -261,6 +300,7 @@ const AiSettingsSchema = z.preprocess(
     readiness: FlowRowSchema,
     ideate: FlowRowSchema,
     createPr: FlowRowSchema,
+    skills: AiSkillsSchema.optional(),
   })
 );
 
@@ -465,6 +505,15 @@ export type AiFlowSettings = z.infer<typeof FlowRowSchema>;
 export type AiImplementSettings = z.infer<typeof AiImplementSchema>;
 /** Roles inside {@link AiImplementSettings} — addressed in dotted-path keys and per-leaf launches. */
 export type AiImplementRole = 'generator' | 'evaluator';
+/**
+ * Durable opt-OUT preference block under `settings.ai.skills` — see {@link AiSkillsSchema}.
+ * `Partial<Record<FlowId, { disabled: readonly string[] }>>`. Exposed for the skills launcher
+ * resolution seam (#216) and the customize picker, which read a flow's saved `disabled` list to
+ * subtract from that flow's bundled defaults at launch.
+ *
+ * @public
+ */
+export type AiSkillsSettings = z.infer<typeof AiSkillsSchema>;
 export type Settings = z.infer<typeof SettingsSchema>;
 
 /**

--- a/src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts
+++ b/src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts
@@ -1,0 +1,32 @@
+/**
+ * Port for reading the RAW (unparsed) bytes of a bundled skill's `SKILL.md`, keyed by skill name.
+ *
+ * Exists so the phase-scoped skill catalog (`phase/catalog.ts`) can hash + copy a bundled skill
+ * VERBATIM without importing the `bundled/` sibling directly — `integration/ai/skills/<x>`
+ * siblings may only reach into `_engine/` (see the SKILLS sibling-isolation fence in
+ * `eslint.config.ts`, `siblingIsolationRule` over `integration/ai/skills`, keyed on `SKILLS`, allowing only `_engine`).
+ * The concrete implementation ({@link createBundledSkillRawReader}) lives next to
+ * `createBundledSkillSource` in `bundled/source.ts`, sharing its bundled-root resolution; the
+ * composition root (`wire()`) is the only place that imports both this port and that concrete
+ * together, which is exactly the shape the fence is designed to allow.
+ *
+ * Kept separate from the parsed {@link SkillSource} port: the catalog's provenance hashing MUST
+ * be computed over the exact on-disk bytes (see `phase/provenance.ts`'s module doc), so a
+ * parse → re-render round trip through `SkillSource` would silently change the hash the
+ * operator's copy is compared against.
+ */
+
+import type { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+
+/** @public */
+export interface BundledSkillRawReader {
+  /**
+   * Read `<bundledRoot>/<name>/SKILL.md` verbatim (no frontmatter parsing, no re-render). `name`
+   * is expected to be a registered `BUNDLED_SKILLS` entry — a missing file surfaces as a
+   * `StorageError` (the bundled root is the single source of truth for the catalog's own
+   * entries, so a missing file for a registered name is a build/packaging bug, not a soft
+   * "not found").
+   */
+  readRaw(name: string): Promise<Result<string, StorageError>>;
+}

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -1,63 +1,137 @@
 /**
- * `FLOW_SKILLS` — code-configured mapping of flow id → bundled skill ids that the flow's AI
- * session should have access to.
+ * `BUNDLED_SKILLS` — the extensible per-skill registry: one row per bundled skill, each row
+ * naming the flows the skill is default-ON for and the flows it is merely *recommended* for.
+ * This replaces the old flat `FLOW_SKILLS` (flow → skill ids) mapping; inverting the table so a
+ * skill owns its own phase assignments keeps adding / re-curating a skill a one-row edit and
+ * lets the opt-in catalog surface per-skill suggestions.
  *
- * The list of recognised flow ids comes from the flow registry (`orchestration/registry.ts`).
+ * Two fields, two distinct jobs:
+ *   - `defaultFor`      — phases where the skill is installed automatically (loading behaviour).
+ *                         `skillsForFlow` derives its result from this column, so it drives what
+ *                         a flow's AI session actually receives.
+ *   - `recommendedFor`  — catalog-only opt-in suggestion (display behaviour). It NEVER loads a
+ *                         skill; the TUI catalog uses it to nudge "this might help here too".
+ *                         May overlap `defaultFor`, but by convention we list only the *extra*
+ *                         phases beyond the defaults to keep the two columns readable.
+ *
+ * Default-set curation: the first eight rows keep the assignments inherited from v1's
+ * `FLOW_SKILLS`; the curated additions below them are promoted into the phases where their
+ * discipline is strongest (rationale inline per row). Overlap between skills is deliberate —
+ * skill bodies are lightweight and the per-run / per-flow opt-out (`settings.ai.skills`,
+ * customize-picker skills step) lets an operator trim any of it. `ralphctl-cherny-workflow` is
+ * the one curated skill left default-OFF: the harness itself already enforces its core loop
+ * (plan gate, check gate, evaluator), so it stays an opt-in reinforcement.
+ *
  * `FlowId` is re-exported from `domain/value/flow-id.ts` so this module, the settings schema,
- * and the launcher all read from one definition — the integration test in
- * `tests/unit/orchestration/skills-registry.test.ts` asserts that every key here exists as a
- * flow in the orchestration registry, and that every skill id referenced has a bundled folder
- * on disk.
+ * the skill sources, and the launcher all read one definition of the flow set. The registry
+ * test (`tests/unit/integration/ai/skills/registry.test.ts`) fences two invariants: every
+ * `FlowId` referenced in either column exists in the orchestration flow registry, and every
+ * skill `name` (again from either column) resolves to a `bundled/<name>/SKILL.md` folder.
  *
- * Order in each list does not matter; adapters install in the order given and that's it.
- *
- * v1 parity: v1's `default/` skills (`alignment`, `abstraction-first`, `iterative-review`)
- * were applied to every phase. We keep the same set on every flow for now; refining
- * per-flow assignments is a follow-up.
+ * Table order is the canonical order: `skillsForFlow` returns matching names in the order they
+ * appear below, and adapters install in that order.
  */
 
-import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
 
 export type { FlowId };
 
-const SKILL_ALIGNMENT = 'ralphctl-alignment';
-const SKILL_ITERATIVE_REVIEW = 'ralphctl-iterative-review';
-const SKILL_ABSTRACTION_FIRST = 'ralphctl-abstraction-first';
-const SKILL_MINIMAL_SCAFFOLDING = 'ralphctl-minimal-scaffolding';
+/** Every AI flow — skills carried over from v1's global `default/` bundle are default-ON here. */
+const ALL_FLOWS = FLOW_IDS;
 
-/** Skill ids referenced below — must each exist as `src/ai/skills/bundled/<id>/SKILL.md`. */
-export const FLOW_SKILLS: Record<FlowId, readonly string[]> = {
-  refine: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
-  plan: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
-  implement: [
-    SKILL_ALIGNMENT,
-    SKILL_ITERATIVE_REVIEW,
-    SKILL_ABSTRACTION_FIRST,
-    SKILL_MINIMAL_SCAFFOLDING,
-    'ralphctl-debugging-and-error-recovery',
-    'ralphctl-test-driven-development',
-    'ralphctl-code-review-and-quality',
-    'ralphctl-surgical-simplicity',
-  ],
-  readiness: [SKILL_ALIGNMENT, SKILL_ITERATIVE_REVIEW, SKILL_ABSTRACTION_FIRST, SKILL_MINIMAL_SCAFFOLDING],
-  ideate: [
-    SKILL_ALIGNMENT,
-    SKILL_ITERATIVE_REVIEW,
-    SKILL_ABSTRACTION_FIRST,
-    SKILL_MINIMAL_SCAFFOLDING,
-    'ralphctl-surgical-simplicity',
-  ],
-  // `createPr` is the camelCase FlowId for the kebab-case orchestration flow `create-pr`.
-  // The mapping lives in the registry test (and in the launcher's `aiFlowIdFor`). Skills
-  // mirror the rest — same default bundle.
-  createPr: [
-    SKILL_ALIGNMENT,
-    SKILL_ITERATIVE_REVIEW,
-    SKILL_ABSTRACTION_FIRST,
-    SKILL_MINIMAL_SCAFFOLDING,
-    'ralphctl-code-review-and-quality',
-  ],
-};
+/**
+ * One bundled skill and its phase assignments. `name` must match a `bundled/<name>/SKILL.md`
+ * folder (and, per the Agent Skills spec, that file's frontmatter `name`); the `ralphctl-`
+ * prefix is required.
+ *
+ * @public
+ */
+export interface BundledSkillEntry {
+  /** `ralphctl-*` — must match the bundled folder name. */
+  readonly name: string;
+  /** Phases where the skill is installed by default (loading; drives `skillsForFlow`). */
+  readonly defaultFor: readonly FlowId[];
+  /** Extra phases the catalog suggests for opt-in (display only; never loads the skill). */
+  readonly recommendedFor: readonly FlowId[];
+}
 
-/** Type-safe lookup. Returns the configured skill ids or an empty list. */
-export const skillsForFlow = (flowId: FlowId): readonly string[] => FLOW_SKILLS[flowId];
+/**
+ * The bundled-skill catalog. Order is significant — see the module doc comment.
+ *
+ * @public
+ */
+export const BUNDLED_SKILLS: readonly BundledSkillEntry[] = [
+  // The four skills below descend from v1's global `default/` bundle, so they stay default-ON
+  // everywhere; there is no phase left to recommend them for.
+  { name: 'ralphctl-alignment', defaultFor: ALL_FLOWS, recommendedFor: [] },
+  { name: 'ralphctl-iterative-review', defaultFor: ALL_FLOWS, recommendedFor: [] },
+  { name: 'ralphctl-abstraction-first', defaultFor: ALL_FLOWS, recommendedFor: [] },
+  { name: 'ralphctl-minimal-scaffolding', defaultFor: ALL_FLOWS, recommendedFor: [] },
+  // Implement-centric skills — recommendedFor names conservative adjacent phases where the
+  // discipline plausibly earns its place beyond the default set.
+  {
+    name: 'ralphctl-debugging-and-error-recovery',
+    defaultFor: ['implement'],
+    recommendedFor: ['readiness'],
+  },
+  {
+    name: 'ralphctl-test-driven-development',
+    defaultFor: ['implement'],
+    recommendedFor: ['plan', 'readiness'],
+  },
+  {
+    name: 'ralphctl-code-review-and-quality',
+    defaultFor: ['implement', 'createPr'],
+    recommendedFor: ['readiness'],
+  },
+  {
+    name: 'ralphctl-surgical-simplicity',
+    defaultFor: ['implement', 'ideate'],
+    recommendedFor: ['refine', 'plan'],
+  },
+  // Curated catalog additions — promoted into the phases where each discipline is strongest
+  // (see the module doc comment for the curation posture).
+  {
+    // The anti-over-engineering ladder pays off where approach and dependencies get chosen
+    // (plan) and code gets written (implement); createPr is review-time — suggestion only.
+    name: 'ralphctl-ponytail',
+    defaultFor: ['plan', 'implement'],
+    recommendedFor: ['createPr'],
+  },
+  {
+    // Guardrails against silent assumptions and unverified completion bite exactly while
+    // planning and implementing; no phase left to merely recommend.
+    name: 'ralphctl-karpathy-guidelines',
+    defaultFor: ['plan', 'implement'],
+    recommendedFor: [],
+  },
+  {
+    // Default-OFF by design: the harness already structures this skill's loop (plan gate,
+    // check gate, evaluator), so it is an opt-in reinforcement, not a default.
+    name: 'ralphctl-cherny-workflow',
+    defaultFor: [],
+    recommendedFor: ['implement', 'createPr'],
+  },
+  {
+    // Divergent→convergent idea shaping is the ideate flow's core job; refine benefits when a
+    // ticket is still fuzzy — suggestion only.
+    name: 'ralphctl-idea-refinement',
+    defaultFor: ['ideate'],
+    recommendedFor: ['refine'],
+  },
+  {
+    // Ubiquitous language and boundary placement sharpen requirements (refine) and drive
+    // module boundaries (plan); implement keeps it as a suggestion.
+    name: 'ralphctl-domain-driven-design',
+    defaultFor: ['refine', 'plan'],
+    recommendedFor: ['implement'],
+  },
+];
+
+/**
+ * Skills default-ON for `flowId`, in table order. Derived from each entry's `defaultFor`, so
+ * `recommendedFor` never affects what a flow actually loads. Signature and behaviour are kept
+ * from the previous flat mapping — the bundled skill source consumes this unchanged.
+ */
+export const skillsForFlow = (flowId: FlowId): readonly string[] =>
+  BUNDLED_SKILLS.filter((entry) => entry.defaultFor.includes(flowId)).map((entry) => entry.name);

--- a/src/integration/ai/skills/_engine/resolve-selection.ts
+++ b/src/integration/ai/skills/_engine/resolve-selection.ts
@@ -1,0 +1,94 @@
+/**
+ * `createResolvedSkillSource` — the SINGLE skill-selection resolution seam. A {@link SkillSource}
+ * decorator that turns a *composed* union of sources (bundled + project + operator + phase-folder)
+ * into the effective per-flow set a launch actually installs:
+ *
+ *   getForFlow(flow) = dedupeByNameLastWins(inner.getForFlow(flow)) − flowDisabled(flow)
+ *
+ * Two steps, two jobs:
+ *
+ *  1. **dedupe by name, LAST occurrence wins.** The launcher composes the union in a fixed order —
+ *     bundled, then project, then operator, then the phase folder LAST — precisely so a later
+ *     source shadows an earlier one for the same install name. A phase-folder copy of
+ *     `ralphctl-foo` therefore beats the bundled `ralphctl-foo`; the operator likewise beats
+ *     bundled. When there are no duplicate names (the common case) this is a byte-for-byte no-op:
+ *     the list and its order are preserved, which is what keeps the zero-config skill set identical
+ *     to the pre-decorator behaviour.
+ *
+ *  2. **subtract the disabled name-set.** `flowDisabled(flow)` returns the names to remove for that
+ *     flow — the launcher supplies the union of the durable `settings.ai.skills[flow].disabled`
+ *     preference and the per-run `LaunchExtras.skillsOverride.disabled`. Subtraction is by exact
+ *     install name, so it applies to ANY skill (bundled, project, operator, or phase-folder) — the
+ *     opt-out is name-based, not source-based.
+ *
+ * `getByName` passes through UNFILTERED and un-deduped. Reason: `getByName` is a name-RESOLUTION
+ * seam, not an install seam — the readiness flow's `offer-skill-suggestions` leaf uses it to decide
+ * whether an AI-suggested name maps to a known bundled skill (install its canonical body) or is
+ * unknown (scaffold a stub). Filtering it by the per-flow disabled set would mislabel a skill the
+ * operator opted OUT of for auto-install as "unknown" and scaffold a wrong stub. Opt-out governs
+ * what a flow AUTO-INSTALLS, never what a name resolves to.
+ *
+ * v2 seam: the subset computation is intentionally hidden behind this one decorator. A future
+ * relevance recommender (rank + keep the most relevant N skills per flow) replaces the
+ * `dedupe − disabled` body here — or swaps `flowDisabled` for a richer `select(flow, skills)` dep —
+ * without changing the {@link SkillSource} contract or touching a single install-skills leaf /
+ * adapter. This doc names that intent; no speculative hook is built for it today.
+ */
+
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import type { FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
+
+/**
+ * Deduplicate by install `name`, keeping the LAST occurrence at its LAST position. Implemented by
+ * recording each name's final index then emitting only the entries that sit at that index, so
+ * de-duplication never re-orders survivors: a list with no duplicate names comes back unchanged
+ * (order and identity), which is the zero-config invariant the launcher relies on.
+ */
+const dedupeByNameLastWins = (skills: readonly Skill[]): readonly Skill[] => {
+  const lastIndexByName = new Map<string, number>();
+  skills.forEach((skill, index) => lastIndexByName.set(skill.name, index));
+  return skills.filter((skill, index) => lastIndexByName.get(skill.name) === index);
+};
+
+/**
+ * Factory input for {@link createResolvedSkillSource}.
+ *
+ * @public
+ */
+export interface ResolvedSkillSourceDeps {
+  /** The composed union source (bundled + project + operator + phase folder, in that order). */
+  readonly inner: SkillSource;
+  /**
+   * Names to SUBTRACT for a flow — the launcher supplies the union of the saved
+   * `settings.ai.skills[flow].disabled` preference and the per-run `skillsOverride.disabled`.
+   * Called per `getForFlow`; the launcher's closure is run-scoped so the returned set is the same
+   * across a run. The `flowId` argument keeps the decorator generic (a v2 recommender can key on
+   * it); duplicate names in the returned array are harmless — they collapse into a `Set`.
+   */
+  readonly flowDisabled: (flowId: FlowId) => readonly string[];
+}
+
+/**
+ * Wrap a composed {@link SkillSource} in the resolution seam. See the module doc for the full
+ * contract (dedupe last-wins on `getForFlow`, disabled-name subtraction, unfiltered `getByName`).
+ *
+ * @public
+ */
+export const createResolvedSkillSource = ({ inner, flowDisabled }: ResolvedSkillSourceDeps): SkillSource => ({
+  async getForFlow(flowId: FlowId): Promise<Result<readonly Skill[], StorageError>> {
+    const resolved = await inner.getForFlow(flowId);
+    if (!resolved.ok) return resolved;
+    const disabled = new Set(flowDisabled(flowId));
+    const kept = dedupeByNameLastWins(resolved.value).filter((skill) => !disabled.has(skill.name));
+    return Result.ok(kept);
+  },
+
+  // Name-resolution seam — pass through UNFILTERED (see module doc: opt-out governs auto-install,
+  // never name resolution; the readiness suggestion leaf must resolve any known name).
+  getByName(name: string): Promise<Result<Skill | undefined, StorageError>> {
+    return inner.getByName(name);
+  },
+});

--- a/src/integration/ai/skills/_engine/resolve-selection.ts
+++ b/src/integration/ai/skills/_engine/resolve-selection.ts
@@ -16,8 +16,10 @@
  *     to the pre-decorator behaviour.
  *
  *  2. **subtract the disabled name-set.** `flowDisabled(flow)` returns the names to remove for that
- *     flow — the launcher supplies the union of the durable `settings.ai.skills[flow].disabled`
- *     preference and the per-run `LaunchExtras.skillsOverride.disabled`. Subtraction is by exact
+ *     flow — the launcher supplies the per-run `LaunchExtras.skillsOverride.disabled` when present,
+ *     otherwise the durable `settings.ai.skills[flow].disabled` preference (the run override
+ *     REPLACES the saved row — never a union — so a run can re-enable a remembered opt-out).
+ *     Subtraction is by exact
  *     install name, so it applies to ANY skill (bundled, project, operator, or phase-folder) — the
  *     opt-out is name-based, not source-based.
  *
@@ -62,9 +64,9 @@ export interface ResolvedSkillSourceDeps {
   /** The composed union source (bundled + project + operator + phase folder, in that order). */
   readonly inner: SkillSource;
   /**
-   * Names to SUBTRACT for a flow — the launcher supplies the union of the saved
-   * `settings.ai.skills[flow].disabled` preference and the per-run `skillsOverride.disabled`.
-   * Called per `getForFlow`; the launcher's closure is run-scoped so the returned set is the same
+   * Names to SUBTRACT for a flow — the launcher supplies the per-run `skillsOverride.disabled`
+   * when present, otherwise the saved `settings.ai.skills[flow].disabled` preference (run
+   * REPLACES saved). Called per `getForFlow`; the launcher's closure is run-scoped so the returned set is the same
    * across a run. The `flowId` argument keeps the decorator generic (a v2 recommender can key on
    * it); duplicate names in the returned array are harmless — they collapse into a `Set`.
    */

--- a/src/integration/ai/skills/_engine/skill-catalog-port.ts
+++ b/src/integration/ai/skills/_engine/skill-catalog-port.ts
@@ -1,0 +1,99 @@
+/**
+ * `SkillCatalogPort` — the port the TUI skill-catalog view drives to enable / disable / update
+ * bundled skills per flow. Port-shaped, so the interface lives in `_engine/` (shared) while the
+ * concrete implementation lives in `phase/catalog.ts` (a later task).
+ *
+ * The catalog's single unit of truth is the filesystem: a skill is "enabled for a flow" iff its
+ * folder exists under `<appRoot>/skills/<flow>/<name>/`. Enable copies the bundled folder in and
+ * writes a `.provenance.json` stamp next to the copied `SKILL.md`; disable removes the folder.
+ * The provenance stamp (see `phase/provenance.ts`) is what lets `list()` report whether each
+ * install is in-sync with the bundle, has an upstream update available, or was locally edited.
+ *
+ * This module deliberately exports interfaces + the {@link SkillInstallStatus} union only — no
+ * behaviour. Keeping the status vocabulary here (rather than in `phase/provenance.ts`) means the
+ * port and the provenance engine share one definition without `_engine/` reaching into a sibling.
+ */
+
+import type { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
+
+/**
+ * Sync state of one on-disk skill copy relative to its bundled origin:
+ *  - `manual`           — folder has no `.provenance.json`; a skill the operator dropped in by
+ *                         hand. Never ours to overwrite or remove via `update`/`updateAll`.
+ *  - `in-sync`          — folder matches its stamp AND the stamp matches the current bundle.
+ *  - `update-available` — folder still matches its stamp, but the bundled skill changed upstream.
+ *  - `locally-modified` — the folder's `SKILL.md` diverges from its stamp (the operator edited
+ *                         the copy). Wins over `update-available` so an edit is never silently lost.
+ *
+ * @public
+ */
+export type SkillInstallStatus = 'manual' | 'in-sync' | 'update-available' | 'locally-modified';
+
+/** One flow where a catalog skill is installed, plus that copy's sync status. @public */
+export interface SkillCatalogInstall {
+  readonly flow: FlowId;
+  readonly status: SkillInstallStatus;
+}
+
+/**
+ * A row in the catalog view: one bundled skill, its registry-derived default/recommended phases,
+ * and where it is currently installed on disk. `installs` is empty when the skill is enabled
+ * nowhere.
+ *
+ * @public
+ */
+export interface SkillCatalogEntry {
+  /** `ralphctl-*` id — matches the bundled folder name. */
+  readonly name: string;
+  /** One-line description carried through from the bundled `SKILL.md` frontmatter. */
+  readonly description: string;
+  /** Phases where this skill is default-ON (registry `defaultFor`). */
+  readonly defaultFor: readonly FlowId[];
+  /** Phases the catalog suggests opting in to (registry `recommendedFor`; may overlap `defaultFor`). */
+  readonly recommendedFor: readonly FlowId[];
+  /** Every flow whose phase dir currently holds a copy of this skill, with its sync status. */
+  readonly installs: readonly SkillCatalogInstall[];
+}
+
+/**
+ * Output port backing the TUI skill catalog. All operations are `Result`-returning and idempotent
+ * where the filesystem allows it.
+ *
+ * @public
+ */
+export interface SkillCatalogPort {
+  /**
+   * One entry per bundled catalog skill, each carrying its registry defaults/recommendations and
+   * the per-flow `installs` derived from the phase folders + their provenance stamps. A hard I/O
+   * failure while scanning the phase dirs surfaces as `StorageError`; a folder without a stamp is
+   * reported as a `manual` install, not an error.
+   */
+  list(): Promise<Result<readonly SkillCatalogEntry[], StorageError>>;
+  /**
+   * Copy the bundled skill folder into each `<appRoot>/skills/<flow>/<name>/` and write a
+   * `.provenance.json` stamp beside the copied `SKILL.md`. Idempotent for an in-sync install
+   * (re-writing identical bytes). A `locally-modified` copy is left untouched — the caller routes
+   * the operator through `update` (with confirmation) to overwrite local edits.
+   */
+  enable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>>;
+  /**
+   * Remove the skill folder (and its sidecar) from each named flow's phase dir. A folder that is
+   * already absent is a no-op. Only touches the `ralphctl-*` copies the catalog manages — never an
+   * operator/project skill.
+   */
+  disable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>>;
+  /**
+   * Overwrite the phase-folder copy in each named flow with the current bundled content and
+   * re-stamp. `update` always overwrites, discarding any local edits, so the caller MUST confirm
+   * before updating a `locally-modified` copy — the confirmation gate is a caller (TUI) concern.
+   */
+  update(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>>;
+  /**
+   * Update every install whose status is `update-available`, skipping `locally-modified` (never
+   * silently discard edits) and `manual` (no stamp — not ours to touch). Returns the skill names
+   * actually updated so the caller can report what changed.
+   */
+  updateAll(): Promise<Result<{ readonly updated: readonly string[] }, StorageError>>;
+}

--- a/src/integration/ai/skills/_engine/skill-catalog-port.ts
+++ b/src/integration/ai/skills/_engine/skill-catalog-port.ts
@@ -26,10 +26,13 @@ import type { FlowId } from '@src/domain/value/flow-id.ts';
  *  - `update-available` — folder still matches its stamp, but the bundled skill changed upstream.
  *  - `locally-modified` — the folder's `SKILL.md` diverges from its stamp (the operator edited
  *                         the copy). Wins over `update-available` so an edit is never silently lost.
+ *  - `broken`           — the folder exists but has no readable `SKILL.md` (e.g. an interrupted
+ *                         copy). It loads nothing and would otherwise be invisible; `disable`
+ *                         removes it, and `update` on a bundled name repairs it.
  *
  * @public
  */
-export type SkillInstallStatus = 'manual' | 'in-sync' | 'update-available' | 'locally-modified';
+export type SkillInstallStatus = 'manual' | 'in-sync' | 'update-available' | 'locally-modified' | 'broken';
 
 /** One flow where a catalog skill is installed, plus that copy's sync status. @public */
 export interface SkillCatalogInstall {
@@ -74,10 +77,16 @@ export interface SkillCatalogPort {
   /**
    * Copy the bundled skill folder into each `<appRoot>/skills/<flow>/<name>/` and write a
    * `.provenance.json` stamp beside the copied `SKILL.md`. Idempotent for an in-sync install
-   * (re-writing identical bytes). A `locally-modified` copy is left untouched — the caller routes
-   * the operator through `update` (with confirmation) to overwrite local edits.
+   * (re-writing identical bytes); an unstamped copy whose bytes equal the current bundle is
+   * repaired (re-stamped) rather than skipped. A `locally-modified` or genuinely `manual` copy is
+   * left untouched and reported in `skipped` — the caller routes the operator through `update`
+   * (with confirmation) to overwrite local edits. The outcome names exactly which flows were
+   * written vs left alone so the caller's feedback never overstates what happened.
    */
-  enable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>>;
+  enable(
+    name: string,
+    flows: readonly FlowId[]
+  ): Promise<Result<{ readonly copied: readonly FlowId[]; readonly skipped: readonly FlowId[] }, StorageError>>;
   /**
    * Remove the skill folder (and its sidecar) from each named flow's phase dir. A folder that is
    * already absent is a no-op. Only touches the `ralphctl-*` copies the catalog manages — never an

--- a/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-alignment
-description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output. Restate the input back to the user; surface assumptions; agree before you write.
+description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output: restate the input back to the user, surface assumptions, name non-goals, and agree before you write. For an input that is still a raw, unshaped idea needing multiple candidate directions before one is chosen, run ralphctl-idea-refinement first; alignment then confirms whichever direction comes out of it.
 ---
 
 # Alignment

--- a/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-alignment
-description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output: restate the input back to the user, surface assumptions, name non-goals, and agree before you write. For an input that is still a raw, unshaped idea needing multiple candidate directions before one is chosen, run ralphctl-idea-refinement first; alignment then confirms whichever direction comes out of it.
+description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output: restate the input back to the user, surface assumptions, name non-goals, and agree before you write. For an input that is still a raw, unshaped idea needing multiple candidate directions before one is chosen, run the ralphctl-idea-refinement skill first when it is installed in this session; alignment then confirms whichever direction comes out of it.
 ---
 
 # Alignment

--- a/src/integration/ai/skills/bundled/ralphctl-cherny-workflow/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-cherny-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-cherny-workflow
-description: Session-discipline skill — settle the plan before touching code, work in small verified increments with a feedback loop that proves each change works, and record corrections so the same mistake is not repeated. Use when executing multi-step coding tasks where batching unverified work would compound risk; bundles plan-first sequencing and learning capture on top of the narrower per-change habits in ralphctl-iterative-review and ralphctl-karpathy-guidelines.
+description: Session-discipline skill — settle the plan before touching code, work in small verified increments with a feedback loop that proves each change works, and record corrections so the same mistake is not repeated. Use when executing multi-step coding tasks where batching unverified work would compound risk; bundles plan-first sequencing and learning capture on top of the narrower per-change habits in ralphctl-iterative-review and (when installed) ralphctl-karpathy-guidelines.
 ---
 
 # Cherny Workflow

--- a/src/integration/ai/skills/bundled/ralphctl-cherny-workflow/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-cherny-workflow/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: ralphctl-cherny-workflow
+description: Session-discipline skill — settle the plan before touching code, work in small verified increments with a feedback loop that proves each change works, and record corrections so the same mistake is not repeated. Use when executing multi-step coding tasks where batching unverified work would compound risk; bundles plan-first sequencing and learning capture on top of the narrower per-change habits in ralphctl-iterative-review and ralphctl-karpathy-guidelines.
+---
+
+# Cherny Workflow
+
+> Distilled from Boris Cherny's (creator of Claude Code) publicly shared workflow practices —
+> his January 2026 ["How I use Claude Code" thread](https://x.com/bcherny/status/2007179832300581177).
+> Clean-room — concepts only, not copied text; interactive-only tips (parallel terminals,
+> permission tuning, editor integration) are deliberately omitted.
+
+Two habits carry most of the value of this workflow: separate planning from execution, and give
+every change a way to prove itself. Cherny's strongest claim is about the second — a working
+verification loop multiplies the quality of the final result, because each increment is either
+demonstrated or rolled back while it is still small.
+
+## When this applies
+
+- **Execute** — the primary home: any task with more than one meaningful step, and any change where "did that actually work?" has a checkable answer.
+- **Create PR** — the summary step: the description writes itself when the work was a sequence of verified increments instead of one opaque batch.
+
+## Plan before code
+
+- Do not start editing until the plan is settled: which files change, in what order, and what proves each step worked. When the task arrives with a plan or acceptance criteria, restate them as your working plan; when it doesn't, write the plan as your first output.
+- Going back and forth on the plan is cheap; going back and forth on a half-applied diff is not. Revise the plan while it is still words.
+- Once the plan is settled, execution should be unremarkable — a step that surprises you is a signal to stop and re-plan, not to improvise forward.
+
+## The verification loop
+
+- Before each step, know its check: the test that should pass, the command that should exit cleanly, the behaviour that should be observable. A step without a check is not ready to execute.
+- Run the check immediately after the step — never accumulate several unverified steps, because a late failure then points at all of them at once.
+- Prefer the narrowest check that can falsify the step (one test file, one build target, one focused run) over broad suites; breadth comes at the end, and the harness owns the final post-task verify gate.
+- When no automated check exists for a step, create the smallest one that would fail if the step were wrong — or state explicitly in a `<note>` signal that the step is unverified and why.
+
+## Small verified increments
+
+- Shape the work so that after every increment the project is in a working state — each one a checkpoint the harness can capture, not a stretch of shared broken ground.
+- If an increment cannot be made safely small (a rename that touches everything, a schema change), isolate it as its own step with its own check, and keep unrelated edits out of it.
+- Re-read your own diff at each checkpoint: is everything in it intentional, and does anything in it belong to a different step?
+
+## Compounding corrections
+
+- When you discover a project-specific gotcha — a convention that contradicted your instinct, a command that behaves unexpectedly, a fix for a recurring failure — record it as a `<learning>` signal so it persists beyond this session.
+- The habit mirrors how Cherny's team maintains their agent-facing project docs: every observed mistake becomes a written correction, so the same steering is never needed twice.
+- Record the correction at the moment you learn it — deferred notes don't get written; the exception is mid-verification, where finishing the check comes first.
+
+## Anti-patterns
+
+- **Code-first sessions.** Editing before the plan exists, then discovering the approach was wrong three files in.
+- **Batch-then-pray.** Making five changes and running one big check at the end — the failure points everywhere and nowhere.
+- **Checkless steps.** "This one's trivial" is how unverified changes slip through; trivial steps have trivial checks.
+- **Silent re-learning.** Hitting the same project quirk twice because the first encounter was never recorded.
+- **Plan drift.** Quietly doing something other than the settled plan; when reality invalidates the plan, update it visibly first.
+
+## Self-check before finishing
+
+- [ ] The executed steps match the settled plan — or the plan was explicitly revised along the way.
+- [ ] Every step's check ran and passed at the time the step was made.
+- [ ] The final diff reads as a sequence of intentional increments, with nothing unexplained.
+- [ ] Any durable gotcha discovered this session was recorded as a `<learning>` signal.

--- a/src/integration/ai/skills/bundled/ralphctl-debugging-and-error-recovery/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-debugging-and-error-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-debugging-and-error-recovery
-description: Systematic root-cause debugging. Use when tests fail, builds break, or behaviour does not match expectations. Follow stop-the-line → reproduce → localize → reduce → root-cause → guard-with-regression-test → verify, not guessing.
+description: Systematic root-cause debugging. Use when tests fail, builds break, or behaviour does not match expectations. Follow stop-the-line → reproduce → localize → reduce → root-cause → guard-with-regression-test → verify, not guessing; the reproduction and regression steps follow the same red-green discipline as ralphctl-test-driven-development.
 license: MIT
 ---
 

--- a/src/integration/ai/skills/bundled/ralphctl-domain-driven-design/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-domain-driven-design/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ralphctl-domain-driven-design
+description: Domain-modelling skill — align code with the business domain through ubiquitous language, bounded contexts, small aggregates, domain events, and core-domain focus. Use when naming concepts, drawing module or service boundaries, deciding entity vs value object, integrating external systems, or when the code no longer matches how the business talks about itself.
+license: MIT
+---
+
+# Domain-Driven Design
+
+> Adapted from [wondelai/skills](https://github.com/wondelai/skills) (MIT), itself distilling
+> Eric Evans' _Domain-Driven Design: Tackling Complexity in the Heart of Software_ (2003).
+> Adapted for ralphctl's harness contract.
+
+Framework for tackling software complexity by modeling code around the business domain. The
+greatest risk in software is not technical failure — it is building a model that does not
+reflect how the business actually works.
+
+**Core principle: the model is the code; the code is the model.** When domain experts and
+developers speak the same language and that language is directly expressed in the codebase,
+complexity becomes manageable and the system evolves gracefully as the business changes.
+
+## When this applies
+
+- **Refine** — name acceptance criteria in the domain's language; a criterion that needs technical jargon to state usually hides an unmodelled concept.
+- **Plan** — draw task boundaries along context and aggregate boundaries, not along technical layers.
+- **Execute** — apply the building blocks below when creating or renaming types, modules, and events.
+
+## 1. Ubiquitous Language
+
+A shared, rigorous language between developers and domain experts, used consistently in
+conversation, documentation, and code. Ambiguity is the root cause of most modeling failures —
+when a developer says "order" and an expert means "purchase request," bugs are inevitable.
+
+- The language emerges from collaboration, not a glossary bolted on after the fact.
+- If a concept is hard to name, the model is likely wrong — naming difficulty is a design signal.
+- Technical jargon (`DataProcessor` vs. `ClaimAdjudicator`) hides domain logic from the experts who could correct it.
+- Name classes and methods after domain concepts and verbs — `LoanApplication`, `policy.underwrite()`, not `RequestHandler`, `process()`.
+- Organize modules by domain concept (`shipping/`, `billing/`), not technical role (`controllers/`, `services/`).
+- In review, flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells.
+
+## 2. Bounded Contexts and Context Mapping
+
+A bounded context is an explicit boundary within which a particular domain model applies. The
+same word ("Customer") can mean different things in different contexts — and that is fine.
+Large systems that force a single unified model inevitably collapse into inconsistency.
+
+- A bounded context is not a microservice — it is a linguistic and model boundary that may contain multiple services; start with modules in a monolith.
+- Context boundaries often align with team boundaries (Conway's Law).
+- The Anti-Corruption Layer is the most important defensive pattern — never let a foreign model leak into your core domain; the exception is a deliberately Conformist integration where you accept the upstream model wholesale to save translation cost.
+- Translate external API responses into your own domain objects at the boundary; wrap legacy systems behind an adapter that speaks your domain language.
+- A Shared Kernel couples two teams; keep it small and explicitly governed.
+
+## 3. Entities, Value Objects, and Aggregates
+
+Entities have identity that persists across state changes. Value Objects are defined entirely by
+their attributes and are immutable. Aggregates are clusters with a single root that enforces
+consistency boundaries.
+
+- Entity test: "Am I the same thing even if all my attributes change?" (a person changes name and address — still the same person).
+- Value Object test: "Am I defined only by my attributes?" (any $10 bill is interchangeable with another).
+- Most things should be Value Objects, not Entities — prefer immutability; replace, never mutate — except where the domain genuinely tracks identity over time.
+- Keep aggregates small (one root plus a minimal cluster); reference other aggregates by ID, not object reference.
+- Immediate consistency only within an aggregate; design for eventual consistency between aggregates.
+
+## 4. Domain Events
+
+A domain event captures something that happened that experts care about, named in past tense
+(`OrderPlaced`, `PaymentReceived`) — a fact that has already occurred. Events decouple cause
+from effect: shipping, billing, and notifications each react to `OrderPlaced` independently,
+without the ordering context knowing about them.
+
+- Events are immutable facts — once published, they cannot be changed or retracted.
+- Domain events are internal to a bounded context; integration events cross boundaries.
+- Not every state change deserves an event — only publish what the domain cares about.
+
+## 5. Repositories and Factories
+
+Repositories provide the illusion of an in-memory collection of domain objects, hiding
+persistence. Factories encapsulate complex creation so aggregates are always born valid — an
+invalid instance becomes unrepresentable.
+
+- The repository interface belongs in the domain layer; its implementation belongs in infrastructure.
+- Repository methods speak the ubiquitous language: `findPendingOrders()`, not `getByStatusCode(3)`.
+- Factories are warranted for complex rules or multi-part assembly; a two-field Value Object just needs a constructor.
+
+## 6. Strategic Design and Distillation
+
+Not all parts of a system are equally important. Identify the Core Domain — where competitive
+advantage lives — and distinguish it from Supporting Subdomains (necessary, not differentiating)
+and Generic Subdomains (commodity).
+
+- Core Domain: invest the deepest modeling. Supporting: build, but don't over-engineer. Generic (auth, email, payments): buy or use off-the-shelf.
+- Revisit what is "core" as the business evolves — today's differentiator may become tomorrow's commodity.
+
+## Common Mistakes
+
+| Mistake                           | Why It Fails                                                                   | Fix                                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Technical names, not domain terms | Logic hidden behind `DataManager`; experts can't validate the model            | Rename to domain terms; if no domain term exists, the concept may be wrong |
+| One model to rule them all        | A single `Customer` class for billing, shipping, and marketing becomes bloated | Bounded contexts: each gets its own `Customer` with only what it needs     |
+| Giant aggregates                  | Concurrency conflicts, slow loads, transactional bottlenecks                   | Keep aggregates small; reference by ID; eventual consistency between       |
+| Anemic domain model               | Objects are data bags; rules scatter across services and duplicate             | Move behavior into entities and value objects; services orchestrate only   |
+| No Anti-Corruption Layer          | Foreign models leak in; code couples to external schemas                       | Wrap every external system behind a translation layer                      |
+| Bounded context = microservice    | Premature extraction; distributed complexity without benefit                   | A context is a model boundary, not a deployment unit                       |
+| Skipping domain experts           | Developers invent a model that doesn't match reality; expensive rework         | Model against the domain vocabulary in the task's source material          |
+
+## Quick Diagnostic
+
+- Can a domain expert read your class names and understand them? If not — rename to the ubiquitous language.
+- Are bounded context boundaries explicitly defined? If not — draw a context map with translations.
+- Are aggregates small (one root + minimal cluster)? If not — split; reference by ID.
+- Do domain objects contain behavior, not just data? If not — move rules out of services into the model.
+- Is there an Anti-Corruption Layer at every external integration? If not — add a translation layer at the boundary.
+- Have you identified which subdomain is core? If not — classify, and spend the deep modeling there.

--- a/src/integration/ai/skills/bundled/ralphctl-idea-refinement/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-idea-refinement/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ralphctl-idea-refinement
+description: Ideation skill — refine a raw, unshaped idea into a sharp, buildable concept through divergent expansion (variation lenses like inversion, simplification, audience shift) followed by convergent stress-testing (user value, feasibility, differentiation), ending in a one-pager with explicit assumptions and a "Not Doing" list. Use when an idea is still vague and multiple directions should be widened before narrowing; once a direction is already concrete, confirming it is the shorter restate-and-agree pass in ralphctl-alignment, not a full ideation cycle.
+license: MIT
+---
+
+# Idea Refinement
+
+> Adapted from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) (MIT).
+> Adapted for ralphctl's harness contract.
+
+You are an ideation partner. Your job is to refine raw ideas into sharp, actionable concepts
+worth building — through structured divergent and convergent thinking, not a template.
+
+## When this applies
+
+- **Ideate** — the primary home: turning a raw prompt or hunch into evaluated, distinct directions.
+- **Refine** — when the input requirement is really an unshaped idea: run a compressed version of the phases below before writing acceptance criteria.
+
+## Philosophy
+
+- Simplicity is the ultimate sophistication. Push toward the simplest version that still solves the real problem.
+- Start with the user experience, work backwards to technology.
+- Say no to 1,000 things. Focus beats breadth.
+- Challenge every assumption. "How it's usually done" is not a reason.
+- Show people the future — don't just give them better horses.
+
+## Phase 1 — Understand & Expand (divergent)
+
+Take the raw idea and open it up.
+
+- **Restate the idea** as a crisp "How Might We" problem statement. This forces clarity on what is actually being solved.
+- **Ask 3-5 sharpening questions** — no more. Who is this for, specifically? What does success look like? What are the real constraints (time, tech, resources)? What's been tried before? Why now? When the session has an interactive channel, ask and wait; when it does not, state the answers you are assuming as explicit assumptions and carry them into Phase 2.
+- **Generate 5-8 idea variations** using these lenses: inversion ("what if we did the opposite?"), constraint removal, audience shift, combination with an adjacent idea, simplification ("the version that's 10x simpler"), the 10x version at massive scale, and the expert lens ("what would domain experts find obvious?"). Pick the lenses that fit the idea — don't run every lens mechanically.
+
+When running inside a codebase, scan for relevant context first — existing architecture,
+patterns, constraints, prior art — and ground the variations in what actually exists,
+referencing specific files and patterns when relevant.
+
+## Phase 2 — Evaluate & Converge
+
+After reactions to Phase 1 (which ideas resonate, pushback, added context) — or, without an
+interactive channel, after weighing the variations against the stated constraints — shift to
+convergent mode:
+
+- **Cluster** the strongest ideas into 2-3 distinct directions. Each direction should feel meaningfully different, not variations on a theme.
+- **Stress-test** each direction against three criteria: user value (painkiller or vitamin?), feasibility (what's the hardest part?), and differentiation (would someone switch from their current solution?).
+- **Surface hidden assumptions.** For each direction, explicitly name what you're betting is true but haven't validated, what could kill the idea, and what you're choosing to ignore (and why that's okay for now). This is where most ideation fails — don't skip it.
+
+Be honest, not supportive. If an idea is weak, say so with kindness. A good ideation partner is
+not a yes-machine: push back on complexity, question real value, and point out when the emperor
+has no clothes.
+
+## Phase 3 — Sharpen & Ship
+
+Produce a concrete artifact — a markdown one-pager that moves work forward:
+
+```markdown
+# [Idea Name]
+
+## Problem Statement
+
+[One-sentence "How Might We" framing]
+
+## Recommended Direction
+
+[The chosen direction and why — 2-3 paragraphs max]
+
+## Key Assumptions to Validate
+
+- [ ] [Assumption — how to test it]
+
+## MVP Scope
+
+[The minimum version that tests the core assumption. What's in, what's out.]
+
+## Not Doing (and Why)
+
+- [Thing] — [reason]
+
+## Open Questions
+
+- [Question that needs answering before building]
+```
+
+The "Not Doing" list is arguably the most valuable part. Focus is about saying no to good ideas —
+make the trade-offs explicit. Deliver the one-pager through the flow's designated output channel
+rather than inventing a location for it.
+
+## Anti-patterns
+
+- **Generating 20+ ideas.** Quality over quantity — 5-8 well-considered variations beat 20 shallow ones.
+- **Yes-machining.** Push back on weak ideas with specificity and kindness.
+- **Skipping "who is this for."** Every good idea starts with a person and their problem.
+- **A plan without surfaced assumptions.** Untested assumptions are the #1 killer of good ideas.
+- **Over-engineering the process.** Three phases, each doing one thing well — resist adding steps.
+- **Listing ideas without a story.** Each variation should have a reason it exists, not just be a bullet point.
+- **Ignoring the codebase.** Inside a project, the existing architecture is a constraint and an opportunity — use it.
+
+## Verification (self-review before finishing)
+
+- [ ] A clear "How Might We" problem statement exists.
+- [ ] The target user and success criteria are defined — or the assumed answers are named explicitly.
+- [ ] Multiple directions were explored, not just the first idea.
+- [ ] Hidden assumptions are listed with validation strategies.
+- [ ] A "Not Doing" list makes trade-offs explicit.
+- [ ] The output is a concrete one-pager, not just conversation.

--- a/src/integration/ai/skills/bundled/ralphctl-iterative-review/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-iterative-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-iterative-review
-description: Cross-phase skill — treat AI output as a controlled feedback loop, not a one-shot generation. Run the cheap check after each meaningful change; re-read your own output before signalling completion.
+description: Cross-phase skill — treat AI output as a controlled feedback loop, not a one-shot generation. Run the cheap check after each meaningful change; re-read your own output before signalling completion. For the fuller session workflow — plan-first sequencing plus durable learning capture — see the opt-in ralphctl-cherny-workflow skill.
 ---
 
 # Iterative Review

--- a/src/integration/ai/skills/bundled/ralphctl-karpathy-guidelines/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-karpathy-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-karpathy-guidelines
-description: Behavioural guardrails against four empirical LLM coding failure modes — silent assumptions, over-complication, orthogonal damage to code you don't fully understand, and declaring done without verification. Use when writing, reviewing, or refactoring code to surface assumptions early, keep changes proportionate to the task, and loop until explicit success criteria pass; broader than the implementation-choice ladder in ralphctl-ponytail or the scope checklist in ralphctl-surgical-simplicity, which it complements rather than duplicates.
+description: Behavioural guardrails against four empirical LLM coding failure modes — silent assumptions, over-complication, orthogonal damage to code you don't fully understand, and declaring done without verification. Use when writing, reviewing, or refactoring code to surface assumptions early, keep changes proportionate to the task, and loop until explicit success criteria pass; broader than the implementation-choice ladder in ralphctl-ponytail or the scope checklist in ralphctl-surgical-simplicity (when those are installed), which it complements rather than duplicates.
 ---
 
 # Karpathy Guidelines

--- a/src/integration/ai/skills/bundled/ralphctl-karpathy-guidelines/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-karpathy-guidelines/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ralphctl-karpathy-guidelines
+description: Behavioural guardrails against four empirical LLM coding failure modes — silent assumptions, over-complication, orthogonal damage to code you don't fully understand, and declaring done without verification. Use when writing, reviewing, or refactoring code to surface assumptions early, keep changes proportionate to the task, and loop until explicit success criteria pass; broader than the implementation-choice ladder in ralphctl-ponytail or the scope checklist in ralphctl-surgical-simplicity, which it complements rather than duplicates.
+---
+
+# Karpathy Guidelines
+
+> Distilled from Andrej Karpathy's public commentary on LLM coding pitfalls — his January 2026
+> [X post on agentic coding](https://x.com/karpathy/status/2015883857489522876). Clean-room —
+> concepts only, not copied text.
+
+Karpathy's observation, after moving most of his coding to agents: the mistakes agents make are
+not random — they cluster into four recurring failure modes. Each mode below pairs the failure
+with the counter-habit that prevents it. Treat these as standing behavioural rules for every
+coding turn, not a checklist to run once.
+
+## When this applies
+
+- **Plan** — modes 1 and 4 dominate: a plan built on an unstated assumption, or with success criteria that can't be checked, fails before any code exists.
+- **Execute** — all four modes: every generation, edit, and refactor is an opportunity to silently assume, over-build, damage bystander code, or stop before verifying.
+
+## Mode 1 — Silent assumptions
+
+The failure: making a plausible assumption on the operator's behalf and running with it
+unchecked — not managing your own confusion, not surfacing inconsistencies, not presenting
+trade-offs, not pushing back when the request conflicts with what the code shows.
+
+The counter-habit:
+
+- When the task is ambiguous, name the ambiguity before acting. With an interactive channel, ask; without one, state the interpretation you chose and why in a `<decision>` or `<note>` signal, then proceed with the least-surprising reading.
+- When the task's description contradicts what you find in the code, surface the contradiction — do not quietly pick a side.
+- When two implementations satisfy the words of the task but differ in consequence, present the trade-off rather than silently committing to one.
+- Push back when the request is likely a mistake. Deference that ships a wrong change is not helpfulness.
+
+## Mode 2 — Over-complication
+
+The failure: bloated abstractions, over-general APIs, a thousand lines where a hundred would do —
+and dead code left behind because nothing forced its cleanup.
+
+The counter-habit:
+
+- Write the simplest version that solves the stated problem. Generality earns its place only when a second concrete caller exists.
+- Prefer one plain function over a class hierarchy, a flag, or a plugin point invented for a future that was never requested.
+- When your change makes code unreachable, delete that code in the same change — dead code you created is your cleanup, not a future task.
+- Re-read your diff asking one question: what can be removed without failing the task?
+
+## Mode 3 — Orthogonal damage
+
+The failure: changing or deleting comments, formatting, or neighbouring code that the task never
+asked about — side effects on things you did not fully understand, orthogonal to the goal.
+
+The counter-habit:
+
+- Preserve comments you did not write unless your change makes them false — then update them, don't drop them.
+- Leave formatting, naming, and structure outside your change's boundary untouched, even when you disagree with it.
+- Never edit code you don't understand just because it sits next to code you do; the exception is when the task itself is to change that code — then understanding it first is the task.
+- If your tooling reformats or rewrites beyond your intended lines, trim the diff back to what the task requires.
+
+## Mode 4 — Unverified completion
+
+The failure: declaring the work done because the code looks right, without ever defining what
+"done" means or demonstrating it.
+
+The counter-habit:
+
+- Before writing code, state the success criteria as checkable predicates — a test that passes, a command that exits cleanly, an observable behaviour.
+- After each meaningful change, run the narrowest check that could falsify it; do not batch many unverified changes and hope.
+- Loop: change → check → compare against the criteria — until the criteria demonstrably pass. "It should work now" is a hypothesis, not a result.
+- Reaching the criteria is your job; the harness owns the final post-task verify gate — arrive at it in a demonstrably clean state rather than certifying completion yourself.
+
+## Self-check before finishing
+
+- [ ] Every assumption I made is either confirmed or explicitly surfaced.
+- [ ] Nothing in the diff exists "for later" — every line serves the stated task.
+- [ ] No comment, formatting, or bystander code changed without a task-driven reason.
+- [ ] The success criteria were stated up front and each one has been demonstrated, not assumed.

--- a/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-minimal-scaffolding
-description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline. Governs the surrounding harness's own scaffolding, not the task's application code — for code-level minimalism see ralphctl-ponytail, ralphctl-surgical-simplicity, and ralphctl-karpathy-guidelines.
+description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline. Governs the surrounding harness's own scaffolding, not the task's application code — for code-level minimalism defer to the ralphctl-ponytail, ralphctl-surgical-simplicity, and ralphctl-karpathy-guidelines skills when installed in this session.
 ---
 
 # Minimal Scaffolding

--- a/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-minimal-scaffolding
-description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline.
+description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline. Governs the surrounding harness's own scaffolding, not the task's application code — for code-level minimalism see ralphctl-ponytail, ralphctl-surgical-simplicity, and ralphctl-karpathy-guidelines.
 ---
 
 # Minimal Scaffolding

--- a/src/integration/ai/skills/bundled/ralphctl-ponytail/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-ponytail/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ralphctl-ponytail
+description: Anti-over-engineering ladder for choosing HOW to implement something — before writing custom code, climb the rungs in order and stop at the first that holds. Does this need to exist at all (YAGNI) → already in the codebase → standard library → native platform feature → already-installed dependency → one line → minimum code that works. Use when picking an implementation approach or evaluating a new dependency; for keeping the footprint of an already-chosen approach small, see ralphctl-surgical-simplicity.
+license: MIT
+---
+
+# Ponytail
+
+> Adapted from [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) (MIT).
+> Adapted for ralphctl's harness contract.
+
+Be a lazy senior developer. Lazy means efficient, not careless — the posture of someone who has
+seen every over-engineered codebase and been paged at 3am for one. The best code is the code
+never written.
+
+## When this applies
+
+- **Plan** — when sizing tasks, prefer the plan whose steps each pass the ladder; a task that
+  exists only to build scaffolding "for later" should not exist.
+- **Execute** — every time you are about to write code: new features, fixes, refactors, and
+  especially the moment before adding a dependency.
+- **Create PR** — when summarising the change, name what was deliberately skipped and when it
+  would be worth adding.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Standard library does it?** Use it.
+4. **Native platform feature covers it?** A built-in form control over a widget library, a stylesheet rule over scripted behaviour, a database constraint over application code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs _after_ you understand the problem,
+not instead of it. Read the task and the code it touches first, trace the real flow end to end,
+then climb. Two rungs work → take the higher one and move on. The first lazy solution that works
+is the right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you edit, find every
+caller of the function you're about to touch. The lazy fix IS the root-cause fix: one guard in
+the shared function is a smaller diff than a guard in every caller — and patching only the path
+the report names leaves every sibling caller still broken. Fix it once, where all callers route
+through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later" — later can scaffold for itself.
+- Deletion over addition. Boring over clever — clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question the rest in a `<note>` signal: "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two standard-library options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`) — simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `// ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Keep any accompanying explanation to a few short lines: what was skipped, when to
+add it. If the explanation is longer than the code, delete the explanation — every paragraph
+defending a simplification is complexity smuggled back in as prose. Explanation the task
+explicitly asked for (a report, a walkthrough, per-step notes) is not debt — give it in full;
+the rule is only against unrequested prose. Deliberate skips worth remembering belong in a
+`<note>` signal: skipped X, add when Y.
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling that prevents data
+loss, security measures, accessibility basics, anything the task explicitly requests. The task
+insists on the full version → build it, no re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the solution, never the reading.
+Trace the whole thing first — every file the change touches, the actual flow — before picking a
+rung. Laziness that skips comprehension to ship a small diff is the dangerous kind: it dresses
+up as efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor reads off. Leave the
+calibration knob, not just less code — the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a loop, a parser, a
+money/security path) leaves ONE runnable check behind — the smallest thing that fails if the
+logic breaks. No frameworks, no fixtures, no per-function suites unless asked. Trivial
+one-liners need no test — YAGNI applies to tests too.
+
+The shortest path to done is the right path.

--- a/src/integration/ai/skills/bundled/ralphctl-ponytail/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-ponytail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-ponytail
-description: Anti-over-engineering ladder for choosing HOW to implement something — before writing custom code, climb the rungs in order and stop at the first that holds. Does this need to exist at all (YAGNI) → already in the codebase → standard library → native platform feature → already-installed dependency → one line → minimum code that works. Use when picking an implementation approach or evaluating a new dependency; for keeping the footprint of an already-chosen approach small, see ralphctl-surgical-simplicity.
+description: Anti-over-engineering ladder for choosing HOW to implement something — before writing custom code, climb the rungs in order and stop at the first that holds. Does this need to exist at all (YAGNI) → already in the codebase → standard library → native platform feature → already-installed dependency → one line → minimum code that works. Use when picking an implementation approach or evaluating a new dependency; for keeping the footprint of an already-chosen approach small, defer to the ralphctl-surgical-simplicity skill when installed.
 license: MIT
 ---
 

--- a/src/integration/ai/skills/bundled/ralphctl-surgical-simplicity/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-surgical-simplicity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-surgical-simplicity
-description: Execute-phase scope-containment checklist — write the minimum code the task needs and touch only the files and lines the task requires; surface out-of-scope findings as notes rather than fixing them inline. Governs the footprint of a change whose approach is already decided; for choosing that implementation approach itself, see ralphctl-ponytail.
+description: Execute-phase scope-containment checklist — write the minimum code the task needs and touch only the files and lines the task requires; surface out-of-scope findings as notes rather than fixing them inline. Governs the footprint of a change whose approach is already decided; for choosing that implementation approach itself, defer to the ralphctl-ponytail skill when installed.
 ---
 
 # Surgical Simplicity

--- a/src/integration/ai/skills/bundled/ralphctl-surgical-simplicity/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-surgical-simplicity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-surgical-simplicity
-description: Execute-phase skill — write the minimum code the task needs and touch only what the task requires; surface out-of-scope findings as notes rather than fixing them inline.
+description: Execute-phase scope-containment checklist — write the minimum code the task needs and touch only the files and lines the task requires; surface out-of-scope findings as notes rather than fixing them inline. Governs the footprint of a change whose approach is already decided; for choosing that implementation approach itself, see ralphctl-ponytail.
 ---
 
 # Surgical Simplicity

--- a/src/integration/ai/skills/bundled/ralphctl-test-driven-development/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-test-driven-development
-description: Execute-phase skill — write the failing test before the code that makes it pass; reproduce bugs with a test before fixing them. Use for any logic change, bug fix, or behavioural modification.
+description: Execute-phase skill — write the failing test before the code that makes it pass; for bug fixes, this is the reproduction test itself. Use for any logic change, bug fix, or behavioural modification; for the full root-cause triage pipeline around an unexpected failure, see ralphctl-debugging-and-error-recovery.
 license: MIT
 ---
 

--- a/src/integration/ai/skills/bundled/source.ts
+++ b/src/integration/ai/skills/bundled/source.ts
@@ -2,7 +2,8 @@
  * `createBundledSkillSource` — implementation of {@link SkillSource} backed by the bundled
  * skill folders that live next to this module (`<name>/SKILL.md`).
  *
- * The set of skills returned per flow comes from {@link FLOW_SKILLS}. For each name in that
+ * The set of skills returned per flow comes from {@link skillsForFlow} (the registry's
+ * `defaultFor` derivation). For each name in that
  * list, the source reads `<bundledRoot>/<name>/SKILL.md`, parses YAML frontmatter (`name`,
  * `description` — frontmatter `name` must match the folder name per the Agent Skills spec)
  * and returns the canonical {@link Skill} record.

--- a/src/integration/ai/skills/bundled/source.ts
+++ b/src/integration/ai/skills/bundled/source.ts
@@ -27,6 +27,7 @@ import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-sourc
 import type { FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
 import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
 import { errorCode, parseSkill } from '@src/integration/ai/skills/_engine/parse-skill.ts';
+import type { BundledSkillRawReader } from '@src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts';
 
 // Default bundled root.
 //   Dev (tsx): this module lives at src/integration/ai/skills/bundled/source.ts — SKILL.md
@@ -118,6 +119,42 @@ export const createBundledSkillSource = (deps: BundledSkillSourceDeps = {}): Ski
       const r = await readSkillOptional(root, name);
       if (r.ok && r.value !== undefined) cache.set(name, r.value);
       return r;
+    },
+  };
+};
+
+/**
+ * Build a {@link BundledSkillRawReader} over the same bundled-root resolution as
+ * {@link createBundledSkillSource}. Kept as a separate factory (not a method tacked onto
+ * `SkillSource`) so the phase-scoped skill catalog can depend on the narrow raw-bytes port
+ * without pulling in the parsed-`Skill` surface — see the port's module doc for why the
+ * distinction matters (provenance hashing must never round-trip through a parse → re-render).
+ *
+ * A tiny per-name cache mirrors `createBundledSkillSource`'s `loadOne` cache: the catalog reads
+ * the same bundled skill repeatedly within one `list()` / `updateAll()` call, and the file never
+ * changes mid-process.
+ *
+ * @public
+ */
+export const createBundledSkillRawReader = (deps: BundledSkillSourceDeps = {}): BundledSkillRawReader => {
+  const root = deps.bundledRoot ?? defaultBundledRoot;
+  const cache = new Map<string, string>();
+
+  return {
+    async readRaw(name: string): Promise<Result<string, StorageError>> {
+      const cached = cache.get(name);
+      if (cached !== undefined) return Result.ok(cached);
+      const path = join(root, name, 'SKILL.md');
+      let raw: string;
+      try {
+        raw = await readFile(path, 'utf-8');
+      } catch (cause) {
+        return Result.error(
+          new StorageError({ subCode: 'io', message: `bundled skill not readable: ${path}`, path, cause })
+        );
+      }
+      cache.set(name, raw);
+      return Result.ok(raw);
     },
   };
 };

--- a/src/integration/ai/skills/operator/source.ts
+++ b/src/integration/ai/skills/operator/source.ts
@@ -19,7 +19,7 @@
  * to the emitted {@link Skill} record.
  *
  * Operator skills are provider-scoped, not flow-scoped: `getForFlow` ignores `flowId` and
- * returns the provider's full set for every skill-mounting flow. They are NOT in `FLOW_SKILLS`.
+ * returns the provider's full set for every skill-mounting flow. They are NOT in `BUNDLED_SKILLS`.
  *
  * Resilience contract (the operator owns these skills — never fail the run for a bad one):
  *  - a missing `<root>/<providerDir>` directory → empty list (no operator skills configured);

--- a/src/integration/ai/skills/phase/catalog.ts
+++ b/src/integration/ai/skills/phase/catalog.ts
@@ -1,0 +1,391 @@
+/**
+ * `createSkillCatalog` — the concrete {@link SkillCatalogPort} implementation. Drives the TUI
+ * skill catalog view: one row per bundled skill (`list()`), copy-on-{@link enable}, folder
+ * removal on {@link disable}, and re-stamp-on-{@link update} / {@link updateAll}.
+ *
+ * The catalog's single unit of truth is the filesystem, exactly as the port's module doc
+ * describes: a skill is "enabled for a flow" iff `<operatorSkillsRoot>/<flowDir>/<name>/` exists.
+ * This module never touches the bundled skill folders directly — reads go through the injected
+ * {@link BundledSkillRawReader} port so the raw bytes copied into a phase folder are byte-for-byte
+ * identical to the bundled origin (required for the provenance hash to mean anything; see
+ * `phase/provenance.ts`).
+ *
+ * Folders that exist under a phase dir but don't match any `BUNDLED_SKILLS` entry are surfaced as
+ * `manual` catalog rows — the operator dropped them in by hand, and `list()` still reports them
+ * (they load exactly like a catalog-managed skill) even though `enable` / `update` have no
+ * bundled content to compare them against. `disable` still works on a manual row: it only ever
+ * touches `<operatorSkillsRoot>/<flowDir>/<name>/`, never the provider-scoped operator skills at
+ * `<operatorSkillsRoot>/<providerDir>/<name>/` (a completely different subtree — see
+ * `operator/source.ts`), so removing a manual phase-folder entry stays within "the catalog's own
+ * scope" even though the folder wasn't catalog-authored.
+ *
+ * Helper functions below take an explicit {@link CatalogCtx} rather than closing over `deps`
+ * directly — keeps each one independently readable/testable-in-isolation and the top-level
+ * factory a thin dispatch table.
+ */
+
+import { type Dirent, promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
+import { removeDir } from '@src/integration/io/fs.ts';
+import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
+import { BUNDLED_SKILLS, type FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
+import { errorCode, parseSkill } from '@src/integration/ai/skills/_engine/parse-skill.ts';
+import type {
+  SkillCatalogEntry,
+  SkillCatalogInstall,
+  SkillCatalogPort,
+  SkillInstallStatus,
+} from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import type { BundledSkillRawReader } from '@src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts';
+import { PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
+import {
+  createProvenanceStore,
+  deriveStatus,
+  hashSkillContent,
+  type ProvenanceStamp,
+  type ProvenanceStore,
+} from '@src/integration/ai/skills/phase/provenance.ts';
+
+/** @public */
+export interface SkillCatalogDeps {
+  /** `<appRoot>/skills` — the same global root `createPhaseSkillSource` reads. */
+  readonly operatorSkillsRoot: AbsolutePath;
+  /** Atomic write seam — same instance the composition root threads through `AppDeps.writeFile`. */
+  readonly writeFile: WriteFile;
+  /** Raw-bytes reader over the bundled skill folders (see the port's module doc for why). */
+  readonly bundledRawReader: BundledSkillRawReader;
+  readonly logger: Logger;
+}
+
+/** Shared context threaded through the module-level helpers below. */
+interface CatalogCtx {
+  readonly operatorSkillsRoot: AbsolutePath;
+  readonly writeFile: WriteFile;
+  readonly provenanceStore: ProvenanceStore;
+}
+
+/** One install's resolved raw bytes + status, or `undefined` when the folder doesn't exist. */
+interface ExistingInstall {
+  readonly raw: string;
+  readonly status: SkillInstallStatus;
+}
+
+/**
+ * The installs found for one skill name, plus the raw bytes of the first one found (if any) —
+ * the manual-entry path uses that raw content to derive a description since it has no bundled
+ * counterpart.
+ */
+interface InstallsForName {
+  readonly installs: readonly SkillCatalogInstall[];
+  readonly firstRaw: string | undefined;
+}
+
+const skillDirPath = (ctx: CatalogCtx, flowId: FlowId, name: string): string =>
+  join(String(ctx.operatorSkillsRoot), PHASE_FLOW_DIR[flowId], name);
+
+/**
+ * Read `<skillDir>/SKILL.md` + its provenance stamp and derive the install's status.
+ * `currentBundledRaw === undefined` means "no bundled counterpart to compare against" (a manual
+ * entry) — status collapses to `'manual'` regardless of any stamp found. Returns
+ * `Result.ok(undefined)` when the folder simply doesn't exist (not an error — the common,
+ * expected case for a not-yet-enabled flow).
+ */
+const readInstall = async (
+  ctx: CatalogCtx,
+  flowId: FlowId,
+  name: string,
+  currentBundledRaw: string | undefined
+): Promise<Result<ExistingInstall | undefined, StorageError>> => {
+  const dirStr = skillDirPath(ctx, flowId, name);
+  const skillMdPath = join(dirStr, 'SKILL.md');
+  let raw: string;
+  try {
+    raw = await fs.readFile(skillMdPath, 'utf-8');
+  } catch (cause) {
+    if (errorCode(cause) === 'ENOENT') return Result.ok(undefined);
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `installed skill not readable: ${skillMdPath}`,
+        path: skillMdPath,
+        cause,
+      })
+    );
+  }
+  const dirAbs = AbsolutePath.parse(dirStr);
+  if (!dirAbs.ok) {
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `install path not absolute: ${dirStr}`, path: dirStr })
+    );
+  }
+  const stampR = await ctx.provenanceStore.readProvenance(dirAbs.value);
+  if (!stampR.ok) return Result.error(stampR.error);
+  const status: SkillInstallStatus =
+    currentBundledRaw === undefined
+      ? 'manual'
+      : deriveStatus({ folderSkillMdRaw: raw, stamp: stampR.value, currentBundledRaw });
+  return Result.ok({ raw, status });
+};
+
+/** Copy `raw` verbatim into `<flowDir>/<name>/SKILL.md` and (re-)write its provenance stamp. */
+const writeInstall = async (
+  ctx: CatalogCtx,
+  flowId: FlowId,
+  name: string,
+  raw: string
+): Promise<Result<void, StorageError>> => {
+  const dirStr = skillDirPath(ctx, flowId, name);
+  const dirAbs = AbsolutePath.parse(dirStr);
+  if (!dirAbs.ok) {
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `install path not absolute: ${dirStr}`, path: dirStr })
+    );
+  }
+  const skillMdAbs = AbsolutePath.parse(join(dirStr, 'SKILL.md'));
+  if (!skillMdAbs.ok) {
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `install SKILL.md path not absolute: ${dirStr}`, path: dirStr })
+    );
+  }
+  const written = await ctx.writeFile(skillMdAbs.value, raw);
+  if (!written.ok) return written;
+  const stamp: ProvenanceStamp = {
+    source: 'bundled',
+    skill: name,
+    contentHash: hashSkillContent(raw),
+    ralphctlVersion: CLI_METADATA.currentVersion,
+    copiedAt: new Date().toISOString(),
+  };
+  return ctx.provenanceStore.writeProvenance(dirAbs.value, stamp);
+};
+
+/** Enumerate the skill-folder names present under one flow's phase dir. Missing dir → `[]`. */
+const listInstalledNames = async (
+  ctx: CatalogCtx,
+  flowId: FlowId
+): Promise<Result<readonly string[], StorageError>> => {
+  const flowRoot = join(String(ctx.operatorSkillsRoot), PHASE_FLOW_DIR[flowId]);
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(flowRoot, { withFileTypes: true });
+  } catch (cause) {
+    if (errorCode(cause) === 'ENOENT') return Result.ok([]);
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `phase skills dir not readable: ${flowRoot}`, path: flowRoot, cause })
+    );
+  }
+  return Result.ok(entries.filter((e) => e.isDirectory() && !e.name.startsWith('.')).map((e) => e.name));
+};
+
+/** Snapshot every phase dir's installed folder names, keyed by flow. */
+const readAllInstalledNames = async (
+  ctx: CatalogCtx
+): Promise<Result<ReadonlyMap<FlowId, readonly string[]>, StorageError>> => {
+  const perFlowNames = new Map<FlowId, readonly string[]>();
+  for (const flowId of FLOW_IDS) {
+    const namesR = await listInstalledNames(ctx, flowId);
+    if (!namesR.ok) return Result.error(namesR.error);
+    perFlowNames.set(flowId, namesR.value);
+  }
+  return Result.ok(perFlowNames);
+};
+
+/**
+ * Resolve every flow's install for `name` (skipping flows where no folder is present).
+ * `currentBundledRaw` is `undefined` for a manual entry — see {@link readInstall}. Also returns
+ * the raw bytes of the first install found so the manual-entry path can derive a description.
+ */
+const buildInstalls = async (
+  ctx: CatalogCtx,
+  perFlowNames: ReadonlyMap<FlowId, readonly string[]>,
+  name: string,
+  currentBundledRaw: string | undefined
+): Promise<Result<InstallsForName, StorageError>> => {
+  const installs: SkillCatalogInstall[] = [];
+  let firstRaw: string | undefined;
+  for (const flowId of FLOW_IDS) {
+    if (!(perFlowNames.get(flowId) ?? []).includes(name)) continue;
+    const installR = await readInstall(ctx, flowId, name, currentBundledRaw);
+    if (!installR.ok) return Result.error(installR.error);
+    if (installR.value === undefined) continue; // race: gone between readdir and read
+    installs.push({ flow: flowId, status: installR.value.status });
+    if (firstRaw === undefined) firstRaw = installR.value.raw;
+  }
+  return Result.ok({ installs, firstRaw });
+};
+
+/**
+ * Pure: `SKILL.md` frontmatter description for `name`, or `''` when the body doesn't parse.
+ * `onInvalid` (when supplied) receives the parse error message so the caller can log it — kept
+ * out-of-band so this stays a plain value function.
+ */
+const descriptionFromRaw = (name: string, raw: string, onInvalid?: (message: string) => void): string => {
+  const parsed = parseSkill('skill', name, name, raw);
+  if (parsed.ok) return parsed.value.description;
+  onInvalid?.(parsed.error.message);
+  return '';
+};
+
+/** Pure: names present under any phase dir that aren't claimed by a registered bundled skill. */
+const collectManualNames = (
+  perFlowNames: ReadonlyMap<FlowId, readonly string[]>,
+  claimedNames: ReadonlySet<string>
+): readonly string[] => {
+  const manual = new Set<string>();
+  for (const flowId of FLOW_IDS) {
+    for (const name of perFlowNames.get(flowId) ?? []) {
+      if (!claimedNames.has(name)) manual.add(name);
+    }
+  }
+  return [...manual].sort();
+};
+
+/** One `BUNDLED_SKILLS` row → its catalog entry, given the flow-name snapshot already read. */
+const buildBundledEntry = async (
+  ctx: CatalogCtx,
+  log: Logger,
+  perFlowNames: ReadonlyMap<FlowId, readonly string[]>,
+  registryEntry: (typeof BUNDLED_SKILLS)[number],
+  bundledRawReader: BundledSkillRawReader
+): Promise<Result<SkillCatalogEntry, StorageError>> => {
+  const bundledR = await bundledRawReader.readRaw(registryEntry.name);
+  if (!bundledR.ok) return Result.error(bundledR.error);
+  const installsR = await buildInstalls(ctx, perFlowNames, registryEntry.name, bundledR.value);
+  if (!installsR.ok) return Result.error(installsR.error);
+  const description = descriptionFromRaw(registryEntry.name, bundledR.value, (message) =>
+    log.warn('bundled skill frontmatter invalid, showing without a description', {
+      name: registryEntry.name,
+      error: message,
+    })
+  );
+  return Result.ok({
+    name: registryEntry.name,
+    description,
+    defaultFor: registryEntry.defaultFor,
+    recommendedFor: registryEntry.recommendedFor,
+    installs: installsR.value.installs,
+  });
+};
+
+/** One hand-dropped (non-bundled) phase-folder name → its `manual` catalog entry. */
+const buildManualEntry = async (
+  ctx: CatalogCtx,
+  perFlowNames: ReadonlyMap<FlowId, readonly string[]>,
+  name: string
+): Promise<Result<SkillCatalogEntry, StorageError>> => {
+  const installsR = await buildInstalls(ctx, perFlowNames, name, undefined);
+  if (!installsR.ok) return Result.error(installsR.error);
+  const description = installsR.value.firstRaw !== undefined ? descriptionFromRaw(name, installsR.value.firstRaw) : '';
+  return Result.ok({ name, description, defaultFor: [], recommendedFor: [], installs: installsR.value.installs });
+};
+
+const buildCatalogList = async (
+  ctx: CatalogCtx,
+  log: Logger,
+  bundledRawReader: BundledSkillRawReader
+): Promise<Result<readonly SkillCatalogEntry[], StorageError>> => {
+  const perFlowNamesR = await readAllInstalledNames(ctx);
+  if (!perFlowNamesR.ok) return Result.error(perFlowNamesR.error);
+  const perFlowNames = perFlowNamesR.value;
+
+  const entries: SkillCatalogEntry[] = [];
+  const claimedNames = new Set<string>();
+  for (const registryEntry of BUNDLED_SKILLS) {
+    claimedNames.add(registryEntry.name);
+    const entryR = await buildBundledEntry(ctx, log, perFlowNames, registryEntry, bundledRawReader);
+    if (!entryR.ok) return Result.error(entryR.error);
+    entries.push(entryR.value);
+  }
+  for (const name of collectManualNames(perFlowNames, claimedNames)) {
+    const entryR = await buildManualEntry(ctx, perFlowNames, name);
+    if (!entryR.ok) return Result.error(entryR.error);
+    entries.push(entryR.value);
+  }
+  return Result.ok(entries);
+};
+
+/** Enable path shared by `enable()`: copy unless the existing install is operator-owned. */
+const enableForFlow = async (
+  ctx: CatalogCtx,
+  flowId: FlowId,
+  name: string,
+  bundledRaw: string
+): Promise<Result<void, StorageError>> => {
+  const existingR = await readInstall(ctx, flowId, name, bundledRaw);
+  if (!existingR.ok) return Result.error(existingR.error);
+  // Never clobber operator-owned content: a hand-dropped folder (`manual`) or a copy the
+  // operator has since edited (`locally-modified`) is left untouched — the caller routes through
+  // `update` (with confirmation) if it really means to overwrite the edit.
+  if (existingR.value?.status === 'manual' || existingR.value?.status === 'locally-modified') {
+    return Result.ok(undefined);
+  }
+  return writeInstall(ctx, flowId, name, bundledRaw);
+};
+
+export const createSkillCatalog = (deps: SkillCatalogDeps): SkillCatalogPort => {
+  const ctx: CatalogCtx = {
+    operatorSkillsRoot: deps.operatorSkillsRoot,
+    writeFile: deps.writeFile,
+    provenanceStore: createProvenanceStore({ writeFile: deps.writeFile }),
+  };
+  const log = deps.logger.named('skills.catalog');
+
+  return {
+    list: () => buildCatalogList(ctx, log, deps.bundledRawReader),
+
+    async enable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>> {
+      const bundledR = await deps.bundledRawReader.readRaw(name);
+      if (!bundledR.ok) return Result.error(bundledR.error);
+      for (const flowId of flows) {
+        const r = await enableForFlow(ctx, flowId, name, bundledR.value);
+        if (!r.ok) return r;
+      }
+      return Result.ok(undefined);
+    },
+
+    async disable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>> {
+      for (const flowId of flows) {
+        const removed = await removeDir(skillDirPath(ctx, flowId, name));
+        // NotFoundError ("already absent") is the documented no-op case — fall through.
+        if (!removed.ok && removed.error.code !== ErrorCode.NotFound) {
+          return Result.error(removed.error);
+        }
+      }
+      return Result.ok(undefined);
+    },
+
+    async update(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>> {
+      const bundledR = await deps.bundledRawReader.readRaw(name);
+      if (!bundledR.ok) return Result.error(bundledR.error);
+      for (const flowId of flows) {
+        const written = await writeInstall(ctx, flowId, name, bundledR.value);
+        if (!written.ok) return written;
+      }
+      return Result.ok(undefined);
+    },
+
+    async updateAll(): Promise<Result<{ readonly updated: readonly string[] }, StorageError>> {
+      const updated = new Set<string>();
+      for (const registryEntry of BUNDLED_SKILLS) {
+        const bundledR = await deps.bundledRawReader.readRaw(registryEntry.name);
+        if (!bundledR.ok) return Result.error(bundledR.error);
+        for (const flowId of FLOW_IDS) {
+          const existingR = await readInstall(ctx, flowId, registryEntry.name, bundledR.value);
+          if (!existingR.ok) return Result.error(existingR.error);
+          if (existingR.value === undefined || existingR.value.status !== 'update-available') continue;
+          const written = await writeInstall(ctx, flowId, registryEntry.name, bundledR.value);
+          if (!written.ok) return written;
+          updated.add(registryEntry.name);
+        }
+      }
+      return Result.ok({ updated: [...updated] });
+    },
+  };
+};

--- a/src/integration/ai/skills/phase/catalog.ts
+++ b/src/integration/ai/skills/phase/catalog.ts
@@ -214,7 +214,13 @@ const buildInstalls = async (
     if (!(perFlowNames.get(flowId) ?? []).includes(name)) continue;
     const installR = await readInstall(ctx, flowId, name, currentBundledRaw);
     if (!installR.ok) return Result.error(installR.error);
-    if (installR.value === undefined) continue; // race: gone between readdir and read
+    if (installR.value === undefined) {
+      // The folder was listed by readdir but holds no readable SKILL.md — an interrupted copy
+      // (or a delete race). Surface it as `broken` instead of dropping it: invisible, it would
+      // be an undeletable ghost that the phase source warns about on every launch.
+      installs.push({ flow: flowId, status: 'broken' });
+      continue;
+    }
     installs.push({ flow: flowId, status: installR.value.status });
     if (firstRaw === undefined) firstRaw = installR.value.raw;
   }
@@ -317,16 +323,24 @@ const enableForFlow = async (
   flowId: FlowId,
   name: string,
   bundledRaw: string
-): Promise<Result<void, StorageError>> => {
+): Promise<Result<'copied' | 'skipped', StorageError>> => {
   const existingR = await readInstall(ctx, flowId, name, bundledRaw);
   if (!existingR.ok) return Result.error(existingR.error);
   // Never clobber operator-owned content: a hand-dropped folder (`manual`) or a copy the
-  // operator has since edited (`locally-modified`) is left untouched — the caller routes through
-  // `update` (with confirmation) if it really means to overwrite the edit.
-  if (existingR.value?.status === 'manual' || existingR.value?.status === 'locally-modified') {
-    return Result.ok(undefined);
+  // operator has since edited (`locally-modified`) is left untouched and reported as skipped —
+  // the caller routes through `update` (with confirmation) if it really means to overwrite.
+  // Exception: an unstamped copy whose bytes EQUAL the current bundle is a stranded pristine
+  // copy (interrupted stamp write), not operator content — re-writing it loses nothing and
+  // repairs the missing sidecar, so a retried enable self-heals instead of no-oping forever.
+  if (existingR.value?.status === 'manual' && existingR.value.raw === bundledRaw) {
+    const repaired = await writeInstall(ctx, flowId, name, bundledRaw);
+    return repaired.ok ? Result.ok('copied') : repaired;
   }
-  return writeInstall(ctx, flowId, name, bundledRaw);
+  if (existingR.value?.status === 'manual' || existingR.value?.status === 'locally-modified') {
+    return Result.ok('skipped');
+  }
+  const written = await writeInstall(ctx, flowId, name, bundledRaw);
+  return written.ok ? Result.ok('copied') : written;
 };
 
 export const createSkillCatalog = (deps: SkillCatalogDeps): SkillCatalogPort => {
@@ -340,14 +354,20 @@ export const createSkillCatalog = (deps: SkillCatalogDeps): SkillCatalogPort => 
   return {
     list: () => buildCatalogList(ctx, log, deps.bundledRawReader),
 
-    async enable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>> {
+    async enable(
+      name: string,
+      flows: readonly FlowId[]
+    ): Promise<Result<{ readonly copied: readonly FlowId[]; readonly skipped: readonly FlowId[] }, StorageError>> {
       const bundledR = await deps.bundledRawReader.readRaw(name);
       if (!bundledR.ok) return Result.error(bundledR.error);
+      const copied: FlowId[] = [];
+      const skipped: FlowId[] = [];
       for (const flowId of flows) {
         const r = await enableForFlow(ctx, flowId, name, bundledR.value);
-        if (!r.ok) return r;
+        if (!r.ok) return Result.error(r.error);
+        (r.value === 'copied' ? copied : skipped).push(flowId);
       }
-      return Result.ok(undefined);
+      return Result.ok({ copied, skipped });
     },
 
     async disable(name: string, flows: readonly FlowId[]): Promise<Result<void, StorageError>> {

--- a/src/integration/ai/skills/phase/provenance.ts
+++ b/src/integration/ai/skills/phase/provenance.ts
@@ -1,0 +1,166 @@
+/**
+ * Provenance stamping + status derivation for copy-on-enable skills.
+ *
+ * When the catalog enables a bundled skill for a flow it copies the bundled folder into
+ * `<appRoot>/skills/<flow>/<name>/` VERBATIM and drops a `.provenance.json` sidecar next to the
+ * copied `SKILL.md`. The sidecar records where the copy came from and a content hash of the
+ * `SKILL.md` bytes at copy time. That stamp is what later lets the catalog answer three questions
+ * for each installed folder without diffing whole files:
+ *
+ *   - did the operator edit their copy?            hash(folder SKILL.md) ≠ stamp.contentHash
+ *   - did the bundled skill change upstream?       stamp.contentHash ≠ hash(current bundled SKILL.md)
+ *   - otherwise                                    in-sync
+ *
+ * All three hashes MUST be taken over the same representation — the raw `SKILL.md` bytes — so the
+ * catalog's enable/update path copies the bundled file verbatim (no parse → re-render round-trip)
+ * and stamps `hashSkillContent(rawBundledBytes)`. The {@link SkillSource} pipeline that feeds the
+ * provider adapters is a separate concern and never reads or writes this sidecar (per the design:
+ * a `Skill` is `{ name, description, content }` from `SKILL.md` only).
+ *
+ * Writes go through the injected atomic {@link WriteFile} seam (`business/io/write-file.ts`) so a
+ * concurrent reader never sees a half-written stamp. Reads use a raw `node:fs` read — consistent
+ * with the sibling `SkillSource` implementations, and a missing / malformed sidecar is a soft
+ * signal (`ok(undefined)`), not a failure: an unstamped folder is simply a manually-dropped skill.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
+import { errorCode } from '@src/integration/ai/skills/_engine/parse-skill.ts';
+import type { SkillInstallStatus } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+
+/** Sidecar filename written inside every catalog-managed skill folder. @public */
+export const PROVENANCE_FILENAME = '.provenance.json';
+
+/**
+ * On-disk shape of `.provenance.json`. Only bundled copies are stamped today, so `source` is the
+ * literal `'bundled'`; `skill` is the `ralphctl-*` id, `contentHash` the sha256 hex of the copied
+ * `SKILL.md` raw bytes, and `copiedAt` an ISO-8601 timestamp of the copy.
+ *
+ * @public
+ */
+export interface ProvenanceStamp {
+  readonly source: 'bundled';
+  readonly skill: string;
+  readonly contentHash: string;
+  readonly ralphctlVersion: string;
+  readonly copiedAt: string;
+}
+
+/** sha256 hex of a `SKILL.md`'s raw content. Pure — the canonical hash for every comparison. @public */
+export const hashSkillContent = (raw: string): string => createHash('sha256').update(raw, 'utf-8').digest('hex');
+
+/**
+ * Derive a folder's sync status relative to its bundled origin. Pure — the caller supplies the raw
+ * bytes of the on-disk `SKILL.md`, the parsed stamp (or `undefined` for an unstamped folder), and
+ * the raw bytes of the current bundled `SKILL.md`.
+ *
+ * Precedence is deliberate: `locally-modified` is checked before `update-available` so that when
+ * BOTH divergences hold (the operator edited their copy AND the bundle moved on) we report the
+ * edit. `update`/`updateAll` overwrite, so surfacing `locally-modified` is what keeps a local edit
+ * from being silently discarded.
+ *
+ * @public
+ */
+export const deriveStatus = (input: {
+  readonly folderSkillMdRaw: string;
+  readonly stamp: ProvenanceStamp | undefined;
+  readonly currentBundledRaw: string;
+}): SkillInstallStatus => {
+  const { folderSkillMdRaw, stamp, currentBundledRaw } = input;
+  if (stamp === undefined) return 'manual';
+  if (hashSkillContent(folderSkillMdRaw) !== stamp.contentHash) return 'locally-modified';
+  if (stamp.contentHash !== hashSkillContent(currentBundledRaw)) return 'update-available';
+  return 'in-sync';
+};
+
+/**
+ * Hand-parse a `.provenance.json` body into a {@link ProvenanceStamp}. Returns `undefined` for any
+ * malformation (not JSON, wrong `source`, or a missing/blank required field) — callers treat a
+ * malformed sidecar the same as a missing one (the folder is a manually-dropped skill), so this
+ * never throws or errors.
+ */
+const parseProvenance = (raw: string): ProvenanceStamp | undefined => {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof data !== 'object' || data === null) return undefined;
+  const rec = data as Record<string, unknown>;
+  const nonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+  if (rec.source !== 'bundled') return undefined;
+  if (!nonEmptyString(rec.skill)) return undefined;
+  if (!nonEmptyString(rec.contentHash)) return undefined;
+  if (!nonEmptyString(rec.ralphctlVersion)) return undefined;
+  if (!nonEmptyString(rec.copiedAt)) return undefined;
+  return {
+    source: 'bundled',
+    skill: rec.skill,
+    contentHash: rec.contentHash,
+    ralphctlVersion: rec.ralphctlVersion,
+    copiedAt: rec.copiedAt,
+  };
+};
+
+const serializeStamp = (stamp: ProvenanceStamp): string => `${JSON.stringify(stamp, null, 2)}\n`;
+
+const sidecarPathIn = (skillDir: AbsolutePath): string => join(String(skillDir), PROVENANCE_FILENAME);
+
+/** Dependencies for {@link createProvenanceStore}. @public */
+export interface ProvenanceStoreDeps {
+  /** Atomic write seam — `createAtomicWriteFile()` in production, a fake in tests. */
+  readonly writeFile: WriteFile;
+}
+
+/** Read/write access to skill-folder `.provenance.json` sidecars. @public */
+export interface ProvenanceStore {
+  /** Atomically write `<skillDir>/.provenance.json` from `stamp`. Overwrites any existing sidecar. */
+  writeProvenance(skillDir: AbsolutePath, stamp: ProvenanceStamp): Promise<Result<void, StorageError>>;
+  /**
+   * Read + parse `<skillDir>/.provenance.json`. A missing file OR a malformed body resolves to
+   * `ok(undefined)` — both mean "not a catalog-stamped folder", which is a normal state (a
+   * manually-dropped skill), not an error. Only a hard read failure (permissions, EISDIR, …)
+   * surfaces as `StorageError`.
+   */
+  readProvenance(skillDir: AbsolutePath): Promise<Result<ProvenanceStamp | undefined, StorageError>>;
+}
+
+/**
+ * Build a {@link ProvenanceStore} over the injected atomic {@link WriteFile} seam.
+ *
+ * @public
+ */
+export const createProvenanceStore = (deps: ProvenanceStoreDeps): ProvenanceStore => ({
+  async writeProvenance(skillDir, stamp) {
+    const path = sidecarPathIn(skillDir);
+    // `skillDir` is already absolute, so joining a constant filename keeps it absolute — this
+    // parse only fails on a programmer error, which we surface as a StorageError rather than throw.
+    const abs = AbsolutePath.parse(path);
+    if (!abs.ok) {
+      return Result.error(
+        new StorageError({ subCode: 'io', message: `provenance sidecar path is not absolute: ${path}`, path })
+      );
+    }
+    return deps.writeFile(abs.value, serializeStamp(stamp));
+  },
+
+  async readProvenance(skillDir) {
+    const path = sidecarPathIn(skillDir);
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf-8');
+    } catch (cause) {
+      if (errorCode(cause) === 'ENOENT') return Result.ok(undefined);
+      return Result.error(
+        new StorageError({ subCode: 'io', message: `provenance sidecar not readable: ${path}`, path, cause })
+      );
+    }
+    return Result.ok(parseProvenance(raw));
+  },
+});

--- a/src/integration/ai/skills/phase/source.ts
+++ b/src/integration/ai/skills/phase/source.ts
@@ -1,0 +1,179 @@
+/**
+ * `createPhaseSkillSource` — a {@link SkillSource} backed by GLOBAL, FLOW-scoped opt-in skills
+ * under `<operatorSkillsRoot>/<flowDir>/<name>/SKILL.md`.
+ *
+ * This is the provider-agnostic sibling of the operator source (`operator/source.ts`). Both read
+ * the same global ralphctl home (`<appRoot>/skills`, computed by `storagePathsFromRoot`), but they
+ * partition it differently:
+ *
+ *   - operator source → `<root>/<providerDir>/<name>/SKILL.md`  (per-provider: `claude/ copilot/ codex/`)
+ *   - phase source    → `<root>/<flowDir>/<name>/SKILL.md`      (per-flow:     `refine/ plan/ …`)
+ *
+ * The flow subdirectories and the provider subdirectories are siblings under the same root, so the
+ * two name sets MUST stay disjoint — a test in `tests/integration/ai/skills/phase/source.test.ts`
+ * asserts `values(PHASE_FLOW_DIR) ∩ values(OPERATOR_PROVIDER_DIR) = ∅`.
+ *
+ * Directory convention — each recognised {@link FlowId} maps to its kebab-case directory via
+ * {@link PHASE_FLOW_DIR}. Every id is its own kebab form except `createPr`, whose directory is
+ * `create-pr` (matching the orchestration flow id). The phase folder is the single opt-in truth:
+ * the TUI catalog copies a bundled skill folder into `<root>/<flow>/` to enable it and removes it
+ * to disable it (see the plan of record) — so this source simply enumerates whatever is present.
+ *
+ * Flow-scoped, NOT provider-scoped: `getForFlow(flowId)` reads ONLY that flow's directory and has
+ * no provider dimension. `getByName` searches every flow directory in the canonical {@link FLOW_IDS}
+ * order and returns the FIRST match; missing directories are silently skipped.
+ *
+ * Namespacing is identical to the operator + bundled sources: each skill's install `name` is
+ * prefixed with `ralphctl-` on the way out (idempotently — an already-prefixed folder is not
+ * doubled), so the adapter's `.git/info/exclude` wildcard (`…/ralphctl-*`) hides these folders from
+ * `git status` and the tracked uninstall reclaims them. The on-disk folder name and frontmatter
+ * `name` stay un-prefixed; the prefix is applied only to the emitted {@link Skill} record.
+ *
+ * Only `SKILL.md` is ever read from a skill folder. A later task stamps a `.provenance.json` sidecar
+ * next to it inside the same folder; that sidecar (and any other non-`SKILL.md` file) is ignored —
+ * the {@link Skill} record is derived from `SKILL.md` alone. Dotfile directory entries (`.git`, …)
+ * are skipped so they never produce a spurious "not readable" warning.
+ *
+ * Resilience contract (identical to the operator source — the operator owns these skills, never
+ * fail the run for a bad one):
+ *  - a missing `<root>/<flowDir>` directory → empty list (no opt-in skills for that flow);
+ *  - an individual unreadable / malformed SKILL.md → a logged warning, skip that skill;
+ *  - the optional contract guard (`warnIfContractViolated`) runs per skill as a WARNING only —
+ *    a violation is logged and the skill is STILL returned for install.
+ */
+
+import { type Dirent, promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import type { FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
+import { errorCode, parseSkill } from '@src/integration/ai/skills/_engine/parse-skill.ts';
+
+/**
+ * Map each {@link FlowId} to its kebab-case opt-in phase subdirectory. Every id is its own kebab
+ * form EXCEPT `createPr`, whose on-disk directory is `create-pr` (matching the orchestration flow
+ * id). The TUI skill catalog imports this to decide where to copy an enabled skill folder.
+ *
+ * The values here MUST stay disjoint from {@link OPERATOR_PROVIDER_DIR}'s values — both sets of
+ * directory names share the `<appRoot>/skills` parent (see the module doc). `source.test.ts` guards
+ * the invariant against future edits to either mapping.
+ *
+ * @public
+ */
+export const PHASE_FLOW_DIR: Record<FlowId, string> = {
+  refine: 'refine',
+  plan: 'plan',
+  implement: 'implement',
+  readiness: 'readiness',
+  ideate: 'ideate',
+  // camelCase FlowId `createPr` → kebab-case directory `create-pr` (the orchestration flow id).
+  createPr: 'create-pr',
+};
+
+/**
+ * Optional per-skill compatibility guard. Wired by the launcher to the shared skill-contract
+ * check; runs as a WARNING only — a violation never blocks install. Left optional so this source
+ * has no hard dependency on the guard: when unset, every skill is returned without a contract check.
+ *
+ * @public
+ */
+export type SkillContractWarner = (skill: Skill) => void;
+
+/**
+ * Folder-name → install-name. Idempotent so an already-prefixed folder is not doubled. Replicated
+ * from the operator source (sibling-isolation forbids a cross-source import); the `ralphctl-`
+ * namespace and its behaviour are identical.
+ */
+const RALPHCTL_SKILL_PREFIX = 'ralphctl-';
+const namespaced = (folderName: string): string =>
+  folderName.startsWith(RALPHCTL_SKILL_PREFIX) ? folderName : `${RALPHCTL_SKILL_PREFIX}${folderName}`;
+
+/**
+ * Factory input for {@link createPhaseSkillSource}. Mirrors the operator source's deps minus the
+ * provider dimension — phase skills are flow-scoped, not provider-scoped.
+ *
+ * @public
+ */
+export interface PhaseSkillSourceDeps {
+  /** `<appRoot>/skills` — the same global root the operator source reads (from `StoragePaths`). */
+  readonly operatorSkillsRoot: AbsolutePath;
+  /** Logged warnings for unreadable / malformed / contract-violating skills. */
+  readonly logger: Logger;
+  /** Optional contract guard — runs per skill as a WARNING (see {@link SkillContractWarner}). */
+  readonly warnIfContractViolated?: SkillContractWarner;
+}
+
+/**
+ * Enumerate + parse every `<root>/<flowDir>/<name>/SKILL.md` for one flow. Best-effort: a missing
+ * flow directory yields `[]`; an unreadable / malformed individual skill is logged and skipped;
+ * dotfile directory entries and non-directory entries (stray files, sidecars) are ignored. The
+ * contract guard (when supplied) runs per surviving skill as a warning and never drops it.
+ */
+const loadFlowSkills = async (deps: PhaseSkillSourceDeps, flowId: FlowId): Promise<readonly Skill[]> => {
+  const log = deps.logger.named('skills.phase');
+  const flowDir = PHASE_FLOW_DIR[flowId];
+  const flowRoot = join(String(deps.operatorSkillsRoot), flowDir);
+
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(flowRoot, { withFileTypes: true });
+  } catch (cause) {
+    // A missing flow directory is the common, non-error case — nothing opted in for this flow.
+    if (errorCode(cause) === 'ENOENT') return [];
+    log.warn('phase skills dir not readable', { flow: flowId, path: flowRoot, cause });
+    return [];
+  }
+
+  const skills: Skill[] = [];
+  for (const entry of entries) {
+    // Only skill folders count: skip stray files (a `.provenance.json` or `README.md` at the flow
+    // level) and dotfile directories (`.git`, editor cruft) so neither becomes a spurious skill.
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+    const name = entry.name;
+    // Read ONLY `SKILL.md`. A `.provenance.json` sidecar inside the same folder is never touched.
+    const path = join(flowRoot, name, 'SKILL.md');
+    let raw: string;
+    try {
+      raw = await fs.readFile(path, 'utf-8');
+    } catch (cause) {
+      log.warn('phase skill not readable, skipping', { flow: flowId, name, path, cause });
+      continue;
+    }
+    const parsed = parseSkill('phase skill', path, name, raw);
+    if (!parsed.ok) {
+      log.warn('phase skill invalid, skipping', { flow: flowId, name, path, error: parsed.error.message });
+      continue;
+    }
+    // Namespace the install name so the adapter's `ralphctl-*` exclude wildcard hides it from
+    // `git status` and the tracked uninstall reclaims it — exactly the bundled lifecycle.
+    const skill: Skill = { ...parsed.value, name: namespaced(parsed.value.name) };
+    // Compatibility guard is advisory: log a warning but still install — the operator owns it.
+    deps.warnIfContractViolated?.(skill);
+    skills.push(skill);
+  }
+  return skills;
+};
+
+/** @public */
+export const createPhaseSkillSource = (deps: PhaseSkillSourceDeps): SkillSource => ({
+  async getForFlow(flowId: FlowId): Promise<Result<readonly Skill[], StorageError>> {
+    return Result.ok(await loadFlowSkills(deps, flowId));
+  },
+
+  async getByName(name: string): Promise<Result<Skill | undefined, StorageError>> {
+    // Search every flow directory in the canonical FLOW_IDS order; the FIRST match wins. Loading in
+    // parallel and then scanning results in order keeps that ordering deterministic. Missing dirs
+    // resolve to `[]` and are skipped.
+    const perFlow = await Promise.all(FLOW_IDS.map((flowId) => loadFlowSkills(deps, flowId)));
+    for (const skills of perFlow) {
+      const hit = skills.find((s) => s.name === name);
+      if (hit) return Result.ok(hit);
+    }
+    return Result.ok(undefined);
+  },
+});

--- a/tests/integration/ai/skills/bundled/source.test.ts
+++ b/tests/integration/ai/skills/bundled/source.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
 
 describe('createBundledSkillSource (production root)', () => {
   // Hits the real `src/ai/skills/bundled/` folder. Asserts the three v1 skills load.
@@ -28,12 +29,13 @@ describe('createBundledSkillSource (production root)', () => {
     expect(alignment?.content).toContain('# Alignment');
   });
 
-  it('returns the same set across flows (current registry assigns all skills to all flows)', async () => {
+  it('returns exactly the registry defaults for each flow, in table order', async () => {
     const a = await source.getForFlow('refine');
     const b = await source.getForFlow('plan');
     expect(a.ok && b.ok).toBe(true);
     if (!(a.ok && b.ok)) return;
-    expect(a.value.map((s) => s.name)).toEqual(b.value.map((s) => s.name));
+    expect(a.value.map((s) => s.name)).toEqual(skillsForFlow('refine'));
+    expect(b.value.map((s) => s.name)).toEqual(skillsForFlow('plan'));
   });
 
   it('getByName resolves a known bundled skill by its exact folder name', async () => {

--- a/tests/integration/ai/skills/launcher-composition.test.ts
+++ b/tests/integration/ai/skills/launcher-composition.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Launcher-level skill-composition cover for `buildComposedSkillSource`
+ * (`src/application/ui/shared/launcher.ts`) — the ONE skill-selection resolution point — plus
+ * `buildSkillCandidates` / `flowMountsSkills`, the customize picker's skills-step data source.
+ *
+ * These tests drive the REAL launcher helpers (not a reconstruction, which could drift) against
+ * the REAL bundled skill source, an empty operator/phase root (a fresh tmpdir), and a repo-less
+ * project so the project source is empty too. They fence:
+ *
+ *   1. Zero-config invariant — no `settings.ai.skills`, no `skillsOverride`, empty phase folders ⇒
+ *      the resolved set is byte-for-byte identical (names + order + content) to today's bundled set.
+ *   2. Opt-out subtraction — a saved `settings.ai.skills[flow].disabled` and a per-run
+ *      `skillsOverride.disabled` both drop the named skill from the resolved set.
+ *   3. Run-replaces-saved semantics — when `extras.skillsOverride` is present it REPLACES the
+ *      saved row outright rather than unioning with it, so a per-run RE-ENABLE of a
+ *      remembered-off skill is possible.
+ *   4. Aliased-flow inheritance — a `review` launch reads `implement`'s disabled row via the shared
+ *      `aiFlowIdFor` mapping (one aliasing rule everywhere).
+ *   5. `buildSkillCandidates` — the pre-subtraction, origin-tagged candidate list the customize
+ *      picker's skills step seeds from, and `flowMountsSkills` — the gate deciding which flows get
+ *      the step at all.
+ *
+ * The runner is never started; the helpers are pure factories, so a minimal `LauncherDeps` suffices.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildComposedSkillSource,
+  buildSkillCandidates,
+  bundledDefaultSkillNames,
+  flowMountsSkills,
+} from '@src/application/ui/shared/launcher.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
+import { createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+const noopLogger = {
+  named: () => noopLogger,
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
+
+/** Repo-less project ⇒ the project skill source contributes nothing. */
+const project = {
+  id: PROJECT_ID,
+  slug: 'fixture-project',
+  displayName: 'Fixture Project',
+  repositories: [],
+} as unknown as Project;
+
+const snapshot = { project } as unknown as AppStateSnapshot;
+
+/** `operatorSkillsRoot` points at a fresh empty dir ⇒ operator + phase sources are both empty. */
+const makeDeps = async (): Promise<LauncherDeps> => {
+  const emptyRoot = await mkdtemp(join(tmpdir(), 'launcher-skills-'));
+  const storage = {
+    operatorSkillsRoot: abs(emptyRoot),
+  } as unknown as StoragePaths;
+  const app = {
+    logger: noopLogger,
+    skillSource: createBundledSkillSource(),
+  } as unknown as AppDeps;
+  return { app, storage, interactive: {} as LauncherDeps['interactive'], runInTerminal: passthroughRunInTerminal };
+};
+
+const forFlow = async (
+  source: SkillSource,
+  flow: Parameters<SkillSource['getForFlow']>[0]
+): Promise<readonly Skill[]> => {
+  const r = await source.getForFlow(flow);
+  if (!r.ok) throw new Error(`getForFlow failed: ${r.error.message}`);
+  return r.value;
+};
+
+const withSkills = (disabled: NonNullable<Settings['ai']['skills']>): Settings => ({
+  ...DEFAULT_SETTINGS,
+  ai: { ...DEFAULT_SETTINGS.ai, skills: disabled },
+});
+
+describe('buildComposedSkillSource — zero-config invariant', () => {
+  it('produces a byte-for-byte identical skill set + order to the bundled-only source today', async () => {
+    const deps = await makeDeps();
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'implement', DEFAULT_SETTINGS, {});
+
+    // Baseline = today's effective set: bundled-only (project + operator + phase are all empty).
+    const baseline = await forFlow(createBundledSkillSource(), 'implement');
+    const actual = await forFlow(resolved, 'implement');
+
+    expect(actual).toEqual(baseline);
+    expect(actual.length).toBeGreaterThan(0); // guards against an accidental empty-vs-empty pass
+  });
+});
+
+describe('buildComposedSkillSource — opt-out subtraction', () => {
+  it('drops a skill named in the saved settings.ai.skills[flow].disabled row', async () => {
+    const deps = await makeDeps();
+    const settings = withSkills({ implement: { disabled: ['ralphctl-alignment'] } });
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'implement', settings, {});
+
+    const names = (await forFlow(resolved, 'implement')).map((s) => s.name);
+    expect(names).not.toContain('ralphctl-alignment');
+    // Everything else the flow loads by default is untouched.
+    const baseline = (await forFlow(createBundledSkillSource(), 'implement')).map((s) => s.name);
+    expect(names).toEqual(baseline.filter((n) => n !== 'ralphctl-alignment'));
+  });
+
+  it('drops a skill named in the per-run skillsOverride.disabled (no saved row)', async () => {
+    const deps = await makeDeps();
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'implement', DEFAULT_SETTINGS, {
+      skillsOverride: { disabled: ['ralphctl-iterative-review'] },
+    });
+
+    const names = (await forFlow(resolved, 'implement')).map((s) => s.name);
+    expect(names).not.toContain('ralphctl-iterative-review');
+  });
+
+  it('a per-run override REPLACES the saved row — it does not union with it', async () => {
+    // Run-replaces-saved semantics (not union): the saved row disables `ralphctl-alignment`, but
+    // this run's override only names `ralphctl-iterative-review`, so alignment is NOT subtracted
+    // for this launch — the override wins outright.
+    const deps = await makeDeps();
+    const settings = withSkills({ implement: { disabled: ['ralphctl-alignment'] } });
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'implement', settings, {
+      skillsOverride: { disabled: ['ralphctl-iterative-review'] },
+    });
+
+    const names = (await forFlow(resolved, 'implement')).map((s) => s.name);
+    expect(names).toContain('ralphctl-alignment');
+    expect(names).not.toContain('ralphctl-iterative-review');
+  });
+
+  it('an empty per-run override RE-ENABLES every saved-disabled skill for the run', async () => {
+    // The mechanism a per-run "re-enable a remembered-off skill" relies on: picking nothing to
+    // disable this run means `skillsOverride: { disabled: [] }`, which still REPLACES the saved
+    // row (an empty array is a defined override, not an absent one).
+    const deps = await makeDeps();
+    const settings = withSkills({ implement: { disabled: ['ralphctl-alignment'] } });
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'implement', settings, {
+      skillsOverride: { disabled: [] },
+    });
+
+    const names = (await forFlow(resolved, 'implement')).map((s) => s.name);
+    expect(names).toContain('ralphctl-alignment');
+    const baseline = (await forFlow(createBundledSkillSource(), 'implement')).map((s) => s.name);
+    expect(names).toEqual(baseline);
+  });
+});
+
+describe('buildComposedSkillSource — aliased-flow row inheritance', () => {
+  it('a review launch reads implement’s saved disabled row (aiFlowIdFor: review → implement)', async () => {
+    const deps = await makeDeps();
+    // The opt-out is stored under implement; a review dispatch must honour it.
+    const settings = withSkills({ implement: { disabled: ['ralphctl-alignment'] } });
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'review', settings, {});
+
+    // Review would enumerate implement's skills — getForFlow('implement') is the phase it resolves.
+    const names = (await forFlow(resolved, 'implement')).map((s) => s.name);
+    expect(names).not.toContain('ralphctl-alignment');
+  });
+
+  it('maps the create-pr orchestration id to the createPr settings row', async () => {
+    const deps = await makeDeps();
+    const settings = withSkills({ createPr: { disabled: ['ralphctl-code-review-and-quality'] } });
+    const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'create-pr', settings, {});
+
+    const names = (await forFlow(resolved, 'createPr')).map((s) => s.name);
+    expect(names).not.toContain('ralphctl-code-review-and-quality');
+  });
+});
+
+describe('flowMountsSkills — gate for the customize picker skills step', () => {
+  it('returns true only for the five flows whose launch context threads ctx.skillSource', () => {
+    for (const id of ['refine', 'plan', 'implement', 'readiness', 'ideate']) {
+      expect(flowMountsSkills(id)).toBe(true);
+    }
+  });
+
+  it('returns false for aliased / non-mounting flows and non-AI flows', () => {
+    for (const id of ['review', 'detect-scripts', 'detect-skills', 'create-pr', 'create-sprint', 'close-sprint']) {
+      expect(flowMountsSkills(id)).toBe(false);
+    }
+  });
+});
+
+describe('buildSkillCandidates — pre-subtraction, origin-tagged candidate list', () => {
+  it('returns empty for a flow with no AI row and for one flowMountsSkills rejects', async () => {
+    const deps = await makeDeps();
+    const nonAi = await buildSkillCandidates(deps, snapshot, 'create-sprint', DEFAULT_SETTINGS);
+    expect(nonAi).toEqual({ candidates: [], savedDisabled: [] });
+
+    // `review` HAS an AI row (aliases implement) but its own launcher never mounts skillSource.
+    const nonMounting = await buildSkillCandidates(deps, snapshot, 'review', DEFAULT_SETTINGS);
+    expect(nonMounting).toEqual({ candidates: [], savedDisabled: [] });
+  });
+
+  it('lists every bundled-default skill for the flow, tagged with origin bundled-default', async () => {
+    const deps = await makeDeps();
+    const result = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS);
+    expect(result.settingsFlow).toBe('implement');
+    const names = result.candidates.map((c) => c.name);
+    expect(names).toEqual(skillsForFlow('implement').slice());
+    for (const candidate of result.candidates) {
+      expect(candidate.origin).toBe('bundled-default');
+      expect(candidate.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('savedDisabled mirrors settings.ai.skills[flow].disabled — candidates are NOT pre-subtracted', async () => {
+    const deps = await makeDeps();
+    const settings = withSkills({ implement: { disabled: ['ralphctl-alignment'] } });
+    const result = await buildSkillCandidates(deps, snapshot, 'implement', settings);
+    expect(result.savedDisabled).toEqual(['ralphctl-alignment']);
+    // Nothing is subtracted here — the disabled skill is still a candidate the picker can toggle.
+    expect(result.candidates.map((c) => c.name)).toContain('ralphctl-alignment');
+  });
+});
+
+describe('bundledDefaultSkillNames', () => {
+  it('keeps only bundled-default-origin names, dropping project / operator / phase-folder names', async () => {
+    const deps = await makeDeps();
+    const { candidates } = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS);
+    const withExtra = [
+      ...candidates,
+      { name: 'ralphctl-fixture-repo-setup', description: 'setup', origin: 'project' as const },
+      { name: 'ralphctl-operator-thing', description: 'operator', origin: 'operator' as const },
+      { name: 'ralphctl-opted-in', description: 'opt-in', origin: 'phase-folder' as const },
+    ];
+    const bundledNames = bundledDefaultSkillNames(withExtra);
+    expect(bundledNames.has('ralphctl-fixture-repo-setup')).toBe(false);
+    expect(bundledNames.has('ralphctl-operator-thing')).toBe(false);
+    expect(bundledNames.has('ralphctl-opted-in')).toBe(false);
+    for (const c of candidates) expect(bundledNames.has(c.name)).toBe(true);
+  });
+});

--- a/tests/integration/ai/skills/launcher-composition.test.ts
+++ b/tests/integration/ai/skills/launcher-composition.test.ts
@@ -30,7 +30,6 @@ import { join } from 'node:path';
 import {
   buildComposedSkillSource,
   buildSkillCandidates,
-  bundledDefaultSkillNames,
   flowMountsSkills,
 } from '@src/application/ui/shared/launcher.ts';
 import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
@@ -210,11 +209,11 @@ describe('buildSkillCandidates — pre-subtraction, origin-tagged candidate list
   it('returns empty for a flow with no AI row and for one flowMountsSkills rejects', async () => {
     const deps = await makeDeps();
     const nonAi = await buildSkillCandidates(deps, snapshot, 'create-sprint', DEFAULT_SETTINGS);
-    expect(nonAi).toEqual({ candidates: [], savedDisabled: [] });
+    expect(nonAi).toEqual({ candidates: [], savedDisabled: [], degraded: false });
 
     // `review` HAS an AI row (aliases implement) but its own launcher never mounts skillSource.
     const nonMounting = await buildSkillCandidates(deps, snapshot, 'review', DEFAULT_SETTINGS);
-    expect(nonMounting).toEqual({ candidates: [], savedDisabled: [] });
+    expect(nonMounting).toEqual({ candidates: [], savedDisabled: [], degraded: false });
   });
 
   it('lists every bundled-default skill for the flow, tagged with origin bundled-default', async () => {
@@ -239,20 +238,20 @@ describe('buildSkillCandidates — pre-subtraction, origin-tagged candidate list
   });
 });
 
-describe('bundledDefaultSkillNames', () => {
-  it('keeps only bundled-default-origin names, dropping project / operator / phase-folder names', async () => {
+describe('buildSkillCandidates — degraded flag + provider override', () => {
+  it('flags a healthy listing as not degraded', async () => {
     const deps = await makeDeps();
-    const { candidates } = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS);
-    const withExtra = [
-      ...candidates,
-      { name: 'ralphctl-fixture-repo-setup', description: 'setup', origin: 'project' as const },
-      { name: 'ralphctl-operator-thing', description: 'operator', origin: 'operator' as const },
-      { name: 'ralphctl-opted-in', description: 'opt-in', origin: 'phase-folder' as const },
-    ];
-    const bundledNames = bundledDefaultSkillNames(withExtra);
-    expect(bundledNames.has('ralphctl-fixture-repo-setup')).toBe(false);
-    expect(bundledNames.has('ralphctl-operator-thing')).toBe(false);
-    expect(bundledNames.has('ralphctl-opted-in')).toBe(false);
-    for (const c of candidates) expect(bundledNames.has(c.name)).toBe(true);
+    const result = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS);
+    expect(result.degraded).toBe(false);
+  });
+
+  it('re-lists with the overridden provider without touching the saved settings row', async () => {
+    const deps = await makeDeps();
+    const saved = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS);
+    const overridden = await buildSkillCandidates(deps, snapshot, 'implement', DEFAULT_SETTINGS, 'openai-codex');
+    // Bundled defaults are provider-agnostic — both listings carry the same names in this
+    // fixture (its operator dirs are empty); the override must not degrade or reorder.
+    expect(overridden.candidates.map((c) => c.name)).toEqual(saved.candidates.map((c) => c.name));
+    expect(overridden.degraded).toBe(false);
   });
 });

--- a/tests/integration/ai/skills/opt-in-roundtrip.test.ts
+++ b/tests/integration/ai/skills/opt-in-roundtrip.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Cross-module opt-in-skills roundtrip — the ONE gap none of the per-module suites cover: the
+ * full lifecycle a real launch actually exercises, driven end-to-end through the REAL catalog
+ * (`createSkillCatalog`), the REAL phase source (`createPhaseSkillSource`, via the launcher), and
+ * the REAL resolution seam (`buildComposedSkillSource` / `createResolvedSkillSource`).
+ *
+ * Per-module edge cases already live in `phase/catalog.test.ts` (enable/disable/update status
+ * transitions), `phase/source.test.ts` (phase-folder enumeration), `phase/provenance.test.ts`
+ * (hash/status derivation), and `launcher-composition.test.ts` (dedupe + opt-out resolution
+ * against empty phase folders). This file does NOT re-derive those — it proves the seam between
+ * them: a catalog `enable()` call is actually visible to a launch's resolved skill set, a
+ * catalog-managed copy actually shadows a bundled default, `disable()` actually removes it from
+ * resolution, `updateAll()` actually distinguishes a stale copy from a locally-modified one, and
+ * the settings/override opt-out still applies to a skill that came from the phase folder rather
+ * than the bundled source.
+ *
+ * `createSkillCatalog` reads `BUNDLED_SKILLS` directly from the registry (not as an injected
+ * dep), so this suite uses the REAL registry entries + the REAL bundled root
+ * (`createBundledSkillRawReader()`) rather than fake skill names — the catalog's `list()` /
+ * `updateAll()` iterate the actual table, so a fake reader would only cover `enable`/`update`
+ * while leaving `list`/`updateAll` reading real (mismatched) content.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
+import { buildComposedSkillSource } from '@src/application/ui/shared/launcher.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
+import { createBundledSkillRawReader, createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import { createSkillCatalog } from '@src/integration/ai/skills/phase/catalog.ts';
+import { PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
+import {
+  createProvenanceStore,
+  hashSkillContent,
+  PROVENANCE_FILENAME,
+} from '@src/integration/ai/skills/phase/provenance.ts';
+import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+const noopLogger = {
+  named: () => noopLogger,
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
+
+/** Repo-less project ⇒ the project skill source contributes nothing to this suite. */
+const project = {
+  id: PROJECT_ID,
+  slug: 'fixture-project',
+  displayName: 'Fixture Project',
+  repositories: [],
+} as unknown as Project;
+
+const snapshot = { project } as unknown as AppStateSnapshot;
+
+const makeDeps = (root: string): LauncherDeps => {
+  const storage = { operatorSkillsRoot: abs(root) } as unknown as StoragePaths;
+  const app = { logger: noopLogger, skillSource: createBundledSkillSource() } as unknown as AppDeps;
+  return { app, storage, interactive: {} as LauncherDeps['interactive'], runInTerminal: passthroughRunInTerminal };
+};
+
+const makeCatalogRoot = async (): Promise<string> => mkdtemp(join(tmpdir(), 'skills-roundtrip-'));
+
+const makeCatalog = (root: string) =>
+  createSkillCatalog({
+    operatorSkillsRoot: abs(root),
+    writeFile: createAtomicWriteFile(),
+    bundledRawReader: createBundledSkillRawReader(),
+    logger: noopLogger,
+  });
+
+const forFlow = async (
+  source: SkillSource,
+  flow: Parameters<SkillSource['getForFlow']>[0]
+): Promise<readonly Skill[]> => {
+  const r = await source.getForFlow(flow);
+  if (!r.ok) throw new Error(`getForFlow failed: ${r.error.message}`);
+  return r.value;
+};
+
+const withSkills = (disabled: NonNullable<Settings['ai']['skills']>): Settings => ({
+  ...DEFAULT_SETTINGS,
+  ai: { ...DEFAULT_SETTINGS.ai, skills: disabled },
+});
+
+describe('opt-in skills — cross-module roundtrip', () => {
+  it('enable() via the catalog resolves through the launcher, shadows a bundled default, and disable() reverses both', async () => {
+    const root = await makeCatalogRoot();
+    const deps = makeDeps(root);
+    const catalog = makeCatalog(root);
+
+    // A skill NOT default-on for 'plan' — proves opt-in ADDS a skill the flow wouldn't otherwise load.
+    const optInSkill = BUNDLED_SKILLS.find((e) => !e.defaultFor.includes('plan'));
+    // A skill that IS default-on for 'plan' — proves a phase-folder copy SHADOWS the bundled default.
+    const shadowSkill = BUNDLED_SKILLS.find((e) => e.defaultFor.includes('plan'));
+    if (optInSkill === undefined || shadowSkill === undefined) {
+      throw new Error('registry fixture requires both a non-default and a default-for-plan entry');
+    }
+
+    // Baseline: before any enable, the opt-in skill is absent and the shadow skill loads unmodified.
+    const baseline = await forFlow(
+      buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', DEFAULT_SETTINGS, {}),
+      'plan'
+    );
+    expect(baseline.map((s) => s.name)).not.toContain(optInSkill.name);
+    expect(baseline.map((s) => s.name)).toContain(shadowSkill.name);
+
+    // (b) enable(name, [flow]) via the catalog — phase folder now holds SKILL.md + provenance.
+    const enabledOptIn = await catalog.enable(optInSkill.name, ['plan']);
+    expect(enabledOptIn.ok).toBe(true);
+    const optInDir = join(root, PHASE_FLOW_DIR.plan, optInSkill.name);
+    const optInSkillMd = await readFile(join(optInDir, 'SKILL.md'), 'utf-8');
+    expect(optInSkillMd.length).toBeGreaterThan(0);
+    const optInProvenance = JSON.parse(await readFile(join(optInDir, PROVENANCE_FILENAME), 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    expect(optInProvenance.source).toBe('bundled');
+    expect(optInProvenance.skill).toBe(optInSkill.name);
+
+    // (c) resolve via the launcher path — the enabled skill now appears for that flow.
+    const afterEnable = await forFlow(
+      buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', DEFAULT_SETTINGS, {}),
+      'plan'
+    );
+    expect(afterEnable.map((s) => s.name)).toContain(optInSkill.name);
+
+    // Shadowing: enable the ALREADY-default skill too, then hand-edit its phase copy. Composition
+    // order (bundled → project → operator → phase, phase LAST) means the resolved decorator's
+    // last-wins dedupe must surface the phase-folder content, not the bundled original.
+    expect((await catalog.enable(shadowSkill.name, ['plan'])).ok).toBe(true);
+    const shadowDir = join(root, PHASE_FLOW_DIR.plan, shadowSkill.name);
+    const shadowedDescription = `CUSTOMIZED shadow copy for ${shadowSkill.name}`;
+    const editedRaw = `---\nname: ${shadowSkill.name}\ndescription: ${shadowedDescription}\n---\n\ncustom body\n`;
+    await writeFile(join(shadowDir, 'SKILL.md'), editedRaw, 'utf-8');
+
+    const afterShadow = await forFlow(
+      buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', DEFAULT_SETTINGS, {}),
+      'plan'
+    );
+    const shadowMatches = afterShadow.filter((s) => s.name === shadowSkill.name);
+    expect(shadowMatches).toHaveLength(1); // deduped, not doubled
+    expect(shadowMatches[0]?.description).toBe(shadowedDescription);
+
+    // (d) disable — both the opt-in addition and the shadowing copy disappear from resolution.
+    expect((await catalog.disable(optInSkill.name, ['plan'])).ok).toBe(true);
+    expect((await catalog.disable(shadowSkill.name, ['plan'])).ok).toBe(true);
+
+    const afterDisable = await forFlow(
+      buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', DEFAULT_SETTINGS, {}),
+      'plan'
+    );
+    expect(afterDisable.map((s) => s.name)).not.toContain(optInSkill.name);
+    const revertedShadow = afterDisable.find((s) => s.name === shadowSkill.name);
+    const bundledShadowSkill = (await forFlow(createBundledSkillSource(), 'plan')).find(
+      (s) => s.name === shadowSkill.name
+    );
+    // Reverts to the bundled default's own description once the shadowing copy is removed.
+    expect(revertedShadow?.description).toBe(bundledShadowSkill?.description);
+  });
+
+  it('updateAll() updates an untampered stale copy but skips a locally-modified one', async () => {
+    const root = await makeCatalogRoot();
+    const catalog = makeCatalog(root);
+    const rawReader = createBundledSkillRawReader();
+
+    const [staleSkill, editedSkill] = BUNDLED_SKILLS;
+    if (staleSkill === undefined || editedSkill === undefined || staleSkill.name === editedSkill.name) {
+      throw new Error('registry fixture requires two distinct BUNDLED_SKILLS entries');
+    }
+
+    // "Untampered stale copy": the folder matches ITS OWN stamp (not locally-modified) but the
+    // stamp is behind the real current bundled content (update-available).
+    const staleDir = join(root, PHASE_FLOW_DIR.implement, staleSkill.name);
+    await mkdir(staleDir, { recursive: true });
+    const oldRaw = `---\nname: ${staleSkill.name}\ndescription: an older ${staleSkill.name} snapshot\n---\n\nold body\n`;
+    await writeFile(join(staleDir, 'SKILL.md'), oldRaw, 'utf-8');
+    const provenanceStore = createProvenanceStore({ writeFile: createAtomicWriteFile() });
+    const staleStamped = await provenanceStore.writeProvenance(abs(staleDir), {
+      source: 'bundled',
+      skill: staleSkill.name,
+      contentHash: hashSkillContent(oldRaw),
+      ralphctlVersion: 'v0.0.0-test',
+      copiedAt: new Date(0).toISOString(),
+    });
+    expect(staleStamped.ok).toBe(true);
+
+    // "Locally-modified" copy: a real enable(), then a hand-edit that leaves the stamp untouched.
+    expect((await catalog.enable(editedSkill.name, ['implement'])).ok).toBe(true);
+    const editedDir = join(root, PHASE_FLOW_DIR.implement, editedSkill.name);
+    const tamperedRaw = `---\nname: ${editedSkill.name}\ndescription: tampered ${editedSkill.name}\n---\n\ntampered body\n`;
+    await writeFile(join(editedDir, 'SKILL.md'), tamperedRaw, 'utf-8');
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value.find((e) => e.name === staleSkill.name)?.installs).toEqual([
+      { flow: 'implement', status: 'update-available' },
+    ]);
+    expect(listed.value.find((e) => e.name === editedSkill.name)?.installs).toEqual([
+      { flow: 'implement', status: 'locally-modified' },
+    ]);
+
+    const result = await catalog.updateAll();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.updated).toContain(staleSkill.name);
+    expect(result.value.updated).not.toContain(editedSkill.name);
+
+    const staleAfter = await readFile(join(staleDir, 'SKILL.md'), 'utf-8');
+    const realStaleRaw = await rawReader.readRaw(staleSkill.name);
+    expect(realStaleRaw.ok).toBe(true);
+    if (realStaleRaw.ok) expect(staleAfter).toBe(realStaleRaw.value);
+
+    const editedAfter = await readFile(join(editedDir, 'SKILL.md'), 'utf-8');
+    expect(editedAfter).toBe(tamperedRaw); // untouched — an edit is never silently discarded
+  });
+
+  it('saved settings disabled-list and run-scoped override REPLACE semantics resolve through the composed source', async () => {
+    const root = await makeCatalogRoot();
+    const deps = makeDeps(root);
+    const catalog = makeCatalog(root);
+
+    const optInSkill = BUNDLED_SKILLS.find((e) => !e.defaultFor.includes('plan'));
+    if (optInSkill === undefined) throw new Error('registry fixture requires a non-default-for-plan entry');
+    expect((await catalog.enable(optInSkill.name, ['plan'])).ok).toBe(true);
+
+    const settings = withSkills({ plan: { disabled: [optInSkill.name] } });
+
+    // Saved disabled-list subtracts even a skill that came from the phase folder, not just bundled.
+    const savedNames = (
+      await forFlow(buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', settings, {}), 'plan')
+    ).map((s) => s.name);
+    expect(savedNames).not.toContain(optInSkill.name);
+
+    // A run override REPLACES the saved row outright — an empty override re-enables it for this run.
+    const overrideNames = (
+      await forFlow(
+        buildComposedSkillSource(deps, snapshot, 'claude-code', 'plan', settings, {
+          skillsOverride: { disabled: [] },
+        }),
+        'plan'
+      )
+    ).map((s) => s.name);
+    expect(overrideNames).toContain(optInSkill.name);
+  });
+});

--- a/tests/integration/ai/skills/phase/catalog.test.ts
+++ b/tests/integration/ai/skills/phase/catalog.test.ts
@@ -318,4 +318,72 @@ describe('createSkillCatalog', () => {
     const updated = await catalog.update('missing-bundle', ['plan']);
     expect(updated.ok).toBe(false);
   });
+
+  it('enable() reports per-flow outcomes: copies fresh flows, skips edit-protected ones', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+    // First enable: both flows fresh → both copied.
+    const first = await catalog.enable(name, ['plan', 'implement']);
+    expect(first.ok && first.value).toEqual({ copied: ['plan', 'implement'], skipped: [] });
+    // Hand-edit the plan copy → edit-protected; re-enable must skip it and re-copy implement.
+    const planDir = join(root, PHASE_FLOW_DIR.plan, name);
+    await writeFile(join(planDir, 'SKILL.md'), 'edited by the operator', 'utf-8');
+    const second = await catalog.enable(name, ['plan', 'implement']);
+    expect(second.ok && second.value).toEqual({ copied: ['implement'], skipped: ['plan'] });
+    expect(await readFile(join(planDir, 'SKILL.md'), 'utf-8')).toBe('edited by the operator');
+  });
+
+  it('enable() repairs a stranded pristine copy whose stamp write was interrupted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+    // Simulate an interrupted enable: SKILL.md written verbatim, sidecar missing.
+    const dir = join(root, PHASE_FLOW_DIR.plan, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'SKILL.md'), fakeBundledContent(name), 'utf-8');
+    const repaired = await catalog.enable(name, ['plan']);
+    expect(repaired.ok && repaired.value).toEqual({ copied: ['plan'], skipped: [] });
+    // The sidecar now exists and the install reads in-sync, not manual.
+    const stamped = await readFile(join(dir, PROVENANCE_FILENAME), 'utf-8');
+    expect(stamped).toContain(name);
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+  });
+
+  it('list() surfaces a folder without SKILL.md as broken, and disable() removes it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+    const dir = join(root, PHASE_FLOW_DIR.ideate, name);
+    await mkdir(dir, { recursive: true });
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'ideate', status: 'broken' }]);
+
+    const removed = await catalog.disable(name, ['ideate']);
+    expect(removed.ok).toBe(true);
+    const after = await catalog.list();
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(findEntry(after.value, name)?.installs).toEqual([]);
+  });
 });

--- a/tests/integration/ai/skills/phase/catalog.test.ts
+++ b/tests/integration/ai/skills/phase/catalog.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { createEventBusLogger } from '@src/business/observability/event-bus-logger.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
+import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
+import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { BundledSkillRawReader } from '@src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
+import { PROVENANCE_FILENAME } from '@src/integration/ai/skills/phase/provenance.ts';
+import { createSkillCatalog } from '@src/integration/ai/skills/phase/catalog.ts';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+const recordingLogger = () => {
+  const bus = createInMemoryEventBus();
+  return createEventBusLogger({ eventBus: bus, clock: IsoTimestamp.now });
+};
+
+/** Deterministic, always-valid synthetic SKILL.md content for `name` at revision `seed`. */
+const fakeBundledContent = (name: string, seed = 0): string =>
+  `---\nname: ${name}\ndescription: ${name} bundled description v${String(seed)}\n---\n\n# ${name}\nbody v${String(seed)}\n`;
+
+/**
+ * Fake {@link BundledSkillRawReader} that resolves ANY name to valid synthetic content by
+ * default — so `list()` / `updateAll()` (which iterate the REAL `BUNDLED_SKILLS` table) never
+ * fail against a registry this test suite doesn't control the exact membership of. Individual
+ * tests mutate `overrides` to simulate "the bundle moved on", or add to `errorFor` to exercise
+ * the read-failure propagation path.
+ */
+const createFakeRawReader = (overrides: Map<string, string>, errorFor: Set<string>): BundledSkillRawReader => ({
+  async readRaw(name: string) {
+    if (errorFor.has(name)) {
+      return Result.error(new StorageError({ subCode: 'io', message: `boom: ${name}`, path: name }));
+    }
+    return Result.ok(overrides.get(name) ?? fakeBundledContent(name));
+  },
+});
+
+const findEntry = (entries: readonly SkillCatalogEntry[], name: string): SkillCatalogEntry | undefined =>
+  entries.find((e) => e.name === name);
+
+describe('createSkillCatalog', () => {
+  it('list() returns one entry per BUNDLED_SKILLS name with registry defaults and no installs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+
+    const result = await catalog.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toHaveLength(BUNDLED_SKILLS.length);
+    for (const registryEntry of BUNDLED_SKILLS) {
+      const entry = findEntry(result.value, registryEntry.name);
+      expect(entry).toBeDefined();
+      expect(entry?.defaultFor).toEqual(registryEntry.defaultFor);
+      expect(entry?.recommendedFor).toEqual(registryEntry.recommendedFor);
+      expect(entry?.installs).toEqual([]);
+      expect(entry?.description).toBe(`${registryEntry.name} bundled description v0`);
+    }
+  });
+
+  it('enable() copies the bundled skill verbatim and stamps provenance; list() reports in-sync', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+
+    const enabled = await catalog.enable(name, ['plan']);
+    expect(enabled.ok).toBe(true);
+
+    const dir = join(root, PHASE_FLOW_DIR.plan, name);
+    const onDisk = await readFile(join(dir, 'SKILL.md'), 'utf-8');
+    expect(onDisk).toBe(fakeBundledContent(name));
+
+    const stamp = JSON.parse(await readFile(join(dir, PROVENANCE_FILENAME), 'utf-8')) as Record<string, unknown>;
+    expect(stamp.source).toBe('bundled');
+    expect(stamp.skill).toBe(name);
+    expect(stamp.ralphctlVersion).toBe(CLI_METADATA.currentVersion);
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const entry = findEntry(listed.value, name);
+    expect(entry?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+  });
+
+  it('enable() is idempotent for an in-sync install (re-copies identical bytes)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+
+    expect((await catalog.enable(name, ['implement'])).ok).toBe(true);
+    expect((await catalog.enable(name, ['implement'])).ok).toBe(true);
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'implement', status: 'in-sync' }]);
+  });
+
+  it('enable() never overwrites a locally-modified copy', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const overrides = new Map<string, string>();
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(overrides, new Set()),
+      logger: recordingLogger(),
+    });
+
+    expect((await catalog.enable(name, ['readiness'])).ok).toBe(true);
+    const dir = join(root, PHASE_FLOW_DIR.readiness, name);
+    const editedContent = `${fakeBundledContent(name)}operator edit\n`;
+    await writeFile(join(dir, 'SKILL.md'), editedContent, 'utf-8');
+
+    // Bundle also moves on — enable must still leave the edited copy alone.
+    overrides.set(name, fakeBundledContent(name, 1));
+    expect((await catalog.enable(name, ['readiness'])).ok).toBe(true);
+
+    const onDisk = await readFile(join(dir, 'SKILL.md'), 'utf-8');
+    expect(onDisk).toBe(editedContent);
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'readiness', status: 'locally-modified' }]);
+  });
+
+  it('list() reports update-available when the bundle moves on after an in-sync enable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const overrides = new Map<string, string>();
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(overrides, new Set()),
+      logger: recordingLogger(),
+    });
+
+    expect((await catalog.enable(name, ['ideate'])).ok).toBe(true);
+    overrides.set(name, fakeBundledContent(name, 1));
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'ideate', status: 'update-available' }]);
+  });
+
+  it('disable() removes the folder + sidecar; a missing folder is a no-op', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+
+    expect((await catalog.enable(name, ['refine'])).ok).toBe(true);
+    const disabled = await catalog.disable(name, ['refine']);
+    expect(disabled.ok).toBe(true);
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([]);
+
+    // Disabling an already-absent flow is a documented no-op, not an error.
+    const again = await catalog.disable(name, ['refine']);
+    expect(again.ok).toBe(true);
+  });
+
+  it('update() overwrites a locally-modified copy and re-stamps to the current bundled content', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const name = BUNDLED_SKILLS[0]!.name;
+    const overrides = new Map<string, string>();
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(overrides, new Set()),
+      logger: recordingLogger(),
+    });
+
+    expect((await catalog.enable(name, ['plan'])).ok).toBe(true);
+    const dir = join(root, PHASE_FLOW_DIR.plan, name);
+    await writeFile(join(dir, 'SKILL.md'), `${fakeBundledContent(name)}operator edit\n`, 'utf-8');
+    overrides.set(name, fakeBundledContent(name, 2));
+
+    const updated = await catalog.update(name, ['plan']);
+    expect(updated.ok).toBe(true);
+
+    const onDisk = await readFile(join(dir, 'SKILL.md'), 'utf-8');
+    expect(onDisk).toBe(fakeBundledContent(name, 2));
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, name)?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+  });
+
+  it('updateAll() updates only update-available installs, skips locally-modified and manual, returns updated names', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const [staleSkill, editedSkill] = BUNDLED_SKILLS;
+    if (staleSkill === undefined || editedSkill === undefined || staleSkill.name === editedSkill.name) {
+      throw new Error('test requires at least two distinct BUNDLED_SKILLS entries');
+    }
+    const overrides = new Map<string, string>();
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(overrides, new Set()),
+      logger: recordingLogger(),
+    });
+
+    // A hand-dropped folder with no bundled counterpart in scope — always 'manual', never touched.
+    const manualDir = join(root, PHASE_FLOW_DIR.implement, 'hand-authored-thing');
+    await mkdir(manualDir, { recursive: true });
+    await writeFile(
+      join(manualDir, 'SKILL.md'),
+      '---\nname: hand-authored-thing\ndescription: dropped in by hand\n---\n\nbody\n',
+      'utf-8'
+    );
+
+    expect((await catalog.enable(staleSkill.name, ['implement'])).ok).toBe(true);
+    expect((await catalog.enable(editedSkill.name, ['implement'])).ok).toBe(true);
+    // staleSkill's bundle moves on (safe to auto-update); editedSkill's copy is hand-edited
+    // (must survive updateAll untouched).
+    overrides.set(staleSkill.name, fakeBundledContent(staleSkill.name, 1));
+    const editedContent = `${fakeBundledContent(editedSkill.name)}operator edit\n`;
+    await writeFile(join(root, PHASE_FLOW_DIR.implement, editedSkill.name, 'SKILL.md'), editedContent, 'utf-8');
+
+    const result = await catalog.updateAll();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.updated).toEqual([staleSkill.name]);
+
+    const staleOnDisk = await readFile(join(root, PHASE_FLOW_DIR.implement, staleSkill.name, 'SKILL.md'), 'utf-8');
+    expect(staleOnDisk).toBe(fakeBundledContent(staleSkill.name, 1));
+    const editedOnDisk = await readFile(join(root, PHASE_FLOW_DIR.implement, editedSkill.name, 'SKILL.md'), 'utf-8');
+    expect(editedOnDisk).toBe(editedContent); // untouched
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const manualEntry = findEntry(listed.value, 'hand-authored-thing');
+    expect(manualEntry).toEqual({
+      name: 'hand-authored-thing',
+      description: 'dropped in by hand',
+      defaultFor: [],
+      recommendedFor: [],
+      installs: [{ flow: 'implement', status: 'manual' }],
+    });
+  });
+
+  it('disable() also removes a manual (non-bundled) phase-folder entry', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const manualDir = join(root, PHASE_FLOW_DIR.refine, 'hand-authored-thing');
+    await mkdir(manualDir, { recursive: true });
+    await writeFile(
+      join(manualDir, 'SKILL.md'),
+      '---\nname: hand-authored-thing\ndescription: dropped in by hand\n---\n\nbody\n',
+      'utf-8'
+    );
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set()),
+      logger: recordingLogger(),
+    });
+
+    const disabled = await catalog.disable('hand-authored-thing', ['refine']);
+    expect(disabled.ok).toBe(true);
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(findEntry(listed.value, 'hand-authored-thing')).toBeUndefined();
+  });
+
+  it('propagates a bundled-read failure from enable() and update()', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-catalog-'));
+    const catalog = createSkillCatalog({
+      operatorSkillsRoot: abs(root),
+      writeFile: createAtomicWriteFile(),
+      bundledRawReader: createFakeRawReader(new Map(), new Set(['missing-bundle'])),
+      logger: recordingLogger(),
+    });
+
+    const enabled = await catalog.enable('missing-bundle', ['plan']);
+    expect(enabled.ok).toBe(false);
+    const updated = await catalog.update('missing-bundle', ['plan']);
+    expect(updated.ok).toBe(false);
+  });
+});

--- a/tests/integration/ai/skills/phase/provenance.test.ts
+++ b/tests/integration/ai/skills/phase/provenance.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
+import {
+  createProvenanceStore,
+  deriveStatus,
+  hashSkillContent,
+  PROVENANCE_FILENAME,
+  type ProvenanceStamp,
+} from '@src/integration/ai/skills/phase/provenance.ts';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+const BUNDLED = '---\nname: ralphctl-alignment\ndescription: Confirm scope\n---\n\n# Alignment\nbody\n';
+
+const stampFor = (raw: string): ProvenanceStamp => ({
+  source: 'bundled',
+  skill: 'ralphctl-alignment',
+  contentHash: hashSkillContent(raw),
+  ralphctlVersion: '9.9.9',
+  copiedAt: '2026-07-02T12:00:00Z',
+});
+
+describe('hashSkillContent', () => {
+  it('is deterministic and returns lowercase sha256 hex', () => {
+    const h = hashSkillContent(BUNDLED);
+    expect(h).toBe(hashSkillContent(BUNDLED));
+    expect(h).toMatch(/^[0-9a-f]{64}$/u);
+  });
+
+  it('differs when a single byte changes', () => {
+    expect(hashSkillContent(BUNDLED)).not.toBe(hashSkillContent(`${BUNDLED} `));
+  });
+});
+
+describe('deriveStatus', () => {
+  it('reports manual when there is no stamp (a hand-dropped folder)', () => {
+    expect(deriveStatus({ folderSkillMdRaw: BUNDLED, stamp: undefined, currentBundledRaw: BUNDLED })).toBe('manual');
+  });
+
+  it('reports in-sync when folder matches the stamp and the stamp matches the bundle', () => {
+    expect(deriveStatus({ folderSkillMdRaw: BUNDLED, stamp: stampFor(BUNDLED), currentBundledRaw: BUNDLED })).toBe(
+      'in-sync'
+    );
+  });
+
+  it('reports update-available when the bundle moved on but the folder still matches its stamp', () => {
+    const newBundled = `${BUNDLED}\nnew upstream line\n`;
+    expect(deriveStatus({ folderSkillMdRaw: BUNDLED, stamp: stampFor(BUNDLED), currentBundledRaw: newBundled })).toBe(
+      'update-available'
+    );
+  });
+
+  it('reports locally-modified when the folder diverges from its stamp', () => {
+    const editedFolder = `${BUNDLED}\noperator edit\n`;
+    expect(deriveStatus({ folderSkillMdRaw: editedFolder, stamp: stampFor(BUNDLED), currentBundledRaw: BUNDLED })).toBe(
+      'locally-modified'
+    );
+  });
+
+  it('lets locally-modified win when the folder is edited AND the bundle also moved on', () => {
+    const editedFolder = `${BUNDLED}\noperator edit\n`;
+    const newBundled = `${BUNDLED}\nnew upstream line\n`;
+    // Both divergences hold; the edit must win so `update` never silently discards it.
+    expect(
+      deriveStatus({ folderSkillMdRaw: editedFolder, stamp: stampFor(BUNDLED), currentBundledRaw: newBundled })
+    ).toBe('locally-modified');
+  });
+});
+
+describe('createProvenanceStore', () => {
+  const store = createProvenanceStore({ writeFile: createAtomicWriteFile() });
+
+  it('round-trips a stamp through write → read', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'provenance-'));
+    const stamp = stampFor(BUNDLED);
+
+    const written = await store.writeProvenance(abs(dir), stamp);
+    expect(written.ok).toBe(true);
+
+    // The sidecar lands at the documented filename and is valid pretty-printed JSON on disk.
+    const onDisk = await readFile(join(dir, PROVENANCE_FILENAME), 'utf-8');
+    expect(JSON.parse(onDisk)).toEqual(stamp);
+
+    const read = await store.readProvenance(abs(dir));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.value).toEqual(stamp);
+  });
+
+  it('returns ok(undefined) for an unstamped folder (missing sidecar)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'provenance-'));
+    const read = await store.readProvenance(abs(dir));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.value).toBeUndefined();
+  });
+
+  it('treats a malformed sidecar as a soft signal → ok(undefined)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'provenance-'));
+    await writeFile(join(dir, PROVENANCE_FILENAME), 'not json at all', 'utf-8');
+    const read = await store.readProvenance(abs(dir));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.value).toBeUndefined();
+  });
+
+  it('treats a well-formed JSON sidecar missing required fields as ok(undefined)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'provenance-'));
+    // Valid JSON, wrong shape (no contentHash / wrong source) — still a soft signal, not an error.
+    await writeFile(join(dir, PROVENANCE_FILENAME), JSON.stringify({ source: 'bundled', skill: 'x' }), 'utf-8');
+    const read = await store.readProvenance(abs(dir));
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.value).toBeUndefined();
+  });
+});

--- a/tests/integration/ai/skills/phase/source.test.ts
+++ b/tests/integration/ai/skills/phase/source.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { createEventBusLogger } from '@src/business/observability/event-bus-logger.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { AppEvent, LogEvent } from '@src/business/observability/events.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+// The operator source lives in a sibling directory; the SOURCE modules may not cross-import (ESLint
+// sibling-isolation), but a TEST may. We import the real `OPERATOR_PROVIDER_DIR` here so the
+// disjointness guard checks the ACTUAL operator constant, not a local copy, and reuse the operator's
+// `RALPHCTL_SKILL_PREFIX` (the same namespace the phase source replicates) for the `ns` helper.
+import { OPERATOR_PROVIDER_DIR, RALPHCTL_SKILL_PREFIX } from '@src/integration/ai/skills/operator/source.ts';
+import { createPhaseSkillSource, PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
+
+const ns = (name: string): string => `${RALPHCTL_SKILL_PREFIX}${name}`;
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+/** A logger backed by a real in-memory bus so tests assert genuine `LogEvent`s, not call spies. */
+const recordingLogger = (): { logger: ReturnType<typeof createEventBusLogger>; logs: LogEvent[] } => {
+  const bus = createInMemoryEventBus();
+  const logs: LogEvent[] = [];
+  bus.subscribe((e: AppEvent) => {
+    if (e.type === 'log') logs.push(e);
+  });
+  return { logger: createEventBusLogger({ eventBus: bus, clock: IsoTimestamp.now }), logs };
+};
+
+const writeSkill = async (
+  root: string,
+  flowDir: string,
+  name: string,
+  opts: { frontmatterName?: string; description?: string } = {}
+): Promise<void> => {
+  const { frontmatterName = name, description = `${name} guidance` } = opts;
+  const dir = join(root, flowDir, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${frontmatterName}\ndescription: ${description}\n---\n\n# ${name}\nbody\n`,
+    'utf-8'
+  );
+};
+
+describe('createPhaseSkillSource', () => {
+  it('returns an empty list (no warning) when the flow directory is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    const { logger, logs } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+    // A missing dir is the common no-config case — not even a warning.
+    expect(logs.filter((l) => l.level === 'warn')).toEqual([]);
+  });
+
+  it('reads <root>/<flowDir>/*/SKILL.md and returns parsed + prefixed skills for that flow only', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'impl-alpha');
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'impl-beta');
+    // A skill under a DIFFERENT flow dir must not leak into `implement`.
+    await writeSkill(root, PHASE_FLOW_DIR.plan, 'plan-only');
+    const { logger } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Install names carry the `ralphctl-` prefix so the adapter's exclude wildcard hides them.
+    expect(result.value.map((s) => s.name).sort()).toEqual([ns('impl-alpha'), ns('impl-beta')]);
+    const alpha = result.value.find((s) => s.name === ns('impl-alpha'));
+    expect(alpha?.description).toBe('impl-alpha guidance');
+    expect(alpha?.content).toContain('# impl-alpha');
+
+    // The plan-only skill is reachable only through the plan directory.
+    const plan = await source.getForFlow('plan');
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.value.map((s) => s.name)).toEqual([ns('plan-only')]);
+  });
+
+  it('does not double-prefix a folder already named ralphctl-*', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    await writeSkill(root, PHASE_FLOW_DIR.refine, 'ralphctl-prewired');
+    const { logger } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('refine');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((s) => s.name)).toEqual(['ralphctl-prewired']);
+  });
+
+  it('resolves the create-pr directory for the createPr flow id', async () => {
+    expect(PHASE_FLOW_DIR.createPr).toBe('create-pr');
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    // Write under the kebab-case directory; the camelCase flow id must find it.
+    await writeSkill(root, 'create-pr', 'pr-checklist');
+    const { logger } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('createPr');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((s) => s.name)).toEqual([ns('pr-checklist')]);
+  });
+
+  it('skips a malformed skill (frontmatter name mismatch) with a logged warning, keeping the rest', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'good-skill');
+    // Folder name vs frontmatter name disagree → parse error → skipped.
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'mismatch-folder', { frontmatterName: 'different-name' });
+    const { logger, logs } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((s) => s.name)).toEqual([ns('good-skill')]);
+    expect(logs.some((l) => l.level === 'warn' && l.message.includes('invalid'))).toBe(true);
+  });
+
+  it('skips an unreadable individual skill with a logged warning, keeping the rest', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    const flowDir = PHASE_FLOW_DIR.implement;
+    await writeSkill(root, flowDir, 'good-skill');
+    // Make `<root>/<flowDir>/wedged/SKILL.md` a DIRECTORY → read fails with EISDIR, skip it.
+    await mkdir(join(root, flowDir, 'wedged', 'SKILL.md'), { recursive: true });
+    const { logger, logs } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((s) => s.name)).toEqual([ns('good-skill')]);
+    expect(logs.some((l) => l.level === 'warn' && l.message.includes('not readable'))).toBe(true);
+  });
+
+  it('emits a warn LogEvent for a contract-violating skill but still returns it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'risky-skill');
+    const { logger, logs } = recordingLogger();
+
+    const violations: string[] = [];
+    const warnIfContractViolated = (skill: Skill): void => {
+      violations.push(skill.name);
+      // A real guard logs through the same logger; emulate that so the LogEvent assertion holds.
+      logger.named('skills.contract').warn('phase skill violates contract', { name: skill.name });
+    };
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger, warnIfContractViolated });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Still installed — the operator owns their skills.
+    expect(result.value.map((s) => s.name)).toEqual([ns('risky-skill')]);
+    expect(violations).toEqual([ns('risky-skill')]);
+    const warnLogs = logs.filter((l) => l.level === 'warn');
+    expect(warnLogs.some((l) => l.message.includes('phase skill violates contract'))).toBe(true);
+  });
+
+  it('ignores non-SKILL.md sidecar files and dotfile entries in the flow directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    const flowDir = PHASE_FLOW_DIR.implement;
+    await writeSkill(root, flowDir, 'real-skill');
+    // A provenance sidecar INSIDE the skill folder — a later task stamps this; it must never be
+    // read as a skill (only `SKILL.md` is).
+    await writeFile(join(root, flowDir, 'real-skill', '.provenance.json'), '{"source":"bundled"}', 'utf-8');
+    // A stray file directly under the flow dir — not a directory, skipped.
+    await writeFile(join(root, flowDir, 'notes.md'), 'scratch', 'utf-8');
+    // A dotfile directory — skipped, and must NOT produce a "not readable" warning.
+    await mkdir(join(root, flowDir, '.git'), { recursive: true });
+    const { logger, logs } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((s) => s.name)).toEqual([ns('real-skill')]);
+    expect(logs.filter((l) => l.level === 'warn')).toEqual([]);
+  });
+
+  it('getByName searches every flow directory and returns undefined for unknown names', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    await writeSkill(root, PHASE_FLOW_DIR.plan, 'in-plan');
+    await writeSkill(root, PHASE_FLOW_DIR.readiness, 'in-readiness');
+    const { logger } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const fromPlan = await source.getByName(ns('in-plan'));
+    expect(fromPlan.ok).toBe(true);
+    if (!fromPlan.ok) return;
+    expect(fromPlan.value?.name).toBe(ns('in-plan'));
+
+    const fromReadiness = await source.getByName(ns('in-readiness'));
+    expect(fromReadiness.ok).toBe(true);
+    if (!fromReadiness.ok) return;
+    expect(fromReadiness.value?.name).toBe(ns('in-readiness'));
+
+    const miss = await source.getByName('nope');
+    expect(miss.ok).toBe(true);
+    if (!miss.ok) return;
+    expect(miss.value).toBeUndefined();
+  });
+
+  it('getByName first match wins in the canonical FLOW_IDS order (refine before implement)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'phase-source-'));
+    // Same folder name in two flow dirs; refine precedes implement in FLOW_IDS, so it wins.
+    await writeSkill(root, PHASE_FLOW_DIR.refine, 'dup-skill', { description: 'from refine' });
+    await writeSkill(root, PHASE_FLOW_DIR.implement, 'dup-skill', { description: 'from implement' });
+    const { logger } = recordingLogger();
+
+    const source = createPhaseSkillSource({ operatorSkillsRoot: abs(root), logger });
+    const hit = await source.getByName(ns('dup-skill'));
+    expect(hit.ok).toBe(true);
+    if (!hit.ok) return;
+    expect(hit.value?.description).toBe('from refine');
+  });
+
+  it('phase flow-dir names are disjoint from operator provider-dir names (shared parent root)', () => {
+    const flowDirs = new Set(Object.values(PHASE_FLOW_DIR));
+    const providerDirs = Object.values(OPERATOR_PROVIDER_DIR);
+    const overlap = providerDirs.filter((d) => flowDirs.has(d));
+    expect(overlap).toEqual([]);
+  });
+});

--- a/tests/integration/application/ui/tui/prompts/multi-choice-initial-roundtrip.test.tsx
+++ b/tests/integration/application/ui/tui/prompts/multi-choice-initial-roundtrip.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * The REAL production path for a pre-seeded multi-choice checklist:
+ *
+ *   createInkInteractivePrompt(queue).askMultiChoice(msg, options, { initial })
+ *     → PromptQueue entry `initial`
+ *     → <PromptHost> conditional spread (prompt-host.tsx)
+ *     → <MultiSelectPrompt initialSelectedValues>
+ *
+ * Every other test either renders MultiSelectPrompt directly with props or scripts the
+ * InteractivePrompt port, so the one spread in PromptHost carried no coverage — yet a regression
+ * there opens every customize-picker checklist EMPTY, and submitting an empty checklist emits
+ * `disabled = everything`, silently disabling all skills for the run. These cases fence the
+ * queue→host threading and the submit round-trip.
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from 'ink-testing-library';
+import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
+import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-interactive-prompt.ts';
+import { PromptHost } from '@src/application/ui/tui/prompts/prompt-host.tsx';
+import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import type { Choice } from '@src/business/interactive/prompt.ts';
+import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+
+const Host = ({ queue }: { readonly queue: ReturnType<typeof createPromptQueue> }): React.JSX.Element => (
+  <UiStateProvider>
+    <PromptHost queue={queue} />
+  </UiStateProvider>
+);
+
+const OPTIONS: ReadonlyArray<Choice<string>> = [
+  { label: 'Alpha', value: 'a' },
+  { label: 'Bravo', value: 'b' },
+  { label: 'Charlie', value: 'c' },
+  { label: 'Delta (protected)', value: 'd', disabled: true, description: 'cannot toggle' },
+];
+
+describe('askMultiChoice initial seeding through the real queue → PromptHost path', () => {
+  it('opens pre-checked to `initial` and ENTER round-trips exactly those values', async () => {
+    const queue = createPromptQueue();
+    const interactive = createInkInteractivePrompt(queue);
+    const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
+
+    const answer = interactive.askMultiChoice<string>('Skills for this run:', OPTIONS, { initial: ['a', 'c'] });
+    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await tick(50); // give useInput's subscription time to attach before the first keypress
+
+    const frame = lastFrame() ?? '';
+    // Alpha + Charlie pre-checked, Bravo not — the exact `initial` seeding, not empty, not all.
+    expect(frame).toMatch(/\[.]\s*Alpha/);
+    expect(frame).toMatch(/\[ ]\s*Bravo/);
+    expect(frame).toMatch(/\[.]\s*Charlie/);
+
+    stdin.write('\r');
+    await tick();
+    const result = await answer;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.value].sort()).toEqual(['a', 'c']);
+    unmount();
+  });
+
+  it('space on a disabled row is a no-op and select-all excludes disabled rows', async () => {
+    const queue = createPromptQueue();
+    const interactive = createInkInteractivePrompt(queue);
+    const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
+
+    const answer = interactive.askMultiChoice<string>('Pick:', OPTIONS, { initial: [] });
+    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await tick(50); // give useInput's subscription time to attach before the first keypress
+
+    // select-all must not pull in the disabled Delta row.
+    stdin.write('a');
+    await tick();
+    stdin.write('\r');
+    await tick();
+    const result = await answer;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...result.value].sort()).toEqual(['a', 'b', 'c']);
+    unmount();
+  });
+
+  it('omitted initial opens with nothing checked (backward compatibility)', async () => {
+    const queue = createPromptQueue();
+    const interactive = createInkInteractivePrompt(queue);
+    const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
+
+    const answer = interactive.askMultiChoice<string>('Pick:', OPTIONS);
+    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await tick(50); // give useInput's subscription time to attach before the first keypress
+    expect(lastFrame() ?? '').toMatch(/\[ ]\s*Alpha/);
+
+    stdin.write('\r');
+    await tick();
+    const result = await answer;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+    unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -35,7 +35,7 @@ import {
   modelCatalogFor,
   runCustomizePicker,
 } from '@src/application/ui/tui/views/flows-customize-picker.ts';
-import { applyOverrideToSettings } from '@src/application/ui/shared/launcher.ts';
+import { applyOverrideToSettings, type SkillCandidatesResult } from '@src/application/ui/shared/launcher.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
@@ -55,7 +55,12 @@ interface ScriptEntryPick {
 interface ScriptEntryCancel {
   readonly action: 'cancel';
 }
-type ScriptEntry = ScriptEntryPick | ScriptEntryCancel;
+interface ScriptEntryMultiPick {
+  readonly action: 'multiPick';
+  /** Each entry is either an option label or a value — first label match wins per entry. */
+  readonly choices: readonly string[];
+}
+type ScriptEntry = ScriptEntryPick | ScriptEntryCancel | ScriptEntryMultiPick;
 
 interface CapturedPrompt {
   readonly message: string;
@@ -77,8 +82,32 @@ const buildScriptedPrompt = (
     async askConfirm() {
       throw new Error('askConfirm not supported by scripted prompt');
     },
-    async askMultiChoice() {
-      throw new Error('askMultiChoice not supported by scripted prompt');
+    async askMultiChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
+      captured.push({ message, options: options.map((o) => o.label) });
+      const entry = script[cursor];
+      cursor += 1;
+      if (entry === undefined) {
+        throw new Error(`scripted prompt exhausted at message: ${message}`);
+      }
+      if (entry.action === 'cancel') {
+        return Result.error(new AbortError({ elementName: 'test', reason: 'scripted cancel' })) as unknown as Result<
+          readonly T[],
+          DomainError
+        >;
+      }
+      if (entry.action !== 'multiPick') {
+        throw new Error(`scripted prompt: expected a multiPick entry at message: ${message}`);
+      }
+      const values = entry.choices.map((choice) => {
+        const found = options.find((o) => o.label === choice) ?? options.find((o) => String(o.value) === choice);
+        if (found === undefined) {
+          throw new Error(
+            `scripted prompt: option '${choice}' not found in ${options.map((o) => o.label).join(' / ')}`
+          );
+        }
+        return found.value;
+      });
+      return Result.ok(values) as unknown as Result<readonly T[], DomainError>;
     },
     async askChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
       captured.push({ message, options: options.map((o) => o.label) });
@@ -92,6 +121,9 @@ const buildScriptedPrompt = (
           T,
           DomainError
         >;
+      }
+      if (entry.action !== 'pick') {
+        throw new Error(`scripted prompt: expected a pick entry at message: ${message}`);
       }
       const found =
         options.find((o) => o.label === entry.choice) ?? options.find((o) => String(o.value) === entry.choice);
@@ -886,5 +918,316 @@ describe('runCustomizePicker — availableModelsFor gates the model step', () =>
     const modelOptions = modelOptionsFromCapture(captured);
     for (const model of subset) expect(modelOptions).toContain(buildExpectedModelLabel(model));
     for (const model of excluded) expect(modelOptions).not.toContain(buildExpectedModelLabel(model));
+  });
+});
+
+describe('runCustomizePicker — skills step (T6)', () => {
+  // Fixture candidates — two bundled-default skills for `refine`, neither saved-disabled.
+  const FIXTURE_CANDIDATES: SkillCandidatesResult = {
+    settingsFlow: 'refine',
+    candidates: [
+      { name: 'ralphctl-alignment', description: 'Confirm scope before diving into work', origin: 'bundled-default' },
+      { name: 'ralphctl-iterative-review', description: 'Iterate on the review', origin: 'bundled-default' },
+    ],
+    savedDisabled: [],
+  };
+
+  /** Row-walk script that keeps every default for `refine` — used as a customize-path prefix. */
+  const KEEP_ROW_SCRIPT: readonly ScriptEntry[] = [
+    { action: 'pick', choice: 'Customize for this run…' },
+    { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai.refine.provider})` },
+    { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai.refine.model})` },
+    { action: 'pick', choice: 'Keep default (auto)' },
+  ];
+
+  it('no skillCandidates supplied → no skills prompt at all, even inside Customize', async () => {
+    const { interactive, captured } = buildScriptedPrompt(KEEP_ROW_SCRIPT);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+    });
+    expect(result.kind).toBe('defaults');
+    expect((result as { skills?: unknown }).skills).toBeUndefined();
+    expect(captured.some((c) => c.message === 'Skills:')).toBe(false);
+  });
+
+  it('candidates present but empty → no skills prompt (same as absent)', async () => {
+    const { interactive, captured } = buildScriptedPrompt(KEEP_ROW_SCRIPT);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: { settingsFlow: 'refine', candidates: [], savedDisabled: [] },
+    });
+    expect(result.kind).toBe('defaults');
+    expect((result as { skills?: unknown }).skills).toBeUndefined();
+    expect(captured.some((c) => c.message === 'Skills:')).toBe(false);
+  });
+
+  it('Keep skills → result carries no skills field; exactly one skills prompt shown', async () => {
+    const { interactive, captured } = buildScriptedPrompt([...KEEP_ROW_SCRIPT, { action: 'pick', choice: 'keep' }]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    expect(result.kind).toBe('defaults');
+    expect((result as { skills?: unknown }).skills).toBeUndefined();
+    const skillsPrompts = captured.filter((c) => c.message === 'Skills:');
+    expect(skillsPrompts).toHaveLength(1);
+    expect(skillsPrompts[0]?.options).toEqual(['Keep skills (2 active)', 'Customize skills for this run…']);
+  });
+
+  it('Customize skills + uncheck one + run-only → skills.disabled = [that name]; saveAsDefault false', async () => {
+    // The checklist opens pre-checked to both candidates; leaving only `ralphctl-alignment`
+    // checked in the submitted (enabled) set disables the other one.
+    const { interactive } = buildScriptedPrompt([
+      ...KEEP_ROW_SCRIPT,
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: ['ralphctl-alignment'] },
+      { action: 'pick', choice: 'run-only' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    if (result.kind !== 'defaults') throw new Error(`expected kind 'defaults', got ${result.kind}`);
+    expect(result.skills).toEqual({ disabled: ['ralphctl-iterative-review'], saveAsDefault: false });
+  });
+
+  it('Customize skills + uncheck one + remember → saveAsDefault true', async () => {
+    const { interactive } = buildScriptedPrompt([
+      ...KEEP_ROW_SCRIPT,
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: ['ralphctl-alignment'] },
+      { action: 'pick', choice: 'remember' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    if (result.kind !== 'defaults') throw new Error(`expected kind 'defaults', got ${result.kind}`);
+    expect(result.skills).toEqual({ disabled: ['ralphctl-iterative-review'], saveAsDefault: true });
+  });
+
+  it('Customize skills + re-check a saved-disabled skill + run-only → skills.disabled = [] (re-enables it)', async () => {
+    // savedDisabled has `ralphctl-iterative-review` off; the checklist opens with it UNCHECKED
+    // (only `ralphctl-alignment` pre-checked). Submitting with BOTH checked re-enables it for
+    // this run — the mechanism a per-run RE-ENABLE relies on.
+    const { interactive } = buildScriptedPrompt([
+      ...KEEP_ROW_SCRIPT,
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: ['ralphctl-alignment', 'ralphctl-iterative-review'] },
+      { action: 'pick', choice: 'run-only' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: { ...FIXTURE_CANDIDATES, savedDisabled: ['ralphctl-iterative-review'] },
+    });
+    if (result.kind !== 'defaults') throw new Error(`expected kind 'defaults', got ${result.kind}`);
+    expect(result.skills).toEqual({ disabled: [], saveAsDefault: false });
+  });
+
+  it('a row change AND a skills change both surface on the same result (kind single)', async () => {
+    const otherModel = CLAUDE_MODELS.find((m) => m !== DEFAULT_SETTINGS.ai.refine.model)!;
+    const { interactive } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai.refine.provider})` },
+      { action: 'pick', choice: otherModel },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: ['ralphctl-iterative-review'] },
+      { action: 'pick', choice: 'run-only' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    if (result.kind !== 'single') throw new Error(`expected kind 'single', got ${result.kind}`);
+    expect(result.override.model).toBe(otherModel);
+    expect(result.skills).toEqual({ disabled: ['ralphctl-alignment'], saveAsDefault: false });
+  });
+
+  it('cancel at the skills entry prompt → kind cancel (row change discarded too)', async () => {
+    const { interactive } = buildScriptedPrompt([...KEEP_ROW_SCRIPT, { action: 'cancel' }]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    expect(result.kind).toBe('cancel');
+  });
+
+  it('cancel at the disable checklist → kind cancel', async () => {
+    const { interactive } = buildScriptedPrompt([
+      ...KEEP_ROW_SCRIPT,
+      { action: 'pick', choice: 'customize' },
+      { action: 'cancel' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    expect(result.kind).toBe('cancel');
+  });
+
+  it('cancel at the remember prompt → kind cancel', async () => {
+    const { interactive } = buildScriptedPrompt([
+      ...KEEP_ROW_SCRIPT,
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: ['ralphctl-alignment'] },
+      { action: 'cancel' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    expect(result.kind).toBe('cancel');
+  });
+
+  it("checklist opens pre-checked to today's effective state (checked = enabled, unchecked = saved-disabled)", async () => {
+    let checklistOptions: readonly string[] | undefined;
+    let checklistInitial: readonly unknown[] | undefined;
+    const interactive: InteractivePrompt = {
+      async askText() {
+        throw new Error('not used');
+      },
+      async askTextArea() {
+        throw new Error('not used');
+      },
+      async askConfirm() {
+        throw new Error('not used');
+      },
+      async askChoice<T>(message: string, options: ReadonlyArray<Choice<T>>) {
+        if (message.includes('What would you like to do?')) {
+          const c = options.find((o) => o.label === 'Customize for this run…');
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        if (message.includes('Provider:') || message.includes('Model:') || message.includes('Effort:')) {
+          const c = options.find((o) => o.label.startsWith('Keep default'));
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        if (message === 'Skills:') {
+          const c = options.find((o) => String(o.value) === 'customize');
+          return Result.ok(c!.value) as unknown as Result<T, DomainError>;
+        }
+        throw new Error(`unexpected askChoice prompt: ${message}`);
+      },
+      async askMultiChoice<T>(
+        _message: string,
+        options: ReadonlyArray<Choice<T>>,
+        opts?: { readonly initial?: readonly T[] }
+      ) {
+        checklistOptions = options.map((o) => o.label);
+        checklistInitial = opts?.initial;
+        return Result.error(new AbortError({ elementName: 'test', reason: 'snapshot' })) as unknown as Result<
+          readonly T[],
+          DomainError
+        >;
+      },
+    };
+    await runCustomizePicker({
+      interactive,
+      flowId: 'refine',
+      flowTitle: 'Refine',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: { ...FIXTURE_CANDIDATES, savedDisabled: ['ralphctl-iterative-review'] },
+    });
+    // Origin marker only — no redundant state suffix; the pre-checked seeding carries the state.
+    expect(checklistOptions).toEqual(['ralphctl-alignment (default)', 'ralphctl-iterative-review (default)']);
+    // Pre-checked to the effective set — only the non-saved-disabled candidate.
+    expect(checklistInitial).toEqual(['ralphctl-alignment']);
+  });
+});
+
+describe('runCustomizePicker — implement skills step runs once, flow-level (T6)', () => {
+  const FIXTURE_CANDIDATES: SkillCandidatesResult = {
+    settingsFlow: 'implement',
+    candidates: [{ name: 'ralphctl-alignment', description: 'Confirm scope', origin: 'bundled-default' }],
+    savedDisabled: [],
+  };
+
+  it('keep-all-defaults on both roles + customize skills → skills step runs exactly once', async () => {
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const { interactive, captured } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      // generator (keep all)
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: `Keep default (${gen.model})` },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      // evaluator (keep all)
+      { action: 'pick', choice: `Keep default (${eva.provider})` },
+      { action: 'pick', choice: `Keep default (${eva.model})` },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      // skills — once, after BOTH roles. Unchecking the lone candidate disables it.
+      { action: 'pick', choice: 'customize' },
+      { action: 'multiPick', choices: [] },
+      { action: 'pick', choice: 'run-only' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    // Both roles kept every default, so `kind` is 'defaults' — modulo the skills change.
+    if (result.kind !== 'defaults') throw new Error(`expected kind 'defaults', got ${result.kind}`);
+    expect(result.skills).toEqual({ disabled: ['ralphctl-alignment'], saveAsDefault: false });
+    // Exactly one "Skills:" prompt — never per-role.
+    expect(captured.filter((c) => c.message === 'Skills:')).toHaveLength(1);
+  });
+
+  it('a generator-only change still surfaces the single flow-level skills step (kind implement)', async () => {
+    const gen = DEFAULT_SETTINGS.ai.implement.generator;
+    const eva = DEFAULT_SETTINGS.ai.implement.evaluator;
+    const newGenModel = CLAUDE_MODELS.find((m) => m !== gen.model)!;
+    const { interactive, captured } = buildScriptedPrompt([
+      { action: 'pick', choice: 'Customize for this run…' },
+      { action: 'pick', choice: `Keep default (${gen.provider})` },
+      { action: 'pick', choice: newGenModel },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      { action: 'pick', choice: `Keep default (${eva.provider})` },
+      { action: 'pick', choice: `Keep default (${eva.model})` },
+      { action: 'pick', choice: 'Keep default (auto)' },
+      { action: 'pick', choice: 'keep' },
+    ]);
+    const result = await runCustomizePicker({
+      interactive,
+      flowId: 'implement',
+      flowTitle: 'Implement',
+      settings: DEFAULT_SETTINGS,
+      skillCandidates: FIXTURE_CANDIDATES,
+    });
+    if (result.kind !== 'implement') throw new Error(`expected kind 'implement', got ${result.kind}`);
+    expect(result.implementRoleOverrides.generator).toEqual({ model: newGenModel });
+    expect(result.skills).toBeUndefined();
+    expect(captured.filter((c) => c.message === 'Skills:')).toHaveLength(1);
   });
 });

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -921,7 +921,7 @@ describe('runCustomizePicker — availableModelsFor gates the model step', () =>
   });
 });
 
-describe('runCustomizePicker — skills step (T6)', () => {
+describe('runCustomizePicker — skills step', () => {
   // Fixture candidates — two bundled-default skills for `refine`, neither saved-disabled.
   const FIXTURE_CANDIDATES: SkillCandidatesResult = {
     settingsFlow: 'refine',
@@ -930,6 +930,7 @@ describe('runCustomizePicker — skills step (T6)', () => {
       { name: 'ralphctl-iterative-review', description: 'Iterate on the review', origin: 'bundled-default' },
     ],
     savedDisabled: [],
+    degraded: false,
   };
 
   /** Row-walk script that keeps every default for `refine` — used as a customize-path prefix. */
@@ -960,7 +961,7 @@ describe('runCustomizePicker — skills step (T6)', () => {
       flowId: 'refine',
       flowTitle: 'Refine',
       settings: DEFAULT_SETTINGS,
-      skillCandidates: { settingsFlow: 'refine', candidates: [], savedDisabled: [] },
+      skillCandidates: { settingsFlow: 'refine', candidates: [], savedDisabled: [], degraded: false },
     });
     expect(result.kind).toBe('defaults');
     expect((result as { skills?: unknown }).skills).toBeUndefined();
@@ -1165,11 +1166,12 @@ describe('runCustomizePicker — skills step (T6)', () => {
   });
 });
 
-describe('runCustomizePicker — implement skills step runs once, flow-level (T6)', () => {
+describe('runCustomizePicker — implement skills step runs once, flow-level', () => {
   const FIXTURE_CANDIDATES: SkillCandidatesResult = {
     settingsFlow: 'implement',
     candidates: [{ name: 'ralphctl-alignment', description: 'Confirm scope', origin: 'bundled-default' }],
     savedDisabled: [],
+    degraded: false,
   };
 
   it('keep-all-defaults on both roles + customize skills → skills step runs exactly once', async () => {

--- a/tests/integration/application/ui/tui/views/skills-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/skills-view.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * Render + interaction tests for `SkillsView`. Uses a hand-rolled in-memory fake
+ * `SkillCatalogPort` (not the real `phase/catalog.ts` filesystem implementation, and not the
+ * real `BUNDLED_SKILLS` content) so these tests stay independent of the actual skill catalog —
+ * except for `name`, which MUST match a real `BUNDLED_SKILLS` entry for the view to treat a row
+ * as "bundled" (`bundledNames` is computed from the real registry import, not from test data).
+ * A synthetic name with no `ralphctl-` prefix is used for the manual-entry case, guaranteed to
+ * never collide with a real bundled skill.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { SkillCatalogEntry, SkillCatalogPort } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { SkillsView } from '@src/application/ui/tui/views/skills-view.tsx';
+import { DOWN, ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+/** In-memory fake catalog: mutates a closured entry array so `enable`/`disable`/`update` are visible on the next `list()`. */
+const fakeCatalog = (initial: readonly SkillCatalogEntry[]): SkillCatalogPort => {
+  let entries = initial;
+  return {
+    async list() {
+      return Result.ok(entries);
+    },
+    async enable(name, flows) {
+      entries = entries.map((e) =>
+        e.name === name
+          ? {
+              ...e,
+              installs: [
+                ...e.installs.filter((i) => !flows.includes(i.flow)),
+                ...flows.map((f) => ({ flow: f, status: 'in-sync' as const })),
+              ],
+            }
+          : e
+      );
+      return Result.ok(undefined);
+    },
+    async disable(name, flows) {
+      entries = entries.map((e) =>
+        e.name === name ? { ...e, installs: e.installs.filter((i) => !flows.includes(i.flow)) } : e
+      );
+      return Result.ok(undefined);
+    },
+    async update(name, flows) {
+      entries = entries.map((e) =>
+        e.name === name
+          ? {
+              ...e,
+              installs: e.installs.map((i) => (flows.includes(i.flow) ? { ...i, status: 'in-sync' as const } : i)),
+            }
+          : e
+      );
+      return Result.ok(undefined);
+    },
+    async updateAll() {
+      const updated: string[] = [];
+      entries = entries.map((e) => {
+        if (!e.installs.some((i) => i.status === 'update-available')) return e;
+        updated.push(e.name);
+        return {
+          ...e,
+          installs: e.installs.map((i) => (i.status === 'update-available' ? { ...i, status: 'in-sync' as const } : i)),
+        };
+      });
+      return Result.ok({ updated });
+    },
+  };
+};
+
+const buildDeps = (skillCatalog: SkillCatalogPort): AppDeps =>
+  ({
+    skillCatalog,
+    storage: { operatorSkillsRoot: abs('/tmp/ralphctl-skills-root-test') },
+  }) as unknown as AppDeps;
+
+const bundledName = (): string => {
+  const entry = BUNDLED_SKILLS[0];
+  if (entry === undefined) throw new Error('BUNDLED_SKILLS is unexpectedly empty');
+  return entry.name;
+};
+
+describe('SkillsView', () => {
+  it('renders a bundled skill row with its description and the always-on default chip', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'Confirm scope before diving into work',
+        defaultFor: ['implement'],
+        recommendedFor: [],
+        installs: [],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain(name);
+    expect(frame).toContain('Confirm scope before diving into work');
+    // Implement is default-on: the phaseDone glyph ('■') marks it regardless of any install row.
+    expect(frame).toContain('■ imp');
+    // Refine is neither default-on nor installed: the phaseDisabled glyph ('◌') marks it.
+    expect(frame).toContain('◌ ref');
+    // No opt-in copies exist anywhere — the hint should point at the enable key + folder.
+    expect(frame).toContain('no opt-in copies yet');
+  });
+
+  it('shows the "(manual)" tag for a phase-folder entry with no matching bundled skill', async () => {
+    const catalog = fakeCatalog([
+      {
+        name: 'hand-authored-thing',
+        description: 'dropped in by hand',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'implement', status: 'manual' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes('hand-authored-thing'));
+    expect(result.lastFrame() ?? '').toContain('(manual)');
+  });
+
+  it('enable: opens the flow picker with recommendedFor preselected, default-on flows disabled', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'a recommendable skill',
+        defaultFor: ['refine'],
+        recommendedFor: ['plan', 'implement'],
+        installs: [],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('e');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain(`Enable "${name}" for:`);
+    // Refine is default-on: shown but disabled with an explanatory description.
+    expect(frame).toContain('Refine');
+    expect(frame).toContain('already default-on');
+    // Plan + Implement are recommended: preselected (checked).
+    expect(frame).toMatch(/\[[xX✔✓]]\s*Plan/);
+    expect(frame).toMatch(/\[[xX✔✓]]\s*Implement/);
+  });
+
+  it('enable: submitting the preselected flows calls enable() and the row reflects in-sync afterwards', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([{ name, description: 'x', defaultFor: [], recommendedFor: ['plan'], installs: [] }]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('e');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('enabled'));
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value[0]?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+  });
+
+  it('enable: a manual entry (no bundled counterpart) rejects with an error toast, no picker opens', async () => {
+    const catalog = fakeCatalog([
+      {
+        name: 'hand-authored-thing',
+        description: 'x',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'implement', status: 'manual' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes('hand-authored-thing'));
+
+    result.stdin.write('e');
+    await waitFor(() => (result.lastFrame() ?? '').includes('nothing to enable'));
+    expect(result.lastFrame() ?? '').not.toContain('Enable "hand-authored-thing" for:');
+  });
+
+  it('disable: removes a non-destructive install directly, no confirm', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      { name, description: 'x', defaultFor: [], recommendedFor: [], installs: [{ flow: 'plan', status: 'in-sync' }] },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('d');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Disable'));
+    result.stdin.write(' '); // toggle Plan on
+    await tick();
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('disabled'));
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value[0]?.installs).toEqual([]);
+  });
+
+  it('disable: confirms before removing a locally-modified install', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'x',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'plan', status: 'locally-modified' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('d');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Disable'));
+    result.stdin.write(' ');
+    await tick();
+    result.stdin.write(ENTER);
+    await waitFor(() => (result.lastFrame() ?? '').includes('permanently lost'));
+    // The install must still be present — nothing happened until the confirm is answered.
+    const midway = await catalog.list();
+    expect(midway.ok && midway.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
+
+    result.stdin.write('y');
+    await waitFor(() => (result.lastFrame() ?? '').includes('disabled'));
+    const after = await catalog.list();
+    expect(after.ok && after.value[0]?.installs).toEqual([]);
+  });
+
+  it('update-all: updates every stale install and reports the count', async () => {
+    const [first, second] = BUNDLED_SKILLS;
+    if (first === undefined || second === undefined || first.name === second.name) {
+      throw new Error('test requires at least two distinct BUNDLED_SKILLS entries');
+    }
+    const catalog = fakeCatalog([
+      {
+        name: first.name,
+        description: 'x',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'plan', status: 'update-available' }],
+      },
+      {
+        name: second.name,
+        description: 'y',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'implement', status: 'in-sync' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(first.name));
+
+    result.stdin.write('U');
+    await waitFor(() => (result.lastFrame() ?? '').includes('updated 1 skill'));
+
+    const listed = await catalog.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value[0]?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+    expect(listed.value[1]?.installs).toEqual([{ flow: 'implement', status: 'in-sync' }]);
+  });
+
+  it('propagates a StorageError from list() as a load-error row', async () => {
+    const catalog: SkillCatalogPort = {
+      list: vi.fn(async () => Result.error(new StorageError({ subCode: 'io', message: 'boom' }))),
+      enable: vi.fn(),
+      disable: vi.fn(),
+      update: vi.fn(),
+      updateAll: vi.fn(),
+    } as unknown as SkillCatalogPort;
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitFor(() => (result.lastFrame() ?? '').includes('Failed to load'));
+    expect(result.lastFrame() ?? '').toContain('Failed to load the skill catalog.');
+  });
+
+  it('reload (r) re-fetches after the cursor has moved', async () => {
+    const [first, second] = BUNDLED_SKILLS;
+    if (first === undefined || second === undefined || first.name === second.name) {
+      throw new Error('test requires at least two distinct BUNDLED_SKILLS entries');
+    }
+    const catalog = fakeCatalog([
+      { name: first.name, description: 'x', defaultFor: [], recommendedFor: [], installs: [] },
+      { name: second.name, description: 'y', defaultFor: [], recommendedFor: [], installs: [] },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(first.name));
+    result.stdin.write(DOWN);
+    await tick();
+    result.stdin.write('r');
+    await waitFor(() => (result.lastFrame() ?? '').includes('reloading'));
+    expect(result.lastFrame() ?? '').toContain(second.name);
+  });
+});

--- a/tests/integration/application/ui/tui/views/skills-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/skills-view.test.tsx
@@ -10,6 +10,8 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { Result } from '@src/domain/result.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
@@ -26,9 +28,14 @@ const abs = (p: string): AbsolutePath => {
 };
 
 /** In-memory fake catalog: mutates a closured entry array so `enable`/`disable`/`update` are visible on the next `list()`. */
-const fakeCatalog = (initial: readonly SkillCatalogEntry[]): SkillCatalogPort => {
+const fakeCatalog = (
+  initial: readonly SkillCatalogEntry[]
+): SkillCatalogPort & { setEntries: (next: readonly SkillCatalogEntry[]) => void } => {
   let entries = initial;
   return {
+    setEntries(next) {
+      entries = next;
+    },
     async list() {
       return Result.ok(entries);
     },
@@ -44,7 +51,7 @@ const fakeCatalog = (initial: readonly SkillCatalogEntry[]): SkillCatalogPort =>
             }
           : e
       );
-      return Result.ok(undefined);
+      return Result.ok({ copied: [...flows], skipped: [] });
     },
     async disable(name, flows) {
       entries = entries.map((e) =>
@@ -78,9 +85,10 @@ const fakeCatalog = (initial: readonly SkillCatalogEntry[]): SkillCatalogPort =>
   };
 };
 
-const buildDeps = (skillCatalog: SkillCatalogPort): AppDeps =>
+const buildDeps = (skillCatalog: SkillCatalogPort, settings: Settings = DEFAULT_SETTINGS): AppDeps =>
   ({
     skillCatalog,
+    settingsRepo: { load: async () => Result.ok(settings) },
     storage: { operatorSkillsRoot: abs('/tmp/ralphctl-skills-root-test') },
   }) as unknown as AppDeps;
 
@@ -289,21 +297,131 @@ describe('SkillsView', () => {
     expect(result.lastFrame() ?? '').toContain('Failed to load the skill catalog.');
   });
 
-  it('reload (r) re-fetches after the cursor has moved', async () => {
+  it('reload (r) re-fetches: state mutated behind the view appears after r', async () => {
     const [first, second] = BUNDLED_SKILLS;
     if (first === undefined || second === undefined || first.name === second.name) {
       throw new Error('test requires at least two distinct BUNDLED_SKILLS entries');
     }
     const catalog = fakeCatalog([
       { name: first.name, description: 'x', defaultFor: [], recommendedFor: [], installs: [] },
-      { name: second.name, description: 'y', defaultFor: [], recommendedFor: [], installs: [] },
     ]);
     const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
     await waitForViewReady(result, (f) => f.includes(first.name));
+    expect(result.lastFrame() ?? '').not.toContain(second.name);
+    // Mutate the underlying catalog OUTSIDE the view, then reload — the new entry appearing
+    // proves `r` actually re-fetched rather than re-rendering stale state.
+    catalog.setEntries([
+      { name: first.name, description: 'x', defaultFor: [], recommendedFor: [], installs: [] },
+      { name: second.name, description: 'y', defaultFor: [], recommendedFor: [], installs: [] },
+    ]);
     result.stdin.write(DOWN);
     await tick();
     result.stdin.write('r');
-    await waitFor(() => (result.lastFrame() ?? '').includes('reloading'));
-    expect(result.lastFrame() ?? '').toContain(second.name);
+    await waitFor(() => (result.lastFrame() ?? '').includes(second.name));
+  });
+
+  it('update (u): declining the overwrite confirm leaves the copy untouched', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'x',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'plan', status: 'locally-modified' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('u');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Overwrite?'));
+    // Nothing written until the confirm is answered.
+    const midway = await catalog.list();
+    expect(midway.ok && midway.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
+
+    result.stdin.write('n');
+    await waitFor(() => !(result.lastFrame() ?? '').includes('Overwrite?'));
+    const declined = await catalog.list();
+    expect(declined.ok && declined.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
+  });
+
+  it('update (u): accepting the overwrite confirm updates the locally-modified copy', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'x',
+        defaultFor: [],
+        recommendedFor: [],
+        installs: [{ flow: 'plan', status: 'locally-modified' }],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+
+    result.stdin.write('u');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Overwrite?'));
+    result.stdin.write('y');
+    await waitFor(() => (result.lastFrame() ?? '').includes('updated'));
+    const after = await catalog.list();
+    expect(after.ok && after.value[0]?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
+  });
+
+  it('update (u): an in-sync-only row reports already up to date', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      { name, description: 'x', defaultFor: [], recommendedFor: [], installs: [{ flow: 'plan', status: 'in-sync' }] },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+    result.stdin.write('u');
+    await waitFor(() => (result.lastFrame() ?? '').includes('already up to date'));
+  });
+
+  it('never offers Create PR — the create-pr launch loads no skills', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      {
+        name,
+        description: 'defaulted onto createPr in the registry',
+        defaultFor: ['createPr'],
+        recommendedFor: ['createPr', 'plan'],
+        installs: [],
+      },
+    ]);
+    const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+    const frame = result.lastFrame() ?? '';
+    // No chip for the non-mounting flow — neither as default-on nor as not-enabled.
+    expect(frame).not.toContain('■ pr');
+    expect(frame).not.toContain('◌ pr');
+
+    result.stdin.write('e');
+    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    const picker = result.lastFrame() ?? '';
+    expect(picker).not.toContain('Create PR');
+    // The mounting recommendation is still preselected.
+    expect(picker).toMatch(/\[[xX✔✓]]\s*Plan/);
+  });
+
+  it('renders "default, off (saved)" when a durable opt-out disables a default flow', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      { name, description: 'x', defaultFor: ['implement'], recommendedFor: [], installs: [] },
+    ]);
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      ai: { ...DEFAULT_SETTINGS.ai, skills: { implement: { disabled: [name] } } },
+    } as Settings;
+    const { result } = renderView(<SkillsView />, {
+      deps: buildDeps(catalog, settings),
+      initial: { id: 'skills' },
+    });
+    await waitForViewReady(result, (f) => f.includes(name));
+    const frame = result.lastFrame() ?? '';
+    // The saved opt-out demotes the "always on" chip: muted ◌ instead of highlighted ■.
+    expect(frame).toContain('◌ imp');
+    expect(frame).not.toContain('■ imp');
   });
 });

--- a/tests/unit/application/ui/tui/views/flows-launch-extras.test.ts
+++ b/tests/unit/application/ui/tui/views/flows-launch-extras.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { SkillCandidatesResult } from '@src/application/ui/shared/launcher.ts';
+import type { CustomizePickerResult } from '@src/application/ui/tui/views/flows-customize-picker.ts';
+import { applySkillsRememberChoice, buildLaunchExtras } from '@src/application/ui/tui/views/flows-launch-extras.ts';
+import type { FlowEntry } from '@src/application/registry.ts';
+import type { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+
+const repoFor = (initial: Settings, failSave = false): { repo: SettingsRepository; saved: { value?: Settings } } => {
+  const saved: { value?: Settings } = {};
+  const repo: SettingsRepository = {
+    path: '/tmp/settings.json',
+    async exists() {
+      return Result.ok(true);
+    },
+    async load() {
+      return Result.ok(initial);
+    },
+    async save(next) {
+      if (failSave) return Result.error(new Error('disk full') as never);
+      saved.value = next;
+      return Result.ok(undefined);
+    },
+  };
+  return { repo, saved };
+};
+
+// Real registry names keep this test honest against the actual default set.
+const IMPLEMENT_DEFAULTS = skillsForFlow('implement');
+const DEFAULT_A = IMPLEMENT_DEFAULTS[0]!;
+const DEFAULT_B = IMPLEMENT_DEFAULTS[1]!;
+
+const candidatesFor = (overrides?: Partial<SkillCandidatesResult>): SkillCandidatesResult => ({
+  settingsFlow: 'implement',
+  candidates: [
+    { name: DEFAULT_A, description: 'a', origin: 'bundled-default' },
+    // A phase-folder COPY of a bundled default — post-dedupe its origin is phase-folder, but by
+    // NAME it is still a registry default and its uncheck must persist.
+    { name: DEFAULT_B, description: 'b (shadowed copy)', origin: 'phase-folder' },
+    { name: 'ralphctl-opted-in-extra', description: 'catalog opt-in', origin: 'phase-folder' },
+  ],
+  savedDisabled: [],
+  degraded: false,
+  ...overrides,
+});
+
+const rememberPicker = (disabled: readonly string[]): CustomizePickerResult => ({
+  kind: 'defaults',
+  skills: { disabled, saveAsDefault: true },
+});
+
+const settingsWithSaved = (disabled: readonly string[]): Settings =>
+  ({
+    ...DEFAULT_SETTINGS,
+    ai: { ...DEFAULT_SETTINGS.ai, skills: { implement: { disabled } } },
+  }) as Settings;
+
+describe('applySkillsRememberChoice — merge-preserve persistence', () => {
+  it('persists unchecked registry defaults by NAME, including a phase-shadowed bundled copy', async () => {
+    const { repo, saved } = repoFor(DEFAULT_SETTINGS);
+    const warning = await applySkillsRememberChoice(
+      repo,
+      DEFAULT_SETTINGS,
+      candidatesFor(),
+      rememberPicker([DEFAULT_A, DEFAULT_B, 'ralphctl-opted-in-extra'])
+    );
+    expect(warning).toBeUndefined();
+    const row = saved.value?.ai.skills?.implement?.disabled ?? [];
+    expect(row).toContain(DEFAULT_A);
+    expect(row).toContain(DEFAULT_B); // by name, despite phase-folder origin
+    expect(row).not.toContain('ralphctl-opted-in-extra'); // non-default unchecks stay run-scoped
+  });
+
+  it('preserves hand-added non-default names and drops re-checked defaults', async () => {
+    const settings = settingsWithSaved(['ralphctl-hand-added', DEFAULT_A]);
+    const { repo, saved } = repoFor(settings);
+    // The user unchecked nothing this run — every default is re-checked.
+    const warning = await applySkillsRememberChoice(repo, settings, candidatesFor(), rememberPicker([]));
+    expect(warning).toBeUndefined();
+    const row = saved.value?.ai.skills?.implement?.disabled ?? [];
+    expect(row).toContain('ralphctl-hand-added'); // survives the rewrite
+    expect(row).not.toContain(DEFAULT_A); // re-checked → removed
+  });
+
+  it('is a no-op for run-only, cancel, and missing candidates', async () => {
+    const { repo, saved } = repoFor(DEFAULT_SETTINGS);
+    const runOnly: CustomizePickerResult = {
+      kind: 'defaults',
+      skills: { disabled: [DEFAULT_A], saveAsDefault: false },
+    };
+    expect(await applySkillsRememberChoice(repo, DEFAULT_SETTINGS, candidatesFor(), runOnly)).toBeUndefined();
+    expect(
+      await applySkillsRememberChoice(repo, DEFAULT_SETTINGS, candidatesFor(), { kind: 'cancel' })
+    ).toBeUndefined();
+    expect(
+      await applySkillsRememberChoice(repo, DEFAULT_SETTINGS, undefined, rememberPicker([DEFAULT_A]))
+    ).toBeUndefined();
+    expect(saved.value).toBeUndefined();
+  });
+
+  it('refuses to persist over a degraded candidate listing', async () => {
+    const settings = settingsWithSaved([DEFAULT_A]);
+    const { repo, saved } = repoFor(settings);
+    const warning = await applySkillsRememberChoice(
+      repo,
+      settings,
+      candidatesFor({ degraded: true, candidates: [] }),
+      rememberPicker([])
+    );
+    expect(warning).toMatch(/not saved/i);
+    expect(saved.value).toBeUndefined(); // the saved opt-out was NOT wiped
+  });
+
+  it('surfaces a save failure as a soft warning', async () => {
+    const { repo } = repoFor(DEFAULT_SETTINGS, true);
+    const warning = await applySkillsRememberChoice(
+      repo,
+      DEFAULT_SETTINGS,
+      candidatesFor(),
+      rememberPicker([DEFAULT_A])
+    );
+    expect(warning).toMatch(/Couldn't remember/i);
+  });
+});
+
+describe('buildLaunchExtras — skillsOverride mapping', () => {
+  const entry = { manifest: { id: 'refine', title: 'Refine' } } as FlowEntry;
+  const ui = { sessionRepositoryId: undefined } as unknown as ReturnType<typeof useUiState>;
+
+  it('maps picker skills.disabled to skillsOverride, including the empty re-enable case', () => {
+    const withDisables = buildLaunchExtras(rememberPicker([DEFAULT_A]), entry, undefined, ui, DEFAULT_SETTINGS);
+    expect(withDisables.skillsOverride).toEqual({ disabled: [DEFAULT_A] });
+    // Empty array is a REAL override (re-enables every remembered-off skill for this run).
+    const emptyOverride = buildLaunchExtras(rememberPicker([]), entry, undefined, ui, DEFAULT_SETTINGS);
+    expect(emptyOverride.skillsOverride).toEqual({ disabled: [] });
+  });
+
+  it('omits skillsOverride when the skills step was kept at default', () => {
+    const kept = buildLaunchExtras({ kind: 'defaults' }, entry, undefined, ui, DEFAULT_SETTINGS);
+    expect(kept.skillsOverride).toBeUndefined();
+  });
+});

--- a/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
-import { flowChipVisual, statusVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+import {
+  chipFlowsFor,
+  flowChipVisual,
+  SKILL_MOUNTING_FLOW_IDS,
+  statusVisual,
+} from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 
 const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
   name: 'ralphctl-example',
@@ -50,5 +55,38 @@ describe('flowChipVisual', () => {
   it('delegates to statusVisual when an install exists and the flow is not default-on', () => {
     const e = entry({ installs: [{ flow: 'refine', status: 'in-sync' }] });
     expect(flowChipVisual('refine', e)).toEqual(statusVisual('in-sync'));
+  });
+
+  it('reports "broken (no SKILL.md)" for a folder the copy left half-written', () => {
+    const e = entry({ installs: [{ flow: 'plan', status: 'broken' }] });
+    const v = flowChipVisual('plan', e);
+    expect(v.label).toBe('broken (no SKILL.md)');
+    expect(v.color).toBe(inkColors.error);
+  });
+
+  it('demotes "always on (default)" to "default, off (saved)" under a durable opt-out', () => {
+    const e = entry({ name: 'ralphctl-example', defaultFor: ['implement'] });
+    const saved = (): ReadonlySet<string> => new Set(['ralphctl-example']);
+    const v = flowChipVisual('implement', e, saved);
+    expect(v.label).toBe('default, off (saved)');
+    expect(v.bold).toBe(false);
+  });
+
+  it('renders a non-mounting flow as inactive even when default-on in the registry', () => {
+    const e = entry({ defaultFor: ['createPr'] });
+    expect(flowChipVisual('createPr', e).label).toBe('inactive (flow loads no skills)');
+  });
+});
+
+describe('SKILL_MOUNTING_FLOW_IDS / chipFlowsFor', () => {
+  it('excludes createPr — no create-pr launch mounts a skill source', () => {
+    expect(SKILL_MOUNTING_FLOW_IDS).not.toContain('createPr');
+    expect(SKILL_MOUNTING_FLOW_IDS).toContain('implement');
+  });
+
+  it('chips cover the mounting flows, plus a leftover install on a non-mounting flow', () => {
+    expect(chipFlowsFor(entry())).toEqual([...SKILL_MOUNTING_FLOW_IDS]);
+    const leftover = entry({ installs: [{ flow: 'createPr', status: 'in-sync' }] });
+    expect(chipFlowsFor(leftover)).toEqual([...SKILL_MOUNTING_FLOW_IDS, 'createPr']);
   });
 });

--- a/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { flowChipVisual, statusVisual } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+
+const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
+  name: 'ralphctl-example',
+  description: 'an example skill',
+  defaultFor: [],
+  recommendedFor: [],
+  installs: [],
+  ...over,
+});
+
+describe('statusVisual', () => {
+  it('maps every SkillInstallStatus to a distinct glyph', () => {
+    const statuses = ['in-sync', 'update-available', 'locally-modified', 'manual'] as const;
+    const glyphsSeen = statuses.map((s) => statusVisual(s).glyph);
+    expect(new Set(glyphsSeen).size).toBe(statuses.length);
+  });
+
+  it('locally-modified uses the dedicated `modified` glyph in error color', () => {
+    const v = statusVisual('locally-modified');
+    expect(v.glyph).toBe(glyphs.modified);
+    expect(v.color).toBe(inkColors.error);
+  });
+
+  it('update-available uses the warning glyph in warning color', () => {
+    const v = statusVisual('update-available');
+    expect(v.glyph).toBe(glyphs.warningGlyph);
+    expect(v.color).toBe(inkColors.warning);
+  });
+});
+
+describe('flowChipVisual', () => {
+  it('reports "always on (default)" for a defaultFor flow, ignoring any install status', () => {
+    const e = entry({ defaultFor: ['implement'], installs: [{ flow: 'implement', status: 'locally-modified' }] });
+    const v = flowChipVisual('implement', e);
+    expect(v.label).toBe('always on (default)');
+    expect(v.glyph).toBe(glyphs.phaseDone);
+    expect(v.bold).toBe(true);
+  });
+
+  it('reports "not enabled" when the flow has no install and is not default-on', () => {
+    const v = flowChipVisual('plan', entry());
+    expect(v.label).toBe('not enabled');
+    expect(v.glyph).toBe(glyphs.phaseDisabled);
+  });
+
+  it('delegates to statusVisual when an install exists and the flow is not default-on', () => {
+    const e = entry({ installs: [{ flow: 'refine', status: 'in-sync' }] });
+    expect(flowChipVisual('refine', e)).toEqual(statusVisual('in-sync'));
+  });
+});

--- a/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import { disableOptions, enableOptions } from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
+
+const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
+  name: 'ralphctl-example',
+  description: 'an example skill',
+  defaultFor: [],
+  recommendedFor: [],
+  installs: [],
+  ...over,
+});
+
+describe('enableOptions', () => {
+  it('offers all six flows', () => {
+    expect(enableOptions(entry())).toHaveLength(6);
+  });
+
+  it('disables a flow the skill is already default-on for, with an explanatory description', () => {
+    const options = enableOptions(entry({ defaultFor: ['implement'] }));
+    const impl = options.find((o) => o.value === 'implement');
+    expect(impl?.disabled).toBe(true);
+    expect(impl?.description).toBe('already default-on');
+  });
+
+  it('leaves a non-default flow enabled and surfaces its current status when installed', () => {
+    const options = enableOptions(entry({ installs: [{ flow: 'plan', status: 'update-available' }] }));
+    const plan = options.find((o) => o.value === 'plan');
+    expect(plan?.disabled).toBe(false);
+    expect(plan?.description).toBe('update available');
+  });
+
+  it('leaves the description unset for a flow with no install and no default', () => {
+    const options = enableOptions(entry());
+    const refine = options.find((o) => o.value === 'refine');
+    expect(refine?.description).toBeUndefined();
+  });
+});
+
+describe('disableOptions', () => {
+  it('offers only the currently-installed flows', () => {
+    const options = disableOptions(
+      entry({
+        installs: [
+          { flow: 'plan', status: 'in-sync' },
+          { flow: 'implement', status: 'locally-modified' },
+        ],
+      })
+    );
+    expect(options.map((o) => o.value)).toEqual(['plan', 'implement']);
+    expect(options.map((o) => o.description)).toEqual(['in sync', 'locally modified']);
+  });
+
+  it('is empty when the skill has no installs', () => {
+    expect(disableOptions(entry())).toEqual([]);
+  });
+});

--- a/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
-import { disableOptions, enableOptions } from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
+import {
+  disableOptions,
+  enableOptions,
+  enablePreselect,
+} from '@src/application/ui/tui/views/skills-view-internals/picker-options.ts';
+import { SKILL_MOUNTING_FLOW_IDS } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 
 const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
   name: 'ralphctl-example',
@@ -12,8 +17,38 @@ const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
 });
 
 describe('enableOptions', () => {
-  it('offers all six flows', () => {
-    expect(enableOptions(entry())).toHaveLength(6);
+  it('offers exactly the skill-mounting flows — never createPr, which loads no skills', () => {
+    const options = enableOptions(entry());
+    expect(options.map((o) => o.value)).toEqual([...SKILL_MOUNTING_FLOW_IDS]);
+    expect(options.some((o) => o.value === 'createPr')).toBe(false);
+  });
+
+  it('disables an edit-protected install (locally-modified / manual) with the overwrite hint', () => {
+    const options = enableOptions(
+      entry({
+        installs: [
+          { flow: 'plan', status: 'locally-modified' },
+          { flow: 'implement', status: 'manual' },
+        ],
+      })
+    );
+    const plan = options.find((o) => o.value === 'plan');
+    const impl = options.find((o) => o.value === 'implement');
+    expect(plan?.disabled).toBe(true);
+    expect(plan?.description).toContain('u overwrites');
+    expect(impl?.disabled).toBe(true);
+  });
+
+  it('enablePreselect keeps only selectable recommendations', () => {
+    const preselect = enablePreselect(
+      entry({
+        // createPr never mounts; refine is default-on; plan is edit-protected; implement is free.
+        recommendedFor: ['createPr', 'refine', 'plan', 'implement'],
+        defaultFor: ['refine'],
+        installs: [{ flow: 'plan', status: 'locally-modified' }],
+      })
+    );
+    expect(preselect).toEqual(['implement']);
   });
 
   it('disables a flow the skill is already default-on for, with an explanatory description', () => {

--- a/tests/unit/domain/entity/settings-skills.test.ts
+++ b/tests/unit/domain/entity/settings-skills.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Contract for the durable per-flow skills opt-OUT preference `settings.ai.skills`.
+ *
+ * Shape: `Partial<Record<FlowId, { disabled: readonly string[] }>>` — optional at every flow
+ * level. Absent means "registry defaults apply" (resolved in the launcher, not the schema).
+ * `disabled` entries are free trimmed non-empty skill names; the domain never validates them
+ * against the integration-side registry. Precedence at launch is per-run override > this saved
+ * preference > registry default — none of which the schema enforces; it only round-trips the key.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SettingsSchema } from '@src/domain/entity/settings.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+
+const withSkills = (skills: unknown): unknown => ({
+  ...DEFAULT_SETTINGS,
+  ai: { ...DEFAULT_SETTINGS.ai, skills },
+});
+
+describe('settings.ai.skills — durable opt-out preference', () => {
+  it('accepts an absent key (DEFAULT_SETTINGS carries no skills block)', () => {
+    const parsed = SettingsSchema.safeParse(DEFAULT_SETTINGS);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toBeUndefined();
+  });
+
+  it('accepts an empty skills object (no flow opts out anything)', () => {
+    const parsed = SettingsSchema.safeParse(withSkills({}));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toEqual({});
+  });
+
+  it('round-trips populated per-flow disabled lists', () => {
+    const skills = {
+      refine: { disabled: ['ralphctl-ponytail'] },
+      implement: { disabled: ['ralphctl-karpathy-guidelines', 'ralphctl-cherny-workflow'] },
+    };
+    const parsed = SettingsSchema.safeParse(withSkills(skills));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toEqual(skills);
+  });
+
+  it('accepts an empty disabled list on a flow (equivalent to nothing disabled)', () => {
+    const parsed = SettingsSchema.safeParse(withSkills({ plan: { disabled: [] } }));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toEqual({ plan: { disabled: [] } });
+  });
+
+  it('is stable under a second parse (schema-level save/load round-trip)', () => {
+    const skills = { createPr: { disabled: ['ralphctl-ponytail'] } };
+    const once = SettingsSchema.safeParse(withSkills(skills));
+    expect(once.success).toBe(true);
+    if (!once.success) return;
+    const twice = SettingsSchema.safeParse(once.data);
+    expect(twice.success).toBe(true);
+    if (!twice.success) return;
+    expect(twice.data.ai.skills).toEqual(skills);
+  });
+
+  it('trims skill-name entries', () => {
+    const parsed = SettingsSchema.safeParse(withSkills({ ideate: { disabled: ['  ralphctl-ponytail  '] } }));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toEqual({ ideate: { disabled: ['ralphctl-ponytail'] } });
+  });
+
+  it('rejects a blank (whitespace-only) skill name — entries must be non-empty when trimmed', () => {
+    const parsed = SettingsSchema.safeParse(withSkills({ refine: { disabled: ['   '] } }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('tolerantly strips an unknown flow key rather than failing the whole parse', () => {
+    const parsed = SettingsSchema.safeParse(
+      withSkills({ bogusFlow: { disabled: ['x'] }, plan: { disabled: ['ralphctl-ponytail'] } })
+    );
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.skills).toEqual({ plan: { disabled: ['ralphctl-ponytail'] } });
+  });
+});

--- a/tests/unit/integration/ai/skills/registry.test.ts
+++ b/tests/unit/integration/ai/skills/registry.test.ts
@@ -2,53 +2,69 @@ import { describe, expect, it } from 'vitest';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { FLOW_SKILLS, skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
+import { BUNDLED_SKILLS, skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
 import { flowRegistry } from '@src/application/registry.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BUNDLED_ROOT = join(HERE, '../../../../../src/integration/ai/skills/bundled');
 
 /**
- * Map a camelCase {@link FlowId} (used in `settings.ai.<flow>` and `FLOW_SKILLS`) to the
+ * Map a camelCase {@link FlowId} (used in `settings.ai.<flow>` and the skill registry) to the
  * kebab-case orchestration id. Most ids round-trip identically; `createPr` ↔ `create-pr`
  * is the one entry that diverges, mirroring the launcher's `aiFlowIdFor` mapping.
  */
 const flowIdToRegistryId = (flowId: string): string => (flowId === 'createPr' ? 'create-pr' : flowId);
 
-describe('FLOW_SKILLS', () => {
-  it('every flow id in FLOW_SKILLS exists in the orchestration registry', () => {
+/** Every flow referenced across both columns of the table. */
+const referencedFlowIds = new Set(BUNDLED_SKILLS.flatMap((entry) => [...entry.defaultFor, ...entry.recommendedFor]));
+
+/** Every skill name referenced across both columns of the table. */
+const referencedSkillNames = new Set(BUNDLED_SKILLS.map((entry) => entry.name));
+
+describe('BUNDLED_SKILLS', () => {
+  it('every flow id referenced (defaultFor or recommendedFor) exists in the orchestration registry', () => {
     const knownFlows = new Set(flowRegistry.map((entry) => entry.manifest.id));
-    for (const flowId of Object.keys(FLOW_SKILLS)) {
-      expect(knownFlows.has(flowIdToRegistryId(flowId))).toBe(true);
+    for (const flowId of referencedFlowIds) {
+      expect(knownFlows.has(flowIdToRegistryId(flowId)), `unknown flow id: ${flowId}`).toBe(true);
     }
   });
 
-  it('every skill id referenced has a bundled folder on disk', () => {
-    const allSkillIds = new Set<string>();
-    for (const ids of Object.values(FLOW_SKILLS)) {
-      for (const id of ids) allSkillIds.add(id);
-    }
-    for (const id of allSkillIds) {
-      const path = join(BUNDLED_ROOT, id, 'SKILL.md');
+  it('every skill name referenced (defaultFor or recommendedFor) has a bundled folder on disk', () => {
+    for (const name of referencedSkillNames) {
+      const path = join(BUNDLED_ROOT, name, 'SKILL.md');
       expect(existsSync(path), `bundled skill missing: ${path}`).toBe(true);
     }
+  });
+
+  it('namespaces every bundled skill name with the ralphctl- prefix', () => {
+    for (const name of referencedSkillNames) {
+      expect(name.startsWith('ralphctl-'), `bundled skill name missing prefix: ${name}`).toBe(true);
+    }
+  });
+
+  it('has exactly one entry per skill name', () => {
+    expect(referencedSkillNames.size).toBe(BUNDLED_SKILLS.length);
   });
 });
 
 describe('skillsForFlow', () => {
-  it('returns the configured ids for a known flow', () => {
-    const ids = skillsForFlow('refine');
-    expect(ids.length).toBeGreaterThan(0);
-    expect(ids).toContain('ralphctl-alignment');
+  it('returns the default skill names for a known flow', () => {
+    const names = skillsForFlow('refine');
+    expect(names.length).toBeGreaterThan(0);
+    expect(names).toContain('ralphctl-alignment');
   });
 
-  it('namespaces every bundled skill id with the ralphctl- prefix', () => {
-    const allSkillIds = new Set<string>();
-    for (const ids of Object.values(FLOW_SKILLS)) {
-      for (const id of ids) allSkillIds.add(id);
-    }
-    for (const id of allSkillIds) {
-      expect(id.startsWith('ralphctl-'), `bundled skill id missing prefix: ${id}`).toBe(true);
-    }
+  it('derives its result from defaultFor only (recommendedFor never loads)', () => {
+    // `ralphctl-surgical-simplicity` is recommendedFor `refine` but NOT defaultFor it.
+    expect(skillsForFlow('refine')).not.toContain('ralphctl-surgical-simplicity');
+    expect(skillsForFlow('implement')).toContain('ralphctl-surgical-simplicity');
+  });
+
+  it('returns names in table order', () => {
+    const names = skillsForFlow('implement');
+    const tableOrder = BUNDLED_SKILLS.filter((entry) => entry.defaultFor.includes('implement')).map(
+      (entry) => entry.name
+    );
+    expect(names).toEqual(tableOrder);
   });
 });

--- a/tests/unit/integration/ai/skills/resolve-selection.test.ts
+++ b/tests/unit/integration/ai/skills/resolve-selection.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit cover for the single skill-selection resolution seam,
+ * `createResolvedSkillSource` (`src/integration/ai/skills/_engine/resolve-selection.ts`).
+ *
+ * The decorator is pure over an injected inner {@link SkillSource}, so every case builds a fake
+ * inner inline — no filesystem, no launcher. Cases fence the four documented behaviours:
+ *   1. dedupe by name keeping the LAST occurrence (phase folder beats bundled);
+ *   2. subtraction of the per-flow disabled name-set;
+ *   3. `getByName` passes through UNFILTERED (opt-out governs auto-install, not name resolution);
+ *   4. empty inputs / error propagation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import type { FlowId } from '@src/integration/ai/skills/_engine/registry.ts';
+import { createResolvedSkillSource } from '@src/integration/ai/skills/_engine/resolve-selection.ts';
+
+const skill = (name: string, marker = name): Skill => ({
+  name,
+  description: `desc for ${name}`,
+  // `marker` lets a test tell two same-named skills apart so it can assert WHICH one survived dedupe.
+  content: `# ${name}\n\n${marker}`,
+});
+
+/** Inner fake whose `getForFlow` returns a fixed list and whose `getByName` scans that same list. */
+const fixedInner = (forFlow: readonly Skill[]): SkillSource => ({
+  async getForFlow() {
+    return Result.ok(forFlow);
+  },
+  async getByName(name: string) {
+    return Result.ok(forFlow.find((s) => s.name === name));
+  },
+});
+
+const names = (r: Result<readonly Skill[], StorageError>): readonly string[] => {
+  if (!r.ok) throw new Error(`expected ok, got error: ${r.error.message}`);
+  return r.value.map((s) => s.name);
+};
+
+describe('createResolvedSkillSource — dedupe (last occurrence wins)', () => {
+  it('keeps the LAST occurrence of a duplicated name at its last position', async () => {
+    const inner = fixedInner([
+      skill('ralphctl-foo', 'bundled'),
+      skill('ralphctl-bar', 'bundled'),
+      skill('ralphctl-foo', 'phase'), // later source — must win
+    ]);
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => [] });
+
+    const result = await source.getForFlow('implement');
+    expect(names(result)).toEqual(['ralphctl-bar', 'ralphctl-foo']);
+    if (!result.ok) throw new Error('unreachable');
+    // The surviving `ralphctl-foo` is the phase-folder copy, not the bundled one.
+    expect(result.value.find((s) => s.name === 'ralphctl-foo')?.content).toContain('phase');
+  });
+
+  it('preserves order and identity byte-for-byte when there are no duplicate names', async () => {
+    const list = [skill('ralphctl-a'), skill('ralphctl-b'), skill('ralphctl-c')];
+    const inner = fixedInner(list);
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => [] });
+
+    const result = await source.getForFlow('refine');
+    expect(names(result)).toEqual(['ralphctl-a', 'ralphctl-b', 'ralphctl-c']);
+  });
+});
+
+describe('createResolvedSkillSource — disabled-name subtraction', () => {
+  it('removes disabled names for the flow', async () => {
+    const inner = fixedInner([skill('ralphctl-a'), skill('ralphctl-b'), skill('ralphctl-c')]);
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => ['ralphctl-b'] });
+
+    const result = await source.getForFlow('implement');
+    expect(names(result)).toEqual(['ralphctl-a', 'ralphctl-c']);
+  });
+
+  it('subtracts AFTER dedupe — disabling a name drops even the surviving (last) copy', async () => {
+    const inner = fixedInner([
+      skill('ralphctl-foo', 'bundled'),
+      skill('ralphctl-foo', 'phase'),
+      skill('ralphctl-keep'),
+    ]);
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => ['ralphctl-foo'] });
+
+    const result = await source.getForFlow('implement');
+    expect(names(result)).toEqual(['ralphctl-keep']);
+  });
+
+  it('is passed the getForFlow flowId so a run-scoped closure can key on it', async () => {
+    const seen: FlowId[] = [];
+    const inner = fixedInner([skill('ralphctl-a')]);
+    const source = createResolvedSkillSource({
+      inner,
+      flowDisabled: (flowId) => {
+        seen.push(flowId);
+        return flowId === 'plan' ? ['ralphctl-a'] : [];
+      },
+    });
+
+    expect(names(await source.getForFlow('refine'))).toEqual(['ralphctl-a']);
+    expect(names(await source.getForFlow('plan'))).toEqual([]);
+    expect(seen).toEqual(['refine', 'plan']);
+  });
+
+  it('tolerates duplicate names in the disabled list (collapsed into a set)', async () => {
+    const inner = fixedInner([skill('ralphctl-a'), skill('ralphctl-b')]);
+    const source = createResolvedSkillSource({
+      inner,
+      flowDisabled: () => ['ralphctl-a', 'ralphctl-a', 'ralphctl-a'],
+    });
+
+    expect(names(await source.getForFlow('implement'))).toEqual(['ralphctl-b']);
+  });
+});
+
+describe('createResolvedSkillSource — getByName passthrough', () => {
+  it('resolves a known name even when it is in the disabled set (opt-out ≠ unknown)', async () => {
+    const inner = fixedInner([skill('ralphctl-a'), skill('ralphctl-b')]);
+    // Disable everything for getForFlow — getByName must still resolve the name.
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => ['ralphctl-a', 'ralphctl-b'] });
+
+    const byName = await source.getByName('ralphctl-a');
+    expect(byName.ok).toBe(true);
+    if (!byName.ok) throw new Error('unreachable');
+    expect(byName.value?.name).toBe('ralphctl-a');
+
+    // And getForFlow still subtracts it — the two seams disagree by design.
+    expect(names(await source.getForFlow('implement'))).toEqual([]);
+  });
+
+  it('returns undefined for a genuinely unknown name', async () => {
+    const inner = fixedInner([skill('ralphctl-a')]);
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => [] });
+
+    const byName = await source.getByName('ralphctl-missing');
+    expect(byName.ok).toBe(true);
+    if (!byName.ok) throw new Error('unreachable');
+    expect(byName.value).toBeUndefined();
+  });
+});
+
+describe('createResolvedSkillSource — empty inputs and error propagation', () => {
+  it('returns an empty list for an empty inner source', async () => {
+    const source = createResolvedSkillSource({ inner: fixedInner([]), flowDisabled: () => ['ralphctl-x'] });
+    expect(names(await source.getForFlow('implement'))).toEqual([]);
+  });
+
+  it('propagates a hard read error from getForFlow without swallowing it', async () => {
+    const err = new StorageError({ subCode: 'io', message: 'disk gone' });
+    const inner: SkillSource = {
+      async getForFlow() {
+        return Result.error(err);
+      },
+      async getByName() {
+        return Result.ok(undefined);
+      },
+    };
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => [] });
+
+    const result = await source.getForFlow('implement');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toBe(err);
+  });
+
+  it('propagates a hard read error from getByName', async () => {
+    const err = new StorageError({ subCode: 'parse', message: 'bad frontmatter' });
+    const inner: SkillSource = {
+      async getForFlow() {
+        return Result.ok([]);
+      },
+      async getByName() {
+        return Result.error(err);
+      },
+    };
+    const source = createResolvedSkillSource({ inner, flowDisabled: () => [] });
+
+    const result = await source.getByName('ralphctl-a');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toBe(err);
+  });
+});


### PR DESCRIPTION
Closes #216.

- `BUNDLED_SKILLS` per-skill registry (`defaultFor`/`recommendedFor`) replaces flat `FLOW_SKILLS`; 5 curated skills added (ponytail, idea-refinement, domain-driven-design vendored MIT; karpathy-guidelines, cherny-workflow clean-room) with re-curated per-phase defaults
- opt-in phase folders `<appRoot>/skills/<flow>/` (provider-agnostic, all six flows) + one resolution seam: dedupe last-wins, run override replaces saved `ai.skills[flow].disabled`
- Skills catalog view (Home, hotkey `K`): enable/disable/update/update-all with provenance statuses (in-sync / update-available / locally-modified / broken); customize picker gains a flow-level skills step with apply-once vs remember
- adversarial multi-agent review (30 confirmed findings) fixed in the three `review pass` commits: remember-save integrity, provider-aware checklist, catalog outcome honesty, createPr exclusion, licensing notices + vendor-cache byte fidelity
- gate: 501 test files / 4520 tests, lint 114/115, prettier, knip all green

https://claude.ai/code/session_014Tr8r4s4LqR8UKBmqaXqP4