### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-03
+
 ### Added
 
 - **`harness.correctiveRetries` setting (1–5, default 2).** When a generator or evaluator AI turn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.15.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.15.0]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green

https://claude.ai/code/session_014Tr8r4s4LqR8UKBmqaXqP4