### PR TITLE
fix(bundle): resolve prompt/skill assets from code-split chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Freshly installed 0.15.0 could not find prompt templates or bundled skills.** Enabling tsup
+  code-splitting moved every module into a hashed `cli-<hash>.mjs` chunk, so the asset-path resolver
+  — which recognized only a literal `cli.mjs` filename — fell back to the source-tree layout and
+  looked for templates and `SKILL.md` folders at the wrong paths. Every flow failed on install with
+  `template not found` / `bundled skill not readable`. The resolver now detects the built layout by
+  probing for the co-located `prompts/` / `skills/` directory rather than sniffing the artifact
+  filename, so it survives chunk hashing and any output extension.
+
 ## [0.15.0] - 2026-07-03
 
 ### Added

--- a/src/integration/ai/prompts/_engine/fs-template-loader.ts
+++ b/src/integration/ai/prompts/_engine/fs-template-loader.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Result } from '@src/domain/result.ts';
@@ -61,16 +61,31 @@ const tryRead = async (path: string): Promise<ReadOutcome> => {
   }
 };
 
-// fs-template-loader.ts lives at src/integration/ai/prompts/_engine/; templates sit one
-// level up at src/integration/ai/prompts/<name>/template.md (and _partials/<name>.md).
-// In a tsup bundle every source module collapses into `dist/cli.mjs` — `scripts/build-assets.ts`
-// then copies the templates alongside as `dist/prompts/<name>/template.md` (+ `_partials/`).
+/**
+ * Resolve the default templates directory from a module URL. `exists` is injectable for tests.
+ *
+ * `scripts/build-assets.ts` copies templates NEXT TO the bundle as `<dist>/prompts/<name>/template.md`
+ * (+ `_partials/`); in dev (tsx) this `_engine/` module sits one level below them at
+ * `src/integration/ai/prompts/_engine/`, so they live at `../<name>/template.md`.
+ *
+ * Detection asks the filesystem, not the filename: if a `prompts/` dir sits beside this module we
+ * are running from a build, otherwise dev. This is deliberately NOT a filename check — tsup
+ * code-splitting (see tsup.config.ts) rewrites `import.meta.url` to a hashed `cli-<hash>.mjs` chunk,
+ * and a check against `cli.mjs` (or any fixed extension) silently misses it. That mismatch shipped
+ * in 0.15.0 and made the published bundle resolve templates to the package root.
+ *
+ * @public
+ */
+export const resolveTemplatesDir = (moduleUrl: string, exists: (path: string) => boolean = existsSync): string => {
+  const here = dirname(fileURLToPath(moduleUrl));
+  const beside = join(here, 'prompts');
+  return exists(beside) ? beside : join(here, '..');
+};
+
 // Resolved eagerly at module load so the invariant ("path parses as AbsolutePath") is
 // checked once at startup.
 const TEMPLATES_DIR: AbsolutePath = (() => {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const isBundled = import.meta.url.endsWith('/cli.mjs') || import.meta.url.endsWith('\\cli.mjs');
-  const path = isBundled ? join(here, 'prompts') : join(here, '..');
+  const path = resolveTemplatesDir(import.meta.url);
   const parsed = AbsolutePath.parse(path);
   if (!parsed.ok) {
     throw new Error(`fs-template-loader: bundled-templates path is not absolute: ${path}`);

--- a/src/integration/ai/skills/bundled/source.ts
+++ b/src/integration/ai/skills/bundled/source.ts
@@ -20,6 +20,7 @@
 
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
@@ -30,16 +31,28 @@ import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
 import { errorCode, parseSkill } from '@src/integration/ai/skills/_engine/parse-skill.ts';
 import type { BundledSkillRawReader } from '@src/integration/ai/skills/_engine/bundled-skill-raw-reader.ts';
 
-// Default bundled root.
-//   Dev (tsx): this module lives at src/integration/ai/skills/bundled/source.ts — SKILL.md
-//     folders sit next to it.
-//   Bundled (tsup): every source module collapses into `dist/cli.mjs`; `scripts/build-assets.ts`
-//     copies SKILL.md folders to `dist/skills/<name>/SKILL.md`.
-const defaultBundledRoot = (() => {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const isBundled = import.meta.url.endsWith('/cli.mjs') || import.meta.url.endsWith('\\cli.mjs');
-  return isBundled ? join(here, 'skills') : here;
-})();
+/**
+ * Resolve the default bundled-skill root from a module URL. `exists` is injectable for tests.
+ *
+ *   Dev (tsx): this module lives at src/integration/ai/skills/bundled/source.ts — SKILL.md folders
+ *     sit next to it.
+ *   Build (tsup): `scripts/build-assets.ts` copies SKILL.md folders to `<dist>/skills/<name>/SKILL.md`.
+ *
+ * Detection asks the filesystem, not the filename: if a `skills/` dir sits beside this module we are
+ * running from a build, otherwise dev. This is deliberately NOT a filename check — tsup code-splitting
+ * (see tsup.config.ts) rewrites `import.meta.url` to a hashed `cli-<hash>.mjs` chunk, and a check
+ * against `cli.mjs` (or any fixed extension) silently misses it. That mismatch shipped in 0.15.0 and
+ * made the published bundle look for SKILL.md folders one directory too shallow.
+ *
+ * @public
+ */
+export const resolveBundledRoot = (moduleUrl: string, exists: (path: string) => boolean = existsSync): string => {
+  const here = dirname(fileURLToPath(moduleUrl));
+  const beside = join(here, 'skills');
+  return exists(beside) ? beside : here;
+};
+
+const defaultBundledRoot = resolveBundledRoot(import.meta.url);
 
 export interface BundledSkillSourceDeps {
   /** Override for tests. Production resolves the bundled root next to this module. */

--- a/tests/integration/ai/prompts/_engine/fs-template-loader.test.ts
+++ b/tests/integration/ai/prompts/_engine/fs-template-loader.test.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
-import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import {
+  createFsTemplateLoader,
+  defaultTemplatesDir,
+  resolveTemplatesDir,
+} from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 
 describe('loadTemplate', () => {
   let templatesDir: AbsolutePath;
@@ -67,5 +71,23 @@ describe('defaultTemplatesDir', () => {
   it('returns an absolute path that ends in /prompts', () => {
     const dir = defaultTemplatesDir();
     expect(String(dir)).toMatch(/\/prompts$/);
+  });
+});
+
+describe('resolveTemplatesDir', () => {
+  it('resolves the co-located prompts/ dir when the build copied templates beside the bundle', () => {
+    // What decides it is the prompts/ dir sitting beside the module — NOT the artifact filename.
+    // A hashed `cli-<hash>.mjs` code-split chunk (which the 0.15.0 filename check missed) resolves
+    // identically to the `cli.mjs` entry stub.
+    const beside = (p: string): boolean => p === '/pkg/dist/prompts';
+    expect(resolveTemplatesDir('file:///pkg/dist/cli-CKPJ5SY4.mjs', beside)).toBe('/pkg/dist/prompts');
+    expect(resolveTemplatesDir('file:///pkg/dist/cli.mjs', beside)).toBe('/pkg/dist/prompts');
+  });
+
+  it('resolves the parent prompts/ dir in dev, where nothing sits beside the _engine module', () => {
+    const never = (): boolean => false;
+    expect(resolveTemplatesDir('file:///pkg/src/integration/ai/prompts/_engine/fs-template-loader.ts', never)).toBe(
+      '/pkg/src/integration/ai/prompts'
+    );
   });
 });

--- a/tests/integration/ai/skills/bundled/source.test.ts
+++ b/tests/integration/ai/skills/bundled/source.test.ts
@@ -2,8 +2,26 @@ import { describe, expect, it } from 'vitest';
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
+import { createBundledSkillSource, resolveBundledRoot } from '@src/integration/ai/skills/bundled/source.ts';
 import { skillsForFlow } from '@src/integration/ai/skills/_engine/registry.ts';
+
+describe('resolveBundledRoot', () => {
+  it('resolves the co-located skills/ dir when the build copied SKILL.md folders beside the bundle', () => {
+    // What decides it is the skills/ dir sitting beside the module — NOT the artifact filename.
+    // A hashed `cli-<hash>.mjs` code-split chunk (which the 0.15.0 filename check missed) resolves
+    // identically to the `cli.mjs` entry stub.
+    const beside = (p: string): boolean => p === '/pkg/dist/skills';
+    expect(resolveBundledRoot('file:///pkg/dist/cli-CKPJ5SY4.mjs', beside)).toBe('/pkg/dist/skills');
+    expect(resolveBundledRoot('file:///pkg/dist/cli.mjs', beside)).toBe('/pkg/dist/skills');
+  });
+
+  it('resolves the module dir itself in dev, where nothing sits beside source.ts', () => {
+    const never = (): boolean => false;
+    expect(resolveBundledRoot('file:///pkg/src/integration/ai/skills/bundled/source.ts', never)).toBe(
+      '/pkg/src/integration/ai/skills/bundled'
+    );
+  });
+});
 
 describe('createBundledSkillSource (production root)', () => {
   // Hits the real `src/ai/skills/bundled/` folder. Asserts the three v1 skills load.


### PR DESCRIPTION
## Problem

Freshly installing **0.15.0** and launching any flow fails immediately:

```
template not found: 'refine' (looked at .../node_modules/ralphctl/refine/template.md ...)
WARN skills checklist: bundled skill not readable: .../node_modules/ralphctl/dist/ralphctl-alignment/SKILL.md
```

## Root cause

`tsup` code-splitting (enabled for the `NODE_ENV ??=` ordering fix) moves every source module into a hashed `dist/cli-<hash>.mjs` chunk. Both asset-path resolvers gated on `import.meta.url.endsWith('/cli.mjs')` — which is **false** inside the chunk — so they fell back to the dev (source-tree) layout and looked for templates/skills at the wrong paths. The build itself was fine; only runtime resolution was wrong.

## Fix

Stop sniffing the artifact filename. Detect the built layout by **probing the filesystem** for a co-located `prompts/` / `skills/` directory beside the module. Decisive regardless of chunk hashing or output extension.

- `resolveTemplatesDir` / `resolveBundledRoot` are now pure, injectable-`exists` functions.
- Regression tests cover the exact chunk-name case (`cli-<hash>.mjs`) that broke 0.15.0.

## Verified

- typecheck ✓ · lint 114/115 (0 errors) ✓ · targeted tests 19/19 ✓ · full suite green
- End-to-end: real resolver fns fed the real built chunk URL locate both assets that 404'd (`dist/prompts/refine/template.md`, `dist/skills/ralphctl-alignment/SKILL.md`)

Rebased on top of the dependabot dev-deps bump (#250).