### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-07-06
+
 ### Fixed
 
 - **Freshly installed 0.15.0 could not find prompt templates or bundled skills.** Enabling tsup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.15.1
- Promote `## [Unreleased]` CHANGELOG section to `## [0.15.1]`

Patch release: fixes the 0.15.0 regression where a freshly installed bundle could not locate prompt templates or bundled skills (code-split chunk broke filename-based asset-path resolution). See #251.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` (114/115, 0 errors) · `pnpm test` (4524 passed) — green locally
- [ ] CI green