### PR TITLE
feat(agents): portable agent definitions (#217)

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -47,6 +47,30 @@ Precedence at launch: per-run override > this saved preference > registry defaul
 the customize picker's checklist; the saved preference is this key; the registry default is the flow's
 bundled skill set.
 
+**Agent-definition role binding — `settings.ai.implement.agents`.** An optional per-role binding of shape
+`{ generator?: string, evaluator?: string }` under `ai.implement.agents`; either, both, or neither role may
+be bound, and an absent block (or absent role key) means that role runs unaided — exactly as before this
+field existed. The bound value is an `AgentDefinition` name resolved against the composed bundled +
+operator catalog (`integration/ai/agents/`; see `ARCHITECTURE.md § Agent definitions subsystem`) — a name
+that doesn't resolve is a logged warning, not a launch failure, and the role falls back to running unaided.
+
+```json
+"implement": {
+  "generator": { "provider": "claude-code", "model": "claude-opus-4-8" },
+  "evaluator": { "provider": "claude-code", "model": "claude-opus-4-8" },
+  "agents": { "generator": "ralphctl-generator" }
+}
+```
+
+Set or clear via `ralphctl settings set ai.implement.agents.<role> <name>` (empty value clears); list
+what's available (bundled + operator, and which role each is currently bound to) via `ralphctl agents list`.
+
+**Precedence when a role is bound — definition > per-flow row > global default.** `resolveAgentOverride`
+(`business/settings/resolve-agent-override.ts`) resolves the effective `model` as the definition's `model`
+when set, else the role's own per-flow row `model` (always present); `effort` follows the same order but
+falls through to the existing per-flow-row → global-default resolution (**Effort resolution** above) when
+neither the definition nor the row set one explicitly.
+
 **Twenty presets across five families** stamp the entire `ai` section plus `harness.escalateOnPlateau`
 in one shot — all equally first-class (none is marked default). Each family carries four variants:
 `mixed` (best-fit provider per flow), `claude-only`, `copilot-only`, `codex-only`. The families:

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -42,8 +42,8 @@ ESLint `no-restricted-imports` (in `eslint.config.ts`) enforces every direction.
 - **No barrel files anywhere under `src/`** — every import names what it pulls in directly. `export *` is banned.
 - **Sibling-isolation in `integration/ai/<concept>/`** — each per-tool / per-variant adapter directory is
   independent. Cross-sibling reach goes through a shared `_engine/` sub-namespace (or `_partials/` for prompts).
-  Applies to `prompts/<flow>/`, `providers/<tool>/`, `readiness/<tool>/`, `skills/<source>/`; per-signal Zod schemas are
-  isolated under `contract/_engine/signals/<kind>/`.
+  Applies to `prompts/<flow>/`, `providers/<tool>/`, `readiness/<tool>/`, `skills/<source>/`,
+  `agents/<source>/`; per-signal Zod schemas are isolated under `contract/_engine/signals/<kind>/`.
 - **Port-shaped names live in `_engine/`** — interfaces / type aliases named `*Port`, `*Adapter`, `*Provider`,
   `*Sink`, `*Loader`, `*Probe`, `*Reader`, `*Writer`, `*Renderer`, `*Detector` must be declared in a concept's
   `_engine/` sub-namespace. Factory inputs named `*Deps` are exempt.
@@ -179,21 +179,22 @@ business/
 Service ports live under `business/<module>/` (one folder per cross-cutting concern). Repository interfaces live
 in `domain/repository/<aggregate>/`.
 
-| Port                                                  | Folder                              | Concrete adapter                                                                                                                                                                                                                                                          |
-| ----------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Logger` + `Sink`                                     | `business/observability/`           | `createEventBusLogger` (re-published as `LogEvent`)                                                                                                                                                                                                                       |
-| `EventBus`                                            | `business/observability/`           | `InMemoryEventBus` (`integration/observability/`)                                                                                                                                                                                                                         |
-| `HeadlessAiProvider`                                  | `integration/ai/providers/_engine/` | `claude` / `copilot` / `codex` adapters under `providers/<tool>/`                                                                                                                                                                                                         |
-| `InteractiveAiProvider`                               | `integration/ai/providers/_engine/` | same per-tool adapters (interactive entrypoint)                                                                                                                                                                                                                           |
-| `PublishSignal` (fn type)                             | `application/flows/_shared/`        | `createPublishSignal(eventBus, source, taskId?)` — the ONE harness-signal channel (`ai-signal` AppEvent)                                                                                                                                                                  |
-| `TemplateLoader`                                      | `integration/ai/prompts/_engine/`   | `FsTemplateLoader` — dev: src tree, bundled: `dist/`                                                                                                                                                                                                                      |
-| `ReadinessProbe`                                      | `integration/ai/readiness/_engine/` | per-tool probes under `readiness/<tool>/`                                                                                                                                                                                                                                 |
-| `SkillsAdapter` + `SkillSource`                       | `integration/ai/skills/_engine/`    | per-tool adapter + bundled / project / operator / phase-folder source, composed and resolved by `createResolvedSkillSource`; `parseSkill` extracts a `Skill` from a `SKILL.md`; `checkSkillContract` validates against six harness rules (S1–S6) — see § Skills subsystem |
-| `SkillCatalogPort`                                    | `integration/ai/skills/_engine/`    | `createSkillCatalog` (`skills/phase/catalog.ts`) — list / enable / disable / update / updateAll over the phase folders, provenance-stamped                                                                                                                                |
-| `GitRunner` / `ShellScriptRunner`                     | `integration/io/`                   | `createGitRunner` / `createShellScriptRunner`                                                                                                                                                                                                                             |
-| `WriteFile` (port) + `FileLocker` (adapter)           | `business/io/` / `integration/io/`  | atomic write helper / `createFileLocker`                                                                                                                                                                                                                                  |
-| `IssueFetcher` / `IssuePusher` / `PullRequestCreator` | `business/scm/`                     | `gh` / `glab` shell wrappers under `integration/scm/`                                                                                                                                                                                                                     |
-| `VersionChecker`                                      | `business/version/`                 | `createNpmVersionChecker` (`integration/version/`)                                                                                                                                                                                                                        |
+| Port                                                  | Folder                              | Concrete adapter                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Logger` + `Sink`                                     | `business/observability/`           | `createEventBusLogger` (re-published as `LogEvent`)                                                                                                                                                                                                                                                                                                                                 |
+| `EventBus`                                            | `business/observability/`           | `InMemoryEventBus` (`integration/observability/`)                                                                                                                                                                                                                                                                                                                                   |
+| `HeadlessAiProvider`                                  | `integration/ai/providers/_engine/` | `claude` / `copilot` / `codex` adapters under `providers/<tool>/`                                                                                                                                                                                                                                                                                                                   |
+| `InteractiveAiProvider`                               | `integration/ai/providers/_engine/` | same per-tool adapters (interactive entrypoint)                                                                                                                                                                                                                                                                                                                                     |
+| `PublishSignal` (fn type)                             | `application/flows/_shared/`        | `createPublishSignal(eventBus, source, taskId?)` — the ONE harness-signal channel (`ai-signal` AppEvent)                                                                                                                                                                                                                                                                            |
+| `TemplateLoader`                                      | `integration/ai/prompts/_engine/`   | `FsTemplateLoader` — dev: src tree, bundled: `dist/`                                                                                                                                                                                                                                                                                                                                |
+| `ReadinessProbe`                                      | `integration/ai/readiness/_engine/` | per-tool probes under `readiness/<tool>/`                                                                                                                                                                                                                                                                                                                                           |
+| `SkillsAdapter` + `SkillSource`                       | `integration/ai/skills/_engine/`    | per-tool adapter + bundled / project / operator / phase-folder source, composed and resolved by `createResolvedSkillSource`; `parseSkill` extracts a `Skill` from a `SKILL.md`; `checkSkillContract` validates against six harness rules (S1–S6) — see § Skills subsystem                                                                                                           |
+| `SkillCatalogPort`                                    | `integration/ai/skills/_engine/`    | `createSkillCatalog` (`skills/phase/catalog.ts`) — list / enable / disable / update / updateAll over the phase folders, provenance-stamped                                                                                                                                                                                                                                          |
+| `AgentDefinitionAdapter` + `AgentDefinitionSource`    | `integration/ai/agents/_engine/`    | per-provider adapter (`claude` / `copilot` / `codex` under `agents/<tool>/`, all backed by `createFilesystemAgentDefinitionAdapter`) + bundled / operator sources composed by `composeAgentDefinitionSources`; `parseAgentDefinition` extracts an `AgentDefinition` from frontmatter Markdown; `checkAgentDefinitionQuality` flags vague bodies — see § Agent definitions subsystem |
+| `GitRunner` / `ShellScriptRunner`                     | `integration/io/`                   | `createGitRunner` / `createShellScriptRunner`                                                                                                                                                                                                                                                                                                                                       |
+| `WriteFile` (port) + `FileLocker` (adapter)           | `business/io/` / `integration/io/`  | atomic write helper / `createFileLocker`                                                                                                                                                                                                                                                                                                                                            |
+| `IssueFetcher` / `IssuePusher` / `PullRequestCreator` | `business/scm/`                     | `gh` / `glab` shell wrappers under `integration/scm/`                                                                                                                                                                                                                                                                                                                               |
+| `VersionChecker`                                      | `business/version/`                 | `createNpmVersionChecker` (`integration/version/`)                                                                                                                                                                                                                                                                                                                                  |
 
 Shared engine-level helpers (not ports — no interface boundary, but architecturally significant):
 
@@ -243,6 +244,61 @@ bundle moved on upstream), or `locally-modified` (the operator edited the copy �
 always wins over `update-available` and `update`/`updateAll` never silently discard an edit). The
 sidecar is catalog-only bookkeeping — no `SkillSource` ever emits or installs it into a session; a
 `Skill` is always `{ name, description, content }` derived from `SKILL.md` alone.
+
+## Agent definitions subsystem (`integration/ai/agents/`)
+
+An `AgentDefinition` (`_engine/agent-definition.ts`) is a named sub-agent persona — Markdown body + YAML
+frontmatter (`name`, `description`, optional `model` / `effort`) — an AI session can delegate to. Unlike
+skills, definitions are not flow-scoped: every source's `list()` returns its full set unconditionally.
+
+| Source     | Folder                            | Scope                                                                                                                                                               |
+| ---------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bundled`  | `integration/ai/agents/bundled/`  | Committed `ralphctl-*` definitions (`_engine/registry.ts`'s `BUNDLED_AGENT_DEFINITIONS`: `ralphctl-generator`, `ralphctl-evaluator`)                                |
+| `operator` | `integration/ai/agents/operator/` | Global drop-ins under `<appRoot>/agents/<name>.md` — one flat directory, no per-provider subfolder (the body is provider-agnostic; only rendering/placement varies) |
+
+`composeAgentDefinitionSources(bundled, operator)` (`_engine/compose-agent-definition-sources.ts`) merges
+the two into one `AgentDefinitionSource`, later-source-wins on a name collision — an operator definition
+overrides a bundled one of the same name. There is no enumerable "project" source: a project-authored file
+already lives where the provider's CLI looks for it, so project-wins precedence is realised one layer down,
+in the adapter's install step (below). `parseAgentDefinition` / `splitFrontmatter` / `parseSimpleYaml`
+(`_engine/parse-agent-definition.ts`) share the same flat-frontmatter reader as `SKILL.md` parsing, and
+assert the frontmatter `name` matches the source file's base name.
+
+Three per-provider renderers (`_engine/render-{claude,copilot,codex}-agent.ts`) turn one canonical
+`AgentDefinition` into a `RenderedAgentFile` (`relPath` + `content`) in that provider's native sub-agent
+format:
+
+| Provider | Renderer             | Native file                               | Notes                                                                                                                                                                                 |
+| -------- | -------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude   | `renderClaudeAgent`  | `.claude/agents/ralphctl-<name>.md`       | YAML frontmatter (`name`, `description`, `model?`, `effort?`) + Markdown body                                                                                                         |
+| Copilot  | `renderCopilotAgent` | `.github/agents/ralphctl-<name>.agent.md` | Same frontmatter shape minus `effort`; rejects a body over `COPILOT_AGENT_MAX_BODY_CHARS` (30000 chars) with a `StorageError` rather than writing a file Copilot would refuse to load |
+| Codex    | `renderCodexAgent`   | `.codex/agents/ralphctl-<name>.toml`      | TOML (`name`, `description`, `developer_instructions`, optional `model` / `model_reasoning_effort`)                                                                                   |
+
+`namespacedAgentFileBase` (`_engine/agent-definition.ts`) applies the `ralphctl-` prefix idempotently so a
+bundled/operator name (already namespaced by its source) is never doubled.
+
+`createFilesystemAgentDefinitionAdapter` (`_engine/filesystem-agent-definition-adapter.ts`) is the one
+`AgentDefinitionAdapter` implementation shared by all three providers — `claude/adapter.ts`,
+`copilot/adapter.ts`, `codex/adapter.ts` each just supply `parentDir` + `renderer` + convention text,
+selected at composition time by `adapter-factory.ts`'s `createAgentDefinitionAdapter` — mirroring
+`createFilesystemSkillsAdapter`. Install is idempotent and **project-definitions-win**: a destination path
+that already exists is left untouched. A manifest-tracked `uninstall` removes only the files a matching
+`install` wrote, then tidies empty parent directories. A wildcard `ralphctl-*` line is appended to
+`.git/info/exclude` on first install so ralphctl-owned agent files stay out of `git status`, exactly as
+skills do.
+
+`checkAgentDefinitionQuality` (`_engine/agent-definition-quality.ts`) is a pure, I/O-free scanner over three
+rules (Q1 body under 40 words, Q2 no headings/list structure, Q3 an evaluator-role definition never
+mentions verification vocabulary) — advisory only. `warnIfVague` runs it against every operator-authored
+definition at load time and logs a warning per concern; a vague definition is still returned for install.
+
+The implement flow is the only current consumer: `settings.ai.implement.agents.{generator,evaluator}`
+optionally binds one composed-catalog definition per role (see `AI-SETTINGS.md § Agent-definition role
+binding` for the settings shape and model/effort precedence); `resolveImplementAgentBindings`
+(`application/ui/shared/launch/implement-agent-bindings.ts`) resolves the binding, installs/uninstalls the
+definition around the per-task subchain (`installAgentDefinitionsLeaf` / `uninstallAgentDefinitionsLeaf` in
+`application/flows/_shared/agents/`), and splices a short "bound sub-agent" announcement into the
+generator/evaluator prompt's `{{AGENT_DEFINITION_SECTION}}`.
 
 ## Repository interfaces (`src/domain/repository/`)
 

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -229,6 +229,18 @@ Status flow: `draft → planned → active → review → done`.
       provider in `settings.ai`, writing one native context file per distinct provider: `CLAUDE.md`
       (claude-code), `.github/copilot-instructions.md` (github-copilot), `AGENTS.md` (openai-codex). A
       single-provider config produces exactly one file; mixed configs produce one per distinct provider.
+- [x] **Portable, provider-native agent definitions** — a bundled + operator-authored `AgentDefinition`
+      catalog (Markdown + YAML frontmatter: `name`, `description`, optional `model`/`effort`) renders to
+      each provider's native sub-agent format at launch — `.claude/agents/*.md` (Claude),
+      `.github/agents/*.agent.md` (Copilot, `COPILOT_AGENT_MAX_BODY_CHARS` 30000-char body cap enforced by
+      the renderer), `.codex/agents/*.toml` (Codex) — via `createFilesystemAgentDefinitionAdapter`, shared
+      across the three per-provider adapters (`integration/ai/agents/{claude,copilot,codex}/`). Bundled
+      definitions (`ralphctl-generator`, `ralphctl-evaluator`) ship in `_engine/registry.ts`'s
+      `BUNDLED_AGENT_DEFINITIONS`; operator drop-ins under `<appRoot>/agents/*.md` win a name collision
+      (`composeAgentDefinitionSources`); a project-authored file already at the destination path always
+      wins over both (install skips it, leaving it untouched). `checkAgentDefinitionQuality` flags vague
+      operator definitions (short body, no structure, or an evaluator-role definition never mentioning
+      verification vocabulary) as warnings only — never blocks install.
 
 ## Per-flow model selection
 
@@ -241,6 +253,13 @@ Status flow: `draft → planned → active → review → done`.
       (`src/domain/value/settings-models/<provider>.ts`) or any non-empty trimmed custom string; the per-flow
       `effort` validates against the provider's native vocabulary. Custom (off-catalog) model ids parse at load
       time and are rejected by the provider CLI at spawn time, not by the persistence schema.
+- [x] **Agent-definition role binding** — `settings.ai.implement.agents.{generator,evaluator}` optionally
+      binds one implement role to a catalog agent-definition's `name`; either, both, or neither role may be
+      bound, and `ralphctl settings set ai.implement.agents.<role> <name>` with an empty value clears it. A
+      resolved binding's `model`/`effort` win over the role's own per-flow row, which otherwise wins over
+      the global `ai.effort` default (`resolveAgentOverride`: definition > per-flow row > global). An
+      unknown or unresolvable bound name is a logged warning, not a launch failure — the role then runs
+      unaided, exactly as if unbound.
 
 ## Doctor
 
@@ -267,7 +286,7 @@ Status flow: `draft → planned → active → review → done`.
 - [x] **Surface is deliberately smaller than the pre-TUI CLI** — interactive flows (refine / plan / ideate /
       implement / readiness / create-sprint) stay TUI-only. The CLI exposes only inspection commands +
       one-shot operations: `doctor`, `completion <shell>`, `export-context`, `export-requirements`, `create-pr`,
-      `settings {show,set,apply-preset}`, `project {list,show,remove}`,
+      `agents {list}`, `settings {show,set,apply-preset}`, `project {list,show,remove}`,
       `sprint {list,show,set-current,activate,close,remove,progress}`,
       `ticket {list,show,add,remove}`, `task {list,show,unblock}`,
       `runs {list,prune}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Portable, authorable agent definitions, ported automatically to each provider's native format.**
+  Author a sub-agent persona once (Markdown + YAML frontmatter) and it renders to `.claude/agents/*.md`
+  (Claude Code), `.github/agents/*.agent.md` (GitHub Copilot), or `.codex/agents/*.toml` (OpenAI Codex)
+  — whichever the launch provider expects. Bundled `ralphctl-generator` / `ralphctl-evaluator`
+  definitions ship out of the box, and operator drop-ins under `<appRoot>/agents/` are reusable across
+  every project. Bind one to the implement generator or evaluator role with
+  `ralphctl settings set ai.implement.agents.<role> <name>`; `ralphctl agents list` shows what's
+  available and which role each is currently bound to.
+
 ## [0.15.1] - 2026-07-06
 
 ### Fixed

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -203,6 +203,14 @@ const READINESS_PROVIDERS = ['claude', 'codex', 'copilot'] as const;
 const SKILLS = ['bundled', 'claude', 'codex', 'copilot', 'operator', 'phase', 'project'] as const;
 
 /**
+ * Sibling concretes under integration/ai/agents/ — the portable agent-definitions subsystem.
+ * Same shape as SKILLS: per-tool adapter directories (`claude`, `codex`, `copilot`) implement
+ * `AgentDefinitionAdapter`; `bundled` and `operator` are definition-source directories. Cross-
+ * sibling reach goes through `agents/_engine/`.
+ */
+const AGENTS = ['bundled', 'claude', 'codex', 'copilot', 'operator'] as const;
+
+/**
  * Domain layer rule. Pure entities + value objects + errors + Result + observability interfaces.
  * May import nothing outside src/domain/. May not import I/O-bearing node modules — domain is
  * the purest layer. Pure node modules (node:path, node:url, ...) remain allowed.
@@ -505,6 +513,24 @@ export default [
     files: [`src/integration/ai/skills/${active}/**/*.{ts,tsx}`],
     rules: {
       'no-restricted-imports': siblingIsolationRule('**/integration/ai/skills', active, SKILLS, ['_engine'], 'skill'),
+    },
+  })),
+
+  // ── integration/ai/agents/<x>/ — sibling-agent-definition isolation ──────────
+  // Per-tool adapter directories (claude/codex/copilot) and definition-source directories
+  // (bundled/operator) are all independent siblings. Cross-sibling sharing goes through
+  // agents/_engine/. The composition switch over the per-tool adapters lives at
+  // agents/adapter-factory.ts (directly under agents/, outside the sibling glob).
+  ...AGENTS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/agents/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': siblingIsolationRule(
+        '**/integration/ai/agents',
+        active,
+        AGENTS,
+        ['_engine'],
+        'agent definition'
+      ),
     },
   })),
 

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -1,21 +1,24 @@
 /**
- * `build-assets.ts` — copy non-code assets (prompt templates, bundled skills)
- * from `src/integration/ai/` into `dist/` so the published `dist/cli.mjs` can
- * locate them at runtime via the bundle-mode branches in
- * `fs-template-loader.ts` and `skills/bundled/source.ts`.
+ * `build-assets.ts` — copy non-code assets (prompt templates, bundled skills,
+ * bundled agent definitions) from `src/integration/ai/` into `dist/` so the
+ * published `dist/cli.mjs` can locate them at runtime via the bundle-mode
+ * branches in `fs-template-loader.ts`, `skills/bundled/source.ts`, and
+ * `agents/bundled/source.ts`.
  *
- * Output layout (must stay in lockstep with those two loader modules):
+ * Output layout (must stay in lockstep with those loader modules):
  *
  *   dist/cli.mjs                              ← tsup output
  *   dist/prompts/<flow>/template.md           ← per-flow prompt templates
  *   dist/prompts/_partials/<name>.md          ← cross-cutting partials
  *   dist/skills/<name>/SKILL.md               ← bundled skill bodies
+ *   dist/agent-definitions/<name>.md          ← bundled agent-definition bodies
  *   dist/manifest.json                        ← startup integrity check
  *
  * The manifest is the runtime "did the build complete?" gate — a partial copy
  * silently producing a bundle that serves empty prompts is the failure mode
  * we're guarding against. Run after `tsup` has produced `dist/cli.mjs`.
- * Idempotent: re-running cleans `dist/prompts/` + `dist/skills/` before re-copying.
+ * Idempotent: re-running cleans `dist/prompts/`, `dist/skills/`, and
+ * `dist/agent-definitions/` before re-copying.
  */
 
 import { cp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
@@ -28,6 +31,7 @@ const ROOT = resolve(HERE, '..');
 const DIST = join(ROOT, 'dist');
 const PROMPTS_SRC = join(ROOT, 'src/integration/ai/prompts');
 const SKILLS_SRC = join(ROOT, 'src/integration/ai/skills/bundled');
+const AGENT_DEFINITIONS_SRC = join(ROOT, 'src/integration/ai/agents/bundled');
 
 if (!existsSync(DIST)) {
   console.error(`[build-assets] dist/ not found at ${DIST} — run \`tsup\` first.`);
@@ -36,8 +40,10 @@ if (!existsSync(DIST)) {
 
 await rm(join(DIST, 'prompts'), { recursive: true, force: true });
 await rm(join(DIST, 'skills'), { recursive: true, force: true });
+await rm(join(DIST, 'agent-definitions'), { recursive: true, force: true });
 await mkdir(join(DIST, 'prompts'), { recursive: true });
 await mkdir(join(DIST, 'skills'), { recursive: true });
+await mkdir(join(DIST, 'agent-definitions'), { recursive: true });
 
 const assets: string[] = [];
 
@@ -69,6 +75,18 @@ for (const entry of skillEntries) {
   for (const f of await walkFiles(dstDir)) {
     assets.push(relative(DIST, f));
   }
+}
+
+// Agent definitions: copy each <name>.md file under src/integration/ai/agents/bundled/.
+//   <name>.md              → dist/agent-definitions/<name>.md
+// (Sibling .ts files like source.ts are excluded — they're the adapter, not the asset.)
+const agentDefinitionEntries = await readdir(AGENT_DEFINITIONS_SRC, { withFileTypes: true });
+for (const entry of agentDefinitionEntries) {
+  if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+  const src = join(AGENT_DEFINITIONS_SRC, entry.name);
+  const dst = join(DIST, 'agent-definitions', entry.name);
+  await cp(src, dst);
+  assets.push(relative(DIST, dst));
 }
 
 assets.sort();

--- a/src/application/bootstrap/storage-paths.ts
+++ b/src/application/bootstrap/storage-paths.ts
@@ -38,6 +38,7 @@ export const LOCKS_SUBDIR = 'locks';
 export const RUNS_SUBDIR = 'runs';
 export const MEMORY_SUBDIR = 'memory';
 export const SKILLS_SUBDIR = 'skills';
+export const AGENTS_SUBDIR = 'agents';
 export const RALPHCTL_HOME_ENV = 'RALPHCTL_HOME';
 
 export interface StoragePaths {
@@ -77,6 +78,17 @@ export interface StoragePaths {
    * directory is a valid empty source (no operator skills configured), not an error.
    */
   readonly operatorSkillsRoot: AbsolutePath;
+  /**
+   * `<appRoot>/agents` — global, provider-agnostic operator drop-in agent definitions. The
+   * operator authors `<name>.md` files directly under this root (no per-provider subdirectory —
+   * an agent definition's body is provider-agnostic; only the per-provider renderer's placement
+   * differs); at flow launch these compose with the bundled set through
+   * {@link composeAgentDefinitionSources} in `agents/_engine/compose-agent-definition-sources.ts`.
+   *
+   * NOT created by `ensureStorageRoots`: the directory is operator-authored, and a missing
+   * directory is a valid empty source (no operator agent definitions configured), not an error.
+   */
+  readonly operatorAgentDefinitionsRoot: AbsolutePath;
 }
 
 export interface ResolveStoragePathsDeps {
@@ -132,6 +144,8 @@ export const storagePathsFromRoot = (appRoot: AbsolutePath): Result<StoragePaths
   if (!memoryRoot.ok) return Result.error(memoryRoot.error);
   const operatorSkillsRoot = AbsolutePath.parse(join(String(appRoot), SKILLS_SUBDIR));
   if (!operatorSkillsRoot.ok) return Result.error(operatorSkillsRoot.error);
+  const operatorAgentDefinitionsRoot = AbsolutePath.parse(join(String(appRoot), AGENTS_SUBDIR));
+  if (!operatorAgentDefinitionsRoot.ok) return Result.error(operatorAgentDefinitionsRoot.error);
   return Result.ok({
     appRoot,
     dataRoot: dataRoot.value,
@@ -141,6 +155,7 @@ export const storagePathsFromRoot = (appRoot: AbsolutePath): Result<StoragePaths
     runsRoot: runsRoot.value,
     memoryRoot: memoryRoot.value,
     operatorSkillsRoot: operatorSkillsRoot.value,
+    operatorAgentDefinitionsRoot: operatorAgentDefinitionsRoot.value,
   }) as Result<StoragePaths, ValidationError>;
 };
 

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -61,6 +61,12 @@ import { createSkillsAdapter } from '@src/integration/ai/skills/adapter-factory.
 import { createBundledSkillRawReader, createBundledSkillSource } from '@src/integration/ai/skills/bundled/source.ts';
 import type { SkillCatalogPort } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { createSkillCatalog } from '@src/integration/ai/skills/phase/catalog.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import { createAgentDefinitionAdapter } from '@src/integration/ai/agents/adapter-factory.ts';
+import { composeAgentDefinitionSources } from '@src/integration/ai/agents/_engine/compose-agent-definition-sources.ts';
+import { createBundledAgentDefinitionSource } from '@src/integration/ai/agents/bundled/source.ts';
+import { createOperatorAgentDefinitionSource } from '@src/integration/ai/agents/operator/source.ts';
 import type { NotificationDispatcher } from '@src/business/observability/notification-dispatcher.ts';
 import { startFileLogSink } from '@src/integration/observability/sinks/file-log-sink.ts';
 import type { FileLogSink, FileLogSinkDeps } from '@src/integration/observability/_engine/file-log-sink.ts';
@@ -223,6 +229,21 @@ export interface AppDeps {
    */
   readonly skillCatalog: SkillCatalogPort;
   /**
+   * Wire-time seed — keyed on the generator role's provider. The implement launcher rebuilds a
+   * role-scoped adapter per role (generator / evaluator may target different providers) via
+   * `createAgentDefinitionAdapter`; this field is the sensible default for any path that consults
+   * `app.agentDefinitionAdapter` before a launch. Mirrors {@link skillsAdapter}'s wire-time-seed
+   * posture.
+   */
+  readonly agentDefinitionAdapter: AgentDefinitionAdapter;
+  /**
+   * Composed bundled + operator agent-definition source (operator overrides bundled on a name
+   * collision — see `composeAgentDefinitionSources`'s doc comment). Unlike {@link skillSource},
+   * agent definitions have no per-project / phase tier: a project-authored definition already
+   * lives where the provider's CLI looks for it, so there is nothing further to compose here.
+   */
+  readonly agentDefinitionSource: AgentDefinitionSource;
+  /**
    * OS-attention notifier. Hooked onto the EventBus by {@link startNotificationSubscriber} at
    * `wire()` time; exposed on `AppDeps` so flows / tests that want to surface a one-shot
    * "ralphctl needs you" cue can call it directly. Production: terminal bell + Darwin
@@ -356,6 +377,17 @@ const noopNotificationDispatcher: NotificationDispatcher = {
   },
 };
 
+/** Wire-time seed adapter, keyed on the generator role's provider — see `AppDeps.agentDefinitionAdapter`. */
+const buildWireAgentDefinitionAdapter = (settings: Settings, logger: Logger): AgentDefinitionAdapter =>
+  createAgentDefinitionAdapter({ provider: settings.ai.implement.generator.provider, logger });
+
+/** Composed bundled + operator agent-definition source — see `AppDeps.agentDefinitionSource`. */
+const buildWireAgentDefinitionSource = (storage: StoragePaths, logger: Logger): AgentDefinitionSource =>
+  composeAgentDefinitionSources(
+    createBundledAgentDefinitionSource(),
+    createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: storage.operatorAgentDefinitionsRoot, logger })
+  );
+
 export const wire = (opts: WireOptions): AppDeps => {
   const spawn: Spawn = opts.spawn ?? defaultPipeSpawn;
   // Env-gated chain.log writes. Reading `process.env` here keeps the integration adapter
@@ -456,6 +488,8 @@ export const wire = (opts: WireOptions): AppDeps => {
     // flow launches get the implement row's provider as the default.
     skillsAdapter: createSkillsAdapter({ provider: opts.settings.ai.implement.generator.provider, logger }),
     skillSource: createBundledSkillSource(),
+    agentDefinitionAdapter: buildWireAgentDefinitionAdapter(opts.settings, logger),
+    agentDefinitionSource: buildWireAgentDefinitionSource(opts.storage, logger),
     skillCatalog: createSkillCatalog({
       operatorSkillsRoot: opts.storage.operatorSkillsRoot,
       writeFile: atomicWriteFile,

--- a/src/application/flows/_shared/agents/install-agent-definitions.ts
+++ b/src/application/flows/_shared/agents/install-agent-definitions.ts
@@ -1,0 +1,51 @@
+/**
+ * `installAgentDefinitionsLeaf` — install a role's bound agent definition into the AI session's
+ * sandbox before the session runs.
+ *
+ * Pairs with {@link uninstallAgentDefinitionsLeaf}. Unlike `installSkillsLeaf` (flow-scoped,
+ * resolved at execute time via a `SkillSource`), a role's binding is resolved ONCE at launch —
+ * there is at most one bound definition per role — so the leaf takes the already-resolved
+ * `AgentDefinition` directly rather than looking it up itself.
+ *
+ * A `definition: undefined` (the role has no binding, or the bound name didn't resolve) is a
+ * no-op: no file is written, so an unbound role's session is left exactly as it was before this
+ * leaf existed.
+ */
+
+import { Result } from '@src/domain/result.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+export interface InstallAgentDefinitionsDeps {
+  readonly agentDefinitionAdapter: AgentDefinitionAdapter;
+}
+
+export interface InstallAgentDefinitionsOptions<TCtx> {
+  readonly name?: string;
+  /** The role's resolved binding, or `undefined` when the role has no binding. */
+  readonly definition: AgentDefinition | undefined;
+  /** Project the chain context to the AI session's cwd. Throws if the upstream leaves haven't
+   * populated it yet — surfaces a misconfigured chain at the failing leaf rather than later. */
+  readonly cwdPicker: (ctx: TCtx) => AbsolutePath;
+}
+
+export const installAgentDefinitionsLeaf = <TCtx>(
+  deps: InstallAgentDefinitionsDeps,
+  opts: InstallAgentDefinitionsOptions<TCtx>
+): Element<TCtx> => {
+  const name = opts.name ?? 'install-agent-definitions';
+  return leaf<TCtx, { readonly cwd: AbsolutePath }, void>(name, {
+    useCase: {
+      async execute(input): Promise<Result<void, DomainError>> {
+        if (opts.definition === undefined) return Result.ok(undefined);
+        return deps.agentDefinitionAdapter.install(input.cwd, [opts.definition]);
+      },
+    },
+    input: (ctx) => ({ cwd: opts.cwdPicker(ctx) }),
+    output: (ctx) => ctx,
+  });
+};

--- a/src/application/flows/_shared/agents/uninstall-agent-definitions.ts
+++ b/src/application/flows/_shared/agents/uninstall-agent-definitions.ts
@@ -1,0 +1,37 @@
+/**
+ * `uninstallAgentDefinitionsLeaf` — uninstall the agent definition the matching
+ * {@link installAgentDefinitionsLeaf} placed into the sandbox.
+ *
+ * Idempotent: dispatching to an adapter that never saw an install (unbound role, or a role whose
+ * bound name never resolved) is a no-op — mirrors `uninstallSkillsLeaf`.
+ */
+
+import type { Element } from '@src/application/chain/element.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+
+export interface UninstallAgentDefinitionsDeps {
+  readonly agentDefinitionAdapter: AgentDefinitionAdapter;
+}
+
+export interface UninstallAgentDefinitionsOptions<TCtx> {
+  readonly name?: string;
+  /** Same picker as the matching `installAgentDefinitionsLeaf` — ensures install/uninstall
+   * target the same sandbox even when the chain has multiple AI sub-sessions per run. */
+  readonly cwdPicker: (ctx: TCtx) => AbsolutePath;
+}
+
+export const uninstallAgentDefinitionsLeaf = <TCtx>(
+  deps: UninstallAgentDefinitionsDeps,
+  opts: UninstallAgentDefinitionsOptions<TCtx>
+): Element<TCtx> => {
+  const name = opts.name ?? 'uninstall-agent-definitions';
+  return leaf<TCtx, { readonly cwd: AbsolutePath }, void>(name, {
+    useCase: {
+      execute: async (input) => deps.agentDefinitionAdapter.uninstall(input.cwd),
+    },
+    input: (ctx) => ({ cwd: opts.cwdPicker(ctx) }),
+    output: (ctx) => ctx,
+  });
+};

--- a/src/application/flows/implement/deps.ts
+++ b/src/application/flows/implement/deps.ts
@@ -14,6 +14,7 @@ import type { ShellScriptRunner } from '@src/integration/io/shell-script-runner.
 import type { FileLocker } from '@src/integration/io/file-locker.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
 import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
 import type { WriteFile } from '@src/business/io/write-file.ts';
 import type { AppendFile } from '@src/business/io/append-file.ts';
@@ -69,6 +70,15 @@ export interface ImplementDeps {
   readonly locksRoot: AbsolutePath;
   readonly skillsAdapter: SkillsAdapter;
   readonly skillSource: SkillSource;
+  /**
+   * Generator-role agent-definition adapter — installs/uninstalls the generator's bound
+   * definition (when one is bound) into `repo.path`. Built by the launcher from
+   * `settings.ai.implement.generator.provider`, independently of {@link evaluatorAgentDefinitionAdapter}
+   * so the two roles can target different providers, exactly like {@link generatorProvider}.
+   */
+  readonly generatorAgentDefinitionAdapter: AgentDefinitionAdapter;
+  /** Evaluator-role agent-definition adapter — see {@link generatorAgentDefinitionAdapter}. */
+  readonly evaluatorAgentDefinitionAdapter: AgentDefinitionAdapter;
   /**
    * Used by `resolveBranchLeaf` on the first run of an implement chain to ask the user how to
    * pin the working tree: keep the current branch, auto-generate `ralphctl/<sprint-id>`, or

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -30,6 +30,7 @@ import { transitionSprintToReviewLeaf } from '@src/application/flows/implement/l
 import { withRepoLock } from '@src/application/flows/_shared/with-repo-lock.ts';
 import { loadLearningsLeaf } from '@src/application/flows/_shared/memory/load-learnings.ts';
 import { resolveLearningsLedgerPath } from '@src/application/flows/_shared/memory/ledger-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
 export type { RepoExecConfig };
 
@@ -91,6 +92,23 @@ export interface CreateImplementFlowOpts {
   readonly evaluatorModel: string;
   /** Evaluator-role effort / reasoning level — threaded into the evaluator AiSession. */
   readonly evaluatorEffort?: string;
+  /**
+   * Generator-role's bound agent definition, resolved once at launch by the launcher —
+   * `undefined` when the role has no binding (or the bound name didn't resolve, AC2). Threaded
+   * into the per-task subchain's install/uninstall leaves.
+   */
+  readonly generatorAgentDefinition?: AgentDefinition;
+  /**
+   * Pre-composed "## Agent Definition" prompt section for the generator role — announces the
+   * native file the launcher installed (or, for a provider with no native discovery format,
+   * the raw definition body). Threaded into every gen-eval turn's generator prompt (round 1 of
+   * a session thread only — a resumed continuation already carries it in-conversation).
+   */
+  readonly generatorAgentDefinitionSection?: string;
+  /** Evaluator-role's bound agent definition — see {@link generatorAgentDefinition}. */
+  readonly evaluatorAgentDefinition?: AgentDefinition;
+  /** Evaluator-role's "## Agent Definition" prompt section — see {@link generatorAgentDefinitionSection}. */
+  readonly evaluatorAgentDefinitionSection?: string;
   /**
    * How preflight handles a dirty working tree. Default `'prompt'` — interactive recovery
    * (Keep / Stash / Reset / Cancel). Non-interactive callers (CI, headless harness) should
@@ -454,15 +472,27 @@ export const createImplementFlow = (deps: ImplementDeps, opts: CreateImplementFl
           providerId: opts.generatorProviderId,
           model: opts.generatorModel,
           ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
+          ...(opts.generatorAgentDefinitionSection !== undefined
+            ? { agentDefinitionSection: opts.generatorAgentDefinitionSection }
+            : {}),
         },
         evaluator: {
           providerId: opts.evaluatorProviderId,
           model: opts.evaluatorModel,
           ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
+          ...(opts.evaluatorAgentDefinitionSection !== undefined
+            ? { agentDefinitionSection: opts.evaluatorAgentDefinitionSection }
+            : {}),
         },
         memoryRoot: opts.memoryRoot,
         projectId: opts.projectId,
         projectSlug: opts.projectSlug,
+        ...(opts.generatorAgentDefinition !== undefined
+          ? { generatorAgentDefinition: opts.generatorAgentDefinition }
+          : {}),
+        ...(opts.evaluatorAgentDefinition !== undefined
+          ? { evaluatorAgentDefinition: opts.evaluatorAgentDefinition }
+          : {}),
       },
       task,
       resolveRepoOrThrow(opts.repositories, task),

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -103,6 +103,13 @@ export interface EvaluatorLeafDeps {
   readonly model: string;
   /** Optional reasoning / effort level forwarded into every `implementSession` AiSession. */
   readonly effort?: string;
+  /**
+   * Pre-composed "## Agent Definition" prompt section (raw content, not yet rendered) — see
+   * `GenEvalLoopRoleConfig.agentDefinitionSection`. Threaded into the FULL evaluate prompt's
+   * `agentDefinition` slot only (round 1 of a session thread); a resumed continuation already
+   * carries it in-conversation.
+   */
+  readonly agentDefinition?: string;
   readonly verifyScript?: string;
   /** From `settings.harness.plateauThreshold` (2–5). */
   readonly plateauThreshold: number;
@@ -197,7 +204,10 @@ const readCappedProgress = async (path: string, currentTaskId: string, model: st
  * prompt automatically — the discriminant is the same field `--resume` consumes.
  */
 const buildEvaluatorPrompt = async (
-  deps: Pick<EvaluatorLeafDeps, 'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model'>,
+  deps: Pick<
+    EvaluatorLeafDeps,
+    'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model' | 'agentDefinition'
+  >,
   args: {
     readonly task: InProgressTask;
     readonly workspaceRoot: AbsolutePath;
@@ -214,6 +224,9 @@ const buildEvaluatorPrompt = async (
   const priorProgress = await readCappedProgress(String(deps.progressFile), String(args.task.id), deps.model);
   const contractPath = join(String(args.workspaceRoot), 'contract.md');
   const hintsCarry = args.generatorHints.length > 0 ? { generatorHints: args.generatorHints } : {};
+  // Agent-definition section rides ONLY the full prompt — a resumed continuation already carries
+  // it in-conversation.
+  const agentDefinitionCarry = deps.agentDefinition !== undefined ? { agentDefinition: deps.agentDefinition } : {};
 
   if (args.priorEvaluatorSessionId === undefined) {
     return buildEvaluatePrompt(deps.templateLoader, {
@@ -224,6 +237,7 @@ const buildEvaluatorPrompt = async (
       priorProgress,
       ...(deps.verifyScript !== undefined ? { verifyScript: deps.verifyScript } : {}),
       ...hintsCarry,
+      ...agentDefinitionCarry,
     });
   }
   return buildEvaluateContinuationPrompt(deps.templateLoader, {

--- a/src/application/flows/implement/leaves/gen-eval-loop.ts
+++ b/src/application/flows/implement/leaves/gen-eval-loop.ts
@@ -83,6 +83,13 @@ export interface GenEvalLoopRoleConfig {
   readonly providerId: string;
   readonly model: string;
   readonly effort?: string;
+  /**
+   * Pre-composed "## Agent Definition" prompt section for this role, resolved once at launch —
+   * absent when the role has no bound definition. Threaded into the generator/evaluator leaf as
+   * `agentDefinition` and rides only the FULL prompt of a session thread (round 1); a resumed
+   * continuation already carries it in-conversation.
+   */
+  readonly agentDefinitionSection?: string;
 }
 
 export interface GenEvalLoopOpts {
@@ -127,6 +134,9 @@ export const createGenEvalLoop = (
     provider: deps.generatorProvider,
     model: opts.generator.model,
     ...(opts.generator.effort !== undefined ? { effort: opts.generator.effort } : {}),
+    ...(opts.generator.agentDefinitionSection !== undefined
+      ? { agentDefinition: opts.generator.agentDefinitionSection }
+      : {}),
   };
   const evaluatorLeafDeps = {
     ...sharedLeafDeps,
@@ -136,6 +146,9 @@ export const createGenEvalLoop = (
     provider: deps.evaluatorProvider,
     model: opts.evaluator.model,
     ...(opts.evaluator.effort !== undefined ? { effort: opts.evaluator.effort } : {}),
+    ...(opts.evaluator.agentDefinitionSection !== undefined
+      ? { agentDefinition: opts.evaluator.agentDefinitionSection }
+      : {}),
   };
 
   // ---------------------------------------------------------------------------

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -106,6 +106,13 @@ export interface GeneratorLeafDeps {
   readonly model: string;
   /** Optional reasoning / effort level forwarded into every `implementSession` AiSession. */
   readonly effort?: string;
+  /**
+   * Pre-composed "## Agent Definition" prompt section (raw content, not yet rendered) — see
+   * `GenEvalLoopRoleConfig.agentDefinitionSection`. Threaded into the FULL implement prompt's
+   * `agentDefinition` slot only (round 1 of a session thread); a resumed continuation already
+   * carries it in-conversation, matching {@link priorLearnings}'s rule.
+   */
+  readonly agentDefinition?: string;
   readonly verifyScript?: string;
   readonly clock: () => IsoTimestamp;
   readonly logger: Logger;
@@ -306,7 +313,10 @@ const isPlateauBreakAttempt = (task: InProgressTask): boolean => {
  *    (best-effort log reads) and passed in as `preVerifyOutput` / `retryFeedback`.
  */
 const buildGeneratorPrompt = async (
-  deps: Pick<GeneratorLeafDeps, 'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model'>,
+  deps: Pick<
+    GeneratorLeafDeps,
+    'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model' | 'agentDefinition'
+  >,
   args: {
     readonly task: InProgressTask;
     readonly workspaceRoot: AbsolutePath;
@@ -360,6 +370,9 @@ const buildGeneratorPrompt = async (
   const priorLearningsCarry = args.priorLearnings.length > 0 ? { priorLearnings: args.priorLearnings } : {};
   // Prior-episodes (R4) rides ONLY the full prompt — same rule as prior-learnings.
   const priorEpisodesCarry = args.priorEpisodes.length > 0 ? { priorEpisodes: args.priorEpisodes } : {};
+  // Agent-definition section rides ONLY the full prompt (a resumed continuation already carries
+  // it in-conversation) — same rule as prior-learnings / prior-episodes.
+  const agentDefinitionCarry = deps.agentDefinition !== undefined ? { agentDefinition: deps.agentDefinition } : {};
 
   if (args.priorGeneratorSessionId === undefined) {
     return buildImplementPrompt(deps.templateLoader, {
@@ -375,6 +388,7 @@ const buildGeneratorPrompt = async (
       ...trajectoryCarry,
       ...priorLearningsCarry,
       ...priorEpisodesCarry,
+      ...agentDefinitionCarry,
       ...preVerifyCarry,
       ...retryFeedbackCarry,
     });

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -36,6 +36,9 @@ import { settleAttemptLeaf } from '@src/application/flows/implement/leaves/settl
 import { startAttemptLeaf } from '@src/application/flows/implement/leaves/start-attempt.ts';
 import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
 import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
+import { installAgentDefinitionsLeaf } from '@src/application/flows/_shared/agents/install-agent-definitions.ts';
+import { uninstallAgentDefinitionsLeaf } from '@src/application/flows/_shared/agents/uninstall-agent-definitions.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
 /**
  * Per-task subchain factory. Returns the `sequential('task-<id>', [...])` element that runs the
@@ -141,6 +144,16 @@ export interface PerTaskSubchainOpts {
    * sprint branch.
    */
   readonly includeBranchPreflight?: boolean;
+  /**
+   * Generator-role's bound agent definition, resolved once at launch — `undefined` when the
+   * role has no binding (or the bound name didn't resolve, AC2). Installed into `repo.path`
+   * once per task, alongside the bundled skills, and removed at the terminal leaf. Spliced
+   * conditionally: an unbound role gets no install/uninstall leaves at all, so its session
+   * trace is byte-for-byte unaffected.
+   */
+  readonly generatorAgentDefinition?: AgentDefinition;
+  /** Evaluator-role's bound agent definition — same lifecycle as {@link generatorAgentDefinition}. */
+  readonly evaluatorAgentDefinition?: AgentDefinition;
 }
 
 // `installSkillsLeaf` writes the bundled skill set to `<repo>/<parentDir>/skills/ralphctl-*/`.
@@ -150,6 +163,73 @@ export interface PerTaskSubchainOpts {
 // roots. The `ralphctl-` prefix + the wildcard line the skills adapter appends to
 // `.git/info/exclude` keeps the harness-authored copies out of the user's git tree.
 const repoCwdPicker = (repoPath: AbsolutePath) => (): AbsolutePath => repoPath;
+
+/**
+ * Per-role agent-definition install leaves — spliced ONLY when that role has a bound definition
+ * (AC2/AC3): an unbound role never gets these leaves, so its session trace is unaffected. Kept as
+ * a helper (rather than inline per-role conditional spreads) so `createPerTaskSubchain` itself
+ * stays under the project's cognitive-complexity ratchet.
+ */
+const buildAgentDefinitionInstallLeaves = (
+  deps: ImplementDeps,
+  opts: PerTaskSubchainOpts,
+  repo: RepoExecConfig,
+  taskId: TaskId
+): Array<Element<ImplementCtx>> => {
+  const leaves: Array<Element<ImplementCtx>> = [];
+  if (opts.generatorAgentDefinition !== undefined) {
+    leaves.push(
+      installAgentDefinitionsLeaf<ImplementCtx>(
+        { agentDefinitionAdapter: deps.generatorAgentDefinitionAdapter },
+        {
+          name: `install-generator-agent-definition-${String(taskId)}`,
+          definition: opts.generatorAgentDefinition,
+          cwdPicker: repoCwdPicker(repo.path),
+        }
+      )
+    );
+  }
+  if (opts.evaluatorAgentDefinition !== undefined) {
+    leaves.push(
+      installAgentDefinitionsLeaf<ImplementCtx>(
+        { agentDefinitionAdapter: deps.evaluatorAgentDefinitionAdapter },
+        {
+          name: `install-evaluator-agent-definition-${String(taskId)}`,
+          definition: opts.evaluatorAgentDefinition,
+          cwdPicker: repoCwdPicker(repo.path),
+        }
+      )
+    );
+  }
+  return leaves;
+};
+
+/** Uninstall-side counterpart of {@link buildAgentDefinitionInstallLeaves} — same per-role gate. */
+const buildAgentDefinitionUninstallLeaves = (
+  deps: ImplementDeps,
+  opts: PerTaskSubchainOpts,
+  repo: RepoExecConfig,
+  taskId: TaskId
+): Array<Element<ImplementCtx>> => {
+  const leaves: Array<Element<ImplementCtx>> = [];
+  if (opts.generatorAgentDefinition !== undefined) {
+    leaves.push(
+      uninstallAgentDefinitionsLeaf<ImplementCtx>(
+        { agentDefinitionAdapter: deps.generatorAgentDefinitionAdapter },
+        { name: `uninstall-generator-agent-definition-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
+      )
+    );
+  }
+  if (opts.evaluatorAgentDefinition !== undefined) {
+    leaves.push(
+      uninstallAgentDefinitionsLeaf<ImplementCtx>(
+        { agentDefinitionAdapter: deps.evaluatorAgentDefinitionAdapter },
+        { name: `uninstall-evaluator-agent-definition-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }
+      )
+    );
+  }
+  return leaves;
+};
 
 /**
  * Pure predicate read by the attempt loop's `shouldStop`. Looks up the task in `ctx.tasks` (the
@@ -223,6 +303,8 @@ export const createPerTaskSubchain = (
           { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
           { name: `install-skills-${String(taskId)}`, flowId: 'implement', cwdPicker: repoCwdPicker(repo.path) }
         ),
+        // Per-role agent-definition install — see {@link buildAgentDefinitionInstallLeaves}.
+        ...buildAgentDefinitionInstallLeaves(deps, opts, repo, taskId),
         // Inner attempt loop. The body is the full per-attempt segment; the loop re-enters it
         // until `terminalTaskStatus` reports the settled task `done`/`blocked` or the `maxAttempts`
         // cap fires. `maxAttempts === 1` runs exactly once (single-attempt-per-launch parity); a
@@ -444,6 +526,10 @@ export const createPerTaskSubchain = (
               ),
             ]
           : []),
+        // Per-role agent-definition uninstall — see {@link buildAgentDefinitionUninstallLeaves}.
+        // MUST run before the terminal `uninstall-skills` leaf below so that leaf stays the
+        // subchain's last element (the TUI's task-completion detector keys on it).
+        ...buildAgentDefinitionUninstallLeaves(deps, opts, repo, taskId),
         uninstallSkillsLeaf<ImplementCtx>(
           { skillsAdapter: deps.skillsAdapter },
           { name: `${opts.terminalLeafName}-${String(taskId)}`, cwdPicker: repoCwdPicker(repo.path) }

--- a/src/application/flows/implement/wave-branch.ts
+++ b/src/application/flows/implement/wave-branch.ts
@@ -516,16 +516,24 @@ const buildOneBranch = (
       providerId: opts.generatorProviderId,
       model: opts.generatorModel,
       ...(opts.generatorEffort !== undefined ? { effort: opts.generatorEffort } : {}),
+      ...(opts.generatorAgentDefinitionSection !== undefined
+        ? { agentDefinitionSection: opts.generatorAgentDefinitionSection }
+        : {}),
     },
     evaluator: {
       providerId: opts.evaluatorProviderId,
       model: opts.evaluatorModel,
       ...(opts.evaluatorEffort !== undefined ? { effort: opts.evaluatorEffort } : {}),
+      ...(opts.evaluatorAgentDefinitionSection !== undefined
+        ? { agentDefinitionSection: opts.evaluatorAgentDefinitionSection }
+        : {}),
     },
     memoryRoot: opts.memoryRoot,
     projectId: opts.projectId,
     projectSlug: opts.projectSlug,
     includeBranchPreflight: false,
+    ...(opts.generatorAgentDefinition !== undefined ? { generatorAgentDefinition: opts.generatorAgentDefinition } : {}),
+    ...(opts.evaluatorAgentDefinition !== undefined ? { evaluatorAgentDefinition: opts.evaluatorAgentDefinition } : {}),
   };
 
   // The per-task subchain is built fresh on the FORKED ctx + worktree repo each time the branch

--- a/src/application/ui/cli/cli.ts
+++ b/src/application/ui/cli/cli.ts
@@ -13,6 +13,7 @@ import { registerSprintCommand } from '@src/application/ui/cli/commands/sprint.t
 import { registerTicketCommand } from '@src/application/ui/cli/commands/ticket.ts';
 import { registerTaskCommand } from '@src/application/ui/cli/commands/task.ts';
 import { registerRunsCommand } from '@src/application/ui/cli/commands/runs.ts';
+import { registerAgentsCommand } from '@src/application/ui/cli/commands/agents.ts';
 import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
 
 /**
@@ -101,6 +102,7 @@ export const runCli = async (argv: readonly string[]): Promise<void> => {
   registerTicketCommand(program);
   registerTaskCommand(program);
   registerRunsCommand(program);
+  registerAgentsCommand(program);
 
   await program.parseAsync([...argv]);
 };

--- a/src/application/ui/cli/commands/agents.ts
+++ b/src/application/ui/cli/commands/agents.ts
@@ -1,0 +1,85 @@
+import type { Command } from 'commander';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createBundledAgentDefinitionSource } from '@src/integration/ai/agents/bundled/source.ts';
+import { createOperatorAgentDefinitionSource } from '@src/integration/ai/agents/operator/source.ts';
+import { createSettingsShowFlow } from '@src/application/flows/settings-show/flow.ts';
+import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import type { AiImplementRole } from '@src/domain/entity/settings.ts';
+
+const IMPLEMENT_ROLES: readonly AiImplementRole[] = ['generator', 'evaluator'];
+
+interface ListedDefinition {
+  readonly tier: 'bundled' | 'operator';
+  readonly definition: AgentDefinition;
+}
+
+/**
+ * Register the `agents` command group.
+ *
+ *   ralphctl agents list
+ *
+ * Operator-facing catalog of the portable agent definitions available to bind to the implement
+ * generator/evaluator role — the bundled vetted set plus any operator drop-ins under
+ * `<appRoot>/agents`. Project-authored definitions have no enumerable source (they already live
+ * where the provider's CLI looks for them — see `composeAgentDefinitionSources`'s doc comment),
+ * so they don't appear here; a project definition still wins a name collision at launch. A
+ * dedicated TUI catalog view is deferred — this CLI listing is the only inspection surface for
+ * now, mirroring how `runs list` / `project list` serve as the CLI-only view for their domains.
+ */
+export const registerAgentsCommand = (program: Command): void => {
+  const agents = program.command('agents').description('inspect portable agent definitions');
+
+  agents
+    .command('list')
+    .description('list bundled + operator agent definitions and which implement role each is bound to')
+    .action(async () => {
+      const { deps, storage } = await bootstrapCli();
+
+      const bundledSource = createBundledAgentDefinitionSource();
+      const operatorSource = createOperatorAgentDefinitionSource({
+        operatorAgentDefinitionsRoot: storage.operatorAgentDefinitionsRoot,
+        logger: deps.logger,
+      });
+
+      const [bundled, operator] = await Promise.all([bundledSource.list(), operatorSource.list()]);
+      if (!bundled.ok) {
+        process.stderr.write(`error: ${bundled.error.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      if (!operator.ok) {
+        process.stderr.write(`error: ${operator.error.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const showFlow = createSettingsShowFlow({ settingsRepo: deps.settingsRepo });
+      const current = await showFlow.execute({ input: undefined });
+      if (!current.ok) {
+        process.stderr.write(`error: ${current.error.error.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      const agentBindings = current.value.ctx.output!.ai.implement.agents;
+
+      // Later tier wins a name collision, mirroring `composeAgentDefinitionSources` — an
+      // operator drop-in shadows a bundled definition of the same name in this listing too.
+      const byName = new Map<string, ListedDefinition>();
+      for (const definition of bundled.value) byName.set(definition.name, { tier: 'bundled', definition });
+      for (const definition of operator.value) byName.set(definition.name, { tier: 'operator', definition });
+
+      if (byName.size === 0) {
+        process.stdout.write('(no agent definitions available)\n');
+        return;
+      }
+
+      const listed = [...byName.values()].sort((a, b) => a.definition.name.localeCompare(b.definition.name));
+      for (const { tier, definition } of listed) {
+        const boundRoles = IMPLEMENT_ROLES.filter((role) => agentBindings?.[role] === definition.name);
+        const boundLabel = boundRoles.length > 0 ? boundRoles.join(', ') : '-';
+        process.stdout.write(
+          `${definition.name.padEnd(28)}  ${tier.padEnd(8)}  bound: ${boundLabel.padEnd(20)}  ${definition.description}\n`
+        );
+      }
+    });
+};

--- a/src/application/ui/cli/commands/settings.ts
+++ b/src/application/ui/cli/commands/settings.ts
@@ -44,6 +44,9 @@ const parseProviderKey = (key: string): { readonly flow: FlowId; readonly role?:
  *      flow in {refine, plan, readiness, ideate}
  *   ai.implement.{generator|evaluator}.{provider,model,effort}
  *                                                      implement splits into a generator + evaluator pair
+ *   ai.implement.agents.{generator|evaluator}          bind an agent-definition name to that role (empty value clears it);
+ *                                                      see `ralphctl agents list` for the available names — any other
+ *                                                      role/flow target is reported as unsupported, not silently accepted
  *   harness.maxTurns | maxAttempts | rateLimitRetries | idleWatchdogMs | plateauThreshold    integer (range-checked)
  *   harness.escalateOnPlateau                          boolean (escalate generator model on plateau)
  *   harness.skipPreVerifyOnFreshSetup                  boolean (skip first pre-verify when this run's setup verified the tree)

--- a/src/application/ui/shared/launch/implement-agent-bindings.ts
+++ b/src/application/ui/shared/launch/implement-agent-bindings.ts
@@ -1,0 +1,120 @@
+/**
+ * Resolve the implement flow's per-role opt-in agent-definition bindings. Split out of
+ * `launch/implement.ts` (which composes these results into the deps/opts bags) so that file
+ * stays under the line-count ratchet — these are pure/async composition helpers with no
+ * dependency on the rest of the launcher's control flow.
+ */
+
+import { type AiImplementRole, type AiImplementSettings, primaryAgentBinding } from '@src/domain/entity/settings.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import { createAgentDefinitionAdapter } from '@src/integration/ai/agents/adapter-factory.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+
+/**
+ * Resolve one implement role's agent-definition binding into the concrete {@link AgentDefinition},
+ * or `undefined` when the role has no binding at all. A bound name that does NOT resolve against
+ * the composed bundled+operator source (a typo, or a definition the operator removed) is reported
+ * as a logged warning rather than a launch failure — the role's session then runs unaided, exactly
+ * as if no binding had been configured (the resilience posture the skills subsystem already uses
+ * for its own opt-in seams).
+ *
+ * @public
+ */
+export const resolveRoleAgentBinding = async (
+  source: AgentDefinitionSource,
+  bindingName: string | undefined,
+  role: AiImplementRole,
+  logger: Logger
+): Promise<AgentDefinition | undefined> => {
+  if (bindingName === undefined) return undefined;
+  const result = await source.getByName(bindingName);
+  const log = logger.named('implement.agents');
+  if (!result.ok) {
+    log.warn(`agent-definition binding lookup failed for the ${role} role — continuing under base behaviour`, {
+      role,
+      name: bindingName,
+      error: result.error.message,
+    });
+    return undefined;
+  }
+  if (result.value === undefined) {
+    log.warn(
+      `agent-definition binding '${bindingName}' not found for the ${role} role — continuing under base behaviour`,
+      { role, name: bindingName }
+    );
+    return undefined;
+  }
+  return result.value;
+};
+
+/**
+ * Build the per-role "## Agent Definition" prompt section for a resolved binding. Every current
+ * provider adapter (Claude / Copilot / Codex) is filesystem-native — the launcher has already
+ * installed the definition's native file by the time the generator/evaluator prompt is built —
+ * so the section ANNOUNCES that file via the adapter's `describeConvention()` rather than
+ * injecting the raw body. A future provider with no native discovery format would inject
+ * `definition.content` directly instead; the seam here is generic enough to add that branch
+ * without touching call sites.
+ *
+ * @public
+ */
+export const buildAgentDefinitionSection = (definition: AgentDefinition, adapter: AgentDefinitionAdapter): string =>
+  [
+    `A bound sub-agent persona is installed for this session: \`${definition.name}\` — ${definition.description}`,
+    adapter.describeConvention(),
+    'Read it and let its instructions guide your approach for this session, in addition to the role above.',
+  ].join(' ');
+
+/** One resolved role's agent-definition binding — both fields absent when the role is unbound. */
+export interface RoleAgentBinding {
+  readonly definition?: AgentDefinition;
+  readonly section?: string;
+}
+
+/**
+ * Resolve both implement roles' agent-definition bindings against the composed bundled+operator
+ * source, and build a role-scoped {@link AgentDefinitionAdapter} for each — generator and
+ * evaluator may target different providers, so each gets its own adapter unconditionally (mirrors
+ * `buildImplementProviders`'s per-role provider construction). A role's `definition`/`section`
+ * stay absent when it has no binding, so downstream composition (install leaves, prompt sections,
+ * model/effort override) is a byte-for-byte no-op for that role.
+ *
+ * @public
+ */
+export const resolveImplementAgentBindings = async (
+  deps: LauncherDeps,
+  implementPair: AiImplementSettings
+): Promise<{
+  readonly generatorAdapter: AgentDefinitionAdapter;
+  readonly evaluatorAdapter: AgentDefinitionAdapter;
+  readonly generator: RoleAgentBinding;
+  readonly evaluator: RoleAgentBinding;
+}> => {
+  const generatorAdapter = createAgentDefinitionAdapter({
+    provider: implementPair.generator.provider,
+    logger: deps.app.logger,
+  });
+  const evaluatorAdapter = createAgentDefinitionAdapter({
+    provider: implementPair.evaluator.provider,
+    logger: deps.app.logger,
+  });
+  const resolveRole = async (role: AiImplementRole, adapter: AgentDefinitionAdapter): Promise<RoleAgentBinding> => {
+    const bindingName = primaryAgentBinding(implementPair.agents, role);
+    const definition = await resolveRoleAgentBinding(
+      deps.app.agentDefinitionSource,
+      bindingName,
+      role,
+      deps.app.logger
+    );
+    if (definition === undefined) return {};
+    return { definition, section: buildAgentDefinitionSection(definition, adapter) };
+  };
+  const [generator, evaluator] = await Promise.all([
+    resolveRole('generator', generatorAdapter),
+    resolveRole('evaluator', evaluatorAdapter),
+  ]);
+  return { generatorAdapter, evaluatorAdapter, generator, evaluator };
+};

--- a/src/application/ui/shared/launch/implement-bags.ts
+++ b/src/application/ui/shared/launch/implement-bags.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure bag-assembly helpers for the implement launcher — `ImplementDeps` / `CreateImplementFlowOpts`
+ * plus the per-role provider + model/effort resolution that feeds both. Split out of
+ * `launch/implement.ts` (which composes these bags into the chain element) so that file stays
+ * under the line-count ratchet.
+ */
+
+import type { CreateImplementFlowOpts, RepoExecConfig } from '@src/application/flows/implement/flow.ts';
+import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
+import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
+import type { Task } from '@src/domain/entity/task.ts';
+import type { Repository } from '@src/domain/entity/repository.ts';
+import type { Sprint } from '@src/domain/entity/sprint.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
+import { type AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { PublishSignal } from '@src/application/flows/_shared/publish-signal.ts';
+import type { AiImplementSettings, Settings } from '@src/domain/entity/settings.ts';
+import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
+import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
+import { resolveAgentOverride } from '@src/business/settings/resolve-agent-override.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { RoleAgentBinding } from '@src/application/ui/shared/launch/implement-agent-bindings.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+
+/** Project repositories → `RepoExecConfig` map keyed by id, the per-task subchain's repo lookup. */
+export const buildRepoExecConfigs = (repositories: readonly Repository[]): Map<RepositoryId, RepoExecConfig> => {
+  const configs = new Map<RepositoryId, RepoExecConfig>();
+  for (const r of repositories) {
+    configs.set(r.id, {
+      path: r.path,
+      name: r.name,
+      ...(r.verifyScript !== undefined ? { verifyScript: r.verifyScript } : {}),
+      ...(r.verifyGates !== undefined ? { verifyGates: r.verifyGates } : {}),
+      ...(r.verifyTimeout !== undefined ? { verifyTimeout: r.verifyTimeout } : {}),
+      ...(r.setupScript !== undefined ? { setupScript: r.setupScript } : {}),
+    });
+  }
+  return configs;
+};
+
+/**
+ * Build one `HeadlessAiProvider` per role from the effective implement pair. The two roles may
+ * target distinct providers — they're constructed independently rather than routed through
+ * `primaryFlowRow` so a cross-provider configuration spawns the right CLI per role. `ctx.provider`
+ * (the launcher-rebuilt primary adapter) is deliberately left unused by the implement launcher —
+ * implement bypasses the single-row seam.
+ *
+ * `resolveAgentOverride` applies the bound-definition > per-flow-row > global-default precedence
+ * per role — `createAiProvider` only dispatches on `row.provider` (never `row.model`), so a
+ * definition-supplied model never needs to change WHICH provider adapter is constructed, only the
+ * `model`/`effort` this function returns for the spawn + the escalation baseline downstream.
+ *
+ * @public
+ */
+export const buildImplementProviders = (
+  implementPair: AiImplementSettings,
+  effectiveSettings: Settings,
+  deps: LauncherDeps,
+  agentDefinitions: { readonly generator?: AgentDefinition; readonly evaluator?: AgentDefinition } = {}
+): {
+  readonly generatorProvider: HeadlessAiProvider;
+  readonly evaluatorProvider: HeadlessAiProvider;
+  readonly generatorModel: string;
+  readonly evaluatorModel: string;
+  readonly generatorEffort: string | undefined;
+  readonly evaluatorEffort: string | undefined;
+} => {
+  const generatorProvider = createAiProvider({
+    row: implementPair.generator,
+    harnessConfig: effectiveSettings.harness,
+    eventBus: deps.app.eventBus,
+  });
+  const evaluatorProvider = createAiProvider({
+    row: implementPair.evaluator,
+    harnessConfig: effectiveSettings.harness,
+    eventBus: deps.app.eventBus,
+  });
+  const generatorResolved = resolveAgentOverride(
+    implementPair.generator,
+    effectiveSettings.ai.effort,
+    agentDefinitions.generator
+  );
+  const evaluatorResolved = resolveAgentOverride(
+    implementPair.evaluator,
+    effectiveSettings.ai.effort,
+    agentDefinitions.evaluator
+  );
+  return {
+    generatorProvider,
+    evaluatorProvider,
+    generatorModel: generatorResolved.model,
+    evaluatorModel: evaluatorResolved.model,
+    generatorEffort: generatorResolved.effort,
+    evaluatorEffort: evaluatorResolved.effort,
+  };
+};
+
+/** Assemble the `ImplementDeps` bag handed to `createImplementFlow` / `buildParallelElement`. */
+export const buildImplementDepsBag = (
+  deps: LauncherDeps,
+  effectiveSettings: Settings,
+  publishSignal: PublishSignal,
+  providers: { readonly generatorProvider: HeadlessAiProvider; readonly evaluatorProvider: HeadlessAiProvider },
+  skillsAdapter: SkillsAdapter,
+  skillSource: SkillSource,
+  agentDefinitionAdapters: { readonly generator: AgentDefinitionAdapter; readonly evaluator: AgentDefinitionAdapter }
+): ImplementDeps => ({
+  sprintRepo: deps.app.sprintRepo,
+  sprintExecutionRepo: deps.app.sprintExecutionRepo,
+  taskRepo: deps.app.taskRepo,
+  generatorProvider: providers.generatorProvider,
+  evaluatorProvider: providers.evaluatorProvider,
+  templateLoader: deps.app.templateLoader,
+  publishSignal,
+  eventBus: deps.app.eventBus,
+  logger: deps.app.logger,
+  clock: deps.app.clock,
+  config: effectiveSettings,
+  gitRunner: deps.app.gitRunner,
+  shellScriptRunner: deps.app.shellScriptRunner,
+  fileLocker: deps.app.fileLocker,
+  locksRoot: deps.storage.locksRoot,
+  skillsAdapter,
+  skillSource,
+  generatorAgentDefinitionAdapter: agentDefinitionAdapters.generator,
+  evaluatorAgentDefinitionAdapter: agentDefinitionAdapters.evaluator,
+  interactive: deps.interactive,
+  writeFile: deps.app.writeFile,
+  appendFile: deps.app.appendFile,
+  // ONE journal mutex per run. Every parallel branch inherits this instance (branches spread this
+  // deps bag), so their `progress-journal-<taskId>` leaves serialise their read-regenerate-write
+  // of the shared `progress.md` through it; the serial path is a single caller, so it is a no-op.
+  journalMutex: createFoldQueue(),
+});
+
+/**
+ * Assemble the `CreateImplementFlowOpts` bag — pure object-literal assembly, no branching.
+ * `repositories` is derived here (via {@link buildRepoExecConfigs}) rather than passed in, so
+ * callers only need to hand over the raw project. `providers.generatorModel`/`evaluatorModel`
+ * already carry the bound-definition override (see `buildImplementProviders`), so this bag — and
+ * every downstream consumer that reads `CreateImplementFlowOpts.generatorModel`/`generatorEffort`
+ * (the gen-eval spawn AND `finalize-gen-eval`'s escalation baseline both read the SAME field) —
+ * sees the overridden value without a second resolution.
+ *
+ * @public
+ */
+export const buildImplementOptsBag = (
+  sprint: Pick<Sprint, 'id'>,
+  project: Pick<Project, 'id' | 'slug' | 'repositories'>,
+  todoTasks: readonly Task[],
+  sprintPaths: { readonly progressPath: AbsolutePath; readonly sprintDirPath: AbsolutePath },
+  implementPair: AiImplementSettings,
+  providers: {
+    readonly generatorModel: string;
+    readonly evaluatorModel: string;
+    readonly generatorEffort: string | undefined;
+    readonly evaluatorEffort: string | undefined;
+  },
+  memoryRoot: AbsolutePath,
+  agentBindings: { readonly generator: RoleAgentBinding; readonly evaluator: RoleAgentBinding } = {
+    generator: {},
+    evaluator: {},
+  }
+): CreateImplementFlowOpts => ({
+  sprintId: sprint.id,
+  todoTasks,
+  repositories: buildRepoExecConfigs(project.repositories),
+  progressFile: sprintPaths.progressPath,
+  sprintDir: sprintPaths.sprintDirPath,
+  generatorProviderId: implementPair.generator.provider,
+  generatorModel: providers.generatorModel,
+  ...(providers.generatorEffort !== undefined ? { generatorEffort: providers.generatorEffort } : {}),
+  evaluatorProviderId: implementPair.evaluator.provider,
+  evaluatorModel: providers.evaluatorModel,
+  ...(providers.evaluatorEffort !== undefined ? { evaluatorEffort: providers.evaluatorEffort } : {}),
+  ...(agentBindings.generator.definition !== undefined
+    ? { generatorAgentDefinition: agentBindings.generator.definition }
+    : {}),
+  ...(agentBindings.generator.section !== undefined
+    ? { generatorAgentDefinitionSection: agentBindings.generator.section }
+    : {}),
+  ...(agentBindings.evaluator.definition !== undefined
+    ? { evaluatorAgentDefinition: agentBindings.evaluator.definition }
+    : {}),
+  ...(agentBindings.evaluator.section !== undefined
+    ? { evaluatorAgentDefinitionSection: agentBindings.evaluator.section }
+    : {}),
+  memoryRoot,
+  projectId: String(project.id),
+  projectSlug: project.slug,
+});

--- a/src/application/ui/shared/launch/implement.ts
+++ b/src/application/ui/shared/launch/implement.ts
@@ -7,7 +7,6 @@ import {
   IMPLEMENT_TASK_TERMINAL_LEAF,
   planImplementWaves,
   type CreateImplementFlowOpts,
-  type RepoExecConfig,
 } from '@src/application/flows/implement/flow.ts';
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
 import {
@@ -24,20 +23,19 @@ import { renderTaskGraphIssue, validateTaskGraph } from '@src/domain/entity/task
 import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
-import type { Repository } from '@src/domain/entity/repository.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { Project } from '@src/domain/entity/project.ts';
-import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { createPublishSignal, type PublishSignal } from '@src/application/flows/_shared/publish-signal.ts';
-import type { AiFlowSettings, AiImplementSettings, Settings } from '@src/domain/entity/settings.ts';
-import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
-import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
-import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
-import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
-import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
+import { type AiFlowSettings, type AiImplementSettings, type Settings } from '@src/domain/entity/settings.ts';
+import { resolveImplementAgentBindings } from '@src/application/ui/shared/launch/implement-agent-bindings.ts';
+import {
+  buildImplementDepsBag,
+  buildImplementOptsBag,
+  buildImplementProviders,
+} from '@src/application/ui/shared/launch/implement-bags.ts';
 import type { LaunchContext } from '@src/application/ui/shared/launch/context.ts';
-import type { LaunchResult, LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 /**
@@ -250,119 +248,6 @@ const resolveImplementSprintPaths = (
   });
 };
 
-/** Project repositories → `RepoExecConfig` map keyed by id, the per-task subchain's repo lookup. */
-const buildRepoExecConfigs = (repositories: readonly Repository[]): Map<RepositoryId, RepoExecConfig> => {
-  const configs = new Map<RepositoryId, RepoExecConfig>();
-  for (const r of repositories) {
-    configs.set(r.id, {
-      path: r.path,
-      name: r.name,
-      ...(r.verifyScript !== undefined ? { verifyScript: r.verifyScript } : {}),
-      ...(r.verifyGates !== undefined ? { verifyGates: r.verifyGates } : {}),
-      ...(r.verifyTimeout !== undefined ? { verifyTimeout: r.verifyTimeout } : {}),
-      ...(r.setupScript !== undefined ? { setupScript: r.setupScript } : {}),
-    });
-  }
-  return configs;
-};
-
-/**
- * Build one `HeadlessAiProvider` per role from the effective implement pair. The two roles may
- * target distinct providers — they're constructed independently rather than routed through
- * `primaryFlowRow` so a cross-provider configuration spawns the right CLI per role. `ctx.provider`
- * (the launcher-rebuilt primary adapter) is deliberately left unused by the implement launcher —
- * implement bypasses the single-row seam.
- */
-const buildImplementProviders = (
-  implementPair: AiImplementSettings,
-  effectiveSettings: Settings,
-  deps: LauncherDeps
-): {
-  readonly generatorProvider: HeadlessAiProvider;
-  readonly evaluatorProvider: HeadlessAiProvider;
-  readonly generatorEffort: string | undefined;
-  readonly evaluatorEffort: string | undefined;
-} => {
-  const generatorProvider = createAiProvider({
-    row: implementPair.generator,
-    harnessConfig: effectiveSettings.harness,
-    eventBus: deps.app.eventBus,
-  });
-  const evaluatorProvider = createAiProvider({
-    row: implementPair.evaluator,
-    harnessConfig: effectiveSettings.harness,
-    eventBus: deps.app.eventBus,
-  });
-  const generatorEffort = resolveEffortForRow(implementPair.generator, effectiveSettings.ai.effort);
-  const evaluatorEffort = resolveEffortForRow(implementPair.evaluator, effectiveSettings.ai.effort);
-  return { generatorProvider, evaluatorProvider, generatorEffort, evaluatorEffort };
-};
-
-/** Assemble the `ImplementDeps` bag handed to `createImplementFlow` / `buildParallelElement`. */
-const buildImplementDepsBag = (
-  deps: LauncherDeps,
-  effectiveSettings: Settings,
-  publishSignal: PublishSignal,
-  providers: { readonly generatorProvider: HeadlessAiProvider; readonly evaluatorProvider: HeadlessAiProvider },
-  skillsAdapter: SkillsAdapter,
-  skillSource: SkillSource
-): ImplementDeps => ({
-  sprintRepo: deps.app.sprintRepo,
-  sprintExecutionRepo: deps.app.sprintExecutionRepo,
-  taskRepo: deps.app.taskRepo,
-  generatorProvider: providers.generatorProvider,
-  evaluatorProvider: providers.evaluatorProvider,
-  templateLoader: deps.app.templateLoader,
-  publishSignal,
-  eventBus: deps.app.eventBus,
-  logger: deps.app.logger,
-  clock: deps.app.clock,
-  config: effectiveSettings,
-  gitRunner: deps.app.gitRunner,
-  shellScriptRunner: deps.app.shellScriptRunner,
-  fileLocker: deps.app.fileLocker,
-  locksRoot: deps.storage.locksRoot,
-  skillsAdapter,
-  skillSource,
-  interactive: deps.interactive,
-  writeFile: deps.app.writeFile,
-  appendFile: deps.app.appendFile,
-  // ONE journal mutex per run. Every parallel branch inherits this instance (branches spread this
-  // deps bag), so their `progress-journal-<taskId>` leaves serialise their read-regenerate-write
-  // of the shared `progress.md` through it; the serial path is a single caller, so it is a no-op.
-  journalMutex: createFoldQueue(),
-});
-
-/**
- * Assemble the `CreateImplementFlowOpts` bag — pure object-literal assembly, no branching.
- * `repositories` is derived here (via {@link buildRepoExecConfigs}) rather than passed in, so
- * callers only need to hand over the raw project.
- */
-const buildImplementOptsBag = (
-  sprint: Pick<Sprint, 'id'>,
-  project: Pick<Project, 'id' | 'slug' | 'repositories'>,
-  todoTasks: readonly Task[],
-  sprintPaths: { readonly progressPath: AbsolutePath; readonly sprintDirPath: AbsolutePath },
-  implementPair: AiImplementSettings,
-  providers: { readonly generatorEffort: string | undefined; readonly evaluatorEffort: string | undefined },
-  memoryRoot: AbsolutePath
-): CreateImplementFlowOpts => ({
-  sprintId: sprint.id,
-  todoTasks,
-  repositories: buildRepoExecConfigs(project.repositories),
-  progressFile: sprintPaths.progressPath,
-  sprintDir: sprintPaths.sprintDirPath,
-  generatorProviderId: implementPair.generator.provider,
-  generatorModel: implementPair.generator.model,
-  ...(providers.generatorEffort !== undefined ? { generatorEffort: providers.generatorEffort } : {}),
-  evaluatorProviderId: implementPair.evaluator.provider,
-  evaluatorModel: implementPair.evaluator.model,
-  ...(providers.evaluatorEffort !== undefined ? { evaluatorEffort: providers.evaluatorEffort } : {}),
-  memoryRoot,
-  projectId: String(project.id),
-  projectSlug: project.slug,
-});
-
 /**
  * Stop the file-log + bus subscriptions when the runner reaches a terminal state. Pending writes
  * still drain in the background — events.ndjson remains consistent post-exit. The subscription
@@ -438,6 +323,7 @@ const buildImplementElement = (
     readonly implementPair: AiImplementSettings;
     readonly publishSignal: PublishSignal;
     readonly providers: ReturnType<typeof buildImplementProviders>;
+    readonly agentBindings: Awaited<ReturnType<typeof resolveImplementAgentBindings>>;
     readonly sprint: Sprint;
     readonly project: Project;
     readonly todoTasks: readonly Task[];
@@ -452,7 +338,8 @@ const buildImplementElement = (
     args.publishSignal,
     args.providers,
     skillsAdapter,
-    skillSource
+    skillSource,
+    { generator: args.agentBindings.generatorAdapter, evaluator: args.agentBindings.evaluatorAdapter }
   );
   const implementOpts = buildImplementOptsBag(
     args.sprint,
@@ -461,7 +348,8 @@ const buildImplementElement = (
     { progressPath: args.progressPath, sprintDirPath: args.sprintDirPath },
     args.implementPair,
     args.providers,
-    deps.storage.memoryRoot
+    deps.storage.memoryRoot,
+    { generator: args.agentBindings.generator, evaluator: args.agentBindings.evaluator }
   );
   const maxParallel = clampParallel(args.effectiveSettings.concurrency.maxParallelTasks);
   return maxParallel === 1
@@ -513,15 +401,23 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   // rebuilds its own per-branch publisher in `wave-branch.ts` (keyed on each task's `taskId`), so
   // this instance is never reused there.
   const publishSignal = createPublishSignal(deps.app.eventBus, 'implement');
+  // Resolve each role's opt-in agent-definition binding (AC2: an unknown bound name is reported
+  // and the role runs unaided) BEFORE building the providers — a bound definition's model/effort
+  // overrides the row (AC5).
+  const agentBindings = await resolveImplementAgentBindings(deps, implementPair);
   // Two independent per-role adapters — the roles may target distinct providers (see
   // `buildImplementProviders`'s doc comment for why `ctx.provider` is unused here).
-  const providers = buildImplementProviders(implementPair, effectiveSettings, deps);
-  const { generatorEffort, evaluatorEffort } = providers;
+  const providers = buildImplementProviders(implementPair, effectiveSettings, deps, {
+    ...(agentBindings.generator.definition !== undefined ? { generator: agentBindings.generator.definition } : {}),
+    ...(agentBindings.evaluator.definition !== undefined ? { evaluator: agentBindings.evaluator.definition } : {}),
+  });
+  const { generatorModel, evaluatorModel, generatorEffort, evaluatorEffort } = providers;
   const element = buildImplementElement(ctx, {
     effectiveSettings,
     implementPair,
     publishSignal,
     providers,
+    agentBindings,
     sprint: snapshot.sprint,
     project: snapshot.project,
     todoTasks,
@@ -541,11 +437,10 @@ export const launchImplement = async (ctx: LaunchContext): Promise<LaunchResult>
   const flattened = flattenLeaves(element);
   const plannedLeaves = flattened.map((e) => e.name);
   const planLabelByName = computePlanLabels(flattened);
-  // Both role models are drawn from the post-merge implementPair so per-launch role overrides
-  // (TUI customize picker or CLI flags) flow through to the rail/banner without a second
-  // settings read.
-  const generatorModel = implementPair.generator.model;
-  const evaluatorModel = implementPair.evaluator.model;
+  // Providers are drawn from the post-merge implementPair, and the models from `providers`
+  // (which already carry a bound definition's override — see `buildImplementProviders`), so
+  // per-launch role overrides AND agent-definition bindings both flow through to the
+  // rail/banner without a second settings read.
   const generatorProviderId = implementPair.generator.provider;
   const evaluatorProviderId = implementPair.evaluator.provider;
   return {

--- a/src/business/settings/apply-key.ts
+++ b/src/business/settings/apply-key.ts
@@ -1,6 +1,13 @@
 import { Result } from '@src/domain/result.ts';
 import { ValidationError } from '@src/domain/value/error/validation-error.ts';
-import type { AiFlowSettings, AiImplementRole, AiProvider, AiSettings, Settings } from '@src/domain/entity/settings.ts';
+import type {
+  AiAgentBindings,
+  AiFlowSettings,
+  AiImplementRole,
+  AiProvider,
+  AiSettings,
+  Settings,
+} from '@src/domain/entity/settings.ts';
 import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
 
 /**
@@ -22,7 +29,11 @@ import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
  * explicitly via `ai.implement.generator.<field>` or `ai.implement.evaluator.<field>`.
  */
 const SETTINGS_KEY_HINT =
-  'supported keys: ai.effort, ai.{flow}.{provider,model,effort} (flow in {refine,plan,readiness,ideate,createPr}), ai.implement.{generator,evaluator}.{provider,model,effort}, harness.{maxTurns,maxAttempts,rateLimitRetries,idleWatchdogMs,plateauThreshold,correctiveRetries,escalateOnPlateau,skipPreVerifyOnFreshSetup}, harness.escalationMap.<fromModel>, logging.level, concurrency.maxParallelTasks, scm.postRefinementComment, ui.notifications.enabled';
+  'supported keys: ai.effort, ai.{flow}.{provider,model,effort} (flow in {refine,plan,readiness,ideate,createPr}), ai.implement.{generator,evaluator}.{provider,model,effort}, ai.implement.agents.{generator,evaluator}, harness.{maxTurns,maxAttempts,rateLimitRetries,idleWatchdogMs,plateauThreshold,correctiveRetries,escalateOnPlateau,skipPreVerifyOnFreshSetup}, harness.escalationMap.<fromModel>, logging.level, concurrency.maxParallelTasks, scm.postRefinementComment, ui.notifications.enabled';
+
+/** Hint attached to a rejected `ai.<flow>.agents.<role>` key targeting an unsupported binding. */
+const AGENT_BINDING_UNSUPPORTED_HINT =
+  'agent-definition binding is supported only for ai.implement.agents.{generator,evaluator} in this release';
 
 const BOOLEAN_VALUE_HINT = "use 'true' or 'false'";
 
@@ -151,6 +162,47 @@ const tryApplyAiImplementRoleKey = (
   return undefined;
 };
 
+/**
+ * `ai.implement.agents.<role>` — bind (or, with an empty value, clear) an agent-definition name
+ * to the implement generator/evaluator role. Every other `ai.<flow>.agents.<key>` shape —
+ * another flow, or an implement sub-key other than `generator`/`evaluator` — targets a
+ * role/flow this release does not support delegating to; that is reported explicitly here
+ * rather than falling through to the generic "unknown settings key" error, so a binding is
+ * never silently ignored.
+ */
+const tryApplyAgentsKey = (
+  current: Settings,
+  key: string,
+  raw: string
+): Result<Settings, ValidationError> | undefined => {
+  const parts = key.split('.');
+  if (parts.length !== 4 || parts[0] !== 'ai' || parts[2] !== 'agents') return undefined;
+  const flow = parts[1] ?? '';
+  const role = parts[3] ?? '';
+  if (flow !== 'implement' || !isImplementRole(role)) {
+    return Result.error(
+      new ValidationError({
+        field: key,
+        value: raw,
+        message: `'${key}' targets a role/flow not supported for agent-definition binding in this release`,
+        hint: AGENT_BINDING_UNSUPPORTED_HINT,
+      })
+    );
+  }
+  const trimmed = raw.trim();
+  const rest: Partial<Record<string, string>> = { ...current.ai.implement.agents };
+  if (trimmed.length === 0) {
+    delete rest[role];
+  } else {
+    rest[role] = trimmed;
+  }
+  const nextAgents = Object.keys(rest).length > 0 ? (rest as AiAgentBindings) : undefined;
+  return Result.ok({
+    ...current,
+    ai: { ...current.ai, implement: { ...current.ai.implement, agents: nextAgents } },
+  });
+};
+
 /** `ai.effort` — global fallback effort; empty input clears it. */
 const tryApplyAiEffortKey = (
   current: Settings,
@@ -175,6 +227,7 @@ const applyAiKey = (current: Settings, key: string, raw: string): Result<Setting
   tryApplyAiFlowKey(current, key, raw) ??
   tryRejectFlatImplementKey(key, raw) ??
   tryApplyAiImplementRoleKey(current, key, raw) ??
+  tryApplyAgentsKey(current, key, raw) ??
   tryApplyAiEffortKey(current, key, raw);
 
 /**

--- a/src/business/settings/resolve-agent-override.ts
+++ b/src/business/settings/resolve-agent-override.ts
@@ -1,0 +1,42 @@
+import type { AiFlowSettings, Settings } from '@src/domain/entity/settings.ts';
+import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
+
+/**
+ * The subset of an `AgentDefinition` this resolver needs. Declared locally rather than
+ * imported — the integration-side `AgentDefinition` type lives in `integration/ai/agents/`,
+ * an outer layer business code may not depend on. Any object carrying `model?`/`effort?`
+ * satisfies this, including an actual `AgentDefinition`.
+ */
+export interface AgentOverrideHints {
+  readonly model?: string;
+  readonly effort?: string;
+}
+
+/** Effective model/effort for one implement role after applying the override precedence. */
+export interface ResolvedAgentOverride {
+  readonly model: string;
+  readonly effort: string | undefined;
+}
+
+/**
+ * Resolve the effective model and effort for one implement role, applying the precedence
+ * bound definition > per-flow row > global default.
+ *
+ * - `model`: the definition's `model` when set, otherwise the row's own `model` (always
+ *   present — every {@link AiFlowSettings} row is fully stamped with a provider-catalog model).
+ * - `effort`: the definition's `effort` when set, otherwise {@link resolveEffortForRow}'s
+ *   result (per-flow row effort, falling through to the global default floored to the row's
+ *   provider).
+ *
+ * `binding` is `undefined` when the role has no bound definition — resolution then falls
+ * straight through to the per-flow row / global default, identical to `resolveEffortForRow`
+ * plus the row's own model.
+ */
+export const resolveAgentOverride = (
+  row: AiFlowSettings,
+  globalEffort: Settings['ai']['effort'],
+  binding: AgentOverrideHints | undefined
+): ResolvedAgentOverride => ({
+  model: binding?.model ?? row.model,
+  effort: binding?.effort ?? resolveEffortForRow(row, globalEffort),
+});

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -88,14 +88,38 @@ const CodexFlowRowSchema = z.object({
 const FlowRowSchema = z.discriminatedUnion('provider', [ClaudeFlowRowSchema, CopilotFlowRowSchema, CodexFlowRowSchema]);
 
 /**
+ * One role's opt-in agent-definition binding — the kebab-case `name` of an authored
+ * {@link AgentDefinition} to delegate that role's session to. Names are free trimmed
+ * non-empty strings — the domain cannot import the integration-side agent-definition sources,
+ * so a name's validity against the bundled/operator catalog is checked at launch (an unknown
+ * name is a harmless no-op), never here. Mirrors {@link FlowSkillsRowSchema}'s posture on
+ * skill names.
+ */
+const AgentBindingNameSchema = z.string().trim().min(1, 'agent definition name must be a non-empty trimmed string');
+
+/**
+ * Manual, opt-in binding of an agent definition to the implement generator and/or evaluator
+ * role, independently — either, both, or neither may be bound. Absent (or an absent `agents`
+ * block on {@link AiImplementSchema}) means "no binding for this role"; the launcher then runs
+ * the role's session unaided by a delegated persona, exactly as before this field existed.
+ */
+const AiAgentBindingsSchema = z.object({
+  generator: AgentBindingNameSchema.optional(),
+  evaluator: AgentBindingNameSchema.optional(),
+});
+
+/**
  * Implement runs two AI sessions per attempt — a generator that produces the change and an
  * evaluator that scores it. Each role carries its own per-flow row so they can run on
  * different providers / models / effort levels. The roles share the same row shape; only the
  * `implement` slot under `ai` carries this pair, every other flow stays on the flat row.
+ *
+ * `agents` is the optional per-role agent-definition binding — see {@link AiAgentBindingsSchema}.
  */
 const AiImplementSchema = z.object({
   generator: FlowRowSchema,
   evaluator: FlowRowSchema,
+  agents: AiAgentBindingsSchema.optional(),
 });
 
 /**
@@ -272,7 +296,7 @@ const AiSkillsSchema = z.object({
  *   ai.effort?            // global default, used when a row omits its own effort
  *   ai.refine             // { provider, model, effort? }
  *   ai.plan               // { provider, model, effort? }
- *   ai.implement          // { generator: { provider, model, effort? }, evaluator: {...} }
+ *   ai.implement          // { generator: {...}, evaluator: {...}, agents?: { generator?, evaluator? } }
  *   ai.readiness          // { provider, model, effort? }
  *   ai.ideate             // { provider, model, effort? }
  *   ai.createPr           // { provider, model, effort? }
@@ -505,6 +529,25 @@ export type AiFlowSettings = z.infer<typeof FlowRowSchema>;
 export type AiImplementSettings = z.infer<typeof AiImplementSchema>;
 /** Roles inside {@link AiImplementSettings} — addressed in dotted-path keys and per-leaf launches. */
 export type AiImplementRole = 'generator' | 'evaluator';
+/**
+ * Optional per-role agent-definition binding under `settings.ai.implement.agents` — see
+ * {@link AiAgentBindingsSchema}. An absent key (or an absent `agents` block) means the role has
+ * no bound definition.
+ *
+ * @public
+ */
+export type AiAgentBindings = z.infer<typeof AiAgentBindingsSchema>;
+
+/**
+ * Resolve the agent-definition name bound to one implement role, or `undefined` when that
+ * role has no binding (including when the whole `agents` block is absent). The "primary"
+ * naming mirrors {@link primaryFlowRow}: a single lookup a caller can use without reaching
+ * into the block's shape directly.
+ *
+ * @public
+ */
+export const primaryAgentBinding = (agents: AiAgentBindings | undefined, role: AiImplementRole): string | undefined =>
+  agents?.[role];
 /**
  * Durable opt-OUT preference block under `settings.ai.skills` — see {@link AiSkillsSchema}.
  * `Partial<Record<FlowId, { disabled: readonly string[] }>>`. Exposed for the skills launcher

--- a/src/integration/ai/agents/_engine/agent-definition-adapter.ts
+++ b/src/integration/ai/agents/_engine/agent-definition-adapter.ts
@@ -1,0 +1,45 @@
+/**
+ * `AgentDefinitionAdapter` — provider-specific install / uninstall of portable agent
+ * definitions into an AI session's sandbox.
+ *
+ * Each AI provider has its own native sub-agent discovery convention:
+ *  - Claude reads `<sessionDir>/.claude/agents/<name>.md`.
+ *  - Copilot reads `<sessionDir>/.github/agents/<name>.agent.md`.
+ *  - Codex reads `<sessionDir>/.codex/agents/<name>.toml`.
+ *
+ * The adapter takes a list of canonical {@link AgentDefinition}s and writes them in the format
+ * the selected provider discovers, following the same shape as {@link SkillsAdapter}: `install`
+ * is idempotent and *project-definitions-win* — a destination that already exists is left
+ * untouched — and `uninstall` removes only the files the matching `install` wrote.
+ */
+
+import type { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+export interface AgentDefinitionAdapter {
+  /**
+   * Install the given agent definitions into the AI session's sandbox at `sessionDir`. Returns
+   * ok on every path including "the render step rejected a definition" (see the Copilot
+   * 30000-char size guard) — the failing definition's error is returned and no file is written
+   * for it. A destination that already exists (a project-authored file) is left untouched.
+   *
+   * Adds `ralphctl-*` tracking (so `uninstall` removes only entries this adapter created) and
+   * appends the `ralphctl-*` wildcard to `.git/info/exclude` on first install so ralphctl-owned
+   * agent files don't show in `git status`.
+   */
+  install(sessionDir: AbsolutePath, definitions: readonly AgentDefinition[]): Promise<Result<void, StorageError>>;
+  /**
+   * Remove only the agent definitions `install` placed at `sessionDir` (manifest-tracked).
+   * Pre-existing project files are never touched. Idempotent — calling without a prior install
+   * (or after a previous uninstall) is a no-op.
+   */
+  uninstall(sessionDir: AbsolutePath): Promise<Result<void, StorageError>>;
+  /**
+   * Short markdown snippet describing where this provider stores native agent definitions and
+   * how the running AI session discovers them. Spliced into authoring prompts so the prompt
+   * template itself stays provider-agnostic.
+   */
+  describeConvention(): string;
+}

--- a/src/integration/ai/agents/_engine/agent-definition-quality.ts
+++ b/src/integration/ai/agents/_engine/agent-definition-quality.ts
@@ -1,0 +1,114 @@
+/**
+ * `checkAgentDefinitionQuality` — a pure, non-blocking scanner that flags agent-definition
+ * bodies too vague to give an AI session concrete guidance.
+ *
+ * Operator-authored agent definitions land directly in a provider's native sub-agent directory
+ * and get delegated to as-is, so a definition that is all mood and no method (short, no
+ * structure, or — for an evaluator-role definition — no mention of how to actually verify
+ * anything) quietly produces a sub-agent that can't do its job. This module is the single
+ * source of truth for that quality bar. It is deliberately I/O-free so two callers can share it:
+ * a future contract test over the bundled set, and {@link warnIfVague} (the operator-source warn
+ * path).
+ *
+ * Mirrors the shape of `skills/_engine/skill-contract-checker.ts` (checkers + a warn helper),
+ * but the concern is different: that module blocks HARNESS-BREAKING instructions; this one flags
+ * LOW-QUALITY (but harmless) guidance. Neither check ever fails the read — both are advisory.
+ */
+
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+/** One quality concern, with enough context for a human to judge it. */
+export interface AgentDefinitionQualityConcern {
+  /** Rule id (`Q1`…`Q3`). */
+  readonly rule: string;
+  /** Human-readable explanation of what's missing and why it matters. */
+  readonly description: string;
+}
+
+/** Result of scanning one agent definition. `pass` is `concerns.length === 0`. */
+export interface AgentDefinitionQualityReport {
+  readonly name: string;
+  readonly concerns: readonly AgentDefinitionQualityConcern[];
+  readonly pass: boolean;
+}
+
+/** Below this word count a body reads as filler rather than actionable guidance. */
+const MIN_WORD_COUNT = 40;
+
+/** A Markdown heading or an ordered/unordered list item — the minimal sign of concrete structure. */
+const HEADING_OR_LIST = /^(?:#{1,6}\s|\s*(?:\d+[.)]|[-*+])\s)/mu;
+
+/** Terms in the name/description that suggest this definition plays an evaluator/reviewer role. */
+const EVALUATOR_HINTS = ['evaluat', 'review', 'judge', 'grade'] as const;
+
+/** Concrete verification vocabulary an evaluator-role body should mention at least once. */
+const VERIFICATION_TERMS = ['verif', 'criteri', 'test', 'evidence', 'pass', 'fail', 'command', 'check'] as const;
+
+const wordCount = (text: string): number =>
+  text
+    .trim()
+    .split(/\s+/u)
+    .filter((w) => w.length > 0).length;
+
+interface Checker {
+  readonly id: string;
+  readonly description: string;
+  /** Returns `true` when the concern is present. */
+  readonly flags: (definition: AgentDefinition) => boolean;
+}
+
+const CHECKERS: readonly Checker[] = [
+  {
+    id: 'Q1',
+    description: `body is under ${String(MIN_WORD_COUNT)} words — too short to give concretely actionable guidance`,
+    flags: (d) => wordCount(d.content) < MIN_WORD_COUNT,
+  },
+  {
+    id: 'Q2',
+    description: 'body has no headings or list items — reads as unstructured prose rather than concrete steps',
+    flags: (d) => !HEADING_OR_LIST.test(d.content),
+  },
+  {
+    id: 'Q3',
+    description:
+      'an evaluator-role definition never mentions verification, criteria, or evidence — guidance is not concretely checkable',
+    flags: (d) => {
+      const identity = `${d.name} ${d.description}`.toLowerCase();
+      const looksLikeEvaluator = EVALUATOR_HINTS.some((hint) => identity.includes(hint));
+      if (!looksLikeEvaluator) return false;
+      const body = d.content.toLowerCase();
+      return !VERIFICATION_TERMS.some((term) => body.includes(term));
+    },
+  },
+];
+
+/**
+ * Scan `definition` against the quality checkers.
+ *
+ * @public
+ */
+export const checkAgentDefinitionQuality = (definition: AgentDefinition): AgentDefinitionQualityReport => {
+  const concerns = CHECKERS.filter((checker) => checker.flags(definition)).map((checker) => ({
+    rule: checker.id,
+    description: checker.description,
+  }));
+  return { name: definition.name, concerns, pass: concerns.length === 0 };
+};
+
+/**
+ * Operator-definition warn path: log one warn-level line per quality concern. Never throws — a
+ * vague operator definition should degrade to a warning, not block install.
+ *
+ * @public
+ */
+export const warnIfVague = (logger: Logger, definition: AgentDefinition): void => {
+  const report = checkAgentDefinitionQuality(definition);
+  for (const concern of report.concerns) {
+    logger.warn('agent definition quality concern', {
+      name: definition.name,
+      rule: concern.rule,
+      description: concern.description,
+    });
+  }
+};

--- a/src/integration/ai/agents/_engine/agent-definition-source.ts
+++ b/src/integration/ai/agents/_engine/agent-definition-source.ts
@@ -1,0 +1,23 @@
+/**
+ * `AgentDefinitionSource` — produces the {@link AgentDefinition}s a given source tier owns.
+ *
+ * Mirrors `SkillSource` (`src/integration/ai/skills/_engine/skill-source.ts`) with one
+ * difference: agent definitions are not flow-scoped the way skills are, so `list()` replaces
+ * `getForFlow(flowId)` — every source in this subsystem returns its full set unconditionally,
+ * and the caller (a composed source, or install-time wiring) decides what to install.
+ */
+
+import type { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+export interface AgentDefinitionSource {
+  /** Every agent definition this source provides. An empty list is a valid, non-error result. */
+  list(): Promise<Result<readonly AgentDefinition[], StorageError>>;
+  /**
+   * Resolve a single agent definition by its exact (namespaced) name. Returns `ok(undefined)`
+   * when no definition of that name exists in this source — the "unknown name" case is NOT an
+   * error. `StorageError` is reserved for a definition that exists but cannot be read or parsed.
+   */
+  getByName(name: string): Promise<Result<AgentDefinition | undefined, StorageError>>;
+}

--- a/src/integration/ai/agents/_engine/agent-definition.ts
+++ b/src/integration/ai/agents/_engine/agent-definition.ts
@@ -59,3 +59,10 @@ export interface AgentDefinition {
   /** Markdown body (everything after the frontmatter block) — the agent's system prompt. */
   readonly content: string;
 }
+
+/** Output of a per-provider native renderer — {@link RALPHCTL_AGENT_PREFIX}-prefixed file. */
+export interface RenderedAgentFile {
+  /** Path relative to `sessionDir`, including the provider's parent directory. */
+  readonly relPath: string;
+  readonly content: string;
+}

--- a/src/integration/ai/agents/_engine/agent-definition.ts
+++ b/src/integration/ai/agents/_engine/agent-definition.ts
@@ -26,6 +26,19 @@ import { z } from 'zod';
 export const RALPHCTL_AGENT_PREFIX = 'ralphctl-';
 
 /**
+ * Idempotent prefixing for a native-render file base name. The bundled and operator sources
+ * already namespace `AgentDefinition.name` with {@link RALPHCTL_AGENT_PREFIX} (mirroring
+ * `Skill.name`'s convention), so a per-provider renderer that unconditionally prepended the
+ * prefix again would double it (`ralphctl-ralphctl-<name>`). Every renderer calls this instead
+ * of concatenating the prefix directly, so a bare (un-namespaced) name — as used by the
+ * renderer unit tests and any future direct caller — still gets prefixed exactly once.
+ *
+ * @public
+ */
+export const namespacedAgentFileBase = (name: string): string =>
+  name.startsWith(RALPHCTL_AGENT_PREFIX) ? name : `${RALPHCTL_AGENT_PREFIX}${name}`;
+
+/**
  * Agent definition name = kebab-case identifier. Must match the source file name on disk so
  * the file layout and the frontmatter agree.
  */

--- a/src/integration/ai/agents/_engine/agent-definition.ts
+++ b/src/integration/ai/agents/_engine/agent-definition.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical AgentDefinition type — the single shape every source produces and every provider
+ * renderer consumes for the portable-agent-definitions subsystem.
+ *
+ * An AgentDefinition is a named sub-agent persona (system prompt + optional model/effort
+ * hints) an AI session can delegate to. The content is provider-agnostic Markdown; the
+ * *placement* (where the file lands so the AI's CLI auto-discovers it) is up to the
+ * per-provider renderer.
+ *
+ * Source-of-truth file format on disk — Markdown with YAML frontmatter:
+ *
+ *     ---
+ *     name: implementer
+ *     description: Writes features, fixes bugs, adds tests
+ *     model: claude-sonnet-5
+ *     effort: high
+ *     ---
+ *     <content>
+ *
+ * `name` is the kebab-case identifier (and source file name on disk).
+ */
+
+import { z } from 'zod';
+
+/** Prefix applied to ralphctl-authored agent definitions so they are namespaced on disk. @public */
+export const RALPHCTL_AGENT_PREFIX = 'ralphctl-';
+
+/**
+ * Agent definition name = kebab-case identifier. Must match the source file name on disk so
+ * the file layout and the frontmatter agree.
+ */
+export const AgentDefinitionNameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u, 'lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens');
+
+/**
+ * On-disk frontmatter shape. `name` and `description` are required. `model` and `effort` are
+ * passed through verbatim as opaque strings — the caller resolves them against each provider's
+ * own model/effort vocabulary; this layer does not validate their values.
+ */
+export const AgentDefinitionFrontmatterSchema = z.object({
+  name: AgentDefinitionNameSchema,
+  description: z.string().min(1).max(1024),
+  model: z.string().optional(),
+  effort: z.string().optional(),
+});
+
+export interface AgentDefinition {
+  /** Kebab-case identifier. Also the on-disk source file name. */
+  readonly name: string;
+  /** One-line "what + when to use" — drives both human readers and AI delegation. */
+  readonly description: string;
+  /** Optional preferred model identifier, opaque to this layer. */
+  readonly model?: string;
+  /** Optional preferred reasoning-effort hint, opaque to this layer. */
+  readonly effort?: string;
+  /** Markdown body (everything after the frontmatter block) — the agent's system prompt. */
+  readonly content: string;
+}

--- a/src/integration/ai/agents/_engine/compose-agent-definition-sources.ts
+++ b/src/integration/ai/agents/_engine/compose-agent-definition-sources.ts
@@ -1,0 +1,51 @@
+/**
+ * `composeAgentDefinitionSources` — compose two or more {@link AgentDefinitionSource}s into one,
+ * with project-wins precedence.
+ *
+ * There are three source tiers, most-general to most-specific:
+ *  1. **bundled** — the vetted set shipped with ralphctl (`agents/bundled/`).
+ *  2. **operator** — global drop-ins under `<appRoot>/agents`, authored once and reused across
+ *     every project (`agents/operator/`).
+ *  3. **project** — a definition the project itself authors directly in its native provider
+ *     directory (e.g. `.claude/agents/ralphctl-<name>.md` committed to the repo).
+ *
+ * The project tier is NOT a source composed here — there is no `AgentDefinitionSource` reading
+ * project-authored files, because those files already live where the provider's CLI looks for
+ * them. Project-wins precedence is realised one layer down, by
+ * `createFilesystemAgentDefinitionAdapter`'s install step: it skips writing a rendered
+ * definition whenever a file already exists at the destination path, leaving a project-authored
+ * copy untouched. This function only has to arbitrate between bundled and operator: later
+ * sources win a name collision, so the conventional call is
+ * `composeAgentDefinitionSources(bundled, operator)` — an operator definition overrides a
+ * bundled one of the same name.
+ *
+ * Errors from any source short-circuit: a hard failure on one tier is never masked by another
+ * tier's empty result.
+ */
+
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+
+export const composeAgentDefinitionSources = (...sources: readonly AgentDefinitionSource[]): AgentDefinitionSource => {
+  const listAll = async (): Promise<Result<readonly AgentDefinition[], StorageError>> => {
+    const byName = new Map<string, AgentDefinition>();
+    for (const source of sources) {
+      const r = await source.list();
+      if (!r.ok) return Result.error(r.error);
+      // Later sources win a name collision — see the module doc comment for the precedence order.
+      for (const definition of r.value) byName.set(definition.name, definition);
+    }
+    return Result.ok([...byName.values()]);
+  };
+
+  return {
+    list: listAll,
+    async getByName(name: string): Promise<Result<AgentDefinition | undefined, StorageError>> {
+      const all = await listAll();
+      if (!all.ok) return Result.error(all.error);
+      return Result.ok(all.value.find((d) => d.name === name));
+    },
+  };
+};

--- a/src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts
+++ b/src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts
@@ -1,0 +1,191 @@
+/**
+ * `createFilesystemAgentDefinitionAdapter` — shared {@link AgentDefinitionAdapter}
+ * implementation backing every provider whose native sub-agent convention is "render each
+ * definition to a provider-specific file under `<sessionDir>/<parentDir>/agents/` and let the
+ * running CLI auto-discover it." Only the {@link RenderedAgentFile} renderer (path + content
+ * shape, format, extension) and the `parentDir` / convention text differ between Claude, Copilot,
+ * and Codex.
+ *
+ * Behaviour (identical across providers):
+ *  - **Project definitions win.** If the renderer's `relPath` already exists under
+ *    `sessionDir`, the user authored their own copy — leave it untouched and exclude it from
+ *    the manifest.
+ *  - **Manifest-tracked uninstall.** `install` records the `relPath`s it actually wrote into a
+ *    per-`sessionDir` Set. `uninstall` removes only those, then attempts to clean up the
+ *    `<parentDir>/agents` and `<parentDir>` directories when they end up empty.
+ *  - **Idempotent.** A second `install` adds only the still-missing definitions; double-
+ *    `uninstall` is a no-op.
+ *  - **Renderer errors abort the batch.** A definition the renderer rejects (e.g. Copilot's
+ *    30000-char body guard) returns the error immediately and writes no file for it; anything
+ *    already written earlier in the same `install` call stays tracked for cleanup.
+ *
+ * Mirrors {@link createFilesystemSkillsAdapter} — see that module for the rationale behind
+ * sharing one implementation across siblings.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, rm, rmdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
+import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+
+export interface FilesystemAgentDefinitionAdapterDeps {
+  /** Provider id — used only for error messages. */
+  readonly providerId: string;
+  /**
+   * Top-level directory the running CLI scans for native agent definitions (e.g. `.claude`,
+   * `.github`, `.codex`). Used to build the `.git/info/exclude` wildcard and to tidy empty
+   * parent dirs on uninstall — the renderer's `relPath` already embeds this prefix.
+   */
+  readonly parentDir: string;
+  /** Renders one canonical definition into the provider's native file shape. */
+  readonly renderer: (definition: AgentDefinition) => Result<RenderedAgentFile, StorageError>;
+  /** Markdown sentence returned from {@link AgentDefinitionAdapter.describeConvention}. */
+  readonly convention: string;
+  /**
+   * Optional logger — used to warn when the best-effort `.git/info/exclude` write fails.
+   * Install still succeeds in that case; the user just sees harness-authored `ralphctl-*`
+   * files in `git status` until the exclude lands manually.
+   */
+  readonly logger?: Logger;
+}
+
+const tryRmdirIfEmpty = async (path: string): Promise<void> => {
+  try {
+    await rmdir(path);
+  } catch {
+    // Non-empty or missing — both are fine, the cleanup is best-effort.
+  }
+};
+
+/**
+ * Write one rendered definition file, skipping when a project copy already exists at the
+ * destination. Returns the relPath actually written (or `undefined` on a skip) so the caller
+ * updates its manifest without re-deriving the join.
+ */
+const writeOne = async (
+  sessionDir: AbsolutePath,
+  providerId: string,
+  definition: AgentDefinition,
+  rendered: RenderedAgentFile
+): Promise<Result<string | undefined, StorageError>> => {
+  const dst = join(String(sessionDir), rendered.relPath);
+  if (existsSync(dst)) return Result.ok(undefined); // project copy wins
+
+  try {
+    await mkdir(dirname(dst), { recursive: true });
+    await writeFile(dst, rendered.content, 'utf-8');
+    return Result.ok(rendered.relPath);
+  } catch (cause) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `${providerId}: failed to install agent definition ${definition.name}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        path: dst,
+        cause,
+      })
+    );
+  }
+};
+
+export const createFilesystemAgentDefinitionAdapter = (
+  deps: FilesystemAgentDefinitionAdapterDeps
+): AgentDefinitionAdapter => {
+  // Per-sessionDir manifest of relPaths this adapter created at install time. Cleared on a
+  // successful uninstall. Not promised across crashed runs — the cleanup is best-effort.
+  const installed = new Map<string, Set<string>>();
+  // Per-sessionDir flag tracking whether we've already attempted to append the wildcard
+  // exclude — avoids re-reading the file on every install call across a long-running session.
+  const excludeAttempted = new Set<string>();
+  const agentsSubdir = join(deps.parentDir, 'agents');
+  const excludePattern = `${agentsSubdir}/ralphctl-*`;
+
+  // Self-healing prune: drop manifest entries whose sessionDir no longer exists on disk (see
+  // createFilesystemSkillsAdapter's identical `pruneStale` for the failure mode this guards).
+  const pruneStale = (): void => {
+    for (const key of [...installed.keys()]) {
+      if (!existsSync(key)) installed.delete(key);
+    }
+  };
+
+  return {
+    async install(
+      sessionDir: AbsolutePath,
+      definitions: readonly AgentDefinition[]
+    ): Promise<Result<void, StorageError>> {
+      pruneStale();
+      const tracked = installed.get(String(sessionDir)) ?? new Set<string>();
+
+      for (const definition of definitions) {
+        const rendered = deps.renderer(definition);
+        if (!rendered.ok) {
+          if (tracked.size > 0) installed.set(String(sessionDir), tracked);
+          return rendered;
+        }
+
+        const written = await writeOne(sessionDir, deps.providerId, definition, rendered.value);
+        if (!written.ok) {
+          if (tracked.size > 0) installed.set(String(sessionDir), tracked);
+          return written;
+        }
+        if (written.value !== undefined) tracked.add(written.value);
+      }
+
+      if (tracked.size > 0) installed.set(String(sessionDir), tracked);
+
+      // Best-effort: append a single wildcard line to <sessionDir>/.git/info/exclude so every
+      // `ralphctl-*` agent definition we manage stays out of `git status`. A non-git tree, a
+      // worktree, or a write-protected `.git/info/exclude` all collapse to "warn and proceed" —
+      // the install itself already succeeded.
+      if (!excludeAttempted.has(String(sessionDir))) {
+        excludeAttempted.add(String(sessionDir));
+        const excluded = await ensureGitExcludeWildcard(sessionDir, excludePattern);
+        if (!excluded.ok) {
+          deps.logger
+            ?.named('agents.exclude')
+            .warn(`${deps.providerId}: failed to update .git/info/exclude: ${excluded.error.message}`);
+        }
+      }
+
+      return Result.ok(undefined);
+    },
+
+    describeConvention(): string {
+      return deps.convention;
+    },
+
+    async uninstall(sessionDir: AbsolutePath): Promise<Result<void, StorageError>> {
+      const key = String(sessionDir);
+      const tracked = installed.get(key);
+      if (tracked === undefined || tracked.size === 0) return Result.ok(undefined);
+
+      try {
+        for (const relPath of tracked) {
+          await rm(join(key, relPath), { recursive: true, force: true });
+        }
+        installed.delete(key);
+      } catch (cause) {
+        return Result.error(
+          new StorageError({
+            subCode: 'io',
+            message: `${deps.providerId}: failed to uninstall agent definitions under ${join(key, agentsSubdir)}: ${cause instanceof Error ? cause.message : String(cause)}`,
+            path: join(key, agentsSubdir),
+            cause,
+          })
+        );
+      }
+
+      // Tidy empty parent dirs we may have created. Failure is benign — the files themselves
+      // are already gone, and a non-empty parent (e.g. a project `.github/` with workflows in
+      // it) is preserved by `tryRmdirIfEmpty`.
+      await tryRmdirIfEmpty(join(key, agentsSubdir));
+      await tryRmdirIfEmpty(join(key, deps.parentDir));
+      return Result.ok(undefined);
+    },
+  };
+};

--- a/src/integration/ai/agents/_engine/parse-agent-definition.ts
+++ b/src/integration/ai/agents/_engine/parse-agent-definition.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared agent-definition parsing helpers — the frontmatter split + naive-YAML reader that
+ * every agent-definition source backed by an on-disk Markdown file consumes.
+ *
+ * Reuses the same flat `key: value` frontmatter shape as SKILL.md — a real YAML lib lands only
+ * when an agent definition needs nested / multiline frontmatter.
+ *
+ * `parseAgentDefinition` validates against {@link AgentDefinitionFrontmatterSchema} and asserts
+ * frontmatter `name` matches the source name. The `label` parameter tailors the error message
+ * prefix so a caller can say "bundled agent X" vs "operator agent X".
+ */
+
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { AgentDefinitionFrontmatterSchema } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+/**
+ * Split an agent-definition file body into frontmatter + content. The frontmatter block is the
+ * first `---` … `---` pair starting at the file's first non-whitespace line; everything after
+ * the closing fence is the body. Returns the body verbatim when no frontmatter is present —
+ * callers then validate frontmatter separately.
+ *
+ * @public
+ */
+export const splitFrontmatter = (raw: string): { readonly frontmatter: string; readonly body: string } => {
+  const trimmed = raw.replace(/^\uFEFF/u, ''); // strip UTF-8 BOM
+  if (!trimmed.startsWith('---')) return { frontmatter: '', body: trimmed };
+  const closing = trimmed.indexOf('\n---', 3);
+  if (closing === -1) return { frontmatter: '', body: trimmed };
+  const frontmatter = trimmed.slice(3, closing).trim();
+  const afterClose = trimmed.slice(closing + 4); // skip "\n---"
+  // Strip every blank line after the closing fence so the body is clean. Stripping only ONE
+  // line-end would keep the standard blank separator line inside the body, and each
+  // parse → render round-trip (render re-inserts the separator) would grow the file by one
+  // blank line.
+  const body = afterClose.replace(/^(?:\r?\n)+/, '');
+  return { frontmatter, body };
+};
+
+/**
+ * Naive YAML key:value parser — keys are simple identifiers, values are strings or single-quoted
+ * strings without escapes. Frontmatter we control is always this shape, so a full YAML parser
+ * is overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
+ *
+ * @public
+ */
+export const parseSimpleYaml = (input: string): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const line of input.split('\n')) {
+    const stripped = line.trim();
+    if (stripped.length === 0 || stripped.startsWith('#')) continue;
+    const colon = stripped.indexOf(':');
+    if (colon === -1) continue;
+    const key = stripped.slice(0, colon).trim();
+    let value = stripped.slice(colon + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+    else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+    result[key] = value;
+  }
+  return result;
+};
+
+/** Narrow an unknown caught value to a Node `fs` error code without leaking `any`. @public */
+export const errorCode = (cause: unknown): string | undefined =>
+  typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string'
+    ? cause.code
+    : undefined;
+
+/**
+ * Parse an already-read agent-definition file body into the canonical {@link AgentDefinition}
+ * record. Split from the read so a file-required path and an optional-file path can share the
+ * frontmatter-validation tail. `label` prefixes the error message (`bundled agent` / `operator
+ * agent`).
+ *
+ * @public
+ */
+export const parseAgentDefinition = (
+  label: string,
+  path: string,
+  name: string,
+  raw: string
+): Result<AgentDefinition, StorageError> => {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  const fm = parseSimpleYaml(frontmatter);
+  const parsed = AgentDefinitionFrontmatterSchema.safeParse(fm);
+  if (!parsed.success) {
+    return Result.error(
+      new StorageError({
+        subCode: 'parse',
+        message: `${label} ${name}: invalid frontmatter (${parsed.error.message})`,
+        path,
+      })
+    );
+  }
+  if (parsed.data.name !== name) {
+    return Result.error(
+      new StorageError({
+        subCode: 'parse',
+        message: `${label} ${name}: frontmatter name '${parsed.data.name}' must match source name`,
+        path,
+      })
+    );
+  }
+  return Result.ok({
+    name: parsed.data.name,
+    description: parsed.data.description,
+    ...(parsed.data.model !== undefined ? { model: parsed.data.model } : {}),
+    ...(parsed.data.effort !== undefined ? { effort: parsed.data.effort } : {}),
+    content: body,
+  });
+};

--- a/src/integration/ai/agents/_engine/registry.ts
+++ b/src/integration/ai/agents/_engine/registry.ts
@@ -1,0 +1,12 @@
+/**
+ * `BUNDLED_AGENT_DEFINITIONS` — the vetted set of shipped agent definitions, one entry per
+ * `bundled/<name>.md` file. Unlike `BUNDLED_SKILLS` (which assigns each skill to a set of
+ * flows), agent definitions are not flow-scoped — every entry here is always available for
+ * install, regardless of which flow is running.
+ *
+ * Each name must match a `bundled/<name>.md` file exactly, `ralphctl-` prefix included, and
+ * that file's frontmatter `name` must match too (`parseAgentDefinition` asserts this). The
+ * registry test (`tests/unit/integration/ai/agents/registry.test.ts`) fences the on-disk half
+ * of that invariant: every name here resolves to a bundled file.
+ */
+export const BUNDLED_AGENT_DEFINITIONS: readonly string[] = ['ralphctl-evaluator', 'ralphctl-generator'];

--- a/src/integration/ai/agents/_engine/render-claude-agent.ts
+++ b/src/integration/ai/agents/_engine/render-claude-agent.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
-import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { namespacedAgentFileBase } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
 export const renderClaudeAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
   const lines = ['---', `name: ${definition.name}`, `description: ${definition.description}`];
@@ -18,6 +18,6 @@ export const renderClaudeAgent = (definition: AgentDefinition): Result<RenderedA
   lines.push('---');
 
   const content = `${lines.join('\n')}\n\n${definition.content.replace(/\s+$/u, '')}\n`;
-  const relPath = join('.claude', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.md`);
+  const relPath = join('.claude', 'agents', `${namespacedAgentFileBase(definition.name)}.md`);
   return Result.ok({ relPath, content });
 };

--- a/src/integration/ai/agents/_engine/render-claude-agent.ts
+++ b/src/integration/ai/agents/_engine/render-claude-agent.ts
@@ -1,0 +1,23 @@
+/**
+ * `renderClaudeAgent` — render an {@link AgentDefinition} into Claude Code's native sub-agent
+ * format: `.claude/agents/ralphctl-<name>.md`, a YAML frontmatter block (`name`, `description`,
+ * optional `model` / `effort`) followed by the Markdown body used as the sub-agent's system
+ * prompt.
+ */
+
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+export const renderClaudeAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
+  const lines = ['---', `name: ${definition.name}`, `description: ${definition.description}`];
+  if (definition.model !== undefined) lines.push(`model: ${definition.model}`);
+  if (definition.effort !== undefined) lines.push(`effort: ${definition.effort}`);
+  lines.push('---');
+
+  const content = `${lines.join('\n')}\n\n${definition.content.replace(/\s+$/u, '')}\n`;
+  const relPath = join('.claude', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.md`);
+  return Result.ok({ relPath, content });
+};

--- a/src/integration/ai/agents/_engine/render-codex-agent.ts
+++ b/src/integration/ai/agents/_engine/render-codex-agent.ts
@@ -1,0 +1,31 @@
+/**
+ * `renderCodexAgent` — render an {@link AgentDefinition} into Codex's native agent format:
+ * `.codex/agents/ralphctl-<name>.toml`, with `name` / `description` / `developer_instructions`
+ * (the Markdown body) plus optional `model` / `model_reasoning_effort` keys.
+ *
+ * Values are encoded as TOML basic strings via `JSON.stringify` — TOML basic-string escaping
+ * (`\"`, `\\`, `\n`, `\t`, …) is a compatible subset of JSON's, so this avoids hand-rolling an
+ * escaper for a body that may contain arbitrary Markdown.
+ */
+
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+const tomlString = (value: string): string => JSON.stringify(value);
+
+export const renderCodexAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
+  const lines = [
+    `name = ${tomlString(definition.name)}`,
+    `description = ${tomlString(definition.description)}`,
+    `developer_instructions = ${tomlString(definition.content.replace(/\s+$/u, ''))}`,
+  ];
+  if (definition.model !== undefined) lines.push(`model = ${tomlString(definition.model)}`);
+  if (definition.effort !== undefined) lines.push(`model_reasoning_effort = ${tomlString(definition.effort)}`);
+
+  const content = `${lines.join('\n')}\n`;
+  const relPath = join('.codex', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.toml`);
+  return Result.ok({ relPath, content });
+};

--- a/src/integration/ai/agents/_engine/render-codex-agent.ts
+++ b/src/integration/ai/agents/_engine/render-codex-agent.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
-import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { namespacedAgentFileBase } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
 const tomlString = (value: string): string => JSON.stringify(value);
 
@@ -26,6 +26,6 @@ export const renderCodexAgent = (definition: AgentDefinition): Result<RenderedAg
   if (definition.effort !== undefined) lines.push(`model_reasoning_effort = ${tomlString(definition.effort)}`);
 
   const content = `${lines.join('\n')}\n`;
-  const relPath = join('.codex', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.toml`);
+  const relPath = join('.codex', 'agents', `${namespacedAgentFileBase(definition.name)}.toml`);
   return Result.ok({ relPath, content });
 };

--- a/src/integration/ai/agents/_engine/render-copilot-agent.ts
+++ b/src/integration/ai/agents/_engine/render-copilot-agent.ts
@@ -12,13 +12,13 @@ import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
-import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { namespacedAgentFileBase } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
 /** Copilot's documented per-agent body size limit. */
 export const COPILOT_AGENT_MAX_BODY_CHARS = 30000;
 
 export const renderCopilotAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
-  const relPath = join('.github', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.agent.md`);
+  const relPath = join('.github', 'agents', `${namespacedAgentFileBase(definition.name)}.agent.md`);
 
   if (definition.content.length > COPILOT_AGENT_MAX_BODY_CHARS) {
     return Result.error(

--- a/src/integration/ai/agents/_engine/render-copilot-agent.ts
+++ b/src/integration/ai/agents/_engine/render-copilot-agent.ts
@@ -1,0 +1,39 @@
+/**
+ * `renderCopilotAgent` — render an {@link AgentDefinition} into GitHub Copilot's native agent
+ * format: `.github/agents/ralphctl-<name>.agent.md`, a YAML frontmatter block (`description`,
+ * `name`, optional `model`) followed by the Markdown body.
+ *
+ * Copilot rejects an agent file whose body exceeds 30000 characters — the renderer enforces
+ * that limit up front and returns a {@link StorageError} instead of producing a file the CLI
+ * would refuse to load.
+ */
+
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+/** Copilot's documented per-agent body size limit. */
+export const COPILOT_AGENT_MAX_BODY_CHARS = 30000;
+
+export const renderCopilotAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
+  const relPath = join('.github', 'agents', `${RALPHCTL_AGENT_PREFIX}${definition.name}.agent.md`);
+
+  if (definition.content.length > COPILOT_AGENT_MAX_BODY_CHARS) {
+    return Result.error(
+      new StorageError({
+        subCode: 'schema-mismatch',
+        message: `copilot agent '${definition.name}': body is ${definition.content.length} chars, exceeds the ${COPILOT_AGENT_MAX_BODY_CHARS}-char Copilot agent size limit`,
+        path: relPath,
+      })
+    );
+  }
+
+  const lines = ['---', `description: ${definition.description}`, `name: ${definition.name}`];
+  if (definition.model !== undefined) lines.push(`model: ${definition.model}`);
+  lines.push('---');
+
+  const content = `${lines.join('\n')}\n\n${definition.content.replace(/\s+$/u, '')}\n`;
+  return Result.ok({ relPath, content });
+};

--- a/src/integration/ai/agents/adapter-factory.ts
+++ b/src/integration/ai/agents/adapter-factory.ts
@@ -1,0 +1,38 @@
+/**
+ * `createAgentDefinitionAdapter` — composition-root factory that picks the
+ * {@link AgentDefinitionAdapter} implementation matching the configured AI provider.
+ *
+ * All three providers share the same on-disk shape — one native file per definition under
+ * `<parentDir>/agents/` — only the parent directory and render format vary:
+ *  - claude  → `.claude/agents/*.md`   (Markdown + YAML frontmatter)
+ *  - copilot → `.github/agents/*.agent.md` (Markdown + YAML frontmatter)
+ *  - codex   → `.codex/agents/*.toml`  (TOML)
+ *
+ * Adding a new provider is one arm here plus a sibling `agents/<provider>/adapter.ts` that
+ * delegates to {@link createFilesystemAgentDefinitionAdapter}.
+ */
+
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import { createClaudeAgentDefinitionAdapter } from '@src/integration/ai/agents/claude/adapter.ts';
+import { createCodexAgentDefinitionAdapter } from '@src/integration/ai/agents/codex/adapter.ts';
+import { createCopilotAgentDefinitionAdapter } from '@src/integration/ai/agents/copilot/adapter.ts';
+
+export interface AgentDefinitionAdapterFactoryDeps {
+  readonly provider: AiProvider;
+  /** Optional logger — surfaces best-effort `.git/info/exclude` write failures as warnings. */
+  readonly logger?: Logger;
+}
+
+export const createAgentDefinitionAdapter = (deps: AgentDefinitionAdapterFactoryDeps): AgentDefinitionAdapter => {
+  const logger = deps.logger;
+  switch (deps.provider) {
+    case 'claude-code':
+      return createClaudeAgentDefinitionAdapter(logger !== undefined ? { logger } : undefined);
+    case 'github-copilot':
+      return createCopilotAgentDefinitionAdapter(logger !== undefined ? { logger } : undefined);
+    case 'openai-codex':
+      return createCodexAgentDefinitionAdapter(logger !== undefined ? { logger } : undefined);
+  }
+};

--- a/src/integration/ai/agents/bundled/ralphctl-evaluator.md
+++ b/src/integration/ai/agents/bundled/ralphctl-evaluator.md
@@ -1,0 +1,32 @@
+---
+name: ralphctl-evaluator
+description: Independently judges whether a change satisfies its stated acceptance criteria — a second pair of eyes before signing off, not a rubber stamp.
+---
+
+You are an evaluator. Your job is to judge whether a proposed change actually satisfies its
+stated goal — not to implement it, not to guess at a looser intent, and not to pass work that
+"looks about right."
+
+## What to check, in order
+
+1. **Read the actual goal** — the acceptance criteria, ticket, or task description as written.
+   Do not infer a softer goal from the diff; the diff must satisfy what was asked, not the other
+   way around.
+2. **Run the verification the goal specifies** — the test suite, the build, the exact command
+   named. A change that looks correct but was never actually run is not done.
+3. **Trace the change against each criterion individually** — a criterion is either verifiably
+   met or it is not. "Partially addressed" is a fail, not a pass with an asterisk.
+4. **Check for regressions outside the stated scope** — a fix that breaks an unrelated invariant
+   fails even if the target criterion now passes.
+5. **Distinguish a real defect from a style preference** — flag correctness bugs, security
+   issues, and unmet criteria as blocking; note stylistic nits separately and never let them
+   block a pass on their own.
+
+## How to report
+
+State a clear verdict — pass or fail — before any explanation. For a fail, name the specific
+criterion or behavior that is unmet and the concrete evidence: a failing command's output, a case
+the change misses, an invariant it breaks. Vague impressions are not evidence. For a pass, name
+what you actually verified, not what you assumed would work. Never soften a fail into "mostly
+done" to avoid friction — an ambiguous verdict is worse than a blunt one, because it lets an
+unfinished change slip through.

--- a/src/integration/ai/agents/bundled/ralphctl-generator.md
+++ b/src/integration/ai/agents/bundled/ralphctl-generator.md
@@ -1,0 +1,33 @@
+---
+name: ralphctl-generator
+description: Implements one scoped change end-to-end — reads existing patterns first, writes the minimum code the task needs, and verifies its own work before reporting done.
+---
+
+You are a generator. Your job is to make one scoped change work, matching the codebase you're
+already in — not to redesign it, and not to stop short of a verified result.
+
+## Before writing code
+
+1. **Read the actual requirement** — the ticket, the failing test, the described behavior. When
+   it's ambiguous, pick the narrowest interpretation that still satisfies it rather than guessing
+   at a larger scope.
+2. **Find the nearest existing pattern** — the way this codebase already solves a similar problem
+   (naming, error handling, test structure, layering) is the template to follow. Introducing a new
+   pattern for something that already has one creates drift a future reader has to reconcile.
+3. **Identify exactly what needs to change** — the specific files and seams — before touching
+   anything, so the edit stays proportionate to the task.
+
+## While writing code
+
+- Make the smallest change that fully satisfies the requirement — no speculative abstractions, no
+  unrequested refactors, no defensive handling for cases that cannot occur here.
+- After each meaningful edit, run the cheapest relevant check available — a type check, a single
+  test file — rather than waiting until the end to discover a mistake made three edits ago.
+- If a limitation or missing context blocks progress, say so explicitly rather than guessing and
+  continuing silently.
+
+## Before reporting done
+
+Run the actual verification the task specifies — the test suite, the build, the named command —
+and read its output rather than assuming it would pass. Report exactly what you verified and how;
+never claim a result you did not observe.

--- a/src/integration/ai/agents/bundled/source.ts
+++ b/src/integration/ai/agents/bundled/source.ts
@@ -1,0 +1,126 @@
+/**
+ * `createBundledAgentDefinitionSource` — implementation of {@link AgentDefinitionSource} backed
+ * by the bundled `<name>.md` files that live next to this module.
+ *
+ * The vetted set comes from {@link BUNDLED_AGENT_DEFINITIONS}. For each name in that list, the
+ * source reads `<bundledRoot>/<name>.md` and parses YAML frontmatter (`name`, `description`,
+ * optional `model` / `effort` — frontmatter `name` must match the file's base name) into the
+ * canonical {@link AgentDefinition} record.
+ *
+ * Resolution of the bundled root mirrors `skills/bundled/source.ts`'s `resolveBundledRoot`: in
+ * dev (`tsx`) the `.md` files sit next to this module; in a production bundle
+ * `scripts/build-assets.ts` copies them into `dist/agent-definitions/`, so `import.meta.url`
+ * resolves correctly in both modes. Detection asks the filesystem (does an `agent-definitions/`
+ * dir sit beside this module?), not the chunk filename — tsup code-splitting rewrites
+ * `import.meta.url` to a hashed chunk, and a filename check would miss it (see the skills
+ * module's doc comment for the incident this guards against). Tests can override the root via
+ * `bundledRoot`.
+ *
+ * Parsing failures (missing file, malformed frontmatter, missing required fields) return a
+ * `StorageError` with `subCode: 'parse'`.
+ */
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import { BUNDLED_AGENT_DEFINITIONS } from '@src/integration/ai/agents/_engine/registry.ts';
+import { errorCode, parseAgentDefinition } from '@src/integration/ai/agents/_engine/parse-agent-definition.ts';
+
+/**
+ * Resolve the default bundled-agent-definition root from a module URL. `exists` is injectable
+ * for tests.
+ *
+ *   Dev (tsx): this module lives at src/integration/ai/agents/bundled/source.ts — `.md` files
+ *     sit next to it.
+ *   Build (tsup): `scripts/build-assets.ts` copies the `.md` files to `<dist>/agent-definitions/`.
+ *
+ * @public
+ */
+export const resolveBundledRoot = (moduleUrl: string, exists: (path: string) => boolean = existsSync): string => {
+  const here = dirname(fileURLToPath(moduleUrl));
+  const beside = join(here, 'agent-definitions');
+  return exists(beside) ? beside : here;
+};
+
+const defaultBundledRoot = resolveBundledRoot(import.meta.url);
+
+export interface BundledAgentDefinitionSourceDeps {
+  /** Override for tests. Production resolves the bundled root next to this module. */
+  readonly bundledRoot?: string;
+}
+
+/** Read + parse a `<name>.md` when the file is REQUIRED — a missing file is a hard `io` error. */
+const readDefinition = async (root: string, name: string): Promise<Result<AgentDefinition, StorageError>> => {
+  const path = join(root, `${name}.md`);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch (cause) {
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `bundled agent definition not readable: ${path}`, path, cause })
+    );
+  }
+  return parseAgentDefinition('bundled agent definition', path, name, raw);
+};
+
+/**
+ * Read + parse a `<name>.md` when the file is OPTIONAL — absence means the name is unknown. A
+ * single async read attempt avoids a TOCTOU window: a missing file (`ENOENT`) resolves to
+ * `ok(undefined)`; any other read failure or a malformed body surfaces as a `StorageError`.
+ */
+const readDefinitionOptional = async (
+  root: string,
+  name: string
+): Promise<Result<AgentDefinition | undefined, StorageError>> => {
+  const path = join(root, `${name}.md`);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch (cause) {
+    if (errorCode(cause) === 'ENOENT') return Result.ok(undefined);
+    return Result.error(
+      new StorageError({ subCode: 'io', message: `bundled agent definition not readable: ${path}`, path, cause })
+    );
+  }
+  return parseAgentDefinition('bundled agent definition', path, name, raw);
+};
+
+export const createBundledAgentDefinitionSource = (
+  deps: BundledAgentDefinitionSourceDeps = {}
+): AgentDefinitionSource => {
+  const root = deps.bundledRoot ?? defaultBundledRoot;
+  const cache = new Map<string, AgentDefinition>();
+
+  const loadOne = async (name: string): Promise<Result<AgentDefinition, StorageError>> => {
+    const cached = cache.get(name);
+    if (cached !== undefined) return Result.ok(cached);
+    const r = await readDefinition(root, name);
+    if (r.ok) cache.set(name, r.value);
+    return r;
+  };
+
+  return {
+    async list(): Promise<Result<readonly AgentDefinition[], StorageError>> {
+      const definitions: AgentDefinition[] = [];
+      for (const name of BUNDLED_AGENT_DEFINITIONS) {
+        const r = await loadOne(name);
+        if (!r.ok) return Result.error(r.error);
+        definitions.push(r.value);
+      }
+      return Result.ok(definitions);
+    },
+
+    async getByName(name: string): Promise<Result<AgentDefinition | undefined, StorageError>> {
+      const cached = cache.get(name);
+      if (cached !== undefined) return Result.ok(cached);
+      const r = await readDefinitionOptional(root, name);
+      if (r.ok && r.value !== undefined) cache.set(name, r.value);
+      return r;
+    },
+  };
+};

--- a/src/integration/ai/agents/claude/adapter.ts
+++ b/src/integration/ai/agents/claude/adapter.ts
@@ -1,0 +1,37 @@
+/**
+ * `createClaudeAgentDefinitionAdapter` — {@link AgentDefinitionAdapter} for the Claude Code
+ * provider. Writes each definition to `<sessionDir>/.claude/agents/ralphctl-<name>.md` so the
+ * running `claude` CLI auto-discovers it as a sub-agent.
+ *
+ * Logic (project-wins, manifest-tracked uninstall, idempotent install) lives in
+ * {@link createFilesystemAgentDefinitionAdapter} — Claude shares it with the codex and copilot
+ * agent-definition adapters, which only differ in `parentDir`, `renderer`, and the convention
+ * text.
+ */
+
+import { createFilesystemAgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts';
+import { renderClaudeAgent } from '@src/integration/ai/agents/_engine/render-claude-agent.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+
+export interface CreateClaudeAgentDefinitionAdapterDeps {
+  readonly logger?: Logger;
+}
+
+const CONVENTION = [
+  'Agent definitions live under `.claude/agents/<name>.md` in this repository. Each file starts',
+  'with a YAML frontmatter block (`name`, `description`, optional `model` / `effort`) followed',
+  'by the markdown system prompt. Before drafting a new one, list `.claude/agents/` and read',
+  'any file whose `name` or `description` overlaps the persona you need.',
+].join(' ');
+
+export const createClaudeAgentDefinitionAdapter = (
+  deps: CreateClaudeAgentDefinitionAdapterDeps = {}
+): AgentDefinitionAdapter =>
+  createFilesystemAgentDefinitionAdapter({
+    providerId: 'claude-code',
+    parentDir: '.claude',
+    renderer: renderClaudeAgent,
+    convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+  });

--- a/src/integration/ai/agents/codex/adapter.ts
+++ b/src/integration/ai/agents/codex/adapter.ts
@@ -1,0 +1,35 @@
+/**
+ * `createCodexAgentDefinitionAdapter` — {@link AgentDefinitionAdapter} for the OpenAI Codex
+ * provider. Writes each definition to `<sessionDir>/.codex/agents/ralphctl-<name>.toml`,
+ * Codex's native TOML agent-definition path.
+ *
+ * Logic (project-wins, manifest-tracked uninstall, idempotent install) lives in
+ * {@link createFilesystemAgentDefinitionAdapter} — shared with the claude and copilot variants.
+ */
+
+import { createFilesystemAgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts';
+import { renderCodexAgent } from '@src/integration/ai/agents/_engine/render-codex-agent.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+
+export interface CreateCodexAgentDefinitionAdapterDeps {
+  readonly logger?: Logger;
+}
+
+const CONVENTION = [
+  'Agent definitions live under `.codex/agents/<name>.toml` in this repository. Each file has',
+  '`name`, `description`, and `developer_instructions` keys (the system prompt), plus optional',
+  '`model` / `model_reasoning_effort`. Before drafting a new one, list `.codex/agents/` and read',
+  'any file whose `name` or `description` overlaps the persona you need.',
+].join(' ');
+
+export const createCodexAgentDefinitionAdapter = (
+  deps: CreateCodexAgentDefinitionAdapterDeps = {}
+): AgentDefinitionAdapter =>
+  createFilesystemAgentDefinitionAdapter({
+    providerId: 'openai-codex',
+    parentDir: '.codex',
+    renderer: renderCodexAgent,
+    convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+  });

--- a/src/integration/ai/agents/copilot/adapter.ts
+++ b/src/integration/ai/agents/copilot/adapter.ts
@@ -1,0 +1,37 @@
+/**
+ * `createCopilotAgentDefinitionAdapter` — {@link AgentDefinitionAdapter} for the GitHub Copilot
+ * provider. Writes each definition to `<sessionDir>/.github/agents/ralphctl-<name>.agent.md`,
+ * Copilot's documented custom-agent path.
+ *
+ * Logic (project-wins, manifest-tracked uninstall, idempotent install) lives in
+ * {@link createFilesystemAgentDefinitionAdapter} — shared with the claude and codex variants.
+ * The 30000-char body size guard lives in {@link renderCopilotAgent}.
+ */
+
+import { createFilesystemAgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts';
+import { renderCopilotAgent } from '@src/integration/ai/agents/_engine/render-copilot-agent.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+
+export interface CreateCopilotAgentDefinitionAdapterDeps {
+  readonly logger?: Logger;
+}
+
+const CONVENTION = [
+  'Agent definitions live under `.github/agents/<name>.agent.md` in this repository. Each file',
+  'starts with a YAML frontmatter block (`description`, `name`, optional `model`) followed by',
+  'the markdown system prompt. Before drafting a new one, list `.github/agents/` and read any',
+  'file whose `name` or `description` overlaps the persona you need. Bodies over 30000',
+  'characters are rejected — keep the system prompt focused.',
+].join(' ');
+
+export const createCopilotAgentDefinitionAdapter = (
+  deps: CreateCopilotAgentDefinitionAdapterDeps = {}
+): AgentDefinitionAdapter =>
+  createFilesystemAgentDefinitionAdapter({
+    providerId: 'github-copilot',
+    parentDir: '.github',
+    renderer: renderCopilotAgent,
+    convention: CONVENTION,
+    ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+  });

--- a/src/integration/ai/agents/operator/source.ts
+++ b/src/integration/ai/agents/operator/source.ts
@@ -1,0 +1,120 @@
+/**
+ * `createOperatorAgentDefinitionSource` — an {@link AgentDefinitionSource} backed by GLOBAL
+ * operator drop-in agent definitions under `<operatorAgentDefinitionsRoot>/<name>.md`.
+ *
+ * The operator authors an agent definition once, under the ralphctl home
+ * (`<appRoot>/agents`, computed by `storagePathsFromRoot`), and it is reused across every
+ * project. Unlike operator skills (`skills/operator/source.ts`), there is NO per-provider
+ * subdirectory here: an agent definition's Markdown body is provider-agnostic — the per-provider
+ * renderer (`agents/{claude,codex,copilot}/`) handles placement and format — so one flat
+ * directory serves every provider.
+ *
+ * Each definition's `name` is namespaced with the `ralphctl-` prefix on the way out (matching the
+ * bundled source), so composed sources dedupe consistently and the on-disk render step's
+ * `.git/info/exclude` wildcard hides installed files the same way it hides bundled ones. The
+ * prefix is idempotent — an operator who already names a file `ralphctl-foo.md` is not
+ * double-prefixed. The on-disk file name (and frontmatter `name`) stay un-prefixed by
+ * convention; the prefix is applied only to the emitted {@link AgentDefinition} record.
+ *
+ * Resilience contract (the operator owns these definitions — never fail the run for a bad one):
+ *  - a missing `<operatorAgentDefinitionsRoot>` directory → empty list (none configured);
+ *  - an individual unreadable / malformed `<name>.md` → a logged warning, skip that definition;
+ *  - the optional quality guard (`warnIfVague`) runs per definition as a WARNING only — a vague
+ *    definition is logged and STILL returned for install.
+ */
+
+import { type Dirent, promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import { errorCode, parseAgentDefinition } from '@src/integration/ai/agents/_engine/parse-agent-definition.ts';
+
+/**
+ * Optional quality guard. Runs as a WARNING only — a vague definition never blocks install. Left
+ * optional so this source has no hard dependency on the guard landing: when unset, every
+ * definition is returned without a quality check.
+ */
+export type AgentDefinitionQualityWarner = (definition: AgentDefinition) => void;
+
+/** File-base-name → install-name. Idempotent so an already-prefixed file is not doubled. @public */
+const namespaced = (baseName: string): string =>
+  baseName.startsWith(RALPHCTL_AGENT_PREFIX) ? baseName : `${RALPHCTL_AGENT_PREFIX}${baseName}`;
+
+export interface OperatorAgentDefinitionSourceDeps {
+  /** `<appRoot>/agents` — the global operator agent-definitions root (from `StoragePaths`). */
+  readonly operatorAgentDefinitionsRoot: AbsolutePath;
+  /** Logged warnings for unreadable / malformed / vague definitions. */
+  readonly logger: Logger;
+  /** Optional quality guard — runs per definition as a WARNING (see {@link AgentDefinitionQualityWarner}). */
+  readonly warnIfVague?: AgentDefinitionQualityWarner;
+}
+
+/**
+ * Enumerate + parse every `<operatorAgentDefinitionsRoot>/<name>.md`. Best-effort: a missing
+ * root yields `[]`; an unreadable / malformed individual definition is logged and skipped. The
+ * quality guard (when supplied) runs per surviving definition as a warning and never drops it.
+ */
+const loadOperatorAgentDefinitions = async (
+  deps: OperatorAgentDefinitionSourceDeps
+): Promise<readonly AgentDefinition[]> => {
+  const log = deps.logger.named('agents.operator');
+  const root = String(deps.operatorAgentDefinitionsRoot);
+
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (cause) {
+    // A missing root is the common, non-error case — no operator agent definitions configured.
+    if (errorCode(cause) === 'ENOENT') return [];
+    log.warn('operator agent definitions dir not readable', { path: root, cause });
+    return [];
+  }
+
+  const definitions: AgentDefinition[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const baseName = entry.name.slice(0, -'.md'.length);
+    const path = join(root, entry.name);
+    let raw: string;
+    try {
+      raw = await fs.readFile(path, 'utf-8');
+    } catch (cause) {
+      log.warn('operator agent definition not readable, skipping', { name: baseName, path, cause });
+      continue;
+    }
+    const parsed = parseAgentDefinition('operator agent definition', path, baseName, raw);
+    if (!parsed.ok) {
+      log.warn('operator agent definition invalid, skipping', {
+        name: baseName,
+        path,
+        error: parsed.error.message,
+      });
+      continue;
+    }
+    // Namespace the install name so composed sources dedupe consistently and the render step's
+    // `ralphctl-*` exclude wildcard hides it from `git status` — exactly the bundled lifecycle.
+    const definition: AgentDefinition = { ...parsed.value, name: namespaced(parsed.value.name) };
+    // Quality guard is advisory: log a warning but still install — the operator owns it.
+    deps.warnIfVague?.(definition);
+    definitions.push(definition);
+  }
+  return definitions;
+};
+
+export const createOperatorAgentDefinitionSource = (
+  deps: OperatorAgentDefinitionSourceDeps
+): AgentDefinitionSource => ({
+  async list(): Promise<Result<readonly AgentDefinition[], StorageError>> {
+    return Result.ok(await loadOperatorAgentDefinitions(deps));
+  },
+
+  async getByName(name: string): Promise<Result<AgentDefinition | undefined, StorageError>> {
+    const all = await loadOperatorAgentDefinitions(deps);
+    return Result.ok(all.find((d) => d.name === name));
+  },
+});

--- a/src/integration/ai/prompts/_engine/renderers/task.ts
+++ b/src/integration/ai/prompts/_engine/renderers/task.ts
@@ -294,6 +294,22 @@ export const renderRetryFeedbackSection = (retryFeedback: string | undefined): s
 };
 
 /**
+ * Render the optional "## Agent Definition" section appended strictly AFTER the base
+ * `<role>`/`<success_criteria>` blocks in both the generator and evaluator prompts. This is the
+ * seam a bound agent definition's persona/instructions render into — and, for a provider with no
+ * native agent format, the in-session direct-fallback body. Because the placeholder always sits
+ * after the base blocks, its content can only ADD instructions, never remove or override the base
+ * role. Absent or empty → empty string so `{{AGENT_DEFINITION_SECTION}}` collapses without leaving
+ * an orphan heading.
+ */
+export const renderAgentDefinitionSection = (agentDefinition: string | undefined): string => {
+  if (agentDefinition === undefined) return '';
+  const trimmed = agentDefinition.trim();
+  if (trimmed.length === 0) return '';
+  return ['## Agent Definition', '', trimmed].join('\n');
+};
+
+/**
  * "Change your approach" directive injected when this task is a plateau-break attempt — i.e. the
  * gen-eval loop stalled (the same evaluator dimensions kept failing across rounds with no real
  * progress) and the escalation policy granted one more attempt. Empty when not a plateau-break

--- a/src/integration/ai/prompts/evaluate/definition.ts
+++ b/src/integration/ai/prompts/evaluate/definition.ts
@@ -7,6 +7,7 @@ import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
 import { renderFloorRubricSection } from '@src/integration/ai/prompts/_engine/renderers/floor-rubric.ts';
 import {
+  renderAgentDefinitionSection,
   renderExtraDimensionsSection,
   renderGeneratorHintsSection,
   renderProjectToolingSection,
@@ -95,6 +96,13 @@ export interface EvaluatePromptParams {
    * always supplies it (empty string when there is no history).
    */
   readonly priorCriteriaVerdictsSection?: string;
+  /**
+   * Optional "## Agent Definition" block rendered strictly AFTER the base `<role>` /
+   * `<success_criteria>` blocks — the seam a bound agent definition's persona renders into, and
+   * (for a provider with no native agent format) the in-session direct-fallback body. Absent or
+   * empty → `{{AGENT_DEFINITION_SECTION}}` collapses cleanly with no orphan heading.
+   */
+  readonly agentDefinitionSection?: string;
 }
 
 const requireNonEmpty =
@@ -186,6 +194,13 @@ export const evaluatePromptDef: PromptDefinition<EvaluatePromptParams> = {
         'Durable per-criterion k-of-N checklist carried across rounds (`Task.criteriaVerdicts`), rendered ' +
         'by `composeCriteriaHistory`. Context only — re-verify independently. Empty → `{{PRIOR_CRITERIA_VERDICTS}}` collapses.',
     },
+    agentDefinitionSection: {
+      placeholder: 'AGENT_DEFINITION_SECTION',
+      optional: true,
+      description:
+        'Optional "## Agent Definition" block rendered after the base role/success-criteria blocks — the ' +
+        'seam for a bound agent persona or in-session direct fallback. Empty → `{{AGENT_DEFINITION_SECTION}}` collapses.',
+    },
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
@@ -221,6 +236,12 @@ export interface BuildEvaluatePromptInput {
    * Omitted or empty → `{{GENERATOR_HINTS_SECTION}}` collapses cleanly.
    */
   readonly generatorHints?: string;
+  /**
+   * Raw "## Agent Definition" content — the seam a bound agent definition's persona renders
+   * into, and (for a provider with no native agent format) the in-session direct-fallback body.
+   * Absent or empty → `{{AGENT_DEFINITION_SECTION}}` collapses cleanly with no orphan heading.
+   */
+  readonly agentDefinition?: string;
 }
 
 /**
@@ -266,4 +287,5 @@ export const buildEvaluatePrompt = async (
       verificationCriteria: input.task.verificationCriteria,
       verdicts: input.task.criteriaVerdicts,
     }),
+    agentDefinitionSection: renderAgentDefinitionSection(input.agentDefinition),
   });

--- a/src/integration/ai/prompts/evaluate/template.md
+++ b/src/integration/ai/prompts/evaluate/template.md
@@ -75,6 +75,8 @@ output contract section at the bottom of this prompt.
 
 </success_criteria>
 
+{{AGENT_DEFINITION_SECTION}}
+
 <task_specification>
 
 **Task:** {{TASK_NAME}}

--- a/src/integration/ai/prompts/implement/definition.ts
+++ b/src/integration/ai/prompts/implement/definition.ts
@@ -6,6 +6,7 @@ import { ValidationError } from '@src/domain/value/error/validation-error.ts';
 import { buildPrompt, type BuildPromptError } from '@src/integration/ai/prompts/_engine/build-prompt.ts';
 import type { PromptDefinition } from '@src/integration/ai/prompts/_engine/definition.ts';
 import {
+  renderAgentDefinitionSection,
   renderPlateauDirectiveSection,
   renderPreVerifyResultsSection,
   renderPriorCritiqueSection,
@@ -24,6 +25,7 @@ import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/templat
 // `renderers/task.ts`. The originals lived here historically; the actual implementations are
 // now in the shared module.
 export {
+  renderAgentDefinitionSection,
   renderVerifyScriptSection,
   renderPriorCritiqueSection,
   renderPriorLearningsSection,
@@ -134,6 +136,14 @@ export interface ImplementPromptParams {
    * fail. Absent or empty (no criterion graded yet) → `{{PRIOR_CRITERIA_VERDICTS}}` collapses cleanly.
    */
   readonly priorCriteriaVerdictsSection?: string;
+  /**
+   * Optional "## Agent Definition" block rendered strictly AFTER the base `<role>` /
+   * `<success_criteria>` blocks — the seam a bound agent definition's persona renders into, and
+   * (for a provider with no native agent format) the in-session direct-fallback body. Absent or
+   * empty → `{{AGENT_DEFINITION_SECTION}}` collapses cleanly with no orphan heading. Default
+   * undefined (empty).
+   */
+  readonly agentDefinitionSection?: string;
 }
 
 const requireNonEmpty =
@@ -250,6 +260,13 @@ export const implementPromptDef: PromptDefinition<ImplementPromptParams> = {
         'Durable per-criterion k-of-N checklist carried across rounds (`Task.criteriaVerdicts`), rendered ' +
         'by `composeCriteriaHistory`. Empty (no criterion graded yet) → `{{PRIOR_CRITERIA_VERDICTS}}` collapses.',
     },
+    agentDefinitionSection: {
+      placeholder: 'AGENT_DEFINITION_SECTION',
+      optional: true,
+      description:
+        'Optional "## Agent Definition" block rendered after the base role/success-criteria blocks — the ' +
+        'seam for a bound agent persona or in-session direct fallback. Empty → `{{AGENT_DEFINITION_SECTION}}` collapses.',
+    },
   },
   partials: {
     HARNESS_CONTEXT: 'harness-context',
@@ -334,6 +351,12 @@ export interface BuildImplementPromptInput {
    * Absent or empty → `{{PRIOR_EPISODES}}` collapses (no `<prior_task_episodes>` block emitted).
    */
   readonly priorEpisodes?: string;
+  /**
+   * Raw "## Agent Definition" content — the seam a bound agent definition's persona renders
+   * into, and (for a provider with no native agent format) the in-session direct-fallback body.
+   * Absent or empty → `{{AGENT_DEFINITION_SECTION}}` collapses cleanly with no orphan heading.
+   */
+  readonly agentDefinition?: string;
 }
 
 /**
@@ -381,4 +404,5 @@ export const buildImplementPrompt = async (
       verificationCriteria: input.task.verificationCriteria,
       verdicts: input.task.criteriaVerdicts,
     }),
+    agentDefinitionSection: renderAgentDefinitionSection(input.agentDefinition),
   });

--- a/src/integration/ai/prompts/implement/template.md
+++ b/src/integration/ai/prompts/implement/template.md
@@ -35,6 +35,8 @@ only after every declared step is done and every verification command passes.
 
 </success_criteria>
 
+{{AGENT_DEFINITION_SECTION}}
+
 <inputs>
 
 ## Task

--- a/tests/e2e/flows/implement-parallel-realgit.test.ts
+++ b/tests/e2e/flows/implement-parallel-realgit.test.ts
@@ -74,6 +74,7 @@ import {
 } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { noopSkillsAdapter, emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
+import { noopAgentDefinitionAdapter } from '@tests/fixtures/agent-definition-fakes.ts';
 import { createFakeProject, type FakeProject } from '@tests/helpers/fake-project.ts';
 
 // ─── skip on Windows — worktrees are posix-heavy ────────────────────────────
@@ -362,6 +363,8 @@ function runTests(): void {
       locksRoot: absolutePath(locksRootPath),
       skillsAdapter: noopSkillsAdapter,
       skillSource: emptySkillSource,
+      generatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
+      evaluatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
       interactive: {
         async askText() {
           throw new Error('askText not expected in parallel real-git test');

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -45,6 +45,7 @@ import { createImplementFlow } from '@src/application/flows/implement/flow.ts';
 import { createFoldQueue } from '@src/application/flows/implement/wave-branch.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+import { noopAgentDefinitionAdapter } from '@tests/fixtures/agent-definition-fakes.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
 import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
@@ -350,6 +351,8 @@ const buildDeps = (
   locksRoot: absolutePath(locksRoot),
   skillsAdapter: noopSkillsAdapter,
   skillSource: emptySkillSource,
+  generatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
+  evaluatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
   interactive: unusedInteractive,
   writeFile: createAtomicWriteFile(),
   appendFile: createAppendFile(),

--- a/tests/e2e/full-stack/implement-review-close.test.ts
+++ b/tests/e2e/full-stack/implement-review-close.test.ts
@@ -59,6 +59,7 @@ import type { HarnessSignal, EvaluationSignal } from '@src/domain/signal.ts';
 
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { noopSkillsAdapter, emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
+import { noopAgentDefinitionAdapter } from '@tests/fixtures/agent-definition-fakes.ts';
 import { createWorkspaceMutatingFakeProvider } from '@tests/fixtures/workspace-mutating-fake-provider.ts';
 import { createFakeAiProvider } from '@tests/fixtures/fake-ai-provider.ts';
 import { createFakeProject, type FakeProject } from '@tests/helpers/fake-project.ts';
@@ -240,6 +241,8 @@ function runTests(): void {
     locksRoot: absolutePath(locksDir),
     skillsAdapter: noopSkillsAdapter,
     skillSource: emptySkillSource,
+    generatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
+    evaluatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
     interactive: unusedInteractive,
     writeFile: createAtomicWriteFile(),
     appendFile: createAppendFile(),

--- a/tests/e2e/full-stack/sprint-lifecycle.test.ts
+++ b/tests/e2e/full-stack/sprint-lifecycle.test.ts
@@ -42,6 +42,7 @@ import type { HarnessSignal, EvaluationSignal } from '@src/domain/signal.ts';
 
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { noopSkillsAdapter, emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
+import { noopAgentDefinitionAdapter } from '@tests/fixtures/agent-definition-fakes.ts';
 import { createWorkspaceMutatingFakeProvider } from '@tests/fixtures/workspace-mutating-fake-provider.ts';
 import { createFakeProject, type FakeProject } from '@tests/helpers/fake-project.ts';
 import { createRealFsApp, type RealFsApp } from '@tests/helpers/real-fs-app.ts';
@@ -219,6 +220,8 @@ function runTests(): void {
     locksRoot: absolutePath(locksDir),
     skillsAdapter: noopSkillsAdapter,
     skillSource: emptySkillSource,
+    generatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
+    evaluatorAgentDefinitionAdapter: noopAgentDefinitionAdapter,
     interactive: unusedInteractive,
     writeFile: createAtomicWriteFile(),
     appendFile: createAppendFile(),

--- a/tests/fixtures/agent-definition-fakes.ts
+++ b/tests/fixtures/agent-definition-fakes.ts
@@ -1,0 +1,23 @@
+/**
+ * Tiny fakes for the agent-definition ports — used by flow tests that construct flow deps
+ * directly and don't care about the agent-definition mechanism (they just need install/uninstall
+ * to succeed as no-ops). Mirrors `tests/fixtures/skills-fakes.ts`.
+ *
+ * Real adapter behaviour (native file rendering per provider) is covered by the dedicated
+ * integration tests under `tests/integration/ai/agents/`.
+ */
+
+import { Result } from '@src/domain/result.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+
+export const noopAgentDefinitionAdapter: AgentDefinitionAdapter = {
+  install: async () => Result.ok(undefined),
+  uninstall: async () => Result.ok(undefined),
+  describeConvention: () => 'Test provider has no agent-definition convention; proceed directly to authoring.',
+};
+
+export const emptyAgentDefinitionSource: AgentDefinitionSource = {
+  list: async () => Result.ok([]),
+  getByName: async () => Result.ok(undefined),
+};

--- a/tests/integration/ai/agents/_engine/compose-agent-definition-sources.test.ts
+++ b/tests/integration/ai/agents/_engine/compose-agent-definition-sources.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import { composeAgentDefinitionSources } from '@src/integration/ai/agents/_engine/compose-agent-definition-sources.ts';
+
+const def = (name: string, description = `${name} guidance`): AgentDefinition => ({
+  name,
+  description,
+  content: `# ${name}\nbody\n`,
+});
+
+const fakeStaticSource = (definitions: readonly AgentDefinition[]): AgentDefinitionSource => ({
+  async list() {
+    return Result.ok(definitions);
+  },
+  async getByName(name: string) {
+    return Result.ok(definitions.find((d) => d.name === name));
+  },
+});
+
+const fakeErrorSource = (error: StorageError): AgentDefinitionSource => ({
+  async list() {
+    return Result.error(error);
+  },
+  async getByName() {
+    return Result.error(error);
+  },
+});
+
+describe('composeAgentDefinitionSources', () => {
+  it('unions definitions from every source', async () => {
+    const bundled = fakeStaticSource([def('ralphctl-evaluator'), def('ralphctl-generator')]);
+    const operator = fakeStaticSource([def('ralphctl-house-reviewer')]);
+    const composed = composeAgentDefinitionSources(bundled, operator);
+
+    const result = await composed.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((d) => d.name).sort()).toEqual([
+      'ralphctl-evaluator',
+      'ralphctl-generator',
+      'ralphctl-house-reviewer',
+    ]);
+  });
+
+  it('a later source wins a name collision (operator overrides bundled)', async () => {
+    const bundled = fakeStaticSource([def('ralphctl-evaluator', 'bundled default')]);
+    const operator = fakeStaticSource([def('ralphctl-evaluator', 'operator override')]);
+    const composed = composeAgentDefinitionSources(bundled, operator);
+
+    const result = await composed.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.description).toBe('operator override');
+  });
+
+  it('getByName resolves through the composed precedence', async () => {
+    const bundled = fakeStaticSource([def('ralphctl-evaluator', 'bundled default')]);
+    const operator = fakeStaticSource([def('ralphctl-evaluator', 'operator override')]);
+    const composed = composeAgentDefinitionSources(bundled, operator);
+
+    const result = await composed.getByName('ralphctl-evaluator');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value?.description).toBe('operator override');
+  });
+
+  it('getByName returns ok(undefined) for a name no source provides', async () => {
+    const composed = composeAgentDefinitionSources(fakeStaticSource([def('ralphctl-evaluator')]));
+    const result = await composed.getByName('ralphctl-unknown');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBeUndefined();
+  });
+
+  it('short-circuits on the first source error, unmasked by a later source', async () => {
+    const error = new StorageError({ subCode: 'io', message: 'boom' });
+    const failing = fakeErrorSource(error);
+    const healthy = fakeStaticSource([def('ralphctl-generator')]);
+    const composed = composeAgentDefinitionSources(failing, healthy);
+
+    const result = await composed.list();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toBe('boom');
+  });
+});

--- a/tests/integration/ai/agents/_engine/filesystem-agent-definition-adapter.test.ts
+++ b/tests/integration/ai/agents/_engine/filesystem-agent-definition-adapter.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createFilesystemAgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'fs-agent-defs-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition = (name: string, content: string): AgentDefinition => ({
+  name,
+  description: `desc for ${name}`,
+  content,
+});
+
+/** Trivial test-only renderer: `<parentDir>/agents/ralphctl-<name>.txt`, raw content. */
+const testRenderer = (def: AgentDefinition): Result<RenderedAgentFile, StorageError> =>
+  Result.ok({
+    relPath: join('.test-provider', 'agents', `ralphctl-${def.name}.txt`),
+    content: def.content,
+  });
+
+const makeAdapter = () =>
+  createFilesystemAgentDefinitionAdapter({
+    providerId: 'test-provider',
+    parentDir: '.test-provider',
+    renderer: testRenderer,
+    convention: 'agents live under .test-provider/agents/',
+  });
+
+describe('createFilesystemAgentDefinitionAdapter — install / uninstall', () => {
+  it('writes each definition via the renderer relPath', async () => {
+    const session = await makeSession();
+    const adapter = makeAdapter();
+
+    const result = await adapter.install(session, [definition('alpha', 'A body'), definition('beta', 'B body')]);
+    expect(result.ok).toBe(true);
+
+    expect(await readFile(join(String(session), '.test-provider/agents/ralphctl-alpha.txt'), 'utf-8')).toBe('A body');
+    expect(await readFile(join(String(session), '.test-provider/agents/ralphctl-beta.txt'), 'utf-8')).toBe('B body');
+  });
+
+  it('project-wins: preserves a pre-existing file at the rendered destination', async () => {
+    const session = await makeSession();
+    const projectFile = join(String(session), '.test-provider/agents/ralphctl-alpha.txt');
+    await mkdir(join(String(session), '.test-provider/agents'), { recursive: true });
+    await writeFile(projectFile, 'PROJECT VERSION', 'utf-8');
+
+    const adapter = makeAdapter();
+    const result = await adapter.install(session, [definition('alpha', 'bundled body')]);
+    expect(result.ok).toBe(true);
+
+    expect(await readFile(projectFile, 'utf-8')).toBe('PROJECT VERSION');
+  });
+
+  it('install is idempotent — second call does not rewrite an already-installed file', async () => {
+    const session = await makeSession();
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('alpha', 'v1')]);
+    const initialMtime = (await stat(join(String(session), '.test-provider/agents/ralphctl-alpha.txt'))).mtimeMs;
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await adapter.install(session, [definition('alpha', 'v2 should not overwrite')]);
+    const secondMtime = (await stat(join(String(session), '.test-provider/agents/ralphctl-alpha.txt'))).mtimeMs;
+    expect(secondMtime).toBe(initialMtime);
+  });
+
+  it('uninstall removes only the definitions install created and leaves pre-existing project files untouched', async () => {
+    const session = await makeSession();
+    const projectFile = join(String(session), '.test-provider/agents/ralphctl-project-owned.txt');
+    await mkdir(join(String(session), '.test-provider/agents'), { recursive: true });
+    await writeFile(projectFile, 'PROJECT', 'utf-8');
+
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('project-owned', 'bundled'), definition('alpha', 'A body')]);
+
+    const uninstall = await adapter.uninstall(session);
+    expect(uninstall.ok).toBe(true);
+
+    // Pre-existing project file survives.
+    expect(await readFile(projectFile, 'utf-8')).toBe('PROJECT');
+    // The file this adapter actually wrote is gone.
+    expect(existsSync(join(String(session), '.test-provider/agents/ralphctl-alpha.txt'))).toBe(false);
+  });
+
+  it('uninstall is a no-op when nothing was installed', async () => {
+    const session = await makeSession();
+    const adapter = makeAdapter();
+    const result = await adapter.uninstall(session);
+    expect(result.ok).toBe(true);
+  });
+
+  it('uninstall tidies empty parent <parentDir>/agents and <parentDir> dirs', async () => {
+    const session = await makeSession();
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('alpha', 'A body')]);
+    await adapter.uninstall(session);
+    expect(existsSync(join(String(session), '.test-provider'))).toBe(false);
+  });
+
+  it('preserves a non-empty parentDir when other content lives there', async () => {
+    const session = await makeSession();
+    await mkdir(join(String(session), '.test-provider'), { recursive: true });
+    await writeFile(join(String(session), '.test-provider/OTHER.txt'), '# other project file', 'utf-8');
+
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('alpha', 'A body')]);
+    await adapter.uninstall(session);
+
+    expect(existsSync(join(String(session), '.test-provider/agents'))).toBe(false);
+    expect(existsSync(join(String(session), '.test-provider/OTHER.txt'))).toBe(true);
+  });
+});
+
+describe('createFilesystemAgentDefinitionAdapter — .git/info/exclude wildcard', () => {
+  it('appends the <parentDir>/agents/ralphctl-* line on first install', async () => {
+    const session = await makeSession();
+    await mkdir(join(String(session), '.git/info'), { recursive: true });
+    await writeFile(join(String(session), '.git/info/exclude'), '# default\n', 'utf-8');
+
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('alpha', 'A body')]);
+
+    const content = await readFile(join(String(session), '.git/info/exclude'), 'utf-8');
+    expect(content).toContain('.test-provider/agents/ralphctl-*');
+  });
+
+  it('does not duplicate the wildcard on repeated installs', async () => {
+    const session = await makeSession();
+    await mkdir(join(String(session), '.git/info'), { recursive: true });
+    await writeFile(join(String(session), '.git/info/exclude'), '', 'utf-8');
+
+    const adapter = makeAdapter();
+    await adapter.install(session, [definition('alpha', 'A body')]);
+    await adapter.install(session, [definition('beta', 'B body')]);
+
+    const content = await readFile(join(String(session), '.git/info/exclude'), 'utf-8');
+    const matches = content.split('\n').filter((l) => l.trim() === '.test-provider/agents/ralphctl-*');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('install proceeds when .git is missing (non-git working tree)', async () => {
+    const session = await makeSession();
+    const adapter = makeAdapter();
+    const result = await adapter.install(session, [definition('alpha', 'A body')]);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(String(session), '.git'))).toBe(false);
+  });
+});
+
+describe('createFilesystemAgentDefinitionAdapter — renderer errors', () => {
+  it('propagates a renderer error and writes no file for the rejected definition', async () => {
+    const session = await makeSession();
+    const failingRenderer = (def: AgentDefinition): Result<RenderedAgentFile, StorageError> =>
+      def.name === 'bad'
+        ? Result.error({ subCode: 'schema-mismatch', message: 'too big', name: 'StorageError' } as StorageError)
+        : testRenderer(def);
+    const adapter = createFilesystemAgentDefinitionAdapter({
+      providerId: 'test-provider',
+      parentDir: '.test-provider',
+      renderer: failingRenderer,
+      convention: 'agents live under .test-provider/agents/',
+    });
+
+    const result = await adapter.install(session, [definition('alpha', 'A body'), definition('bad', 'too long')]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('too big');
+
+    // The definition before the failing one was still written.
+    expect(existsSync(join(String(session), '.test-provider/agents/ralphctl-alpha.txt'))).toBe(true);
+    expect(existsSync(join(String(session), '.test-provider/agents/ralphctl-bad.txt'))).toBe(false);
+  });
+});

--- a/tests/integration/ai/agents/bundled/source.test.ts
+++ b/tests/integration/ai/agents/bundled/source.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createBundledAgentDefinitionSource, resolveBundledRoot } from '@src/integration/ai/agents/bundled/source.ts';
+import { BUNDLED_AGENT_DEFINITIONS } from '@src/integration/ai/agents/_engine/registry.ts';
+
+describe('resolveBundledRoot', () => {
+  it('resolves the co-located agent-definitions/ dir when the build copied .md files beside the bundle', () => {
+    const beside = (p: string): boolean => p === '/pkg/dist/agent-definitions';
+    expect(resolveBundledRoot('file:///pkg/dist/cli-CKPJ5SY4.mjs', beside)).toBe('/pkg/dist/agent-definitions');
+    expect(resolveBundledRoot('file:///pkg/dist/cli.mjs', beside)).toBe('/pkg/dist/agent-definitions');
+  });
+
+  it('resolves the module dir itself in dev, where nothing sits beside source.ts', () => {
+    const never = (): boolean => false;
+    expect(resolveBundledRoot('file:///pkg/src/integration/ai/agents/bundled/source.ts', never)).toBe(
+      '/pkg/src/integration/ai/agents/bundled'
+    );
+  });
+});
+
+describe('createBundledAgentDefinitionSource (production root)', () => {
+  const source = createBundledAgentDefinitionSource();
+
+  it('lists exactly the registry defaults', async () => {
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((d) => d.name).sort()).toEqual([...BUNDLED_AGENT_DEFINITIONS].sort());
+  });
+
+  it('reads name + description from frontmatter and a non-trivial body', async () => {
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const evaluator = result.value.find((d) => d.name === 'ralphctl-evaluator');
+    expect(evaluator?.description.length).toBeGreaterThan(0);
+    expect(evaluator?.content.length).toBeGreaterThan(0);
+    const generator = result.value.find((d) => d.name === 'ralphctl-generator');
+    expect(generator?.description.length).toBeGreaterThan(0);
+    expect(generator?.content.length).toBeGreaterThan(0);
+  });
+
+  it('getByName resolves a known bundled definition by its exact file name', async () => {
+    const result = await source.getByName('ralphctl-evaluator');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value?.name).toBe('ralphctl-evaluator');
+  });
+
+  it('getByName returns ok(undefined) for an unknown name (not an error)', async () => {
+    const result = await source.getByName('ralphctl-does-not-exist');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBeUndefined();
+  });
+});
+
+describe('createBundledAgentDefinitionSource (custom root)', () => {
+  it('errors out cleanly when a registry-referenced file is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bundled-agents-'));
+    const source = createBundledAgentDefinitionSource({ bundledRoot: root });
+    const result = await source.list();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/bundled agent definition not readable/u);
+  });
+
+  it('rejects malformed frontmatter with a parse error', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bundled-agents-'));
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, 'ralphctl-evaluator.md'), '---\ndescription: only description\n---\n\nbody\n', 'utf-8');
+    await writeFile(
+      join(root, 'ralphctl-generator.md'),
+      '---\nname: ralphctl-generator\ndescription: ok\n---\nbody\n',
+      'utf-8'
+    );
+    const source = createBundledAgentDefinitionSource({ bundledRoot: root });
+    const result = await source.list();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/invalid frontmatter/u);
+  });
+
+  it('getByName surfaces a StorageError when a present file has malformed frontmatter', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bundled-agents-'));
+    await writeFile(join(root, 'broken.md'), '---\ndescription: only description\n---\n\nbody\n', 'utf-8');
+    const source = createBundledAgentDefinitionSource({ bundledRoot: root });
+    const result = await source.getByName('broken');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/invalid frontmatter/u);
+  });
+
+  it('requires frontmatter name to match the file base name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'bundled-agents-'));
+    await writeFile(
+      join(root, 'ralphctl-evaluator.md'),
+      '---\nname: mismatch\ndescription: ok\n---\n\nbody\n',
+      'utf-8'
+    );
+    await writeFile(
+      join(root, 'ralphctl-generator.md'),
+      '---\nname: ralphctl-generator\ndescription: ok\n---\nbody\n',
+      'utf-8'
+    );
+    const source = createBundledAgentDefinitionSource({ bundledRoot: root });
+    const result = await source.list();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/must match source name/u);
+  });
+});

--- a/tests/integration/ai/agents/claude/adapter.test.ts
+++ b/tests/integration/ai/agents/claude/adapter.test.ts
@@ -59,4 +59,14 @@ describe('createClaudeAgentDefinitionAdapter — golden render', () => {
     const adapter = createClaudeAgentDefinitionAdapter();
     expect(adapter.describeConvention()).toContain('.claude/agents/');
   });
+
+  it('does not double-prefix a name that already carries the ralphctl- prefix', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ name: 'ralphctl-evaluator' })]);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-evaluator.md'), 'utf-8');
+    expect(written).toContain('name: ralphctl-evaluator');
+  });
 });

--- a/tests/integration/ai/agents/claude/adapter.test.ts
+++ b/tests/integration/ai/agents/claude/adapter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createClaudeAgentDefinitionAdapter } from '@src/integration/ai/agents/claude/adapter.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-agents-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'implementer',
+  description: 'Writes features, fixes bugs, adds tests.',
+  content: 'You are an implementer.\n',
+  ...overrides,
+});
+
+describe('createClaudeAgentDefinitionAdapter — golden render', () => {
+  it('writes the definition to <sessionDir>/.claude/agents/ralphctl-<name>.md', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+
+    const result = await adapter.install(session, [definition({ model: 'claude-sonnet-5', effort: 'high' })]);
+    expect(result.ok).toBe(true);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-implementer.md'), 'utf-8');
+    expect(written).toBe(
+      [
+        '---',
+        'name: implementer',
+        'description: Writes features, fixes bugs, adds tests.',
+        'model: claude-sonnet-5',
+        'effort: high',
+        '---',
+        '',
+        'You are an implementer.',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('omits optional model / effort frontmatter keys when absent', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition()]);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-implementer.md'), 'utf-8');
+    expect(written).not.toContain('model:');
+    expect(written).not.toContain('effort:');
+  });
+
+  it('describeConvention mentions .claude/agents/', () => {
+    const adapter = createClaudeAgentDefinitionAdapter();
+    expect(adapter.describeConvention()).toContain('.claude/agents/');
+  });
+});

--- a/tests/integration/ai/agents/codex/adapter.test.ts
+++ b/tests/integration/ai/agents/codex/adapter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createCodexAgentDefinitionAdapter } from '@src/integration/ai/agents/codex/adapter.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'codex-agents-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'implementer',
+  description: 'Writes features, fixes bugs, adds tests.',
+  content: 'You are an implementer.\n',
+  ...overrides,
+});
+
+describe('createCodexAgentDefinitionAdapter — golden render', () => {
+  it('writes the definition to <sessionDir>/.codex/agents/ralphctl-<name>.toml with the body under developer_instructions', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+
+    const result = await adapter.install(session, [definition({ model: 'claude-sonnet-5', effort: 'high' })]);
+    expect(result.ok).toBe(true);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-implementer.toml'), 'utf-8');
+    expect(written).toBe(
+      [
+        'name = "implementer"',
+        'description = "Writes features, fixes bugs, adds tests."',
+        'developer_instructions = "You are an implementer."',
+        'model = "claude-sonnet-5"',
+        'model_reasoning_effort = "high"',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('escapes quotes and newlines inside the body via TOML basic-string escaping', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ content: 'Line one.\nQuote: "hello"\n' })]);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-implementer.toml'), 'utf-8');
+    expect(written).toContain('developer_instructions = "Line one.\\nQuote: \\"hello\\""');
+  });
+
+  it('omits optional model / model_reasoning_effort keys when absent', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition()]);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-implementer.toml'), 'utf-8');
+    expect(written).not.toContain('model');
+  });
+
+  it('describeConvention mentions .codex/agents/', () => {
+    const adapter = createCodexAgentDefinitionAdapter();
+    expect(adapter.describeConvention()).toContain('.codex/agents/');
+  });
+});

--- a/tests/integration/ai/agents/codex/adapter.test.ts
+++ b/tests/integration/ai/agents/codex/adapter.test.ts
@@ -65,4 +65,14 @@ describe('createCodexAgentDefinitionAdapter — golden render', () => {
     const adapter = createCodexAgentDefinitionAdapter();
     expect(adapter.describeConvention()).toContain('.codex/agents/');
   });
+
+  it('does not double-prefix a name that already carries the ralphctl- prefix', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ name: 'ralphctl-evaluator' })]);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-evaluator.toml'), 'utf-8');
+    expect(written).toContain('name = "ralphctl-evaluator"');
+  });
 });

--- a/tests/integration/ai/agents/copilot/adapter.test.ts
+++ b/tests/integration/ai/agents/copilot/adapter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createCopilotAgentDefinitionAdapter } from '@src/integration/ai/agents/copilot/adapter.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'copilot-agents-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'implementer',
+  description: 'Writes features, fixes bugs, adds tests.',
+  content: 'You are an implementer.\n',
+  ...overrides,
+});
+
+describe('createCopilotAgentDefinitionAdapter — golden render', () => {
+  it('writes the definition to <sessionDir>/.github/agents/ralphctl-<name>.agent.md', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+
+    const result = await adapter.install(session, [definition({ model: 'claude-sonnet-5' })]);
+    expect(result.ok).toBe(true);
+
+    const written = await readFile(join(String(session), '.github/agents/ralphctl-implementer.agent.md'), 'utf-8');
+    expect(written).toBe(
+      [
+        '---',
+        'description: Writes features, fixes bugs, adds tests.',
+        'name: implementer',
+        'model: claude-sonnet-5',
+        '---',
+        '',
+        'You are an implementer.',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('describeConvention mentions .github/agents/', () => {
+    const adapter = createCopilotAgentDefinitionAdapter();
+    expect(adapter.describeConvention()).toContain('.github/agents/');
+  });
+});
+
+describe('createCopilotAgentDefinitionAdapter — 30000-char body size guard', () => {
+  it('returns a StorageError and writes no file when the body exceeds 30000 chars', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+    const oversized = definition({ content: 'x'.repeat(30001) });
+
+    const result = await adapter.install(session, [oversized]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.subCode).toBe('schema-mismatch');
+      expect(result.error.message).toContain('30000');
+    }
+
+    expect(existsSync(join(String(session), '.github/agents/ralphctl-implementer.agent.md'))).toBe(false);
+    expect(existsSync(join(String(session), '.github'))).toBe(false);
+  });
+
+  it('accepts a body at exactly the 30000-char limit', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+    const atLimit = definition({ content: 'x'.repeat(30000) });
+
+    const result = await adapter.install(session, [atLimit]);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(String(session), '.github/agents/ralphctl-implementer.agent.md'))).toBe(true);
+  });
+});

--- a/tests/integration/ai/agents/copilot/adapter.test.ts
+++ b/tests/integration/ai/agents/copilot/adapter.test.ts
@@ -48,6 +48,16 @@ describe('createCopilotAgentDefinitionAdapter — golden render', () => {
     const adapter = createCopilotAgentDefinitionAdapter();
     expect(adapter.describeConvention()).toContain('.github/agents/');
   });
+
+  it('does not double-prefix a name that already carries the ralphctl- prefix', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ name: 'ralphctl-evaluator' })]);
+
+    const written = await readFile(join(String(session), '.github/agents/ralphctl-evaluator.agent.md'), 'utf-8');
+    expect(written).toContain('name: ralphctl-evaluator');
+  });
 });
 
 describe('createCopilotAgentDefinitionAdapter — 30000-char body size guard', () => {

--- a/tests/integration/ai/agents/operator/source.test.ts
+++ b/tests/integration/ai/agents/operator/source.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { createEventBusLogger } from '@src/business/observability/event-bus-logger.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { AppEvent, LogEvent } from '@src/business/observability/events.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { RALPHCTL_AGENT_PREFIX } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { warnIfVague } from '@src/integration/ai/agents/_engine/agent-definition-quality.ts';
+import { createOperatorAgentDefinitionSource } from '@src/integration/ai/agents/operator/source.ts';
+
+const ns = (name: string): string => `${RALPHCTL_AGENT_PREFIX}${name}`;
+
+const abs = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`bad path: ${p}`);
+  return r.value;
+};
+
+/** A logger backed by a real in-memory bus so tests assert genuine `LogEvent`s, not call spies. */
+const recordingLogger = (): { logger: ReturnType<typeof createEventBusLogger>; logs: LogEvent[] } => {
+  const bus = createInMemoryEventBus();
+  const logs: LogEvent[] = [];
+  bus.subscribe((e: AppEvent) => {
+    if (e.type === 'log') logs.push(e);
+  });
+  return { logger: createEventBusLogger({ eventBus: bus, clock: IsoTimestamp.now }), logs };
+};
+
+const writeDefinition = async (
+  root: string,
+  name: string,
+  frontmatterName: string = name,
+  body = `# ${name}\nbody\n`
+): Promise<void> => {
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, `${name}.md`),
+    `---\nname: ${frontmatterName}\ndescription: ${name} guidance\n---\n\n${body}`,
+    'utf-8'
+  );
+};
+
+describe('createOperatorAgentDefinitionSource', () => {
+  it('reads <root>/*.md flat, with no per-provider subdirectory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    await writeDefinition(root, 'house-reviewer');
+    await writeDefinition(root, 'commit-writer');
+    const { logger } = recordingLogger();
+
+    const source = createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: abs(root), logger });
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const names = result.value.map((d) => d.name).sort();
+    expect(names).toEqual([ns('commit-writer'), ns('house-reviewer')]);
+    const houseReviewer = result.value.find((d) => d.name === ns('house-reviewer'));
+    expect(houseReviewer?.description).toBe('house-reviewer guidance');
+    expect(houseReviewer?.content).toContain('# house-reviewer');
+  });
+
+  it('does not double-prefix a file the operator already named ralphctl-*', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    await writeDefinition(root, 'ralphctl-prewired');
+    const { logger } = recordingLogger();
+
+    const source = createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: abs(root), logger });
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((d) => d.name)).toEqual(['ralphctl-prewired']);
+  });
+
+  it('returns an empty list when the operator root is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    const { logger, logs } = recordingLogger();
+
+    const source = createOperatorAgentDefinitionSource({
+      operatorAgentDefinitionsRoot: abs(join(root, 'does-not-exist')),
+      logger,
+    });
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+    expect(logs.filter((l) => l.level === 'warn')).toEqual([]);
+  });
+
+  it.skipIf(process.getuid?.() === 0)(
+    'skips an unreadable individual definition with a logged warning, keeping the rest',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+      await writeDefinition(root, 'good-definition');
+      // Strip read permission from `<root>/wedged.md` → readFile fails with EACCES, skip it.
+      await writeDefinition(root, 'wedged');
+      await chmod(join(root, 'wedged.md'), 0o000);
+      const { logger, logs } = recordingLogger();
+
+      const source = createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: abs(root), logger });
+      const result = await source.list();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((d) => d.name)).toEqual([ns('good-definition')]);
+      expect(logs.some((l) => l.level === 'warn' && l.message.includes('not readable'))).toBe(true);
+    }
+  );
+
+  it('skips a malformed definition (frontmatter name mismatch) with a logged warning', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    await writeDefinition(root, 'good-definition');
+    await writeDefinition(root, 'mismatch-file', 'different-name');
+    const { logger, logs } = recordingLogger();
+
+    const source = createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: abs(root), logger });
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((d) => d.name)).toEqual([ns('good-definition')]);
+    expect(logs.some((l) => l.level === 'warn' && l.message.includes('invalid'))).toBe(true);
+  });
+
+  it('getByName resolves a single operator definition and returns undefined for unknown names', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    await writeDefinition(root, 'house-reviewer');
+    const { logger } = recordingLogger();
+
+    const source = createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: abs(root), logger });
+    const hit = await source.getByName(ns('house-reviewer'));
+    expect(hit.ok).toBe(true);
+    if (!hit.ok) return;
+    expect(hit.value?.name).toBe(ns('house-reviewer'));
+
+    const miss = await source.getByName('nope');
+    expect(miss.ok).toBe(true);
+    if (!miss.ok) return;
+    expect(miss.value).toBeUndefined();
+  });
+
+  it('a well-formed but vague definition raises a non-blocking warning yet is still returned', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'operator-agents-'));
+    // Short, unstructured body — trips the quality warner's Q1 (too short) and Q2 (no structure).
+    await writeDefinition(root, 'vague-agent', 'vague-agent', 'Be helpful.\n');
+    const { logger, logs } = recordingLogger();
+
+    const warnIfVagueGuard = (definition: AgentDefinition): void => warnIfVague(logger, definition);
+    const source = createOperatorAgentDefinitionSource({
+      operatorAgentDefinitionsRoot: abs(root),
+      logger,
+      warnIfVague: warnIfVagueGuard,
+    });
+    const result = await source.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Still returned for use — the operator owns their definitions.
+    expect(result.value.map((d) => d.name)).toEqual([ns('vague-agent')]);
+    const warnLogs = logs.filter((l) => l.level === 'warn');
+    expect(warnLogs.some((l) => l.message.includes('agent definition quality concern'))).toBe(true);
+  });
+});

--- a/tests/integration/ai/prompts/evaluate/definition.test.ts
+++ b/tests/integration/ai/prompts/evaluate/definition.test.ts
@@ -291,6 +291,42 @@ describe('buildEvaluatePrompt — end-to-end against the real template', () => {
     expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
   });
 
+  it('renders the agent-definition section after the base role/success-criteria blocks, leaving them intact', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildEvaluatePrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+      agentDefinition: 'You are the "release-notes" agent. Focus on user-facing wording.',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain('## Agent Definition');
+    expect(result.value).toContain('You are the "release-notes" agent. Focus on user-facing wording.');
+    // Additive, not destructive: the base role/success-criteria content survives verbatim.
+    expect(result.value).toContain('<role>');
+    expect(result.value).toContain('</success_criteria>');
+    const successCriteriaIdx = result.value.indexOf('</success_criteria>');
+    const agentDefinitionIdx = result.value.indexOf('## Agent Definition');
+    expect(agentDefinitionIdx).toBeGreaterThan(successCriteriaIdx);
+    expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it('collapses the agent-definition section with no orphan heading when absent', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildEvaluatePrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).not.toContain('## Agent Definition');
+    expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
   it('renders extra dimensions after the floor dimensions when planner attached them', async () => {
     const ticket = makeApprovedTicket();
     const task = unwrap(

--- a/tests/integration/ai/prompts/implement/definition.test.ts
+++ b/tests/integration/ai/prompts/implement/definition.test.ts
@@ -10,6 +10,7 @@ import { extractPlaceholders } from '@src/integration/ai/prompts/_engine/extract
 import {
   buildImplementPrompt,
   implementPromptDef,
+  renderAgentDefinitionSection,
   renderPreVerifyResultsSection,
   renderPriorCritiqueSection,
   renderProjectToolingSection,
@@ -228,6 +229,23 @@ describe('renderRetryFeedbackSection', () => {
   it('returns the empty string for empty / whitespace input', () => {
     expect(renderRetryFeedbackSection('')).toBe('');
     expect(renderRetryFeedbackSection('   ')).toBe('');
+  });
+});
+
+describe('renderAgentDefinitionSection', () => {
+  it('renders a heading + the verbatim content when provided', () => {
+    const out = renderAgentDefinitionSection('You are the "release-notes" agent. Focus on user-facing wording.');
+    expect(out).toContain('## Agent Definition');
+    expect(out).toContain('You are the "release-notes" agent. Focus on user-facing wording.');
+  });
+
+  it('returns the empty string when undefined', () => {
+    expect(renderAgentDefinitionSection(undefined)).toBe('');
+  });
+
+  it('returns the empty string for empty / whitespace input', () => {
+    expect(renderAgentDefinitionSection('')).toBe('');
+    expect(renderAgentDefinitionSection('   \n\t')).toBe('');
   });
 });
 
@@ -456,6 +474,46 @@ describe('buildImplementPrompt — end-to-end against the real template', () => 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value).not.toContain('## Prior criteria verdicts');
+    expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it('renders the agent-definition section after the base role/success-criteria blocks, leaving them intact', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildImplementPrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      progressFile: '/tmp/ralph/sprint-1/progress.md',
+      priorProgress: '',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+      agentDefinition: 'You are the "release-notes" agent. Focus on user-facing wording.',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain('## Agent Definition');
+    expect(result.value).toContain('You are the "release-notes" agent. Focus on user-facing wording.');
+    // Additive, not destructive: the base role/success-criteria content survives verbatim.
+    expect(result.value).toContain('<role>');
+    expect(result.value).toContain('</success_criteria>');
+    const successCriteriaIdx = result.value.indexOf('</success_criteria>');
+    const agentDefinitionIdx = result.value.indexOf('## Agent Definition');
+    expect(agentDefinitionIdx).toBeGreaterThan(successCriteriaIdx);
+    expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it('collapses the agent-definition section with no orphan heading when absent', async () => {
+    const task = makeTaskWith({ name: 'export CSV' });
+    const result = await buildImplementPrompt(deps, {
+      task,
+      projectPath: '/tmp/ralph/main-repo',
+      progressFile: '/tmp/ralph/sprint-1/progress.md',
+      priorProgress: '',
+      outputContractSection: SAMPLE_CONTRACT_SECTION,
+      contractPath: CONTRACT_PATH,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).not.toContain('## Agent Definition');
     expect(result.value).not.toMatch(/\{\{[A-Z_]+\}\}/);
   });
 

--- a/tests/integration/application/bootstrap/storage-paths.test.ts
+++ b/tests/integration/application/bootstrap/storage-paths.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENTS_SUBDIR,
   APP_ROOT_DIR,
   CONFIG_SUBDIR,
   DATA_SUBDIR,
@@ -30,6 +31,7 @@ describe('resolveStoragePaths', () => {
     expect(String(result.value.runsRoot)).toBe('/home/alice/.ralphctl/data/runs');
     expect(String(result.value.memoryRoot)).toBe('/home/alice/.ralphctl/data/memory');
     expect(String(result.value.operatorSkillsRoot)).toBe('/home/alice/.ralphctl/skills');
+    expect(String(result.value.operatorAgentDefinitionsRoot)).toBe('/home/alice/.ralphctl/agents');
   });
 
   it('uses os.homedir() by default', () => {
@@ -44,6 +46,7 @@ describe('resolveStoragePaths', () => {
     expect(String(result.value.runsRoot)).toContain(`${DATA_SUBDIR}/${RUNS_SUBDIR}`);
     expect(String(result.value.memoryRoot)).toContain(`${DATA_SUBDIR}/${MEMORY_SUBDIR}`);
     expect(String(result.value.operatorSkillsRoot)).toContain(`${APP_ROOT_DIR}/${SKILLS_SUBDIR}`);
+    expect(String(result.value.operatorAgentDefinitionsRoot)).toContain(`${APP_ROOT_DIR}/${AGENTS_SUBDIR}`);
   });
 
   it('returns ValidationError when homedir is not absolute', () => {
@@ -63,6 +66,7 @@ describe('resolveStoragePaths', () => {
     expect(String(result.value.locksRoot)).toBe('/var/lib/ralphctl-test/state/locks');
     expect(String(result.value.memoryRoot)).toBe('/var/lib/ralphctl-test/data/memory');
     expect(String(result.value.operatorSkillsRoot)).toBe('/var/lib/ralphctl-test/skills');
+    expect(String(result.value.operatorAgentDefinitionsRoot)).toBe('/var/lib/ralphctl-test/agents');
   });
 
   it('falls back to homedir layout when RALPHCTL_HOME is empty', () => {
@@ -130,6 +134,20 @@ describe('ensureStorageRoots', () => {
 
     // The skills root is operator-created; ensureStorageRoots must not materialise it.
     await expect(fs.stat(String(paths.value.operatorSkillsRoot))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('computes operatorAgentDefinitionsRoot but does NOT create it (operator-authored, missing = empty)', async () => {
+    const paths = resolveStoragePaths({ homedir: () => fakeHome, env: {} });
+    if (!paths.ok) throw new Error('resolveStoragePaths failed');
+    expect(String(paths.value.operatorAgentDefinitionsRoot)).toBe(`${fakeHome}/.ralphctl/${AGENTS_SUBDIR}`);
+
+    const result = await ensureStorageRoots(paths.value);
+    expect(result.ok).toBe(true);
+
+    // The agents root is operator-created; ensureStorageRoots must not materialise it.
+    await expect(fs.stat(String(paths.value.operatorAgentDefinitionsRoot))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   it('is idempotent — running twice does not fail or duplicate work', async () => {

--- a/tests/integration/application/flows/_shared/agents/install-agent-definitions.test.ts
+++ b/tests/integration/application/flows/_shared/agents/install-agent-definitions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createClaudeAgentDefinitionAdapter } from '@src/integration/ai/agents/claude/adapter.ts';
+import { installAgentDefinitionsLeaf } from '@src/application/flows/_shared/agents/install-agent-definitions.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'install-agent-definitions-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'ralphctl-evaluator',
+  description: 'Reviews the generator turn.',
+  content: 'You are an evaluator.\n',
+  ...overrides,
+});
+
+describe('installAgentDefinitionsLeaf', () => {
+  it('installs the correct native file for the role provider when a definition is bound', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+    const leaf = installAgentDefinitionsLeaf<{ readonly cwd: AbsolutePath }>(
+      { agentDefinitionAdapter: adapter },
+      { definition: definition(), cwdPicker: (ctx) => ctx.cwd }
+    );
+
+    const result = await leaf.execute({ cwd: session });
+    expect(result.ok).toBe(true);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-evaluator.md'), 'utf-8');
+    expect(written).toContain('name: ralphctl-evaluator');
+  });
+
+  it('is a no-op when the role has no bound definition (definition undefined)', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+    const leaf = installAgentDefinitionsLeaf<{ readonly cwd: AbsolutePath }>(
+      { agentDefinitionAdapter: adapter },
+      { definition: undefined, cwdPicker: (ctx) => ctx.cwd }
+    );
+
+    const result = await leaf.execute({ cwd: session });
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(String(session), '.claude'))).toBe(false);
+  });
+});

--- a/tests/integration/application/flows/_shared/agents/uninstall-agent-definitions.test.ts
+++ b/tests/integration/application/flows/_shared/agents/uninstall-agent-definitions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { createClaudeAgentDefinitionAdapter } from '@src/integration/ai/agents/claude/adapter.ts';
+import { installAgentDefinitionsLeaf } from '@src/application/flows/_shared/agents/install-agent-definitions.ts';
+import { uninstallAgentDefinitionsLeaf } from '@src/application/flows/_shared/agents/uninstall-agent-definitions.ts';
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'uninstall-agent-definitions-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const definition: AgentDefinition = {
+  name: 'ralphctl-evaluator',
+  description: 'Reviews the generator turn.',
+  content: 'You are an evaluator.\n',
+};
+
+describe('uninstallAgentDefinitionsLeaf', () => {
+  it('removes the file the matching install leaf placed', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+    const cwdPicker = (ctx: { readonly cwd: AbsolutePath }): AbsolutePath => ctx.cwd;
+
+    const install = installAgentDefinitionsLeaf<{ readonly cwd: AbsolutePath }>(
+      { agentDefinitionAdapter: adapter },
+      { definition, cwdPicker }
+    );
+    await install.execute({ cwd: session });
+    expect(existsSync(join(String(session), '.claude/agents/ralphctl-evaluator.md'))).toBe(true);
+
+    const uninstall = uninstallAgentDefinitionsLeaf<{ readonly cwd: AbsolutePath }>(
+      { agentDefinitionAdapter: adapter },
+      { cwdPicker }
+    );
+    const result = await uninstall.execute({ cwd: session });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(String(session), '.claude/agents/ralphctl-evaluator.md'))).toBe(false);
+  });
+
+  it('is idempotent — uninstalling without a prior install is a no-op', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+    const uninstall = uninstallAgentDefinitionsLeaf<{ readonly cwd: AbsolutePath }>(
+      { agentDefinitionAdapter: adapter },
+      { cwdPicker: (ctx) => ctx.cwd }
+    );
+
+    const result = await uninstall.execute({ cwd: session });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/integration/application/ui/tui/_harness.tsx
+++ b/tests/integration/application/ui/tui/_harness.tsx
@@ -90,6 +90,7 @@ const defaultStorage = (): StoragePaths => {
     runsRoot: absPath(cwd),
     memoryRoot: absPath(cwd),
     operatorSkillsRoot: absPath(cwd),
+    operatorAgentDefinitionsRoot: absPath(cwd),
   };
 };
 

--- a/tests/integration/application/ui/tui/components/memory-pressure-banner.test.tsx
+++ b/tests/integration/application/ui/tui/components/memory-pressure-banner.test.tsx
@@ -15,6 +15,12 @@
  *
  * Lightweight `AppDeps` cast: the component only reads `deps.eventBus.subscribe`, matching the
  * StatusBanner test pattern. The cast is sound — the component never reaches other deps fields.
+ *
+ * Assertions after a bus publish are wrapped in `waitFor` (polling, ~3s ceiling) rather than a
+ * single fixed `setImmediate` tick — under heavy CPU contention from concurrent vitest forks a
+ * one-shot tick can resolve before Ink's render queue has actually settled, which is exactly the
+ * class of flake `_wait.ts`'s doc comment describes and the rest of the TUI test suite already
+ * guards against.
  */
 
 import { render } from 'ink-testing-library';
@@ -24,6 +30,7 @@ import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { MemoryPressureBanner } from '@src/application/ui/tui/components/memory-pressure-banner.tsx';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const renderBanner = (bus: ReturnType<typeof createInMemoryEventBus>): ReturnType<typeof render> => {
   const deps = { eventBus: bus } as unknown as AppDeps;
@@ -33,9 +40,6 @@ const renderBanner = (bus: ReturnType<typeof createInMemoryEventBus>): ReturnTyp
     </DepsProvider>
   );
 };
-
-/** Yield long enough for Ink to flush a bus publish into a re-render. */
-const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 const makeEvent = (
   severity: 'warning' | 'critical' | 'recovered',
@@ -64,12 +68,12 @@ describe('MemoryPressureBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish(makeEvent('warning', 0.87, 104_857_600, 120_000_000));
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('87%');
-    expect(frame).toContain('consider aborting and restarting');
-    expect(frame).toContain('memory pressure');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('87%');
+      expect(frame).toContain('consider aborting and restarting');
+      expect(frame).toContain('memory pressure');
+    });
     r.unmount();
   });
 
@@ -78,12 +82,12 @@ describe('MemoryPressureBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish(makeEvent('critical', 0.95, 99_614_720, 104_857_600));
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('95%');
-    expect(frame).toContain('auto-cleared in-memory buffers');
-    expect(frame).toContain('memory critical');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('95%');
+      expect(frame).toContain('auto-cleared in-memory buffers');
+      expect(frame).toContain('memory critical');
+    });
     r.unmount();
   });
 
@@ -93,13 +97,11 @@ describe('MemoryPressureBanner', () => {
 
     // First transition to warning so there is something to clear.
     bus.publish(makeEvent('warning'));
-    await flush();
-    expect(r.lastFrame() ?? '').toContain('memory pressure');
+    await waitFor(() => expect(r.lastFrame() ?? '').toContain('memory pressure'));
 
     // Then recover — banner must disappear.
     bus.publish(makeEvent('recovered'));
-    await flush();
-    expect(r.lastFrame() ?? '').toBe('');
+    await waitFor(() => expect(r.lastFrame() ?? '').toBe(''));
     r.unmount();
   });
 
@@ -109,11 +111,8 @@ describe('MemoryPressureBanner', () => {
 
     // 104_857_600 bytes = 100 MB; 120_000_000 bytes ≈ 114 MB
     bus.publish(makeEvent('warning', 0.87, 104_857_600, 120_000_000));
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
     // formatMb rounds to 0 decimal places.
-    expect(frame).toContain('100 MB');
+    await waitFor(() => expect(r.lastFrame() ?? '').toContain('100 MB'));
     r.unmount();
   });
 
@@ -122,9 +121,7 @@ describe('MemoryPressureBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish({ type: 'log', level: 'info', message: 'noise', at: IsoTimestamp.now() });
-    await flush();
-
-    expect(r.lastFrame() ?? '').toBe('');
+    await waitFor(() => expect(r.lastFrame() ?? '').toBe(''));
     r.unmount();
   });
 
@@ -133,15 +130,17 @@ describe('MemoryPressureBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish(makeEvent('warning', 0.75));
-    await flush();
-    expect(r.lastFrame() ?? '').toContain('memory pressure');
-    expect(r.lastFrame() ?? '').not.toContain('memory critical');
+    await waitFor(() => {
+      expect(r.lastFrame() ?? '').toContain('memory pressure');
+      expect(r.lastFrame() ?? '').not.toContain('memory critical');
+    });
 
     bus.publish(makeEvent('critical', 0.96));
-    await flush();
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('memory critical');
-    expect(frame).toContain('auto-cleared in-memory buffers');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('memory critical');
+      expect(frame).toContain('auto-cleared in-memory buffers');
+    });
     r.unmount();
   });
 
@@ -150,8 +149,7 @@ describe('MemoryPressureBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish(makeEvent('warning'));
-    await flush();
-    expect(r.lastFrame() ?? '').toContain('memory pressure');
+    await waitFor(() => expect(r.lastFrame() ?? '').toContain('memory pressure'));
 
     // After unmount the component no longer holds a listener — the bus can be used freely.
     r.unmount();

--- a/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
+++ b/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
@@ -52,6 +52,7 @@ const buildStorage = (dataRoot: string): StoragePaths => ({
   runsRoot: absPath(dataRoot),
   memoryRoot: absPath(dataRoot),
   operatorSkillsRoot: absPath(dataRoot),
+  operatorAgentDefinitionsRoot: absPath(dataRoot),
 });
 
 const writeProgressFile = async (dataRoot: string, body: string): Promise<void> => {

--- a/tests/integration/application/ui/tui/components/status-banner.test.tsx
+++ b/tests/integration/application/ui/tui/components/status-banner.test.tsx
@@ -13,6 +13,12 @@
  *
  * Lightweight `AppDeps` cast: the component only reads `deps.eventBus.subscribe`, faking the
  * rest would add noise. Same shape the sibling `ChainLogDegradedBanner` test uses.
+ *
+ * Assertions after a bus publish are wrapped in `waitFor` (polling, ~3s ceiling) rather than a
+ * single fixed `setImmediate` tick — under heavy CPU contention from concurrent vitest forks a
+ * one-shot tick can resolve before Ink's render queue has actually settled, which is exactly the
+ * class of flake `_wait.ts`'s doc comment describes and the rest of the TUI test suite already
+ * guards against.
  */
 
 import { render } from 'ink-testing-library';
@@ -22,6 +28,7 @@ import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { StatusBanner } from '@src/application/ui/tui/components/status-banner.tsx';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const renderBanner = (bus: ReturnType<typeof createInMemoryEventBus>): ReturnType<typeof render> => {
   const deps = { eventBus: bus } as unknown as AppDeps;
@@ -31,8 +38,6 @@ const renderBanner = (bus: ReturnType<typeof createInMemoryEventBus>): ReturnTyp
     </DepsProvider>
   );
 };
-
-const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 const tick = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -55,12 +60,12 @@ describe('StatusBanner', () => {
       message: 'Rate limit — waiting 30s',
       at: IsoTimestamp.now(),
     });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('Rate limit — waiting 30s');
-    expect(frame).toContain('i ');
-    expect(frame).toContain('press d to dismiss');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('Rate limit — waiting 30s');
+      expect(frame).toContain('i ');
+      expect(frame).toContain('press d to dismiss');
+    });
     r.unmount();
   });
 
@@ -75,11 +80,11 @@ describe('StatusBanner', () => {
       message: 'Watchdog killed stuck process (90s idle)',
       at: IsoTimestamp.now(),
     });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('Watchdog killed stuck process (90s idle)');
-    expect(frame).toContain('⚠');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('Watchdog killed stuck process (90s idle)');
+      expect(frame).toContain('⚠');
+    });
     r.unmount();
   });
 
@@ -94,11 +99,11 @@ describe('StatusBanner', () => {
       message: 'Setup script failed for /tmp/repo: pnpm install',
       at: IsoTimestamp.now(),
     });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('Setup script failed for /tmp/repo: pnpm install');
-    expect(frame).toContain('✗');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('Setup script failed for /tmp/repo: pnpm install');
+      expect(frame).toContain('✗');
+    });
     r.unmount();
   });
 
@@ -110,15 +115,15 @@ describe('StatusBanner', () => {
     bus.publish({ type: 'banner-show', id: 'info-1', tier: 'info', message: 'Info one', at: IsoTimestamp.now() });
     bus.publish({ type: 'banner-show', id: 'err-1', tier: 'error', message: 'Error one', at: IsoTimestamp.now() });
     bus.publish({ type: 'banner-show', id: 'warn-1', tier: 'warn', message: 'Warn one', at: IsoTimestamp.now() });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    const errIdx = frame.indexOf('Error one');
-    const warnIdx = frame.indexOf('Warn one');
-    const infoIdx = frame.indexOf('Info one');
-    expect(errIdx).toBeGreaterThanOrEqual(0);
-    expect(warnIdx).toBeGreaterThan(errIdx);
-    expect(infoIdx).toBeGreaterThan(warnIdx);
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      const errIdx = frame.indexOf('Error one');
+      const warnIdx = frame.indexOf('Warn one');
+      const infoIdx = frame.indexOf('Info one');
+      expect(errIdx).toBeGreaterThanOrEqual(0);
+      expect(warnIdx).toBeGreaterThan(errIdx);
+      expect(infoIdx).toBeGreaterThan(warnIdx);
+    });
     r.unmount();
   });
 
@@ -130,15 +135,15 @@ describe('StatusBanner', () => {
     bus.publish({ type: 'banner-show', id: 'b2', tier: 'warn', message: 'second', at: IsoTimestamp.now() });
     bus.publish({ type: 'banner-show', id: 'b3', tier: 'warn', message: 'third', at: IsoTimestamp.now() });
     bus.publish({ type: 'banner-show', id: 'b4', tier: 'warn', message: 'fourth', at: IsoTimestamp.now() });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    // 3 visible, the 4th is hidden behind the collapse marker.
-    expect(frame).toContain('first');
-    expect(frame).toContain('second');
-    expect(frame).toContain('third');
-    expect(frame).not.toContain('fourth');
-    expect(frame).toContain('+1 more');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      // 3 visible, the 4th is hidden behind the collapse marker.
+      expect(frame).toContain('first');
+      expect(frame).toContain('second');
+      expect(frame).toContain('third');
+      expect(frame).not.toContain('fourth');
+      expect(frame).toContain('+1 more');
+    });
     r.unmount();
   });
 
@@ -147,13 +152,10 @@ describe('StatusBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish({ type: 'banner-show', id: 'b1', tier: 'warn', message: 'hello', at: IsoTimestamp.now() });
-    await flush();
-    expect(r.lastFrame() ?? '').toContain('hello');
+    await waitFor(() => expect(r.lastFrame() ?? '').toContain('hello'));
 
     bus.publish({ type: 'banner-clear', id: 'b1', at: IsoTimestamp.now() });
-    await flush();
-
-    expect(r.lastFrame() ?? '').toBe('');
+    await waitFor(() => expect(r.lastFrame() ?? '').toBe(''));
     r.unmount();
   });
 
@@ -162,15 +164,15 @@ describe('StatusBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish({ type: 'banner-show', id: 'b1', tier: 'warn', message: 'first text', at: IsoTimestamp.now() });
-    await flush();
+    await waitFor(() => expect(r.lastFrame() ?? '').toContain('first text'));
     bus.publish({ type: 'banner-show', id: 'b1', tier: 'warn', message: 'updated text', at: IsoTimestamp.now() });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('updated text');
-    expect(frame).not.toContain('first text');
-    // Not "+1 more" — same id replaced in place.
-    expect(frame).not.toContain('more');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('updated text');
+      expect(frame).not.toContain('first text');
+      // Not "+1 more" — same id replaced in place.
+      expect(frame).not.toContain('more');
+    });
     r.unmount();
   });
 
@@ -180,14 +182,15 @@ describe('StatusBanner', () => {
 
     bus.publish({ type: 'banner-show', id: 'info-1', tier: 'info', message: 'info line', at: IsoTimestamp.now() });
     bus.publish({ type: 'banner-show', id: 'err-1', tier: 'error', message: 'error line', at: IsoTimestamp.now() });
-    await flush();
-
-    expect(r.lastFrame() ?? '').toContain('error line');
-    expect(r.lastFrame() ?? '').toContain('info line');
+    await waitFor(() => {
+      expect(r.lastFrame() ?? '').toContain('error line');
+      expect(r.lastFrame() ?? '').toContain('info line');
+    });
 
     r.stdin.write('d');
     // useInput dispatches asynchronously; give Ink a tick to flush the keystroke through
-    // its raw-input handler and re-render. flush() alone races the keystroke.
+    // its raw-input handler and re-render — a single microtask/macrotask yield alone races
+    // the keystroke.
     await tick(80);
 
     const frame = r.lastFrame() ?? '';
@@ -202,9 +205,7 @@ describe('StatusBanner', () => {
     const r = renderBanner(bus);
 
     bus.publish({ type: 'log', level: 'info', message: 'noise', at: IsoTimestamp.now() });
-    await flush();
-
-    expect(r.lastFrame() ?? '').toBe('');
+    await waitFor(() => expect(r.lastFrame() ?? '').toBe(''));
     r.unmount();
   });
 
@@ -230,17 +231,17 @@ describe('StatusBanner', () => {
         at: IsoTimestamp.now(),
       });
     }
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    // The early error MUST still render (it was never evicted).
-    expect(frame).toContain('critical issue');
-    // Retained count is the cap (50): 1 error + 49 most-recent infos. The oldest infos are
-    // evicted; `noise 0` through `noise 10` are gone (49 infos retained → noise 11..noise 59).
-    // The "+N more" row reports overflow past MAX_VISIBLE — 50 retained - 3 visible = 47 more.
-    expect(frame).toContain('+47 more');
-    expect(frame).not.toContain('noise 0 ');
-    expect(frame).not.toContain('noise 10 ');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      // The early error MUST still render (it was never evicted).
+      expect(frame).toContain('critical issue');
+      // Retained count is the cap (50): 1 error + 49 most-recent infos. The oldest infos are
+      // evicted; `noise 0` through `noise 10` are gone (49 infos retained → noise 11..noise 59).
+      // The "+N more" row reports overflow past MAX_VISIBLE — 50 retained - 3 visible = 47 more.
+      expect(frame).toContain('+47 more');
+      expect(frame).not.toContain('noise 0 ');
+      expect(frame).not.toContain('noise 10 ');
+    });
     r.unmount();
   });
 
@@ -256,11 +257,11 @@ describe('StatusBanner', () => {
       cause: 'attempt 2/4',
       at: IsoTimestamp.now(),
     });
-    await flush();
-
-    const frame = r.lastFrame() ?? '';
-    expect(frame).toContain('Rate limit — waiting 30s');
-    expect(frame).toContain('attempt 2/4');
+    await waitFor(() => {
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toContain('Rate limit — waiting 30s');
+      expect(frame).toContain('attempt 2/4');
+    });
     r.unmount();
   });
 });

--- a/tests/integration/application/ui/tui/quit-hint-suppression.test.tsx
+++ b/tests/integration/application/ui/tui/quit-hint-suppression.test.tsx
@@ -54,6 +54,7 @@ const stubStorage = (): StoragePaths => {
     runsRoot: p,
     memoryRoot: p,
     operatorSkillsRoot: p,
+    operatorAgentDefinitionsRoot: p,
   };
 };
 

--- a/tests/unit/application/flows/implement/flow-shape.test.ts
+++ b/tests/unit/application/flows/implement/flow-shape.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { Task } from '@src/domain/entity/task.ts';
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { guard } from '@src/application/chain/build/guard.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
@@ -423,6 +424,99 @@ describe('createPerTaskSubchain — quarantine-blocked-diff placement (serial-pa
     // The terminal leaf is still the last body element on the parallel path.
     const children = taskBodyChildren(buildSubchain(false));
     expect(children[children.length - 1]?.name).toMatch(/^uninstall-skills-/);
+  });
+});
+
+describe('createPerTaskSubchain — agent-definition install/uninstall splicing', () => {
+  const readConfig = () =>
+    Promise.resolve({ maxTurns: 5, escalateOnPlateau: false, escalationMap: {}, maxAttempts: 3 });
+
+  const definition = (name: string): AgentDefinition => ({
+    name,
+    description: 'A bound persona.',
+    content: 'You are a persona.\n',
+  });
+
+  // Local re-declaration of the sibling describe block's helpers — those are scoped to their own
+  // `describe` callback, not this one. Both builders take an explicit `task` so a byte-for-byte
+  // comparison across two builds isn't perturbed by `makeTodoTask`'s fresh id per call.
+  const taskBodyChildren = (shape: ShapeNode): readonly ShapeNode[] => {
+    const body = findByName(shape, shape.name.replace('task-', 'task-body-'));
+    return body?.children ?? [];
+  };
+
+  const buildSubchainWithBindings = (
+    task: Task,
+    bindings: {
+      readonly generatorAgentDefinition?: AgentDefinition;
+      readonly evaluatorAgentDefinition?: AgentDefinition;
+    }
+  ): ShapeNode => {
+    const opts = makeOpts([task]);
+    const subchain = createPerTaskSubchain(
+      stubDeps(),
+      {
+        sprintDir: opts.sprintDir,
+        progressFile: opts.progressFile,
+        terminalLeafName: IMPLEMENT_TASK_TERMINAL_LEAF,
+        generator: { providerId: opts.generatorProviderId, model: opts.generatorModel },
+        evaluator: { providerId: opts.evaluatorProviderId, model: opts.evaluatorModel },
+        memoryRoot: opts.memoryRoot,
+        projectId: opts.projectId,
+        projectSlug: opts.projectSlug,
+        includeBranchPreflight: true,
+        ...bindings,
+      },
+      task,
+      resolveRepoOrThrow(opts.repositories, task),
+      readConfig
+    );
+    return snapshot(subchain);
+  };
+
+  it('no bindings at all means no agent-definition install/uninstall leaves anywhere in the trace', () => {
+    const allNames = names(buildSubchainWithBindings(makeTodoTask({ name: 'do-work' }), {}));
+    expect(allNames.some((n) => n.includes('agent-definition'))).toBe(false);
+  });
+
+  it('a generator-only binding installs/uninstalls only the generator leaves — the evaluator role is unaffected (AC3)', () => {
+    const allNames = names(
+      buildSubchainWithBindings(makeTodoTask({ name: 'do-work' }), {
+        generatorAgentDefinition: definition('ralphctl-generator'),
+      })
+    );
+    expect(allNames.some((n) => n.startsWith('install-generator-agent-definition-'))).toBe(true);
+    expect(allNames.some((n) => n.startsWith('uninstall-generator-agent-definition-'))).toBe(true);
+    expect(allNames.some((n) => n.startsWith('install-evaluator-agent-definition-'))).toBe(false);
+    expect(allNames.some((n) => n.startsWith('uninstall-evaluator-agent-definition-'))).toBe(false);
+  });
+
+  it('an evaluator-only binding installs/uninstalls only the evaluator leaves — the generator role is unaffected (AC3)', () => {
+    const allNames = names(
+      buildSubchainWithBindings(makeTodoTask({ name: 'do-work' }), {
+        evaluatorAgentDefinition: definition('ralphctl-evaluator'),
+      })
+    );
+    expect(allNames.some((n) => n.startsWith('install-evaluator-agent-definition-'))).toBe(true);
+    expect(allNames.some((n) => n.startsWith('uninstall-evaluator-agent-definition-'))).toBe(true);
+    expect(allNames.some((n) => n.startsWith('install-generator-agent-definition-'))).toBe(false);
+    expect(allNames.some((n) => n.startsWith('uninstall-generator-agent-definition-'))).toBe(false);
+  });
+
+  it('the uninstall leaves land BEFORE the terminal uninstall-skills leaf', () => {
+    const children = taskBodyChildren(
+      buildSubchainWithBindings(makeTodoTask({ name: 'do-work' }), {
+        generatorAgentDefinition: definition('ralphctl-generator'),
+        evaluatorAgentDefinition: definition('ralphctl-evaluator'),
+      })
+    );
+    const allNames = children.map((c) => c.name);
+    expect(allNames[allNames.length - 1]).toMatch(/^uninstall-skills-/);
+    const genIdx = allNames.findIndex((n) => n.startsWith('uninstall-generator-agent-definition-'));
+    const evalIdx = allNames.findIndex((n) => n.startsWith('uninstall-evaluator-agent-definition-'));
+    expect(genIdx).toBeGreaterThanOrEqual(0);
+    expect(evalIdx).toBeGreaterThan(genIdx);
+    expect(evalIdx).toBe(allNames.length - 2);
   });
 });
 

--- a/tests/unit/application/ui/cli/commands/agents.test.ts
+++ b/tests/unit/application/ui/cli/commands/agents.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
+
+describe('ralphctl agents list', () => {
+  let cli: CliHome;
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+  });
+
+  afterEach(async () => cli.cleanup());
+
+  it('lists the vetted bundled set on a fresh install, unbound', async () => {
+    const result = await runCliCaptured(cli, ['agents', 'list']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('ralphctl-evaluator');
+    expect(result.stdout).toContain('ralphctl-generator');
+    expect(result.stdout).toContain('bundled');
+    // Neither role is bound yet.
+    expect(result.stdout).not.toContain('bound: evaluator');
+    expect(result.stdout).not.toContain('bound: generator');
+  });
+
+  it('shows the bound role after `settings set ai.implement.agents.evaluator`', async () => {
+    const setResult = await runCliCaptured(cli, [
+      'settings',
+      'set',
+      'ai.implement.agents.evaluator',
+      'ralphctl-evaluator',
+    ]);
+    expect(setResult.exitCode).toBe(0);
+
+    const listResult = await runCliCaptured(cli, ['agents', 'list']);
+    expect(listResult.exitCode).toBe(0);
+    const evaluatorLine = listResult.stdout.split('\n').find((line) => line.startsWith('ralphctl-evaluator'));
+    expect(evaluatorLine).toContain('bound: evaluator');
+    const generatorLine = listResult.stdout.split('\n').find((line) => line.startsWith('ralphctl-generator'));
+    expect(generatorLine).toContain('bound: -');
+  });
+});
+
+describe('ralphctl settings set ai.implement.agents.<role> — binding + unsupported-target reporting', () => {
+  let cli: CliHome;
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+  });
+
+  afterEach(async () => cli.cleanup());
+
+  it('binds a vetted definition to the evaluator role', async () => {
+    const setResult = await runCliCaptured(cli, [
+      'settings',
+      'set',
+      'ai.implement.agents.evaluator',
+      'ralphctl-evaluator',
+    ]);
+    expect(setResult.exitCode).toBe(0);
+    expect(setResult.stdout).toContain('ai.implement.agents.evaluator = ralphctl-evaluator');
+
+    const showResult = await runCliCaptured(cli, ['settings', 'show']);
+    expect(showResult.exitCode).toBe(0);
+    const parsed = JSON.parse(showResult.stdout) as {
+      readonly ai: { readonly implement: { readonly agents?: { readonly evaluator?: string } } };
+    };
+    expect(parsed.ai.implement.agents?.evaluator).toBe('ralphctl-evaluator');
+  });
+
+  it('reports (not silently accepts) a binding targeting an unsupported flow', async () => {
+    const result = await runCliCaptured(cli, ['settings', 'set', 'ai.plan.agents.generator', 'ralphctl-generator']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not supported for agent-definition binding in this release');
+
+    // Nothing was persisted under ai.plan (the flow row has no agents field at all).
+    const showResult = await runCliCaptured(cli, ['settings', 'show']);
+    const parsed = JSON.parse(showResult.stdout) as { readonly ai: { readonly plan: Record<string, unknown> } };
+    expect(parsed.ai.plan['agents']).toBeUndefined();
+  });
+
+  it('reports (not silently accepts) a binding targeting an unsupported implement role', async () => {
+    const result = await runCliCaptured(cli, ['settings', 'set', 'ai.implement.agents.reviewer', 'ralphctl-evaluator']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not supported for agent-definition binding in this release');
+
+    const showResult = await runCliCaptured(cli, ['settings', 'show']);
+    const parsed = JSON.parse(showResult.stdout) as {
+      readonly ai: { readonly implement: { readonly agents?: Record<string, unknown> } };
+    };
+    expect(parsed.ai.implement.agents).toBeUndefined();
+  });
+});

--- a/tests/unit/application/ui/shared/launch/agent-bindings.test.ts
+++ b/tests/unit/application/ui/shared/launch/agent-bindings.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `resolveRoleAgentBinding` / `buildAgentDefinitionSection` / `resolveImplementAgentBindings` —
+ * the per-role opt-in agent-definition binding resolution the implement launcher composes into
+ * the deps/opts bags. A missing bound name must be reported and the role must run unaided (AC2);
+ * an evaluator-only binding must leave the generator role's resolution untouched (AC3).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Logger } from '@src/business/observability/logger.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import type { AgentDefinitionAdapter } from '@src/integration/ai/agents/_engine/agent-definition-adapter.ts';
+import type { AgentDefinitionSource } from '@src/integration/ai/agents/_engine/agent-definition-source.ts';
+import type { AiImplementSettings } from '@src/domain/entity/settings.ts';
+import {
+  buildAgentDefinitionSection,
+  resolveImplementAgentBindings,
+  resolveRoleAgentBinding,
+} from '@src/application/ui/shared/launch/implement-agent-bindings.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+
+interface RecordingLogger extends Logger {
+  readonly warnings: Array<{ readonly message: string; readonly meta?: unknown }>;
+}
+
+const recordingLogger = (): RecordingLogger => {
+  const warnings: Array<{ readonly message: string; readonly meta?: unknown }> = [];
+  const self: RecordingLogger = {
+    warnings,
+    debug() {},
+    info() {},
+    warn(message: string, meta?: unknown) {
+      warnings.push({ message, meta });
+    },
+    error() {},
+    named: () => self,
+  };
+  return self;
+};
+
+const definition = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'ralphctl-evaluator',
+  description: 'Reviews the generator turn.',
+  content: 'You are an evaluator.\n',
+  ...overrides,
+});
+
+const sourceReturning = (found: AgentDefinition | undefined): AgentDefinitionSource => ({
+  list: async () => Result.ok(found !== undefined ? [found] : []),
+  getByName: async () => Result.ok(found),
+});
+
+const erroringSource: AgentDefinitionSource = {
+  list: async () => Result.error(new StorageError({ subCode: 'io', message: 'boom', path: '/x' })),
+  getByName: async () => Result.error(new StorageError({ subCode: 'io', message: 'boom', path: '/x' })),
+};
+
+describe('resolveRoleAgentBinding', () => {
+  it('returns undefined when the role has no binding at all', async () => {
+    const logger = recordingLogger();
+    const result = await resolveRoleAgentBinding(sourceReturning(definition()), undefined, 'generator', logger);
+    expect(result).toBeUndefined();
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it('resolves the bound name against the source when found', async () => {
+    const logger = recordingLogger();
+    const found = definition();
+    const result = await resolveRoleAgentBinding(sourceReturning(found), 'ralphctl-evaluator', 'evaluator', logger);
+    expect(result).toBe(found);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it('reports a missing bound name and continues under base behaviour (AC2)', async () => {
+    const logger = recordingLogger();
+    const result = await resolveRoleAgentBinding(sourceReturning(undefined), 'ralphctl-nope', 'generator', logger);
+    expect(result).toBeUndefined();
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]?.message).toContain('ralphctl-nope');
+    expect(logger.warnings[0]?.message).toContain('not found');
+  });
+
+  it('reports a source lookup failure and continues under base behaviour', async () => {
+    const logger = recordingLogger();
+    const result = await resolveRoleAgentBinding(erroringSource, 'ralphctl-evaluator', 'generator', logger);
+    expect(result).toBeUndefined();
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]?.message).toContain('lookup failed');
+  });
+});
+
+describe('buildAgentDefinitionSection', () => {
+  it('announces the bound definition name and the adapter convention', () => {
+    const adapter: AgentDefinitionAdapter = {
+      install: async () => Result.ok(undefined),
+      uninstall: async () => Result.ok(undefined),
+      describeConvention: () => 'Files live under .claude/agents/.',
+    };
+    const section = buildAgentDefinitionSection(definition(), adapter);
+    expect(section).toContain('ralphctl-evaluator');
+    expect(section).toContain('.claude/agents/');
+  });
+});
+
+describe('resolveImplementAgentBindings', () => {
+  const implementPair = (agents?: AiImplementSettings['agents']): AiImplementSettings =>
+    ({
+      generator: { provider: 'claude-code', model: 'claude-sonnet-5' },
+      evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+      ...(agents !== undefined ? { agents } : {}),
+    }) as AiImplementSettings;
+
+  const launcherDeps = (agentDefinitionSource: AgentDefinitionSource, logger: Logger): LauncherDeps =>
+    ({
+      app: { agentDefinitionSource, logger, eventBus: createInMemoryEventBus() },
+    }) as unknown as LauncherDeps;
+
+  it('both roles unbound resolve to empty bindings', async () => {
+    const deps = launcherDeps(sourceReturning(undefined), recordingLogger());
+    const bindings = await resolveImplementAgentBindings(deps, implementPair());
+    expect(bindings.generator).toStrictEqual({});
+    expect(bindings.evaluator).toStrictEqual({});
+  });
+
+  it('an evaluator-only binding resolves only the evaluator role — the generator role is untouched (AC3)', async () => {
+    const found = definition();
+    const deps = launcherDeps(sourceReturning(found), recordingLogger());
+    const bindings = await resolveImplementAgentBindings(deps, implementPair({ evaluator: 'ralphctl-evaluator' }));
+
+    expect(bindings.generator).toStrictEqual({});
+    expect(bindings.evaluator.definition).toBe(found);
+    expect(bindings.evaluator.section).toBeDefined();
+  });
+
+  it('a binding to a non-existent name resolves to an empty binding for that role', async () => {
+    const logger = recordingLogger();
+    const deps = launcherDeps(sourceReturning(undefined), logger);
+    const bindings = await resolveImplementAgentBindings(deps, implementPair({ generator: 'ralphctl-missing' }));
+
+    expect(bindings.generator).toStrictEqual({});
+    expect(logger.warnings.some((w) => w.message.includes('ralphctl-missing'))).toBe(true);
+  });
+});

--- a/tests/unit/application/ui/shared/launch/distill-confirm-abort.test.ts
+++ b/tests/unit/application/ui/shared/launch/distill-confirm-abort.test.ts
@@ -122,6 +122,7 @@ const STUB_STORAGE = {
   stateRoot: absolutePath('/tmp/ralphctl-distill-confirm-test/state'),
   runsRoot: absolutePath('/tmp/ralphctl-distill-confirm-test/data/runs'),
   operatorSkillsRoot: absolutePath('/tmp/ralphctl-distill-confirm-test/skills'),
+  operatorAgentDefinitionsRoot: absolutePath('/tmp/ralphctl-distill-confirm-test/agents'),
 };
 
 /** No-op append — review and close-sprint both thread this port into the flow factory. */

--- a/tests/unit/application/ui/shared/launch/implement-bags.test.ts
+++ b/tests/unit/application/ui/shared/launch/implement-bags.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `buildImplementProviders` / `buildImplementOptsBag` — proves a bound agent definition's
+ * model/effort overrides the per-flow row (AC5). `CreateImplementFlowOpts.generatorModel` /
+ * `generatorEffort` is the SAME field both the gen-eval spawn (`GenEvalLoopRoleConfig` built from
+ * these opts in `flow.ts`) and `finalize-gen-eval`'s escalation baseline
+ * (`configuredGeneratorModel`/`configuredGeneratorEffort`) read — so asserting the value here
+ * proves both downstream consumers see the override.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AiImplementSettings, Settings } from '@src/domain/entity/settings.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { buildImplementOptsBag, buildImplementProviders } from '@src/application/ui/shared/launch/implement-bags.ts';
+import type { LauncherDeps } from '@src/application/ui/shared/launcher.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { absolutePath, slug } from '@tests/fixtures/domain.ts';
+
+const implementPair = (): AiImplementSettings =>
+  ({
+    generator: { provider: 'claude-code', model: 'claude-sonnet-5', effort: 'low' },
+    evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+  }) as AiImplementSettings;
+
+const effectiveSettings = (globalEffort?: string): Settings =>
+  ({
+    harness: { rateLimitRetries: 0, idleWatchdogMs: 60_000 },
+    ai: { ...(globalEffort !== undefined ? { effort: globalEffort } : {}) },
+  }) as unknown as Settings;
+
+const launcherDeps = (): LauncherDeps => ({ app: { eventBus: createInMemoryEventBus() } }) as unknown as LauncherDeps;
+
+const definition: AgentDefinition = {
+  name: 'ralphctl-generator',
+  description: 'Implements the task.',
+  content: 'You are an implementer.\n',
+  model: 'claude-opus-4-8',
+  effort: 'max',
+};
+
+describe('buildImplementProviders', () => {
+  it('falls through to the row model/effort when no definition is bound', () => {
+    const result = buildImplementProviders(implementPair(), effectiveSettings(), launcherDeps());
+    expect(result.generatorModel).toBe('claude-sonnet-5');
+    expect(result.generatorEffort).toBe('low');
+  });
+
+  it("a bound generator definition's model/effort override the row (AC5)", () => {
+    const result = buildImplementProviders(implementPair(), effectiveSettings(), launcherDeps(), {
+      generator: definition,
+    });
+    expect(result.generatorModel).toBe('claude-opus-4-8');
+    expect(result.generatorEffort).toBe('max');
+    // The evaluator role is untouched by the generator-only binding (AC3's precedence guarantee).
+    expect(result.evaluatorModel).toBe('gpt-5.5');
+  });
+});
+
+describe('buildImplementOptsBag', () => {
+  const sprint = { id: 'sprint-1' } as never;
+  const project = { id: 'proj-1', slug: slug('proj-1'), repositories: [] } as never;
+  const sprintPaths = {
+    progressPath: absolutePath('/sprints/s1/progress.md'),
+    sprintDirPath: absolutePath('/sprints/s1'),
+  };
+
+  it('the overridden generatorModel/generatorEffort reach the opts bag that feeds BOTH the spawn and the escalation baseline', () => {
+    const providers = buildImplementProviders(implementPair(), effectiveSettings(), launcherDeps(), {
+      generator: definition,
+    });
+    const opts = buildImplementOptsBag(
+      sprint,
+      project,
+      [],
+      sprintPaths,
+      implementPair(),
+      providers,
+      absolutePath('/data/memory')
+    );
+
+    expect(opts.generatorModel).toBe('claude-opus-4-8');
+    expect(opts.generatorEffort).toBe('max');
+  });
+
+  it('threads the resolved agent-definition + prompt section into the opts bag per role', () => {
+    const providers = buildImplementProviders(implementPair(), effectiveSettings(), launcherDeps(), {
+      generator: definition,
+    });
+    const opts = buildImplementOptsBag(
+      sprint,
+      project,
+      [],
+      sprintPaths,
+      implementPair(),
+      providers,
+      absolutePath('/data/memory'),
+      { generator: { definition, section: 'announced section' }, evaluator: {} }
+    );
+
+    expect(opts.generatorAgentDefinition).toBe(definition);
+    expect(opts.generatorAgentDefinitionSection).toBe('announced section');
+    expect(opts.evaluatorAgentDefinition).toBeUndefined();
+    expect(opts.evaluatorAgentDefinitionSection).toBeUndefined();
+  });
+});

--- a/tests/unit/application/ui/shared/launcher-pin.test.ts
+++ b/tests/unit/application/ui/shared/launcher-pin.test.ts
@@ -45,6 +45,7 @@ const storage = (): StoragePaths => {
     runsRoot: absPath(cwd),
     memoryRoot: absPath(cwd),
     operatorSkillsRoot: absPath(cwd),
+    operatorAgentDefinitionsRoot: absPath(cwd),
   };
 };
 

--- a/tests/unit/business/settings/apply-key.test.ts
+++ b/tests/unit/business/settings/apply-key.test.ts
@@ -155,6 +155,59 @@ describe('applySettingsKey', () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error.message).toContain('not a boolean');
   });
+
+  it('binds an agent-definition name to the evaluator role under ai.implement.agents.evaluator', () => {
+    const result = applySettingsKey(DEFAULT_SETTINGS, 'ai.implement.agents.evaluator', 'ralphctl-evaluator');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.ai.implement.agents?.evaluator).toBe('ralphctl-evaluator');
+      // Generator left untouched — per-role keys edit one role at a time.
+      expect(result.value.ai.implement.agents?.generator).toBeUndefined();
+    }
+  });
+
+  it('binds an agent-definition name to the generator role under ai.implement.agents.generator', () => {
+    const result = applySettingsKey(DEFAULT_SETTINGS, 'ai.implement.agents.generator', 'ralphctl-generator');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.ai.implement.agents?.generator).toBe('ralphctl-generator');
+  });
+
+  it('clears an agent-definition binding when given an empty string', () => {
+    const seeded = applySettingsKey(DEFAULT_SETTINGS, 'ai.implement.agents.evaluator', 'ralphctl-evaluator');
+    expect(seeded.ok).toBe(true);
+    if (!seeded.ok) return;
+    const cleared = applySettingsKey(seeded.value, 'ai.implement.agents.evaluator', '');
+    expect(cleared.ok).toBe(true);
+    if (cleared.ok) expect(cleared.value.ai.implement.agents?.evaluator).toBeUndefined();
+  });
+
+  it('drops the whole agents block once every role binding is cleared', () => {
+    const seeded = applySettingsKey(DEFAULT_SETTINGS, 'ai.implement.agents.evaluator', 'ralphctl-evaluator');
+    expect(seeded.ok).toBe(true);
+    if (!seeded.ok) return;
+    const cleared = applySettingsKey(seeded.value, 'ai.implement.agents.evaluator', '');
+    expect(cleared.ok).toBe(true);
+    if (cleared.ok) expect(cleared.value.ai.implement.agents).toBeUndefined();
+  });
+
+  it('rejects binding an agent definition to a flow other than implement', () => {
+    const result = applySettingsKey(DEFAULT_SETTINGS, 'ai.refine.agents.evaluator', 'ralphctl-evaluator');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('not supported for agent-definition binding in this release');
+      expect(result.error.hint).toContain('ai.implement.agents.{generator,evaluator}');
+    }
+  });
+
+  it('rejects binding an agent definition to an implement role other than generator/evaluator', () => {
+    const result = applySettingsKey(DEFAULT_SETTINGS, 'ai.implement.agents.reviewer', 'ralphctl-evaluator');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('not supported for agent-definition binding in this release');
+    }
+  });
 });
 
 describe('parseSettingsKvSyntax', () => {

--- a/tests/unit/business/settings/resolve-agent-override.test.ts
+++ b/tests/unit/business/settings/resolve-agent-override.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { AiFlowSettings } from '@src/domain/entity/settings.ts';
+import { resolveAgentOverride } from '@src/business/settings/resolve-agent-override.ts';
+
+const claudeRow = (effort?: string): AiFlowSettings =>
+  ({
+    provider: 'claude-code',
+    model: 'claude-sonnet-5',
+    ...(effort !== undefined ? { effort } : {}),
+  }) as AiFlowSettings;
+
+const codexRow = (effort?: string): AiFlowSettings =>
+  ({ provider: 'openai-codex', model: 'gpt-5.5', ...(effort !== undefined ? { effort } : {}) }) as AiFlowSettings;
+
+describe('resolveAgentOverride', () => {
+  it('falls through to the per-flow row model/effort when no definition is bound', () => {
+    const row = claudeRow('high');
+    expect(resolveAgentOverride(row, 'medium', undefined)).toEqual({ model: 'claude-sonnet-5', effort: 'high' });
+  });
+
+  it('falls through to the global default effort when neither a definition nor the row specify one', () => {
+    const row = claudeRow();
+    expect(resolveAgentOverride(row, 'medium', undefined)).toEqual({ model: 'claude-sonnet-5', effort: 'medium' });
+  });
+
+  it('leaves model/effort undefined-floored when nothing is set anywhere', () => {
+    const row = claudeRow();
+    expect(resolveAgentOverride(row, undefined, undefined)).toEqual({ model: 'claude-sonnet-5', effort: undefined });
+  });
+
+  it('a definition specifying both model and effort overrides a differing per-flow row', () => {
+    const row = claudeRow('low');
+    const resolved = resolveAgentOverride(row, 'medium', { model: 'claude-opus-4-8', effort: 'max' });
+    expect(resolved).toEqual({ model: 'claude-opus-4-8', effort: 'max' });
+  });
+
+  it('a definition specifying neither model nor effort falls through to the per-flow row', () => {
+    const row = claudeRow('high');
+    const resolved = resolveAgentOverride(row, 'medium', {});
+    expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'high' });
+  });
+
+  it('a definition specifying neither falls through to the global default when the row omits effort', () => {
+    const row = claudeRow();
+    const resolved = resolveAgentOverride(row, 'xhigh', {});
+    expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'xhigh' });
+  });
+
+  it('a definition specifying only model keeps the row/global-derived effort', () => {
+    const row = claudeRow('high');
+    const resolved = resolveAgentOverride(row, 'medium', { model: 'claude-opus-4-8' });
+    expect(resolved).toEqual({ model: 'claude-opus-4-8', effort: 'high' });
+  });
+
+  it('a definition specifying only effort keeps the row model', () => {
+    const row = claudeRow();
+    const resolved = resolveAgentOverride(row, 'medium', { effort: 'max' });
+    expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'max' });
+  });
+
+  it('a bound definition effort still composes with the provider floor when it is the global that supplies it', () => {
+    // The definition wins outright here — 'xhigh' passes through verbatim, unfloored, because
+    // a definition-supplied effort bypasses resolveEffortForRow's provider-floor table
+    // entirely (that table only applies to the global-default fallback path).
+    const row = codexRow();
+    const resolved = resolveAgentOverride(row, 'medium', { effort: 'xhigh' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
+  });
+
+  it('floors the global default to the codex provider ceiling when no definition/row effort is set', () => {
+    const row = codexRow();
+    const resolved = resolveAgentOverride(row, 'xhigh', undefined);
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+  });
+});

--- a/tests/unit/domain/entity/settings-agents.test.ts
+++ b/tests/unit/domain/entity/settings-agents.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Contract for the optional `settings.ai.implement.agents` role-binding block.
+ *
+ * Shape: `{ generator?: string; evaluator?: string }` — both keys optional. Absent (or an
+ * absent `agents` block altogether) means "no binding for this role". Names are free trimmed
+ * non-empty strings; the domain never validates them against the integration-side
+ * agent-definition catalog.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { primaryAgentBinding, SettingsSchema } from '@src/domain/entity/settings.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+
+const withAgents = (agents: unknown): unknown => ({
+  ...DEFAULT_SETTINGS,
+  ai: {
+    ...DEFAULT_SETTINGS.ai,
+    implement: { ...DEFAULT_SETTINGS.ai.implement, agents },
+  },
+});
+
+describe('settings.ai.implement.agents — role-binding preference', () => {
+  it('accepts an absent block (DEFAULT_SETTINGS carries no agents block)', () => {
+    const parsed = SettingsSchema.safeParse(DEFAULT_SETTINGS);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toBeUndefined();
+  });
+
+  it('accepts an empty agents object (no role bound)', () => {
+    const parsed = SettingsSchema.safeParse(withAgents({}));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual({});
+  });
+
+  it('round-trips an independent generator binding', () => {
+    const parsed = SettingsSchema.safeParse(withAgents({ generator: 'ralphctl-implementer' }));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual({ generator: 'ralphctl-implementer' });
+  });
+
+  it('round-trips an independent evaluator binding', () => {
+    const parsed = SettingsSchema.safeParse(withAgents({ evaluator: 'ralphctl-evaluator' }));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual({ evaluator: 'ralphctl-evaluator' });
+  });
+
+  it('round-trips both roles bound to distinct definitions', () => {
+    const agents = { generator: 'ralphctl-implementer', evaluator: 'ralphctl-evaluator' };
+    const parsed = SettingsSchema.safeParse(withAgents(agents));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual(agents);
+  });
+
+  it('trims agent-name entries', () => {
+    const parsed = SettingsSchema.safeParse(withAgents({ generator: '  ralphctl-implementer  ' }));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual({ generator: 'ralphctl-implementer' });
+  });
+
+  it('rejects a blank (whitespace-only) agent name', () => {
+    const parsed = SettingsSchema.safeParse(withAgents({ generator: '   ' }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('strips a target key outside generator/evaluator rather than failing the whole parse', () => {
+    const parsed = SettingsSchema.safeParse(
+      withAgents({ reviewer: 'ralphctl-reviewer', generator: 'ralphctl-implementer' })
+    );
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.agents).toEqual({ generator: 'ralphctl-implementer' });
+  });
+
+  it('is stable under a second parse (schema-level save/load round-trip)', () => {
+    const agents = { evaluator: 'ralphctl-evaluator' };
+    const once = SettingsSchema.safeParse(withAgents(agents));
+    expect(once.success).toBe(true);
+    if (!once.success) return;
+    const twice = SettingsSchema.safeParse(once.data);
+    expect(twice.success).toBe(true);
+    if (!twice.success) return;
+    expect(twice.data.ai.implement.agents).toEqual(agents);
+  });
+});
+
+describe('primaryAgentBinding', () => {
+  it('returns undefined when the agents block is absent', () => {
+    expect(primaryAgentBinding(undefined, 'generator')).toBeUndefined();
+    expect(primaryAgentBinding(undefined, 'evaluator')).toBeUndefined();
+  });
+
+  it('returns undefined for a role with no binding', () => {
+    expect(primaryAgentBinding({ generator: 'ralphctl-implementer' }, 'evaluator')).toBeUndefined();
+  });
+
+  it('returns the bound name for the requested role', () => {
+    const agents = { generator: 'ralphctl-implementer', evaluator: 'ralphctl-evaluator' };
+    expect(primaryAgentBinding(agents, 'generator')).toBe('ralphctl-implementer');
+    expect(primaryAgentBinding(agents, 'evaluator')).toBe('ralphctl-evaluator');
+  });
+});

--- a/tests/unit/integration/ai/agents/agent-definition-quality.test.ts
+++ b/tests/unit/integration/ai/agents/agent-definition-quality.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { createEventBusLogger } from '@src/business/observability/event-bus-logger.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { AppEvent, LogEvent } from '@src/business/observability/events.ts';
+import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import {
+  checkAgentDefinitionQuality,
+  warnIfVague,
+} from '@src/integration/ai/agents/_engine/agent-definition-quality.ts';
+
+const SUFFICIENT_BODY = [
+  '## Steps',
+  '',
+  '1. Read the requirement carefully before writing any code, so the change matches what was',
+  '   actually asked for instead of a broader guess.',
+  '2. Find the nearest existing pattern in this codebase and follow its naming, structure, and',
+  '   error handling instead of introducing something new.',
+  '3. Run the relevant check after each meaningful edit, and read its output before moving on.',
+  '',
+].join('\n');
+
+const def = (overrides: Partial<AgentDefinition> = {}): AgentDefinition => ({
+  name: 'ralphctl-house-agent',
+  description: 'House guidance for this repository.',
+  content: SUFFICIENT_BODY,
+  ...overrides,
+});
+
+describe('checkAgentDefinitionQuality', () => {
+  it('passes a well-structured, sufficiently detailed definition', () => {
+    const report = checkAgentDefinitionQuality(def());
+    expect(report.pass).toBe(true);
+    expect(report.concerns).toEqual([]);
+  });
+
+  it('flags a body under the minimum word count (Q1)', () => {
+    const report = checkAgentDefinitionQuality(def({ content: 'Be helpful.\n' }));
+    expect(report.pass).toBe(false);
+    expect(report.concerns.some((c) => c.rule === 'Q1')).toBe(true);
+  });
+
+  it('flags a body with no headings or list items (Q2)', () => {
+    const longProse =
+      'This agent should generally try to be helpful and do a good job across a wide variety ' +
+      'of situations without any particular structure or concrete steps to follow at all.';
+    const report = checkAgentDefinitionQuality(def({ content: longProse }));
+    expect(report.pass).toBe(false);
+    expect(report.concerns.some((c) => c.rule === 'Q2')).toBe(true);
+  });
+
+  it('flags an evaluator-role definition that never mentions verification (Q3)', () => {
+    const report = checkAgentDefinitionQuality(
+      def({
+        name: 'ralphctl-reviewer',
+        description: 'Reviews changes and gives feedback.',
+        content: '## Steps\n\n1. Read the change.\n2. Give your opinion on it.\n3. Be nice about it.\n',
+      })
+    );
+    expect(report.pass).toBe(false);
+    expect(report.concerns.some((c) => c.rule === 'Q3')).toBe(true);
+  });
+
+  it('does not flag Q3 for a non-evaluator definition even without verification vocabulary', () => {
+    const report = checkAgentDefinitionQuality(def({ name: 'ralphctl-writer', description: 'Writes prose.' }));
+    expect(report.concerns.some((c) => c.rule === 'Q3')).toBe(false);
+  });
+
+  it('passes an evaluator-role definition that concretely mentions verification', () => {
+    const report = checkAgentDefinitionQuality(
+      def({
+        name: 'ralphctl-evaluator',
+        description: 'Judges whether a change satisfies its acceptance criteria.',
+        content: [
+          '## Steps',
+          '',
+          '1. Read the acceptance criteria as written, without loosening them to match the diff.',
+          '2. Run the test command the task specifies and read its output as evidence.',
+          '3. Trace each criterion individually and report a clear pass or fail verdict.',
+          '',
+        ].join('\n'),
+      })
+    );
+    expect(report.pass).toBe(true);
+  });
+});
+
+describe('warnIfVague', () => {
+  const recordingLogger = (): { logger: ReturnType<typeof createEventBusLogger>; logs: LogEvent[] } => {
+    const bus = createInMemoryEventBus();
+    const logs: LogEvent[] = [];
+    bus.subscribe((e: AppEvent) => {
+      if (e.type === 'log') logs.push(e);
+    });
+    return { logger: createEventBusLogger({ eventBus: bus, clock: IsoTimestamp.now }), logs };
+  };
+
+  it('logs one warning per concern for a vague definition', () => {
+    const { logger, logs } = recordingLogger();
+    warnIfVague(logger, def({ content: 'Be helpful.\n' }));
+    const warnLogs = logs.filter((l) => l.level === 'warn');
+    expect(warnLogs.length).toBeGreaterThan(0);
+    expect(warnLogs.every((l) => l.message === 'agent definition quality concern')).toBe(true);
+  });
+
+  it('logs nothing for a well-formed definition', () => {
+    const { logger, logs } = recordingLogger();
+    warnIfVague(logger, def());
+    expect(logs.filter((l) => l.level === 'warn')).toEqual([]);
+  });
+});

--- a/tests/unit/integration/ai/agents/agent-definition.test.ts
+++ b/tests/unit/integration/ai/agents/agent-definition.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AgentDefinitionFrontmatterSchema,
+  AgentDefinitionNameSchema,
+} from '@src/integration/ai/agents/_engine/agent-definition.ts';
+
+describe('AgentDefinitionNameSchema', () => {
+  it('accepts kebab-case names', () => {
+    expect(AgentDefinitionNameSchema.safeParse('implementer').success).toBe(true);
+    expect(AgentDefinitionNameSchema.safeParse('code-reviewer').success).toBe(true);
+    expect(AgentDefinitionNameSchema.safeParse('a').success).toBe(true);
+    expect(AgentDefinitionNameSchema.safeParse('agent-1').success).toBe(true);
+  });
+  it('rejects PascalCase / camelCase / underscores', () => {
+    expect(AgentDefinitionNameSchema.safeParse('Implementer').success).toBe(false);
+    expect(AgentDefinitionNameSchema.safeParse('codeReviewer').success).toBe(false);
+    expect(AgentDefinitionNameSchema.safeParse('code_reviewer').success).toBe(false);
+    expect(AgentDefinitionNameSchema.safeParse('').success).toBe(false);
+  });
+  it('rejects leading / trailing / consecutive hyphens', () => {
+    expect(AgentDefinitionNameSchema.safeParse('-implementer').success).toBe(false);
+    expect(AgentDefinitionNameSchema.safeParse('implementer-').success).toBe(false);
+    expect(AgentDefinitionNameSchema.safeParse('foo--bar').success).toBe(false);
+  });
+  it('rejects names longer than 64 chars', () => {
+    expect(AgentDefinitionNameSchema.safeParse('a'.repeat(64)).success).toBe(true);
+    expect(AgentDefinitionNameSchema.safeParse('a'.repeat(65)).success).toBe(false);
+  });
+});
+
+describe('AgentDefinitionFrontmatterSchema', () => {
+  it('parses minimal well-formed frontmatter', () => {
+    const result = AgentDefinitionFrontmatterSchema.safeParse({
+      name: 'implementer',
+      description: 'Writes features, fixes bugs, adds tests.',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('implementer');
+      expect(result.data.model).toBeUndefined();
+      expect(result.data.effort).toBeUndefined();
+    }
+  });
+  it('parses the optional model / effort fields', () => {
+    const result = AgentDefinitionFrontmatterSchema.safeParse({
+      name: 'implementer',
+      description: 'Writes features, fixes bugs, adds tests.',
+      model: 'claude-sonnet-5',
+      effort: 'high',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.model).toBe('claude-sonnet-5');
+      expect(result.data.effort).toBe('high');
+    }
+  });
+  it('rejects missing name or description', () => {
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ name: 'x' }).success).toBe(false);
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ description: 'x' }).success).toBe(false);
+    expect(AgentDefinitionFrontmatterSchema.safeParse({}).success).toBe(false);
+  });
+  it('rejects names that violate the naming convention', () => {
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ name: 'BadName', description: 'y' }).success).toBe(false);
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ name: '-bad', description: 'y' }).success).toBe(false);
+  });
+  it('rejects descriptions longer than 1024 chars', () => {
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ name: 'x', description: 'a'.repeat(1024) }).success).toBe(true);
+    expect(AgentDefinitionFrontmatterSchema.safeParse({ name: 'x', description: 'a'.repeat(1025) }).success).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/integration/ai/agents/parse-agent-definition.test.ts
+++ b/tests/unit/integration/ai/agents/parse-agent-definition.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentDefinition, splitFrontmatter } from '@src/integration/ai/agents/_engine/parse-agent-definition.ts';
+
+describe('splitFrontmatter', () => {
+  it('splits frontmatter from a body that follows immediately after the closing fence', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\nbody line\n');
+    expect(frontmatter).toBe('name: x');
+    expect(body).toBe('body line\n');
+  });
+
+  it('strips the blank separator line after the closing fence', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\n\nbody line\n');
+    expect(frontmatter).toBe('name: x');
+    expect(body).toBe('body line\n');
+  });
+
+  it('returns the body verbatim when no frontmatter is present', () => {
+    const { frontmatter, body } = splitFrontmatter('just a body\n');
+    expect(frontmatter).toBe('');
+    expect(body).toBe('just a body\n');
+  });
+});
+
+describe('parseAgentDefinition', () => {
+  it('parses a valid agent definition round-trip', () => {
+    const raw =
+      '---\nname: implementer\ndescription: Writes features, fixes bugs, adds tests.\nmodel: claude-sonnet-5\neffort: high\n---\nYou are an implementer.\n';
+    const result = parseAgentDefinition('bundled agent', '/path/implementer.md', 'implementer', raw);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        name: 'implementer',
+        description: 'Writes features, fixes bugs, adds tests.',
+        model: 'claude-sonnet-5',
+        effort: 'high',
+        content: 'You are an implementer.\n',
+      });
+    }
+  });
+
+  it('returns a parse StorageError when the description is missing', () => {
+    const raw = '---\nname: implementer\n---\nYou are an implementer.\n';
+    const result = parseAgentDefinition('bundled agent', '/path/implementer.md', 'implementer', raw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.subCode).toBe('parse');
+    }
+  });
+
+  it('returns a parse StorageError when the frontmatter name does not match the source name', () => {
+    const raw = '---\nname: other\ndescription: Writes features.\n---\nYou are an implementer.\n';
+    const result = parseAgentDefinition('bundled agent', '/path/implementer.md', 'implementer', raw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.subCode).toBe('parse');
+    }
+  });
+});

--- a/tests/unit/integration/ai/agents/registry.test.ts
+++ b/tests/unit/integration/ai/agents/registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BUNDLED_AGENT_DEFINITIONS } from '@src/integration/ai/agents/_engine/registry.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_ROOT = join(HERE, '../../../../../src/integration/ai/agents/bundled');
+
+describe('BUNDLED_AGENT_DEFINITIONS', () => {
+  it('has at least an evaluator and a generator definition', () => {
+    expect(BUNDLED_AGENT_DEFINITIONS).toContain('ralphctl-evaluator');
+    expect(BUNDLED_AGENT_DEFINITIONS).toContain('ralphctl-generator');
+  });
+
+  it('every name resolves to a bundled <name>.md file on disk', () => {
+    for (const name of BUNDLED_AGENT_DEFINITIONS) {
+      const path = join(BUNDLED_ROOT, `${name}.md`);
+      expect(existsSync(path), `bundled agent definition missing: ${path}`).toBe(true);
+    }
+  });
+
+  it('namespaces every bundled agent definition name with the ralphctl- prefix', () => {
+    for (const name of BUNDLED_AGENT_DEFINITIONS) {
+      expect(name.startsWith('ralphctl-'), `bundled agent definition name missing prefix: ${name}`).toBe(true);
+    }
+  });
+
+  it('has no duplicate names', () => {
+    expect(new Set(BUNDLED_AGENT_DEFINITIONS).size).toBe(BUNDLED_AGENT_DEFINITIONS.length);
+  });
+});


### PR DESCRIPTION
## Portable agent definitions (#217)

Author a sub-agent persona **once** (Markdown + YAML frontmatter) and render it to whichever provider's native format the launch provider expects:

- `.claude/agents/*.md` — Claude Code
- `.github/agents/*.agent.md` — GitHub Copilot
- `.codex/agents/*.toml` — OpenAI Codex

Bundled `ralphctl-generator` / `ralphctl-evaluator` definitions ship out of the box; operator drop-ins under `<appRoot>/agents/` are reusable across every project. Bind one to the implement generator or evaluator role with `ralphctl settings set ai.implement.agents.<role> <name>`, and `ralphctl agents list` shows what's available and which role each is currently bound to.

## What's inside

- **Domain model + parser** — agent-definition entity and frontmatter parser.
- **Prompt templates** — additive agent-definition section in the implement/evaluate templates (empty-safe substitution).
- **Per-provider renderers** — native renderers + porting adapters for Claude / Copilot / Codex.
- **Sources & registry** — bundled + operator definition sources, a registry, and a quality warner for weak definitions.
- **Settings binding** — `ai.implement.agents.<role>` role-binding with a definition > per-flow row > global override precedence.
- **Gen-eval wiring** — bindings flow into implement gen-eval sessions.
- **CLI surface** — `ralphctl agents list`; bind via `ralphctl settings set`.
- **Docs** — REQUIREMENTS, ARCHITECTURE, AI-SETTINGS, and CHANGELOG updated to match.

## Testing

`pnpm verify` (typecheck + lint + test). +4,411 / −269 across 85 files, heavy on new test coverage (domain, integration adapters per provider, settings precedence, CLI, flow-shape fences, prompt placeholder parity).
