### PR TITLE
feat: research quick-wins — context fix, harness instrumentation, skills close-out

### DIFF
--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -6,3 +6,4 @@
   sub-chain, attempt outer loop, task-graph validation
 - [project_windowed_list_review.md](project_windowed_list_review.md) — Windowed-list / ScrollRegion review findings: WindowedList dead export, new flaky windowing test, pick-sprint-view not migrated
 - [project_coalesced_buffer_review.md](project_coalesced_buffer_review.md) — CoalescedBuffer onCritical window-not-cleared bug + double-seed nit from 0.10.0 commit-storm fix
+- [project_esc_collapse_claim_seam.md](project_esc_collapse_claim_seam.md) — Wide Implement view Esc-collapse-before-pop: claimEscape suppresses pop, keymap collapses; undefined-sentinel ref establishes mount-time claim

--- a/.claude/agent-memory/reviewer/project_esc_collapse_claim_seam.md
+++ b/.claude/agent-memory/reviewer/project_esc_collapse_claim_seam.md
@@ -1,0 +1,20 @@
+---
+name: esc-collapse-claim-seam
+description: How the wide Implement view's Esc-collapse-before-pop works (claimEscape seam) — trace + why the undefined-sentinel ref matters
+metadata:
+  type: project
+---
+
+Wide-layout (≥140-col) Implement view Esc-collapse-before-pop wiring (branch feat/research-quickwins, reviewed 2026-07-18, PASS).
+
+**The trace (who collapses the card):** On Esc, BOTH `useGlobalKeys` and `TasksPanel`'s `useTasksPanelInput` `useInput` handlers fire on the same keystroke.
+
+- `use-global-keys.ts`: `if (key.escape && !ui.escapeClaimed) router.pop()` — the claim (counter-based `claimEscape`, `escapeClaims > 0`) suppresses the pop. It does NOT collapse anything.
+- The actual collapse is `handleEscapeCollapse` in `tasks-panel-internals/keymap.ts` — `setExpandedTaskIds` deletes the focused id. So the claim + the panel's own handler are two halves; neither alone is enough.
+- `LIVE_SIGNAL_TEXT` (signal stream) renders only inside `ExpandedProgressBlock`/`SignalsSection` which return null when `!cardExpanded` — so asserting `not.toContain(signalText)` is a genuine visual-collapse check.
+
+**Why the undefined-sentinel ref (real bug the implementer caught):** the active task auto-expands from lazy initial state, so `focusedCardExpanded` is already `true` on first render. `useTaskCardState`'s NEW `onExpandedCardChange` report effect seeds `prevFocusedCardExpandedRef = useRef(undefined)` (NOT `useRef(current)`) so the mount-time `true` is reported once — establishing the claim BEFORE the operator's first keystroke. Seeding with `current` (as the sibling `onFocusedCardChange` does) would suppress that one report and the first Esc would pop instead of collapse.
+
+**Asymmetry note:** the sibling `onFocusedCardChange` still seeds with `current`, so its consumer (sidebar highlight caret in `implement-sidebar.tsx`, `focusedTaskId`) shows no caret on first paint until first interaction. Pre-existing, cosmetic, out of scope — running task is still identifiable via its status glyph. Does not bite materially.
+
+**Claim lifecycle:** `ImplementMainArea` holds `focusedCardExpanded` state + `useEffect(() => (focusedCardExpanded ? claimEscape() : undefined), [focusedCardExpanded, claimEscape])` — mirrors `sprint-detail-view.tsx:322`. Counter-based claim is reference-counted (safe under overlap); effect cleanup releases on collapse/focus-move-to-collapsed/unmount. `ImplementMainAreaProps = Omit<TasksPanelHostProps, 'onExpandedCardChange'>` — the component owns that prop, wide-layout callers can't pass it. Narrow path (`ExecuteLayout`) never mounts `ImplementMainArea`.

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -719,8 +719,15 @@ Two-stage pipeline:
 Template / skill loading is dual-mode:
 
 - **Dev (`tsx`)** — reads from `src/integration/ai/{prompts,skills}/`. `FsTemplateLoader` and `bundledSkillSource`
-  detect mode via `import.meta.url`.
-- **Bundled (`dist/cli.mjs`)** — reads from `dist/{prompts,skills}/`. Missing assets fail fast with a repair hint.
+  detect mode by probing the filesystem for a co-located `prompts/` / `skills/` dir beside the running module —
+  never by artifact filename. tsup code-splitting rewrites `import.meta.url` to a hashed `cli-<hash>.mjs` chunk,
+  and an earlier filename check (`import.meta.url.endsWith('/cli.mjs')`) missed that chunk and shipped a bundle
+  that silently served empty prompts in 0.15.0; fixed in 0.15.1 (`resolveTemplatesDir` / `resolveBundledRoot`).
+- **Bundled (`dist/cli.mjs`)** — reads from `dist/{prompts,skills}/`. `integration/system/bundle-integrity.ts`
+  runs once at startup (bundle mode only, same filesystem-probe detection against `dist/manifest.json`) and
+  existence-checks every asset the manifest names plus a `packageVersion` cross-check, so a partial install
+  fails fast at boot with a "reinstall ralphctl" hint instead of surfacing a generic `StorageError` the first
+  time a flow touches a missing template.
 
 CI smoke-tests `node dist/cli.mjs --version` from arbitrary cwd plus a real `npm install` from the packed tarball.
 
@@ -728,8 +735,6 @@ CI smoke-tests `node dist/cli.mjs --version` from arbitrary cwd plus a real `npm
 
 - **Real-provider e2e** — every Claude / Copilot / Codex provider test uses a fake `spawn`. Vendor JSON-shape
   drift will surface here first. Same gap as v0.6.x; deferred.
-- **Bundle-mode detection robustness** — `import.meta.url.endsWith('/cli.mjs')` would silently no-op if the
-  published bin is renamed. Candidate replacement: `existsSync(<here>/manifest.json)`.
 - **Cross-provider escalation** — plateau escalation today stays within a provider (e.g. Sonnet → Opus);
   switching providers mid-task carries auth/context/tool hazards and is deferred.
 - **Learning-ledger retrieval / embeddings** — the distill step reads the full ledger (no retrieval engine).

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -357,8 +357,19 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
 
 - [x] **Two-stage build** — `tsup` compiles `dist/cli.mjs`; `tsx scripts/build-assets.ts` copies prompts +
       bundled skills into `dist/{prompts,skills}/` and writes `dist/manifest.json`.
-- [x] **Dual-mode loading** — `FsTemplateLoader` and `bundledSkillSource` detect bundled mode via
-      `import.meta.url`. Dev reads from `src/`; bundled reads from `dist/`.
+- [x] **Dual-mode loading** — `FsTemplateLoader` and `bundledSkillSource` detect bundled mode by probing the
+      filesystem for a co-located `prompts/` / `skills/` dir beside the running module, never by artifact
+      filename — tsup code-splitting rewrites `import.meta.url` to a hashed `cli-<hash>.mjs` chunk, and an
+      earlier filename check (`import.meta.url.endsWith('/cli.mjs')`) missed that chunk, shipping a bundle
+      that silently served empty prompts in 0.15.0. Fixed in 0.15.1 (`resolveTemplatesDir` / `resolveBundledRoot`).
+- [x] **Startup bundle-integrity probe** — `integration/system/bundle-integrity.ts` runs once per process
+      (wired into both `ui/cli/bootstrap.ts` and `ui/tui/launch.ts`, right after `wire()`, via the shared
+      `run-bundle-integrity-check.ts`). Bundle-mode-only, detected the same filesystem-probe way as the item
+      above (a `manifest.json` sitting beside the running module; absent in `tsx` dev, so dev silently skips):
+      existence-checks every asset `scripts/build-assets.ts` recorded and cross-checks the manifest's
+      `packageVersion` against `cli-metadata.ts`'s running version. A missing asset or version mismatch
+      surfaces a one-line `StorageError` naming the count/mismatch plus a "reinstall ralphctl" hint; a
+      malformed/unparseable manifest degrades to a warning log, never a hard crash.
 - [x] **CI tarball smoke** — `pnpm pack` + `npm install` into a tmp dir + `ralphctl --version` from arbitrary
       cwd exits 0 and prints the version from `package.json`.
 - [x] **`--provenance`** flag on npm publish.
@@ -389,8 +400,6 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
 - **Cross-provider escalation** — escalation today stays within a provider (e.g. Sonnet → Opus); switching
   providers mid-task carries auth/context/tool hazards and is deferred.
 - **Real-provider e2e tests** — every Claude / Copilot / Codex provider test uses a fake `spawn`.
-- **Bundle-mode detection robustness** — `import.meta.url.endsWith('/cli.mjs')` is a fragile detection; a
-  follow-up should switch to `existsSync(<here>/manifest.json)`.
 - **Onboarding-status doctor probe** — no per-(project, repo) "onboarding state" is modeled in the domain
   (`Project` / `Repository` carry no onboarding field), so doctor reports none. Per-(project, repo) health is
   instead covered by the `integrity` probes (repo-path resolution, default-branch resolution, sprint/execution
@@ -399,11 +408,6 @@ See [DESIGN-SYSTEM.md](./DESIGN-SYSTEM.md) for tokens, components, view patterns
   queue (`prompt-queue.ts`) is a strict serial mutex that shifts resolved prompts off and discards them. A
   transcript keeping resolved prompts visible (dim, clearing after an idle window) was specced but never built
   and runs counter to the modal-queue design; deferred.
-- **Asset-integrity check** — `scripts/build-assets.ts` writes `dist/manifest.json` as a build-completeness
-  record, but no runtime code reads it: a missing template / skill surfaces only a generic `StorageError` from
-  the loaders, with no manifest cross-check and no repair hint. A startup integrity pass against the manifest
-  (with a "reinstall the package" hint) is deferred — it pairs with the bundle-mode item above (both would give
-  the write-only manifest a runtime role).
 
 ## Procedural memory
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,44 @@ to [Semantic Versioning](https://semver.org/).
   every project. Bind one to the implement generator or evaluator role with
   `ralphctl settings set ai.implement.agents.<role> <name>`; `ralphctl agents list` shows what's
   available and which role each is currently bound to.
+- **`ralphctl skills list`.** CLI counterpart to the TUI skills catalog: each skill's tier, the flows
+  it is enabled for (saved opt-outs applied), and its provenance (in sync / update available / locally
+  modified) — for scripting and quick inspection outside the TUI.
+- **Skills in the Create PR flow.** The PR-drafting session now mounts the same curated skills as the
+  other flows. The code-review skill stays a recommended opt-in there rather than a default — its
+  review-signal guidance can conflict with the flow's single-summary output contract.
+- **Clear a saved skill opt-out from the catalog.** Press `c` on a skill in the catalog (hotkey `K`)
+  to clear a remembered per-flow opt-out — previously only possible by re-answering the remember
+  prompt on a later run.
+- **Startup install-integrity check.** A broken or half-upgraded global install (missing bundled
+  prompt/skill assets, or a `dist/` built for a different version) is now caught at launch with a
+  one-line "reinstall ralphctl" hint, instead of failing mid-flow with a generic storage error — the
+  failure class behind the 0.15.1 patch release.
+- **Plateau exits name their detector.** `progress.md` and escalation events now record which plateau
+  detector fired (threshold / diversity / entropy), so a long run's exit behaviour can be audited from
+  the journal instead of guessed at.
+- **Corrective-nudge visibility.** When a session produces an invalid `signals.json` and the harness
+  re-prompts it, the per-task journal outcome now reports how many corrective nudges were spent (they
+  remain exempt from the turn/attempt budget).
+- **Sessions are told what tooling they have.** Implement generator and evaluator prompts now name the
+  bound sub-agent persona and the skills installed for the run, instead of always rendering
+  "(none detected)".
+
+### Fixed
+
+- **Long-sprint context was silently truncated.** A fixed 4,000-character substitution backstop chopped
+  the carefully capped progress journal and prior learnings down to their last 4K characters —
+  discarding the sprint state header, pinned lifecycle breadcrumbs, and earlier-attempt history that
+  the prompts explicitly tell the model to honor. The backstop now only fires on true overflow, and a
+  fence test ties its ceiling to the largest supported context window.
+- **Esc in the wide Implement layout.** With a task card expanded, Esc now collapses the card first; a
+  second Esc leaves the view as before.
+
+### Changed
+
+- **The bundled minimal-scaffolding skill speaks downstream language.** Internal orchestrator
+  vocabulary was removed from its body; the discipline it teaches — question every component, remove
+  one at a time, measure, default to subtraction — is unchanged.
 
 ## [0.15.1] - 2026-07-06
 

--- a/scripts/build-assets.ts
+++ b/scripts/build-assets.ts
@@ -16,7 +16,9 @@
  *
  * The manifest is the runtime "did the build complete?" gate — a partial copy
  * silently producing a bundle that serves empty prompts is the failure mode
- * we're guarding against. Run after `tsup` has produced `dist/cli.mjs`.
+ * we're guarding against. `integration/system/bundle-integrity.ts` reads it once at startup
+ * (bundle mode only) and existence-checks every listed asset plus `packageVersion` against the
+ * running package. Run after `tsup` has produced `dist/cli.mjs`.
  * Idempotent: re-running cleans `dist/prompts/`, `dist/skills/`, and
  * `dist/agent-definitions/` before re-copying.
  */
@@ -25,6 +27,7 @@ import { cp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import pkg from '../package.json' with { type: 'json' };
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..');
@@ -92,7 +95,14 @@ for (const entry of agentDefinitionEntries) {
 assets.sort();
 
 const manifest = {
-  version: 1,
+  // Manifest layout version — bump when the shape below changes, independent of the package
+  // release cadence. `integration/system/bundle-integrity.ts` doesn't read this today; it's
+  // recorded for a future schema migration.
+  schemaVersion: 1,
+  // Package release this manifest was generated for. `bundle-integrity.ts`'s startup probe
+  // cross-checks this against `cli-metadata.ts`'s running version to catch a half-upgraded
+  // global install (e.g. `dist/cli.mjs` replaced but stale `dist/prompts/` left behind).
+  packageVersion: pkg.version,
   generatedAt: new Date().toISOString(),
   assets,
 };

--- a/src/application/bootstrap/run-bundle-integrity-check.ts
+++ b/src/application/bootstrap/run-bundle-integrity-check.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared bundle-integrity pre-flight — run once per process by both composition roots
+ * (`ui/cli/bootstrap.ts`'s `bootstrapCli` and `ui/tui/launch.ts`'s `bootstrap`), immediately
+ * after `wire()` so `deps.logger` is available for the malformed-manifest warning path.
+ *
+ * Bundle-mode-only: `checkBundleIntegrity` is a silent no-op in dev (`tsx`), where there is no
+ * `dist/manifest.json` beside the running module. A hard failure (missing asset / version
+ * mismatch) throws, mirroring the `paths` / `ensureStorageRoots` / `settingsRepo.load()`
+ * pre-flights it sits beside at each call site — the CLI bootstrap leaves it uncaught (existing
+ * behaviour for every pre-flight there), `launchTui` catches it into a one-line stderr message.
+ * A malformed manifest logs at warning level and never blocks startup.
+ */
+
+import type { Logger } from '@src/business/observability/logger.ts';
+import { checkBundleIntegrity } from '@src/integration/system/bundle-integrity.ts';
+
+export const runBundleIntegrityCheck = async (logger: Logger): Promise<void> => {
+  const result = await checkBundleIntegrity();
+  if (!result.ok) throw new Error(`bundle-integrity: ${result.error.message}`);
+  if (result.value.kind === 'malformed') {
+    logger.warn(`bundle-integrity: ${result.value.reason}`);
+  }
+};

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -44,9 +44,7 @@ import type { ModelAvailabilityProbeRegistry } from '@src/integration/ai/provide
 import { claudeModelAvailabilityProbe } from '@src/integration/ai/providers/claude/model-availability-probe.ts';
 import { codexModelAvailabilityProbe } from '@src/integration/ai/providers/codex/model-availability-probe.ts';
 import { copilotModelAvailabilityProbe } from '@src/integration/ai/providers/copilot/model-availability-probe.ts';
-import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
-import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
-import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
@@ -349,17 +347,6 @@ const PROBES: ReadinessProbeRegistry = {
 };
 
 /**
- * Static model catalog per provider — the full official list the availability probe filters
- * down. Mirrors `modelCatalogFor` in the picker; both read the same domain CATALOG arrays so a
- * model bump can never drift between the picker fallback and the probe input.
- */
-const MODEL_CATALOGS: Readonly<Record<AiProvider, readonly string[]>> = {
-  'claude-code': CLAUDE_MODELS,
-  'github-copilot': COPILOT_MODELS,
-  'openai-codex': CODEX_MODELS,
-};
-
-/**
  * Model-availability probe registry, keyed by {@link AiProvider}. Static module-level singletons
  * bundled here so `wire()` can dispatch per-provider without each caller carrying a registry
  * literal. Keyed on the provider union (vs. {@link PROBES}, which is keyed on `AssistantTool`).
@@ -437,7 +424,7 @@ export const wire = (opts: WireOptions): AppDeps => {
   const availableModelsFor = (provider: AiProvider): Promise<readonly string[]> => {
     const existing = availableModelsInFlight.get(provider);
     if (existing !== undefined) return existing;
-    const pending = MODEL_AVAILABILITY_PROBES[provider].availableModels(MODEL_CATALOGS[provider]);
+    const pending = MODEL_AVAILABILITY_PROBES[provider].availableModels(PROVIDER_TRAITS[provider].modelCatalog);
     availableModelsInFlight.set(provider, pending);
     return pending;
   };

--- a/src/application/flows/create-pr/deps.ts
+++ b/src/application/flows/create-pr/deps.ts
@@ -9,6 +9,8 @@ import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
+import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 
 /**
  * Dependency contract for the create-pr flow.
@@ -51,4 +53,13 @@ export interface CreatePrDeps {
   readonly logger: Logger;
   /** Model identifier — picked from `settings.ai.createPr.model` by the CLI / TUI surfaces. */
   readonly model: string;
+  /**
+   * Composed skill source for the `createPr` flow — the CLI / TUI surfaces build this via
+   * `buildComposedSkillSource` directly (create-pr never reaches `launchFlow`'s dispatch), so it
+   * always resolves the settings/registry default set; there is no per-run customize-picker
+   * override for this flow.
+   */
+  readonly skillSource: SkillSource;
+  /** Provider-matched skills adapter — installs into the AI sub-chain's unit-root sandbox. */
+  readonly skillsAdapter: SkillsAdapter;
 }

--- a/src/application/flows/create-pr/flow.ts
+++ b/src/application/flows/create-pr/flow.ts
@@ -9,6 +9,8 @@ import { createPushBranchLeaf } from '@src/application/flows/create-pr/leaves/pu
 import { createCreatePrLeaf } from '@src/application/flows/create-pr/leaves/create-pr-leaf.ts';
 import { createLoadCreatePrContextLeaf } from '@src/application/flows/create-pr/leaves/load-create-pr-context-leaf.ts';
 import { generatePrContentLeaf } from '@src/application/flows/create-pr/leaves/generate-pr-content-leaf.ts';
+import { installSkillsLeaf } from '@src/application/flows/_shared/skills/install-skills.ts';
+import { uninstallSkillsLeaf } from '@src/application/flows/_shared/skills/uninstall-skills.ts';
 import { buildUnitLeaf } from '@src/application/flows/_shared/build-unit.ts';
 import { renderPromptToFileLeaf } from '@src/application/flows/_shared/render-prompt-to-file.ts';
 import {
@@ -40,7 +42,9 @@ export interface CreateCreatePrFlowOpts {
  *     load-create-pr-context,         // hydrate sprint + tasks + headBranch onto ctx
  *     build-create-pr-unit,           // mkdir <sprintDir>/create-pr/<run-slug>/
  *     render-prompt-to-file,          // write prompt.md
+ *     install-skills,                 // copy the createPr flow's skills into the unit root
  *     generate-pr-content,            // headless AI authoring → ctx.aiContent
+ *     uninstall-skills,               // remove them again (skipped if an abort short-circuits)
  *     create-pr,                      // gh pr create / glab mr create + persist URL
  *   ])
  *
@@ -113,6 +117,10 @@ export const createCreatePrFlow = (deps: CreatePrDeps, opts: CreateCreatePrFlowO
           write: (ctx, path) => ({ ...ctx, currentPromptFile: path }),
         }
       ),
+      installSkillsLeaf<CreatePrCtx>(
+        { skillsAdapter: deps.skillsAdapter, skillSource: deps.skillSource },
+        { name: 'install-skills', flowId: 'createPr', cwdPicker: unitRootCwdPicker('install-skills') }
+      ),
       generatePrContentLeaf({
         provider: deps.provider,
         templateLoader: deps.templateLoader,
@@ -120,7 +128,11 @@ export const createCreatePrFlow = (deps: CreatePrDeps, opts: CreateCreatePrFlowO
         eventBus: deps.eventBus,
         logger: deps.logger,
         model: deps.model,
-      })
+      }),
+      uninstallSkillsLeaf<CreatePrCtx>(
+        { skillsAdapter: deps.skillsAdapter },
+        { name: 'uninstall-skills', cwdPicker: unitRootCwdPicker('uninstall-skills') }
+      )
     );
   }
 
@@ -128,6 +140,21 @@ export const createCreatePrFlow = (deps: CreatePrDeps, opts: CreateCreatePrFlowO
 
   return sequential<CreatePrCtx>('create-pr', children);
 };
+
+/**
+ * Shared `cwdPicker` for the install/uninstall-skills leaves bracketing `generate-pr-content` —
+ * both must target the same sandbox (`ctx.currentUnitRoot`, populated by `build-create-pr-unit`).
+ * `leafName` names the failing leaf in the thrown error so a misordered chain surfaces at the
+ * leaf that actually broke, not a generic message.
+ */
+const unitRootCwdPicker =
+  (leafName: string) =>
+  (ctx: CreatePrCtx): AbsolutePath => {
+    if (ctx.currentUnitRoot === undefined) {
+      throw new Error(`${leafName}: currentUnitRoot missing — build-create-pr-unit must run first`);
+    }
+    return ctx.currentUnitRoot;
+  };
 
 /**
  * Slugify a branch name so it can be used as a stable folder name. Replaces `/` and any

--- a/src/application/flows/implement/ctx.ts
+++ b/src/application/flows/implement/ctx.ts
@@ -179,6 +179,19 @@ export interface ImplementCtx {
    */
   readonly currentAttemptNotes?: readonly string[] | undefined;
   /**
+   * Per-attempt count of corrective `signals.json` nudges the GENERATOR needed this attempt
+   * (see `validateSignalsFileWithCorrectiveRetry`). Nudges consume no turn/attempt budget by
+   * design (near-miss recovery must not eat the real budget), so a persistently malformed AI can
+   * burn `correctiveRetries × turns` hidden extra spawns that appear in no other operator-facing
+   * counter — this field is the ONLY surface for them. Pure observability: never read by any
+   * business decision. Accumulated across every turn of the attempt by the generator leaf, read
+   * by `progress-journal-<taskId>` to render the outcome clause, then cleared alongside the other
+   * per-attempt accumulators. Undefined until the first turn that needed a nudge.
+   */
+  readonly currentAttemptGeneratorNudges?: number | undefined;
+  /** Evaluator mirror of {@link currentAttemptGeneratorNudges} — same lifecycle, same rationale. */
+  readonly currentAttemptEvaluatorNudges?: number | undefined;
+  /**
    * Cross-sprint procedural memory loaded ONCE in the implement prologue (`load-prior-learnings`)
    * from this project's append-only learnings ledger (`<memoryRoot>/<projectId>/learnings.ndjson`),
    * filtered to the not-yet-promoted records (`promotedAt === null` — promoted ones already live in

--- a/src/application/flows/implement/leaves/_shared/compose-project-tooling.ts
+++ b/src/application/flows/implement/leaves/_shared/compose-project-tooling.ts
@@ -1,0 +1,46 @@
+/**
+ * Compose the "## Project Tooling" prompt body — a compact, one-line-per-tool catalog threaded
+ * into `{{PROJECT_TOOLING}}` by both the generator and evaluator prompt builders (see
+ * `renderProjectToolingSection`). Shared between `generator.ts` and `evaluator.ts` so both sides
+ * of the gen-eval loop name the same tooling the same way.
+ *
+ * Every fact here comes from an EXISTING resolution seam — the portable-agents feature's
+ * per-role binding (`PerTaskSubchainOpts.generatorAgentDefinition` / `.evaluatorAgentDefinition`,
+ * threaded down as a bare name) and the per-flow skill catalog (`ImplementDeps.skillSource`, the
+ * same source `installSkillsLeaf` already reads before the AI session starts). No new detection
+ * is introduced here — this only NAMES what the harness already resolved and installed, per the
+ * empirical finding that explicit tool naming carries a large agent-compliance multiplier.
+ *
+ * Pure. Empty facts → `''` so `renderProjectToolingSection` falls back to its own
+ * "(none detected)" default — this module never emits that fallback text itself.
+ */
+
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+
+export interface ProjectToolingFacts {
+  /**
+   * This role's bound agent-definition NAME (the portable-agents feature) — the same identifier
+   * the prompt's `## Agent Definition` section already announces. Repeated here so the one
+   * tool-catalog section is complete for a reader who only skims `{{PROJECT_TOOLING}}`. Absent
+   * when the role has no binding.
+   */
+  readonly agentDefinitionName?: string;
+  /** Skills installed for this flow's AI session — name + one-line "when to use" description. */
+  readonly skills?: ReadonlyArray<Pick<Skill, 'name' | 'description'>>;
+}
+
+export const composeProjectTooling = (facts: ProjectToolingFacts): string => {
+  const lines: string[] = [];
+  const agentName = facts.agentDefinitionName?.trim();
+  if (agentName !== undefined && agentName.length > 0) {
+    lines.push(
+      `- Subagent: \`${agentName}\` — the bound persona for this session (see the bound sub-agent persona note above); check this session's native subagent listing to delegate to it directly.`
+    );
+  }
+  for (const skill of facts.skills ?? []) {
+    const name = skill.name.trim();
+    if (name.length === 0) continue;
+    lines.push(`- Skill: \`${name}\` — ${skill.description.trim()}`);
+  }
+  return lines.join('\n');
+};

--- a/src/application/flows/implement/leaves/_shared/nudge-count-carry.ts
+++ b/src/application/flows/implement/leaves/_shared/nudge-count-carry.ts
@@ -1,0 +1,12 @@
+/**
+ * Conditional per-attempt counter carry for the corrective-nudge cost-visibility tally — returns
+ * `{ [field]: prior + delta }` only when `delta` is positive (a turn that needed no nudge
+ * contributes nothing), else `{}`. Shared by the generator/evaluator leaves' `xOutput` ctx-merge
+ * functions so a zero-delta turn (the common case) adds no extra branch to their already-branchy
+ * reducers.
+ */
+export const positiveCountCarry = <K extends string>(
+  field: K,
+  delta: number,
+  prior: number | undefined
+): Partial<Record<K, number>> => (delta > 0 ? ({ [field]: (prior ?? 0) + delta } as Partial<Record<K, number>>) : {});

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -47,6 +47,7 @@ import {
   composeGeneratorHints,
   type GeneratorHintsInput,
 } from '@src/application/flows/implement/leaves/_shared/generator-hints.ts';
+import { positiveCountCarry } from '@src/application/flows/implement/leaves/_shared/nudge-count-carry.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
 
@@ -180,6 +181,24 @@ interface EvaluatorOutput {
    * projection so the next round's evaluator can resume the same thread.
    */
   readonly capturedSessionId?: SessionId;
+  /**
+   * Corrective `signals.json` nudges this turn needed (`0` on a clean first parse) — read from
+   * `validateSignalsFileWithCorrectiveRetry`'s `nudgeCount`. Accumulates onto
+   * `ctx.currentAttemptEvaluatorNudges` so the journal leaf can render the cost-visibility
+   * clause. Pure observability; never affects retry semantics.
+   */
+  readonly correctiveNudgeCount: number;
+}
+
+/**
+ * Per-turn out-channel for the corrective-nudge tally — mutated in place after
+ * `validateSignalsFileWithCorrectiveRetry` resolves. Mirrors the generator leaf's
+ * `GeneratorTurnAccumulators`: `callEvaluate` is bound to the business use case's fixed
+ * `Result<readonly HarnessSignal[], DomainError>>` signature, so the count rides out via this
+ * closure-captured mutable object instead of widening that return type.
+ */
+interface EvaluatorTurnMeta {
+  correctiveNudgeCount: number;
 }
 
 /**
@@ -359,6 +378,7 @@ const makeEvaluatorCallEvaluate =
       readonly signalsFile: AbsolutePath;
       readonly outputDir: AbsolutePath;
       readonly signal: AbortSignal | undefined;
+      readonly meta: EvaluatorTurnMeta;
     }
   ): RunEvaluatorTurnProps['callEvaluate'] =>
   async (task) => {
@@ -439,7 +459,10 @@ const makeEvaluatorCallEvaluate =
       evaluatorOutputContract
     );
     if (!validated.ok) return Result.error(validated.error);
-    const signals = validated.value;
+    const signals = validated.value.signals;
+    // Cost-visibility out-channel — see EvaluatorTurnMeta's docstring for why this rides a
+    // mutated field rather than widening `callEvaluate`'s return type.
+    args.meta.correctiveNudgeCount = validated.value.nudgeCount;
 
     // Publish every validated signal onto the one harness-signal channel.
     for (const sig of signals) deps.publishSignal(sig);
@@ -480,7 +503,10 @@ const makeEvaluatorExecute =
     if (!outputDirPath.ok) return Result.error(outputDirPath.error);
     const outputDir = outputDirPath.value;
 
-    const callEvaluate = makeEvaluatorCallEvaluate(deps, { input, signalsFile, outputDir, signal });
+    // Cost-visibility out-channel for this turn's corrective-nudge tally — closure-captured so
+    // `execute` can stamp it onto `EvaluatorOutput` after the use case returns.
+    const meta: EvaluatorTurnMeta = { correctiveNudgeCount: 0 };
+    const callEvaluate = makeEvaluatorCallEvaluate(deps, { input, signalsFile, outputDir, signal, meta });
 
     // Fingerprint the working tree's uncommitted changes for this round so the plateau
     // predicate's progress exemption measures real code change instead of commit-message
@@ -507,6 +533,7 @@ const makeEvaluatorExecute =
 
     return Result.ok({
       task: result.value.task,
+      correctiveNudgeCount: meta.correctiveNudgeCount,
       ...(result.value.evaluation !== undefined ? { evaluation: result.value.evaluation } : {}),
       ...(result.value.exit !== undefined ? { exit: result.value.exit } : {}),
       ...(result.value.turnRecord !== undefined ? { turnRecord: result.value.turnRecord } : {}),
@@ -578,6 +605,13 @@ const evaluatorOutput = (ctx: ImplementCtx, out: EvaluatorOutput): ImplementCtx 
   // Latest captured evaluator sessionId wins; only OVERWRITE when this turn produced one
   // (preserves the prior turn's thread when this spawn failed to report an id).
   const sessionCarry = out.capturedSessionId !== undefined ? { priorEvaluatorSessionId: out.capturedSessionId } : {};
+  // Cost-visibility tally — accumulates across every turn of the attempt, same lifecycle as the
+  // generator leaf's mirror field. Zero-noise: a turn with no nudge contributes nothing.
+  const evaluatorNudgesCarry = positiveCountCarry(
+    'currentAttemptEvaluatorNudges',
+    out.correctiveNudgeCount,
+    ctx.currentAttemptEvaluatorNudges
+  );
   const next: ImplementCtx = {
     ...ctx,
     currentTask: out.task,
@@ -589,6 +623,7 @@ const evaluatorOutput = (ctx: ImplementCtx, out: EvaluatorOutput): ImplementCtx 
     lastEvaluation: out.evaluation,
     ...(nextHistory !== undefined ? { plateauHistory: nextHistory } : {}),
     ...sessionCarry,
+    ...evaluatorNudgesCarry,
   };
   if (out.exit === undefined) return next;
   return { ...next, lastExit: out.exit };

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -18,6 +18,7 @@ import type { AiSignal, EvaluationSignal, HarnessSignal } from '@src/domain/sign
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { PublishSignal } from '@src/application/flows/_shared/publish-signal.ts';
 import { buildEvaluatePrompt } from '@src/integration/ai/prompts/evaluate/definition.ts';
 import { buildEvaluateContinuationPrompt } from '@src/integration/ai/prompts/evaluate-continuation/definition.ts';
@@ -41,6 +42,7 @@ import {
   writeRoundPrompt,
 } from '@src/application/flows/implement/leaves/round-artifacts.ts';
 import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+import { composeProjectTooling } from '@src/application/flows/implement/leaves/_shared/compose-project-tooling.ts';
 import {
   composeGeneratorHints,
   type GeneratorHintsInput,
@@ -104,12 +106,28 @@ export interface EvaluatorLeafDeps {
   /** Optional reasoning / effort level forwarded into every `implementSession` AiSession. */
   readonly effort?: string;
   /**
-   * Pre-composed "## Agent Definition" prompt section (raw content, not yet rendered) — see
+   * Pre-composed bound-agent-definition prompt body (raw content — `renderAgentDefinitionSection`
+   * wraps it under the "## Agent Definition" heading at render time) — see
    * `GenEvalLoopRoleConfig.agentDefinitionSection`. Threaded into the FULL evaluate prompt's
    * `agentDefinition` slot only (round 1 of a session thread); a resumed continuation already
    * carries it in-conversation.
    */
   readonly agentDefinition?: string;
+  /**
+   * This role's bound agent-definition NAME (the portable-agents feature's bare identifier, not
+   * the rendered {@link agentDefinition} section) — threaded separately so the FULL prompt's
+   * `{{PROJECT_TOOLING}}` catalog can name the same binding `{{AGENT_DEFINITION_SECTION}}`
+   * already announces, without re-parsing the rendered prose. Absent when the role has no
+   * binding. See `compose-project-tooling.ts`.
+   */
+  readonly agentDefinitionName?: string;
+  /**
+   * Per-flow skill catalog port — the same source `installSkillsLeaf` reads to install this
+   * task's skills into the session sandbox. Read again here (best-effort) to name each installed
+   * skill in the FULL prompt's `{{PROJECT_TOOLING}}` catalog (round 1 of a session thread only).
+   * Absent → the catalog simply omits the skills lines.
+   */
+  readonly skillSource?: SkillSource;
   readonly verifyScript?: string;
   /** From `settings.harness.plateauThreshold` (2–5). */
   readonly plateauThreshold: number;
@@ -203,10 +221,38 @@ const readCappedProgress = async (path: string, currentTaskId: string, model: st
  * re-send the full context. A provider that never reports a session id keeps getting the full
  * prompt automatically — the discriminant is the same field `--resume` consumes.
  */
+
+/**
+ * Resolve the FULL prompt's `{{PROJECT_TOOLING}}` carry (round 1 of a session thread only — the
+ * continuation prompt does not declare the placeholder, mirroring `agentDefinition`'s
+ * full-prompt-only rule). Mirrors the generator leaf's `resolveGeneratorProjectToolingCarry` —
+ * same facts, same `'implement'` flow id (the skill catalog is flow-wide, shared by both roles).
+ * Returns the ready-to-spread `{ projectTooling }` fragment (or `{}`) so the caller stays a flat,
+ * branch-free spread. Best-effort: a skill-source read failure degrades to naming only the bound
+ * agent definition (or to nothing at all) rather than failing the turn.
+ */
+const resolveEvaluatorProjectToolingCarry = async (
+  deps: Pick<EvaluatorLeafDeps, 'agentDefinitionName' | 'skillSource'>
+): Promise<{ readonly projectTooling?: string }> => {
+  const skills = deps.skillSource !== undefined ? await deps.skillSource.getForFlow('implement') : undefined;
+  const projectTooling = composeProjectTooling({
+    ...(deps.agentDefinitionName !== undefined ? { agentDefinitionName: deps.agentDefinitionName } : {}),
+    ...(skills?.ok === true ? { skills: skills.value } : {}),
+  });
+  return projectTooling.length > 0 ? { projectTooling } : {};
+};
+
 const buildEvaluatorPrompt = async (
   deps: Pick<
     EvaluatorLeafDeps,
-    'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model' | 'agentDefinition'
+    | 'templateLoader'
+    | 'cwd'
+    | 'progressFile'
+    | 'verifyScript'
+    | 'model'
+    | 'agentDefinition'
+    | 'agentDefinitionName'
+    | 'skillSource'
   >,
   args: {
     readonly task: InProgressTask;
@@ -229,6 +275,7 @@ const buildEvaluatorPrompt = async (
   const agentDefinitionCarry = deps.agentDefinition !== undefined ? { agentDefinition: deps.agentDefinition } : {};
 
   if (args.priorEvaluatorSessionId === undefined) {
+    const projectToolingCarry = await resolveEvaluatorProjectToolingCarry(deps);
     return buildEvaluatePrompt(deps.templateLoader, {
       task: args.task,
       projectPath: String(deps.cwd),
@@ -236,6 +283,7 @@ const buildEvaluatorPrompt = async (
       outputContractSection: args.outputContractSection,
       priorProgress,
       ...(deps.verifyScript !== undefined ? { verifyScript: deps.verifyScript } : {}),
+      ...projectToolingCarry,
       ...hintsCarry,
       ...agentDefinitionCarry,
     });

--- a/src/application/flows/implement/leaves/gen-eval-loop.ts
+++ b/src/application/flows/implement/leaves/gen-eval-loop.ts
@@ -1,5 +1,6 @@
 import { Result } from '@src/domain/result.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { PublishSignal } from '@src/application/flows/_shared/publish-signal.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
@@ -64,6 +65,13 @@ export interface GenEvalLoopDeps {
   readonly publishSignal: PublishSignal;
   readonly writeFile: WriteFile;
   /**
+   * Per-flow skill catalog port — threaded into both gen-eval leaves so the FULL prompt's
+   * `{{PROJECT_TOOLING}}` catalog can name this task's installed skills (the same source
+   * `installSkillsLeaf` already reads). Optional so a caller that doesn't care about tooling
+   * naming (most tests) can omit it.
+   */
+  readonly skillSource?: SkillSource;
+  /**
    * Git transport — threaded into the evaluator leaf so it can fingerprint the working tree's
    * uncommitted changes each round for the plateau predicate's work-product exemption.
    */
@@ -90,6 +98,13 @@ export interface GenEvalLoopRoleConfig {
    * continuation already carries it in-conversation.
    */
   readonly agentDefinitionSection?: string;
+  /**
+   * This role's bound agent-definition NAME (bare identifier) — threaded into the generator/
+   * evaluator leaf as `agentDefinitionName` so the FULL prompt's `{{PROJECT_TOOLING}}` catalog
+   * can name the same binding `agentDefinitionSection` already announces in prose. Absent when
+   * the role has no bound definition.
+   */
+  readonly agentDefinitionName?: string;
 }
 
 export interface GenEvalLoopOpts {
@@ -128,6 +143,7 @@ export const createGenEvalLoop = (
     plateauThreshold: deps.plateauThreshold,
     correctiveRetries: deps.correctiveRetries,
     ...(opts.verifyScript !== undefined ? { verifyScript: opts.verifyScript } : {}),
+    ...(deps.skillSource !== undefined ? { skillSource: deps.skillSource } : {}),
   };
   const generatorLeafDeps = {
     ...sharedLeafDeps,
@@ -136,6 +152,9 @@ export const createGenEvalLoop = (
     ...(opts.generator.effort !== undefined ? { effort: opts.generator.effort } : {}),
     ...(opts.generator.agentDefinitionSection !== undefined
       ? { agentDefinition: opts.generator.agentDefinitionSection }
+      : {}),
+    ...(opts.generator.agentDefinitionName !== undefined
+      ? { agentDefinitionName: opts.generator.agentDefinitionName }
       : {}),
   };
   const evaluatorLeafDeps = {
@@ -148,6 +167,9 @@ export const createGenEvalLoop = (
     ...(opts.evaluator.effort !== undefined ? { effort: opts.evaluator.effort } : {}),
     ...(opts.evaluator.agentDefinitionSection !== undefined
       ? { agentDefinition: opts.evaluator.agentDefinitionSection }
+      : {}),
+    ...(opts.evaluator.agentDefinitionName !== undefined
+      ? { agentDefinitionName: opts.evaluator.agentDefinitionName }
       : {}),
   };
 

--- a/src/application/flows/implement/leaves/gen-eval-loop.ts
+++ b/src/application/flows/implement/leaves/gen-eval-loop.ts
@@ -272,7 +272,7 @@ export const createGenEvalLoop = (
       },
       output: (ctx, out) => {
         if (!out.shouldExit || out.dimensions === undefined) return ctx;
-        return { ...ctx, lastExit: { kind: 'plateau', dimensions: out.dimensions } };
+        return { ...ctx, lastExit: { kind: 'plateau', dimensions: out.dimensions, source: 'diversity' } };
       },
     }
   );
@@ -348,7 +348,7 @@ export const createGenEvalLoop = (
       output: (ctx, out) => {
         if (!out.shouldExit) return ctx;
         // Re-use the plateau exit kind so the escalation ladder applies the same remedy.
-        return { ...ctx, lastExit: { kind: 'plateau', dimensions: [] } };
+        return { ...ctx, lastExit: { kind: 'plateau', dimensions: [], source: 'entropy' } };
       },
     }
   );

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -47,6 +47,7 @@ import {
 } from '@src/application/flows/implement/leaves/round-artifacts.ts';
 import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
 import { composeProjectTooling } from '@src/application/flows/implement/leaves/_shared/compose-project-tooling.ts';
+import { positiveCountCarry } from '@src/application/flows/implement/leaves/_shared/nudge-count-carry.ts';
 import {
   formatPreVerifyResults,
   formatRetryFeedback,
@@ -252,6 +253,13 @@ interface GeneratorOutput {
    * so the journal leaf can render the per-attempt `### Notes` subsection.
    */
   readonly notesEmitted: readonly string[];
+  /**
+   * Corrective `signals.json` nudges this turn needed (`0` on a clean first parse) — read from
+   * `validateSignalsFileWithCorrectiveRetry`'s `nudgeCount`. Accumulates onto
+   * `ctx.currentAttemptGeneratorNudges` so the journal leaf can render the cost-visibility clause.
+   * Pure observability; never affects retry semantics.
+   */
+  readonly correctiveNudgeCount: number;
 }
 
 /**
@@ -513,12 +521,19 @@ const composeVerifyBlocks = async (
   };
 };
 
-/** Per-turn signal-text accumulators — mutated in place by {@link accumulateAndEmitSignals}. */
+/**
+ * Per-turn signal-text accumulators — mutated in place by {@link accumulateAndEmitSignals}.
+ * `correctiveNudgeCount` is a sibling out-channel of the same shape: `callImplement` is bound to
+ * the business use case's fixed `Result<readonly HarnessSignal[], DomainError>>` signature, so the
+ * nudge tally rides out via this closure-captured mutable object instead of widening that return
+ * type.
+ */
 interface GeneratorTurnAccumulators {
   readonly decisionsEmitted: string[];
   readonly changesEmitted: string[];
   readonly learningsEmitted: LearningEntry[];
   readonly notesEmitted: string[];
+  correctiveNudgeCount: number;
 }
 
 /**
@@ -744,7 +759,10 @@ const makeGeneratorCallImplement =
       generatorOutputContract
     );
     if (!validated.ok) return Result.error(validated.error);
-    const signals = validated.value;
+    const signals = validated.value.signals;
+    // Cost-visibility out-channel — see GeneratorTurnAccumulators' docstring for why this rides
+    // a mutated field rather than widening `callImplement`'s return type.
+    args.accumulators.correctiveNudgeCount = validated.value.nudgeCount;
 
     accumulateAndEmitSignals(deps, signals, args.accumulators);
 
@@ -796,6 +814,7 @@ const makeGeneratorExecute =
       changesEmitted: [],
       learningsEmitted: [],
       notesEmitted: [],
+      correctiveNudgeCount: 0,
     };
     const logTailReader = deps.logTailReader ?? createFsLogTailReader();
     const callImplement = makeGeneratorCallImplement(deps, taskId, {
@@ -940,6 +959,14 @@ const generatorOutput = (ctx: ImplementCtx, out: GeneratorOutput): ImplementCtx 
     out.notesEmitted.length > 0
       ? { currentAttemptNotes: [...(ctx.currentAttemptNotes ?? []), ...out.notesEmitted] }
       : {};
+  // Cost-visibility tally — accumulates across every turn of the attempt, same lifecycle as the
+  // signal accumulators above. Zero-noise: a turn with no nudge contributes nothing (ctx field
+  // stays undefined until the first nudge fires).
+  const generatorNudgesCarry = positiveCountCarry(
+    'currentAttemptGeneratorNudges',
+    out.correctiveNudgeCount,
+    ctx.currentAttemptGeneratorNudges
+  );
   // Per-turn signal-kind distribution (R2) — stamped fresh every turn (overwrites the prior
   // turn's map) so the entropy-plateau heuristic in the gen-eval loop sees the current turn's
   // action diversity, never an accumulation across turns.
@@ -969,6 +996,7 @@ const generatorOutput = (ctx: ImplementCtx, out: GeneratorOutput): ImplementCtx 
       ...changesCarry,
       ...learningsCarry,
       ...notesCarry,
+      ...generatorNudgesCarry,
       ...actionCountsCarry,
     };
   }
@@ -984,6 +1012,7 @@ const generatorOutput = (ctx: ImplementCtx, out: GeneratorOutput): ImplementCtx 
     ...changesCarry,
     ...learningsCarry,
     ...notesCarry,
+    ...generatorNudgesCarry,
     ...actionCountsCarry,
   };
 };

--- a/src/application/flows/implement/leaves/generator.ts
+++ b/src/application/flows/implement/leaves/generator.ts
@@ -20,6 +20,7 @@ import type { AiSignal, HarnessSignal, LearningEntry } from '@src/domain/signal.
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { PublishSignal } from '@src/application/flows/_shared/publish-signal.ts';
 import { buildImplementPrompt } from '@src/integration/ai/prompts/implement/definition.ts';
 import { buildImplementContinuationPrompt } from '@src/integration/ai/prompts/implement-continuation/definition.ts';
@@ -45,6 +46,7 @@ import {
   writeRoundPrompt,
 } from '@src/application/flows/implement/leaves/round-artifacts.ts';
 import { capProgressBody, progressCapBudgetForModel } from '@src/application/flows/_shared/progress/cap-progress.ts';
+import { composeProjectTooling } from '@src/application/flows/implement/leaves/_shared/compose-project-tooling.ts';
 import {
   formatPreVerifyResults,
   formatRetryFeedback,
@@ -107,12 +109,28 @@ export interface GeneratorLeafDeps {
   /** Optional reasoning / effort level forwarded into every `implementSession` AiSession. */
   readonly effort?: string;
   /**
-   * Pre-composed "## Agent Definition" prompt section (raw content, not yet rendered) — see
+   * Pre-composed bound-agent-definition prompt body (raw content — `renderAgentDefinitionSection`
+   * wraps it under the "## Agent Definition" heading at render time) — see
    * `GenEvalLoopRoleConfig.agentDefinitionSection`. Threaded into the FULL implement prompt's
    * `agentDefinition` slot only (round 1 of a session thread); a resumed continuation already
    * carries it in-conversation, matching {@link priorLearnings}'s rule.
    */
   readonly agentDefinition?: string;
+  /**
+   * This role's bound agent-definition NAME (the portable-agents feature's bare identifier, not
+   * the rendered {@link agentDefinition} section) — threaded separately so the FULL prompt's
+   * `{{PROJECT_TOOLING}}` catalog can name the same binding `{{AGENT_DEFINITION_SECTION}}`
+   * already announces, without re-parsing the rendered prose. Absent when the role has no
+   * binding. See `compose-project-tooling.ts`.
+   */
+  readonly agentDefinitionName?: string;
+  /**
+   * Per-flow skill catalog port — the same source `installSkillsLeaf` reads to install this
+   * task's skills into the session sandbox. Read again here (best-effort) to name each installed
+   * skill in the FULL prompt's `{{PROJECT_TOOLING}}` catalog (round 1 of a session thread only).
+   * Absent → the catalog simply omits the skills lines.
+   */
+  readonly skillSource?: SkillSource;
   readonly verifyScript?: string;
   readonly clock: () => IsoTimestamp;
   readonly logger: Logger;
@@ -312,10 +330,38 @@ const isPlateauBreakAttempt = (task: InProgressTask): boolean => {
  *  - the `<pre_verify_results>` / `<retry_feedback>` verify blocks — already composed by the leaf
  *    (best-effort log reads) and passed in as `preVerifyOutput` / `retryFeedback`.
  */
+
+/**
+ * Resolve the FULL prompt's `{{PROJECT_TOOLING}}` carry (round 1 of a session thread only — the
+ * continuation prompt does not declare the placeholder, mirroring `agentDefinition`'s
+ * full-prompt-only rule). Returns the ready-to-spread `{ projectTooling }` fragment (or `{}` when
+ * there is nothing to name) so the caller stays a flat, branch-free spread — matching the shape
+ * of every other `*Carry` in {@link buildGeneratorPrompt}. Best-effort: a skill-source read
+ * failure degrades to naming only the bound agent definition (or to nothing at all) rather than
+ * failing the turn — tooling-catalog enrichment must never block a generator round.
+ */
+const resolveGeneratorProjectToolingCarry = async (
+  deps: Pick<GeneratorLeafDeps, 'agentDefinitionName' | 'skillSource'>
+): Promise<{ readonly projectTooling?: string }> => {
+  const skills = deps.skillSource !== undefined ? await deps.skillSource.getForFlow('implement') : undefined;
+  const projectTooling = composeProjectTooling({
+    ...(deps.agentDefinitionName !== undefined ? { agentDefinitionName: deps.agentDefinitionName } : {}),
+    ...(skills?.ok === true ? { skills: skills.value } : {}),
+  });
+  return projectTooling.length > 0 ? { projectTooling } : {};
+};
+
 const buildGeneratorPrompt = async (
   deps: Pick<
     GeneratorLeafDeps,
-    'templateLoader' | 'cwd' | 'progressFile' | 'verifyScript' | 'model' | 'agentDefinition'
+    | 'templateLoader'
+    | 'cwd'
+    | 'progressFile'
+    | 'verifyScript'
+    | 'model'
+    | 'agentDefinition'
+    | 'agentDefinitionName'
+    | 'skillSource'
   >,
   args: {
     readonly task: InProgressTask;
@@ -375,6 +421,7 @@ const buildGeneratorPrompt = async (
   const agentDefinitionCarry = deps.agentDefinition !== undefined ? { agentDefinition: deps.agentDefinition } : {};
 
   if (args.priorGeneratorSessionId === undefined) {
+    const projectToolingCarry = await resolveGeneratorProjectToolingCarry(deps);
     return buildImplementPrompt(deps.templateLoader, {
       task: args.task,
       projectPath: String(deps.cwd),
@@ -383,6 +430,7 @@ const buildGeneratorPrompt = async (
       priorProgress,
       outputContractSection: args.outputContractSection,
       ...(deps.verifyScript !== undefined ? { verifyScript: deps.verifyScript } : {}),
+      ...projectToolingCarry,
       ...(priorCritique !== undefined ? { priorCritique } : {}),
       ...(plateauBreak ? { plateauBreak: true } : {}),
       ...trajectoryCarry,

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -247,6 +247,19 @@ export const terminalTaskStatus = (ctx: ImplementCtx, taskId: TaskId): boolean =
   return task.status === 'done' || task.status === 'blocked';
 };
 
+/**
+ * Fold a role's already-resolved bound agent-definition NAME onto its `GenEvalLoopRoleConfig` —
+ * the same `AgentDefinition` {@link buildAgentDefinitionInstallLeaves} installs, read again here
+ * so the FULL prompt's `{{PROJECT_TOOLING}}` catalog can name the same binding
+ * `agentDefinitionSection` already announces in prose. A no-op (returns `role` unchanged) when
+ * the role has no binding. Split out of `createPerTaskSubchain` so this call site's extra branch
+ * doesn't grow that function's own complexity budget.
+ */
+const withAgentDefinitionName = (
+  role: GenEvalLoopRoleConfig,
+  definition: AgentDefinition | undefined
+): GenEvalLoopRoleConfig => (definition !== undefined ? { ...role, agentDefinitionName: definition.name } : role);
+
 export const createPerTaskSubchain = (
   deps: ImplementDeps,
   opts: PerTaskSubchainOpts,
@@ -359,6 +372,9 @@ export const createPerTaskSubchain = (
                 templateLoader: deps.templateLoader,
                 publishSignal: deps.publishSignal,
                 writeFile: deps.writeFile,
+                // Threaded so the FULL prompt's `{{PROJECT_TOOLING}}` catalog can name this
+                // task's installed skills — the same source `installSkillsLeaf` above reads.
+                skillSource: deps.skillSource,
                 gitRunner: deps.gitRunner,
                 clock: deps.clock,
                 logger: deps.logger,
@@ -373,8 +389,11 @@ export const createPerTaskSubchain = (
                 sprintDir: opts.sprintDir,
                 progressFile: opts.progressFile,
                 ...(repo.verifyScript !== undefined ? { verifyScript: repo.verifyScript } : {}),
-                generator: opts.generator,
-                evaluator: opts.evaluator,
+                // Fold in each role's bound agent-definition NAME (already resolved for the
+                // install/uninstall leaves above) so `{{PROJECT_TOOLING}}` names the same
+                // binding `{{AGENT_DEFINITION_SECTION}}` already announces in prose.
+                generator: withAgentDefinitionName(opts.generator, opts.generatorAgentDefinition),
+                evaluator: withAgentDefinitionName(opts.evaluator, opts.evaluatorAgentDefinition),
               },
               taskId
             ),

--- a/src/application/flows/implement/leaves/progress-journal.ts
+++ b/src/application/flows/implement/leaves/progress-journal.ts
@@ -82,6 +82,12 @@ interface JournalInput {
   readonly decisions: readonly string[];
   readonly learnings: readonly LearningEntry[];
   readonly notes: readonly string[];
+  /**
+   * Per-attempt corrective-nudge tally (generator + evaluator), present only when at least one
+   * nudge fired this attempt — zero-noise on the well-formed path. See
+   * `ImplementCtx.currentAttemptGeneratorNudges` for the full rationale.
+   */
+  readonly correctiveNudges?: { readonly generator: number; readonly evaluator: number };
   /** Canonical sprint identity + lifecycle, for the derived state header. Undefined → identity is preserved from the file. */
   readonly sprint?: Sprint | undefined;
   /** Branch / PR url for the derived state header. */
@@ -267,6 +273,7 @@ const buildAttemptSection = (input: JournalInput, totalRounds: number, clock: ()
     learnings: input.learnings,
     notes: input.notes,
     ...(attempt?.commitSha !== undefined ? { commitSha: String(attempt.commitSha) } : {}),
+    ...(input.correctiveNudges !== undefined ? { correctiveNudges: input.correctiveNudges } : {}),
     timestamp: clock(),
   });
 };
@@ -368,6 +375,14 @@ export const progressJournalLeaf = (
         });
       }
       const roundN = ctx.currentRoundNum ?? task.attempts.length;
+      // Zero-noise gate: only surface the tally when at least one nudge fired this attempt — a
+      // well-formed attempt renders no additional line.
+      const generatorNudges = ctx.currentAttemptGeneratorNudges ?? 0;
+      const evaluatorNudges = ctx.currentAttemptEvaluatorNudges ?? 0;
+      const correctiveNudgesCarry =
+        generatorNudges + evaluatorNudges > 0
+          ? { correctiveNudges: { generator: generatorNudges, evaluator: evaluatorNudges } }
+          : {};
       return {
         progressFile: opts.progressFile,
         task,
@@ -379,21 +394,25 @@ export const progressJournalLeaf = (
         sprint: ctx.sprint,
         execution: ctx.execution,
         allTasks,
+        ...correctiveNudgesCarry,
       };
     },
-    // settle-attempt clears its own per-attempt fields but leaves the signal accumulators for
-    // us to read. We clear all four here so the next ATTEMPT (and the next task) starts with
-    // empty accumulators. This is the per-attempt reset boundary: the journal leaf is the LAST
-    // element of the attempt-body sequential and runs UNCONDITIONALLY on every loop iteration —
-    // including a red-post-verify retry (T6) where the task settled `in_progress`. So a retried
-    // attempt never inherits the REJECTED attempt's change/learning/note hints; the next
-    // generator turn (and the evaluator hints derived from these accumulators) sees only its own
-    // attempt's signals, not the prior failed attempt's leftovers.
+    // settle-attempt clears its own per-attempt fields but leaves the signal accumulators (and the
+    // corrective-nudge tallies) for us to read. We clear all six here so the next ATTEMPT (and the
+    // next task) starts with empty accumulators. This is the per-attempt reset boundary: the
+    // journal leaf is the LAST element of the attempt-body sequential and runs UNCONDITIONALLY on
+    // every loop iteration — including a red-post-verify retry (T6) where the task settled
+    // `in_progress`. So a retried attempt never inherits the REJECTED attempt's change/learning/
+    // note hints (or nudge tally); the next generator turn (and the evaluator hints derived from
+    // these accumulators) sees only its own attempt's signals, not the prior failed attempt's
+    // leftovers.
     output: (ctx) => ({
       ...ctx,
       currentAttemptDecisions: undefined,
       currentAttemptChanges: undefined,
       currentAttemptLearnings: undefined,
       currentAttemptNotes: undefined,
+      currentAttemptGeneratorNudges: undefined,
+      currentAttemptEvaluatorNudges: undefined,
     }),
   });

--- a/src/application/flows/implement/leaves/progress-journal.ts
+++ b/src/application/flows/implement/leaves/progress-journal.ts
@@ -152,7 +152,11 @@ const toJournalWarning = (warning: AttemptWarning): JournalWarning => {
     case 'budget-exhausted':
       return { kind: 'budget-exhausted', turnsUsed: warning.turnsUsed, turnBudget: warning.turnBudget };
     case 'plateau':
-      return { kind: 'plateau', dimensions: warning.dimensions };
+      return {
+        kind: 'plateau',
+        dimensions: warning.dimensions,
+        ...(warning.source !== undefined ? { source: warning.source } : {}),
+      };
     case 'malformed':
       return { kind: 'malformed', detail: warning.detail };
     case 'verify-failed': {

--- a/src/application/flows/implement/merge-wave.ts
+++ b/src/application/flows/implement/merge-wave.ts
@@ -76,6 +76,9 @@ const _exhaustive = {
   currentAttemptChanges: SIGNAL_ACCUM,
   currentAttemptLearnings: SIGNAL_ACCUM,
   currentAttemptNotes: SIGNAL_ACCUM,
+  // Corrective-nudge tallies — same per-attempt lifecycle as the signal accumulators above.
+  currentAttemptGeneratorNudges: SIGNAL_ACCUM,
+  currentAttemptEvaluatorNudges: SIGNAL_ACCUM,
 } satisfies Record<keyof ImplementCtx, MergeClass>;
 
 // Reference the guard so it is not dead-code-eliminated / lint-flagged; its whole purpose is the

--- a/src/application/ui/cli/bootstrap.ts
+++ b/src/application/ui/cli/bootstrap.ts
@@ -19,6 +19,7 @@ import {
 } from '@src/application/bootstrap/storage-paths.ts';
 import { detectLegacyLayout, renderLegacyLayoutMessage } from '@src/application/bootstrap/legacy-layout-detector.ts';
 import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
+import { runBundleIntegrityCheck } from '@src/application/bootstrap/run-bundle-integrity-check.ts';
 
 export interface CliBootstrap {
   readonly deps: AppDeps;
@@ -57,5 +58,10 @@ export const bootstrapCli = async (): Promise<CliBootstrap> => {
   if (!settings.ok) throw new Error(`settings: ${settings.error.message}`);
 
   const deps = wire({ storage: paths.value, settings: settings.value });
+
+  // Runs once per process: a CLI invocation is one subcommand per process, and `bootstrapCli`
+  // is called exactly once per invocation. See run-bundle-integrity-check.ts for the full story.
+  await runBundleIntegrityCheck(deps.logger);
+
   return { deps, storage: paths.value };
 };

--- a/src/application/ui/cli/cli.ts
+++ b/src/application/ui/cli/cli.ts
@@ -14,6 +14,7 @@ import { registerTicketCommand } from '@src/application/ui/cli/commands/ticket.t
 import { registerTaskCommand } from '@src/application/ui/cli/commands/task.ts';
 import { registerRunsCommand } from '@src/application/ui/cli/commands/runs.ts';
 import { registerAgentsCommand } from '@src/application/ui/cli/commands/agents.ts';
+import { registerSkillsCommand } from '@src/application/ui/cli/commands/skills.ts';
 import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
 
 /**
@@ -103,6 +104,7 @@ export const runCli = async (argv: readonly string[]): Promise<void> => {
   registerTaskCommand(program);
   registerRunsCommand(program);
   registerAgentsCommand(program);
+  registerSkillsCommand(program);
 
   await program.parseAsync([...argv]);
 };

--- a/src/application/ui/cli/commands/create-pr.ts
+++ b/src/application/ui/cli/commands/create-pr.ts
@@ -2,10 +2,16 @@ import type { Command } from 'commander';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { resolveSprintDir } from '@src/integration/persistence/storage.ts';
 import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
+import type { CreatePrCtx } from '@src/application/flows/create-pr/ctx.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
+import { createSkillsAdapter } from '@src/integration/ai/skills/adapter-factory.ts';
+import { buildComposedSkillSource } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
 import { pinFallbackNotice, resolveSprintId } from '@src/application/ui/cli/resolve-sprint-selection.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
+import type { Element } from '@src/application/chain/element.ts';
 
 interface Opts {
   readonly sprint?: string;
@@ -16,6 +22,53 @@ interface Opts {
   readonly body?: string;
   readonly ai: boolean;
 }
+
+/**
+ * Build the createPr provider + composed skill source + flow. Extracted from the command action
+ * to keep it under the per-function line budget. The skill source is composed directly (not via
+ * `launchFlow` — this command never reaches that dispatch, see `flowMountsSkills`'s doc comment)
+ * with a project-less snapshot: a one-shot PR-summary spawn over an already-pushed diff has no
+ * use for the project-scoped (detect-skills) source.
+ */
+const buildCreatePrFlow = (deps: AppDeps, storage: StoragePaths, useAi: boolean): Element<CreatePrCtx> => {
+  // Rebuild the provider from the `createPr` settings row — `deps.provider` is wired from the
+  // `implement` row at boot, which mismatches the createPr model in a mixed-provider config.
+  const resolvedProvider = deps.settings.ai.createPr.provider;
+  const provider = createAiProvider({
+    flow: 'createPr',
+    ai: deps.settings.ai,
+    harnessConfig: deps.settings.harness,
+    eventBus: deps.eventBus,
+  });
+  const skillSource = buildComposedSkillSource(
+    { app: deps, storage },
+    {},
+    resolvedProvider,
+    'create-pr',
+    deps.settings,
+    {}
+  );
+  const skillsAdapter = createSkillsAdapter({ provider: resolvedProvider, logger: deps.logger });
+  return createCreatePrFlow(
+    {
+      sprintRepo: deps.sprintRepo,
+      sprintExecutionRepo: deps.sprintExecutionRepo,
+      taskRepo: deps.taskRepo,
+      pullRequestCreator: deps.pullRequestCreator,
+      gitRunner: deps.gitRunner,
+      eventBus: deps.eventBus,
+      clock: deps.clock,
+      provider,
+      templateLoader: deps.templateLoader,
+      writeFile: deps.writeFile,
+      logger: deps.logger,
+      model: deps.settings.ai.createPr.model,
+      skillSource,
+      skillsAdapter,
+    },
+    { useAi }
+  );
+};
 
 /**
  * Register the `create-pr` CLI command.
@@ -88,31 +141,7 @@ export const registerCreatePrCommand = (program: Command): void => {
         process.exitCode = 1;
         return;
       }
-      // Rebuild the provider from the `createPr` settings row — `deps.provider` is wired from the
-      // `implement` row at boot, which mismatches the createPr model in a mixed-provider config.
-      const provider = createAiProvider({
-        flow: 'createPr',
-        ai: deps.settings.ai,
-        harnessConfig: deps.settings.harness,
-        eventBus: deps.eventBus,
-      });
-      const flow = createCreatePrFlow(
-        {
-          sprintRepo: deps.sprintRepo,
-          sprintExecutionRepo: deps.sprintExecutionRepo,
-          taskRepo: deps.taskRepo,
-          pullRequestCreator: deps.pullRequestCreator,
-          gitRunner: deps.gitRunner,
-          eventBus: deps.eventBus,
-          clock: deps.clock,
-          provider,
-          templateLoader: deps.templateLoader,
-          writeFile: deps.writeFile,
-          logger: deps.logger,
-          model: deps.settings.ai.createPr.model,
-        },
-        { useAi: opts.ai }
-      );
+      const flow = buildCreatePrFlow(deps, storage, opts.ai);
       const result = await flow.execute({
         input: {
           sprintId,

--- a/src/application/ui/cli/commands/skills.ts
+++ b/src/application/ui/cli/commands/skills.ts
@@ -1,0 +1,131 @@
+import type { Command } from 'commander';
+import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { SKILL_MOUNTING_FLOW_IDS } from '@src/application/ui/shared/launcher.ts';
+import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
+import type { SkillCatalogEntry, SkillInstallStatus } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import type { AiSkillsSettings } from '@src/domain/entity/settings.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+
+/** Resolve a flow's saved opt-out set (`settings.ai.skills.<flow>.disabled`), `undefined`-safe. */
+const savedDisabledFrom = (skills: AiSkillsSettings | undefined): ((flowId: FlowId) => ReadonlySet<string>) => {
+  const byFlow = new Map<FlowId, ReadonlySet<string>>();
+  for (const flowId of FLOW_IDS) byFlow.set(flowId, new Set(skills?.[flowId]?.disabled ?? []));
+  return (flowId) => byFlow.get(flowId) ?? new Set();
+};
+
+/**
+ * Flows where `entry` will actually load on the next run: `defaultFor` minus any saved
+ * opt-out, plus any mounting flow carrying a live (non-`broken`) opt-in phase-folder copy.
+ * Mirrors the decision tree in the TUI catalog's `flowChipVisual` (same module) without the
+ * Ink chip rendering.
+ */
+const enabledFlowsFor = (
+  entry: SkillCatalogEntry,
+  savedDisabled: (flowId: FlowId) => ReadonlySet<string>
+): readonly FlowId[] =>
+  SKILL_MOUNTING_FLOW_IDS.filter((flowId) => {
+    if (entry.defaultFor.includes(flowId)) return !savedDisabled(flowId).has(entry.name);
+    const install = entry.installs.find((i) => i.flow === flowId);
+    return install !== undefined && install.status !== 'broken';
+  });
+
+/**
+ * Worst-first severity rank for one {@link SkillInstallStatus} — a `Record` over the full union
+ * so adding a 6th status without a rank here fails typecheck instead of silently sorting it
+ * last. `in-sync` outranks `manual` only to preserve the exact precedence the original
+ * `Set.has` fallthrough used; the two never actually co-occur on one entry (a bundled entry's
+ * installs are never `manual`, a hand-dropped entry's installs are always `manual`).
+ */
+const PROVENANCE_RANK: Record<SkillInstallStatus, number> = {
+  'locally-modified': 5,
+  broken: 4,
+  'update-available': 3,
+  'in-sync': 2,
+  manual: 1,
+};
+
+/** One-line label for a single install's status — mirrors the TUI's `statusVisual` switch. */
+const provenanceLabel = (status: SkillInstallStatus): string => {
+  switch (status) {
+    case 'locally-modified':
+      return 'locally modified';
+    case 'broken':
+      return 'broken copy';
+    case 'update-available':
+      return 'update available';
+    case 'in-sync':
+      return 'in sync';
+    case 'manual':
+      return 'manual';
+  }
+};
+
+/**
+ * Provenance/staleness summary across every install of `entry`, worst-first so a
+ * locally-modified or broken copy is never masked by a merely update-available sibling. `-` is
+ * reserved for the no-install case — the common shape for a skill that only ever loads via
+ * `defaultFor` (default loading never goes through the phase folder, so it has no install to
+ * report on).
+ */
+const provenanceFor = (entry: SkillCatalogEntry): string => {
+  if (entry.installs.length === 0) return '-';
+  const worst = entry.installs.reduce((acc, i) => (PROVENANCE_RANK[i.status] > PROVENANCE_RANK[acc.status] ? i : acc));
+  return provenanceLabel(worst.status);
+};
+
+const formatSkillLine = (
+  entry: SkillCatalogEntry,
+  bundledNames: ReadonlySet<string>,
+  savedDisabled: (flowId: FlowId) => ReadonlySet<string>
+): string => {
+  const tier = bundledNames.has(entry.name) ? 'bundled' : 'manual';
+  const flowsLabel = enabledFlowsFor(entry, savedDisabled).join(', ') || '-';
+  const provenance = provenanceFor(entry);
+  return `${entry.name.padEnd(38)}  ${tier.padEnd(8)}  flows: ${flowsLabel.padEnd(44)}  ${provenance.padEnd(18)}  ${entry.description}`;
+};
+
+/**
+ * Register the `skills` command group.
+ *
+ *   ralphctl skills list
+ *
+ * Operator-facing catalog of the bundled skills available to opt in per flow, plus any
+ * hand-dropped ("manual") phase-folder skill the operator installed directly. Mirrors
+ * `ralphctl agents list` — the CLI-only inspection surface for a catalog the TUI otherwise
+ * manages interactively (`Skills` view, hotkey `K`). "Enabled flows" already folds in saved
+ * `settings.ai.skills` opt-outs so the column reflects what actually loads next, not just the
+ * registry defaults.
+ */
+export const registerSkillsCommand = (program: Command): void => {
+  const skills = program.command('skills').description('inspect the bundled skill catalog');
+
+  skills
+    .command('list')
+    .description('list bundled + manually-dropped skills, their tier, enabled flows, and provenance')
+    .action(async () => {
+      const { deps } = await bootstrapCli();
+
+      const catalogR = await deps.skillCatalog.list();
+      if (!catalogR.ok) {
+        process.stderr.write(`error: ${catalogR.error.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (catalogR.value.length === 0) {
+        process.stdout.write('(no skills bundled)\n');
+        return;
+      }
+
+      // A settings read failure is non-fatal here, mirroring the TUI catalog's posture — the
+      // listing still renders, opt-out nuance is just lost (every default reads as enabled).
+      const settingsR = await deps.settingsRepo.load();
+      const savedDisabled = savedDisabledFrom(settingsR.ok ? settingsR.value.ai.skills : undefined);
+      const bundledNames = new Set(BUNDLED_SKILLS.map((e) => e.name));
+
+      const sorted = [...catalogR.value].sort((a, b) => a.name.localeCompare(b.name));
+      for (const entry of sorted) {
+        process.stdout.write(`${formatSkillLine(entry, bundledNames, savedDisabled)}\n`);
+      }
+    });
+};

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -26,13 +26,13 @@ import type { AppStateSnapshot } from '@src/application/ui/shared/state-snapshot
 import type { RepositoryId } from '@src/domain/value/id/repository-id.ts';
 import { composeSkillSources, createProjectSkillSource } from '@src/integration/ai/skills/project/source.ts';
 import { createOperatorSkillSource } from '@src/integration/ai/skills/operator/source.ts';
-import { createPhaseSkillSource } from '@src/integration/ai/skills/phase/source.ts';
+import { createPhaseSkillSource, PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
 import { createResolvedSkillSource } from '@src/integration/ai/skills/_engine/resolve-selection.ts';
 import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import { warnIfContractViolated as checkContract } from '@src/integration/ai/skills/_engine/skill-contract-checker.ts';
 import { type AiFlowSettings, type AiProvider, primaryFlowRow, type Settings } from '@src/domain/entity/settings.ts';
-import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
 import { resolveEffort } from '@src/business/settings/resolve-effort.ts';
 import type { RunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
 import type { LaunchContext } from '@src/application/ui/shared/launch/context.ts';
@@ -295,6 +295,20 @@ const aiFlowIdFor = (flowId: string): FlowId | undefined => {
  */
 export const flowMountsSkills = (flowId: string): boolean =>
   flowId === 'refine' || flowId === 'plan' || flowId === 'implement' || flowId === 'readiness' || flowId === 'ideate';
+
+/**
+ * Every {@link FlowId} whose launch context actually mounts a skill source, derived from
+ * {@link flowMountsSkills} (the single source of truth) keyed back to `FlowId` via
+ * {@link PHASE_FLOW_DIR}. Shared by the TUI skill catalog (row chips — see
+ * `ui/tui/views/skills-view-internals/flow-visual.ts`) and `ralphctl skills list` (the
+ * "enabled flows" column) so the two surfaces can never drift on which flows a skill can
+ * actually load into.
+ *
+ * @public
+ */
+export const SKILL_MOUNTING_FLOW_IDS: readonly FlowId[] = FLOW_IDS.filter((flowId) =>
+  flowMountsSkills(PHASE_FLOW_DIR[flowId])
+);
 
 /**
  * Per-field merge of `override` onto an `AiFlowSettings` row. Each field of the override is

--- a/src/application/ui/shared/launcher.ts
+++ b/src/application/ui/shared/launcher.ts
@@ -200,6 +200,16 @@ export interface LauncherDeps {
   readonly runInTerminal: RunInTerminal;
 }
 
+/**
+ * The subset of {@link LauncherDeps} that skill-source composition actually reads — narrower
+ * than the full bag so a caller with no `InteractivePrompt` / `RunInTerminal` (a one-shot CLI
+ * command, or a TUI view that never pauses the host) can compose a skill source without
+ * inventing ports it never uses. A full `LauncherDeps` object still satisfies this structurally.
+ *
+ * @public
+ */
+export type SkillCompositionDeps = Pick<LauncherDeps, 'app' | 'storage'>;
+
 const sessionId = (): string => `r-${Math.random().toString(36).slice(2, 10)}-${String(Date.now())}`;
 
 /** The `ok: true` branch of {@link LaunchResult} — the shape {@link sessionHintsFromLaunchResult} reads. */
@@ -283,18 +293,29 @@ const aiFlowIdFor = (flowId: string): FlowId | undefined => {
 };
 
 /**
- * Flows whose launch context actually threads `ctx.skillSource` into the dispatched use case
- * (see each `launch/<flow>.ts`) — the only flows where a per-run skills customization has any
- * effect. `review` / `detect-scripts` / `detect-skills` reuse another flow's AI row via
- * {@link aiFlowIdFor} but their own launchers never read `ctx.skillSource`, so a skills override
- * for them would silently no-op; `create-pr` never reaches the chain launcher at all (routed to
- * its own view). The customize picker's skills step is skipped entirely for a flow this returns
- * `false` for, rather than presenting a checklist that wouldn't do anything.
+ * Flows whose AI session actually gets a composed skill source installed — the only flows
+ * where a per-run skills customization has any effect. `review` / `detect-scripts` /
+ * `detect-skills` reuse another flow's AI row via {@link aiFlowIdFor} but their own launchers
+ * never read `ctx.skillSource`, so a skills override for them would silently no-op.
+ *
+ * `create-pr` mounts skills too, but never reaches `launchFlow`'s dispatch switch — it's routed
+ * to its own view (`create-pr-view.tsx`) and its own CLI command, each calling
+ * {@link buildComposedSkillSource} directly around the `generate-pr-content` leaf. It therefore
+ * has no customize-picker skills step (no per-run checklist / opt-out UI); it always installs
+ * the settings/registry-resolved default set for the `createPr` row.
+ *
+ * The customize picker's skills step is skipped entirely for a flow this returns `false` for,
+ * rather than presenting a checklist that wouldn't do anything.
  *
  * @public
  */
 export const flowMountsSkills = (flowId: string): boolean =>
-  flowId === 'refine' || flowId === 'plan' || flowId === 'implement' || flowId === 'readiness' || flowId === 'ideate';
+  flowId === 'refine' ||
+  flowId === 'plan' ||
+  flowId === 'implement' ||
+  flowId === 'readiness' ||
+  flowId === 'ideate' ||
+  flowId === 'create-pr';
 
 /**
  * Every {@link FlowId} whose launch context actually mounts a skill source, derived from
@@ -447,8 +468,8 @@ const buildLaunchAdapters = (deps: LauncherDeps, flowId: string, settings: Setti
  * source that actually gets installed).
  */
 const buildSkillSourceQuad = (
-  deps: LauncherDeps,
-  snapshot: AppStateSnapshot,
+  deps: SkillCompositionDeps,
+  snapshot: Pick<AppStateSnapshot, 'project'>,
   resolvedProvider: AiProvider,
   warnIfContractViolated?: (skill: Skill) => void
 ): {
@@ -497,8 +518,8 @@ const buildSkillSourceQuad = (
  * @public
  */
 export const buildComposedSkillSource = (
-  deps: LauncherDeps,
-  snapshot: AppStateSnapshot,
+  deps: SkillCompositionDeps,
+  snapshot: Pick<AppStateSnapshot, 'project'>,
   resolvedProvider: AiProvider,
   flowId: string,
   settings: Settings,
@@ -565,8 +586,8 @@ export interface SkillCandidatesResult {
  * @public
  */
 export const buildSkillCandidates = async (
-  deps: LauncherDeps,
-  snapshot: AppStateSnapshot,
+  deps: SkillCompositionDeps,
+  snapshot: Pick<AppStateSnapshot, 'project'>,
   flowId: string,
   settings: Settings,
   providerOverride?: AiProvider

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -156,6 +156,14 @@ export interface TasksPanelProps {
    * the panel is fully self-contained (existing callers are unaffected).
    */
   readonly onFocusedCardChange?: (taskId: string | undefined) => void;
+  /**
+   * Optional callback fired when the focused card's expansion state changes (deduplicated —
+   * only called when the boolean value differs from the previous call). The wide-layout
+   * `ImplementMainArea` uses this to claim the `esc` keystroke (via `useUiState().claimEscape()`)
+   * while an expanded card is focused, so pressing Esc collapses the card instead of popping the
+   * route. Absent ⇒ the panel is fully self-contained (existing callers are unaffected).
+   */
+  readonly onExpandedCardChange?: (expanded: boolean) => void;
 }
 
 interface TaskCardState {
@@ -179,7 +187,8 @@ interface TaskCardState {
  */
 const useTaskCardState = (
   bucketed: BucketedExecution,
-  onFocusedCardChange: ((taskId: string | undefined) => void) | undefined
+  onFocusedCardChange: ((taskId: string | undefined) => void) | undefined,
+  onExpandedCardChange: ((expanded: boolean) => void) | undefined
 ): TaskCardState => {
   // The active (first non-completed) task — anchor for the `e` criteria hotkey AND the
   // default card-cursor position. Recomputed each render so the `useInput` callback always
@@ -258,6 +267,23 @@ const useTaskCardState = (
     }
   });
 
+  // Report the focused card's expansion state upward (Esc-claim seam). Same dedup + ref
+  // pattern as `onFocusedCardChange` above, with one deliberate difference: the "previous"
+  // ref seeds as `undefined` (not the current value) so the FIRST post-mount effect run always
+  // reports the mount-time state. The active task auto-expands from the lazy initial state (see
+  // above), so `focusedCardExpanded` is frequently already `true` on the very first render —
+  // seeding the ref with that same value (as `onFocusedCardChange` does) would suppress the one
+  // report the caller needs to claim `esc` before the operator's first keystroke.
+  const prevFocusedCardExpandedRef = useRef<boolean | undefined>(undefined);
+  const onExpandedCardChangeRef = useRef(onExpandedCardChange);
+  onExpandedCardChangeRef.current = onExpandedCardChange;
+  useEffect(() => {
+    if (focusedCardExpanded !== prevFocusedCardExpandedRef.current) {
+      prevFocusedCardExpandedRef.current = focusedCardExpanded;
+      onExpandedCardChangeRef.current?.(focusedCardExpanded);
+    }
+  });
+
   return {
     activeTaskIdx,
     activeTaskId,
@@ -303,7 +329,14 @@ type TaskBlockProps = React.ComponentProps<typeof TaskBlock>;
  */
 type TaskRowProps = Omit<
   TasksPanelProps,
-  'bucketed' | 'maxSignalsPerTask' | 'maxTasks' | 'maxOrphanSignals' | 'inputActive' | 'nowMs' | 'onFocusedCardChange'
+  | 'bucketed'
+  | 'maxSignalsPerTask'
+  | 'maxTasks'
+  | 'maxOrphanSignals'
+  | 'inputActive'
+  | 'nowMs'
+  | 'onFocusedCardChange'
+  | 'onExpandedCardChange'
 >;
 
 /**
@@ -411,6 +444,7 @@ export const TasksPanel = ({
   inputActive = false,
   nowMs,
   onFocusedCardChange,
+  onExpandedCardChange,
   ...rest
 }: TasksPanelProps): React.JSX.Element => {
   // Render-time fallback for the idle-ticker clock. The execute view passes a polled `now` so
@@ -439,7 +473,7 @@ export const TasksPanel = ({
   // Card-cursor / expansion state — see `useTaskCardState`. Spread wholesale below (into both
   // `useTasksPanelInput` and `derived`) rather than destructured field-by-field so this
   // orchestrator stays a thin threading layer instead of re-enumerating the cluster's shape.
-  const cardState = useTaskCardState(bucketed, onFocusedCardChange);
+  const cardState = useTaskCardState(bucketed, onFocusedCardChange, onExpandedCardChange);
 
   const focusedIndex = focusedKey !== undefined ? flatKeys.indexOf(focusedKey) : -1;
   const effectiveFocusedKey = focusedIndex >= 0 ? focusedKey : undefined;

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -42,6 +42,7 @@ import { startHeapWatchdog } from '@src/integration/observability/heap-watchdog.
 import { writeHeapSnapshotToDir } from '@src/integration/observability/heap-snapshot.ts';
 import { createOsNotificationDispatcher } from '@src/integration/observability/os-notification-dispatcher.ts';
 import { startNotificationSubscriber } from '@src/business/observability/notification-subscriber.ts';
+import { runBundleIntegrityCheck } from '@src/application/bootstrap/run-bundle-integrity-check.ts';
 
 interface Bootstrapped {
   readonly app: Parameters<typeof App>[0];
@@ -271,6 +272,12 @@ const bootstrap = async (): Promise<Bootstrapped> => {
   const logBus = createBusSink<LogEvent>({ maxEntries: 2000 });
 
   const deps = wire({ storage: paths.value, settings: settings.value });
+
+  // Runs once per process: `launchTui` is the single bare-`ralphctl` entry point and `bootstrap`
+  // runs exactly once per invocation. A hard failure throws here and is caught by `launchTui`
+  // below, which renders it as a one-line stderr message instead of a raw stack trace. See
+  // run-bundle-integrity-check.ts for the full story.
+  await runBundleIntegrityCheck(deps.logger);
 
   // Forward EventBus 'ai-signal' events into the TUI's harness bus. See createSignalForwarder
   // for the full rationale.

--- a/src/application/ui/tui/views/create-pr-view.tsx
+++ b/src/application/ui/tui/views/create-pr-view.tsx
@@ -22,6 +22,8 @@ import { HelpOverlay } from '@src/application/ui/tui/components/help-overlay.tsx
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { createCreatePrFlow } from '@src/application/flows/create-pr/flow.ts';
 import { createAiProvider } from '@src/application/bootstrap/provider-factory.ts';
+import { createSkillsAdapter } from '@src/integration/ai/skills/adapter-factory.ts';
+import { buildComposedSkillSource } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 import { resolveSprintDir } from '@src/integration/persistence/storage.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
@@ -197,15 +199,32 @@ interface ExecuteCreatePrFlowArgs {
  * row) — in a mixed-provider config that would hand the createPr model string to the implement
  * provider's CLI, a provider/model mismatch. The model is already sourced from
  * `ai.createPr.model`, so the provider must match it.
+ *
+ * The composed skill source is built directly via `buildComposedSkillSource` rather than through
+ * `launchFlow` — this view never reaches that dispatch switch (see `flowMountsSkills`'s doc
+ * comment). The snapshot is intentionally project-less: this is a one-shot summarisation step
+ * over an already-pushed diff, not a per-repo engineering session, so the project-scoped skill
+ * source (detect-skills output) contributes nothing here by design, and omitting it keeps this
+ * view's composition symmetric with the CLI command's (which has no project on hand either).
  */
 const executeCreatePrFlow = async (args: ExecuteCreatePrFlowArgs): Promise<RunState> => {
   const { deps, sprintId, sprintDir, cwd, useAi } = args;
+  const resolvedProvider = deps.settings.ai.createPr.provider;
   const provider = createAiProvider({
     flow: 'createPr',
     ai: deps.settings.ai,
     harnessConfig: deps.settings.harness,
     eventBus: deps.eventBus,
   });
+  const skillSource = buildComposedSkillSource(
+    { app: deps, storage: deps.storage },
+    {},
+    resolvedProvider,
+    'create-pr',
+    deps.settings,
+    {}
+  );
+  const skillsAdapter = createSkillsAdapter({ provider: resolvedProvider, logger: deps.logger });
   const flow = createCreatePrFlow(
     {
       sprintRepo: deps.sprintRepo,
@@ -220,6 +239,8 @@ const executeCreatePrFlow = async (args: ExecuteCreatePrFlowArgs): Promise<RunSt
       writeFile: deps.writeFile,
       logger: deps.logger,
       model: deps.settings.ai.createPr.model,
+      skillSource,
+      skillsAdapter,
     },
     { useAi }
   );

--- a/src/application/ui/tui/views/execute-view-internals/implement-main-area.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/implement-main-area.tsx
@@ -1,38 +1,46 @@
 /**
  * ImplementMainArea — the right-hand main pane of the redesigned Implement view (≥140 col
- * breakpoint). A thin typed wrapper over `TasksPanelHost`: it forwards every prop unchanged
- * (its `ImplementMainAreaProps` is an alias of `TasksPanelHostProps`) and exists only to give the
- * wide-layout main pane its own named seam.
+ * breakpoint). A thin typed wrapper over `TasksPanelHost` that forwards every prop unchanged
+ * (`ImplementMainAreaProps` omits only `onExpandedCardChange`, which this component owns) and
+ * exists only to give the wide-layout main pane its own named seam.
  *
  * Passive-minimap model (v0.7.0): the main-area cards are the sole input owner (via the forwarded
  * `inputActive`), and `onFocusedCardChange` is what `WideLayout` stores as `focusedTaskId` and
  * passes to `ImplementSidebar` so the sidebar highlights the focused card — no separate sidebar
  * cursor, no Tab toggle, no imperative handle.
+ *
+ * Esc-collapse-before-pop: while the focused card is expanded, this component claims `esc` via
+ * `useUiState().claimEscape()` so the global `router.pop()` (`use-global-keys.ts`) stands down
+ * and `TasksPanel`'s own `useInput` handler (`handleEscapeCollapse` in
+ * `tasks-panel-internals/keymap.ts`) collapses the card instead. The claim is released the
+ * instant the card collapses (or the focused card changes to a collapsed one) and on unmount —
+ * see the `useEffect` below, which mirrors the `claimEscape` usage in `sprint-detail-view.tsx`.
  */
 
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   TasksPanelHost,
   type TasksPanelHostProps,
 } from '@src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx';
+import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 
-export type ImplementMainAreaProps = TasksPanelHostProps;
+export type ImplementMainAreaProps = Omit<TasksPanelHostProps, 'onExpandedCardChange'>;
 
 /**
  * @public — main pane for the redesigned Implement view; wired by `implement-layout.tsx`.
  */
-export const ImplementMainArea = (props: ImplementMainAreaProps): React.JSX.Element | null => (
-  // TODO (REQ-3 Esc-collapse): While a focused card is expanded in the main panel, Esc should
-  // collapse it instead of popping the route. The correct wire-up:
-  //   - `TasksPanel` detects `focusedCardExpanded` (already computed at ~tasks-panel.tsx:237).
-  //   - Call `ui.claimEscape()` (from `useUiState()` in `ui-state-context.tsx`) when expanded,
-  //     release on collapse / unmount.
-  //   - `TasksPanel` is a generic component without TUI context; wiring requires either:
-  //     (a) threading `claimEscape`/`releaseEscape` callbacks from `ImplementMainArea` into
-  //         `TasksPanelHost` and then into `TasksPanel` (prop drilling), or
-  //     (b) a new `onExpandedCardChange` prop on `TasksPanel` so `ImplementMainArea` can call
-  //         `useUiState()` here and `claimEscape` / release based on that callback.
-  //   Option (b) is cleanest; it mirrors the `onFocusedCardChange` pattern already in place.
-  //   Deferred: the global Esc pops the route currently, which is acceptable but not ideal.
-  <TasksPanelHost {...props} />
-);
+export const ImplementMainArea = (props: ImplementMainAreaProps): React.JSX.Element | null => {
+  const ui = useUiState();
+  const claimEscape = ui.claimEscape;
+  const [focusedCardExpanded, setFocusedCardExpanded] = useState(false);
+  const onExpandedCardChange = useCallback((expanded: boolean) => {
+    setFocusedCardExpanded(expanded);
+  }, []);
+
+  // Claim `esc` while (and only while) the focused card is expanded. The effect's cleanup —
+  // run on every dep change AND on unmount — releases the claim, so toggling collapsed↔expanded
+  // repeatedly never double-claims or leaks a stale claim past this component's lifetime.
+  useEffect(() => (focusedCardExpanded ? claimEscape() : undefined), [focusedCardExpanded, claimEscape]);
+
+  return <TasksPanelHost {...props} onExpandedCardChange={onExpandedCardChange} />;
+};

--- a/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/tasks-panel-host.tsx
@@ -58,6 +58,8 @@ export interface TasksPanelHostProps {
   readonly taskState: readonly Task[] | undefined;
   /** Optional callback — fired (deduped) when the focused card id changes. See `TasksPanel`. */
   readonly onFocusedCardChange?: (taskId: string | undefined) => void;
+  /** Optional callback — fired (deduped) when the focused card's expansion state changes. See `TasksPanel`. */
+  readonly onExpandedCardChange?: (expanded: boolean) => void;
 }
 
 const TasksPanelHostImpl = ({
@@ -70,6 +72,7 @@ const TasksPanelHostImpl = ({
   now,
   taskState,
   onFocusedCardChange,
+  onExpandedCardChange,
 }: TasksPanelHostProps): React.JSX.Element | null => {
   const taskCriteriaById = useMemo<ReadonlyMap<string, readonly string[]> | undefined>(() => {
     if (taskState === undefined) return undefined;
@@ -185,6 +188,7 @@ const TasksPanelHostImpl = ({
       inputActive={inputActive}
       nowMs={now}
       {...(onFocusedCardChange !== undefined ? { onFocusedCardChange } : {})}
+      {...(onExpandedCardChange !== undefined ? { onExpandedCardChange } : {})}
       {...(descriptor.taskNames !== undefined ? { nameById: descriptor.taskNames } : {})}
       {...(descriptor.taskRecovering !== undefined ? { recoveringByTaskId: descriptor.taskRecovering } : {})}
       {...(taskCriteriaById !== undefined ? { taskCriteriaById } : {})}

--- a/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
+++ b/src/application/ui/tui/views/skills-view-internals/flow-visual.ts
@@ -3,22 +3,17 @@
  * so the glyph/colour/label decisions are unit-testable without mounting Ink.
  */
 
-import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
 import type { SkillCatalogEntry, SkillInstallStatus } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
-import { PHASE_FLOW_DIR } from '@src/integration/ai/skills/phase/source.ts';
-import { flowMountsSkills } from '@src/application/ui/shared/launcher.ts';
+import { SKILL_MOUNTING_FLOW_IDS } from '@src/application/ui/shared/launcher.ts';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 
 /**
- * Flows whose launch context actually mounts a skill source — derived from the launcher's
- * `flowMountsSkills` (the single source of truth), keyed back to `FlowId` via the phase-dir
- * mapping (dir names equal the orchestration dispatch ids). The catalog offers, preselects, and
- * renders chips ONLY for these: advertising an enable target no launch ever consumes (createPr
- * today — its flow has no skill-mounting dispatch) would misrepresent effect.
+ * Re-exported for existing consumers (`picker-options.ts`, this module's own tests) — the
+ * canonical derivation now lives in `ui/shared/launcher.ts` next to `flowMountsSkills` so the
+ * TUI catalog and `ralphctl skills list` can never drift on which flows a skill can load into.
  */
-export const SKILL_MOUNTING_FLOW_IDS: readonly FlowId[] = FLOW_IDS.filter((flowId) =>
-  flowMountsSkills(PHASE_FLOW_DIR[flowId])
-);
+export { SKILL_MOUNTING_FLOW_IDS };
 
 /**
  * Flows a row renders chips for: every mounting flow, plus any NON-mounting flow that already

--- a/src/application/ui/tui/views/skills-view-internals/picker-options.ts
+++ b/src/application/ui/tui/views/skills-view-internals/picker-options.ts
@@ -14,13 +14,13 @@ import {
 } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 
 /**
- * Every skill-MOUNTING flow is offered (a flow whose launch never mounts a skill source —
- * createPr today — is not listed at all: enabling there would advertise an effect that never
- * happens). A flow the skill is already default-ON for is disabled (opting it in would be a
- * no-op — it loads regardless, see `flowChipVisual`'s doc comment) but still shown so the
- * operator understands why it's greyed out; likewise an edit-protected copy (`locally-modified`
- * / `manual`) is shown disabled — `enable` deliberately skips those, `u` (update, with confirm)
- * is the overwrite path.
+ * Every skill-MOUNTING flow is offered (a flow whose launch never mounts a skill source — none
+ * today; every real `FlowId` mounts, createPr included — is not listed at all: enabling there
+ * would advertise an effect that never happens). A flow the skill is already default-ON for is
+ * disabled (opting it in would be a no-op — it loads regardless, see `flowChipVisual`'s doc
+ * comment) but still shown so the operator understands why it's greyed out; likewise an
+ * edit-protected copy (`locally-modified` / `manual`) is shown disabled — `enable` deliberately
+ * skips those, `u` (update, with confirm) is the overwrite path.
  */
 export const enableOptions = (entry: SkillCatalogEntry): ReadonlyArray<Choice<FlowId>> =>
   SKILL_MOUNTING_FLOW_IDS.map((flowId) => {

--- a/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
+++ b/src/application/ui/tui/views/skills-view-internals/use-skill-catalog-actions.ts
@@ -1,9 +1,9 @@
 /**
  * Action state + handlers for the Skills catalog view — enable / disable / update / update-all,
- * plus the enable/disable flow-picker and destructive-confirm state they drive. Extracted from
- * `skills-view.tsx` so the view stays a thin render + key-dispatch layer; the sequencing rules
- * (when a confirm is required, what "up to date" means) live here where they're one hook away
- * from a unit test.
+ * plus the enable/disable flow-picker, the destructive-confirm state they drive, and clearing a
+ * durable `settings.ai.skills` opt-out. Extracted from `skills-view.tsx` so the view stays a thin
+ * render + key-dispatch layer; the sequencing rules (when a confirm is required, what "up to
+ * date" means) live here where they're one hook away from a unit test.
  *
  * Handlers are module-level functions taking an explicit {@link ActionCtx} rather than closures
  * inside the hook — keeps `useSkillCatalogActions` itself a thin dispatch table and each rule
@@ -14,7 +14,10 @@ import { useMemo, useState } from 'react';
 import type { RefObject } from 'react';
 import type { Result } from '@src/domain/result.ts';
 import type { StorageError } from '@src/domain/value/error/storage-error.ts';
-import type { FlowId } from '@src/domain/value/flow-id.ts';
+import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { createSettingsSetFlow } from '@src/application/flows/settings-set/flow.ts';
 import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
 import type {
   SkillCatalogEntry,
@@ -22,6 +25,7 @@ import type {
   SkillInstallStatus,
 } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { feedback, type StructuredFeedback } from '@src/application/ui/tui/components/feedback-line.tsx';
+import { FLOW_LABEL } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { useIsMounted } from '@src/application/ui/tui/runtime/use-is-mounted.ts';
 
@@ -63,6 +67,7 @@ export const confirmTitle = (cs: ConfirmState): string =>
 /** Threaded through every module-level handler below — one bag, one signature per handler. */
 interface ActionCtx {
   readonly skillCatalog: SkillCatalogPort;
+  readonly settingsRepo: SettingsRepository;
   readonly mountedRef: RefObject<boolean>;
   readonly reload: () => void;
   readonly setBusy: (busy: boolean) => void;
@@ -70,6 +75,14 @@ interface ActionCtx {
   readonly setPicker: (value: PickerState | undefined) => void;
   readonly setConfirmState: (value: ConfirmState | undefined) => void;
 }
+
+/**
+ * Flows where `settings.ai.skills[flow].disabled` currently names `skillName` — the ONLY way
+ * this state can be cleared today is by re-running a flow's customize picker and choosing
+ * "remember" again with the skill re-checked. {@link doClearSavedOptOut} is the direct clear.
+ */
+const savedOptOutFlowsFor = (settings: Settings | undefined, skillName: string): readonly FlowId[] =>
+  FLOW_IDS.filter((flowId) => (settings?.ai.skills?.[flowId]?.disabled ?? []).includes(skillName));
 
 /** Run one catalog mutation, translate the Result into feedback, and reload the list on success. */
 const runCatalogOp = async <T>(
@@ -181,6 +194,38 @@ const doRunUpdateAll = (ctx: ActionCtx): void => {
   );
 };
 
+/** Persist a settings mutation via the same seam the customize picker's "remember" writes. */
+const runSettingsOp = async (ctx: ActionCtx, next: Settings, successLabel: () => string): Promise<void> => {
+  ctx.setBusy(true);
+  const saved = await createSettingsSetFlow({ settingsRepo: ctx.settingsRepo }).execute({ input: { next } });
+  if (!ctx.mountedRef.current) return;
+  ctx.setBusy(false);
+  if (!saved.ok) {
+    ctx.setActionFeedback(feedback('error', `${glyphs.cross} ${saved.error.error.message}`));
+    return;
+  }
+  ctx.setActionFeedback(feedback('success', successLabel()));
+  ctx.reload();
+};
+
+/**
+ * Remove `entry.name` from every flow's `settings.ai.skills[flow].disabled` row — the direct
+ * counterpart to the customize picker's "remember" opt-out, which today is the only other way to
+ * touch this state. No-op (and never called by the view — see the hint's `enabledWhen`) when
+ * settings failed to load or the entry has no saved opt-out anywhere.
+ */
+const doClearSavedOptOut = (ctx: ActionCtx, settings: Settings | undefined, entry: SkillCatalogEntry): void => {
+  const flows = savedOptOutFlowsFor(settings, entry.name);
+  if (settings === undefined || flows.length === 0) return;
+  const nextSkills = { ...settings.ai.skills };
+  for (const flowId of flows) {
+    nextSkills[flowId] = { disabled: (nextSkills[flowId]?.disabled ?? []).filter((n) => n !== entry.name) };
+  }
+  const next: Settings = { ...settings, ai: { ...settings.ai, skills: nextSkills } };
+  const flowLabels = flows.map((f) => FLOW_LABEL[f]).join(', ');
+  void runSettingsOp(ctx, next, () => `${glyphs.check} cleared saved opt-out for "${entry.name}" (${flowLabels})`);
+};
+
 export interface UseSkillCatalogActionsResult {
   readonly picker: PickerState | undefined;
   readonly confirmState: ConfirmState | undefined;
@@ -196,10 +241,15 @@ export interface UseSkillCatalogActionsResult {
   readonly submitPicker: (flows: readonly FlowId[]) => void;
   readonly submitConfirm: (confirmed: boolean) => void;
   readonly flashInfo: (text: string) => void;
+  /** Flows where the entry currently has a saved opt-out — gates the clear-opt-out hint/key. */
+  readonly savedOptOutFlows: (entry: SkillCatalogEntry) => readonly FlowId[];
+  readonly clearSavedOptOut: (entry: SkillCatalogEntry) => void;
 }
 
 export const useSkillCatalogActions = (
   skillCatalog: SkillCatalogPort,
+  settingsRepo: SettingsRepository,
+  settings: Settings | undefined,
   reload: () => void
 ): UseSkillCatalogActionsResult => {
   const mountedRef = useIsMounted();
@@ -210,7 +260,16 @@ export const useSkillCatalogActions = (
   const [actionFeedback, setActionFeedback] = useState<StructuredFeedback | undefined>(undefined);
   const [busy, setBusy] = useState(false);
 
-  const ctx: ActionCtx = { skillCatalog, mountedRef, reload, setBusy, setActionFeedback, setPicker, setConfirmState };
+  const ctx: ActionCtx = {
+    skillCatalog,
+    settingsRepo,
+    mountedRef,
+    reload,
+    setBusy,
+    setActionFeedback,
+    setPicker,
+    setConfirmState,
+  };
 
   return {
     picker,
@@ -226,5 +285,7 @@ export const useSkillCatalogActions = (
     submitPicker: (flows) => doSubmitPicker(ctx, picker, flows),
     submitConfirm: (confirmed) => doSubmitConfirm(ctx, confirmState, confirmed),
     flashInfo: (text) => setActionFeedback(feedback('info', text)),
+    savedOptOutFlows: (entry) => savedOptOutFlowsFor(settings, entry.name),
+    clearSavedOptOut: (entry) => doClearSavedOptOut(ctx, settings, entry),
   };
 };

--- a/src/application/ui/tui/views/skills-view.tsx
+++ b/src/application/ui/tui/views/skills-view.tsx
@@ -15,6 +15,9 @@
  *             locally-modified copy)
  *   U         update every install whose status is update-available, catalog-wide (never touches
  *             locally-modified or manual installs — no confirm needed)
+ *   c         clear the focused skill's saved opt-out (`settings.ai.skills.<flow>.disabled`) —
+ *             only offered when it actually has one; otherwise the only way to clear it is
+ *             re-running a flow's customize picker and choosing "remember" again
  *   r         reload
  *
  * A `defaultFor` flow always renders "always on (default)" regardless of any phase-folder copy —
@@ -38,7 +41,8 @@ import { useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx
 import { useViewHints } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
 import { useBreakpoint } from '@src/application/ui/tui/runtime/use-breakpoint.ts';
 import { FLOW_IDS, type FlowId } from '@src/domain/value/flow-id.ts';
-import type { AiSkillsSettings } from '@src/domain/entity/settings.ts';
+import type { Settings } from '@src/domain/entity/settings.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { SkillRow } from '@src/application/ui/tui/views/skills-view-internals/skill-row.tsx';
 import {
@@ -61,12 +65,28 @@ const CHROME_ROWS = 8;
  */
 const ROW_HEIGHT = 7;
 
+interface SkillsViewState {
+  readonly entries: readonly SkillCatalogEntry[];
+  readonly settings: Settings | undefined;
+}
+
+/**
+ * Loader for `useAsyncLoad` — the catalog listing plus a settings read, used both to make a
+ * "default" chip honest ("default, off (saved)") and to drive the clear-opt-out action. A
+ * settings read failure is non-fatal — the catalog still renders, chips just lose that nuance
+ * and the clear-opt-out action has nothing to clear. Extracted so `SkillsView` stays under the
+ * per-function line budget.
+ */
+const loadSkillsViewState = async (deps: AppDeps): Promise<SkillsViewState> => {
+  const r = await deps.skillCatalog.list();
+  if (!r.ok) throw new Error(r.error.message);
+  const settingsR = await deps.settingsRepo.load();
+  return { entries: r.value, settings: settingsR.ok ? settingsR.value : undefined };
+};
+
 interface SkillsBodyProps {
   readonly helpOpen: boolean;
-  readonly state: AsyncLoadState<
-    { readonly entries: readonly SkillCatalogEntry[]; readonly skills: AiSkillsSettings | undefined },
-    unknown
-  >;
+  readonly state: AsyncLoadState<SkillsViewState, unknown>;
   readonly picker: PickerState | undefined;
   readonly confirmState: ConfirmState | undefined;
   readonly entries: readonly SkillCatalogEntry[];
@@ -174,19 +194,13 @@ export const SkillsView = (): React.JSX.Element => {
   const ui = useUiState();
   const bp = useBreakpoint();
 
-  const { state, reload } = useAsyncLoad<{
-    readonly entries: readonly SkillCatalogEntry[];
-    readonly skills: AiSkillsSettings | undefined;
-  }>(async () => {
-    const r = await deps.skillCatalog.list();
-    if (!r.ok) throw new Error(r.error.message);
-    // Saved per-flow opt-outs make a "default" chip honest ("default, off (saved)"). A settings
-    // read failure is non-fatal here — the catalog still renders, chips just lose that nuance.
-    const settingsR = await deps.settingsRepo.load();
-    return { entries: r.value, skills: settingsR.ok ? settingsR.value.ai.skills : undefined };
-  }, [deps.skillCatalog, deps.settingsRepo]);
+  const { state, reload } = useAsyncLoad<SkillsViewState>(
+    () => loadSkillsViewState(deps),
+    [deps.skillCatalog, deps.settingsRepo]
+  );
   const entries = state.kind === 'ok' ? state.value.entries : [];
-  const skills = state.kind === 'ok' ? state.value.skills : undefined;
+  const settings = state.kind === 'ok' ? state.value.settings : undefined;
+  const skills = settings?.ai.skills;
 
   const EMPTY_NAMES: ReadonlySet<string> = useMemo(() => new Set(), []);
   const savedDisabled = useMemo(() => {
@@ -195,7 +209,7 @@ export const SkillsView = (): React.JSX.Element => {
     return (flowId: FlowId): ReadonlySet<string> => byFlow.get(flowId) ?? EMPTY_NAMES;
   }, [skills, EMPTY_NAMES]);
 
-  const actions = useSkillCatalogActions(deps.skillCatalog, reload);
+  const actions = useSkillCatalogActions(deps.skillCatalog, deps.settingsRepo, settings, reload);
   const { picker, confirmState, bundledNames } = actions;
 
   const claimPrompt = ui.claimPrompt;
@@ -210,12 +224,17 @@ export const SkillsView = (): React.JSX.Element => {
     active: listActive,
   });
 
+  // Gates both the footer hint and the key handler below — pressing `c` only does something
+  // when the focused entry actually has a durable opt-out saved somewhere.
+  const canClearOptOut = focusedItem !== undefined && actions.savedOptOutFlows(focusedItem).length > 0;
+
   useViewHints([
     { keys: '↑/↓/j/k', label: 'move' },
     { keys: 'e', label: 'enable' },
     { keys: 'd', label: 'disable' },
     { keys: 'u', label: 'update' },
     { keys: 'U', label: 'update all' },
+    { keys: 'c', label: 'clear opt-out', enabledWhen: canClearOptOut },
     { keys: 'r', label: 'reload' },
   ]);
 
@@ -235,6 +254,7 @@ export const SkillsView = (): React.JSX.Element => {
     if (input === 'e') actions.startEnable(target);
     else if (input === 'd') actions.startDisable(target);
     else if (input === 'u') actions.runUpdate(target);
+    else if (input === 'c' && canClearOptOut) actions.clearSavedOptOut(target);
   });
 
   return (

--- a/src/business/observability/events.ts
+++ b/src/business/observability/events.ts
@@ -1,6 +1,7 @@
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { AiSignal } from '@src/domain/signal.ts';
+import type { PlateauSource } from '@src/domain/entity/attempt.ts';
 
 /**
  * Application-wide structured events. Producers (chain runner, use cases,
@@ -305,6 +306,12 @@ export interface AiSignalEvent {
  *                  ladder. `'plateau'` is kept as a member so any consumer that matched the
  *                  prior single-literal shape still narrows. `'malformed'` is deliberately
  *                  absent — that exit is the evaluator's failure and never escalates the model.
+ *  - `plateauSource` — WHICH plateau detector fired (see {@link PlateauSource} for the 1:1
+ *                  mapping to the loop-diversity / entropy guards' banner causes), only present
+ *                  when `reason === 'plateau'`. Pure instrumentation for the periodic
+ *                  detector-load-bearing audit (`.claude/docs/HARNESS-PRINCIPLES.md` § 14) —
+ *                  OPTIONAL and additive, absent on a `budget-exhausted` reason or a legacy
+ *                  event emitted before this field existed.
  */
 export interface ModelEscalatedEvent {
   readonly type: 'model-escalated';
@@ -313,6 +320,7 @@ export interface ModelEscalatedEvent {
   readonly from: string;
   readonly to: string;
   readonly reason: 'plateau' | 'budget-exhausted';
+  readonly plateauSource?: PlateauSource;
   readonly at: IsoTimestamp;
 }
 

--- a/src/business/sprint/render-journal-entry.ts
+++ b/src/business/sprint/render-journal-entry.ts
@@ -31,12 +31,19 @@ export type JournalVerdict = 'pass' | 'pass-with-warning' | 'escalated' | 'block
  *  - `detail`      — one-line human detail (malformed parse error, verify stderr head, crash
  *                    exit/signal text, …).
  *  - `dimensions`  — failed-criterion ids, present only for the `plateau` kind.
+ *  - `source`      — WHICH of the three plateau detectors fired (`threshold` / `diversity` /
+ *                    `entropy` — mirrors the domain `PlateauSource`, redeclared here rather than
+ *                    imported so the renderer stays decoupled from the entity), present only for
+ *                    the `plateau` kind and only when the leaf could resolve it. Pure
+ *                    instrumentation for the periodic detector-load-bearing audit — never changes
+ *                    which sentence renders, only appends a parenthetical.
  *  - `turnsUsed` / `turnBudget` — present only for the `budget-exhausted` kind.
  */
 export interface JournalWarning {
   readonly kind: 'budget-exhausted' | 'plateau' | 'malformed' | 'verify-failed' | 'crashed';
   readonly detail?: string;
   readonly dimensions?: readonly string[];
+  readonly source?: 'threshold' | 'diversity' | 'entropy';
   readonly turnsUsed?: number;
   readonly turnBudget?: number;
 }
@@ -219,7 +226,10 @@ const warningSentence = (warning: JournalWarning): string => {
         warning.dimensions !== undefined && warning.dimensions.length > 0
           ? ` on the same failed dimension${warning.dimensions.length === 1 ? '' : 's'}: ${warning.dimensions.join(', ')}`
           : '';
-      return `The evaluator plateaued — two consecutive evaluations flagged the identical failure${dims}.`;
+      // Detector attribution — pure instrumentation, appended as a parenthetical so the main
+      // clause stays byte-identical for records written before this field existed.
+      const detector = warning.source !== undefined ? ` (detector: ${warning.source})` : '';
+      return `The evaluator plateaued — two consecutive evaluations flagged the identical failure${dims}${detector}.`;
     }
     case 'malformed':
       return `The evaluator output could not be parsed${parenDetail(warning.detail)}.`;

--- a/src/business/sprint/render-journal-entry.ts
+++ b/src/business/sprint/render-journal-entry.ts
@@ -136,6 +136,14 @@ export interface JournalEntryInput {
   readonly notes: readonly string[];
   /** Commit sha that landed (truncated). Missing when the attempt blocked. */
   readonly commitSha?: string;
+  /**
+   * Per-attempt corrective-nudge tally (generator + evaluator `signals.json` contract-failure
+   * retries — see `validateSignalsFileWithCorrectiveRetry`). Nudges consume no turn/attempt
+   * budget by design, so this is the ONLY operator-facing surface for them — pure cost-visibility
+   * instrumentation, never a failure signal on its own. Present only when at least one nudge
+   * fired this attempt; absent renders no additional line (zero-noise on the well-formed path).
+   */
+  readonly correctiveNudges?: { readonly generator: number; readonly evaluator: number };
   readonly timestamp: IsoTimestamp;
 }
 
@@ -269,15 +277,32 @@ const remedySentence = (
 };
 
 /**
- * Append the `### Outcome detail` subsection — the plain-prose explanation of a non-clean exit.
- * No-op when there is neither a warning nor an escalation (the clean-pass path), so a pass entry
- * stays byte-identical to the pre-widening output.
+ * One plain-prose sentence naming how many `signals.json` corrective nudges the generator /
+ * evaluator needed this attempt. Independent of `warning`/`escalation` — a corrective nudge can
+ * fire on an otherwise clean pass, so this bullet is gated on its own presence, not the others'.
+ */
+const correctiveNudgesSentence = (nudges: { readonly generator: number; readonly evaluator: number }): string => {
+  const total = nudges.generator + nudges.evaluator;
+  const parts: string[] = [];
+  if (nudges.generator > 0) parts.push(`generator: ${String(nudges.generator)}`);
+  if (nudges.evaluator > 0) parts.push(`evaluator: ${String(nudges.evaluator)}`);
+  const breakdown = parts.length > 0 ? ` (${parts.join(', ')})` : '';
+  const noun = total === 1 ? 'nudge' : 'nudges';
+  return `${String(total)} corrective signals.json ${noun} issued this attempt${breakdown} — these do not count against the turn/attempt budget.`;
+};
+
+/**
+ * Append the `### Outcome detail` subsection — the plain-prose explanation of a non-clean exit,
+ * plus the corrective-nudge cost-visibility line when present. No-op when there is neither a
+ * warning, an escalation, nor a nudge tally (the clean-pass path), so a pass entry stays
+ * byte-identical to the pre-widening output.
  */
 const appendOutcomeDetail = (lines: string[], input: JournalEntryInput): void => {
   const bullets: string[] = [];
   if (input.warning !== undefined) bullets.push(warningSentence(input.warning));
   const remedy = remedySentence(input.verdict, input.escalation, input.warning);
   if (remedy !== undefined) bullets.push(remedy);
+  if (input.correctiveNudges !== undefined) bullets.push(correctiveNudgesSentence(input.correctiveNudges));
   if (bullets.length === 0) return;
   lines.push('### Outcome detail');
   for (const b of bullets) lines.push(`- ${b}`);

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -3,6 +3,7 @@ import type { EventBus } from '@src/business/observability/event-bus.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import { escalationLadderCyclicFrom, mergeEscalationMap, nextEffortRung } from '@src/business/task/escalation-map.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { PlateauSource } from '@src/domain/entity/attempt.ts';
 import type { InProgressTask } from '@src/domain/entity/task.ts';
 import { recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -279,6 +280,15 @@ export interface ApplyEscalationProps {
    * banner / log copy so a budget-exhausted-driven escalation is not mislabeled as a plateau.
    */
   readonly trigger: EscalationTrigger;
+  /**
+   * WHICH plateau detector fired (threshold / diversity / entropy — see {@link PlateauSource}),
+   * forwarded onto the `model-escalated` event so the periodic detector-load-bearing audit (see
+   * `.claude/docs/HARNESS-PRINCIPLES.md` § 14) can attribute escalations without re-deriving them
+   * from the progress journal. OPTIONAL: absent on a `budget-exhausted` trigger (no plateau
+   * detector involved) and on a legacy in-flight `plateau` exit that predates this field — pure
+   * instrumentation, never gates the decision.
+   */
+  readonly plateauSource?: PlateauSource;
   readonly eventBus: EventBus;
   readonly logger: Logger;
   readonly clock: () => IsoTimestamp;
@@ -326,6 +336,7 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
         from: decision.from,
         to: decision.to,
         reason: trigger,
+        ...(props.plateauSource !== undefined ? { plateauSource: props.plateauSource } : {}),
         at: now,
       });
       eventBus.publish({

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -133,7 +133,14 @@ const mapExit = (exit: GenEvalExit): { verdict: RunTaskVerdict; warning?: Attemp
     case 'malformed':
       return { verdict: 'malformed', warning: { kind: 'malformed', detail: exit.detail } };
     case 'plateau':
-      return { verdict: 'failed', warning: { kind: 'plateau', dimensions: exit.dimensions } };
+      return {
+        verdict: 'failed',
+        warning: {
+          kind: 'plateau',
+          dimensions: exit.dimensions,
+          ...(exit.source !== undefined ? { source: exit.source } : {}),
+        },
+      };
     case BUDGET_EXHAUSTED_EXIT:
       return {
         verdict: 'failed',
@@ -192,6 +199,10 @@ const resolveEscalatableRemedy = (
     task: props.task,
     decision,
     trigger,
+    // Forward WHICH plateau detector fired (undefined on a budget-exhausted trigger, or a legacy
+    // plateau exit that predates this field) so the `model-escalated` event carries the same
+    // attribution the progress journal records.
+    ...(exit.kind === 'plateau' && exit.source !== undefined ? { plateauSource: exit.source } : {}),
     eventBus: props.eventBus,
     logger: props.logger,
     clock: props.clock,

--- a/src/business/task/gen-eval-exit.ts
+++ b/src/business/task/gen-eval-exit.ts
@@ -1,3 +1,5 @@
+import type { PlateauSource } from '@src/domain/entity/attempt.ts';
+
 /**
  * Outcome types for one run of the gen-eval inner loop. Owned by the business layer because the
  * decision tree from exit → (settle verdict, attempt warning) is domain logic — settle-attempt
@@ -18,7 +20,9 @@ export type RunTaskVerdict = 'passed' | 'failed' | 'malformed';
  *                          terminal verdict; the attempt is retried within maxAttempts, then
  *                          blocked at the cap.
  *   - `malformed`         — evaluator emitted no terminal verdict; attempt fails with warning.
- *   - `plateau`           — two consecutive evaluator runs flagged the same failed dimensions.
+ *   - `plateau`           — one of three detectors fired (see {@link PlateauSource}): the
+ *                          count-based threshold, the loop-diversity guard, or the action-entropy
+ *                          guard. `source` names which one — optional, pure instrumentation.
  *   - `budget-exhausted`  — `maxTurns` reached without a terminal verdict.
  */
 export type GenEvalExit =
@@ -26,5 +30,5 @@ export type GenEvalExit =
   | { readonly kind: 'self-blocked'; readonly reason: string }
   | { readonly kind: 'crashed'; readonly reason: string }
   | { readonly kind: 'malformed'; readonly detail: string }
-  | { readonly kind: 'plateau'; readonly dimensions: readonly string[] }
+  | { readonly kind: 'plateau'; readonly dimensions: readonly string[]; readonly source?: PlateauSource }
   | { readonly kind: 'budget-exhausted'; readonly turnsUsed: number; readonly turnBudget: number };

--- a/src/business/task/run-evaluator-turn.ts
+++ b/src/business/task/run-evaluator-turn.ts
@@ -53,7 +53,10 @@ export type EvaluatorTurnExit =
   | { readonly kind: 'passed' }
   | { readonly kind: 'self-blocked'; readonly reason: string }
   | { readonly kind: 'malformed'; readonly detail: string }
-  | { readonly kind: 'plateau'; readonly dimensions: readonly string[] };
+  // `source: 'threshold'` — this is the ONLY plateau detector this use case ever produces (the
+  // loop-diversity / entropy detectors run downstream in `gen-eval-loop.ts`, outside the
+  // business layer). See `PlateauSource` (`domain/entity/attempt.ts`) for the full 1:1 mapping.
+  | { readonly kind: 'plateau'; readonly dimensions: readonly string[]; readonly source: 'threshold' };
 
 export interface RunEvaluatorTurnProps {
   readonly task: InProgressTask;
@@ -261,7 +264,13 @@ const handleWarningVerdict = (
   evaluation: EvaluationSignal,
   log: Logger
 ): TurnResult => {
-  const warned = recordRunningAttemptWarning(task, { kind: 'plateau', dimensions: verdict.dimensions });
+  // Soft variant of the count-based detector — stamp the same source the hard exit carries, so
+  // done-with-warning attempts feed the per-detector audit too.
+  const warned = recordRunningAttemptWarning(task, {
+    kind: 'plateau',
+    dimensions: verdict.dimensions,
+    source: 'threshold',
+  });
   if (!warned.ok) {
     log.error('cannot record plateau warning on attempt', { taskId: task.id, error: warned.error.message });
     return Result.error(warned.error);
@@ -330,7 +339,7 @@ export const runEvaluatorTurnUseCase = async (props: RunEvaluatorTurnProps): Pro
     return Result.ok({
       task: recorded.value,
       evaluation,
-      exit: { kind: 'plateau', dimensions: verdict.dimensions },
+      exit: { kind: 'plateau', dimensions: verdict.dimensions, source: 'threshold' },
       turnRecord: currentRecord,
     });
   }

--- a/src/domain/entity/attempt.ts
+++ b/src/domain/entity/attempt.ts
@@ -30,6 +30,25 @@ export interface Evaluation {
 }
 
 /**
+ * Which of the three gen-eval plateau detectors produced a `plateau` exit — pure instrumentation
+ * for the periodic "is this detector still load-bearing or redundant scaffolding?" audit (see
+ * `.claude/docs/HARNESS-PRINCIPLES.md` § 14 and the "Model-bump audit checklist"); no detection
+ * behaviour hinges on this value. 1:1 with the `banner-show` `cause` strings the loop-diversity /
+ * entropy guards publish in `gen-eval-loop.ts`:
+ *
+ *  - `threshold` — the count-based consecutive-non-improving-turns check (`plateauThreshold`,
+ *                  `computePlateauVerdict` in `business/task/plateau-detection.ts`, wired through
+ *                  `runEvaluatorTurnUseCase`). No banner — this detector runs deep in the business
+ *                  layer, ahead of any `EventBus` wiring.
+ *  - `diversity` — the loop-diversity guard (banner cause `'loop-diversity-exhausted'`).
+ *  - `entropy`   — the action-entropy guard (banner cause `'low-action-entropy'`).
+ *
+ * OPTIONAL everywhere it appears: absent on every persisted record written before this field
+ * existed — old on-disk `tasks.json` rows must keep parsing without it.
+ */
+export type PlateauSource = 'threshold' | 'diversity' | 'entropy';
+
+/**
  * Structured warning attached to an attempt when the gen-eval inner loop terminates without a
  * passed evaluation but the task still settles as `done` (vs `blocked`), OR when an attempt is
  * failed-and-retried. The kinds:
@@ -51,7 +70,7 @@ export interface Evaluation {
  */
 export type AttemptWarning =
   | { readonly kind: 'budget-exhausted'; readonly turnsUsed: number; readonly turnBudget: number }
-  | { readonly kind: 'plateau'; readonly dimensions: readonly string[] }
+  | { readonly kind: 'plateau'; readonly dimensions: readonly string[]; readonly source?: PlateauSource }
   | { readonly kind: 'malformed'; readonly detail: string }
   | { readonly kind: 'verify-failed'; readonly exitCode: number | null; readonly stderr: string }
   | { readonly kind: 'crashed'; readonly detail: string };

--- a/src/domain/value/settings-models/context-window.ts
+++ b/src/domain/value/settings-models/context-window.ts
@@ -50,6 +50,17 @@ export const contextWindowFor = (model: string | undefined): number | undefined 
 };
 
 /**
+ * The largest window in the table — the single figure any window-scaled budget derived from
+ * this catalog (e.g. `progressCapBudgetForModel`'s sibling-section budget, or a backstop cap
+ * sized to never fire below the largest legitimate window-scaled output) must stay pinned to.
+ * Recomputed from the table itself so a new catalog entry with a bigger window is picked up
+ * automatically rather than requiring a second hand-maintained constant.
+ *
+ * @public
+ */
+export const MAX_CONTEXT_WINDOW = Math.max(...Object.values(CONTEXT_WINDOW));
+
+/**
  * Compact display label for a model's context window size:
  *   `200_000` → `"200K"`, `1_000_000` → `"1M"`, `1_200_000` → `"1.2M"`.
  * Returns `undefined` when the model is unknown or unset — callers should omit the label.

--- a/src/integration/ai/contract/_engine/corrective-retry.ts
+++ b/src/integration/ai/contract/_engine/corrective-retry.ts
@@ -25,21 +25,34 @@ import { validateSignalsFile } from '@src/integration/ai/contract/_engine/valida
  * primitives are still banned; this is the in-leaf loop CLAUDE.md explicitly allows, mirroring
  * `providers/_engine/run-with-rate-limit-retry.ts`'s idiom):
  *
- *   1. {@link validateSignalsFile} the spawn's output dir. On success, return immediately.
+ *   1. {@link validateSignalsFile} the spawn's output dir. On success, return immediately with
+ *      `nudgeCount: 0`.
  *   2. On a NON-correctable failure (user abort, rate-limit, or a `MigrationGapError` the AI
  *      cannot fix by re-emitting), return the error verbatim — the caller self-blocks.
  *   3. On a CORRECTABLE failure (signals-missing / invalid-json / schema-mismatch), loop up to
  *      `correctiveRetries` times: build a short corrective prompt gated by the LATEST error class,
  *      re-invoke the provider via the caller-supplied {@link reinvoke} callback (the leaf owns the
  *      resumed spawn so session / resume / abort threading stays there), then re-validate. Return
- *      on the first fixed file; a spawn-level error short-circuits; exhausting every nudge returns
- *      the last contract error so the caller self-blocks.
+ *      on the first fixed file, with `nudgeCount` set to the 1-based attempt index that fixed it; a
+ *      spawn-level error short-circuits; exhausting every nudge returns the last contract error so
+ *      the caller self-blocks.
  *
  * `reinvoke(corrective, attempt)` MUST spawn the provider on the SAME resumed session (so the model
  * sees the corrective message as a follow-up turn) targeting the SAME `signals.json` path, then
  * resolve once the spawn has returned. A spawn-level error (`Result.error`) short-circuits — the
  * caller self-blocks with that error. `AbortError` from the re-invoke propagates transparently. The
  * `attempt` index (1-based) lets the leaf name per-nudge forensic artifacts.
+ *
+ * `nudgeCount` on the success path is pure cost-visibility instrumentation: nudges consume no
+ * turn/attempt budget by design (near-miss recovery must not eat the real budget), so it is the
+ * ONLY operator-facing counter for them. The caller accumulates it per-attempt onto `ImplementCtx`
+ * for the progress journal to render — never touches when/how retries fire.
+ *
+ * Deliberately scoped to the SUCCESS path only: an exhausted retry sequence self-blocks the task,
+ * which is already loud (blocked status + reason) through an existing channel. The audit finding
+ * this closes is the OPPOSITE case — a persistently-malformed-but-self-correcting AI that recovers
+ * every time and so never surfaces as a problem, silently burning `correctiveRetries × turns ×
+ * attempts` spawns across a whole run. That is what `nudgeCount` makes visible.
  */
 export interface CorrectiveRetryDeps {
   readonly outputDir: AbsolutePath;
@@ -142,15 +155,28 @@ const correctiveBody = (err: DomainError, signalsPath: string, selfContainedCont
 };
 
 /**
+ * Success payload — the validated signals plus the corrective-nudge tally that produced them.
+ */
+export interface CorrectiveRetryOutcome<TSig extends AiSignal> {
+  readonly signals: readonly TSig[];
+  /**
+   * Number of corrective nudges consumed before a valid `signals.json` landed — `0` when the
+   * FIRST parse already succeeded (the common case). Pure observability; see the module
+   * docstring's closing paragraph for why this never affects retry semantics.
+   */
+  readonly nudgeCount: number;
+}
+
+/**
  * Validate the spawn's `signals.json`; on a correctable contract failure, re-prompt once on the
  * resumed session and re-validate. See the module docstring for the full flow + rationale.
  */
 export const validateSignalsFileWithCorrectiveRetry = async <TSig extends AiSignal>(
   deps: CorrectiveRetryDeps,
   contract: AiOutputContract<TSig>
-): Promise<Result<readonly TSig[], DomainError>> => {
+): Promise<Result<CorrectiveRetryOutcome<TSig>, DomainError>> => {
   const first = await validateSignalsFile(deps.outputDir, contract);
-  if (first.ok) return first;
+  if (first.ok) return Result.ok({ signals: first.value, nudgeCount: 0 });
 
   let lastErr: DomainError = first.error;
   if (!isCorrectableContractError(lastErr)) return Result.error(lastErr);
@@ -185,7 +211,7 @@ export const validateSignalsFileWithCorrectiveRetry = async <TSig extends AiSign
     const revalidated = await validateSignalsFile(deps.outputDir, contract);
     if (revalidated.ok) {
       log.info('corrective retry produced a valid signals.json', { outputDir: String(deps.outputDir), attempt });
-      return revalidated;
+      return Result.ok({ signals: revalidated.value, nudgeCount: attempt });
     }
     lastErr = revalidated.error;
   }

--- a/src/integration/ai/prompts/_engine/compress-section.ts
+++ b/src/integration/ai/prompts/_engine/compress-section.ts
@@ -15,6 +15,31 @@
 export const SECTION_CHAR_CAP = 4_000;
 
 /**
+ * Backstop cap for sections whose PRODUCER already applies its own window-scaled, section-aware
+ * cap before substitution — `capProgressBody` for `PRIOR_PROGRESS` (via `progressCapBudgetForModel`
+ * in `application/flows/_shared/progress/cap-progress.ts`), `composePriorLearnings` for
+ * `PRIOR_LEARNINGS`. Those producers put the highest-value content at the HEAD (sprint state
+ * header, pinned lifecycle breadcrumbs, elision notes, the current task's full attempt history —
+ * the "depth guarantee") and bound breadth with a token budget scaled to the resolved model's
+ * context window (up to ~1M tokens today). The blunt `SECTION_CHAR_CAP` tail-slice is far smaller
+ * than that budget and keeps the TAIL, so applying it on top of an already-capped value silently
+ * destroyed the producer's careful head-first prioritisation.
+ *
+ * This constant is sized to the LARGEST legitimate pre-capped output — the biggest known context
+ * window's sibling budget, in characters, plus a generous allowance for the unbudgeted header band
+ * and current-task depth guarantee — so it never fires against a well-behaved producer. It exists
+ * ONLY as catastrophic-overflow insurance for a future producer that forgets to pre-cap; when it
+ * does fire, the existing tail-slice + notice semantics still apply (true overflow only).
+ *
+ * `200_000 = round(1_000_000 * 0.04) tokens * 4 chars/token + 40_000` — mirrors the arithmetic in
+ * `progressCapBudgetForModel` (`PROGRESS_BUDGET_FRACTION` * `CHARS_PER_TOKEN`) against
+ * `MAX_CONTEXT_WINDOW` (`domain/value/settings-models/context-window.ts`), plus a 40,000-char depth
+ * allowance. A drift-fence test recomputes this from the live catalog and fails if a bigger context
+ * window ever ships without raising this cap.
+ */
+export const PRECAPPED_SECTION_CHAR_CAP = 200_000;
+
+/**
  * Tail-compress `content` to at most `cap` characters.
  *
  * - Content at or below `cap`: returned unchanged.

--- a/src/integration/ai/prompts/_engine/substitute.ts
+++ b/src/integration/ai/prompts/_engine/substitute.ts
@@ -2,7 +2,7 @@ import { Result } from '@src/domain/result.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import { extractPlaceholders } from '@src/integration/ai/prompts/_engine/extract-placeholders.ts';
-import { compressSection, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
+import { compressSection, PRECAPPED_SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
 
 /**
  * Placeholder substitution for `.md` prompt templates.
@@ -35,14 +35,24 @@ import { compressSection, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_
 const PLACEHOLDER_PATTERN = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
 
 /**
- * Keys whose substituted values are tail-compressed when they exceed {@link SECTION_CHAR_CAP}.
- * These are large dynamic sections (progress journals, learning ledgers) that grow unboundedly
- * over a long sprint. Keeping the tail (most recent content) follows the "Lost in the Middle"
- * guidance — older entries are less useful and pushing them into the middle of the context
- * degrades model attention on the task-critical sections that follow.
+ * Keys whose substituted values are tail-compressed when they overflow {@link PRECAPPED_SECTION_CHAR_CAP}.
+ * These are large dynamic sections (progress journals, learning ledgers) that grow unboundedly over
+ * a long sprint. Keeping the tail (most recent content) follows the "Lost in the Middle" guidance —
+ * older entries are less useful and pushing them into the middle of the context degrades model
+ * attention on the task-critical sections that follow.
+ *
+ * Two-tier scheme: every key here has a PRODUCER that already applies its own window-scaled,
+ * section-aware cap before substitution (`capProgressBody` for `PRIOR_PROGRESS`,
+ * `composePriorLearnings` for `PRIOR_LEARNINGS`) — so this pass maps them to
+ * {@link PRECAPPED_SECTION_CHAR_CAP}, the large overflow backstop, rather than the original
+ * `SECTION_CHAR_CAP`. Re-applying the tight 4K cap on top of an already-capped value
+ * destroyed the producer's head-first prioritisation (sprint state header, pinned lifecycle
+ * breadcrumbs, current-task depth) by tail-slicing it away. `SECTION_CHAR_CAP` remains the default
+ * tier — reach for it directly (not via this set) for any future compressible key with no
+ * producer-side cap of its own.
  *
  * Episode summaries are deliberately excluded: they are hard-bounded to a handful of short items
- * well under the cap, and their substituted value self-wraps in an opening/closing tag (unlike
+ * well under either cap, and their substituted value self-wraps in an opening/closing tag (unlike
  * the wrappers for the keys below, which live in template.md). Tail-slicing would drop the
  * leading open tag, leaving a dangling close tag outside any tag — malformed.
  */
@@ -56,8 +66,8 @@ export const substitute = (template: string, values: Readonly<Record<string, str
     // the literal "undefined".
     const value = values[key];
     if (value === undefined) return match;
-    if (COMPRESSIBLE_KEYS.has(key) && value.length > SECTION_CHAR_CAP) {
-      return compressSection(value);
+    if (COMPRESSIBLE_KEYS.has(key) && value.length > PRECAPPED_SECTION_CHAR_CAP) {
+      return compressSection(value, PRECAPPED_SECTION_CHAR_CAP);
     }
     return value;
   });

--- a/src/integration/ai/providers/_engine/provider-traits.ts
+++ b/src/integration/ai/providers/_engine/provider-traits.ts
@@ -1,0 +1,107 @@
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { ProviderInstallGuidance } from '@src/integration/system/_engine/detect-cli.ts';
+import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
+import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
+import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
+
+/**
+ * Every static per-provider fact ralphctl needs, in one row. PATH binary, install guidance,
+ * readiness target file, skills parent directory, and the model catalog all vary by
+ * {@link AiProvider} but never change at runtime — bundling them here means a fourth backend's
+ * static data lands in ONE object literal instead of four scattered `Record<AiProvider, …>`
+ * maps spread across `integration/system`, `integration/ai/readiness`, `integration/ai/skills`,
+ * and `application/bootstrap`. `Record<AiProvider, ProviderTraits>` gives TypeScript
+ * exhaustiveness over the `AiProvider` union, so adding a member to that union without filling
+ * in a row here is a compile error, not a silent runtime gap.
+ *
+ * Lives under `providers/_engine/` — the sanctioned cross-sibling / cross-concept surface —
+ * because every consumer sits in a different concept (`integration/system`,
+ * `integration/ai/readiness`, `integration/ai/skills`, `application/bootstrap`) and none of
+ * them are siblings of each other.
+ */
+export interface ProviderTraits {
+  /**
+   * PATH binary the adapter spawns. MUST match `providers/<tool>/{headless,interactive}.ts` —
+   * probing the wrong binary here would let the launch fail-fast pass and then the real spawn
+   * fail.
+   */
+  readonly binary: string;
+  /** Per-vendor install guidance (docs URL + OS-specific install commands). */
+  readonly installGuidance: ProviderInstallGuidance;
+  /**
+   * Readiness artefact target path, relative to the repo root — `CLAUDE.md` / `AGENTS.md` /
+   * `.github/copilot-instructions.md`.
+   */
+  readonly contextFileTargetPath: string;
+  /** Skills parent directory, relative to the session root — `.claude` / `.agents` / `.github`. */
+  readonly skillsParentDir: string;
+  /** Full official model catalog the availability probe filters down. */
+  readonly modelCatalog: readonly string[];
+}
+
+const NPM_INSTALL_CLAUDE = 'npm install -g @anthropic-ai/claude-code';
+const NPM_INSTALL_COPILOT = 'npm install -g @github/copilot';
+const NPM_INSTALL_CODEX = 'npm install -g @openai/codex';
+
+/**
+ * Install-guidance sources (verified against vendor docs at the time of writing):
+ *   - claude-code:    https://docs.claude.com/en/docs/claude-code/setup
+ *   - github-copilot: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli
+ *                     plus https://cli.github.com (for the underlying `gh` install)
+ *   - openai-codex:   https://github.com/openai/codex
+ */
+export const PROVIDER_TRAITS: Readonly<Record<AiProvider, ProviderTraits>> = {
+  'claude-code': {
+    binary: 'claude',
+    installGuidance: {
+      docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup',
+      commandsByPlatform: {
+        darwin: [
+          'brew install --cask claude-code',
+          'curl -fsSL https://claude.ai/install.sh | bash',
+          NPM_INSTALL_CLAUDE,
+        ],
+        linux: ['curl -fsSL https://claude.ai/install.sh | bash', NPM_INSTALL_CLAUDE],
+        win32: ['winget install Anthropic.ClaudeCode', 'irm https://claude.ai/install.ps1 | iex', NPM_INSTALL_CLAUDE],
+      },
+    },
+    contextFileTargetPath: 'CLAUDE.md',
+    skillsParentDir: '.claude',
+    modelCatalog: CLAUDE_MODELS,
+  },
+  'github-copilot': {
+    binary: 'copilot',
+    installGuidance: {
+      docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
+      commandsByPlatform: {
+        darwin: ['brew install copilot-cli', NPM_INSTALL_COPILOT],
+        linux: [NPM_INSTALL_COPILOT, 'brew install copilot-cli'],
+        win32: ['winget install GitHub.Copilot', NPM_INSTALL_COPILOT],
+      },
+    },
+    contextFileTargetPath: '.github/copilot-instructions.md',
+    skillsParentDir: '.github',
+    modelCatalog: COPILOT_MODELS,
+  },
+  'openai-codex': {
+    binary: 'codex',
+    installGuidance: {
+      docsUrl: 'https://github.com/openai/codex',
+      commandsByPlatform: {
+        darwin: [
+          'brew install --cask codex',
+          'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+          NPM_INSTALL_CODEX,
+        ],
+        linux: ['curl -fsSL https://chatgpt.com/codex/install.sh | sh', NPM_INSTALL_CODEX],
+        win32: [
+          'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+          NPM_INSTALL_CODEX,
+        ],
+      },
+    },
+    contextFileTargetPath: 'AGENTS.md',
+    skillsParentDir: '.agents',
+    modelCatalog: CODEX_MODELS,
+  },
+};

--- a/src/integration/ai/providers/_engine/session-permissions.ts
+++ b/src/integration/ai/providers/_engine/session-permissions.ts
@@ -28,6 +28,20 @@
  *    expose, and may write signals.json to outputDir, but Edit / MultiEdit / Bash are denied.
  *  - {@link FULL_AUTO}: implement (generator + evaluator) and apply-feedback (review). The
  *    AI may modify any file in the cwd / additionalRoots topology + run shell commands.
+ *
+ * ## When a CLI's gate is coarser than these booleans
+ *
+ * Not every underlying CLI exposes a permission gate this granular. When a CLI's native modes
+ * don't line up one-to-one with `canModifyRepoFiles` / `canRunShell` / `canAccessNetwork`, the
+ * adapter maps to the nearest supported mode and documents the resulting over-grant or
+ * under-grant inline, at the mapping site — never by adding a tool-specific field here (see the
+ * port-not-mechanism rule above). The reference precedent is the codex adapter's `sandboxFor`
+ * (`providers/codex/headless.ts`): Codex `exec` has only `read-only` (blocks the mandatory
+ * `signals.json` write, so it's unusable under audit-[09]) and `workspace-write` (allows any
+ * write inside the mounted topology). Every codex profile therefore maps to `workspace-write`,
+ * which over-grants relative to `canModifyRepoFiles=false` — the comment beside `sandboxFor`
+ * names this explicitly and defers to cwd + `additionalRoots` + `outputDir` as the real
+ * boundary, exactly as the topology-over-permissions note above describes.
  */
 export interface SessionPermissions {
   /**

--- a/src/integration/ai/readiness/_engine/setup.ts
+++ b/src/integration/ai/readiness/_engine/setup.ts
@@ -4,7 +4,8 @@ import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/h
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import type { ReadinessState } from '@src/integration/ai/readiness/_engine/state.ts';
-import type { AssistantTool } from '@src/integration/ai/readiness/_engine/tool.ts';
+import { providerForTool, type AssistantTool } from '@src/integration/ai/readiness/_engine/tool.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { Repository } from '@src/domain/entity/repository.ts';
@@ -12,24 +13,16 @@ import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 
 /**
- * Per-tool target path for the readiness artefact, relative to the repo root. Centralised so
- * the chain leaf, the CLI's "where will it write?" preview, and any doctor command agree on the
- * convention.
+ * Per-tool target path for the readiness artefact, relative to the repo root — derived from
+ * {@link PROVIDER_TRAITS}. Centralised so the chain leaf, the CLI's "where will it write?"
+ * preview, and any doctor command agree on the convention.
  *
  *  - `claude-code`  → `CLAUDE.md` (Claude's project memory).
  *  - `copilot`      → `.github/copilot-instructions.md` (Copilot's canonical instructions file).
  *  - `codex`        → `AGENTS.md` (cross-tool spec; Codex reads it when present).
  */
-export const targetPathFor = (tool: AssistantTool): string => {
-  switch (tool) {
-    case 'claude-code':
-      return 'CLAUDE.md';
-    case 'copilot':
-      return '.github/copilot-instructions.md';
-    case 'codex':
-      return 'AGENTS.md';
-  }
-};
+export const targetPathFor = (tool: AssistantTool): string =>
+  PROVIDER_TRAITS[providerForTool(tool)].contextFileTargetPath;
 
 /**
  * Function-injection contract for the prompt builder. The chain leaf supplies a closure that

--- a/src/integration/ai/readiness/_engine/tool.ts
+++ b/src/integration/ai/readiness/_engine/tool.ts
@@ -7,6 +7,9 @@ import type { AiProvider } from '@src/domain/entity/settings.ts';
  */
 export type AssistantTool = 'claude-code' | 'copilot' | 'codex';
 
+/** The `claude-code` id — shared literal between both directions of the provider/tool mapping below. */
+const CLAUDE_CODE_ID = 'claude-code' as const;
+
 /**
  * Map an {@link AiProvider} to the matching {@link AssistantTool}. Used by the readiness flow
  * to translate the per-flow provider rows (`settings.ai.<flow>.provider`) into the tool whose
@@ -15,11 +18,27 @@ export type AssistantTool = 'claude-code' | 'copilot' | 'codex';
  */
 export const toolForProvider = (provider: AiProvider): AssistantTool => {
   switch (provider) {
-    case 'claude-code':
-      return 'claude-code';
+    case CLAUDE_CODE_ID:
+      return CLAUDE_CODE_ID;
     case 'github-copilot':
       return 'copilot';
     case 'openai-codex':
       return 'codex';
+  }
+};
+
+/**
+ * Inverse of {@link toolForProvider} — maps an {@link AssistantTool} back to the
+ * {@link AiProvider} that drives it. Used to key provider-level static data (e.g.
+ * `PROVIDER_TRAITS`) from readiness code, which speaks `AssistantTool`.
+ */
+export const providerForTool = (tool: AssistantTool): AiProvider => {
+  switch (tool) {
+    case CLAUDE_CODE_ID:
+      return CLAUDE_CODE_ID;
+    case 'copilot':
+      return 'github-copilot';
+    case 'codex':
+      return 'openai-codex';
   }
 };

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -80,9 +80,15 @@ export const BUNDLED_SKILLS: readonly BundledSkillEntry[] = [
     recommendedFor: ['plan', 'readiness'],
   },
   {
+    // createPr is opt-in only, not default: this skill's guidance coaches emitting <note> /
+    // <decision> signals, but create-pr's output contract
+    // (generate-pr-content.contract.ts) accepts ONLY a single pr-content signal — a model
+    // following the skill's default advice there produces an invalid signals.json and the leaf
+    // silently falls back to the template body, defeating AI authoring. Conscious opt-in via
+    // the catalog avoids that conflict by default while keeping it discoverable.
     name: 'ralphctl-code-review-and-quality',
-    defaultFor: ['implement', 'createPr'],
-    recommendedFor: ['readiness'],
+    defaultFor: ['implement'],
+    recommendedFor: ['readiness', 'createPr'],
   },
   {
     name: 'ralphctl-surgical-simplicity',

--- a/src/integration/ai/skills/adapter-factory.ts
+++ b/src/integration/ai/skills/adapter-factory.ts
@@ -3,13 +3,11 @@
  * implementation matching the configured AI provider.
  *
  * All three providers now have a real filesystem adapter (the on-disk shape is identical —
- * Agent Skills SKILL.md folders — only the parent directory varies):
- *  - claude  → `.claude/skills/`
- *  - codex   → `.agents/skills/`
- *  - copilot → `.github/skills/`
+ * Agent Skills SKILL.md folders — only the parent directory varies, per provider, via
+ * `skillsParentDir` in `providers/_engine/provider-traits.ts`).
  *
- * Adding a new provider is one arm here plus a sibling `skills/<provider>/adapter.ts` that
- * delegates to {@link createFilesystemSkillsAdapter}.
+ * Adding a new provider is one row in `provider-traits.ts` plus one arm here plus a sibling
+ * `skills/<provider>/adapter.ts` that delegates to {@link createFilesystemSkillsAdapter}.
  */
 
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';

--- a/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-minimal-scaffolding/SKILL.md
@@ -1,58 +1,59 @@
 ---
 name: ralphctl-minimal-scaffolding
-description: Cross-phase skill — question every harness component on every model bump; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline. Governs the surrounding harness's own scaffolding, not the task's application code — for code-level minimalism defer to the ralphctl-ponytail, ralphctl-surgical-simplicity, and ralphctl-karpathy-guidelines skills when installed in this session.
+description: Cross-phase skill — question every piece of AI-workflow scaffolding on every model upgrade; remove non-load-bearing pieces one at a time with measurement. Complexity drifts upward by default; subtraction requires discipline. Governs scaffolding built around AI usage (prompts, wrapper scripts, guardrails, validation steps), not the task's application code — for code-level minimalism defer to the ralphctl-ponytail, ralphctl-surgical-simplicity, and ralphctl-karpathy-guidelines skills when installed in this session.
 ---
 
 # Minimal Scaffolding
 
 > "Find the simplest solution possible, and only increase complexity when needed. Every component encodes
 > assumptions about model limitations. Stress-test assumptions; they can go stale quickly as models improve.
-> Remove one component at a time when simplifying. Re-examine entire harness when new model releases; strip
-> non-load-bearing pieces."
+> Remove one component at a time when simplifying. Re-examine the whole system when a new model releases;
+> strip non-load-bearing pieces."
 >
 > — Anthropic, [_Harness Design for Long-Running Application Development_](https://www.anthropic.com/engineering/harness-design-long-running-apps)
 
-Harness complexity drifts upward. Each component that solves a real problem at the time of its addition
-becomes a permanent fixture — even after the model capability that made it necessary has improved past the
-threshold. Without an active counter-pressure, the harness grows into a weight that slows iteration and
-obscures the actual design signal. Minimal scaffolding is not a one-time decision at design time; it is a
-discipline applied on every model release and on every proposed addition.
+Scaffolding built around AI usage — prompts, wrapper scripts, extra validation steps, guardrails — drifts
+upward in complexity by default. Each piece that solves a real problem at the time of its addition becomes a
+permanent fixture, even after the model capability that made it necessary has improved past the threshold.
+Without an active counter-pressure, the scaffolding grows into a weight that slows iteration and obscures the
+actual design signal. Minimal scaffolding is not a one-time decision at design time; it is a discipline
+applied on every model upgrade and on every proposed addition.
 
 ## When this applies
 
-- **Refine** — before proposing that the refine phase needs a new guard, new evaluator, or new validation
-  step, ask whether the model would produce the right output without it given a well-scoped prompt.
-- **Plan** — before adding a new planning sub-agent or splitting a flow into more phases, ask whether the
-  additional structure would improve output quality measurably, or whether it is defensive scaffolding
-  against a past model's limitations.
-- **Execute** — before wiring a new chain primitive, a new leaf, or a new wrapper around the evaluator, ask
-  which assumption about current model capability the addition encodes, and whether that assumption is still
-  valid.
+- **Refine** — before proposing that the requirements need an extra review gate, an extra validation pass,
+  or an approval step to compensate for the model, ask whether the model would produce the right output
+  without it given a well-scoped prompt.
+- **Plan** — before adding an extra AI-assisted review step or splitting the work into more stages, ask
+  whether the additional structure would improve output quality measurably, or whether it is defensive
+  scaffolding against a past model's limitations.
+- **Execute** — before wiring a new wrapper, guard clause, or retry layer around an existing AI-assisted
+  check, ask which assumption about current model capability the addition encodes, and whether that
+  assumption is still valid.
 
 ## What to do
 
 1. **Start with the simplest viable shape.** Draft the simplest version that could work given today's model
    capability. Only add components when the simple version demonstrably fails.
-2. **Question every component on every model bump.** When a new model version ships, re-read
-   `HARNESS-PRINCIPLES.md` § 14 and § 18 in the project's `.claude/docs/` directory. For each `applied` row,
-   ask: "Would removing this component degrade output quality on the new model?" If the answer is uncertain,
-   run the test.
-3. **Remove one component at a time, measure.** Never refactor two components simultaneously — you cannot
-   isolate the regression. Remove one; run the project's check gate; observe output quality; decide.
+2. **Question every component on every model upgrade.** When a new model version ships, re-read the
+   project's own notes on why each piece of AI-workflow scaffolding exists, if the project keeps them. For
+   each one, ask: "Would removing this component degrade output quality on the new model?" If the answer is
+   uncertain, run the test.
+3. **Remove one component at a time, measure.** Never remove two pieces of scaffolding simultaneously — you
+   cannot isolate the regression. Remove one; run the project's check gate; observe output quality; decide.
 4. **Default toward subtraction over addition.** When in doubt, omit. Adding a component later when its
    need is proven is cheaper than carrying a component whose need was assumed.
 
 ## Anti-patterns
 
-- **Stacking primitives "just in case".** Adding a `guard` around the evaluator, a `loop` around the guard,
-  and a retry decorator around the loop — each layer may have been justified at the time, but the stack
-  encodes four separate assumptions, each of which needs re-validation on every model bump.
-- **Treating scaffolding as load-bearing without measurement.** "We've always had the idle watchdog" is not
-  a reason to keep it — it is a reason to measure whether it still fires in practice. If it never fires on
-  the current model, it may be removable.
-- **Mass refactors that change more than one component at a time.** Removing the plateau detector and the
-  idle watchdog in the same PR makes it impossible to attribute a quality change to either. One component
-  at a time.
+- **Stacking guardrails "just in case".** Adding a validation wrapper around a check, a retry loop around
+  the wrapper, and a review gate around the retry loop — each layer may have been justified at the time, but
+  the stack encodes several separate assumptions, each of which needs re-validation on every model upgrade.
+- **Treating scaffolding as load-bearing without measurement.** "We've always had this check" is not a
+  reason to keep it — it is a reason to measure whether it still fires in practice. If it never fires on the
+  current model, it may be removable.
+- **Mass refactors that change more than one piece of scaffolding at a time.** Removing two guardrails in
+  the same change makes it impossible to attribute a quality change to either. One piece at a time.
 - **Never re-auditing existing scaffolding when models get better.** Capability improvements accrue quietly.
   A component that was essential for an older model may be transparently handled by a newer one. Without an
-  explicit re-audit cadence, the harness ossifies around old assumptions.
+  explicit re-audit cadence, AI-workflow scaffolding ossifies around old assumptions.

--- a/src/integration/ai/skills/claude/adapter.ts
+++ b/src/integration/ai/skills/claude/adapter.ts
@@ -11,6 +11,7 @@
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { CreateClaudeSkillsAdapterDeps } from '@src/integration/ai/skills/_engine/claude-skills-adapter-deps.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 
 const CONVENTION = [
   'Skills live under `.claude/skills/<name>/SKILL.md` in this repository. Each `SKILL.md`',
@@ -22,7 +23,7 @@ const CONVENTION = [
 export const createClaudeSkillsAdapter = (deps: CreateClaudeSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'claude-code',
-    parentDir: '.claude',
+    parentDir: PROVIDER_TRAITS['claude-code'].skillsParentDir,
     convention: CONVENTION,
     ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/ai/skills/codex/adapter.ts
+++ b/src/integration/ai/skills/codex/adapter.ts
@@ -10,6 +10,7 @@
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { CreateCodexSkillsAdapterDeps } from '@src/integration/ai/skills/_engine/codex-skills-adapter-deps.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 
 const CONVENTION = [
   'Skills live under `.agents/skills/<name>/SKILL.md` in this repository. Each `SKILL.md`',
@@ -21,7 +22,7 @@ const CONVENTION = [
 export const createCodexSkillsAdapter = (deps: CreateCodexSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'openai-codex',
-    parentDir: '.agents',
+    parentDir: PROVIDER_TRAITS['openai-codex'].skillsParentDir,
     convention: CONVENTION,
     ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/ai/skills/copilot/adapter.ts
+++ b/src/integration/ai/skills/copilot/adapter.ts
@@ -14,6 +14,7 @@
 import { createFilesystemSkillsAdapter } from '@src/integration/ai/skills/_engine/filesystem-skills-adapter.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 import type { CreateCopilotSkillsAdapterDeps } from '@src/integration/ai/skills/_engine/copilot-skills-adapter-deps.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 
 const CONVENTION = [
   'Skills live under `.github/skills/<name>/SKILL.md` in this repository. Each `SKILL.md`',
@@ -25,7 +26,7 @@ const CONVENTION = [
 export const createCopilotSkillsAdapter = (deps: CreateCopilotSkillsAdapterDeps = {}): SkillsAdapter =>
   createFilesystemSkillsAdapter({
     providerId: 'github-copilot',
-    parentDir: '.github',
+    parentDir: PROVIDER_TRAITS['github-copilot'].skillsParentDir,
     convention: CONVENTION,
     ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
   });

--- a/src/integration/persistence/task/attempt.schema.ts
+++ b/src/integration/persistence/task/attempt.schema.ts
@@ -12,9 +12,14 @@ const BudgetExhaustedWarningSchema = z.object({
   turnsUsed: z.number().int().nonnegative(),
   turnBudget: z.number().int().positive(),
 });
+/** Mirrors {@link PlateauSource} — see `domain/entity/attempt.ts` for the detector mapping. */
+const PlateauSourceSchema = z.enum(['threshold', 'diversity', 'entropy']);
 const PlateauWarningSchema = z.object({
   kind: z.literal('plateau'),
   dimensions: z.array(z.string()).readonly(),
+  // Optional — absent on every record written before this field existed; old on-disk rows must
+  // keep parsing without it.
+  source: PlateauSourceSchema.optional(),
 });
 const MalformedWarningSchema = z.object({
   kind: z.literal('malformed'),

--- a/src/integration/system/bundle-integrity.ts
+++ b/src/integration/system/bundle-integrity.ts
@@ -1,0 +1,142 @@
+/**
+ * Startup integrity probe for a published bundle. `scripts/build-assets.ts` writes
+ * `dist/manifest.json` (`{ schemaVersion, packageVersion, generatedAt, assets[] }`) as a
+ * build-completeness record — until this module, nothing read it back, so an interrupted
+ * publish or truncated npm tarball surfaced only as a generic `StorageError` deep inside
+ * `FsTemplateLoader` / `bundledSkillSource`, the same confusing failure class the 0.15.1
+ * bundle-detection regression needed a patch release to diagnose.
+ *
+ * Bundle-mode detection mirrors `resolveTemplatesDir` / `resolveBundledRoot`: probe the
+ * filesystem for `manifest.json` sitting beside the running module, never the artifact
+ * filename. In dev (`tsx`) this module lives at `src/integration/system/bundle-integrity.ts`
+ * with nothing beside it, so the probe is a silent no-op; in a published bundle it's compiled
+ * into `dist/cli.mjs` (or one of tsup's hashed code-split chunks), which sits directly beside
+ * `dist/manifest.json` and every asset dir the manifest names.
+ *
+ * Two failure classes, both actionable, both surfaced as a `StorageError` naming a "reinstall
+ * ralphctl" hint:
+ *   - **missing asset(s)** — the exact 0.15.1-shaped failure mode: a partial copy or truncated
+ *     tarball left `dist/manifest.json` naming files that never landed.
+ *   - **package-version mismatch** — a half-upgraded global install: `dist/cli.mjs` was replaced
+ *     but the co-located assets (or vice versa) are stale from a different release.
+ *
+ * A malformed / unparseable manifest degrades to a `'malformed'` status (not a `Result.error`) —
+ * the probe must never brick a working install over its own bookkeeping file; callers log it at
+ * warning level and continue.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { pathExists, readJson } from '@src/integration/io/fs.ts';
+import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
+
+const REINSTALL_HINT = 'reinstall ralphctl (npm i -g ralphctl / pnpm add -g ralphctl)';
+
+const ManifestSchema = z.object({
+  schemaVersion: z.number(),
+  packageVersion: z.string(),
+  generatedAt: z.string(),
+  assets: z.array(z.string()),
+});
+
+/** Outcome that does not warrant a hard startup failure — the caller decides how to render it. */
+export type BundleIntegrityStatus =
+  | { readonly kind: 'skipped' } // dev mode: no manifest.json beside the running module
+  | { readonly kind: 'ok' } // bundle mode: manifest parsed, version matches, every asset present
+  | { readonly kind: 'malformed'; readonly reason: string }; // bundle mode: manifest unreadable / bad shape
+
+export interface CheckBundleIntegrityDeps {
+  /** Test seam — defaults to this module's own `import.meta.url`. */
+  readonly moduleUrl?: string;
+  /** Test seam for the beside-the-module existence probe — defaults to `existsSync`. */
+  readonly exists?: (path: string) => boolean;
+  /** Test seam — defaults to `CLI_METADATA.currentVersion`. */
+  readonly currentVersion?: string;
+}
+
+/**
+ * Resolve `manifest.json` beside this module, or `undefined` in dev mode where nothing sits
+ * there. Deliberately NOT a filename check for the same reason the sibling resolvers aren't:
+ * tsup code-splitting rewrites `import.meta.url` to a hashed `cli-<hash>.mjs` chunk, and a check
+ * against a fixed filename would silently miss it.
+ *
+ * @public
+ */
+export const resolveManifestPath = (
+  moduleUrl: string,
+  exists: (path: string) => boolean = existsSync
+): string | undefined => {
+  const here = dirname(fileURLToPath(moduleUrl));
+  const manifestPath = join(here, 'manifest.json');
+  return exists(manifestPath) ? manifestPath : undefined;
+};
+
+/** Existence-check every asset path (relative to the manifest's directory) in parallel — presence only, no hashing. */
+const findMissingAssets = async (assetRoot: string, assets: readonly string[]): Promise<readonly string[]> => {
+  const checks = await Promise.all(
+    assets.map(async (rel) => {
+      const found = await pathExists(join(assetRoot, rel));
+      const present = found.ok && found.value;
+      return present ? undefined : rel;
+    })
+  );
+  return checks.filter((rel): rel is string => rel !== undefined);
+};
+
+/**
+ * Run the startup integrity probe. `Result.error` carries the two hard-failure diagnostics
+ * (missing assets / version mismatch) as a `StorageError` the composition root already knows
+ * how to render (`throw new Error(`bundle-integrity: ${result.error.message}`)`, same idiom as
+ * the storage-paths / settings-load pre-flights it sits beside). `Result.ok` carries every other
+ * outcome, including the malformed-manifest warning — that path must never abort startup.
+ */
+export const checkBundleIntegrity = async (
+  deps: CheckBundleIntegrityDeps = {}
+): Promise<Result<BundleIntegrityStatus, StorageError>> => {
+  const moduleUrl = deps.moduleUrl ?? import.meta.url;
+  const currentVersion = deps.currentVersion ?? CLI_METADATA.currentVersion;
+  const manifestPath = resolveManifestPath(moduleUrl, deps.exists);
+  if (manifestPath === undefined) return Result.ok({ kind: 'skipped' });
+
+  const raw = await readJson(manifestPath);
+  if (!raw.ok) {
+    return Result.ok({ kind: 'malformed', reason: `${manifestPath}: ${raw.error.message}` });
+  }
+  const parsed = ManifestSchema.safeParse(raw.value);
+  if (!parsed.success) {
+    return Result.ok({ kind: 'malformed', reason: `${manifestPath}: does not match the expected manifest shape` });
+  }
+
+  if (parsed.data.packageVersion !== currentVersion) {
+    return Result.error(
+      new StorageError({
+        subCode: 'schema-mismatch',
+        message:
+          `ralphctl install looks half-upgraded — ${manifestPath} was built for ` +
+          `${parsed.data.packageVersion} but the running package is ${currentVersion}. ${REINSTALL_HINT}.`,
+        path: manifestPath,
+        hint: REINSTALL_HINT,
+      })
+    );
+  }
+
+  const missing = await findMissingAssets(dirname(manifestPath), parsed.data.assets);
+  if (missing.length > 0) {
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message:
+          `ralphctl install is missing ${String(missing.length)} bundled asset(s) declared in ` +
+          `${manifestPath}. ${REINSTALL_HINT}.`,
+        path: manifestPath,
+        hint: REINSTALL_HINT,
+      })
+    );
+  }
+
+  return Result.ok({ kind: 'ok' });
+};

--- a/src/integration/system/detect-cli.ts
+++ b/src/integration/system/detect-cli.ts
@@ -1,5 +1,6 @@
 import { commandExists } from '@src/integration/io/command-exists.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
+import { PROVIDER_TRAITS } from '@src/integration/ai/providers/_engine/provider-traits.ts';
 import type {
   DetectInstalledProvidersOptions,
   InstallPlatform,
@@ -16,59 +17,25 @@ import type {
  * the real spawn fail (`gh` is a separate SCM dependency for create-pr / issue sync, not the
  * Copilot AI backend).
  *
- * Single source of truth — used by `detectInstalledProviders`, the apply-preset warning surface,
- * and the fail-fast launch helper.
+ * Derived from {@link PROVIDER_TRAITS} — used by `detectInstalledProviders`, the apply-preset
+ * warning surface, and the fail-fast launch helper.
  */
 export const PROVIDER_BINARY: Readonly<Record<AiProvider, string>> = {
-  'claude-code': 'claude',
-  'github-copilot': 'copilot',
-  'openai-codex': 'codex',
+  'claude-code': PROVIDER_TRAITS['claude-code'].binary,
+  'github-copilot': PROVIDER_TRAITS['github-copilot'].binary,
+  'openai-codex': PROVIDER_TRAITS['openai-codex'].binary,
 };
 
-const NPM_INSTALL_CLAUDE = 'npm install -g @anthropic-ai/claude-code';
-const NPM_INSTALL_COPILOT = 'npm install -g @github/copilot';
-const NPM_INSTALL_CODEX = 'npm install -g @openai/codex';
-
 /**
- * Per-vendor install guidance entries. Sources (verified against vendor docs at the time of
- * writing):
- *   - claude-code:    https://docs.claude.com/en/docs/claude-code/setup
- *   - github-copilot: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-in-the-cli
- *                     plus https://cli.github.com (for the underlying `gh` install)
- *   - openai-codex:   https://github.com/openai/codex
- *
- * Single source of truth — adding a new provider means one entry here plus the existing entry
- * in `PROVIDER_BINARY`. Port-shaped types ({@link ProviderInstallGuidance}, {@link InstallPlatform})
- * live in `_engine/detect-cli.ts`.
+ * Per-vendor install guidance entries, derived from {@link PROVIDER_TRAITS}. Adding a new
+ * provider means one row in `provider-traits.ts` — this map and {@link PROVIDER_BINARY} pick
+ * it up automatically. Port-shaped types ({@link ProviderInstallGuidance}) live in
+ * `_engine/detect-cli.ts`.
  */
 export const PROVIDER_INSTALL_GUIDANCE: Readonly<Record<AiProvider, ProviderInstallGuidance>> = {
-  'claude-code': {
-    docsUrl: 'https://docs.claude.com/en/docs/claude-code/setup',
-    commandsByPlatform: {
-      darwin: ['brew install --cask claude-code', 'curl -fsSL https://claude.ai/install.sh | bash', NPM_INSTALL_CLAUDE],
-      linux: ['curl -fsSL https://claude.ai/install.sh | bash', NPM_INSTALL_CLAUDE],
-      win32: ['winget install Anthropic.ClaudeCode', 'irm https://claude.ai/install.ps1 | iex', NPM_INSTALL_CLAUDE],
-    },
-  },
-  'github-copilot': {
-    docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli',
-    commandsByPlatform: {
-      darwin: ['brew install copilot-cli', NPM_INSTALL_COPILOT],
-      linux: [NPM_INSTALL_COPILOT, 'brew install copilot-cli'],
-      win32: ['winget install GitHub.Copilot', NPM_INSTALL_COPILOT],
-    },
-  },
-  'openai-codex': {
-    docsUrl: 'https://github.com/openai/codex',
-    commandsByPlatform: {
-      darwin: ['brew install --cask codex', 'curl -fsSL https://chatgpt.com/codex/install.sh | sh', NPM_INSTALL_CODEX],
-      linux: ['curl -fsSL https://chatgpt.com/codex/install.sh | sh', NPM_INSTALL_CODEX],
-      win32: [
-        'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
-        NPM_INSTALL_CODEX,
-      ],
-    },
-  },
+  'claude-code': PROVIDER_TRAITS['claude-code'].installGuidance,
+  'github-copilot': PROVIDER_TRAITS['github-copilot'].installGuidance,
+  'openai-codex': PROVIDER_TRAITS['openai-codex'].installGuidance,
 };
 
 /**

--- a/tests/e2e/cli/skills.test.ts
+++ b/tests/e2e/cli/skills.test.ts
@@ -17,11 +17,12 @@ describe('ralphctl skills list', () => {
     expect(result.exitCode).toBe(0);
 
     // Descends from v1's global default bundle — default-ON for every flow whose launcher
-    // actually mounts skills (createPr is excluded, see skills.ts's module doc).
+    // actually mounts skills, createPr included (its view / CLI compose a skill source
+    // directly — see `flowMountsSkills`'s doc comment in launcher.ts).
     const alignmentLine = result.stdout.split('\n').find((line) => line.startsWith('ralphctl-alignment'));
     expect(alignmentLine).toBeDefined();
     expect(alignmentLine).toContain('bundled');
-    expect(alignmentLine).toContain('flows: refine, plan, implement, readiness, ideate');
+    expect(alignmentLine).toContain('flows: refine, plan, implement, readiness, ideate, createPr');
 
     // Curated addition scoped to a single phase — proves the column isn't just "every flow".
     const ideationLine = result.stdout.split('\n').find((line) => line.startsWith('ralphctl-idea-refinement'));
@@ -43,6 +44,6 @@ describe('ralphctl skills list', () => {
     expect(alignmentLine).toBeDefined();
     // "implement" no longer sits between "plan," and "readiness," once opted out — a plain
     // `not.toContain('implement')` would false-positive on unrelated description prose.
-    expect(alignmentLine).toContain('flows: refine, plan, readiness, ideate');
+    expect(alignmentLine).toContain('flows: refine, plan, readiness, ideate, createPr');
   });
 });

--- a/tests/e2e/cli/skills.test.ts
+++ b/tests/e2e/cli/skills.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createJsonSettingsRepository } from '@src/integration/persistence/settings/json-settings-repository.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
+
+describe('ralphctl skills list', () => {
+  let cli: CliHome;
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+  });
+
+  afterEach(async () => cli.cleanup());
+
+  it('lists the bundled catalog with tier + enabled flows on a fresh install', async () => {
+    const result = await runCliCaptured(cli, ['skills', 'list']);
+    expect(result.exitCode).toBe(0);
+
+    // Descends from v1's global default bundle — default-ON for every flow whose launcher
+    // actually mounts skills (createPr is excluded, see skills.ts's module doc).
+    const alignmentLine = result.stdout.split('\n').find((line) => line.startsWith('ralphctl-alignment'));
+    expect(alignmentLine).toBeDefined();
+    expect(alignmentLine).toContain('bundled');
+    expect(alignmentLine).toContain('flows: refine, plan, implement, readiness, ideate');
+
+    // Curated addition scoped to a single phase — proves the column isn't just "every flow".
+    const ideationLine = result.stdout.split('\n').find((line) => line.startsWith('ralphctl-idea-refinement'));
+    expect(ideationLine).toBeDefined();
+    expect(ideationLine).toContain('flows: ideate');
+    expect(ideationLine).not.toContain('flows: refine');
+  });
+
+  it('reflects a saved opt-out by dropping that flow from the enabled-flows column', async () => {
+    const settingsRepo = createJsonSettingsRepository({ configRoot: cli.paths.configRoot });
+    await settingsRepo.save({
+      ...DEFAULT_SETTINGS,
+      ai: { ...DEFAULT_SETTINGS.ai, skills: { implement: { disabled: ['ralphctl-alignment'] } } },
+    });
+
+    const result = await runCliCaptured(cli, ['skills', 'list']);
+    expect(result.exitCode).toBe(0);
+    const alignmentLine = result.stdout.split('\n').find((line) => line.startsWith('ralphctl-alignment'));
+    expect(alignmentLine).toBeDefined();
+    // "implement" no longer sits between "plan," and "readiness," once opted out — a plain
+    // `not.toContain('implement')` would false-positive on unrelated description prose.
+    expect(alignmentLine).toContain('flows: refine, plan, readiness, ideate');
+  });
+});

--- a/tests/e2e/flows/create-pr.test.ts
+++ b/tests/e2e/flows/create-pr.test.ts
@@ -33,6 +33,7 @@ import { dirname } from 'node:path';
 import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 import type { AiSignalEvent } from '@src/business/observability/events.ts';
+import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
 
 const fakeSprintRepo = (sprint: Sprint): SprintRepository =>
   ({
@@ -137,7 +138,12 @@ const stubAiDeps = {
   writeFile: refusingWriteFile,
   logger: noopLogger,
   model: 'test-model',
-} satisfies Pick<CreatePrDeps, 'provider' | 'templateLoader' | 'writeFile' | 'logger' | 'model'>;
+  skillSource: emptySkillSource,
+  skillsAdapter: noopSkillsAdapter,
+} satisfies Pick<
+  CreatePrDeps,
+  'provider' | 'templateLoader' | 'writeFile' | 'logger' | 'model' | 'skillSource' | 'skillsAdapter'
+>;
 
 describe('create-pr flow — happy path', () => {
   it('pushes the branch, then opens the PR and persists the URL on the sprint execution', async () => {
@@ -447,6 +453,8 @@ describe('create-pr flow — useAi=true happy path', () => {
           writeFile: realWriteFile,
           logger: noopLogger,
           model: 'test-model',
+          skillSource: emptySkillSource,
+          skillsAdapter: noopSkillsAdapter,
         },
         { useAi: true }
       );
@@ -509,6 +517,8 @@ describe('create-pr flow — useAi=true happy path', () => {
           writeFile: realWriteFile,
           logger: noopLogger,
           model: 'test-model',
+          skillSource: emptySkillSource,
+          skillsAdapter: noopSkillsAdapter,
         },
         { useAi: true }
       );

--- a/tests/integration/ai/skills/launcher-composition.test.ts
+++ b/tests/integration/ai/skills/launcher-composition.test.ts
@@ -183,23 +183,30 @@ describe('buildComposedSkillSource — aliased-flow row inheritance', () => {
 
   it('maps the create-pr orchestration id to the createPr settings row', async () => {
     const deps = await makeDeps();
-    const settings = withSkills({ createPr: { disabled: ['ralphctl-code-review-and-quality'] } });
+    // ralphctl-alignment is one of the four ALL_FLOWS defaults (content-generic, no contract
+    // tension with create-pr's single-signal output contract) — it's actually present by
+    // default for createPr, so disabling it proves the opt-out subtraction, unlike a skill
+    // that's createPr-recommendedFor-only (e.g. ralphctl-code-review-and-quality) and was
+    // never in the resolved set to begin with.
+    const settings = withSkills({ createPr: { disabled: ['ralphctl-alignment'] } });
     const resolved = buildComposedSkillSource(deps, snapshot, 'claude-code', 'create-pr', settings, {});
 
     const names = (await forFlow(resolved, 'createPr')).map((s) => s.name);
-    expect(names).not.toContain('ralphctl-code-review-and-quality');
+    expect(names).not.toContain('ralphctl-alignment');
   });
 });
 
 describe('flowMountsSkills — gate for the customize picker skills step', () => {
-  it('returns true only for the five flows whose launch context threads ctx.skillSource', () => {
-    for (const id of ['refine', 'plan', 'implement', 'readiness', 'ideate']) {
+  it('returns true for every flow whose AI session gets a composed skill source', () => {
+    // create-pr mounts too, but via its own view / CLI calling buildComposedSkillSource
+    // directly — it never reaches launchFlow's dispatch, so it has no customize-picker step.
+    for (const id of ['refine', 'plan', 'implement', 'readiness', 'ideate', 'create-pr']) {
       expect(flowMountsSkills(id)).toBe(true);
     }
   });
 
-  it('returns false for aliased / non-mounting flows and non-AI flows', () => {
-    for (const id of ['review', 'detect-scripts', 'detect-skills', 'create-pr', 'create-sprint', 'close-sprint']) {
+  it('returns false for aliased flows and non-AI flows', () => {
+    for (const id of ['review', 'detect-scripts', 'detect-skills', 'create-sprint', 'close-sprint']) {
       expect(flowMountsSkills(id)).toBe(false);
     }
   });

--- a/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator-contract.test.ts
@@ -17,6 +17,8 @@ import { createMockHeadlessProvider, type SpawnFixture } from '@tests/helpers/mo
 import type { GitRunner } from '@src/integration/io/git-runner.ts';
 import type { EvaluatorLeafDeps } from '@src/application/flows/implement/leaves/evaluator.ts';
 import { evaluatorLeaf } from '@src/application/flows/implement/leaves/evaluator.ts';
+import type { GeneratorLeafDeps } from '@src/application/flows/implement/leaves/generator.ts';
+import { generatorLeaf } from '@src/application/flows/implement/leaves/generator.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 /** Clean-tree git stub — the post-spawn fingerprint call is inert in these contract tests. */
@@ -448,6 +450,8 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     expect(result.value.ctx.lastEvaluation?.status).toBe('passed');
     // Exactly two spawns: the original + ONE corrective retry (no loop).
     expect(mock.invocations).toHaveLength(2);
+    // Cost-visibility tally: the one nudge that recovered the verdict lands on ctx.
+    expect(result.value.ctx.currentAttemptEvaluatorNudges).toBe(1);
     // Forensic body mirror: the initial spawn captures `body.txt`, the corrective nudge captures a
     // distinct `body-corrective-1.txt` so a nudge never clobbers the original spawn's capture.
     expect(String(mock.invocations[0]?.session.bodyFile)).toMatch(/\/rounds\/\d+\/evaluator\/body\.txt$/);
@@ -557,6 +561,8 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     expect(result.value.ctx.lastExit?.kind).toBe('passed');
     // Original spawn + 2 corrective nudges.
     expect(mock.invocations).toHaveLength(3);
+    // Cost-visibility tally: BOTH nudges this turn needed land on ctx (the second one recovered).
+    expect(result.value.ctx.currentAttemptEvaluatorNudges).toBe(2);
   });
 
   it('corrective retry exhausted after two nudges (correctiveRetries=2 → 3 spawns) → self-block', async () => {
@@ -571,6 +577,100 @@ describe('evaluatorLeaf — audit-[09] contract', () => {
     expectSelfBlock(result, 'schema');
     // Original spawn + 2 corrective nudges, then self-block.
     expect(mock.invocations).toHaveLength(3);
+    // Cost-visibility tally is scoped to RECOVERED turns (see corrective-retry.ts docstring): an
+    // exhausted/self-blocked turn is already loud via the block reason, so no count lands on ctx.
+    if (result.ok) expect(result.value.ctx.currentAttemptEvaluatorNudges).toBeUndefined();
+  });
+
+  // ── Cross-role: generator + evaluator nudge tallies accumulate independently on the same ctx ──
+  it('generator and evaluator nudge tallies land on separate ctx fields without clobbering each other', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const generatorSignalsPath = join(String(root.root), 'rounds', '1', 'generator', 'signals.json');
+    const generatorSequences = new Map<string, readonly SpawnFixture[]>([
+      [
+        generatorSignalsPath,
+        [
+          {
+            kind: 'ok',
+            payload: {
+              schemaVersion: 1,
+              signals: [
+                { type: 'commit-message', subject: 'first', timestamp: '2026-05-22T10:00:00.000Z' },
+                { type: 'commit-message', subject: 'second', timestamp: '2026-05-22T10:00:01.000Z' },
+              ],
+            },
+          },
+          {
+            kind: 'ok',
+            payload: {
+              schemaVersion: 1,
+              signals: [{ type: 'commit-message', subject: 'fixed', timestamp: '2026-05-22T10:00:02.000Z' }],
+            },
+          },
+        ],
+      ],
+    ]);
+    const generatorMock = createMockHeadlessProvider({ sequences: generatorSequences });
+    const generatorWriteFile: GeneratorLeafDeps['writeFile'] = async (path, content) => {
+      await fs.mkdir(join(String(path), '..'), { recursive: true });
+      await fs.writeFile(String(path), content, 'utf8');
+      return Result.ok(undefined);
+    };
+    const generatorDeps: GeneratorLeafDeps = {
+      provider: generatorMock.provider,
+      templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+      publishSignal: createPublishSignal(createInMemoryEventBus(), 'generator'),
+      writeFile: generatorWriteFile,
+      cwd: absolutePath('/tmp/ralph/fake-cwd'),
+      sprintDir: absolutePath('/tmp/ralph/fake-sprint-dir'),
+      progressFile: absolutePath('/tmp/ralph/fake-sprint-dir/progress.md'),
+      model: 'test-model',
+      clock: () => FIXED_NOW,
+      logger: noopLogger,
+      eventBus: createInMemoryEventBus(),
+      maxTurns: 5,
+      plateauThreshold: 2,
+      correctiveRetries: 1,
+    };
+
+    const genResult = await generatorLeaf(generatorDeps, task.id).execute(baseCtx(task));
+    expect(genResult.ok).toBe(true);
+    if (!genResult.ok) return;
+    expect(genResult.value.ctx.currentAttemptGeneratorNudges).toBe(1);
+    expect(genResult.value.ctx.currentAttemptEvaluatorNudges).toBeUndefined();
+
+    // Feed the generator's ctx straight into the evaluator leaf — same attempt, next role.
+    const sequences = new Map<string, readonly SpawnFixture[]>([
+      [
+        signalsFilePath(),
+        [
+          {
+            kind: 'ok',
+            payload: {
+              schemaVersion: 1,
+              signals: [
+                {
+                  type: 'evaluation',
+                  status: 'passed',
+                  dimensions: [{ dimension: 'correctness', passed: true, finding: 'all good' }],
+                  timestamp: '2026-05-22T10:00:00.000Z',
+                },
+              ],
+            },
+          },
+          { kind: 'ok', payload: { schemaVersion: 1, signals: [passedEvaluation] } },
+        ],
+      ],
+    ]);
+    const mock = createMockHeadlessProvider({ sequences });
+    const evalResult = await evaluatorLeaf(twoRetryDeps(mock), task.id).execute(genResult.value.ctx);
+
+    expect(evalResult.ok).toBe(true);
+    if (!evalResult.ok) return;
+    // Both tallies are present, independently — the evaluator's nudge did not clobber the
+    // generator's, and vice versa.
+    expect(evalResult.value.ctx.currentAttemptGeneratorNudges).toBe(1);
+    expect(evalResult.value.ctx.currentAttemptEvaluatorNudges).toBe(1);
   });
 
   // ── Stale-clear: a self-blocked round must CLEAR a prior round's lastEvaluation ──

--- a/tests/integration/application/flows/implement/leaves/evaluator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator.test.ts
@@ -9,7 +9,9 @@ import { absolutePath, FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@
 import { recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import { evaluatorLeaf } from '@src/application/flows/implement/leaves/evaluator.ts';
 
 describe('evaluatorLeaf', () => {
@@ -237,6 +239,59 @@ describe('evaluatorLeaf', () => {
       expect(await readPrompt(1)).toContain('independent code reviewer');
       expect(await readPrompt(2)).toContain('independent code reviewer');
       expect(await readPrompt(2)).not.toContain('# Re-evaluate — Round');
+    });
+  });
+
+  // `{{PROJECT_TOOLING}}` naming (research-quickwins): mirrors the generator leaf's equivalent
+  // block — the FULL evaluate prompt threads the same bound agent-definition name + this flow's
+  // installed skills so the evaluator sees explicitly-named tooling instead of the template's
+  // default "(none detected)" fallback.
+  describe('project tooling catalog', () => {
+    const fakeSkillSource = (): SkillSource => ({
+      getForFlow: async () =>
+        Result.ok([
+          {
+            name: 'alignment',
+            description: 'Confirm scope before diving into work',
+            content: '# alignment\n',
+          },
+        ]),
+      getByName: async () => Result.ok(undefined),
+    });
+
+    const baseCtx = (task: ReturnType<typeof makeInProgressTaskWithRunningAttempt>): ImplementCtx => ({
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+      currentTask: task,
+      currentRoundNum: 1,
+      taskWorkspaceRoot: root.root,
+    });
+
+    it('names the bound agent definition and installed skills in the FULL prompt', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const leaf = evaluatorLeaf(
+        { ...buildDeps(), agentDefinitionName: 'code-reviewer', skillSource: fakeSkillSource() },
+        task.id
+      );
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+
+      const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'evaluator', 'prompt.md'), 'utf8');
+      expect(content).toContain('- Subagent: `code-reviewer`');
+      expect(content).toContain('- Skill: `alignment` — Confirm scope before diving into work');
+      expect(content).not.toContain('(none detected)');
+    });
+
+    it('falls back to the template default when neither an agent definition nor skills are available', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const leaf = evaluatorLeaf({ ...buildDeps(), skillSource: emptySkillSource }, task.id);
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+
+      const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'evaluator', 'prompt.md'), 'utf8');
+      expect(content).toContain('(none detected)');
+      expect(content).not.toContain('- Subagent:');
+      expect(content).not.toContain('- Skill:');
     });
   });
 });

--- a/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
+++ b/tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts
@@ -469,6 +469,10 @@ describe('createGenEvalLoop — entropy-check (R2) live behavior', () => {
     if (!result.ok) return;
     // The entropy guard reuses the plateau exit kind so the escalation ladder applies the remedy.
     expect(result.value.ctx.lastExit?.kind).toBe('plateau');
+    // Attribution: this exit came from the entropy detector specifically — instrumentation only,
+    // no effect on the exit decision itself.
+    const exit = result.value.ctx.lastExit;
+    expect(exit?.kind === 'plateau' && exit.source).toBe('entropy');
     // Fires exactly at the window boundary (turn 3 = DIVERSITY_WINDOW_SIZE), with budget remaining.
     expect(result.value.ctx.genEvalTurn).toBe(3);
     const entropyBanner = banners.find(
@@ -503,5 +507,139 @@ describe('createGenEvalLoop — entropy-check (R2) live behavior', () => {
       (e) => e.type === 'banner-show' && e.id === `entropy-plateau-${String(task.id)}`
     );
     expect(entropyBanner).toBeUndefined();
+  });
+});
+
+// ── Behavioral test: loop-diversity fires on a repeated failure fingerprint (R1) ────────────────
+
+/**
+ * The loop-diversity guard is the FIRST plateau source to run inside `evaluator-guard` (it
+ * precedes the entropy check). To isolate it from the other two detectors:
+ *  - the evaluator's own count-based plateau predicate: the scripted critique is genuinely
+ *    dissimilar every turn (reusing the entropy suite's `CRITIQUES` list), so the critique-shift
+ *    exemption returns `progress` and the count-based predicate never fires — even though the
+ *    SAME dimension fails every turn (which is exactly what the diversity fingerprint needs).
+ *  - the entropy guard: the generator emits one of each narrative kind every turn (uniform
+ *    distribution, H = 1), so it never sees low entropy.
+ * That leaves the diversity guard as the only possible plateau exit.
+ */
+describe('createGenEvalLoop — loop-diversity guard (R1) live behavior', () => {
+  let root: Awaited<ReturnType<typeof makeTmpRoot>>;
+
+  beforeEach(async () => {
+    root = await makeTmpRoot();
+  });
+
+  afterEach(async () => {
+    await root.cleanup();
+  });
+
+  const ts = FIXED_NOW;
+  const taskVerified = (output: string): HarnessSignal => ({ type: 'task-verified', output, timestamp: ts });
+  const note = (text: string): HarnessSignal => ({ type: 'note', text, timestamp: ts });
+  const decision = (text: string): HarnessSignal => ({ type: 'decision', text, timestamp: ts });
+  const change = (text: string): HarnessSignal => ({ type: 'change', text, timestamp: ts });
+  const learning = (text: string): HarnessSignal => ({ type: 'learning', text, timestamp: ts });
+
+  const FLOOR = ['correctness', 'completeness', 'safety', 'consistency', 'robustness'] as const;
+  const CRITIQUES = [
+    'first round complaint about a parser edge case in the tokenizer module',
+    'second turn raises a completely different retry-semantics concern entirely',
+    'third pass flags a SQL injection vector in the dynamic query builder layer',
+    'fourth review worries about timezone handling around daylight-saving boundaries',
+    'fifth look questions the cache eviction policy under sustained memory pressure',
+  ];
+  /**
+   * A FAILED verdict for turn `i` (0-indexed): the SAME dimension fails every turn (identical
+   * fingerprint → diversity guard trips), but the critique is distinct every turn (critique-shift
+   * exemption → the count-based evaluator plateau stays quiet).
+   */
+  const failSameDim = (i: number): HarnessSignal => ({
+    type: 'evaluation',
+    status: 'failed',
+    dimensions: FLOOR.map((d) => ({
+      dimension: d,
+      passed: d !== 'correctness',
+      finding: d === 'correctness' ? 'nope' : 'ok',
+    })),
+    critique: CRITIQUES[i] ?? `fallback critique number ${String(i)} mentioning unique token ${String(i * 7919)}`,
+    timestamp: ts,
+  });
+
+  it("exits with a plateau attributed to 'diversity' when the failure fingerprint repeats for >= window turns", async () => {
+    const generatorProvider = createFakeAiProvider({
+      responses: { implement: '' },
+      // Diverse spread of signal kinds every turn keeps the entropy guard quiet (H = 1).
+      signals: { implement: [taskVerified('ok'), decision('d'), change('c'), learning('l'), note('n')] },
+    });
+    let evalTurn = 0;
+    const evaluatorProvider = createFakeAiProvider({
+      responses: { evaluate: '' },
+      signals: {
+        evaluate: () => {
+          const sig = failSameDim(evalTurn);
+          evalTurn += 1;
+          return [sig];
+        },
+      },
+    });
+    const task = makeInProgressTaskWithRunningAttempt();
+    const eventBus = createInMemoryEventBus();
+    const banners: AppEvent[] = [];
+    eventBus.subscribe((e) => {
+      if (e.type === 'banner-show') banners.push(e);
+    });
+    const loop = createGenEvalLoop(
+      {
+        generatorProvider,
+        evaluatorProvider,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        publishSignal: () => {},
+        writeFile: async () => Result.ok(undefined),
+        clock: () => FIXED_NOW,
+        logger: noopLogger,
+        eventBus,
+        readConfig: async () => ({ maxTurns: 5 }),
+        maxTurns: 5,
+        plateauThreshold: 2,
+        correctiveRetries: 2,
+        gitRunner: {
+          async run() {
+            return Result.ok({ stdout: '', stderr: '', exitCode: 0 });
+          },
+        },
+      },
+      {
+        cwd: absolutePath('/tmp/ralph/fake-cwd'),
+        sprintDir: root.root,
+        progressFile: absolutePath('/tmp/ralph/fake-sprint-dir/progress.md'),
+        generator: { providerId: 'claude-code', model: 'claude-opus-4-8' },
+        evaluator: { providerId: 'claude-code', model: 'claude-opus-4-8' },
+      },
+      task.id
+    );
+
+    const ctx: ImplementCtx = {
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+      currentTask: task,
+      taskWorkspaceRoot: root.root,
+    };
+
+    const result = await loop.execute(ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ctx.lastExit?.kind).toBe('plateau');
+    // Attribution: this exit came from the loop-diversity detector specifically.
+    const exit = result.value.ctx.lastExit;
+    expect(exit?.kind === 'plateau' && exit.source).toBe('diversity');
+    // Fires exactly at the window boundary (turn 3 = DIVERSITY_WINDOW_SIZE), with budget remaining.
+    expect(result.value.ctx.genEvalTurn).toBe(3);
+    const diversityBanner = banners.find(
+      (e) => e.type === 'banner-show' && e.id === `loop-diversity-${String(task.id)}`
+    );
+    expect(diversityBanner).toBeDefined();
+    if (diversityBanner?.type === 'banner-show') expect(diversityBanner.cause).toBe('loop-diversity-exhausted');
   });
 });

--- a/tests/integration/application/flows/implement/leaves/generator-contract.test.ts
+++ b/tests/integration/application/flows/implement/leaves/generator-contract.test.ts
@@ -333,4 +333,88 @@ describe('generatorLeaf — audit-[09] contract', () => {
     if (result.ok) return;
     expect(result.error.error).toBeInstanceOf(AbortError);
   });
+
+  // ── Corrective retry — cost-visibility tally lands on ctx.currentAttemptGeneratorNudges ──
+  describe('corrective retry — cost-visibility tally', () => {
+    // Two commit-message signals fail the "at most one commit-message" refinement (case 5 above)
+    // — a correctable schema failure that triggers a nudge.
+    const twoCommitMessages: SpawnFixture = {
+      kind: 'ok',
+      payload: {
+        schemaVersion: 1,
+        signals: [
+          { type: 'commit-message', subject: 'first', timestamp: '2026-05-22T10:00:00.000Z' },
+          { type: 'commit-message', subject: 'second', timestamp: '2026-05-22T10:00:01.000Z' },
+        ],
+      },
+    };
+    const oneCommitMessage: SpawnFixture = {
+      kind: 'ok',
+      payload: {
+        schemaVersion: 1,
+        signals: [{ type: 'commit-message', subject: 'fixed', timestamp: '2026-05-22T10:00:02.000Z' }],
+      },
+    };
+
+    it('recovers on the first nudge: ctx.currentAttemptGeneratorNudges is 1', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const sequences = new Map<string, readonly SpawnFixture[]>([
+        [signalsFilePath(), [twoCommitMessages, oneCommitMessage]],
+      ]);
+      const mock = createMockHeadlessProvider({ sequences });
+      const deps: GeneratorLeafDeps = { ...buildDeps(new Map()), provider: mock.provider };
+      const leaf = generatorLeaf(deps, task.id);
+
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.ctx.lastExit).toBeUndefined();
+      expect(mock.invocations).toHaveLength(2);
+      expect(result.value.ctx.currentAttemptGeneratorNudges).toBe(1);
+    });
+
+    it('exhausted retries (self-block): ctx.currentAttemptGeneratorNudges stays unset', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      // correctiveRetries: 2 on buildDeps — three vacuous spawns exhaust every nudge.
+      const sequences = new Map<string, readonly SpawnFixture[]>([
+        [signalsFilePath(), [twoCommitMessages, twoCommitMessages, twoCommitMessages]],
+      ]);
+      const mock = createMockHeadlessProvider({ sequences });
+      const deps: GeneratorLeafDeps = { ...buildDeps(new Map()), provider: mock.provider };
+      const leaf = generatorLeaf(deps, task.id);
+
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.ctx.lastExit?.kind).toBe('self-blocked');
+      expect(mock.invocations).toHaveLength(3);
+      // An exhausted/self-blocked turn is already loud via the block reason — no tally lands on
+      // ctx (see corrective-retry.ts's docstring for the scoping rationale).
+      expect(result.value.ctx.currentAttemptGeneratorNudges).toBeUndefined();
+    });
+
+    it('accumulates across successive rounds of the same attempt', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const round1Signals = join(String(root.root), 'rounds', '1', 'generator', 'signals.json');
+      const round2Signals = join(String(root.root), 'rounds', '2', 'generator', 'signals.json');
+      const sequences = new Map<string, readonly SpawnFixture[]>([
+        [round1Signals, [twoCommitMessages, oneCommitMessage]],
+        [round2Signals, [twoCommitMessages, oneCommitMessage]],
+      ]);
+      const mock = createMockHeadlessProvider({ sequences });
+      const deps: GeneratorLeafDeps = { ...buildDeps(new Map()), provider: mock.provider };
+      const leaf = generatorLeaf(deps, task.id);
+
+      const round1 = await leaf.execute(baseCtx(task));
+      expect(round1.ok).toBe(true);
+      if (!round1.ok) return;
+      expect(round1.value.ctx.currentAttemptGeneratorNudges).toBe(1);
+
+      const round2 = await leaf.execute({ ...round1.value.ctx, currentRoundNum: 2 });
+      expect(round2.ok).toBe(true);
+      if (!round2.ok) return;
+      // Second round's nudge ADDS onto the first — same attempt, not reset per-round.
+      expect(round2.value.ctx.currentAttemptGeneratorNudges).toBe(2);
+    });
+  });
 });

--- a/tests/integration/application/flows/implement/leaves/generator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/generator.test.ts
@@ -24,7 +24,9 @@ import {
 import { escalationBannerId } from '@src/business/task/escalation-policy.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+import { emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import { generatorLeaf } from '@src/application/flows/implement/leaves/generator.ts';
 
 describe('generatorLeaf', () => {
@@ -511,6 +513,50 @@ describe('generatorLeaf', () => {
       expect(await readPrompt(1)).toContain('# Task Execution Protocol');
       expect(await readPrompt(2)).toContain('# Task Execution Protocol');
       expect(await readPrompt(2)).not.toContain('# Continue — Round');
+    });
+  });
+
+  // `{{PROJECT_TOOLING}}` naming (research-quickwins): the FULL prompt threads the bound
+  // agent-definition name + this flow's installed skills so the generator sees explicitly-named
+  // tooling instead of the template's default "(none detected)" fallback.
+  describe('project tooling catalog', () => {
+    const fakeSkillSource = (): SkillSource => ({
+      getForFlow: async () =>
+        Result.ok([
+          {
+            name: 'alignment',
+            description: 'Confirm scope before diving into work',
+            content: '# alignment\n',
+          },
+        ]),
+      getByName: async () => Result.ok(undefined),
+    });
+
+    it('names the bound agent definition and installed skills in the FULL prompt', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const leaf = generatorLeaf(
+        { ...buildDeps(), agentDefinitionName: 'code-reviewer', skillSource: fakeSkillSource() },
+        task.id
+      );
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+
+      const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'generator', 'prompt.md'), 'utf8');
+      expect(content).toContain('- Subagent: `code-reviewer`');
+      expect(content).toContain('- Skill: `alignment` — Confirm scope before diving into work');
+      expect(content).not.toContain('(none detected)');
+    });
+
+    it('falls back to the template default when neither an agent definition nor skills are available', async () => {
+      const task = makeInProgressTaskWithRunningAttempt();
+      const leaf = generatorLeaf({ ...buildDeps(), skillSource: emptySkillSource }, task.id);
+      const result = await leaf.execute(baseCtx(task));
+      expect(result.ok).toBe(true);
+
+      const content = await fs.readFile(join(String(root.root), 'rounds', '1', 'generator', 'prompt.md'), 'utf8');
+      expect(content).toContain('(none detected)');
+      expect(content).not.toContain('- Subagent:');
+      expect(content).not.toContain('- Skill:');
     });
   });
 });

--- a/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
+++ b/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
@@ -8,7 +8,10 @@
  *  - regenerate-in-place preserves prior attempt sections verbatim (append-only sections)
  *  - per-attempt signal accumulators render as deduped subsections; empty lists drop their heading
  *  - the `created` timestamp is preserved across regenerations
- *  - all four accumulators clear on the output ctx
+ *  - all six per-attempt accumulators (four signal kinds + generator/evaluator nudge tallies)
+ *    clear on the output ctx
+ *  - the corrective-nudge cost-visibility clause renders when the ctx tally is non-zero and is
+ *    omitted entirely on a well-formed attempt
  *  - FAIL-LOUD section write: retry-once self-heal, and a visible gap marker when writes keep failing
  *  - missing task on ctx throws an InvalidStateError (chain-shape contract)
  *
@@ -277,7 +280,7 @@ describe('progressJournalLeaf', () => {
     expect(written).toContain('### Notes');
   });
 
-  it('clears all four signal accumulators on the output ctx so the next task starts fresh', async () => {
+  it('clears all six per-attempt accumulators on the output ctx so the next task starts fresh', async () => {
     const task = makeDoneTask({ name: 'clears' });
     const leaf = progressJournalLeaf(
       journalDeps(createAtomicWriteFile(), () => FIXED_NOW),
@@ -290,6 +293,8 @@ describe('progressJournalLeaf', () => {
         currentAttemptChanges: ['c'],
         currentAttemptLearnings: [{ text: 'l' }],
         currentAttemptNotes: ['n'],
+        currentAttemptGeneratorNudges: 2,
+        currentAttemptEvaluatorNudges: 1,
       })
     );
     if (!result.ok) throw result.error;
@@ -297,6 +302,39 @@ describe('progressJournalLeaf', () => {
     expect(result.value.ctx.currentAttemptChanges).toBeUndefined();
     expect(result.value.ctx.currentAttemptLearnings).toBeUndefined();
     expect(result.value.ctx.currentAttemptNotes).toBeUndefined();
+    expect(result.value.ctx.currentAttemptGeneratorNudges).toBeUndefined();
+    expect(result.value.ctx.currentAttemptEvaluatorNudges).toBeUndefined();
+  });
+
+  it('renders the corrective-nudge clause with a per-role breakdown when the ctx tally is non-zero', async () => {
+    const task = makeDoneTask({ name: 'nudged' });
+    const leaf = progressJournalLeaf(
+      journalDeps(createAtomicWriteFile(), () => FIXED_NOW),
+      { progressFile, totalRounds: 5 },
+      task.id
+    );
+    const result = await leaf.execute(
+      ctxFor([task], { currentAttemptGeneratorNudges: 2, currentAttemptEvaluatorNudges: 1 })
+    );
+    expect(result.ok).toBe(true);
+    const written = await read();
+    expect(written).toContain('### Outcome detail');
+    expect(written).toContain('3 corrective signals.json nudges issued this attempt');
+    expect(written).toContain('(generator: 2, evaluator: 1)');
+  });
+
+  it('omits the corrective-nudge clause when neither role needed a nudge (zero-noise)', async () => {
+    const task = makeDoneTask({ name: 'well-formed' });
+    const leaf = progressJournalLeaf(
+      journalDeps(createAtomicWriteFile(), () => FIXED_NOW),
+      { progressFile, totalRounds: 5 },
+      task.id
+    );
+    const result = await leaf.execute(ctxFor([task]));
+    expect(result.ok).toBe(true);
+    const written = await read();
+    expect(written).not.toContain('corrective signals.json');
+    expect(written).not.toContain('### Outcome detail');
   });
 
   it('fail-loud: a first write failure self-heals on the retry (content lands, chain proceeds)', async () => {

--- a/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
+++ b/tests/integration/application/flows/implement/leaves/progress-journal.test.ts
@@ -150,6 +150,32 @@ describe('progressJournalLeaf', () => {
     expect(written).not.toContain('Task completed successfully.');
   });
 
+  it('includes the plateau detector attribution in Outcome detail when the warning carries a source', async () => {
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const warned = unwrap(
+      recordRunningAttemptWarning(inProgress, { kind: 'plateau', dimensions: ['C1'], source: 'diversity' })
+    );
+    const verified = unwrap(recordRunningAttemptVerification(warned));
+    const done = unwrap(markTaskDone(verified, FIXED_LATER));
+    const leaf = progressJournalLeaf(journalDeps(createAtomicWriteFile()), { progressFile, totalRounds: 5 }, done.id);
+    const result = await leaf.execute(ctxFor([done], { currentRoundNum: 3 }));
+    expect(result.ok).toBe(true);
+    const written = await read();
+    expect(written).toContain('(detector: diversity)');
+  });
+
+  it('omits the detector parenthetical when the warning carries no source (legacy record)', async () => {
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const warned = unwrap(recordRunningAttemptWarning(inProgress, { kind: 'plateau', dimensions: ['C1'] }));
+    const verified = unwrap(recordRunningAttemptVerification(warned));
+    const done = unwrap(markTaskDone(verified, FIXED_LATER));
+    const leaf = progressJournalLeaf(journalDeps(createAtomicWriteFile()), { progressFile, totalRounds: 5 }, done.id);
+    const result = await leaf.execute(ctxFor([done], { currentRoundNum: 3 }));
+    expect(result.ok).toBe(true);
+    const written = await read();
+    expect(written).not.toContain('(detector:');
+  });
+
   it('derives verdict=escalated for an in_progress task whose attempt failed and climbed a rung', async () => {
     const inProgress = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const warned = unwrap(recordRunningAttemptWarning(inProgress, { kind: 'plateau', dimensions: ['C1'] }));

--- a/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
@@ -25,6 +25,7 @@ import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { absolutePath, makeReviewSprint } from '@tests/fixtures/domain.ts';
+import { emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 
@@ -112,7 +113,8 @@ const makeDeps = (overrides: Partial<AppDeps> = {}): AppDeps =>
         return Result.ok(undefined);
       },
     },
-    storage: { dataRoot: absolutePath('/tmp/data') },
+    storage: { dataRoot: absolutePath('/tmp/data'), operatorSkillsRoot: absolutePath('/tmp/data/skills') },
+    skillSource: emptySkillSource,
     eventBus: {
       publish() {},
       subscribe() {

--- a/tests/integration/application/ui/tui/views/implement-main-area.test.tsx
+++ b/tests/integration/application/ui/tui/views/implement-main-area.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ImplementMainArea — Esc-collapse-before-pop wiring (wide-layout ≥140 col Implement view).
+ *
+ * Mounts `useGlobalKeys` alongside `ImplementMainArea` inside the shared `renderView` harness
+ * (which already provides `UiStateProvider` + `RouterProvider`) so the test exercises the real
+ * "esc → collapse card" vs "esc → router.pop()" race, not a synthetic stand-in. A second route
+ * is pushed on mount so a pop is observable (`renderView`'s single `initial` entry can't pop).
+ *
+ * `ImplementMainArea` claims `esc` (via `useUiState().claimEscape()`) whenever the focused card
+ * is expanded — `TasksPanel`'s own `useInput` collapses the card on the same keystroke — and
+ * releases the claim the instant the card collapses or the component unmounts.
+ */
+
+import React from 'react';
+import { Text, useInput } from 'ink';
+import { describe, expect, it, vi } from 'vitest';
+import { useRouter } from '@src/application/ui/tui/runtime/router.tsx';
+import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
+import { ImplementMainArea } from '@src/application/ui/tui/views/execute-view-internals/implement-main-area.tsx';
+import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+
+const ts = (n: number): IsoTimestamp => new Date(Date.UTC(2026, 0, 1, 0, 0, n)).toISOString() as IsoTimestamp;
+
+const LIVE_SIGNAL_TEXT = 'task-1 live change';
+
+/** One running task, auto-expanded on mount (the active-task seed in `useTaskCardState`). */
+const BUCKETED: BucketedExecution = {
+  tasks: [
+    {
+      id: 'task-1',
+      status: 'running',
+      subSteps: [],
+      evaluations: [],
+      signals: [{ type: 'change', text: LIVE_SIGNAL_TEXT, timestamp: ts(1) }],
+      genEvalRound: 0,
+    },
+  ],
+  orphanSignals: [],
+};
+
+const DESCRIPTOR: SessionDescriptor = {
+  id: 'sess-esc-test',
+  flowId: 'implement',
+  title: 'Esc Collapse Test Sprint',
+  status: 'running',
+  startedAt: Date.now(),
+  trace: [],
+};
+
+const noopEventBus: EventBus = {
+  publish: vi.fn(),
+  subscribe: () => () => undefined,
+} as unknown as EventBus;
+
+const stubDeps = (): AppDeps => ({ eventBus: noopEventBus }) as unknown as AppDeps;
+
+/**
+ * Mounts the real global key handler + a route-depth probe + `ImplementMainArea`. Pushes a
+ * second route on mount so `router.pop()` is observable, and exposes a `u` hotkey to unmount
+ * `ImplementMainArea` on demand (scenario c — claim-release-on-unmount).
+ */
+const Harness = (): React.JSX.Element => {
+  useGlobalKeys();
+  const router = useRouter();
+  const pushedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (pushedRef.current) return;
+    pushedRef.current = true;
+    router.push({ id: 'implement-second' });
+  }, [router]);
+
+  const [mounted, setMounted] = React.useState(true);
+  useInput((input) => {
+    if (input === 'u') setMounted(false);
+  });
+
+  return (
+    <>
+      <Text>
+        ROUTE:{router.current.id}:{String(router.stack.length)}
+      </Text>
+      {mounted && (
+        <ImplementMainArea
+          bucketed={BUCKETED}
+          descriptor={DESCRIPTOR}
+          isRunning={true}
+          maxSignalsPerTask={8}
+          maxTasks={5}
+          inputActive={true}
+          now={Date.now()}
+          taskState={undefined}
+        />
+      )}
+    </>
+  );
+};
+
+const mount = (): ReturnType<typeof renderView> =>
+  renderView(<Harness />, { deps: stubDeps(), initial: { id: 'implement-first' } });
+
+describe('ImplementMainArea — Esc collapse-before-pop', () => {
+  it('Esc collapses the expanded focused card and does NOT pop the route', async () => {
+    const { result } = mount();
+    await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
+    // Confirm the second route + the live claim's precondition (card expanded) both settled.
+    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:implement-second:2'));
+
+    result.stdin.write(ESC);
+    await tick(60);
+
+    const frame = result.lastFrame() ?? '';
+    // Card collapsed — its signal stream is no longer rendered.
+    expect(frame).not.toContain(LIVE_SIGNAL_TEXT);
+    // The route did NOT pop — the claim kept the global handler's router.pop() from firing.
+    expect(frame).toContain('ROUTE:implement-second:2');
+
+    result.unmount();
+  });
+
+  it('Esc with no expanded card pops the route as before', async () => {
+    const { result } = mount();
+    await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
+    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:implement-second:2'));
+
+    // First Esc collapses the auto-expanded card (releasing the claim).
+    result.stdin.write(ESC);
+    await tick(60);
+    expect(result.lastFrame() ?? '').not.toContain(LIVE_SIGNAL_TEXT);
+    expect(result.lastFrame() ?? '').toContain('ROUTE:implement-second:2');
+
+    // Second Esc — no card expanded, no claim held — the global handler pops the route.
+    result.stdin.write(ESC);
+    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:implement-first:1'));
+    expect(result.lastFrame() ?? '').toContain('ROUTE:implement-first:1');
+
+    result.unmount();
+  });
+
+  it('unmounting while expanded releases the claim (no stale claim blocking Esc elsewhere)', async () => {
+    const { result } = mount();
+    await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
+    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:implement-second:2'));
+
+    // Unmount ImplementMainArea while its focused card is still expanded — the claim is live.
+    result.stdin.write('u');
+    await tick(30);
+    expect(result.lastFrame() ?? '').not.toContain(LIVE_SIGNAL_TEXT);
+
+    // A leaked claim would swallow this Esc forever; the unmount cleanup must have released it.
+    result.stdin.write(ESC);
+    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:implement-first:1'));
+    expect(result.lastFrame() ?? '').toContain('ROUTE:implement-first:1');
+
+    result.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/implement-view-redesign.test.tsx
+++ b/tests/integration/application/ui/tui/views/implement-view-redesign.test.tsx
@@ -20,6 +20,7 @@ import { render } from 'ink-testing-library';
 import { describe, expect, it, vi } from 'vitest';
 import { ImplementSidebar } from '@src/application/ui/tui/views/execute-view-internals/implement-sidebar.tsx';
 import { ExecuteBody } from '@src/application/ui/tui/views/execute-view-internals/body.tsx';
+import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { useResponsiveLayout } from '@src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts';
 import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
 import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
@@ -234,37 +235,43 @@ describe('ExecuteBody — wide layout redesign at 180×50', () => {
     // "now" is (BASE_MS + 3 min) so the label's `Date.now()` seed is deterministic; restored
     // immediately after the synchronous render + frame capture.
     vi.useFakeTimers({ now: BASE_MS + 180_000 });
+    // ImplementMainArea (mounted by ExecuteBody's wide-layout path) reads `useUiState()` to
+    // claim `esc` while an expanded card is focused — needs a UiStateProvider ancestor.
     const { lastFrame, unmount } = render(
-      React.createElement(ExecuteBody, {
-        descriptor,
-        sessionList: [],
-        sessionId: 'sess-visual-test-001',
-        isRunning: true,
-        now: BASE_MS + 180_000,
-        elapsed: '3m00s',
-        layout,
-        termColumns: cols,
-        termRows: rows,
-        bucketed,
-        executionState: undefined,
-        taskState: undefined,
-        tokenUsage: makeCumulativeTokenUsage(),
-        tasksDone: 0,
-        tasksTotal: 2,
-        currentTask: task,
-        currentTaskIdx: 0,
-        currentTaskName: 'Implement auth middleware',
-        currentSubStep: 'generator',
-        tasksPanel: null,
-        logEntries: [],
-        cancelScopeOpen: false,
-        attemptElapsedMs: 8500,
-        remainingTaskCount: 1,
-        onCancelAttempt: vi.fn(),
-        onCancelFlow: vi.fn(),
-        onDismissCancelScope: vi.fn(),
-        pinnedSprintStale: false,
-      })
+      React.createElement(
+        UiStateProvider,
+        null,
+        React.createElement(ExecuteBody, {
+          descriptor,
+          sessionList: [],
+          sessionId: 'sess-visual-test-001',
+          isRunning: true,
+          now: BASE_MS + 180_000,
+          elapsed: '3m00s',
+          layout,
+          termColumns: cols,
+          termRows: rows,
+          bucketed,
+          executionState: undefined,
+          taskState: undefined,
+          tokenUsage: makeCumulativeTokenUsage(),
+          tasksDone: 0,
+          tasksTotal: 2,
+          currentTask: task,
+          currentTaskIdx: 0,
+          currentTaskName: 'Implement auth middleware',
+          currentSubStep: 'generator',
+          tasksPanel: null,
+          logEntries: [],
+          cancelScopeOpen: false,
+          attemptElapsedMs: 8500,
+          remainingTaskCount: 1,
+          onCancelAttempt: vi.fn(),
+          onCancelFlow: vi.fn(),
+          onDismissCancelScope: vi.fn(),
+          pinnedSprintStale: false,
+        })
+      )
     );
     const frame = lastFrame() ?? '';
     vi.useRealTimers();
@@ -318,37 +325,42 @@ describe('ExecuteBody — wide layout redesign at 220×60', () => {
     // See the 180×50 describe block above — HeaderCard's elapsed text ticks via its own
     // internal `useLiveClock`, so the system clock is frozen for the render + frame capture.
     vi.useFakeTimers({ now: BASE_MS + 180_000 });
+    // See the 180×50 describe block above — ImplementMainArea needs a UiStateProvider ancestor.
     const { lastFrame, unmount } = render(
-      React.createElement(ExecuteBody, {
-        descriptor,
-        sessionList: [],
-        sessionId: 'sess-visual-test-001',
-        isRunning: true,
-        now: BASE_MS + 180_000,
-        elapsed: '3m00s',
-        layout,
-        termColumns: cols,
-        termRows: rows,
-        bucketed,
-        executionState: undefined,
-        taskState: undefined,
-        tokenUsage: makeCumulativeTokenUsage(),
-        tasksDone: 0,
-        tasksTotal: 2,
-        currentTask: task,
-        currentTaskIdx: 0,
-        currentTaskName: 'Implement auth middleware',
-        currentSubStep: 'generator',
-        tasksPanel: null,
-        logEntries: [],
-        cancelScopeOpen: false,
-        attemptElapsedMs: 8500,
-        remainingTaskCount: 1,
-        onCancelAttempt: vi.fn(),
-        onCancelFlow: vi.fn(),
-        onDismissCancelScope: vi.fn(),
-        pinnedSprintStale: false,
-      })
+      React.createElement(
+        UiStateProvider,
+        null,
+        React.createElement(ExecuteBody, {
+          descriptor,
+          sessionList: [],
+          sessionId: 'sess-visual-test-001',
+          isRunning: true,
+          now: BASE_MS + 180_000,
+          elapsed: '3m00s',
+          layout,
+          termColumns: cols,
+          termRows: rows,
+          bucketed,
+          executionState: undefined,
+          taskState: undefined,
+          tokenUsage: makeCumulativeTokenUsage(),
+          tasksDone: 0,
+          tasksTotal: 2,
+          currentTask: task,
+          currentTaskIdx: 0,
+          currentTaskName: 'Implement auth middleware',
+          currentSubStep: 'generator',
+          tasksPanel: null,
+          logEntries: [],
+          cancelScopeOpen: false,
+          attemptElapsedMs: 8500,
+          remainingTaskCount: 1,
+          onCancelAttempt: vi.fn(),
+          onCancelFlow: vi.fn(),
+          onDismissCancelScope: vi.fn(),
+          pinnedSprintStale: false,
+        })
+      )
     );
     const frame = lastFrame() ?? '';
     vi.useRealTimers();

--- a/tests/integration/application/ui/tui/views/skills-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/skills-view.test.tsx
@@ -379,7 +379,7 @@ describe('SkillsView', () => {
     await waitFor(() => (result.lastFrame() ?? '').includes('already up to date'));
   });
 
-  it('never offers Create PR — the create-pr launch loads no skills', async () => {
+  it('offers Create PR — its view / CLI compose a skill source directly, same as any mounting flow', async () => {
     const name = bundledName();
     const catalog = fakeCatalog([
       {
@@ -393,15 +393,17 @@ describe('SkillsView', () => {
     const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
     await waitForViewReady(result, (f) => f.includes(name));
     const frame = result.lastFrame() ?? '';
-    // No chip for the non-mounting flow — neither as default-on nor as not-enabled.
-    expect(frame).not.toContain('■ pr');
+    // createPr is default-on: the phaseDone glyph ('■') marks it like any other mounting flow.
+    expect(frame).toContain('■ pr');
     expect(frame).not.toContain('◌ pr');
 
     result.stdin.write('e');
     await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
     const picker = result.lastFrame() ?? '';
-    expect(picker).not.toContain('Create PR');
-    // The mounting recommendation is still preselected.
+    // Offered but disabled — it's already default-on for createPr, same treatment as any flow.
+    expect(picker).toContain('Create PR');
+    expect(picker).toContain('already default-on');
+    // Plan is recommended (not default-on): still preselected.
     expect(picker).toMatch(/\[[xX✔✓]]\s*Plan/);
   });
 
@@ -423,5 +425,60 @@ describe('SkillsView', () => {
     // The saved opt-out demotes the "always on" chip: muted ◌ instead of highlighted ■.
     expect(frame).toContain('◌ imp');
     expect(frame).not.toContain('■ imp');
+  });
+
+  it('clear opt-out (c): removes a durable disable and the row reflects it after reload', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      { name, description: 'x', defaultFor: ['implement'], recommendedFor: [], installs: [] },
+    ]);
+    // `load` mirrors the repository's read-after-write: the second load (triggered by the
+    // action's reload()) must see whatever `save` last wrote, not the original fixture.
+    let current: Settings = {
+      ...DEFAULT_SETTINGS,
+      ai: { ...DEFAULT_SETTINGS.ai, skills: { implement: { disabled: [name] } } },
+    };
+    const deps = {
+      skillCatalog: catalog,
+      settingsRepo: {
+        load: async () => Result.ok(current),
+        save: async (next: Settings) => {
+          current = next;
+          return Result.ok(undefined);
+        },
+      },
+      storage: { operatorSkillsRoot: abs('/tmp/ralphctl-skills-root-test') },
+    } as unknown as AppDeps;
+
+    const { result } = renderView(<SkillsView />, { deps, initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+    expect(result.lastFrame() ?? '').toContain('◌ imp');
+
+    result.stdin.write('c');
+    await waitFor(() => (result.lastFrame() ?? '').includes('■ imp'));
+
+    expect(current.ai.skills?.implement?.disabled).toEqual([]);
+  });
+
+  it('clear opt-out (c) is a no-op when the focused skill has no saved opt-out anywhere', async () => {
+    const name = bundledName();
+    const catalog = fakeCatalog([
+      { name, description: 'x', defaultFor: ['implement'], recommendedFor: [], installs: [] },
+    ]);
+    const save = vi.fn(async () => Result.ok(undefined));
+    const deps = {
+      skillCatalog: catalog,
+      settingsRepo: { load: async () => Result.ok(DEFAULT_SETTINGS), save },
+      storage: { operatorSkillsRoot: abs('/tmp/ralphctl-skills-root-test') },
+    } as unknown as AppDeps;
+
+    const { result } = renderView(<SkillsView />, { deps, initial: { id: 'skills' } });
+    await waitForViewReady(result, (f) => f.includes(name));
+    // No saved opt-out anywhere for this entry — the always-on chip is already showing.
+    expect(result.lastFrame() ?? '').toContain('■ imp');
+
+    result.stdin.write('c');
+    await tick();
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/system/bundle-integrity.test.ts
+++ b/tests/integration/system/bundle-integrity.test.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkBundleIntegrity, resolveManifestPath } from '@src/integration/system/bundle-integrity.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
+
+describe('resolveManifestPath', () => {
+  it('resolves manifest.json beside a hashed code-split chunk in bundle mode', () => {
+    // What decides it is manifest.json sitting beside the module — NOT the artifact filename.
+    // A hashed `cli-<hash>.mjs` code-split chunk (which a filename check would miss) resolves
+    // identically to the `cli.mjs` entry stub.
+    const beside = (p: string): boolean => p === '/pkg/dist/manifest.json';
+    expect(resolveManifestPath('file:///pkg/dist/cli-CKPJ5SY4.mjs', beside)).toBe('/pkg/dist/manifest.json');
+    expect(resolveManifestPath('file:///pkg/dist/cli.mjs', beside)).toBe('/pkg/dist/manifest.json');
+  });
+
+  it('returns undefined in dev, where nothing sits beside the module', () => {
+    const never = (): boolean => false;
+    expect(resolveManifestPath('file:///pkg/src/integration/system/bundle-integrity.ts', never)).toBeUndefined();
+  });
+});
+
+describe('checkBundleIntegrity', () => {
+  let root: string;
+  let cleanup: () => Promise<void>;
+  let moduleUrl: string;
+
+  const writeManifest = async (manifest: unknown): Promise<void> => {
+    await fs.writeFile(join(root, 'manifest.json'), JSON.stringify(manifest), 'utf8');
+  };
+
+  const writeAsset = async (relPath: string): Promise<void> => {
+    const abs = join(root, relPath);
+    await fs.mkdir(dirname(abs), { recursive: true });
+    await fs.writeFile(abs, 'asset body', 'utf8');
+  };
+
+  beforeEach(async () => {
+    const tmp = await makeTmpRoot();
+    root = String(tmp.root);
+    cleanup = tmp.cleanup;
+    // Mirrors a published bundle: the probe module is compiled into a file that lives directly
+    // beside `manifest.json` (`dist/cli.mjs` or one of tsup's hashed chunks) — the exact filename
+    // doesn't matter, only that it sits in the same directory as `manifest.json`.
+    moduleUrl = pathToFileURL(join(root, 'cli.mjs')).toString();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('(d) skips silently in dev mode — no manifest.json beside the module', async () => {
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '1.2.3' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({ kind: 'skipped' });
+  });
+
+  it('(a) passes silently in bundle mode when every asset is present and the version matches', async () => {
+    await writeAsset('prompts/refine/template.md');
+    await writeAsset('skills/ralphctl-alignment/SKILL.md');
+    await writeManifest({
+      schemaVersion: 1,
+      packageVersion: '1.2.3',
+      generatedAt: new Date().toISOString(),
+      assets: ['prompts/refine/template.md', 'skills/ralphctl-alignment/SKILL.md'],
+    });
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '1.2.3' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({ kind: 'ok' });
+  });
+
+  it('(b) errors with a reinstall hint naming the missing count when asset(s) are absent', async () => {
+    await writeAsset('prompts/refine/template.md');
+    await writeManifest({
+      schemaVersion: 1,
+      packageVersion: '1.2.3',
+      generatedAt: new Date().toISOString(),
+      assets: ['prompts/refine/template.md', 'skills/ralphctl-alignment/SKILL.md', 'prompts/plan/template.md'],
+    });
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '1.2.3' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('missing 2');
+    expect(result.error.message).toMatch(/reinstall ralphctl/);
+    expect(result.error.hint).toMatch(/reinstall ralphctl/);
+  });
+
+  it('(c) errors with a reinstall hint when the manifest version does not match the running package', async () => {
+    await writeManifest({
+      schemaVersion: 1,
+      packageVersion: '1.0.0',
+      generatedAt: new Date().toISOString(),
+      assets: [],
+    });
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '2.0.0' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('1.0.0');
+    expect(result.error.message).toContain('2.0.0');
+    expect(result.error.message).toMatch(/reinstall ralphctl/);
+  });
+
+  it('a version mismatch is reported even when assets are also missing (cheap check runs first)', async () => {
+    await writeManifest({
+      schemaVersion: 1,
+      packageVersion: '1.0.0',
+      generatedAt: new Date().toISOString(),
+      assets: ['prompts/refine/template.md'],
+    });
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '2.0.0' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.subCode).toBe('schema-mismatch');
+  });
+
+  it('(e) degrades to a warning-level skip on an unparseable manifest, never a hard failure', async () => {
+    await fs.writeFile(join(root, 'manifest.json'), 'not valid json {{{', 'utf8');
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '1.2.3' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.kind).toBe('malformed');
+  });
+
+  it('(e) degrades to a warning-level skip when the manifest does not match the expected shape', async () => {
+    await writeManifest({ unexpected: 'shape' });
+
+    const result = await checkBundleIntegrity({ moduleUrl, currentVersion: '1.2.3' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.kind).toBe('malformed');
+  });
+});

--- a/tests/unit/application/bootstrap/run-bundle-integrity-check.test.ts
+++ b/tests/unit/application/bootstrap/run-bundle-integrity-check.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contract for `application/bootstrap/run-bundle-integrity-check.ts` — the seam both
+ * composition roots (`ui/cli/bootstrap.ts`, `ui/tui/launch.ts`) actually call. The core
+ * `checkBundleIntegrity` probe is mocked (its own dual-mode / manifest-shape behaviour is
+ * covered by `tests/integration/system/bundle-integrity.test.ts`) so this suite asserts only the
+ * three branches `runBundleIntegrityCheck` adds on top: throw-on-error, warn-on-malformed, and
+ * silence otherwise.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@src/business/observability/logger.ts';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { BundleIntegrityStatus } from '@src/integration/system/bundle-integrity.ts';
+import { runBundleIntegrityCheck } from '@src/application/bootstrap/run-bundle-integrity-check.ts';
+
+const checkBundleIntegrityMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@src/integration/system/bundle-integrity.ts', () => ({
+  checkBundleIntegrity: checkBundleIntegrityMock,
+}));
+
+const fakeLogger = (): { readonly logger: Logger; readonly warn: ReturnType<typeof vi.fn> } => {
+  const warn = vi.fn();
+  const noop = vi.fn();
+  const logger: Logger = {
+    debug: noop,
+    info: noop,
+    warn,
+    error: noop,
+    named: () => logger,
+  };
+  return { logger, warn };
+};
+
+describe('runBundleIntegrityCheck', () => {
+  it('throws with the actionable message when the core check reports Result.error (missing assets / version mismatch)', async () => {
+    checkBundleIntegrityMock.mockResolvedValueOnce(
+      Result.error(
+        new StorageError({
+          subCode: 'io',
+          message: 'ralphctl install is missing 2 bundled asset(s) declared in dist/manifest.json. reinstall ralphctl.',
+        })
+      )
+    );
+    const { logger, warn } = fakeLogger();
+
+    await expect(runBundleIntegrityCheck(logger)).rejects.toThrow(
+      /bundle-integrity: ralphctl install is missing 2 bundled asset\(s\)/
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning (does not throw) when the core check reports kind 'malformed'", async () => {
+    const status: BundleIntegrityStatus = { kind: 'malformed', reason: 'dist/manifest.json: invalid JSON' };
+    checkBundleIntegrityMock.mockResolvedValueOnce(Result.ok(status));
+    const { logger, warn } = fakeLogger();
+
+    await expect(runBundleIntegrityCheck(logger)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toBe('bundle-integrity: dist/manifest.json: invalid JSON');
+  });
+
+  it("is silent — no throw, no warn — when the core check reports kind 'ok'", async () => {
+    const status: BundleIntegrityStatus = { kind: 'ok' };
+    checkBundleIntegrityMock.mockResolvedValueOnce(Result.ok(status));
+    const { logger, warn } = fakeLogger();
+
+    await expect(runBundleIntegrityCheck(logger)).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("is silent — no throw, no warn — when the core check reports kind 'skipped' (dev mode)", async () => {
+    const status: BundleIntegrityStatus = { kind: 'skipped' };
+    checkBundleIntegrityMock.mockResolvedValueOnce(Result.ok(status));
+    const { logger, warn } = fakeLogger();
+
+    await expect(runBundleIntegrityCheck(logger)).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/application/flows/create-pr/flow-shape.test.ts
+++ b/tests/unit/application/flows/create-pr/flow-shape.test.ts
@@ -23,7 +23,9 @@ describe('createCreatePrFlow — chain-shape fence', () => {
       'load-create-pr-context',
       'build-create-pr-unit',
       'render-prompt-to-file',
+      'install-skills',
       'generate-pr-content',
+      'uninstall-skills',
       'create-pr',
     ]);
   });

--- a/tests/unit/application/flows/create-pr/leaves/create-pr-leaf.test.ts
+++ b/tests/unit/application/flows/create-pr/leaves/create-pr-leaf.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
 import { createCreatePrLeaf } from '@src/application/flows/create-pr/leaves/create-pr-leaf.ts';
 import type { CreatePrDeps } from '@src/application/flows/create-pr/deps.ts';
 import type { CreatePrCtx } from '@src/application/flows/create-pr/ctx.ts';
@@ -105,6 +106,8 @@ const buildDeps = (sprint: Sprint, exec: SprintExecution, creator: PullRequestCr
   writeFile: stubWriteFile,
   logger: noopLogger,
   model: 'test-model',
+  skillSource: emptySkillSource,
+  skillsAdapter: noopSkillsAdapter,
 });
 
 describe('createCreatePrLeaf — title/body precedence', () => {

--- a/tests/unit/application/flows/create-pr/leaves/push-branch-leaf.test.ts
+++ b/tests/unit/application/flows/create-pr/leaves/push-branch-leaf.test.ts
@@ -14,6 +14,7 @@ import { createInMemoryEventBus } from '@src/integration/observability/in-memory
 import { absolutePath, FIXED_LATER, makeReviewSprint } from '@tests/fixtures/domain.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { createPushBranchLeaf } from '@src/application/flows/create-pr/leaves/push-branch-leaf.ts';
+import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
 import type { CreatePrDeps } from '@src/application/flows/create-pr/deps.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
@@ -95,6 +96,8 @@ const stubCreatePrDeps = (overrides: {
   writeFile: stubWriteFile,
   logger: noopLogger,
   model: 'test-model',
+  skillSource: emptySkillSource,
+  skillsAdapter: noopSkillsAdapter,
 });
 
 const sprint = makeReviewSprint();

--- a/tests/unit/application/ui/cli/commands/skills.test.ts
+++ b/tests/unit/application/ui/cli/commands/skills.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import type * as RegistryModule from '@src/integration/ai/skills/_engine/registry.ts';
+import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
+
+// Empty catalog is unreachable through a real bundled build (BUNDLED_SKILLS always ships at
+// least one row) — mock the registry to exercise the CLI's empty-state branch the same way a
+// downstream build stripped of every skill would hit it.
+vi.mock('@src/integration/ai/skills/_engine/registry.ts', async () => {
+  const actual = await vi.importActual<typeof RegistryModule>('@src/integration/ai/skills/_engine/registry.ts');
+  return { ...actual, BUNDLED_SKILLS: [] };
+});
+
+describe('ralphctl skills list — empty catalog', () => {
+  it('renders the empty-state line when no skills are bundled and none are dropped in manually', async () => {
+    const cli: CliHome = await createCliHome();
+    try {
+      const result = await runCliCaptured(cli, ['skills', 'list']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('(no skills bundled)');
+    } finally {
+      await cli.cleanup();
+    }
+  });
+});

--- a/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/flow-visual.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
 import type { SkillCatalogEntry } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
+import type { FlowId } from '@src/domain/value/flow-id.ts';
 import {
   chipFlowsFor,
   flowChipVisual,
   SKILL_MOUNTING_FLOW_IDS,
   statusVisual,
 } from '@src/application/ui/tui/views/skills-view-internals/flow-visual.ts';
+
+/**
+ * Every real `FlowId` mounts skills now (create-pr included — see `flowMountsSkills`), so
+ * `SKILL_MOUNTING_FLOW_IDS` is currently the full `FlowId` set. The "non-mounting flow" branches
+ * in `flowChipVisual` / `chipFlowsFor` stay defensively coded for a future flow that ships
+ * without skill-mounting support; this synthetic id exercises that branch since no real `FlowId`
+ * can anymore.
+ */
+const NON_MOUNTING_FLOW = 'legacy-flow' as unknown as FlowId;
 
 const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
   name: 'ralphctl-example',
@@ -73,20 +83,20 @@ describe('flowChipVisual', () => {
   });
 
   it('renders a non-mounting flow as inactive even when default-on in the registry', () => {
-    const e = entry({ defaultFor: ['createPr'] });
-    expect(flowChipVisual('createPr', e).label).toBe('inactive (flow loads no skills)');
+    const e = entry({ defaultFor: [NON_MOUNTING_FLOW] });
+    expect(flowChipVisual(NON_MOUNTING_FLOW, e).label).toBe('inactive (flow loads no skills)');
   });
 });
 
 describe('SKILL_MOUNTING_FLOW_IDS / chipFlowsFor', () => {
-  it('excludes createPr — no create-pr launch mounts a skill source', () => {
-    expect(SKILL_MOUNTING_FLOW_IDS).not.toContain('createPr');
+  it('includes createPr — the create-pr view / CLI mount a composed skill source directly', () => {
+    expect(SKILL_MOUNTING_FLOW_IDS).toContain('createPr');
     expect(SKILL_MOUNTING_FLOW_IDS).toContain('implement');
   });
 
   it('chips cover the mounting flows, plus a leftover install on a non-mounting flow', () => {
     expect(chipFlowsFor(entry())).toEqual([...SKILL_MOUNTING_FLOW_IDS]);
-    const leftover = entry({ installs: [{ flow: 'createPr', status: 'in-sync' }] });
-    expect(chipFlowsFor(leftover)).toEqual([...SKILL_MOUNTING_FLOW_IDS, 'createPr']);
+    const leftover = entry({ installs: [{ flow: NON_MOUNTING_FLOW, status: 'in-sync' }] });
+    expect(chipFlowsFor(leftover)).toEqual([...SKILL_MOUNTING_FLOW_IDS, NON_MOUNTING_FLOW]);
   });
 });

--- a/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
+++ b/tests/unit/application/ui/tui/views/skills-view-internals/picker-options.test.ts
@@ -17,10 +17,10 @@ const entry = (over: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry => ({
 });
 
 describe('enableOptions', () => {
-  it('offers exactly the skill-mounting flows — never createPr, which loads no skills', () => {
+  it('offers exactly the skill-mounting flows, createPr included', () => {
     const options = enableOptions(entry());
     expect(options.map((o) => o.value)).toEqual([...SKILL_MOUNTING_FLOW_IDS]);
-    expect(options.some((o) => o.value === 'createPr')).toBe(false);
+    expect(options.some((o) => o.value === 'createPr')).toBe(true);
   });
 
   it('disables an edit-protected install (locally-modified / manual) with the overwrite hint', () => {
@@ -42,13 +42,13 @@ describe('enableOptions', () => {
   it('enablePreselect keeps only selectable recommendations', () => {
     const preselect = enablePreselect(
       entry({
-        // createPr never mounts; refine is default-on; plan is edit-protected; implement is free.
+        // refine is default-on; plan is edit-protected; createPr and implement are free.
         recommendedFor: ['createPr', 'refine', 'plan', 'implement'],
         defaultFor: ['refine'],
         installs: [{ flow: 'plan', status: 'locally-modified' }],
       })
     );
-    expect(preselect).toEqual(['implement']);
+    expect(preselect).toEqual(['createPr', 'implement']);
   });
 
   it('disables a flow the skill is already default-on for, with an explanatory description', () => {

--- a/tests/unit/business/sprint/render-journal-entry.test.ts
+++ b/tests/unit/business/sprint/render-journal-entry.test.ts
@@ -184,6 +184,28 @@ describe('renderJournalEntry', () => {
     expect(out).toContain('Remedy: kept the attempt with the warning attached');
   });
 
+  it('appends the detector attribution parenthetical when the plateau warning carries a source', () => {
+    const out = renderJournalEntry(
+      baseInput({
+        verdict: 'pass-with-warning',
+        warning: { kind: 'plateau', dimensions: ['C1'], source: 'threshold' },
+      })
+    );
+    expect(out).toContain('plateaued');
+    expect(out).toContain('(detector: threshold)');
+  });
+
+  it('omits the detector parenthetical when the plateau warning carries no source', () => {
+    const out = renderJournalEntry(
+      baseInput({
+        verdict: 'pass-with-warning',
+        warning: { kind: 'plateau', dimensions: ['C1'] },
+      })
+    );
+    expect(out).toContain('plateaued');
+    expect(out).not.toContain('(detector:');
+  });
+
   it('renders budget-exhausted turn counts in the Outcome detail prose', () => {
     const out = renderJournalEntry(
       baseInput({

--- a/tests/unit/business/sprint/render-journal-entry.test.ts
+++ b/tests/unit/business/sprint/render-journal-entry.test.ts
@@ -256,6 +256,37 @@ describe('renderJournalEntry', () => {
     expect(out).toContain('verify script ran red');
     expect(out).toContain('exit 1 — 2 tests failed');
   });
+
+  it('renders the corrective-nudge cost-visibility clause with a per-role breakdown when present', () => {
+    const out = renderJournalEntry(baseInput({ correctiveNudges: { generator: 2, evaluator: 1 } }));
+    expect(out).toContain('### Outcome detail');
+    expect(out).toContain('3 corrective signals.json nudges issued this attempt');
+    expect(out).toContain('(generator: 2, evaluator: 1)');
+    expect(out).toContain('do not count against the turn/attempt budget');
+  });
+
+  it('singularises the nudge noun when exactly one nudge fired', () => {
+    const out = renderJournalEntry(baseInput({ correctiveNudges: { generator: 1, evaluator: 0 } }));
+    expect(out).toContain('1 corrective signals.json nudge issued this attempt');
+    expect(out).toContain('(generator: 1)');
+    expect(out).not.toContain('evaluator:');
+  });
+
+  it('a clean pass with zero nudges omits the clause entirely (zero-noise)', () => {
+    const out = renderJournalEntry(baseInput());
+    expect(out).not.toContain('corrective signals.json');
+    expect(out).not.toContain('### Outcome detail');
+  });
+
+  it('renders the nudge clause on an otherwise-clean pass (independent of warning/escalation)', () => {
+    // A corrective nudge can fire on a turn that still ends in a clean pass — the clause must not
+    // be gated on `warning`/`escalation` being present.
+    const out = renderJournalEntry(baseInput({ verdict: 'pass', correctiveNudges: { generator: 1, evaluator: 0 } }));
+    expect(out).toContain('- Verdict: pass');
+    expect(out).toContain('### Outcome detail');
+    expect(out).toContain('1 corrective signals.json nudge issued this attempt');
+    expect(out).not.toContain('Remedy:');
+  });
 });
 
 describe('renderJournalEntry — heading-forgery neutralization (journal structure is load-bearing)', () => {

--- a/tests/unit/business/task/escalation-policy.test.ts
+++ b/tests/unit/business/task/escalation-policy.test.ts
@@ -369,6 +369,53 @@ describe('applyEscalation', () => {
     expect(banner?.id).toBe(escalationBannerId(String(task.id)));
   });
 
+  it('on escalate: forwards plateauSource onto the model-escalated event when supplied', () => {
+    // Pure instrumentation: the caller (finalize-gen-eval) forwards WHICH plateau detector fired
+    // so the model-bump audit can attribute the escalation without re-deriving it from the
+    // progress journal.
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const { bus, events } = captureBus();
+
+    const applied = applyEscalation({
+      task,
+      decision: { kind: 'escalate', from: 'claude-sonnet-4-6', to: 'claude-opus-4-8' },
+      trigger: 'plateau',
+      plateauSource: 'diversity',
+      eventBus: bus,
+      logger: noopLogger,
+      clock: fixedClock,
+    });
+    expect(applied.ok).toBe(true);
+
+    const escalated = events.find(
+      (e): e is Extract<AppEvent, { type: 'model-escalated' }> => e.type === 'model-escalated'
+    );
+    expect(escalated?.plateauSource).toBe('diversity');
+  });
+
+  it('on escalate: omits plateauSource from the event when the caller does not supply it', () => {
+    // Legacy/budget-exhausted path — no plateau detector involved, so the field is absent
+    // (never `undefined`-valued) rather than defaulting to a guessed source.
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const { bus, events } = captureBus();
+
+    applyEscalation({
+      task,
+      decision: { kind: 'escalate', from: 'claude-sonnet-4-6', to: 'claude-opus-4-8' },
+      trigger: 'budget-exhausted',
+      eventBus: bus,
+      logger: noopLogger,
+      clock: fixedClock,
+    });
+
+    const escalated = events.find(
+      (e): e is Extract<AppEvent, { type: 'model-escalated' }> => e.type === 'model-escalated'
+    );
+    expect(escalated).toBeDefined();
+    expect(escalated?.plateauSource).toBeUndefined();
+    expect('plateauSource' in (escalated ?? {})).toBe(false);
+  });
+
   it('on escalate-effort: info banner naming the effort bump, NO stamping, no model-escalated event', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const { bus, events } = captureBus();

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -296,6 +296,58 @@ describe('finalizeGenEvalUseCase', () => {
     expect(events.some((e) => e.type === 'model-escalated')).toBe(true);
   });
 
+  it('plateau escalate with an attributed exit: source threads onto both the warning and the model-escalated event', async () => {
+    // Pure instrumentation — the escalation DECISION is unaffected by which detector fired; only
+    // the attribution on the warning + event changes.
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const bus = newBus();
+    const events: Array<{ type: string; plateauSource?: string }> = [];
+    bus.subscribe((e) => events.push(e as { type: string; plateauSource?: string }));
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'], source: 'entropy' },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 5 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: bus,
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.warning).toEqual({ kind: 'plateau', dimensions: ['correctness'], source: 'entropy' });
+    const escalated = events.find((e) => e.type === 'model-escalated');
+    expect(escalated?.plateauSource).toBe('entropy');
+  });
+
+  it('plateau exit without a source (legacy in-flight ctx) → warning + event carry no source', async () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const bus = newBus();
+    const events: Array<{ type: string; plateauSource?: string }> = [];
+    bus.subscribe((e) => events.push(e as { type: string; plateauSource?: string }));
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 5 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: bus,
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.warning).toEqual({ kind: 'plateau', dimensions: ['correctness'] });
+    expect('source' in (result.value.warning ?? {})).toBe(false);
+    const escalated = events.find((e) => e.type === 'model-escalated');
+    expect(escalated?.plateauSource).toBeUndefined();
+    expect('plateauSource' in (escalated ?? {})).toBe(false);
+  });
+
   it('plateau topped-out (nudged then plateaued again): verdict failed, plateau warning, no shouldFailAttempt, no blockedReason (preserves work)', async () => {
     // Mutant-kill: a mutant that drops the topped-out guard would incorrectly set shouldFailAttempt.
     const initial = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });

--- a/tests/unit/business/task/run-evaluator-turn-plateau-stamps.test.ts
+++ b/tests/unit/business/task/run-evaluator-turn-plateau-stamps.test.ts
@@ -122,6 +122,9 @@ describe('runEvaluatorTurnUseCase — turnRecord verdict stamp (D2)', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.exit?.kind).toBe('plateau');
+    // The count-based threshold detector always stamps 'threshold' — instrumentation only, no
+    // effect on the decision itself.
+    expect(result.value.exit?.kind === 'plateau' && result.value.exit.source).toBe('threshold');
     expect(result.value.turnRecord).toBeDefined();
     expect(result.value.turnRecord?.verdict).toBe('plateau');
   });

--- a/tests/unit/integration/ai/contract/_engine/corrective-retry.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/corrective-retry.test.ts
@@ -69,6 +69,11 @@ describe('validateSignalsFileWithCorrectiveRetry', () => {
     );
     expect(result.ok).toBe(true);
     expect(calls).toBe(0);
+    // Cost-visibility tally: a clean first parse needed zero nudges.
+    if (result.ok) {
+      expect(result.value.nudgeCount).toBe(0);
+      expect(result.value.signals).toHaveLength(1);
+    }
   });
 
   it('re-invokes once with a Zod-issue corrective prompt and recovers when the retry writes valid output', async () => {
@@ -100,6 +105,8 @@ describe('validateSignalsFileWithCorrectiveRetry', () => {
     expect(correctiveSeen).toContain('OUTPUT CONTRACT SECTION (self-contained)');
     expect(correctiveSeen).toContain('do NOT invent a verdict');
     expect(correctiveSeen).toMatch(/at `0`:/);
+    // Cost-visibility tally: exactly one nudge fixed it.
+    if (result.ok) expect(result.value.nudgeCount).toBe(1);
   });
 
   it('self-blocks (returns the last error) after a single nudge when correctiveRetries=1', async () => {
@@ -143,6 +150,8 @@ describe('validateSignalsFileWithCorrectiveRetry', () => {
     );
     expect(result.ok).toBe(true);
     expect(attemptsSeen).toEqual([1, 2]);
+    // Cost-visibility tally: the SECOND nudge is the one that fixed it.
+    if (result.ok) expect(result.value.nudgeCount).toBe(2);
   });
 
   it('exhausts all nudges (correctiveRetries=2 → 3 spawns total) then self-blocks with the last error', async () => {

--- a/tests/unit/integration/ai/prompts/_engine/substitute.test.ts
+++ b/tests/unit/integration/ai/prompts/_engine/substitute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import { assertTemplateKeysFilled, substitute } from '@src/integration/ai/prompts/_engine/substitute.ts';
+import { PRECAPPED_SECTION_CHAR_CAP, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
 
 describe('substitute', () => {
   it('replaces a single placeholder with the matching value', () => {
@@ -86,5 +87,57 @@ describe('assertTemplateKeysFilled — template-side fence', () => {
     const result = assertTemplateKeysFilled(rendered, template, [partialBody], values, 'test-builder');
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.message).toContain('{{VERIFY_SCRIPT}}');
+  });
+});
+
+describe('COMPRESSIBLE_KEYS — two-tier compression (regression)', () => {
+  /**
+   * Builds a `capProgressBody`-shaped value: a header band, a full current-task attempt section,
+   * and several sibling sections — well over the old 4,000-char `SECTION_CHAR_CAP` but nowhere near
+   * `PRECAPPED_SECTION_CHAR_CAP`. Doesn't need to come from the real `capProgressBody` — the bug is
+   * that ANY pre-capped value over 4K chars got blindly re-truncated regardless of its producer.
+   */
+  const buildPreCappedProgressBody = (): string => {
+    const header = '# Sprint: demo\n\n- id: s-1\n- created: 2026-06-09T00:00:00.000Z\n\n';
+    const currentTaskSection =
+      `## Task: implement-thing — Attempt 3 · id:task-current\n\n` +
+      `_2026-06-09T00:00:00.000Z_\n\n${'earlier attempt warnings and remedies. '.repeat(150)}\n`;
+    const siblingSection = (name: string): string =>
+      `## Task: ${name} — Attempt 1 · id:task-${name}\n\n_2026-06-09T00:00:00.000Z_\n\n${'sibling work. '.repeat(50)}\n`;
+    return header + currentTaskSection + siblingSection('a') + siblingSection('b') + siblingSection('c');
+  };
+
+  it('PRIOR_PROGRESS over the old 4K cap but under PRECAPPED_SECTION_CHAR_CAP rides byte-for-byte (head retained, no truncation notice)', () => {
+    const body = buildPreCappedProgressBody();
+    expect(body.length).toBeGreaterThan(SECTION_CHAR_CAP);
+    expect(body.length).toBeLessThan(PRECAPPED_SECTION_CHAR_CAP);
+
+    const rendered = substitute('Journal:\n{{PRIOR_PROGRESS}}', { PRIOR_PROGRESS: body });
+
+    expect(rendered).toBe(`Journal:\n${body}`);
+    expect(rendered).not.toContain('earlier content omitted');
+    // The head — sprint header + the current task's own history — survives verbatim.
+    expect(rendered).toContain('# Sprint: demo');
+    expect(rendered).toContain('## Task: implement-thing — Attempt 3 · id:task-current');
+  });
+
+  it('PRIOR_LEARNINGS over the old 4K cap but under PRECAPPED_SECTION_CHAR_CAP rides byte-for-byte', () => {
+    const body = `- ${'a learning. '.repeat(400)}`;
+    expect(body.length).toBeGreaterThan(SECTION_CHAR_CAP);
+    expect(body.length).toBeLessThan(PRECAPPED_SECTION_CHAR_CAP);
+
+    const rendered = substitute('Learnings:\n{{PRIOR_LEARNINGS}}', { PRIOR_LEARNINGS: body });
+
+    expect(rendered).toBe(`Learnings:\n${body}`);
+    expect(rendered).not.toContain('earlier content omitted');
+  });
+
+  it('a PRIOR_PROGRESS value that genuinely overflows PRECAPPED_SECTION_CHAR_CAP still gets tail-compressed with the notice', () => {
+    const body = 'x'.repeat(PRECAPPED_SECTION_CHAR_CAP + 500);
+    const rendered = substitute('Journal:\n{{PRIOR_PROGRESS}}', { PRIOR_PROGRESS: body });
+
+    expect(rendered).toContain('earlier content omitted');
+    const tail = body.slice(-PRECAPPED_SECTION_CHAR_CAP);
+    expect(rendered.endsWith(tail)).toBe(true);
   });
 });

--- a/tests/unit/integration/ai/prompts/compress-section.test.ts
+++ b/tests/unit/integration/ai/prompts/compress-section.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { compressSection, SECTION_CHAR_CAP } from '@src/integration/ai/prompts/_engine/compress-section.ts';
+import {
+  compressSection,
+  PRECAPPED_SECTION_CHAR_CAP,
+  SECTION_CHAR_CAP,
+} from '@src/integration/ai/prompts/_engine/compress-section.ts';
+import { MAX_CONTEXT_WINDOW } from '@src/domain/value/settings-models/context-window.ts';
 
 describe('compressSection', () => {
   it('returns content unchanged when at or below the default cap', () => {
@@ -77,5 +82,28 @@ describe('compressSection', () => {
     const result = compressSection(content, cap);
     expect(typeof result).toBe('string');
     expect(result).toContain(`showing last ${String(cap)} chars of ${String(content.length)} total`);
+  });
+});
+
+describe('PRECAPPED_SECTION_CHAR_CAP — drift fence', () => {
+  // Mirrors the arithmetic in `progressCapBudgetForModel`
+  // (`src/application/flows/_shared/progress/cap-progress.ts`): a sibling-section token budget of
+  // `round(window * PROGRESS_BUDGET_FRACTION)` tokens, at `CHARS_PER_TOKEN` chars/token. Duplicated
+  // here (rather than imported) because `compress-section.ts` is an integration-layer module and
+  // must not import from `application/**` — this test may cross that boundary, the module itself
+  // may not.
+  const CHARS_PER_TOKEN = 4;
+  const PROGRESS_BUDGET_FRACTION = 0.04;
+  /** Matches the depth allowance baked into {@link PRECAPPED_SECTION_CHAR_CAP}'s derivation. */
+  const DEPTH_ALLOWANCE_CHARS = 40_000;
+
+  it('never fires below the largest legitimate pre-capped output the model catalog can produce', () => {
+    const maxSiblingBudgetChars = Math.round(MAX_CONTEXT_WINDOW * PROGRESS_BUDGET_FRACTION) * CHARS_PER_TOKEN;
+    const maxLegitimatePreCappedChars = maxSiblingBudgetChars + DEPTH_ALLOWANCE_CHARS;
+    expect(PRECAPPED_SECTION_CHAR_CAP).toBeGreaterThanOrEqual(maxLegitimatePreCappedChars);
+  });
+
+  it('stays a strictly larger tier than the default SECTION_CHAR_CAP', () => {
+    expect(PRECAPPED_SECTION_CHAR_CAP).toBeGreaterThan(SECTION_CHAR_CAP);
   });
 });

--- a/tests/unit/integration/persistence/task/legacy-shape-tolerance.test.ts
+++ b/tests/unit/integration/persistence/task/legacy-shape-tolerance.test.ts
@@ -78,6 +78,39 @@ describe('Attempt round-trip — legacy verification body silently dropped on lo
     }
   });
 
+  it('a pre-attribution plateau warning (no `source` field) loads cleanly', () => {
+    // Pre-instrumentation `tasks.json` rows recorded a plateau warning with no `source` — the
+    // field is additive/optional, so old on-disk data must keep parsing without it.
+    const legacyAttempt = {
+      n: 3,
+      startedAt: '2026-05-01T10:00:00.000Z',
+      status: 'failed',
+      finishedAt: '2026-05-01T10:45:00.000Z',
+      warning: { kind: 'plateau', dimensions: ['correctness', 'completeness'] },
+    };
+    const parsed = fromJsonAttempt(legacyAttempt);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.warning).toEqual({ kind: 'plateau', dimensions: ['correctness', 'completeness'] });
+      expect((parsed.value.warning as Record<string, unknown> | undefined)?.['source']).toBeUndefined();
+    }
+  });
+
+  it('a plateau warning WITH a `source` round-trips it', () => {
+    const attempt = {
+      n: 4,
+      startedAt: '2026-05-01T10:00:00.000Z',
+      status: 'failed',
+      finishedAt: '2026-05-01T11:00:00.000Z',
+      warning: { kind: 'plateau', dimensions: ['robustness'], source: 'diversity' },
+    };
+    const parsed = fromJsonAttempt(attempt);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.warning).toEqual({ kind: 'plateau', dimensions: ['robustness'], source: 'diversity' });
+    }
+  });
+
   it('a pre-refactor attempt with a legacy evaluation drops the evaluation body too', () => {
     const legacyAttempt = {
       n: 2,


### PR DESCRIPTION
Lands the quick-wins tier of the improvement-research pass. #260 is the durable index (rejected/deferred candidates with reasons); the deferred track lives in #255–#259.

## Highlights

- **fix(prompts):** the 4,000-char substitution backstop no longer discards the window-scaled progress-journal / prior-learnings context — it now fires on true overflow only, with a drift-fence test tied to the largest catalog context window
- **feat(harness):** plateau exits attribute their detector (`threshold | diversity | entropy`) in progress.md + escalation events; corrective signals.json nudges are tallied per attempt (budget semantics unchanged)
- **feat(implement):** generator/evaluator prompts name the bound agent definition and the skills actually installed for the run
- **refactor(providers):** per-provider static facts consolidated into one `PROVIDER_TRAITS` table — shrinks the touch-list for the upcoming backends (#258, #259)
- **feat(boot):** bundle-mode integrity probe over `dist/manifest.json` — the 0.15.1 broken-install failure class now surfaces as a one-line reinstall hint at launch
- **feat(cli):** `ralphctl skills list`
- **feat(skills):** #216 deferred items closed out — minimal-scaffolding body rewritten downstream-neutral, create-pr mounts skills (code-review skill demoted to a documented opt-in there), catalog `c` key clears saved per-flow opt-outs
- **fix(tui):** Esc collapses an expanded task card before popping the route (wide layout)

## Verification

Full gate green: typecheck clean · lint 0 errors / 114 warnings (below the 115 ratchet) · 4,710 tests across 524 files passing. Every code item was implemented and adversarially gate-reviewed before commit.
