### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-18
+
 ### Added
 
 - **Portable, authorable agent definitions, ported automatically to each provider's native format.**
@@ -21,8 +23,10 @@ to [Semantic Versioning](https://semver.org/).
   it is enabled for (saved opt-outs applied), and its provenance (in sync / update available / locally
   modified) — for scripting and quick inspection outside the TUI.
 - **Skills in the Create PR flow.** The PR-drafting session now mounts the same curated skills as the
-  other flows. The code-review skill stays a recommended opt-in there rather than a default — its
-  review-signal guidance can conflict with the flow's single-summary output contract.
+  other flows. Its output contract keeps only the authored PR title/body and quietly drops any stray
+  narrative signal (`note` / `decision` / `learning`) a mounted skill might coach, so a skill can't
+  derail PR authoring by nudging the model off-contract. The code-review skill is offered as a
+  recommended opt-in there rather than a default.
 - **Clear a saved skill opt-out from the catalog.** Press `c` on a skill in the catalog (hotkey `K`)
   to clear a remembered per-flow opt-out — previously only possible by re-answering the remember
   prompt on a later run.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",
@@ -70,34 +70,34 @@
   "dependencies": {
     "commander": "^15.0.0",
     "cross-spawn": "^7.0.6",
-    "ink": "^7.0.3",
+    "ink": "^7.1.1",
     "proper-lockfile": "^4.1.2",
-    "react": "^19.2.6",
+    "react": "^19.2.7",
     "typescript-result": "^3.5.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/cross-spawn": "^6.0.6",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.1",
     "@types/proper-lockfile": "^4.1.4",
-    "@types/react": "^19.2.14",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@types/react": "^19.2.17",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-sonarjs": "^4.0.3",
-    "globals": "^17.6.0",
+    "globals": "^17.7.0",
     "husky": "^9.1.7",
     "ink-testing-library": "^4.0.0",
     "jiti": "^2.7.0",
-    "knip": "^6.14.1",
-    "lint-staged": "^17.0.5",
-    "prettier": "^3.8.3",
+    "knip": "^6.27.0",
+    "lint-staged": "^17.0.8",
+    "prettier": "^3.9.5",
     "tsup": "^8.5.1",
-    "tsx": "^4.22.1",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.10"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,13 +15,13 @@ importers:
         specifier: ^7.0.6
         version: 7.0.6
       ink:
-        specifier: ^7.0.3
-        version: 7.1.0(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^7.1.1
+        version: 7.1.1(@types/react@19.2.17)(react@19.2.7)
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
       react:
-        specifier: ^19.2.6
+        specifier: ^19.2.7
         version: 19.2.7
       typescript-result:
         specifier: ^3.5.2
@@ -37,17 +37,17 @@ importers:
         specifier: ^6.0.6
         version: 6.0.6
       '@types/node':
-        specifier: ^26.0.0
-        version: 26.1.0
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
       '@types/react':
-        specifier: ^19.2.14
+        specifier: ^19.2.17
         version: 19.2.17
       '@vitest/coverage-v8':
-        specifier: ^4.1.6
-        version: 4.1.9(vitest@4.1.9)
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: ^10.4.0
         version: 10.6.0(jiti@2.7.0)
@@ -58,7 +58,7 @@ importers:
         specifier: ^4.0.3
         version: 4.1.0(eslint@10.6.0(jiti@2.7.0))
       globals:
-        specifier: ^17.6.0
+        specifier: ^17.7.0
         version: 17.7.0
       husky:
         specifier: ^9.1.7
@@ -70,20 +70,20 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       knip:
-        specifier: ^6.14.1
-        version: 6.24.0
+        specifier: ^6.27.0
+        version: 6.27.0
       lint-staged:
-        specifier: ^17.0.5
+        specifier: ^17.0.8
         version: 17.0.8
       prettier:
-        specifier: ^3.8.3
-        version: 3.9.4
+        specifier: ^3.9.5
+        version: 3.9.5
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       tsx:
-        specifier: ^4.22.1
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -91,8 +91,8 @@ importers:
         specifier: ^8.59.3
         version: 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
-        specifier: ^4.1.6
-        version: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -134,16 +134,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -158,11 +150,6 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -174,10 +161,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -829,19 +812,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-android-arm-eabi@4.60.4':
-    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.4':
-    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.2':
@@ -849,19 +822,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.4':
-    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.2':
     resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.4':
-    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.2':
@@ -869,19 +832,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.4':
-    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.4':
-    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.2':
@@ -889,23 +842,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
-    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
@@ -913,23 +854,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
-    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
@@ -937,23 +866,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
-    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
@@ -961,23 +878,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
-    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
@@ -985,23 +890,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
-    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
@@ -1009,21 +902,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1033,51 +914,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.4':
-    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.4':
-    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.4':
-    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.62.2':
     resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
-    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
-    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
@@ -1085,18 +940,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
-    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
 
@@ -1123,17 +968,14 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/proper-lockfile@4.1.4':
     resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
@@ -1175,6 +1017,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/tsconfig-utils@8.64.0':
+    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/type-utils@8.62.1':
     resolution: {integrity: sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1184,6 +1032,10 @@ packages:
 
   '@typescript-eslint/types@8.62.1':
     resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.64.0':
+    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.62.1':
@@ -1203,20 +1055,20 @@ packages:
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/coverage-v8@4.1.9':
-    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.9
-      vitest: 4.1.9
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1226,20 +1078,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1273,8 +1125,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@1.0.4:
-    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
@@ -1284,17 +1136,17 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.32:
-    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1316,8 +1168,8 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1347,8 +1199,8 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
-  cli-truncate@6.0.0:
-    resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
     engines: {node: '>=22'}
 
   code-excerpt@4.0.0:
@@ -1396,8 +1248,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  electron-to-chromium@1.5.361:
-    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+  electron-to-chromium@1.5.393:
+    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1406,11 +1258,11 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
-  es-toolkit@1.48.1:
-    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1493,8 +1345,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
@@ -1593,8 +1445,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   imurmurhash@0.1.4:
@@ -1614,8 +1466,8 @@ packages:
       '@types/react':
         optional: true
 
-  ink@7.1.0:
-    resolution: {integrity: sha512-VWE6/yeLtFCJBNLflyI2OSylyXK1Rc24LuXup8Qt+icwkmmycFNdbn8IkSp6Frc0h1iA0NOvvi1ajW44U/w3Qg==}
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -1699,8 +1551,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  knip@6.24.0:
-    resolution: {integrity: sha512-PokLlgeEjLh1rAsB7ts+52wZ37HBr1nDhE6NNONwEaXdeZGCJOkP7ZlIAI2Gtu8xohquzTWy75bc/1diI9shQw==}
+  knip@6.27.0:
+    resolution: {integrity: sha512-CngYEYrD0n20N06FXA8n3u/0Wnnugoa+B9k14OP+iKIgkCHuzvIdsP3nfwjhByoc1WfogpxfiriMboAXFETDUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1720,8 +1572,8 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+  listr2@10.2.2:
+    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
     engines: {node: '>=22.13.0'}
 
   load-tsconfig@0.2.5:
@@ -1773,24 +1625,24 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
   onetime@5.1.2:
@@ -1838,10 +1690,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -1871,16 +1719,16 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.9.4:
-    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
+  prettier@3.9.5:
+    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1934,11 +1782,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rollup@4.60.4:
-    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
 
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
@@ -2010,8 +1853,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2021,8 +1864,8 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
     engines: {node: '>=20'}
 
   strip-ansi@7.2.0:
@@ -2067,10 +1910,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -2114,8 +1953,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.23.0:
-    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2123,8 +1962,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@5.7.0:
-    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
 
   typescript-eslint@8.62.1:
@@ -2146,8 +1985,8 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
-  unbash@4.0.2:
-    resolution: {integrity: sha512-8gwNZ29+0/3zmXw7ToIHZtg6wK37xnniRUdBt7B27xZxaxfgR5tGMaGHT0t0dLtBV9fXE7zurh0s6Z1DHVjfWg==}
+  unbash@4.0.3:
+    resolution: {integrity: sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w==}
     engines: {node: '>=14'}
 
   undici-types@8.3.0:
@@ -2202,20 +2041,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2273,8 +2112,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2356,7 +2195,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.6
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -2378,11 +2217,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -2392,10 +2227,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -2418,11 +2249,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -2824,151 +2650,76 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.4':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.4':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.4':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.4':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.4':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.4':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.4':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.4':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.4':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
@@ -2988,19 +2739,17 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
 
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@26.1.0':
+  '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -3023,7 +2772,7 @@ snapshots:
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 10.6.0(jiti@2.7.0)
-      ignore: 7.0.5
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -3044,8 +2793,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -3057,6 +2806,10 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.62.1
 
   '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -3073,6 +2826,8 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.62.1': {}
+
+  '@typescript-eslint/types@8.64.0': {}
 
   '@typescript-eslint/typescript-estree@8.62.1(typescript@6.0.3)':
     dependencies:
@@ -3105,58 +2860,58 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.9
-      ast-v8-to-istanbul: 1.0.4
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
-      std-env: 4.1.0
+      obug: 2.1.4
+      std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.9':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@4.1.9':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3185,7 +2940,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.4:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -3195,19 +2950,19 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.32: {}
+  baseline-browser-mapping@2.10.43: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.6:
     dependencies:
-      baseline-browser-mapping: 2.10.32
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.361
-      node-releases: 2.0.46
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.393
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   builtin-modules@3.3.0: {}
 
@@ -3220,7 +2975,7 @@ snapshots:
 
   cac@6.7.14: {}
 
-  caniuse-lite@1.0.30001793: {}
+  caniuse-lite@1.0.30001806: {}
 
   chai@6.2.2: {}
 
@@ -3243,12 +2998,12 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.1
+      string-width: 8.2.2
 
-  cli-truncate@6.0.0:
+  cli-truncate@6.1.1:
     dependencies:
       slice-ansi: 9.0.0
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   code-excerpt@4.0.0:
     dependencies:
@@ -3280,15 +3035,15 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  electron-to-chromium@1.5.361: {}
+  electron-to-chromium@1.5.393: {}
 
   emoji-regex@10.6.0: {}
 
   environment@1.1.0: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.3.1: {}
 
-  es-toolkit@1.48.1: {}
+  es-toolkit@1.49.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3357,7 +3112,7 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       eslint: 10.6.0(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.4.3
@@ -3454,7 +3209,7 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3483,7 +3238,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.60.4
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -3531,7 +3286,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   imurmurhash@0.1.4: {}
 
@@ -3541,7 +3296,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  ink@7.1.0(@types/react@19.2.17)(react@19.2.7):
+  ink@7.1.1(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0
@@ -3550,9 +3305,9 @@ snapshots:
       chalk: 5.6.2
       cli-boxes: 4.0.1
       cli-cursor: 4.0.0
-      cli-truncate: 6.0.0
+      cli-truncate: 6.1.1
       code-excerpt: 4.0.0
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0
@@ -3562,12 +3317,12 @@ snapshots:
       signal-exit: 3.0.7
       slice-ansi: 9.0.0
       stack-utils: 2.0.6
-      string-width: 8.2.1
+      string-width: 8.2.2
       terminal-size: 4.0.1
-      type-fest: 5.7.0
+      type-fest: 5.8.0
       widest-line: 6.0.0
       wrap-ansi: 10.0.0
-      ws: 8.21.0
+      ws: 8.21.1
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.17
@@ -3626,7 +3381,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@6.24.0:
+  knip@6.27.0:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       formatly: 0.3.0
@@ -3638,7 +3393,7 @@ snapshots:
       smol-toml: 1.7.0
       strip-json-comments: 5.0.3
       tinyglobby: 0.2.17
-      unbash: 4.0.2
+      unbash: 4.0.3
       yaml: 2.9.0
       zod: 4.4.3
 
@@ -3653,14 +3408,14 @@ snapshots:
 
   lint-staged@17.0.8:
     dependencies:
-      listr2: 10.2.1
-      picomatch: 4.0.4
+      listr2: 10.2.2
+      picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
-  listr2@10.2.1:
+  listr2@10.2.2:
     dependencies:
       cli-truncate: 5.2.0
       eventemitter3: 5.0.4
@@ -3708,7 +3463,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   mlly@1.8.2:
     dependencies:
@@ -3725,15 +3480,15 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
-  node-releases@2.0.46: {}
+  node-releases@2.0.51: {}
 
   object-assign@4.1.1: {}
 
-  obug@2.1.3: {}
+  obug@2.1.4: {}
 
   onetime@5.1.2:
     dependencies:
@@ -3817,8 +3572,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
@@ -3829,24 +3582,24 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.16
-      tsx: 4.23.0
+      postcss: 8.5.19
+      tsx: 4.23.1
       yaml: 2.9.0
 
-  postcss@8.5.16:
+  postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.9.4: {}
+  prettier@3.9.5: {}
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -3891,37 +3644,6 @@ snapshots:
   retry@0.12.0: {}
 
   rfdc@1.4.1: {}
-
-  rollup@4.60.4:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.4
-      '@rollup/rollup-android-arm64': 4.60.4
-      '@rollup/rollup-darwin-arm64': 4.60.4
-      '@rollup/rollup-darwin-x64': 4.60.4
-      '@rollup/rollup-freebsd-arm64': 4.60.4
-      '@rollup/rollup-freebsd-x64': 4.60.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
-      '@rollup/rollup-linux-arm64-gnu': 4.60.4
-      '@rollup/rollup-linux-arm64-musl': 4.60.4
-      '@rollup/rollup-linux-loong64-gnu': 4.60.4
-      '@rollup/rollup-linux-loong64-musl': 4.60.4
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
-      '@rollup/rollup-linux-ppc64-musl': 4.60.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
-      '@rollup/rollup-linux-riscv64-musl': 4.60.4
-      '@rollup/rollup-linux-s390x-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-musl': 4.60.4
-      '@rollup/rollup-openbsd-x64': 4.60.4
-      '@rollup/rollup-openharmony-arm64': 4.60.4
-      '@rollup/rollup-win32-arm64-msvc': 4.60.4
-      '@rollup/rollup-win32-ia32-msvc': 4.60.4
-      '@rollup/rollup-win32-x64-gnu': 4.60.4
-      '@rollup/rollup-win32-x64-msvc': 4.60.4
-      fsevents: 2.3.3
 
   rollup@4.62.2:
     dependencies:
@@ -4005,7 +3727,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.2.0: {}
 
   string-argv@0.3.2: {}
 
@@ -4015,7 +3737,7 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.1:
+  string-width@8.2.2:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
@@ -4058,11 +3780,6 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -4081,7 +3798,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4092,16 +3809,16 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.0)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.60.4
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.19
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -4109,7 +3826,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.23.0:
+  tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -4119,7 +3836,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.7.0:
+  type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -4140,13 +3857,13 @@ snapshots:
 
   ufo@1.6.4: {}
 
-  unbash@4.0.2: {}
+  unbash@4.0.3: {}
 
   undici-types@8.3.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.6
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -4154,46 +3871,46 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+  vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.19
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.23.0
+      tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@26.1.0)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.1.0
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 
@@ -4210,14 +3927,14 @@ snapshots:
 
   widest-line@6.0.0:
     dependencies:
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   word-wrap@1.2.5: {}
 
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
-      string-width: 8.2.1
+      string-width: 8.2.2
       strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
@@ -4226,7 +3943,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.21.0: {}
+  ws@8.21.1: {}
 
   yallist@3.1.1: {}
 

--- a/src/application/bootstrap/wire.ts
+++ b/src/application/bootstrap/wire.ts
@@ -65,6 +65,7 @@ import { createAgentDefinitionAdapter } from '@src/integration/ai/agents/adapter
 import { composeAgentDefinitionSources } from '@src/integration/ai/agents/_engine/compose-agent-definition-sources.ts';
 import { createBundledAgentDefinitionSource } from '@src/integration/ai/agents/bundled/source.ts';
 import { createOperatorAgentDefinitionSource } from '@src/integration/ai/agents/operator/source.ts';
+import { warnIfVague } from '@src/integration/ai/agents/_engine/agent-definition-quality.ts';
 import type { NotificationDispatcher } from '@src/business/observability/notification-dispatcher.ts';
 import { startFileLogSink } from '@src/integration/observability/sinks/file-log-sink.ts';
 import type { FileLogSink, FileLogSinkDeps } from '@src/integration/observability/_engine/file-log-sink.ts';
@@ -372,7 +373,11 @@ const buildWireAgentDefinitionAdapter = (settings: Settings, logger: Logger): Ag
 const buildWireAgentDefinitionSource = (storage: StoragePaths, logger: Logger): AgentDefinitionSource =>
   composeAgentDefinitionSources(
     createBundledAgentDefinitionSource(),
-    createOperatorAgentDefinitionSource({ operatorAgentDefinitionsRoot: storage.operatorAgentDefinitionsRoot, logger })
+    createOperatorAgentDefinitionSource({
+      operatorAgentDefinitionsRoot: storage.operatorAgentDefinitionsRoot,
+      logger,
+      warnIfVague: (definition) => warnIfVague(logger, definition),
+    })
   );
 
 export const wire = (opts: WireOptions): AppDeps => {

--- a/src/application/flows/create-pr/leaves/generate-pr-content.contract.ts
+++ b/src/application/flows/create-pr/leaves/generate-pr-content.contract.ts
@@ -8,11 +8,13 @@ import type { AiOutputContract, SidecarRule } from '@src/integration/ai/contract
 /**
  * Per-leaf I/O contract for the create-pr flow's optional AI authoring step — audit-[09].
  *
- * Accepts ONLY `pr-content`. No narrative fan-out (`learning` / `note` / `decision`): the
- * create-pr session runs post-implement, after the sprint reaches review/done. There is no
- * active progress journal to enrich at that point — narrative signals would be silently
- * dropped on the floor, and the prompt instructs the AI to focus solely on authoring the PR
- * title + body.
+ * Keeps ONLY `pr-content`. Any narrative fan-out (`learning` / `note` / `decision`) a mounted
+ * skill may coach is DROPPED, not rejected: the create-pr session runs post-implement, after
+ * the sprint reaches review/done, so there is no active progress journal to enrich — such
+ * signals are silently dropped on the floor rather than failing the whole array, so a single
+ * stray signal can't quietly defeat AI PR authoring (the leaf would otherwise fall back to the
+ * generic template body). The prompt still instructs the AI to focus solely on authoring the
+ * PR title + body.
  *
  * `pr-content` is constrained to exactly one occurrence so the leaf has a single
  * deterministic { title, body } to thread downstream.
@@ -32,9 +34,21 @@ const PR_CONTENT_KIND = 'pr-content';
 const exactlyOnePrContent = (signals: ReadonlyArray<{ readonly type: string }>): boolean =>
   signals.filter((s) => s.type === PR_CONTENT_KIND).length === 1;
 
+/** Structural pre-filter — the pipe below validates each survivor's full `pr-content` shape. */
+const isPrContentSignal = (signal: unknown): boolean =>
+  typeof signal === 'object' && signal !== null && (signal as { readonly type?: unknown }).type === PR_CONTENT_KIND;
+
+// Tolerant by design (see the module doc): drop any non-`pr-content` signal a mounted skill may
+// have coached (a stray `<note>` / `<decision>` / `<learning>`) BEFORE validation, then validate
+// the surviving pr-content signals and require exactly one. Filtering first means one stray
+// narrative signal no longer fails the whole array — which would have silently defeated AI PR
+// authoring. A malformed pr-content still fails the pipe; zero pr-content still fails the refine.
 const signalsArraySchemaRaw = z
-  .array(prContentSignalSchema)
-  .refine(exactlyOnePrContent, 'exactly one pr-content signal per create-pr spawn');
+  .array(z.unknown())
+  .transform((signals) => signals.filter(isPrContentSignal))
+  .pipe(
+    z.array(prContentSignalSchema).refine(exactlyOnePrContent, 'exactly one pr-content signal per create-pr spawn')
+  );
 
 /**
  * Cast bridge between Zod's inferred shape (optional fields widened to `T | undefined`

--- a/src/application/ui/cli/commands/agents.ts
+++ b/src/application/ui/cli/commands/agents.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 import { createBundledAgentDefinitionSource } from '@src/integration/ai/agents/bundled/source.ts';
 import { createOperatorAgentDefinitionSource } from '@src/integration/ai/agents/operator/source.ts';
+import { warnIfVague } from '@src/integration/ai/agents/_engine/agent-definition-quality.ts';
 import { createSettingsShowFlow } from '@src/application/flows/settings-show/flow.ts';
 import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
 import type { AiImplementRole } from '@src/domain/entity/settings.ts';
@@ -39,6 +40,7 @@ export const registerAgentsCommand = (program: Command): void => {
       const operatorSource = createOperatorAgentDefinitionSource({
         operatorAgentDefinitionsRoot: storage.operatorAgentDefinitionsRoot,
         logger: deps.logger,
+        warnIfVague: (definition) => warnIfVague(deps.logger, definition),
       });
 
       const [bundled, operator] = await Promise.all([bundledSource.list(), operatorSource.list()]);

--- a/src/business/settings/resolve-agent-override.ts
+++ b/src/business/settings/resolve-agent-override.ts
@@ -1,5 +1,5 @@
 import type { AiFlowSettings, Settings } from '@src/domain/entity/settings.ts';
-import { resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
+import { clampEffortToProvider, resolveEffortForRow } from '@src/business/settings/resolve-effort.ts';
 
 /**
  * The subset of an `AgentDefinition` this resolver needs. Declared locally rather than
@@ -24,9 +24,10 @@ export interface ResolvedAgentOverride {
  *
  * - `model`: the definition's `model` when set, otherwise the row's own `model` (always
  *   present — every {@link AiFlowSettings} row is fully stamped with a provider-catalog model).
- * - `effort`: the definition's `effort` when set, otherwise {@link resolveEffortForRow}'s
- *   result (per-flow row effort, falling through to the global default floored to the row's
- *   provider).
+ * - `effort`: the definition's `effort` when set, but floored to the row's provider (e.g. an
+ *   agent definition's `xhigh`/`max` clamps to `high` on a codex row, same as the global-default
+ *   path — see {@link clampEffortToProvider}); otherwise {@link resolveEffortForRow}'s result
+ *   (per-flow row effort, falling through to the global default floored to the row's provider).
  *
  * `binding` is `undefined` when the role has no bound definition — resolution then falls
  * straight through to the per-flow row / global default, identical to `resolveEffortForRow`
@@ -38,5 +39,8 @@ export const resolveAgentOverride = (
   binding: AgentOverrideHints | undefined
 ): ResolvedAgentOverride => ({
   model: binding?.model ?? row.model,
-  effort: binding?.effort ?? resolveEffortForRow(row, globalEffort),
+  effort:
+    binding?.effort !== undefined
+      ? clampEffortToProvider(binding.effort, row.provider)
+      : resolveEffortForRow(row, globalEffort),
 });

--- a/src/business/settings/resolve-effort.ts
+++ b/src/business/settings/resolve-effort.ts
@@ -38,6 +38,24 @@ export const resolveEffortForRow = (
 };
 
 /**
+ * Clamp an arbitrary effort string to a value the provider's adapter accepts.
+ *
+ * Exported so callers that source effort from somewhere other than the global-default fallback
+ * (e.g. an agent-definition binding — see `resolveAgentOverride`) can still apply the same
+ * per-provider floor. Without this, a binding-supplied `xhigh`/`max` reaches the codex CLI
+ * verbatim; codex only accepts `minimal | low | medium | high` and rejects unknown levels,
+ * so an unclamped value fails every spawn for that role.
+ *
+ * Only the known-dangerous codex case is floored — any other string (including values outside
+ * the superset) passes through unchanged, letting the provider CLI be the final arbiter of
+ * genuinely unknown effort levels.
+ */
+export const clampEffortToProvider = (effort: string, provider: AiProvider): string => {
+  if (provider === 'openai-codex' && (effort === 'xhigh' || effort === 'max')) return 'high';
+  return effort;
+};
+
+/**
  * Clamp the unified global effort to a value the provider's adapter accepts.
  *
  * - claude-code: identity (its native vocabulary IS the superset).
@@ -45,14 +63,5 @@ export const resolveEffortForRow = (
  *   surfaced as a per-flow opt-out and never selected globally).
  * - openai-codex: `minimal | low | medium | high`. `xhigh` / `max` clamp to `high`.
  */
-const _floorForProvider = (effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max', provider: AiProvider): string => {
-  switch (provider) {
-    case 'claude-code':
-    case 'github-copilot':
-      return effort;
-    case 'openai-codex': {
-      if (effort === 'xhigh' || effort === 'max') return 'high';
-      return effort;
-    }
-  }
-};
+const _floorForProvider = (effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max', provider: AiProvider): string =>
+  clampEffortToProvider(effort, provider);

--- a/src/business/sprint/render-journal-entry.ts
+++ b/src/business/sprint/render-journal-entry.ts
@@ -34,9 +34,12 @@ export type JournalVerdict = 'pass' | 'pass-with-warning' | 'escalated' | 'block
  *  - `source`      — WHICH of the three plateau detectors fired (`threshold` / `diversity` /
  *                    `entropy` — mirrors the domain `PlateauSource`, redeclared here rather than
  *                    imported so the renderer stays decoupled from the entity), present only for
- *                    the `plateau` kind and only when the leaf could resolve it. Pure
- *                    instrumentation for the periodic detector-load-bearing audit — never changes
- *                    which sentence renders, only appends a parenthetical.
+ *                    the `plateau` kind and only when the leaf could resolve it. Selects which of
+ *                    the three plateau sentences renders (see `warningSentence`'s `plateau`
+ *                    branch) — each detector observes something different, so only `threshold`
+ *                    legitimately reads as "two consecutive evaluations flagged the identical
+ *                    failure". Absent `source` (legacy records written before this field existed)
+ *                    falls back to the `threshold` wording.
  *  - `turnsUsed` / `turnBudget` — present only for the `budget-exhausted` kind.
  */
 export interface JournalWarning {
@@ -216,6 +219,38 @@ const parenDetail = (detail: string | undefined): string =>
   detail !== undefined && detail.trim().length > 0 ? ` (${detail.trim()})` : '';
 
 /**
+ * The plateau warning's sentence — branched on `source` because the three detectors observe
+ * genuinely different things (see `PlateauSource` in `domain/entity/attempt.ts`); reusing one
+ * clause would misattribute the `threshold` detector's "identical failure" wording to detectors
+ * that never compare two evaluations' failure sets. A `(detector: …)` parenthetical is appended
+ * when the source is known; an absent `source` (legacy records) falls back to `threshold` wording.
+ */
+const plateauSentence = (warning: JournalWarning): string => {
+  const dims =
+    warning.dimensions !== undefined && warning.dimensions.length > 0
+      ? ` on the same failed dimension${warning.dimensions.length === 1 ? '' : 's'}: ${warning.dimensions.join(', ')}`
+      : '';
+  const detector = warning.source !== undefined ? ` (detector: ${warning.source})` : '';
+  if (warning.source === 'diversity') {
+    // `loop-diversity-check` (gen-eval-loop.ts) — the generator re-emitted the same failed-
+    // dimension fingerprint for the last 3 consecutive turns without changing approach;
+    // dimensions carries that repeated failed set, same as `threshold`.
+    return `The evaluator plateaued — the generator repeated the same failed-dimension pattern across the last 3 consecutive turns without changing approach${dims}${detector}.`;
+  }
+  if (warning.source === 'entropy') {
+    // `entropy-check` (gen-eval-loop.ts) — Shannon entropy over the generator's reported signal-
+    // kind distribution for the latest turn collapsed below threshold. This detector never
+    // compares two evaluations' failure sets, so it always carries `dimensions: []` — `dims` is
+    // deliberately not interpolated into this sentence.
+    return `The evaluator plateaued — the generator's reported actions collapsed onto a narrow set of signal kinds this turn (low action-kind diversity)${detector}.`;
+  }
+  // `threshold` (business/task/plateau-detection.ts) is the only detector that compares two
+  // consecutive evaluations' failed-dimension sets — also the fallback wording for legacy records
+  // written before `source` existed.
+  return `The evaluator plateaued — two consecutive evaluations flagged the identical failure${dims}${detector}.`;
+};
+
+/**
  * One plain-prose sentence describing what the warning means for the next attempt. The journal
  * is the generator's cross-attempt memory, so this names the failure mode explicitly instead of
  * leaning on a glyph or jargon.
@@ -229,16 +264,8 @@ const warningSentence = (warning: JournalWarning): string => {
           : ' after exhausting the turn budget';
       return `The evaluator did not pass${turns}.`;
     }
-    case 'plateau': {
-      const dims =
-        warning.dimensions !== undefined && warning.dimensions.length > 0
-          ? ` on the same failed dimension${warning.dimensions.length === 1 ? '' : 's'}: ${warning.dimensions.join(', ')}`
-          : '';
-      // Detector attribution — pure instrumentation, appended as a parenthetical so the main
-      // clause stays byte-identical for records written before this field existed.
-      const detector = warning.source !== undefined ? ` (detector: ${warning.source})` : '';
-      return `The evaluator plateaued — two consecutive evaluations flagged the identical failure${dims}${detector}.`;
-    }
+    case 'plateau':
+      return plateauSentence(warning);
     case 'malformed':
       return `The evaluator output could not be parsed${parenDetail(warning.detail)}.`;
     case 'verify-failed': {

--- a/src/integration/ai/agents/_engine/render-claude-agent.ts
+++ b/src/integration/ai/agents/_engine/render-claude-agent.ts
@@ -3,6 +3,9 @@
  * format: `.claude/agents/ralphctl-<name>.md`, a YAML frontmatter block (`name`, `description`,
  * optional `model` / `effort`) followed by the Markdown body used as the sub-agent's system
  * prompt.
+ *
+ * Frontmatter scalars are emitted as YAML double-quoted strings via `JSON.stringify` — YAML's
+ * double-quoted scalar escaping (`\"`, `\\`, `\n`, `\t`, …) is a compatible subset of JSON's.
  */
 
 import { join } from 'node:path';
@@ -11,10 +14,12 @@ import type { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AgentDefinition, RenderedAgentFile } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 import { namespacedAgentFileBase } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 
+const yamlString = (value: string): string => JSON.stringify(value);
+
 export const renderClaudeAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
-  const lines = ['---', `name: ${definition.name}`, `description: ${definition.description}`];
-  if (definition.model !== undefined) lines.push(`model: ${definition.model}`);
-  if (definition.effort !== undefined) lines.push(`effort: ${definition.effort}`);
+  const lines = ['---', `name: ${yamlString(definition.name)}`, `description: ${yamlString(definition.description)}`];
+  if (definition.model !== undefined) lines.push(`model: ${yamlString(definition.model)}`);
+  if (definition.effort !== undefined) lines.push(`effort: ${yamlString(definition.effort)}`);
   lines.push('---');
 
   const content = `${lines.join('\n')}\n\n${definition.content.replace(/\s+$/u, '')}\n`;

--- a/src/integration/ai/agents/_engine/render-copilot-agent.ts
+++ b/src/integration/ai/agents/_engine/render-copilot-agent.ts
@@ -6,6 +6,9 @@
  * Copilot rejects an agent file whose body exceeds 30000 characters — the renderer enforces
  * that limit up front and returns a {@link StorageError} instead of producing a file the CLI
  * would refuse to load.
+ *
+ * Frontmatter scalars are emitted as YAML double-quoted strings via `JSON.stringify` — YAML's
+ * double-quoted scalar escaping (`\"`, `\\`, `\n`, `\t`, …) is a compatible subset of JSON's.
  */
 
 import { join } from 'node:path';
@@ -16,6 +19,8 @@ import { namespacedAgentFileBase } from '@src/integration/ai/agents/_engine/agen
 
 /** Copilot's documented per-agent body size limit. */
 export const COPILOT_AGENT_MAX_BODY_CHARS = 30000;
+
+const yamlString = (value: string): string => JSON.stringify(value);
 
 export const renderCopilotAgent = (definition: AgentDefinition): Result<RenderedAgentFile, StorageError> => {
   const relPath = join('.github', 'agents', `${namespacedAgentFileBase(definition.name)}.agent.md`);
@@ -30,8 +35,8 @@ export const renderCopilotAgent = (definition: AgentDefinition): Result<Rendered
     );
   }
 
-  const lines = ['---', `description: ${definition.description}`, `name: ${definition.name}`];
-  if (definition.model !== undefined) lines.push(`model: ${definition.model}`);
+  const lines = ['---', `description: ${yamlString(definition.description)}`, `name: ${yamlString(definition.name)}`];
+  if (definition.model !== undefined) lines.push(`model: ${yamlString(definition.model)}`);
   lines.push('---');
 
   const content = `${lines.join('\n')}\n\n${definition.content.replace(/\s+$/u, '')}\n`;

--- a/src/integration/ai/skills/_engine/registry.ts
+++ b/src/integration/ai/skills/_engine/registry.ts
@@ -80,12 +80,11 @@ export const BUNDLED_SKILLS: readonly BundledSkillEntry[] = [
     recommendedFor: ['plan', 'readiness'],
   },
   {
-    // createPr is opt-in only, not default: this skill's guidance coaches emitting <note> /
-    // <decision> signals, but create-pr's output contract
-    // (generate-pr-content.contract.ts) accepts ONLY a single pr-content signal — a model
-    // following the skill's default advice there produces an invalid signals.json and the leaf
-    // silently falls back to the template body, defeating AI authoring. Conscious opt-in via
-    // the catalog avoids that conflict by default while keeping it discoverable.
+    // createPr is recommended opt-in, not default. This skill coaches emitting review-oriented
+    // <note> / <decision> signals; create-pr's output contract keeps only the single pr-content
+    // signal and DROPS any such narrative signal (generate-pr-content.contract.ts is tolerant by
+    // design), so recommending it here is safe. It stays opt-in rather than default because
+    // review-signal guidance is only sometimes what you want while authoring a PR body.
     name: 'ralphctl-code-review-and-quality',
     defaultFor: ['implement'],
     recommendedFor: ['readiness', 'createPr'],

--- a/tests/integration/ai/agents/claude/adapter.test.ts
+++ b/tests/integration/ai/agents/claude/adapter.test.ts
@@ -32,10 +32,10 @@ describe('createClaudeAgentDefinitionAdapter — golden render', () => {
     expect(written).toBe(
       [
         '---',
-        'name: implementer',
-        'description: Writes features, fixes bugs, adds tests.',
-        'model: claude-sonnet-5',
-        'effort: high',
+        'name: "implementer"',
+        'description: "Writes features, fixes bugs, adds tests."',
+        'model: "claude-sonnet-5"',
+        'effort: "high"',
         '---',
         '',
         'You are an implementer.',
@@ -67,6 +67,32 @@ describe('createClaudeAgentDefinitionAdapter — golden render', () => {
     await adapter.install(session, [definition({ name: 'ralphctl-evaluator' })]);
 
     const written = await readFile(join(String(session), '.claude/agents/ralphctl-evaluator.md'), 'utf-8');
-    expect(written).toContain('name: ralphctl-evaluator');
+    expect(written).toContain('name: "ralphctl-evaluator"');
+  });
+});
+
+describe('createClaudeAgentDefinitionAdapter — YAML frontmatter escaping', () => {
+  it('quotes and escapes a description containing a colon-space, a leading #, and a double-quote', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+    const tricky = 'Reviews diffs: focuses on security, flags "#unsafe" patterns';
+
+    await adapter.install(session, [definition({ description: tricky })]);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-implementer.md'), 'utf-8');
+    expect(written).toContain(`description: ${JSON.stringify(tricky)}`);
+    expect(written).not.toContain(`description: ${tricky}`);
+  });
+
+  it('does not let an embedded newline in the description inject a second frontmatter line', async () => {
+    const session = await makeSession();
+    const adapter = createClaudeAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ description: 'Line one\nname: injected' })]);
+
+    const written = await readFile(join(String(session), '.claude/agents/ralphctl-implementer.md'), 'utf-8');
+    const frontmatterLines = written.split('---')[1]?.split('\n').filter(Boolean) ?? [];
+    expect(frontmatterLines).toHaveLength(2);
+    expect(written).toContain('description: "Line one\\nname: injected"');
   });
 });

--- a/tests/integration/ai/agents/codex/adapter.test.ts
+++ b/tests/integration/ai/agents/codex/adapter.test.ts
@@ -76,3 +76,29 @@ describe('createCodexAgentDefinitionAdapter — golden render', () => {
     expect(written).toContain('name = "ralphctl-evaluator"');
   });
 });
+
+describe('createCodexAgentDefinitionAdapter — TOML string escaping', () => {
+  it('quotes and escapes a description containing a colon-space, a leading #, and a double-quote', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+    const tricky = 'Reviews diffs: focuses on security, flags "#unsafe" patterns';
+
+    await adapter.install(session, [definition({ description: tricky })]);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-implementer.toml'), 'utf-8');
+    expect(written).toContain(`description = ${JSON.stringify(tricky)}`);
+    expect(written).not.toContain(`description = ${tricky}`);
+  });
+
+  it('does not let an embedded newline in the description inject a second line', async () => {
+    const session = await makeSession();
+    const adapter = createCodexAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ description: 'Line one\nname = "injected"' })]);
+
+    const written = await readFile(join(String(session), '.codex/agents/ralphctl-implementer.toml'), 'utf-8');
+    const lines = written.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(3);
+    expect(written).toContain('description = "Line one\\nname = \\"injected\\""');
+  });
+});

--- a/tests/integration/ai/agents/copilot/adapter.test.ts
+++ b/tests/integration/ai/agents/copilot/adapter.test.ts
@@ -33,9 +33,9 @@ describe('createCopilotAgentDefinitionAdapter — golden render', () => {
     expect(written).toBe(
       [
         '---',
-        'description: Writes features, fixes bugs, adds tests.',
-        'name: implementer',
-        'model: claude-sonnet-5',
+        'description: "Writes features, fixes bugs, adds tests."',
+        'name: "implementer"',
+        'model: "claude-sonnet-5"',
         '---',
         '',
         'You are an implementer.',
@@ -56,7 +56,33 @@ describe('createCopilotAgentDefinitionAdapter — golden render', () => {
     await adapter.install(session, [definition({ name: 'ralphctl-evaluator' })]);
 
     const written = await readFile(join(String(session), '.github/agents/ralphctl-evaluator.agent.md'), 'utf-8');
-    expect(written).toContain('name: ralphctl-evaluator');
+    expect(written).toContain('name: "ralphctl-evaluator"');
+  });
+});
+
+describe('createCopilotAgentDefinitionAdapter — YAML frontmatter escaping', () => {
+  it('quotes and escapes a description containing a colon-space, a leading #, and a double-quote', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+    const tricky = 'Reviews diffs: focuses on security, flags "#unsafe" patterns';
+
+    await adapter.install(session, [definition({ description: tricky })]);
+
+    const written = await readFile(join(String(session), '.github/agents/ralphctl-implementer.agent.md'), 'utf-8');
+    expect(written).toContain(`description: ${JSON.stringify(tricky)}`);
+    expect(written).not.toContain(`description: ${tricky}`);
+  });
+
+  it('does not let an embedded newline in the description inject a second frontmatter line', async () => {
+    const session = await makeSession();
+    const adapter = createCopilotAgentDefinitionAdapter();
+
+    await adapter.install(session, [definition({ description: 'Line one\nname: injected' })]);
+
+    const written = await readFile(join(String(session), '.github/agents/ralphctl-implementer.agent.md'), 'utf-8');
+    const frontmatterLines = written.split('---')[1]?.split('\n').filter(Boolean) ?? [];
+    expect(frontmatterLines).toHaveLength(2);
+    expect(written).toContain('description: "Line one\\nname: injected"');
   });
 });
 

--- a/tests/integration/application/bootstrap/wire.test.ts
+++ b/tests/integration/application/bootstrap/wire.test.ts
@@ -13,6 +13,7 @@ import { ensureStorageRoots, storagePathsFromRoot } from '@src/application/boots
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { RALPHCTL_DEBUG_TRACE_ENV, wire } from '@src/application/bootstrap/wire.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { LogEvent } from '@src/business/observability/events.ts';
 import { createRefineFlow } from '@src/application/flows/refine/flow.ts';
 import { makeDraftSprint, makeDraftSprintBundle, makePendingTicket, makeProject } from '@tests/fixtures/domain.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
@@ -119,6 +120,35 @@ describe('wire', () => {
 
     expect(a.projectRepo).not.toBe(b.projectRepo);
     expect(a.sprintRepo).not.toBe(b.sprintRepo);
+  });
+
+  it('wires the operator quality guard so a vague agent definition logs a warning through agentDefinitionSource', async () => {
+    const appRoot = AbsolutePath.parse(`${tmpHome}/.ralphctl-test`);
+    if (!appRoot.ok) throw new Error('appRoot parse failed');
+    const paths = storagePathsFromRoot(appRoot.value);
+    if (!paths.ok) throw new Error('storagePathsFromRoot failed');
+    await ensureStorageRoots(paths.value);
+
+    // A vague operator definition: short body, no headings/list items — trips Q1 and Q2.
+    const operatorRoot = String(paths.value.operatorAgentDefinitionsRoot);
+    await fs.mkdir(operatorRoot, { recursive: true });
+    await fs.writeFile(
+      join(operatorRoot, 'vague.md'),
+      '---\nname: vague\ndescription: vague guidance\n---\n\ntoo short\n',
+      'utf-8'
+    );
+
+    const deps = wire({ storage: paths.value, settings: DEFAULT_SETTINGS });
+    const logs: LogEvent[] = [];
+    deps.eventBus.subscribe((e) => {
+      if (e.type === 'log') logs.push(e);
+    });
+
+    const result = await deps.agentDefinitionSource.list();
+    expect(result.ok).toBe(true);
+
+    const qualityWarnings = logs.filter((l) => l.level === 'warn' && l.message === 'agent definition quality concern');
+    expect(qualityWarnings.length).toBeGreaterThan(0);
   });
 
   it('exposes a real provider built from config; refine runs end-to-end with a fake spawn', async () => {

--- a/tests/integration/application/flows/_shared/agents/install-agent-definitions.test.ts
+++ b/tests/integration/application/flows/_shared/agents/install-agent-definitions.test.ts
@@ -35,7 +35,9 @@ describe('installAgentDefinitionsLeaf', () => {
     expect(result.ok).toBe(true);
 
     const written = await readFile(join(String(session), '.claude/agents/ralphctl-evaluator.md'), 'utf-8');
-    expect(written).toContain('name: ralphctl-evaluator');
+    // Frontmatter scalars are emitted as YAML double-quoted strings (JSON.stringify) so a
+    // description/name containing a colon or newline can't corrupt the block — see renderClaudeAgent.
+    expect(written).toContain('name: "ralphctl-evaluator"');
   });
 
   it('is a no-op when the role has no bound definition (definition undefined)', async () => {

--- a/tests/integration/application/flows/create-pr/leaves/generate-pr-content.contract.test.ts
+++ b/tests/integration/application/flows/create-pr/leaves/generate-pr-content.contract.test.ts
@@ -30,12 +30,35 @@ describe('generatePrContentOutputContract', () => {
     }
   });
 
-  it('rejects non-pr-content signal kinds (narrative fan-out is not part of the contract)', () => {
+  it('drops non-pr-content signal kinds and keeps the single pr-content (tolerant fan-out)', () => {
+    // A mounted skill may coach a stray `<note>` / `<decision>` / `<learning>` during PR
+    // authoring. The contract drops those rather than failing the whole array, so one stray
+    // signal cannot silently defeat AI PR authoring — it keeps exactly the pr-content signal.
     const result = generatePrContentOutputContract.signalsSchema.safeParse([
-      { type: 'pr-content', title: 't', body: 'b', timestamp: TS },
-      // `learning` is intentionally NOT part of the create-pr contract — narrative signals
-      // would be silently dropped at post-implement time. Schema must reject.
       { type: 'learning', text: 'a learning', timestamp: TS },
+      { type: 'pr-content', title: 't', body: 'b', timestamp: TS },
+      { type: 'note', text: 'a note', timestamp: TS },
+    ]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ type: 'pr-content', title: 't', body: 'b' });
+    }
+  });
+
+  it('still rejects a stray-signal array with zero pr-content (drops to empty, then refine fails)', () => {
+    const result = generatePrContentOutputContract.signalsSchema.safeParse([
+      { type: 'note', text: 'only a note', timestamp: TS },
+    ]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain('exactly one pr-content');
+    }
+  });
+
+  it('still rejects a malformed pr-content signal (missing body) after filtering', () => {
+    const result = generatePrContentOutputContract.signalsSchema.safeParse([
+      { type: 'pr-content', title: 'no body', timestamp: TS },
     ]);
     expect(result.success).toBe(false);
   });

--- a/tests/unit/business/settings/resolve-agent-override.test.ts
+++ b/tests/unit/business/settings/resolve-agent-override.test.ts
@@ -58,13 +58,31 @@ describe('resolveAgentOverride', () => {
     expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'max' });
   });
 
-  it('a bound definition effort still composes with the provider floor when it is the global that supplies it', () => {
-    // The definition wins outright here — 'xhigh' passes through verbatim, unfloored, because
-    // a definition-supplied effort bypasses resolveEffortForRow's provider-floor table
-    // entirely (that table only applies to the global-default fallback path).
+  it('floors a binding-supplied xhigh to the codex provider ceiling', () => {
+    // A definition-bound effort still goes through the same provider floor as the
+    // global-default path — codex only accepts minimal|low|medium|high and rejects
+    // unknown levels, so an unclamped xhigh would fail every spawn for this role.
     const row = codexRow();
     const resolved = resolveAgentOverride(row, 'medium', { effort: 'xhigh' });
-    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+  });
+
+  it('floors a binding-supplied max to the codex provider ceiling', () => {
+    const row = codexRow();
+    const resolved = resolveAgentOverride(row, 'medium', { effort: 'max' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+  });
+
+  it('leaves a binding-supplied xhigh untouched on a claude-code row (identity)', () => {
+    const row = claudeRow();
+    const resolved = resolveAgentOverride(row, 'medium', { effort: 'xhigh' });
+    expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'xhigh' });
+  });
+
+  it('passes an unknown/out-of-vocabulary binding effort through unchanged', () => {
+    const row = codexRow();
+    const resolved = resolveAgentOverride(row, 'medium', { effort: 'ultra-mega' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'ultra-mega' });
   });
 
   it('floors the global default to the codex provider ceiling when no definition/row effort is set', () => {

--- a/tests/unit/business/settings/resolve-effort.test.ts
+++ b/tests/unit/business/settings/resolve-effort.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Settings } from '@src/domain/entity/settings.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { resolveEffort } from '@src/business/settings/resolve-effort.ts';
+import { clampEffortToProvider, resolveEffort } from '@src/business/settings/resolve-effort.ts';
 
 const withGlobalEffort = (effort: Settings['ai']['effort']): Settings => ({
   ...DEFAULT_SETTINGS,
@@ -92,5 +92,22 @@ describe('resolveEffort', () => {
 
   it('returns the per-flow value verbatim for the configured provider', () => {
     expect(resolveEffort('plan', withPerFlowEffort('plan', 'low'))).toBe('low');
+  });
+});
+
+describe('clampEffortToProvider', () => {
+  it('floors xhigh/max to high for codex', () => {
+    expect(clampEffortToProvider('xhigh', 'openai-codex')).toBe('high');
+    expect(clampEffortToProvider('max', 'openai-codex')).toBe('high');
+  });
+
+  it('passes effort through unchanged for claude-code and github-copilot', () => {
+    expect(clampEffortToProvider('xhigh', 'claude-code')).toBe('xhigh');
+    expect(clampEffortToProvider('max', 'github-copilot')).toBe('max');
+  });
+
+  it('passes an unknown effort string through unchanged for every provider', () => {
+    expect(clampEffortToProvider('ultra-mega', 'openai-codex')).toBe('ultra-mega');
+    expect(clampEffortToProvider('ultra-mega', 'claude-code')).toBe('ultra-mega');
   });
 });

--- a/tests/unit/business/sprint/render-journal-entry.test.ts
+++ b/tests/unit/business/sprint/render-journal-entry.test.ts
@@ -206,6 +206,46 @@ describe('renderJournalEntry', () => {
     expect(out).not.toContain('(detector:');
   });
 
+  it('renders the "identical failure" wording for the threshold detector', () => {
+    const out = renderJournalEntry(
+      baseInput({
+        verdict: 'pass-with-warning',
+        warning: { kind: 'plateau', dimensions: ['C1'], source: 'threshold' },
+      })
+    );
+    expect(out).toContain('two consecutive evaluations flagged the identical failure');
+    expect(out).toContain('on the same failed dimension: C1');
+    expect(out).toContain('(detector: threshold)');
+  });
+
+  it('renders the repeated-approach wording (not "identical failure") for the diversity detector', () => {
+    const out = renderJournalEntry(
+      baseInput({
+        verdict: 'pass-with-warning',
+        warning: { kind: 'plateau', dimensions: ['C1', 'C2'], source: 'diversity' },
+      })
+    );
+    expect(out).toContain(
+      'the generator repeated the same failed-dimension pattern across the last 3 consecutive turns without changing approach'
+    );
+    expect(out).toContain('on the same failed dimensions: C1, C2');
+    expect(out).toContain('(detector: diversity)');
+    expect(out).not.toContain('identical failure');
+  });
+
+  it('renders the signal-kind-collapse wording with no dimensions clause for the entropy detector', () => {
+    const out = renderJournalEntry(
+      baseInput({
+        verdict: 'pass-with-warning',
+        warning: { kind: 'plateau', dimensions: [], source: 'entropy' },
+      })
+    );
+    expect(out).toContain("the generator's reported actions collapsed onto a narrow set of signal kinds");
+    expect(out).toContain('(detector: entropy)');
+    expect(out).not.toContain('identical failure');
+    expect(out).not.toContain('on the same failed dimension');
+  });
+
   it('renders budget-exhausted turn counts in the Outcome detail prose', () => {
     const out = renderJournalEntry(
       baseInput({


### PR DESCRIPTION
Release **0.16.0** — the portable agent-definitions feature (#217) + research quick-wins, hardened by a pre-release multi-agent review of the `v0.15.1..HEAD` diff.

## Pre-release review fixes (commit `6d10d90d`)

A workflow reviewed the diff across 8 dimensions with 3-vote adversarial verification. 7 findings, all confirmed, all fixed:

- **Agent renderers escape YAML frontmatter.** Claude/Copilot renderers quote scalars via `JSON.stringify` — a colon/newline/`#` in a description no longer corrupts the emitted native agent file (Codex already did this for TOML).
- **Bound effort is floored to the provider.** A definition-bound `xhigh`/`max` no longer reaches Codex verbatim and breaks the spawn.
- **Create-PR contract is tolerant.** It drops stray narrative signals (`note`/`decision`/`learning`) a mounted skill might coach and keeps the single `pr-content`, instead of rejecting the whole array and silently falling back to a template body.
- **Operator agent-definition quality warner is wired** at both call sites (`wire`, `agents list`).
- **Plateau journal sentence is accurate per detector** — entropy/diversity exits are no longer mislabelled as "identical failure".

## Release mechanics (commit `8db14fae`)

- `package.json` → 0.16.0; `CHANGELOG.md` `[Unreleased]` promoted to `[0.16.0] - 2026-07-18`.
- In-range dep bumps (ink, react, vitest, prettier, tsx, knip, @types/*, coverage-v8, globals, lint-staged). **Held back** for a dedicated PR: TypeScript 6→7 (major) and the eslint/sonarjs/typescript-eslint linter bumps (they re-score untouched code over the lint ratchet).

## Verification

typecheck ✓ · lint 114/115 ✓ · format ✓ · **4728/4728 tests** ✓ · build ✓ (bundle stamped 0.16.0, startup integrity probe passes).