### PR TITLE
feat: refresh provider model catalogs for July 2026 models

### DIFF
--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -84,3 +84,6 @@
 - [project_plateau_predicate_count_based.md](project_plateau_predicate_count_based.md) — plateau predicate is
   failed-dim-COUNT based (not identical-set); critique-shift (Jaccard<0.5) is the lever to keep a multi-turn loop test
   running; R2 entropy guard reads ctx.lastTurnActionCounts (signal-kind proxy) stamped by generator every turn
+- [project_provider_literal_duplication_lint_cap.md](project_provider_literal_duplication_lint_cap.md) — a new
+  provider-keyed table in settings.ts (raw 'github-copilot'/'openai-codex' literals) can tip sonarjs/no-duplicate-string
+  and blow the ratcheted lint cap; hoist PROVIDER_GITHUB_COPILOT/PROVIDER_OPENAI_CODEX like PROVIDER_CLAUDE_CODE

--- a/.claude/agent-memory/implementer/project_provider_literal_duplication_lint_cap.md
+++ b/.claude/agent-memory/implementer/project_provider_literal_duplication_lint_cap.md
@@ -1,0 +1,28 @@
+---
+name: project-provider-literal-duplication-lint-cap
+description: Adding a provider-keyed lookup table (e.g. RETIRED_MODEL_REMAPS) with repeated
+  raw 'github-copilot' / 'openai-codex' string literals can push src/domain/entity/settings.ts
+  over the ratcheted lint warning cap via sonarjs/no-duplicate-string
+metadata:
+  type: project
+---
+
+`src/domain/entity/settings.ts` already had `PROVIDER_CLAUDE_CODE` as a hoisted constant for the
+`'claude-code'` literal, but `'github-copilot'` and `'openai-codex'` were still spelled out raw at
+each z.literal() call site. Adding a per-provider table (e.g. the 2026-07-26 provider
+model-catalog refresh's `RETIRED_MODEL_REMAPS`) that references these strings multiple times each
+pushed the file over sonarjs's 3-occurrence `no-duplicate-string` threshold, which tipped the
+project's ratcheted `eslint --max-warnings` cap from 115 to 116 and failed `pnpm lint`.
+
+**Why:** the lint cap (see [[project_lint_warning_reduction_2026-06-30]]) is a hard ratchet —
+any net-new warning anywhere in the diff fails the gate, even in a file whose complexity/size
+warnings are unrelated to your change.
+
+**How to apply:** when editing `settings.ts` (or any file with an existing `no-duplicate-string`
+warning) to add a new table/array keyed by provider id, hoist `PROVIDER_GITHUB_COPILOT` /
+`PROVIDER_OPENAI_CODEX` constants alongside `PROVIDER_CLAUDE_CODE` and reuse them at every
+z.literal()/comparison site (schema definitions, migration tables, row-shape guards) rather than
+adding more raw literal occurrences. This is a general pattern: before landing a lint-passing
+change, re-run `pnpm lint` and treat ANY new warning in a touched file as your responsibility to
+fix by constant-hoisting, not as pre-existing drift — check `git diff <file>` for the literal
+before assuming it predates your change.

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -7,3 +7,5 @@
 - [project_windowed_list_review.md](project_windowed_list_review.md) — Windowed-list / ScrollRegion review findings: WindowedList dead export, new flaky windowing test, pick-sprint-view not migrated
 - [project_coalesced_buffer_review.md](project_coalesced_buffer_review.md) — CoalescedBuffer onCritical window-not-cleared bug + double-seed nit from 0.10.0 commit-storm fix
 - [project_esc_collapse_claim_seam.md](project_esc_collapse_claim_seam.md) — Wide Implement view Esc-collapse-before-pop: claimEscape suppresses pop, keymap collapses; undefined-sentinel ref establishes mount-time claim
+- [project_duplicate_codex_effort_clamp.md](project_duplicate_codex_effort_clamp.md) — RESOLVED: readiness's duplicate codex effort floor deleted + pinned by a test; watch for a new copy appearing outside resolve-effort.ts
+- [project_model_refresh_review_2026-07-26.md](project_model_refresh_review_2026-07-26.md) — Opus 5 / GPT-5.6 refresh review: what the catalog-fingerprint gate catches vs. where drift actually lands

--- a/.claude/agent-memory/reviewer/project_duplicate_codex_effort_clamp.md
+++ b/.claude/agent-memory/reviewer/project_duplicate_codex_effort_clamp.md
@@ -1,0 +1,29 @@
+---
+name: duplicate-codex-effort-clamp
+description: RESOLVED 2026-07-26 — the readiness flow's hand-copied codex effort floor is gone; effort clamping now has exactly one implementation, pinned by an integration test
+metadata:
+  type: project
+---
+
+`src/application/flows/readiness/flow.ts` used to define its own private `resolveEffortForRow(ai, flow)`
+with an inline copy of the codex effort floor (`if (row.provider === 'openai-codex' && …) return 'high'`)
+instead of calling the exported `clampEffortToProvider` from `src/business/settings/resolve-effort.ts`.
+Its docblock claimed the floor table matched — nothing mechanized the claim, so the two drifted.
+
+**Why it mattered:** it bit the 2026-07-26 provider model-catalog refresh. That change relaxed the codex
+clamp from `xhigh|max → high` to `max → xhigh`, updated every other consumer, and left the readiness copy
+untouched — `mixed-frontier` (global `max`, codex row) resolved to `xhigh` everywhere except readiness.
+Typecheck, lint and the full suite were green throughout.
+
+**Current state (fixed in the same 2026-07-26 pass):** the duplicate is deleted; readiness calls
+`clampEffortToProvider` directly (application → business is a legal direction), and
+`tests/integration/application/flows/readiness/effort-resolution.test.ts` runs the readiness chain with a
+global codex `max` and asserts the recorded session effort equals `clampEffortToProvider('max',
+'openai-codex')`. A grep of `src/` shows exactly one `provider === 'openai-codex' && effort === …` clamp.
+
+**How to apply:** on any diff touching provider effort vocabulary, the clamp, or `PROVIDER_EFFORT_LEVELS`,
+re-run the grep for effort-floor literals across `src/` (not just `src/business/`) — a second
+implementation reappearing outside `resolve-effort.ts` is the failure mode, and only the readiness test
+currently pins a consumer to the shared clamp.
+
+Related: [[project_model_refresh_review_2026-07-26]]

--- a/.claude/agent-memory/reviewer/project_model_refresh_review_2026-07-26.md
+++ b/.claude/agent-memory/reviewer/project_model_refresh_review_2026-07-26.md
@@ -1,0 +1,30 @@
+---
+name: project-model-refresh-review-2026-07-26
+description: Review of the Opus 5 / GPT-5.6 provider model-catalog refresh — what the catalog-fingerprint gate does and does NOT catch
+metadata:
+  type: project
+---
+
+Reviewed the provider model-catalog refresh (Claude Opus 5, GPT-5.6 Sol/Terra/Luna, codex effort
+`low..ultra`, Fable un-suspended) on 2026-07-26. All five gates green; one major finding
+(see [[duplicate-codex-effort-clamp]]), the rest doc/comment drift.
+
+**Why this matters for future model bumps:** the catalog-fingerprint test
+(`tests/unit/business/task/escalation-map.test.ts`) is a genuinely strong fence — it caught nothing
+wrong here because the ladder lockstep assertions really do cover orphaned rungs, and the three recorded
+hashes reproduce exactly when recomputed independently (sha256 of the sorted ids, first 16 hex chars).
+Recomputing them yourself is a cheap, high-value check that the implementer ran the test rather than
+hand-writing hashes.
+
+**What the fence does NOT cover, and where drift actually lands:**
+
+- duplicated behaviour outside the catalogs (the readiness effort clamp — the one real bug)
+- doc comments naming specific model ids / effort vocabularies in the provider adapters
+  (`codex/headless.ts`, `_engine/ai-session.ts`), `resolve-agent-override.ts`, and the TUI docblocks
+  (`settings-editor.tsx` suspension examples, `settings-view-model.ts` chain example,
+  `header-card.tsx` provider/model pairing)
+- suspension-guard comments that name the model that was suspended, once the list goes empty
+
+**How to apply:** on the next model bump, verify the fingerprints independently, then grep the id strings
+and effort-level strings across `src/` (not just the changed modules) — the comment drift list above is
+the same set every time.

--- a/.claude/agent-memory/tester/MEMORY.md
+++ b/.claude/agent-memory/tester/MEMORY.md
@@ -63,163 +63,20 @@ if (process.platform === 'win32') return;
 - **`src/` uses `import type` for type-only imports** — enforced by lint
 - **No barrel files** — imports always point to source modules directly
 - **`// Ported from afe771f9~1:src/...`** comment convention marks tests backported from legacy
-- **`Leaf.input()` throws are caught by `runLeaf`**: the framework catches the throw from `input()` and wraps it in
-  `Result.error` — the promise resolves, it does NOT reject. Use `result.ok === false` assertions, NOT
-  `rejects.toThrow`.
-- **`resolveStoragePaths()` inside a leaf execute body**: it reads `process.env.RALPHCTL_ROOT` at call time (not import
-  time). Set the env var in `beforeEach`/`afterEach` — no vitest setup file needed for leaves that call it inline.
-- **`Sprint.recordCheckRun(repo, at)`** returns a plain `Sprint` (no `Result` wrapper); `setBranch` and
-  `setAffectedRepositories` return `Result<Sprint, InvalidStateError>`.
+- **`Leaf.input()` throws are caught by `runLeaf`**: the framework catches the throw from `input()` and wraps it in `Result.error` — the promise resolves, it does NOT reject. Use `result.ok === false` assertions, NOT `rejects.toThrow`.
+- **`resolveStoragePaths()` inside a leaf execute body**: it reads `process.env.RALPHCTL_ROOT` at call time (not import time). Set the env var in `beforeEach`/`afterEach` — no vitest setup file needed for leaves that call it inline.
+- **`Sprint.recordCheckRun(repo, at)`** returns a plain `Sprint` (no `Result` wrapper); `setBranch` and `setAffectedRepositories` return `Result<Sprint, InvalidStateError>`.
 
-### Gen-eval exit mapping (2026-06-10)
+## Topic index (session-specific patterns — one line each, detail in the linked file)
 
-`finalize-gen-eval` `mapExit` semantics — important for writing correct assertions:
-
-- `passed` → `{ verdict: 'passed' }` — NO warning, NO blockedReason.
-- `self-blocked` → `{ verdict: 'failed', blockedReason }` — NO warning.
-- `malformed` → `{ verdict: 'malformed', warning: { kind: 'malformed', detail } }`.
-- `plateau` → `{ verdict: 'failed' }` — NO warning (plateau is an escalation trigger, not done-with-warning).
-- `budget-exhausted` → `{ verdict: 'failed', warning: { kind: 'budget-exhausted', turnsUsed, turnBudget } }`.
-
-The `shouldFailAttempt` field is controlled by the escalation policy (not mapExit), so it can appear independently of the warning. A mutant test needs to assert BOTH fields explicitly — a vacuous `if (result.ok && result.value.warning?.kind === 'plateau')` guard always passes and kills nothing.
-
-### Launcher HITL distill confirm gate (2026-05-31)
-
-`tests/unit/application/ui/shared/launch/distill-confirm-abort.test.ts` — 10 tests covering `launchCloseSprint` and `launchReview`:
-
-- `abort` (AbortError) on distill confirm → `{ ok: false, reason: 'Cancelled.' }` (load-bearing: fails if guard removed)
-- `Result.ok(false)` on distill confirm → runner returned (no cancel; distillRequested: false)
-- `Result.ok(true)` on distill confirm → runner returned (distillRequested: true)
-- close-sprint: first close confirm aborted → Cancelled
-- no sprint selected / no project loaded → early failure from each launcher
-
-**Key patterns:**
-
-- `LaunchContext` stub: partial `AppDeps` cast `as never` for fields the launch path never reaches before the guard
-- `identityBridge = <T>(r: Runner<T>) => r` — no event bus needed for launcher unit tests
-- `makeSnapshot({ omitSprint: true })` / `makeSnapshot({ omitProject: true })` — `exactOptionalPropertyTypes` forbids `{ sprint: undefined }` in a `Partial<AppStateSnapshot>` spread; use named boolean flags instead
-- `scriptedConfirm` builds the prompt fake as an array of response factories (zero-arg functions); `void input` suppresses unused-var lint
-
-### Parallel implement wave ordering + lock regression (CS-1D, 2026-06-02)
-
-`tests/integration/application/flows/implement/parallel-ordering-and-lock.test.ts` — 7 tests:
-
-- `scheduleIntoWaves` puts an `in_progress` prerequisite in wave 0 and its dependent `todo` in wave 1
-- Dependent wave index is strictly greater than its prerequisite for multi-hop chain (a→b→c)
-- Parallel element executes all wave-0 branches before any wave-1 branch starts (log-order fence)
-- Non-fatal wave-0 failure absorbed; wave-1 still runs after wave-0 settles
-- concurrent `saveAll` (epilogue) + `update` (branch settle) on real `FsTaskRepository` never tears tasks.json
-- High-concurrency (16 ops) interleaved `saveAll`+`update` always lands a consistent 4-task set
-- Sprint-scoped lock is held when the epilogue runs (`epilogueCalledWhileLockHeld === true`)
-
-**Key pattern**: `scheduleIntoWaves` is status-agnostic — it uses `task.order` + `dependsOn` only. In_progress-first ordering from `resolveImplementQueue` is already baked in the queue before `scheduleIntoWaves` sees it; the wave scheduler enforces the dependency fence.
-
-### Parallel implement real-git e2e test (2026-05-30)
-
-`tests/e2e/flows/implement-parallel-realgit.test.ts` — proves parallel path against a REAL git repo.
-**Real bug found (since FIXED via `gitDeleteBranch`; assertion now green):** `gitWorktreeRemove --force`
-left the `wt-*` branch refs behind — see [[project_parallel_worktree_branch_leak_bug]].
-Happy-path assertions that DID pass: runner `completed`, all 3 tasks `done`, sprint `review`,
-4 commits on sprint branch (wave order A/B before C), worktree DIRECTORIES cleaned up.
-Provider pattern: `session.cwd` is the worktree path in the parallel path — write real files there.
-
-### Sprint-selection redesign tests (2026-05-22)
-
-New test files under `tests/integration/application/ui/tui/views/` and `tests/unit/`:
-
-- `sprint-bound-flow-reseat.test.tsx` — reseat wiring contract using fake runner; asserts `setSprint` called on
-  `completed+ctx.sprint`, NOT on `aborted`/`failed`/`started`.
-- `tests/unit/application/ui/shared/state-snapshot-done-filter.test.ts` — `loadAppStateSnapshot` recentSprints excludes
-  `done` sprints.
-- `tests/unit/application/ui/tui/runtime/selection-done-on-boot.test.tsx` — `SelectionProvider` clears
-  sprintId/sprintLabel when rehydrated sprint has `status: 'done'`. **Requires `sprintRepo` prop on SelectionProvider.**
-- `home-create-hotkey.test.tsx` — `+` on Home routes to create-sprint flow; no-op without project.
-- `home-switch-feedback.test.tsx` — "✓ now on <name>" feedback after switch; disappears after ~3s with fake timers.
-- `pick-sprint-create-row.test.tsx` — PickSprintView renders "Create new sprint" row BEFORE project groups; Enter on it
-  launches create-sprint.
-- `sprint-detail-no-auto-sync.test.tsx` — SprintDetailView MUST NOT call `setSprint` on mount (inverse of old
-  behaviour). Uses `Object.assign(selection, { setSprint: spy })` pattern from `MakeSpy` component.
-- `sprint-detail-make-current.test.tsx` — `m` key calls `setSprint(id, name)`; `· current` badge visible when sprint
-  matches selection.
-
-**Key pattern: MakeSpy / intercept pattern for selection** — `Object.assign(selection, { setSprint: spy })` inside a
-child component `useEffect` lets you intercept context calls without forking the provider.
-
-**JSX in test files**: Always use `.tsx` extension even for unit tests that import/render React components.
-
-**Fake timers + ink-testing-library**: `vi.useFakeTimers()` + `vi.runAllTimersAsync()` causes infinite loops due to
-Ink's Spinner `setInterval`. Use `vi.advanceTimersByTimeAsync(N)` instead. For time-gated render conditions (e.g. a
-toast freshness check), use `vi.spyOn(Date, 'now').mockReturnValue(BASE_TIME + 3100)` to advance the clock, then force a
-re-render via a context state change (e.g. `selection.setSprint(...)` from a helper component) —
-`setLocalError((curr) => curr)` bails out of React render (same value → no render committed). The `SwitchTrigger` helper
-pattern (component that calls `selection.setSprint` in a once-only `useEffect`) is preferred over keyboard navigation
-for deterministic sprint-switch tests. **`frame.indexOf('Alpha Project')` matches ViewShell breadcrumb chrome** — use
-line-by-line search filtering lines containing `'project:'` to find the actual group header row.
-
-**`ActionMenu` cursor + UUIDv7 ordering**: `makeDraftSprint` generates time-ordered UUIDs; created later = larger UUID =
-appears first in `recentSprints` (DESC sort). `initialMenuIndex` seeds to the current sprint's row. Pressing `k` (up)
-from the current sprint's row reaches the newer sprint at index 0.
-
-### Gen-eval turn step-order fence + crash-attribution (Batch F, 2026-06-12)
-
-`tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` — 4 tests:
-
-- Loop-entry guard: refuses to enter when ctx.lastExit already set (original test)
-- Shape fence: asserts gen-eval-turn children order = [resolve-round-num, stamp-meta-generator, stamp-role-meta-generator, generator-leaf, evaluator-guard] by name
-- Evaluator-guard body order: [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf]
-- Crash-attribution: generator spawn fails (recoverable `InvalidStateError`) → loop returns ok with `lastExit.kind==='self-blocked'` AND `rounds/1/generator/meta.json` + `role-meta.json` exist on disk
-
-**Key gotcha**: `InvalidStateError` (code='invalid-state') is treated as RECOVERABLE by `turn-error-policy.ts` — the generator error becomes `self-blocked` exit, NOT a loop `Result.error`. Use `createAtomicWriteFile()` for real file writes in behavioral tests.
-
-**Sequential composites do NOT emit their own trace entry** — only leaves emit trace entries. Assert leaf names in runner.trace, not composite names like 'implement' or 'review'.
-
-### Meta-run flow failure arcs (Batch F, 2026-06-12)
-
-`tests/e2e/meta-flows/run.test.ts` — added 2 arcs:
-
-- Implement-failure: use `makeDoneSprint()` → `loadAndAssertSprintSubChain` fails → review never starts → `feedback.md` never created, runner `status==='failed'`, trace ends with `{ elementName: 'run', status: 'failed' }`
-- Review-failure: use `passingProvider` for implement + `failingReviewProvider` (RateLimitError) + `reviewFailingInteractive` (`askTextArea` returns non-empty body) → implement succeeds, sprint reaches 'review', review-round fails → runner `status==='failed'`, `feedback.md` exists (ensureFeedbackFile ran), trace contains 'load-sprint' (implement) + 'review-round' (review failure)
-
-**`RateLimitError` is NOT Aborted** — runner.status becomes 'failed', not 'aborted'. AbortError → 'aborted'.
-
-**Review termination**: `terminatingInteractive.askTextArea` returning `''` leads to `isTerminationRound=true` → review SUCCEEDS (exit='terminated'). For review to fail, provide non-empty body AND use a provider that returns RateLimitError.
-
-### Progress-overlay flake elimination (Batch F, 2026-06-12)
-
-Pattern: add a SEEDED sentinel text to `SeedSelection` that renders only when `seeded=true` (sprint or focusedRun effect has committed). Replace `await tick(50)` with `await waitFor(() => lastFrame().includes('SEEDED'))`.
-
-The sentinel stays visible even after the overlay opens (SeedSelection is rendered outside GlobalHarness's conditional), so asserting overlay content and `not.toContain('UNDERLYING_VIEW')` still works.
-
-For scroll clamp assertions: replace final fixed tick after PgDn/PgUp loops with `waitFor(() => lastFrame().includes('TAIL-LINE'))` or `waitFor(() => lastFrame().includes('HEAD-LINE'))`.
-
-Proved: 10/10 isolated runs pass, 689/689 tui suite passes.
-
-### Full-stack e2e wiring tests (2026-06-12)
-
-`tests/e2e/full-stack/implement-review-close.test.ts` and `tests/e2e/full-stack/sprint-lifecycle.test.ts` — 7+ tests.
-
-**R1 constraint (critical)**: the implement LAUNCHER bypasses `app.deps.provider` — it builds per-role providers
-from settings. For full-stack tests, construct `ImplementDeps` manually from `app.deps` sub-repos + the fake
-provider pair; do NOT set `app.deps.provider`.
-
-**ImplementDeps harness field defaults**: `plateauThreshold`, `escalateOnPlateau`, `escalationMap` all live in
-`config.harness` — pass them in explicitly when testing escalation/plateau arcs.
-
-**TUI mount in ink-testing-library** — `<App deps storage buses sessions queue logLevelGate initialView>`:
-
-- `buses.log` must be `BusSink<LogEvent>` (typed) — `createBusSink<LogEvent>({ maxEntries: N })`.
-- `buses.harness` is `BusSink<HarnessSignal>`.
-- Import `LogEvent` from `@src/business/observability/events.ts`.
-- `createSessionManager` from `@src/application/ui/tui/runtime/session-manager.ts`.
-- `createPromptQueue` from `@src/application/ui/tui/prompts/prompt-queue.ts`.
-- `createLogLevelGate` from `@src/business/observability/log-level-filter.ts`.
-
-**Sprint pre-setup for implement flow**: persist both `sprint.json` AND `execution.json` (with branch already set
-via `setExecutionBranch`) so `resolveBranchLeaf` does not stall on interactive prompt.
-
-**createWorkspaceMutatingFakeProvider**: lives at `tests/fixtures/workspace-mutating-fake-provider.ts`.
-Extends `FakeAiProviderScript` with `fileWrites` map. The inner `createFakeAiProvider` handles signal dispatch;
-the wrapper writes files before delegating. Split type-only imports from value imports to satisfy lint.
-
-**`blockKind` values**: `'own'` for tasks that emitted a task-blocked signal; `'upstream'` for tasks blocked by
-a dependency gate because a prerequisite is not done.
+- [model-catalog-refresh-2026-07-26.md](model-catalog-refresh-2026-07-26.md) — model-catalog/ladder bumps break "top of ladder" test fixtures far outside the catalog/preset files; run the FULL suite, don't trust a spec's file list
+- [fingerprint-audit-gate-pattern.md](fingerprint-audit-gate-pattern.md) — recompute escalation-map.test.ts's SHA-256 catalog fingerprints by running the test and pasting the actual hash, never by hand
+- [gen-eval-exit-mapping.md](gen-eval-exit-mapping.md) — finalize-gen-eval mapExit verdict/warning/blockedReason truth table
+- [launcher-hitl-distill-confirm.md](launcher-hitl-distill-confirm.md) — launchCloseSprint/launchReview HITL distill confirm gate test patterns
+- [parallel-implement-wave-ordering-lock.md](parallel-implement-wave-ordering-lock.md) — scheduleIntoWaves dependency-fence + concurrent FsTaskRepository integrity tests
+- [parallel-implement-realgit-e2e.md](parallel-implement-realgit-e2e.md) — real-git parallel worktree e2e test + the worktree branch-leak bug it caught
+- [sprint-selection-redesign-tests.md](sprint-selection-redesign-tests.md) — reseat wiring, done-sprint filtering, MakeSpy intercept, fake-timer toast tests, ActionMenu cursor/UUIDv7 ordering
+- [gen-eval-turn-step-order-fence.md](gen-eval-turn-step-order-fence.md) — gen-eval-loop.test.ts shape fence + crash-attribution (InvalidStateError is recoverable)
+- [meta-run-flow-failure-arcs.md](meta-run-flow-failure-arcs.md) — implement-failure/review-failure arcs; RateLimitError yields 'failed' not 'aborted'
+- [progress-overlay-flake-elimination.md](progress-overlay-flake-elimination.md) — SEEDED sentinel + waitFor pattern to eliminate flaky ink-testing-library overlay/scroll tests
+- [full-stack-e2e-wiring.md](full-stack-e2e-wiring.md) — full-stack e2e wiring: implement launcher bypasses app.deps.provider, TUI mount plumbing, sprint pre-setup

--- a/.claude/agent-memory/tester/fingerprint-audit-gate-pattern.md
+++ b/.claude/agent-memory/tester/fingerprint-audit-gate-pattern.md
@@ -1,0 +1,24 @@
+---
+name: fingerprint-audit-gate-pattern
+description: How to recompute the deliberately-failing SHA-256 catalog fingerprint test in escalation-map.test.ts after a model-catalog bump — never hand-compute, run the test and read the actual hash from the failure output
+metadata:
+  type: feedback
+---
+
+`tests/unit/business/task/escalation-map.test.ts` fingerprints `CLAUDE_MODELS` / `CODEX_MODELS` /
+`COPILOT_MODELS` (sorted, joined, sha256, first 16 hex chars) and pins the three hashes as a
+deliberate verify-gate: the test is DESIGNED to fail the moment any catalog changes, forcing a
+human/agent to walk the HARNESS-PRINCIPLES.md model-bump checklist before silencing it.
+
+**Procedure that works:** don't hand-compute the hash or guess. After all catalog edits land, run
+`npx vitest run tests/unit/business/task/escalation-map.test.ts` — the failure output prints
+`Expected: "<old>" / Received: "<new>"` for the FIRST mismatching assertion only (synchronous
+`expect` throws stop the test, so only one of the three shows). To get all three at once, write a
+one-off script importing the three `*_MODELS` arrays with ABSOLUTE paths (not relative — a script
+run from a scratchpad dir needs `/full/path/to/src/...`) and run it with `npx tsx`, replicating the
+test's exact fingerprint function (sort, join with `\n`, sha256, slice(0,16)). Paste the three
+printed hashes directly into the test's `toBe(...)` calls — do not modify the fingerprint function
+itself.
+
+This is the same pattern as any "pin a hash / snapshot as an audit trigger" test — the fix is
+always "run it, read the diff, paste the actual value," never "compute it by hand."

--- a/.claude/agent-memory/tester/full-stack-e2e-wiring.md
+++ b/.claude/agent-memory/tester/full-stack-e2e-wiring.md
@@ -1,0 +1,39 @@
+---
+name: full-stack-e2e-wiring
+description: tests/e2e/full-stack wiring patterns — implement launcher bypasses app.deps.provider, TUI mount plumbing for ink-testing-library, sprint pre-setup, workspace-mutating fake provider
+metadata:
+  type: feedback
+---
+
+`tests/e2e/full-stack/implement-review-close.test.ts` and
+`tests/e2e/full-stack/sprint-lifecycle.test.ts` — 7+ tests.
+
+**R1 constraint (critical)**: the implement LAUNCHER bypasses `app.deps.provider` — it builds
+per-role providers from settings. For full-stack tests, construct `ImplementDeps` manually from
+`app.deps` sub-repos + the fake provider pair; do NOT set `app.deps.provider`.
+
+**ImplementDeps harness field defaults**: `plateauThreshold`, `escalateOnPlateau`,
+`escalationMap` all live in `config.harness` — pass them in explicitly when testing
+escalation/plateau arcs.
+
+**TUI mount in ink-testing-library** —
+`<App deps storage buses sessions queue logLevelGate initialView>`:
+
+- `buses.log` must be `BusSink<LogEvent>` (typed) — `createBusSink<LogEvent>({ maxEntries: N })`.
+- `buses.harness` is `BusSink<HarnessSignal>`.
+- Import `LogEvent` from `@src/business/observability/events.ts`.
+- `createSessionManager` from `@src/application/ui/tui/runtime/session-manager.ts`.
+- `createPromptQueue` from `@src/application/ui/tui/prompts/prompt-queue.ts`.
+- `createLogLevelGate` from `@src/business/observability/log-level-filter.ts`.
+
+**Sprint pre-setup for implement flow**: persist both `sprint.json` AND `execution.json` (with the
+branch already set via `setExecutionBranch`) so `resolveBranchLeaf` does not stall on an
+interactive prompt.
+
+**`createWorkspaceMutatingFakeProvider`**: lives at
+`tests/fixtures/workspace-mutating-fake-provider.ts`. Extends `FakeAiProviderScript` with a
+`fileWrites` map. The inner `createFakeAiProvider` handles signal dispatch; the wrapper writes
+files before delegating. Split type-only imports from value imports to satisfy lint.
+
+**`blockKind` values**: `'own'` for tasks that emitted a task-blocked signal; `'upstream'` for
+tasks blocked by a dependency gate because a prerequisite is not done.

--- a/.claude/agent-memory/tester/gen-eval-exit-mapping.md
+++ b/.claude/agent-memory/tester/gen-eval-exit-mapping.md
@@ -1,0 +1,22 @@
+---
+name: gen-eval-exit-mapping
+description: finalize-gen-eval mapExit verdict/warning/blockedReason truth table — use when writing or auditing gen-eval loop assertions
+metadata:
+  type: feedback
+---
+
+`finalize-gen-eval` `mapExit` semantics — important for writing correct assertions:
+
+- `passed` → `{ verdict: 'passed' }` — NO warning, NO blockedReason.
+- `self-blocked` → `{ verdict: 'failed', blockedReason }` — NO warning.
+- `malformed` → `{ verdict: 'malformed', warning: { kind: 'malformed', detail } }`.
+- `plateau` → `{ verdict: 'failed' }` — NO warning (plateau is an escalation trigger, not done-with-warning).
+- `budget-exhausted` → `{ verdict: 'failed', warning: { kind: 'budget-exhausted', turnsUsed, turnBudget } }`.
+
+The `shouldFailAttempt` field is controlled by the escalation policy (not `mapExit`), so it can
+appear independently of the warning. A mutant test needs to assert BOTH fields explicitly — a
+vacuous `if (result.ok && result.value.warning?.kind === 'plateau')` guard always passes and kills
+nothing.
+
+See also [[model-catalog-refresh-2026-07-26]] for how "top of ladder" model fixtures in these same
+tests break silently when the escalation ladder gains a new rung.

--- a/.claude/agent-memory/tester/gen-eval-turn-step-order-fence.md
+++ b/.claude/agent-memory/tester/gen-eval-turn-step-order-fence.md
@@ -1,0 +1,23 @@
+---
+name: gen-eval-turn-step-order-fence
+description: gen-eval-loop.test.ts shape fence + crash-attribution — InvalidStateError is recoverable, only leaves emit trace entries
+metadata:
+  type: feedback
+---
+
+`tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` — 4 tests:
+
+- Loop-entry guard: refuses to enter when `ctx.lastExit` is already set.
+- Shape fence: asserts gen-eval-turn children order = [resolve-round-num, stamp-meta-generator,
+  stamp-role-meta-generator, generator-leaf, evaluator-guard] by name.
+- Evaluator-guard body order: [stamp-meta-evaluator, stamp-role-meta-evaluator, evaluator-leaf].
+- Crash-attribution: generator spawn fails (recoverable `InvalidStateError`) → loop returns ok with
+  `lastExit.kind==='self-blocked'` AND `rounds/1/generator/meta.json` + `role-meta.json` exist on
+  disk.
+
+**Key gotcha**: `InvalidStateError` (code='invalid-state') is treated as RECOVERABLE by
+`turn-error-policy.ts` — the generator error becomes a `self-blocked` exit, NOT a loop
+`Result.error`. Use `createAtomicWriteFile()` for real file writes in behavioral tests.
+
+**Sequential composites do NOT emit their own trace entry** — only leaves emit trace entries.
+Assert leaf names in `runner.trace`, not composite names like 'implement' or 'review'.

--- a/.claude/agent-memory/tester/launcher-hitl-distill-confirm.md
+++ b/.claude/agent-memory/tester/launcher-hitl-distill-confirm.md
@@ -1,0 +1,27 @@
+---
+name: launcher-hitl-distill-confirm
+description: Test patterns for launchCloseSprint/launchReview HITL distill confirm gate — LaunchContext stubbing, identityBridge, scriptedConfirm
+metadata:
+  type: feedback
+---
+
+`tests/unit/application/ui/shared/launch/distill-confirm-abort.test.ts` — 10 tests covering
+`launchCloseSprint` and `launchReview`:
+
+- `abort` (AbortError) on distill confirm → `{ ok: false, reason: 'Cancelled.' }` (load-bearing:
+  fails if the guard is removed)
+- `Result.ok(false)` on distill confirm → runner returned (no cancel; distillRequested: false)
+- `Result.ok(true)` on distill confirm → runner returned (distillRequested: true)
+- close-sprint: first close confirm aborted → Cancelled
+- no sprint selected / no project loaded → early failure from each launcher
+
+**Key patterns:**
+
+- `LaunchContext` stub: partial `AppDeps` cast `as never` for fields the launch path never reaches
+  before the guard
+- `identityBridge = <T>(r: Runner<T>) => r` — no event bus needed for launcher unit tests
+- `makeSnapshot({ omitSprint: true })` / `makeSnapshot({ omitProject: true })` —
+  `exactOptionalPropertyTypes` forbids `{ sprint: undefined }` in a `Partial<AppStateSnapshot>`
+  spread; use named boolean flags instead
+- `scriptedConfirm` builds the prompt fake as an array of response factories (zero-arg functions);
+  `void input` suppresses unused-var lint

--- a/.claude/agent-memory/tester/meta-run-flow-failure-arcs.md
+++ b/.claude/agent-memory/tester/meta-run-flow-failure-arcs.md
@@ -1,0 +1,24 @@
+---
+name: meta-run-flow-failure-arcs
+description: tests/e2e/meta-flows/run.test.ts implement-failure and review-failure arcs — RateLimitError yields 'failed' not 'aborted'; review termination vs failure distinction
+metadata:
+  type: feedback
+---
+
+`tests/e2e/meta-flows/run.test.ts` failure arcs:
+
+- Implement-failure: `makeDoneSprint()` → `loadAndAssertSprintSubChain` fails → review never
+  starts → `feedback.md` never created, runner `status==='failed'`, trace ends with
+  `{ elementName: 'run', status: 'failed' }`.
+- Review-failure: `passingProvider` for implement + `failingReviewProvider` (RateLimitError) +
+  `reviewFailingInteractive` (`askTextArea` returns a non-empty body) → implement succeeds, sprint
+  reaches 'review', review-round fails → runner `status==='failed'`, `feedback.md` exists
+  (ensureFeedbackFile ran), trace contains 'load-sprint' (implement) + 'review-round' (review
+  failure).
+
+**`RateLimitError` is NOT Aborted** — `runner.status` becomes `'failed'`, not `'aborted'`.
+`AbortError` → `'aborted'`.
+
+**Review termination**: `terminatingInteractive.askTextArea` returning `''` leads to
+`isTerminationRound=true` → review SUCCEEDS (exit='terminated'). For review to genuinely fail,
+provide a non-empty body AND use a provider that returns `RateLimitError`.

--- a/.claude/agent-memory/tester/model-catalog-refresh-2026-07-26.md
+++ b/.claude/agent-memory/tester/model-catalog-refresh-2026-07-26.md
@@ -1,0 +1,35 @@
+---
+name: model-catalog-refresh-2026-07-26
+description: Pattern for updating tests after a model-catalog/escalation-ladder refresh (Opus 5 / GPT-5.6 bump) — ladder-rung changes cascade into "top of ladder" test fixtures far beyond the catalog/preset files themselves
+metadata:
+  type: feedback
+---
+
+When a provider model-catalog refresh changes `DEFAULT_ESCALATION_MAP` rungs — especially when a
+model that was previously the TOP of a ladder (no outgoing key) gains a new rung — grep is not
+enough to find every affected test. `decideEscalation` checks the model-mapping rung BEFORE the
+same-model effort rung / nudge / topped-out branches, so any test that hardcodes a "top of ladder"
+model (to exercise `nudge`, `topped-out`, or `escalate-effort`) breaks silently if that model later
+gains a rung — the test starts exercising `escalate` instead, with a confusing "expected X to be Y"
+diff that names the OLD top-of-ladder value, not the new one.
+
+**Where this bit in the 2026-07-26 refresh** (`claude-opus-4-8` gained a rung to the new
+`claude-opus-5` flagship): `tests/unit/business/task/escalation-policy.test.ts`,
+`escalation-policy-branches.test.ts`, `finalize-gen-eval.test.ts`, and one e2e fixture in
+`tests/e2e/flows/implement.test.ts` all had tests pinned to `claude-opus-4-8` as "the top" — every
+one had to move to the new actual top (`claude-opus-5`) to keep testing the same branch. None of
+these files are named "escalation-map" or "presets", so they are easy to miss if you only chase the
+catalog/preset files named in a change spec.
+
+**How to find them:** after updating `DEFAULT_ESCALATION_MAP`, run the FULL `tests/unit` +
+`tests/integration` + `tests/e2e` suite (not just the files a spec names) and read every failure's
+diff — a diff shape like `expected 'escalate' to be 'nudge'` or `expected '<new-model>' to be
+'<old-model>'` is the signature of a stale top-of-ladder fixture. Don't assume the change spec's
+enumerated test-file list is exhaustive; treat it as a floor, not a ceiling. See
+[[fingerprint-audit-gate-pattern]] for the parallel gate on the catalog side.
+
+Also: `resolveEffort`/`clampEffortToProvider` behavioral changes (e.g. codex floor moving from
+`xhigh/max → high` to `max → xhigh`) ripple into `resolve-agent-override.test.ts` even though that
+file's name gives no hint it touches provider effort clamping — it re-derives through the same
+`clampEffortToProvider` seam. Grep for the exported function name across `tests/`, not just for
+literal model/effort strings, to find every consumer.

--- a/.claude/agent-memory/tester/parallel-implement-realgit-e2e.md
+++ b/.claude/agent-memory/tester/parallel-implement-realgit-e2e.md
@@ -1,0 +1,16 @@
+---
+name: parallel-implement-realgit-e2e
+description: implement-parallel-realgit.test.ts proves the parallel worktree path against a REAL git repo — worktree branch-leak bug history + session.cwd provider pattern
+metadata:
+  type: feedback
+---
+
+`tests/e2e/flows/implement-parallel-realgit.test.ts` — proves the parallel path against a REAL git
+repo. **Real bug found (since FIXED via `gitDeleteBranch`; assertion now green):**
+`gitWorktreeRemove --force` left the `wt-*` branch refs behind.
+
+Happy-path assertions that DID pass: runner `completed`, all 3 tasks `done`, sprint `review`, 4
+commits on the sprint branch (wave order A/B before C), worktree DIRECTORIES cleaned up.
+
+Provider pattern: `session.cwd` is the worktree path in the parallel path — write real files
+there, not at the sprint dir root.

--- a/.claude/agent-memory/tester/parallel-implement-wave-ordering-lock.md
+++ b/.claude/agent-memory/tester/parallel-implement-wave-ordering-lock.md
@@ -1,0 +1,21 @@
+---
+name: parallel-implement-wave-ordering-lock
+description: scheduleIntoWaves dependency-fence tests + concurrent FsTaskRepository saveAll/update integrity — parallel-ordering-and-lock.test.ts
+metadata:
+  type: feedback
+---
+
+`tests/integration/application/flows/implement/parallel-ordering-and-lock.test.ts` — 7 tests:
+
+- `scheduleIntoWaves` puts an `in_progress` prerequisite in wave 0 and its dependent `todo` in wave 1
+- Dependent wave index is strictly greater than its prerequisite for a multi-hop chain (a→b→c)
+- Parallel element executes all wave-0 branches before any wave-1 branch starts (log-order fence)
+- Non-fatal wave-0 failure absorbed; wave-1 still runs after wave-0 settles
+- concurrent `saveAll` (epilogue) + `update` (branch settle) on real `FsTaskRepository` never tears
+  tasks.json
+- High-concurrency (16 ops) interleaved `saveAll`+`update` always lands a consistent 4-task set
+- Sprint-scoped lock is held when the epilogue runs (`epilogueCalledWhileLockHeld === true`)
+
+**Key pattern**: `scheduleIntoWaves` is status-agnostic — it uses `task.order` + `dependsOn` only.
+In_progress-first ordering from `resolveImplementQueue` is already baked into the queue before
+`scheduleIntoWaves` sees it; the wave scheduler enforces the dependency fence.

--- a/.claude/agent-memory/tester/progress-overlay-flake-elimination.md
+++ b/.claude/agent-memory/tester/progress-overlay-flake-elimination.md
@@ -1,0 +1,21 @@
+---
+name: progress-overlay-flake-elimination
+description: Eliminate flaky ink-testing-library overlay/scroll tests by asserting on a SEEDED sentinel via waitFor instead of a fixed tick delay
+metadata:
+  type: feedback
+---
+
+Pattern: add a SEEDED sentinel text to `SeedSelection` that renders only when `seeded=true` (sprint
+or focusedRun effect has committed). Replace `await tick(50)` with
+`await waitFor(() => lastFrame().includes('SEEDED'))`.
+
+The sentinel stays visible even after the overlay opens (SeedSelection renders outside
+GlobalHarness's conditional), so asserting overlay content and `not.toContain('UNDERLYING_VIEW')`
+still works.
+
+For scroll clamp assertions: replace the final fixed tick after PgDn/PgUp loops with
+`waitFor(() => lastFrame().includes('TAIL-LINE'))` or
+`waitFor(() => lastFrame().includes('HEAD-LINE'))`.
+
+Proved: 10/10 isolated runs pass, 689/689 tui suite passes (as of 2026-06-12 — see
+[[project_flaky_progress_overlay_test]] in the reviewer/project index for the fix landing).

--- a/.claude/agent-memory/tester/sprint-selection-redesign-tests.md
+++ b/.claude/agent-memory/tester/sprint-selection-redesign-tests.md
@@ -1,0 +1,48 @@
+---
+name: sprint-selection-redesign-tests
+description: Test files + patterns from the sprint-selection redesign (reseat wiring, done-sprint filtering, MakeSpy intercept, fake-timer toast tests, ActionMenu cursor/UUIDv7 ordering)
+metadata:
+  type: feedback
+---
+
+Test files under `tests/integration/application/ui/tui/views/` and `tests/unit/`:
+
+- `sprint-bound-flow-reseat.test.tsx` — reseat wiring contract using a fake runner; asserts
+  `setSprint` called on `completed+ctx.sprint`, NOT on `aborted`/`failed`/`started`.
+- `tests/unit/application/ui/shared/state-snapshot-done-filter.test.ts` — `loadAppStateSnapshot`
+  recentSprints excludes `done` sprints.
+- `tests/unit/application/ui/tui/runtime/selection-done-on-boot.test.tsx` — `SelectionProvider`
+  clears sprintId/sprintLabel when the rehydrated sprint has `status: 'done'`. **Requires
+  `sprintRepo` prop on SelectionProvider.**
+- `home-create-hotkey.test.tsx` — `+` on Home routes to create-sprint flow; no-op without a project.
+- `home-switch-feedback.test.tsx` — "✓ now on <name>" feedback after switch; disappears after ~3s
+  with fake timers.
+- `pick-sprint-create-row.test.tsx` — PickSprintView renders "Create new sprint" row BEFORE project
+  groups; Enter on it launches create-sprint.
+- `sprint-detail-no-auto-sync.test.tsx` — SprintDetailView MUST NOT call `setSprint` on mount
+  (inverse of old behaviour). Uses `Object.assign(selection, { setSprint: spy })` (the MakeSpy
+  pattern) from a helper component.
+- `sprint-detail-make-current.test.tsx` — `m` key calls `setSprint(id, name)`; `· current` badge
+  visible when the sprint matches selection.
+
+**MakeSpy / intercept pattern for selection** — `Object.assign(selection, { setSprint: spy })`
+inside a child component `useEffect` lets you intercept context calls without forking the provider.
+
+**JSX in test files**: always use `.tsx` even for unit tests that merely import/render React
+components.
+
+**Fake timers + ink-testing-library**: `vi.useFakeTimers()` + `vi.runAllTimersAsync()` causes
+infinite loops due to Ink's Spinner `setInterval`. Use `vi.advanceTimersByTimeAsync(N)` instead. For
+time-gated render conditions (e.g. a toast freshness check), use
+`vi.spyOn(Date, 'now').mockReturnValue(BASE_TIME + 3100)` to advance the clock, then force a
+re-render via a context state change (e.g. `selection.setSprint(...)` from a helper component) —
+`setLocalError((curr) => curr)` bails out of React render (same value → no render committed). The
+`SwitchTrigger` helper pattern (a component that calls `selection.setSprint` in a once-only
+`useEffect`) is preferred over keyboard navigation for deterministic sprint-switch tests.
+`frame.indexOf('Alpha Project')` matches ViewShell breadcrumb chrome — filter lines containing
+`'project:'` line-by-line to find the actual group header row instead.
+
+**`ActionMenu` cursor + UUIDv7 ordering**: `makeDraftSprint` generates time-ordered UUIDs; created
+later = larger UUID = appears first in `recentSprints` (DESC sort). `initialMenuIndex` seeds to the
+current sprint's row. Pressing `k` (up) from the current sprint's row reaches the newer sprint at
+index 0.

--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -17,13 +17,14 @@ provider's native vocabulary.
 
 **Effort resolution** at every AI-spawning leaf (`src/business/settings/resolve-effort.ts`): per-flow
 `ai.<flow>.effort` wins; otherwise the global `ai.effort` floored to the row's provider ceiling;
-otherwise the provider CLI's default. Codex caps at `high` — `xhigh` and `max` collapse to `high` when
-floored from the global value; `minimal` is reachable only via an explicit per-flow override. The
-implement generator's resolved effort also feeds the escalation policy's same-model effort rung, whose
-target is provider- and model-aware: a Claude generator at the top of the model ladder climbs its own effort
-tiers (Claude Code's default is `xhigh` on xhigh-capable models, so the shipped default `claude-opus-4-8`
-with effort unset escalates to `max`, not `high`), while Copilot/Codex escalate to a fixed `high` — see
-`PERFORMANCE.md § plateau escalation`).
+otherwise the provider CLI's default. Codex accepts `low..ultra` — from the **global** value, `max` floors
+to `xhigh` (only the GPT-5.6 family accepts `max`); `ultra` (sol/terra-only, plan-gated) is reachable only
+via an explicit per-flow effort; `minimal` no longer exists — persisted rows migrate to `low` at parse
+time. The implement generator's resolved effort also feeds the escalation policy's same-model effort rung,
+whose target is provider- and model-aware: a Claude generator at the top of the model ladder climbs its own
+effort tiers (Claude Code's default is `xhigh` on xhigh-capable models, so the shipped default
+`claude-opus-5` with effort unset escalates to `max`, not `high`), while Copilot escalates to a fixed
+`high` and Codex to a fixed `xhigh` — see `PERFORMANCE.md § plateau escalation`).
 
 **Single-provider configurations are first-class.** Every row may point at the same provider, or every row
 at a different one; the launcher rebuilds the provider / interactive-AI / skills-adapter trio per launch
@@ -85,26 +86,28 @@ in one shot — all equally first-class (none is marked default). Each family ca
   — cheap generate tier paired with a permanently-flagship evaluator gate — the only family that
   intentionally splits `implement.generator` and `implement.evaluator` onto different models. The generator
   climbs to the flagship on plateau via the escalation ladder (`escalateOnPlateau` stamped `true`). The
-  Codex variant (`gpt-5.4` gen → `gpt-5.5` gate) has the narrowest gap of the family.
+  Codex variant (`gpt-5.6-terra` gen → `gpt-5.6-sol` gate) has the narrowest gap of the family.
 - **fast** (`mixed-fast`, `claude-fast`, `copilot-fast`, `codex-fast`) — cheapest viable tier at `low`
   effort across the board. Implement uses sonnet/mini (not haiku — too weak to author code reliably); light
   flows drop further. This is the only family with `escalateOnPlateau` stamped **`false`** — a plateau
   settles (done-with-warning) rather than climbing the ladder, which is what keeps the family genuinely
-  cheap and predictable. `codex-fast` uses `minimal` effort for the lightest Codex rows.
+  cheap and predictable.
 - **frontier** (`mixed-frontier`, `claude-frontier`, `copilot-frontier`, `codex-frontier`) — flagship
-  everywhere at `max` effort. Codex is floored to `high` (its effort ceiling). Tops out at opus;
-  `claude-fable-5` is intentionally not referenced — it is export-control-suspended and would be rejected
-  at launch. Restoring fable is a one-line model swap when the suspension lifts.
+  everywhere at `max` effort. Codex now genuinely stamps `max` too (`gpt-5.6-sol` is the only tier that
+  accepts it); `ultra` is deliberately not used (plan-gated to Plus+, would brick spawns on lower plans).
+  Tops out at Opus 5 / GPT-5.6 Sol; `claude-fable-5` is intentionally not referenced — it is priced at 2×
+  Opus and stays opt-in only (not a suspension — see below).
 
 **`applyPreset` stamps `harness.escalateOnPlateau`** alongside the AI section. Standard / economic /
 strong-gate / frontier all stamp it `true`; fast stamps it `false`. The rest of `harness` (`maxTurns`,
 `escalationMap`, `plateauThreshold`, …) plus all other top-level settings keys are preserved verbatim.
 
 **Model-tier ordering.** The ladders each family relies on are grounded in SWE-bench rankings (June
-2026 data): Claude haiku < sonnet < opus < fable; GPT mini < 5.4 < 5.5. These orderings explain why
-the cheap-to-strong tier progressions are wired the way they are — not as guaranteed scores (OpenAI
-stopped publishing SWE-bench Verified after contamination concerns, and results swing significantly with
-scaffolding). Treat this as relative-ordering rationale, not a performance promise.
+2026 data): Claude haiku < sonnet < opus < fable; GPT mini < 5.4 < 5.5 < 5.6 (luna < terra < sol). These
+orderings explain why the cheap-to-strong tier progressions are wired the way they are — not as
+guaranteed scores (OpenAI stopped publishing SWE-bench Verified after contamination concerns, and
+results swing significantly with scaffolding). Treat this as relative-ordering rationale, not a
+performance promise.
 
 Apply via `ralphctl settings apply-preset <name>` or from the TUI settings view. Re-applying overwrites
 every `ai` row plus `harness.escalateOnPlateau` in one transaction; subsequent per-key edits via
@@ -112,54 +115,68 @@ every `ai` row plus `harness.escalateOnPlateau` in one transaction; subsequent p
 
 **Model catalog versions used by the presets** (verified against the tool versions noted per row):
 
-- Claude Code — `claude-haiku-4-5` / `claude-sonnet-4-6` / `claude-sonnet-5` / `claude-opus-4-8`
-  (verified against Claude Code v2.1.197; `claude-sonnet-5` requires v2.1.197+). `claude-sonnet-5` is
-  the Sonnet-5 successor to Sonnet 4.6 and the **default Sonnet** across presets, the new-install
-  defaults, and the escalation ladder; `claude-sonnet-4-6` is kept alongside it (both Active at
-  Anthropic) so pinned 4.6 configs keep working. Sonnet 5 has **no `[1m]` variant** — on the Anthropic
-  API it always runs at its native 1M window in Claude Code, so the 1M figure is recorded against the
-  bare id in the context-window tables (the only base id, not a `[1m]` variant, to carry 1M). The
-  catalog additionally lists the frontier tier `claude-fable-5` plus the 1M-context variants
-  `claude-opus-4-8[1m]` and `claude-fable-5[1m]` (the `[1m]` suffix is Claude Code's long-context
-  syntax for models whose Claude-Code default is 200K, passed through verbatim — on large repos the 1M
-  window avoids mid-session compaction during deep implement runs) as **opt-in only** — no preset,
-  default, or built-in escalation rung references them; pick per row or add an
-  `'claude-opus-4-8': 'claude-fable-5'` rung via `settings.harness.escalationMap`. **Temporarily
-  suspended (2026-06-12 Anthropic export-control directive):** the `claude-fable-5` family stays in the
-  catalog but is currently rejected at launch with a clear message and flagged `(suspended)` in the
-  pickers; it will be restored when access returns (single-list revert in
-  `settings-models/suspended-models.ts`).
-- GitHub Copilot — lists 22 models reconciled to GitHub's supported-models doc (as of 2026-06-30;
-  Sonnet 5 went GA for Copilot that day): OpenAI `gpt-5-mini`, `gpt-5.3-codex`, `gpt-5.4`,
-  `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`; Anthropic `claude-haiku-4.5`, `claude-opus-4.5`,
-  `claude-opus-4.6`, `claude-opus-4.6-fast`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-fable-5`,
-  `claude-sonnet-4.5` (default), `claude-sonnet-4.6`, `claude-sonnet-5`; Google `gemini-2.5-pro`,
-  `gemini-3-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`; Microsoft `mai-code-1-flash`;
-  fine-tuned `raptor-mini-preview`. Note: Sonnet 5's Copilot slug carries no dot/date, so it is the
-  SAME string (`claude-sonnet-5`) as the Claude-Code id — the escalation map has one value per key,
-  so the dash-form (Claude-Code) rung `claude-sonnet-5 → claude-opus-4-8` wins it and Copilot's
-  curated presets stay on `claude-sonnet-4.6` (see `escalation-map.ts`).
-- OpenAI Codex — adds `gpt-5.3-codex-spark` (text-only research preview, ChatGPT Pro only);
-  `gpt-5.2` and `gpt-5.3-codex` are deprecated for ChatGPT sign-in but kept in the allowlist because
-  they remain available via API-key auth. `gpt-5.5` is the frontier default — the model `codex-only`
-  runs implement on and the top rung of the Codex escalation ladder; `gpt-5.4` is the strong frontier
-  coder one tier below it, where `codex-economic` starts implement (verified against Codex CLI
-  v0.138.0). The `codex-only` preset moves implement off the deprecated `gpt-5.3-codex` to `gpt-5.5`.
+- Claude Code — `claude-haiku-4-5` / `claude-sonnet-4-6` / `claude-sonnet-5` / `claude-opus-4-8` /
+  `claude-opus-5` (verified against Claude Code v2.1.197; `claude-sonnet-5` requires v2.1.197+;
+  `claude-opus-5` ships at the same price as Opus 4.8 — vendor-stated drop-in). `claude-opus-5` is the
+  Opus 4.8 successor and the **default Opus** across presets, the new-install defaults, and the
+  escalation ladder; `claude-opus-4-8` is kept alongside it (both Active at Anthropic) so pinned 4.8
+  configs keep working, and now carries a ladder rung up to Opus 5. Like Sonnet 5, Opus 5 has
+  **no `[1m]` variant** — on the Anthropic API it always runs at its native 1M window in Claude Code, so
+  the 1M figure is recorded against the bare id in the context-window tables (Sonnet 5 and Opus 5 are now
+  both base ids, not `[1m]` variants, that carry native 1M); 128K output; a separate rate-limit bucket
+  from the Opus 4.x family. The catalog additionally lists the frontier tier `claude-fable-5` plus the
+  1M-context variants `claude-opus-4-8[1m]` and `claude-fable-5[1m]` (the `[1m]` suffix is Claude Code's
+  long-context syntax for models whose Claude-Code default is 200K, passed through verbatim — on large
+  repos the 1M window avoids mid-session compaction during deep implement runs) as **opt-in only** — no
+  preset, default, or built-in escalation rung references them; pick per row or add a
+  `'claude-opus-5': 'claude-fable-5'` rung via `settings.harness.escalationMap`. Fable is **GA as of July
+  2026** — the 2026-06-12 export-control suspension has been lifted (`settings-models/suspended-models.ts`
+  keeps the kill-switch mechanism, now empty) — it stays opt-in for a different reason: 2× the Opus price
+  is an operator spend decision, not a capability gate.
+- GitHub Copilot — lists 28 models reconciled to GitHub's supported-models doc (as of 2026-07-26):
+  OpenAI `gpt-5-mini`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`,
+  `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`; Anthropic `claude-haiku-4.5`, `claude-opus-4.5`,
+  `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-opus-4.8-fast`, `claude-opus-5`,
+  `claude-fable-5`, `claude-sonnet-4.5` (default), `claude-sonnet-4.6`, `claude-sonnet-5`; Google
+  `gemini-2.5-pro`, `gemini-3-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.6-flash`;
+  Microsoft `mai-code-1-flash`; Moonshot `kimi-k2.7-code`; fine-tuned `raptor-mini-preview`. Added since
+  the last reconciliation: `claude-opus-4.8-fast`, `claude-opus-5`, `gpt-5.6-sol`, `gpt-5.6-terra`,
+  `gpt-5.6-luna`, `gemini-3.6-flash`, `kimi-k2.7-code` — `gpt-5.6-sol` is CLI-verified (Copilot CLI
+  1.0.75); `claude-opus-4.8-fast`, `gemini-3.6-flash`, and `kimi-k2.7-code` are convention-derived (could
+  not be validated on the reference account). Removed: `claude-opus-4.6-fast` (delisted; remaps to
+  `claude-opus-4.8-fast`). Note: `claude-opus-5`'s Copilot slug carries no dot/date, so — like Sonnet 5
+  and Fable 5 — it is the SAME string (`claude-opus-5`) as the Claude-Code id; it is also plan-gated
+  (Pro+/Max/Business/Enterprise) on Copilot, and per the existing passthrough-probe policy fails at spawn
+  with a clear error on gated accounts, so Copilot's curated presets and the dot-form escalation ladder
+  deliberately stay on `claude-opus-4.8` (see `escalation-map.ts`).
+- OpenAI Codex — verified against the live CLI model cache (codex CLI v0.145.0,
+  `~/.codex/models_cache.json`, 2026-07-26). `gpt-5.6-sol` is the flagship and the top rung of the Codex
+  escalation ladder — the model `codex-only` / `codex-frontier` run implement on; `gpt-5.6-terra` is the
+  balanced everyday tier (`codex-economic` / `codex-strong-gate`'s author role); `gpt-5.6-luna` is the
+  most cost-efficient 5.6 tier (ladder: luna → terra → sol). `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` remain
+  in the catalog for pinned configs and chain into the 5.6 family (`gpt-5.5 → gpt-5.6-sol`). The 5.6
+  family requires codex CLI ≥ ~0.145 — older CLIs reject with "requires a newer version of Codex". Bare
+  `gpt-5.6` is an API-only alias rejected under ChatGPT auth and is deliberately NOT listed. `gpt-5.2` /
+  `gpt-5.3-codex` / `gpt-5.3-codex-spark` are gone from the CLI entirely and were REMOVED from the
+  catalog; persisted rows silently remap to `gpt-5.5` at parse time (`gpt-5.3-codex` stays in the
+  **Copilot** catalog — GitHub still lists it — so the remap is codex-provider-guarded). Effort
+  vocabulary is now `low..ultra`; `minimal` was retired and persisted rows migrate to `low`.
 
 **Default escalation posture (effort rung, no model ladder).** `DEFAULT_SETTINGS.ai.implement.generator` is
-`claude-opus-4-8`, which has no key in `DEFAULT_ESCALATION_MAP` — so the shipped default never
-model-escalates. It is NOT inert, though: at the top of the model ladder the graduated policy first raises
-reasoning effort on the same model (the `escalate-effort` rung). opus is xhigh-capable and its effort is
-unset, so Claude Code's implicit default is already `xhigh` — the rung therefore climbs to `max` in a single
-step (a fixed `high` would be a no-op or a downgrade). Then — on a further plateau, opus now at `max` — it
-fires the same-model nudge (a change-of-approach directive), then settles `done-with-warning`. For the shipped
-default the effort rung fires exactly once (unset `→ max`; the next plateau sees `max` and falls through to
-the nudge). To also activate a live MODEL ladder, use one
-of the `*-economic` presets (where `implement.generator` starts on Sonnet and escalates to Opus) or add a
-custom rung via `settings.harness.escalationMap`:
+`claude-opus-5`, which has no key in `DEFAULT_ESCALATION_MAP` — so the shipped default never
+model-escalates. (A pinned `claude-opus-4-8` generator DOES model-escalate now — it carries a live rung up
+to `claude-opus-5` — before the effort rung below applies.) The default's effort rung is NOT inert, though:
+at the top of the model ladder the graduated policy first raises reasoning effort on the same model (the
+`escalate-effort` rung). opus is xhigh-capable and its effort is unset, so Claude Code's implicit default is
+already `xhigh` — the rung therefore climbs to `max` in a single step (a fixed `high` would be a no-op or a
+downgrade). Then — on a further plateau, opus now at `max` — it fires the same-model nudge (a
+change-of-approach directive), then settles `done-with-warning`. For the shipped default the effort rung
+fires exactly once (unset `→ max`; the next plateau sees `max` and falls through to the nudge). To also
+activate a live MODEL ladder, use one of the `*-economic` presets (where `implement.generator` starts on
+Sonnet and escalates to Opus) or add a custom rung via `settings.harness.escalationMap`:
 
 ```json
-"escalationMap": { "claude-opus-4-8": "claude-fable-5" }
+"escalationMap": { "claude-opus-5": "claude-fable-5" }
 ```
 
 `claude-fable-5` and its 1M-context variant `claude-fable-5[1m]` are in the Claude catalog as

--- a/.claude/docs/HARNESS-PRINCIPLES.md
+++ b/.claude/docs/HARNESS-PRINCIPLES.md
@@ -461,3 +461,13 @@ this checklist before updating the recorded hash:
    is it now overhead?" (§ 14 — remove non-load-bearing pieces one at a time, with measurement.)
 4. **Update the recorded fingerprint** in the test only after steps 1–3, so the hash bump is a deliberate
    record that the audit ran, not a reflex to make CI green.
+
+**Model-bump audit log.**
+
+- **2026-07-26 — Claude Opus 5 / GPT-5.6 (Sol, Terra, Luna) refresh.** Step 1 (orphaned rungs) is
+  mechanized and passed — `DEFAULT_ESCALATION_MAP` was updated in lockstep with the catalog edits, no
+  stranded key/destination. Step 2: the only `partial`/`gap` rows in this doc are §14 and §18, both
+  self-referential to this audit mechanism — neither is closed by a same-generation model tier bump, so
+  no promotion. Step 3: rows 1–13 and 15–17 (`applied`) reviewed — this bump is a same-architecture tier
+  refresh (higher-capability models within the existing Claude / Codex / Copilot families, not a new
+  capability class), so no component was identified as newly non-load-bearing; no removals.

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -121,21 +121,27 @@ settles done-with-warning. Two `settings.harness` knobs tune it:
 The escalation policy is a **graduated remedy ladder** (`src/business/task/escalation-policy.ts`)
 spent cheapest-first across successive plateau or budget-exhausted exits:
 (1) **model escalation** — climbs **one rung per exit** up `DEFAULT_ESCALATION_MAP`
-(`src/business/task/escalation-map.ts`, seeding the common in-provider rungs Claude Haiku → Sonnet →
-Opus in both dash-form Claude-Code/Codex ids and dot-form Copilot ids; Codex / Copilot `gpt-5-mini`,
-`gpt-5.4-mini` and the economic full tier `gpt-5.4` → `gpt-5.5`, kept in lockstep with
-`domain/value/settings-models/` by code review). Each exit re-reads the most-recent
+(`src/business/task/escalation-map.ts`): dash-form Claude-Code ids climb Haiku → Sonnet 5 → Opus 5, with
+the legacy Sonnet 4.6 / Opus 4.8 generation chaining through its own tier and converging at the same
+flagship; dot-form Copilot ids climb Haiku → Sonnet 4.6 → Opus 4.8 (the ladder deliberately tops out below
+Opus 5, which is plan-gated on Copilot); Codex / Copilot GPT minis (`gpt-5-mini`, `gpt-5.4-mini`) step to
+the `gpt-5.5` full tier, which itself climbs into the GPT-5.6 family (`gpt-5.5 → gpt-5.6-sol`,
+`gpt-5.6-luna → gpt-5.6-terra → gpt-5.6-sol`) — kept in lockstep with `domain/value/settings-models/` by
+the catalog-fingerprint verify gate. Each exit re-reads the most-recent
 `Task.escalatedToModel` as the generator model, so the policy returns `escalate` repeatedly and the
 task climbs through every intermediate rung (bounded by `maxAttempts`).
 (2) **effort escalation** — when the generator reaches the top of the model ladder (no stronger rung) the
 policy tries a cheaper same-model remedy BEFORE the nudge: raise reasoning effort (`escalate-effort`) to a
 **provider- and model-aware target** (`nextEffortRung` in `escalation-map.ts`) when the provider/model
 exposes an effort dimension and the generator still has headroom. Claude is model-aware — Claude Code's own
-CLI default is `xhigh` on xhigh-capable models (Opus 4.7/4.8, Sonnet 5, Fable 5), so the rung climbs Claude's
-own tiers (`…→ xhigh → max`) rather than stamping a fixed `high` that would be a no-op or a downgrade of the
-implicit default; an explicit `low|medium|high` climbs to `xhigh`, and `unset` (the CLI default) or `xhigh`
-climbs to `max`, capping there. A non-xhigh-capable Claude model (Sonnet 4.6, CLI default `high`) climbs
-straight to `max`. Copilot/Codex keep the fixed target `EFFORT_ESCALATION_TARGET` (`high`). It stamps
+CLI default is `xhigh` on xhigh-capable models (Opus 4.7/4.8, Sonnet 5, Opus 5, Fable 5), so the rung climbs
+Claude's own tiers (`…→ xhigh → max`) rather than stamping a fixed `high` that would be a no-op or a
+downgrade of the implicit default; an explicit `low|medium|high` climbs to `xhigh`, and `unset` (the CLI
+default) or `xhigh` climbs to `max`, capping there. A non-xhigh-capable Claude model (Sonnet 4.6, CLI
+default `high`) climbs straight to `max`. Copilot keeps the fixed target `EFFORT_ESCALATION_TARGET`
+(`high`); Codex keeps its own fixed target `CODEX_EFFORT_ESCALATION_TARGET` (`xhigh`) — `xhigh` is accepted
+by every codex catalog model, unlike the old shared `high` target, which every codex preset already
+stamped on implement and so left the rung permanently spent for them. It stamps
 `Task.escalatedToEffort` (no model change), the generator leaf prefers that over the configured `effort` at
 spawn, and the next plateau sees the raised effort. Fires once for the shipped default (unset `→ max` in a
 single step) and is strictly bounded generally — the stamped effort climbs monotonically to the terminal
@@ -159,7 +165,7 @@ while the attempt budget remains, falling back to done-with-warning at the cap.
 introduced have `task.maxAttempts === undefined`; `decideEscalation` and the per-task loop cap both fall
 back to `settings.harness.maxAttempts` so the attempt budget binds for them too.
 
-**Default posture: effort rung, then nudge.** The shipped default generator model (`claude-opus-4-8`) has
+**Default posture: effort rung, then nudge.** The shipped default generator model (`claude-opus-5`) has
 no key in `DEFAULT_ESCALATION_MAP`, so the harness never model-escalates it. But the effort rung IS live for
 the default posture: opus is xhigh-capable and its effort is unset (Claude Code's implicit default is
 `xhigh`), so on a plateau at the top of the ladder the rung raises reasoning effort to `max` on the same
@@ -175,7 +181,7 @@ fields are re-stampable and hold the MOST-RECENT transition; the cost ceiling is
 plus `maxAttempts` (each escalate / effort-bump / nudge fails the running attempt, consuming budget), not by
 a once-per-task cap. A non-passing exit with no attempt budget left, or after the top-of-ladder nudge,
 preserves the work (done-with-warning) — never blocks.
-Cross-provider escalation (e.g. `claude-opus-4-8` → `gpt-5.5`) is intentionally deferred — switching
+Cross-provider escalation (e.g. `claude-opus-5` → `gpt-5.6-sol`) is intentionally deferred — switching
 providers mid-task carries auth / context / tool-availability hazards.
 
 **Verify-gate cost and scoping.** In a measured 23-min single-task sprint, the repo-wide verify script ran four

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -55,7 +55,7 @@ single-attempt behaviour.
 `{ generator, evaluator }` pair — each role carries its own `{ provider, model, effort? }` row, so
 the two sessions can run on different providers / models / effort levels (effort resolution rules
 described in `AI-SETTINGS.md` apply per-row). Default: generator runs `claude-code` /
-`claude-opus-4-8`, evaluator runs `openai-codex` / `gpt-5.5` — deep-coder reasoning on the produce
+`claude-opus-5`, evaluator runs `openai-codex` / `gpt-5.6-sol` — deep-coder reasoning on the produce
 side, an independent reviewer on the score side. Every other flow (`refine` / `plan` / `readiness` /
 `ideate` / `createPr`) keeps the flat `{ provider, model, effort? }` row shape; the analogous
 generator-evaluator split for the `plan` flow is deferred to future work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Opus 5** (`claude-opus-5`) — the Opus 4.8 successor at the same price, natively 1M context (no
+  `[1m]` variant, same as Sonnet 5). It's now the default Opus across `DEFAULT_SETTINGS`, every curated
+  preset, and the built-in escalation ladder; `claude-opus-4-8` stays in the catalog for pinned configs
+  and now carries a live ladder rung up to Opus 5.
+- **GPT-5.6 family for Codex and Copilot** — `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced), and
+  `gpt-5.6-luna` (most cost-efficient), verified against the codex CLI 0.145.0 model cache. New ladder
+  rungs: `gpt-5.5 → gpt-5.6-sol` and `gpt-5.6-luna → gpt-5.6-terra → gpt-5.6-sol`. Requires codex CLI ≥
+  ~0.145; older CLIs reject the new models with a clear error.
+- **New Codex effort levels `xhigh` / `max` / `ultra`.** The Codex effort vocabulary is no longer floored
+  to `high` — `xhigh` is valid on every catalog model, `max` on the 5.6 family, and `ultra` (plan-gated) on
+  Sol/Terra. `minimal` is retired; persisted rows silently migrate to `low`.
+- **Copilot catalog additions**: `claude-opus-4.8-fast`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`,
+  `gemini-3.6-flash`, `kimi-k2.7-code`, and `claude-opus-5` (catalog + pin-only — plan-gated on Copilot, so
+  curated presets and the default ladder stay on `claude-opus-4.8`). `gpt-5.6-sol` is CLI-verified;
+  `claude-opus-4.8-fast`, `gemini-3.6-flash`, and `kimi-k2.7-code` are convention-derived from GitHub's
+  docs and could not be validated on the reference account.
+
+### Changed
+
+- Implement evaluator default → `openai-codex` / `gpt-5.6-sol` (was `gpt-5.5`).
+- Codex presets re-tiered onto the GPT-5.6 family (`gpt-5.5` → `gpt-5.6-sol`, `gpt-5.4` → `gpt-5.6-terra`
+  across the affected rows); `codex-economic`'s ideate row moves off its former mini/full-tier gap onto
+  `gpt-5.6-terra`. `codex-frontier` now genuinely stamps `max` effort instead of being floored to `high`.
+- Codex plateau effort-escalation target rises from `high` to `xhigh` (`high` was permanently dead for
+  every codex preset, which stamps implement at `high` already).
+- **Fable 5's export-control suspension is lifted** — `claude-fable-5` is pickable again. It remains
+  opt-in only (no preset row, no default escalation rung): at 2× the Opus price, adding it is an operator
+  spend decision, not something ralphctl steers a task into automatically.
+
+### Removed
+
+- Codex `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark` — gone from the codex CLI's model cache; pinned
+  rows silently remap to `gpt-5.5` on load (`gpt-5.3-codex` is unaffected on the **Copilot** catalog, where
+  GitHub still lists it).
+- Copilot `claude-opus-4.6-fast` — delisted by GitHub; pinned rows remap to `claude-opus-4.8-fast`.
+- Codex effort `minimal` — no longer a valid reasoning-effort level; persisted rows remap to `low`.
+
 ## [0.16.0] - 2026-07-18
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,21 @@ Only the latest version is supported — no backporting, no parallel branches.
 The sections below give per-version context for what changed and why, in case
 you're crossing a big jump and want to know what to expect.
 
+## 0.16.x → 0.17.0
+
+Nothing to do by hand. July 2026 model refresh — defaults, presets, and the escalation ladder move to
+Claude Opus 5 and the GPT-5.6 family (Sol / Terra / Luna). Silent parse-time remaps keep pinned configs
+working: Copilot `claude-opus-4.6-fast` → `claude-opus-4.8-fast`; Codex `gpt-5.2` / `gpt-5.3-codex` /
+`gpt-5.3-codex-spark` → `gpt-5.5`; Codex effort `minimal` → `low` (the level no longer exists). Canonical
+shape lands on the next `save()`. Notes: GPT-5.6 models require codex CLI ≥ ~0.145; Claude Opus 5 and
+Fable 5 on Copilot depend on your Copilot plan (unavailable models fail at spawn with a clear message);
+Fable 5 is un-suspended and pickable again (still opt-in only — nothing selects it by default);
+`claude-opus-4.8-fast` (the Copilot remap target) is a convention-derived slug not yet verified against
+a live Copilot CLI — if it's rejected at spawn, re-pin the row to `claude-opus-4.8`. One deliberate
+depth/spend increase: an existing global `ai.effort: xhigh` or `max` combined with codex rows now
+resolves to `xhigh` (was floored to `high`) — pin a per-row `effort` to keep the old level. See
+[CHANGELOG](./CHANGELOG.md#unreleased).
+
 ## 0.8.x → 0.9.0
 
 Nothing to do on upgrade. Parallel task execution is opt-in — `settings.concurrency.maxParallelTasks`

--- a/src/application/flows/readiness/flow.ts
+++ b/src/application/flows/readiness/flow.ts
@@ -31,6 +31,7 @@ import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.t
 import { type AssistantTool, toolForProvider } from '@src/integration/ai/readiness/_engine/tool.ts';
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
+import { clampEffortToProvider } from '@src/business/settings/resolve-effort.ts';
 
 export interface CreateReadinessFlowOpts {
   readonly projectId: ProjectId;
@@ -82,7 +83,7 @@ const pickRowForProvider = (ai: AiSettings, provider: AiProvider): FlowId => {
 /**
  * Per-tool effort resolution. Mirrors `resolveEffort(flowId, settings)` semantics but reads
  * just the `AiSettings` slice the flow holds — per-row effort wins, otherwise the global
- * effort is floored to what the provider's CLI accepts. Floor table matches
+ * effort is floored via the shared {@link clampEffortToProvider} clamp from
  * `business/settings/resolve-effort.ts`. For `implement` reads from the generator role.
  */
 const resolveEffortForRow = (ai: AiSettings, flow: FlowId): string | undefined => {
@@ -90,8 +91,7 @@ const resolveEffortForRow = (ai: AiSettings, flow: FlowId): string | undefined =
   if (row.effort !== undefined) return row.effort;
   const globalEffort = ai.effort;
   if (globalEffort === undefined) return undefined;
-  if (row.provider === 'openai-codex' && (globalEffort === 'xhigh' || globalEffort === 'max')) return 'high';
-  return globalEffort;
+  return clampEffortToProvider(globalEffort, row.provider);
 };
 
 /**

--- a/src/application/ui/tui/views/execute-view-internals/header-card.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/header-card.tsx
@@ -48,7 +48,7 @@ interface HeaderCardProps {
  * operator can clearly see each role, even when generator === evaluator. When the role's provider
  * id is known it renders dim before the model (secondary context) — model stays highlighted.
  *
- *   ↳ generator  github-copilot · claude-opus-4-8 · high
+ *   ↳ generator  github-copilot · claude-opus-4.8 · high
  *   ↳ evaluator  openai-codex · gpt-5.5 · medium
  *
  * Non-implement flows (at most one model set): single `model <name>` line, optionally prefixed

--- a/src/application/ui/tui/views/settings-editor.tsx
+++ b/src/application/ui/tui/views/settings-editor.tsx
@@ -34,9 +34,11 @@ import { contextWindowLabel } from '@src/domain/value/settings-models/context-wi
  *
  *   'claude-sonnet-4-6'    →  'claude-sonnet-4-6  ·  200K'
  *   'claude-opus-4-8[1m]' →  'claude-opus-4-8[1m]  ·  1M'
- *   'claude-fable-5[1m]'  →  'claude-fable-5[1m]  ·  1M  (suspended)'
- *   'claude-fable-5'      →  'claude-fable-5  ·  (suspended)'
+ *   'claude-opus-5'        →  'claude-opus-5  ·  1M'
  *   'gpt-5.5'             →  'gpt-5.5'   (no window known — no annotation)
+ *
+ * The `(suspended)` suffix only appears while `SUSPENDED_MODELS` is non-empty — the kill-switch
+ * is currently unused (see suspended-models.ts) so no catalog id renders it today.
  */
 const annotateModelLabel = (model: string): string => {
   const windowPart = contextWindowLabel(model);

--- a/src/application/ui/tui/views/settings-view-model.ts
+++ b/src/application/ui/tui/views/settings-view-model.ts
@@ -204,7 +204,7 @@ export const escalationTargetsFor = (from: string): readonly string[] => {
 };
 
 export interface EscalationChain {
-  /** Model ids in climb order, e.g. `['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-8']`. */
+  /** Model ids in climb order, e.g. `['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-5']`. */
   readonly models: readonly string[];
   /** True when any rung on the chain comes from the user's overrides (not the built-in map). */
   readonly customised: boolean;

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -7,12 +7,13 @@ import {
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 
 // Model identifiers referenced more than once below, hoisted to named constants so each literal
-// appears once. The dash spelling (`claude-sonnet-5`, `claude-opus-4-8`) is the claude-code
-// catalog form. Sonnet 5 is the default Sonnet for Claude Code.
+// appears once. The dash spelling (`claude-sonnet-5`, `claude-opus-5`) is the claude-code
+// catalog form. Sonnet 5 is the default Sonnet for Claude Code; Opus 5 is the default Opus.
 const CLAUDE_SONNET = 'claude-sonnet-5';
-const CLAUDE_OPUS = 'claude-opus-4-8';
+const CLAUDE_OPUS = 'claude-opus-5';
 const GPT_5_MINI = 'gpt-5-mini';
 const GPT_5_4_MINI = 'gpt-5.4-mini';
+const GPT_5_6_SOL = 'gpt-5.6-sol';
 
 /**
  * Per-provider, per-flow default model picks. Used by the welcome flow when the user picks a
@@ -43,13 +44,12 @@ const DEFAULT_MODELS_BY_PROVIDER: Readonly<Record<AiProvider, Readonly<Record<Fl
   },
   'openai-codex': {
     refine: GPT_5_4_MINI,
-    plan: 'gpt-5.5',
-    // `gpt-5.3-codex` is deprecated for ChatGPT sign-in — the "reset implement to Codex" path
-    // rides the frontier default `gpt-5.5` instead, matching the CODEX_ONLY preset decision so
-    // the everyday autonomous loop works under ChatGPT auth and sits at the top of the ladder.
-    implement: 'gpt-5.5',
+    plan: GPT_5_6_SOL,
+    // `gpt-5.6-sol` is the codex flagship (codex CLI ≥ 0.145); it tops the Codex escalation
+    // ladder, so the reset-to-codex implement default and the ladder top stay aligned.
+    implement: GPT_5_6_SOL,
     readiness: GPT_5_4_MINI,
-    ideate: 'gpt-5.5',
+    ideate: GPT_5_6_SOL,
     createPr: GPT_5_4_MINI,
   },
 };
@@ -86,8 +86,10 @@ export const defaultAiSettingsForProvider = (provider: AiProvider): AiSettings =
  * settings via the TUI settings panel or `ralphctl settings set <key> <value>`.
  *
  * The implement row deliberately splits roles across providers: Claude Opus drives the
- * generator (deep coder reasoning) while Codex GPT-5.5 drives the evaluator (independent
- * second opinion). Single-provider users override via a preset.
+ * generator (deep coder reasoning) while Codex GPT-5.6 Sol drives the evaluator (independent
+ * second opinion). Effort is deliberately left unset on the evaluator row per the fresh-default
+ * policy above — the CLI's own default applies; raise `ai.effort` to deepen the gate.
+ * Single-provider users override via a preset.
  */
 export const DEFAULT_SETTINGS: Settings = {
   schemaVersion: CURRENT_SCHEMA_VERSION,
@@ -95,7 +97,7 @@ export const DEFAULT_SETTINGS: Settings = {
     ...defaultAiSettingsForProvider('claude-code'),
     implement: {
       generator: { provider: 'claude-code', model: CLAUDE_OPUS },
-      evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+      evaluator: { provider: 'openai-codex', model: GPT_5_6_SOL },
     },
   },
   harness: {

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -17,7 +17,8 @@ import type { AiSettings, Settings } from '@src/domain/entity/settings.ts';
  *                   only family that splits generator and evaluator onto different models.
  *   fast          — cheapest viable tier at `low` effort, optimising speed/cost over quality;
  *                   the only family with `escalateOnPlateau` stamped OFF so a plateau settles.
- *   frontier      — flagship everywhere at `max` effort (codex floored to `high`).
+ *   frontier      — flagship everywhere at `max` effort (tops out at Opus 5 / GPT-5.6 Sol; codex
+ *                   is no longer floored — the 5.6 flagship accepts `max` directly).
  *
  * Applying a preset stamps the AI section AND `harness.escalateOnPlateau`. Preset identity is
  * NOT persisted; the next per-row edit sticks and nothing remembers which preset was applied.
@@ -71,20 +72,27 @@ export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as
 
 // Provider and model identifiers referenced across the preset matrices below, hoisted so each
 // literal appears once. The dash vs dot spelling is provider-specific and load-bearing:
-// claude-code uses the dash form (`claude-opus-4-8`, `claude-sonnet-5` → OPUS / SONNET / HAIKU)
+// claude-code uses the dash form (`claude-opus-5`, `claude-sonnet-5` → OPUS / SONNET / HAIKU)
 // while github-copilot uses the dotted form (`claude-…-4.8` → COPILOT_OPUS / COPILOT_SONNET). Do
 // not normalise one into the other. Sonnet 5 is the default Sonnet for Claude Code; Copilot's
 // curated presets stay on Sonnet 4.6 (its slug collides with the Claude-Code id — see escalation-map).
+// `COPILOT_OPUS` deliberately stays `claude-opus-4.8` — `claude-opus-5` is plan-gated on Copilot
+// (Pro+/Max/Business/Enterprise), so steering the curated Copilot presets there would brick spawns
+// on lower plans; `claude-opus-5` is catalog + pin-only on Copilot. Like `claude-sonnet-5`,
+// `claude-opus-5` is an undotted shared-slug id — identical on both the Claude-Code and Copilot
+// catalogs — see escalation-map.ts.
 const CLAUDE = 'claude-code';
 const COPILOT = 'github-copilot';
 const CODEX = 'openai-codex';
-const OPUS = 'claude-opus-4-8';
+const OPUS = 'claude-opus-5';
 const SONNET = 'claude-sonnet-5';
 const HAIKU = 'claude-haiku-4-5';
 const COPILOT_OPUS = 'claude-opus-4.8';
 const COPILOT_SONNET = 'claude-sonnet-4.6';
 const GPT_5_MINI = 'gpt-5-mini';
 const GPT_5_4_MINI = 'gpt-5.4-mini';
+const GPT_5_6_SOL = 'gpt-5.6-sol';
+const GPT_5_6_TERRA = 'gpt-5.6-terra';
 
 /**
  * The `mixed` preset matrix — best-of-breed across the three providers. Effort pattern:
@@ -97,7 +105,7 @@ const GPT_5_4_MINI = 'gpt-5.4-mini';
  */
 const MIXED: AiSettings = {
   effort: 'high',
-  refine: { provider: CODEX, model: 'gpt-5.5' },
+  refine: { provider: CODEX, model: GPT_5_6_SOL },
   plan: { provider: COPILOT, model: COPILOT_SONNET, effort: 'xhigh' },
   implement: {
     generator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
@@ -117,8 +125,8 @@ const MIXED: AiSettings = {
  *   readiness → light (cheap, single-shot)
  *   refine → mid-tier
  *
- * Effort matrix mirrors Mixed: `implement` and `plan` at `xhigh` (Codex floors `xhigh`
- * back to `high` at resolve time via the provider ceiling), `readiness` at `medium`,
+ * Effort matrix mirrors Mixed: `implement` and `plan` at `xhigh` (Codex now accepts `xhigh` on
+ * every catalog model — the vocabulary no longer floors it), `readiness` at `medium`,
  * `refine` and `ideate` inherit global `high`. Implement.generator and implement.evaluator
  * share the same row — the preset story is "every flow on this provider".
  */
@@ -150,16 +158,14 @@ const COPILOT_ONLY: AiSettings = {
 
 const CODEX_ONLY: AiSettings = {
   effort: 'high',
-  refine: { provider: CODEX, model: 'gpt-5.4' },
-  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+  refine: { provider: CODEX, model: GPT_5_6_TERRA },
+  plan: { provider: CODEX, model: GPT_5_6_SOL, effort: 'xhigh' },
   implement: {
-    // gpt-5.3-codex is deprecated for ChatGPT sign-in — implement now rides the frontier
-    // default so the everyday autonomous loop keeps working under ChatGPT auth.
-    generator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
-    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+    generator: { provider: CODEX, model: GPT_5_6_SOL, effort: 'xhigh' },
+    evaluator: { provider: CODEX, model: GPT_5_6_SOL, effort: 'xhigh' },
   },
   readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
-  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  ideate: { provider: CODEX, model: GPT_5_6_SOL },
   createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
@@ -176,8 +182,8 @@ const CODEX_ONLY: AiSettings = {
  * share the same row — splitting roles is an explicit per-row edit, not a preset.
  *
  * `refine` / `readiness` / `createPr` drop to the cheap tier across all four; `ideate` drops a
- * tier too, EXCEPT `codex-economic` where it stays on `gpt-5.5` — Codex has no cheaper
- * coding-grade tier that suits single-shot ideation, so the row matches `codex-only`.
+ * tier too, in every family including `codex-economic` — the GPT-5.6 family's `terra` tier is
+ * the intermediate tier the cheap-ideation row needed.
  */
 const MIXED_ECONOMIC: AiSettings = {
   effort: 'high',
@@ -221,13 +227,13 @@ const COPILOT_ECONOMIC: AiSettings = {
 const CODEX_ECONOMIC: AiSettings = {
   effort: 'high',
   refine: { provider: CODEX, model: GPT_5_4_MINI },
-  plan: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
+  plan: { provider: CODEX, model: GPT_5_6_TERRA, effort: 'high' },
   implement: {
-    generator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
-    evaluator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
+    generator: { provider: CODEX, model: GPT_5_6_TERRA, effort: 'high' },
+    evaluator: { provider: CODEX, model: GPT_5_6_TERRA, effort: 'high' },
   },
   readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
-  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  ideate: { provider: CODEX, model: GPT_5_6_TERRA },
   createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
@@ -272,8 +278,9 @@ const CLAUDE_STRONG_GATE: AiSettings = {
  * rejecting it, never escalating the author. The evaluator stays flagship regardless: the gate
  * is strong from the first round, generation is cheap until a task proves it needs more.
  *
- * Codex's `gpt-5.4`→`gpt-5.5` gate is the NARROWEST of the family — the two Codex tiers sit one
- * rung apart with a small capability gap, so the cheap author is already close to the gate.
+ * Codex's `gpt-5.6-terra`→`gpt-5.6-sol` gate is the NARROWEST of the family — the two Codex
+ * tiers sit one rung apart with a small capability gap, so the cheap author is already close
+ * to the gate.
  */
 const MIXED_STRONG_GATE: AiSettings = {
   effort: 'high',
@@ -304,14 +311,15 @@ const COPILOT_STRONG_GATE: AiSettings = {
 const CODEX_STRONG_GATE: AiSettings = {
   effort: 'high',
   refine: { provider: CODEX, model: GPT_5_4_MINI },
-  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+  plan: { provider: CODEX, model: GPT_5_6_SOL, effort: 'xhigh' },
   implement: {
-    // Narrowest gate of the family: gpt-5.4 author climbs the single rung to the gpt-5.5 gate.
-    generator: { provider: CODEX, model: 'gpt-5.4', effort: 'high' },
-    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+    // Narrowest gate of the family: terra author climbs the single default-ladder rung to the
+    // sol gate.
+    generator: { provider: CODEX, model: GPT_5_6_TERRA, effort: 'high' },
+    evaluator: { provider: CODEX, model: GPT_5_6_SOL, effort: 'xhigh' },
   },
   readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'medium' },
-  ideate: { provider: CODEX, model: 'gpt-5.5' },
+  ideate: { provider: CODEX, model: GPT_5_6_SOL },
   createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
@@ -323,8 +331,8 @@ const CODEX_STRONG_GATE: AiSettings = {
  * Implement deliberately uses sonnet / gpt-mini, NOT haiku: haiku (and the codex nano tier) is
  * too weak to author code reliably, so the cheapest model that can still complete a task gates
  * the implement rows even in the fast family. Light flows (refine / readiness / ideate / createPr)
- * drop further — `codex-fast` leans on `minimal` effort for those light flows where Codex offers
- * a cheaper-than-low rung.
+ * drop further — `codex-fast`'s light flows leave `effort` unset so they inherit the family's
+ * global `low`; Codex no longer has a below-`low` rung (`minimal` was retired).
  */
 const MIXED_FAST: AiSettings = {
   effort: 'low',
@@ -367,30 +375,35 @@ const COPILOT_FAST: AiSettings = {
 
 const CODEX_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
+  refine: { provider: CODEX, model: GPT_5_4_MINI },
   plan: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
   implement: {
     generator: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
     evaluator: { provider: CODEX, model: GPT_5_4_MINI, effort: 'low' },
   },
-  readiness: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
+  readiness: { provider: CODEX, model: GPT_5_4_MINI },
   ideate: { provider: CODEX, model: GPT_5_4_MINI },
-  createPr: { provider: CODEX, model: GPT_5_4_MINI, effort: 'minimal' },
+  createPr: { provider: CODEX, model: GPT_5_4_MINI },
 };
 
 /**
  * Frontier family — flagship everywhere at MAX effort: quality over cost, every flow on the
- * strongest model. Codex is floored to `high` (its effort ceiling — global `ai.effort` stays
- * `high` on `codex-frontier` so nothing implies a `max` codex row, which the schema would reject).
+ * strongest model. Codex is no longer floored: the GPT-5.6 flagship (`gpt-5.6-sol`) accepts
+ * `max`, so `codex-frontier` stamps the global effort AND the plan/implement rows at `max`
+ * directly (readiness stays `high`; refine/ideate/createPr leave effort unset and inherit the
+ * global `max`, which the codex provider clamp floors to `xhigh` at resolve time). `ultra` is
+ * deliberately NOT stamped anywhere in this family — it is plan-gated to Plus+ and would brick
+ * spawns on lower plans; operators opt in per-row.
  *
- * The family tops out at opus. `claude-fable-5` is intentionally NOT referenced even though it
- * is the catalog tier above opus: it is export-control-suspended and would be rejected at launch,
- * so the flagship-everywhere story stops at opus. Restoring fable when the suspension lifts is a
- * one-line model swap on the implement / plan rows here.
+ * The family tops out at Opus 5 / GPT-5.6 Sol. `claude-fable-5` is intentionally NOT referenced
+ * even though it is the catalog tier above Opus 5: Fable is 2x the Opus price, an operator spend
+ * decision rather than a flagship default, so the flagship-everywhere story stops at Opus 5.
+ * Opting in is a one-line model swap on the implement / plan rows here, or an `escalationMap`
+ * rung (`'claude-opus-5': 'claude-fable-5'`).
  */
 const MIXED_FRONTIER: AiSettings = {
   effort: 'max',
-  refine: { provider: CODEX, model: 'gpt-5.5' },
+  refine: { provider: CODEX, model: GPT_5_6_SOL },
   plan: { provider: CLAUDE, model: OPUS, effort: 'max' },
   implement: {
     generator: { provider: CLAUDE, model: OPUS, effort: 'max' },
@@ -398,7 +411,7 @@ const MIXED_FRONTIER: AiSettings = {
   },
   readiness: { provider: CLAUDE, model: OPUS, effort: 'high' },
   ideate: { provider: CLAUDE, model: OPUS },
-  createPr: { provider: CODEX, model: 'gpt-5.5' },
+  createPr: { provider: CODEX, model: GPT_5_6_SOL },
 };
 
 const CLAUDE_FRONTIER: AiSettings = {
@@ -428,17 +441,16 @@ const COPILOT_FRONTIER: AiSettings = {
 };
 
 const CODEX_FRONTIER: AiSettings = {
-  // Codex ceiling — global stays `high` so nothing implies a `max` codex row.
-  effort: 'high',
-  refine: { provider: CODEX, model: 'gpt-5.5' },
-  plan: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+  effort: 'max',
+  refine: { provider: CODEX, model: GPT_5_6_SOL },
+  plan: { provider: CODEX, model: GPT_5_6_SOL, effort: 'max' },
   implement: {
-    generator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
-    evaluator: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
+    generator: { provider: CODEX, model: GPT_5_6_SOL, effort: 'max' },
+    evaluator: { provider: CODEX, model: GPT_5_6_SOL, effort: 'max' },
   },
-  readiness: { provider: CODEX, model: 'gpt-5.5', effort: 'high' },
-  ideate: { provider: CODEX, model: 'gpt-5.5' },
-  createPr: { provider: CODEX, model: 'gpt-5.5' },
+  readiness: { provider: CODEX, model: GPT_5_6_SOL, effort: 'high' },
+  ideate: { provider: CODEX, model: GPT_5_6_SOL },
+  createPr: { provider: CODEX, model: GPT_5_6_SOL },
 };
 
 /**

--- a/src/business/settings/resolve-agent-override.ts
+++ b/src/business/settings/resolve-agent-override.ts
@@ -24,10 +24,11 @@ export interface ResolvedAgentOverride {
  *
  * - `model`: the definition's `model` when set, otherwise the row's own `model` (always
  *   present — every {@link AiFlowSettings} row is fully stamped with a provider-catalog model).
- * - `effort`: the definition's `effort` when set, but floored to the row's provider (e.g. an
- *   agent definition's `xhigh`/`max` clamps to `high` on a codex row, same as the global-default
- *   path — see {@link clampEffortToProvider}); otherwise {@link resolveEffortForRow}'s result
- *   (per-flow row effort, falling through to the global default floored to the row's provider).
+ * - `effort`: the definition's `effort` when set, but floored to the row's provider (e.g. a
+ *   binding-supplied `xhigh` passes through unclamped on a codex row, `max` floors to `xhigh`,
+ *   and `ultra` passes through with the CLI as arbiter — same as the global-default path, see
+ *   {@link clampEffortToProvider}); otherwise {@link resolveEffortForRow}'s result (per-flow row
+ *   effort, falling through to the global default floored to the row's provider).
  *
  * `binding` is `undefined` when the role has no bound definition — resolution then falls
  * straight through to the per-flow row / global default, identical to `resolveEffortForRow`

--- a/src/business/settings/resolve-effort.ts
+++ b/src/business/settings/resolve-effort.ts
@@ -42,16 +42,18 @@ export const resolveEffortForRow = (
  *
  * Exported so callers that source effort from somewhere other than the global-default fallback
  * (e.g. an agent-definition binding — see `resolveAgentOverride`) can still apply the same
- * per-provider floor. Without this, a binding-supplied `xhigh`/`max` reaches the codex CLI
- * verbatim; codex only accepts `minimal | low | medium | high` and rejects unknown levels,
- * so an unclamped value fails every spawn for that role.
+ * per-provider floor. Codex accepts `low..xhigh` on every catalog model, so `xhigh` now passes
+ * through unclamped; `max` still clamps because only the 5.6 family accepts it and this clamp
+ * has no model context to narrow further. Explicit per-flow `max` / `ultra` bypasses this clamp
+ * entirely (row effort returns verbatim, below) with the codex CLI as the final arbiter — same
+ * policy as custom model ids.
  *
  * Only the known-dangerous codex case is floored — any other string (including values outside
  * the superset) passes through unchanged, letting the provider CLI be the final arbiter of
  * genuinely unknown effort levels.
  */
 export const clampEffortToProvider = (effort: string, provider: AiProvider): string => {
-  if (provider === 'openai-codex' && (effort === 'xhigh' || effort === 'max')) return 'high';
+  if (provider === 'openai-codex' && effort === 'max') return 'xhigh';
   return effort;
 };
 
@@ -61,7 +63,7 @@ export const clampEffortToProvider = (effort: string, provider: AiProvider): str
  * - claude-code: identity (its native vocabulary IS the superset).
  * - github-copilot: identity (Copilot accepts everything in the superset; `none` is only
  *   surfaced as a per-flow opt-out and never selected globally).
- * - openai-codex: `minimal | low | medium | high`. `xhigh` / `max` clamp to `high`.
+ * - openai-codex: `max` clamps to `xhigh`; everything else identity.
  */
 const _floorForProvider = (effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max', provider: AiProvider): string =>
   clampEffortToProvider(effort, provider);

--- a/src/business/task/escalation-map.ts
+++ b/src/business/task/escalation-map.ts
@@ -15,10 +15,11 @@ import type { Logger } from '@src/business/observability/logger.ts';
 /**
  * Built-in escalation ladder. Keys are the model id the generator is currently spawning
  * with; values are the model id to switch to after a plateau exit. The Claude ladders are
- * climbed cheapest-first one rung per plateau — each tier points at the next stronger tier, so
- * an economic preset that starts a tier below flagship climbs through every intermediate rung
- * (haiku → sonnet → opus). The GPT mini tiers instead step straight to the frontier default
- * (`gpt-5.5`); the economic full tier (`gpt-5.4`) climbs the single remaining rung to it.
+ * climbed cheapest-first one rung per plateau — the current-generation dash tier jumps straight
+ * to the same-price current flagship (Sonnet 5 → Opus 5), while legacy tiers climb gradually
+ * through their own generation and converge at the flagship (Sonnet 4.6 → Opus 4.8 → Opus 5).
+ * The GPT mini tiers step to the old-generation full tier, which chains into the new GPT-5.6
+ * family (`gpt-5.4` → `gpt-5.5` → `gpt-5.6-sol`); within 5.6, `luna` → `terra` → `sol`.
  * Entries are seeded from the per-provider model catalogs at
  * `domain/value/settings-models/` — weakening or removing an entry here implies the
  * corresponding model is no longer in catalog, so this file and the catalog are kept in
@@ -32,27 +33,48 @@ import type { Logger } from '@src/business/observability/logger.ts';
  * lockstep with `domain/value/settings-models/`.
  *
  * Sonnet 5 is the default Sonnet for the dash-form (Claude-Code) ladder: Haiku climbs to
- * `claude-sonnet-5`, which climbs to `claude-opus-4-8`. The legacy `claude-sonnet-4-6` rung is
- * RETAINED so configs explicitly pinned to Sonnet 4.6 still climb to Opus. The Copilot dot-form
+ * `claude-sonnet-5`, which climbs directly to `claude-opus-5` — same price, vendor-stated
+ * drop-in, strictly better, so no intermediate rung is worth spending. The legacy
+ * `claude-sonnet-4-6` rung is RETAINED so configs explicitly pinned to Sonnet 4.6 still climb
+ * (to `claude-opus-4-8`), and `claude-opus-4-8` itself now carries a rung to `claude-opus-5` so
+ * pinned Opus-4.8 configs get a live escalation step at the same price. The Copilot dot-form
  * ladder deliberately stays on `claude-sonnet-4.6`: Sonnet 5's slug carries no dot/date, so its
  * Copilot id is the SAME string (`claude-sonnet-5`) as the Claude-Code id — a flat map has one
- * value per key, and the dash form (the primary provider) wins it pointing at `claude-opus-4-8`.
+ * value per key, and the dash form (the primary provider) wins it pointing at `claude-opus-5`.
  * A Copilot row pinned to `claude-sonnet-5` therefore has no dot-form Opus rung; that edge is
  * accepted rather than mis-routing the Claude-Code climb to a dot-form Opus id Claude Code rejects.
+ *
+ * `claude-opus-5` (like `claude-sonnet-5`) is likewise an undotted shared-slug id — identical on
+ * both catalogs. It appears only as a DESTINATION here, never a key: because both catalogs carry
+ * the identical string, the destination is valid whichever provider's row climbed to it, so the
+ * flat-map single-value constraint costs nothing. It deliberately has no key of its own — it is
+ * the dash-form top of the ladder (Fable is opt-in only, at 2x the Opus price, never a default
+ * rung — see the `escalationMap` promotion path noted below) — and giving it a key would also
+ * collide with any future dot-form need. The dot-form ladder deliberately stops at
+ * `claude-opus-4.8`: `claude-opus-5` is plan-gated on Copilot (Pro+/Max/Business/Enterprise), so
+ * the default ladder must never steer a mid-task Copilot spawn into a model many accounts cannot
+ * use — opt in explicitly via `escalationMap` (`'claude-opus-4.8': 'claude-opus-5'`) if desired.
  */
 export const DEFAULT_ESCALATION_MAP: Readonly<Record<string, string>> = {
-  // Claude (Claude-Code / Codex dash-form) — Haiku → Sonnet 5 → Opus; Sonnet 4.6 still climbs.
+  // Claude (Claude-Code dash-form) — Haiku → Sonnet 5 → Opus 5; legacy tiers chain through their
+  // own generation (Sonnet 4.6 → Opus 4.8 → Opus 5) and converge at the flagship.
   'claude-haiku-4-5': 'claude-sonnet-5',
-  'claude-sonnet-5': 'claude-opus-4-8',
+  'claude-sonnet-5': 'claude-opus-5',
   'claude-sonnet-4-6': 'claude-opus-4-8',
-  // Claude (Copilot dot-form) — Haiku → Sonnet 4.6 → Opus (Sonnet 5 shares the dash-form key above).
+  'claude-opus-4-8': 'claude-opus-5',
+  // Claude (Copilot dot-form) — Haiku → Sonnet 4.6 → Opus 4.8. Opus 4.8 is deliberately the
+  // dot-form top: claude-opus-5 is plan-gated on Copilot, so the default ladder never steers a
+  // mid-task spawn into a model many accounts cannot use (add a rung via escalationMap to opt in).
   'claude-haiku-4.5': 'claude-sonnet-4.6',
   'claude-sonnet-4.6': 'claude-opus-4.8',
-  // Copilot/Codex GPT — mini variants step up to their full-tier frontier, and the
-  // economic full tier (`gpt-5.4`) climbs to the flagship.
+  // Copilot/Codex GPT — minis step to the 5.5 full tier; the 5.5/5.4 generation chains into the
+  // 5.6 family; within 5.6, luna → terra → sol (sol is the flagship top rung).
   'gpt-5-mini': 'gpt-5.5',
   'gpt-5.4-mini': 'gpt-5.5',
   'gpt-5.4': 'gpt-5.5',
+  'gpt-5.5': 'gpt-5.6-sol',
+  'gpt-5.6-luna': 'gpt-5.6-terra',
+  'gpt-5.6-terra': 'gpt-5.6-sol',
 };
 
 /**
@@ -102,24 +124,44 @@ export const escalationLadderCyclicFrom = (map: Readonly<Record<string, string>>
 };
 
 /**
- * The reasoning-effort level the Copilot / Codex effort rung climbs TO. Fixed at `high`: it is a
- * member of both those providers' effort vocabularies (Copilot `none..max`, Codex `minimal..high`),
- * it is the level the Codex vocabulary tops out at, and it is a meaningful step up from the ~medium
- * effort those CLIs default a fresh row to. Claude does NOT use this constant — its rung is
- * model-aware (see {@link nextEffortRung}) because Claude Code's own default is `xhigh` on
- * xhigh-capable models, so a fixed `high` target would be a no-op or an outright downgrade.
+ * The reasoning-effort level the Copilot effort rung climbs TO. Fixed at `high`: it is a member
+ * of the Copilot effort vocabulary (`none..max`), and it is a meaningful step up from the ~medium
+ * effort the CLI defaults a fresh row to. Non-OpenAI models' effort semantics are opaque, so
+ * Copilot stays conservative here. Claude does NOT use this constant — its rung is model-aware
+ * (see {@link nextEffortRung}) because Claude Code's own default is `xhigh` on xhigh-capable
+ * models, so a fixed `high` target would be a no-op or an outright downgrade. Codex uses its own
+ * fixed target, {@link CODEX_EFFORT_ESCALATION_TARGET}, not this one.
  *
  * @public
  */
 export const EFFORT_ESCALATION_TARGET = 'high';
 
 /**
- * Effort levels at or above {@link EFFORT_ESCALATION_TARGET}. A Copilot / Codex generator already
- * running at one of these has no headroom for the effort rung — it is spent and the policy falls
- * through to the same-model nudge. Uses the Copilot superset (`high | xhigh | max`); the Codex
- * vocabulary tops out at `high`, which is covered. Not consulted on the Claude path.
+ * The reasoning-effort level the Codex effort rung climbs TO. Fixed at `xhigh`: it is accepted by
+ * every codex catalog model since the CLI's `low | medium | high | xhigh | max | ultra` vocabulary
+ * change, so the rung is live for every preset — the old shared `high` target left it permanently
+ * spent for every codex preset, which stamps `high` on implement by default. `max` / `ultra` are
+ * deliberately NOT the target: they are narrower than the full catalog (5.6-family-only /
+ * sol-terra-only, plan-gated) and this rung has no per-model context to know whether they apply.
+ *
+ * @public
+ */
+export const CODEX_EFFORT_ESCALATION_TARGET = 'xhigh';
+
+/**
+ * Effort levels at or above {@link EFFORT_ESCALATION_TARGET}. A Copilot generator already running
+ * at one of these has no headroom for the effort rung — it is spent and the policy falls through
+ * to the same-model nudge. Copilot-only: Codex uses {@link CODEX_EFFORT_AT_OR_ABOVE_TARGET}.
  */
 const EFFORT_AT_OR_ABOVE_TARGET: ReadonlySet<string> = new Set(['high', 'xhigh', 'max']);
+
+/**
+ * Effort levels at or above {@link CODEX_EFFORT_ESCALATION_TARGET}. A Codex generator already
+ * running at one of these has no headroom for the effort rung. `max` / `ultra` are narrower than
+ * the universal `xhigh` target but both still count as "at or above" it — a generator already
+ * running one of the narrower tiers is never downgraded to `xhigh` by this rung.
+ */
+const CODEX_EFFORT_AT_OR_ABOVE_TARGET: ReadonlySet<string> = new Set(['xhigh', 'max', 'ultra']);
 
 /**
  * Providers that expose a reasoning-effort dimension the adapter can raise. All three current
@@ -154,8 +196,8 @@ const CLAUDE_EFFORTLESS_MODELS: ReadonlySet<string> = new Set(['claude-haiku-4-5
 /**
  * Effort-capable Claude models whose Claude-Code CLI default is `high`, NOT `xhigh` — i.e. models
  * that do not expose the `xhigh` tier. Sonnet 4.6 is the only such model in the Claude-Code catalog.
- * Every OTHER effort-capable Claude model (Sonnet 5, Opus 4.7/4.8, Fable 5, and — by default — any
- * future frontier id not listed here) is treated as xhigh-capable, whose CLI default is `xhigh`.
+ * Every OTHER effort-capable Claude model (Sonnet 5, Opus 4.7/4.8/5, Fable 5, and — by default —
+ * any future frontier id not listed here) is treated as xhigh-capable, whose CLI default is `xhigh`.
  * Kept in lockstep with the per-provider catalogs in `domain/value/settings-models/`: the catalog
  * fingerprint test flags a model bump so this classification is re-checked alongside the ladder.
  */
@@ -167,7 +209,7 @@ const CLAUDE_HIGH_DEFAULT_MODELS: ReadonlySet<string> = new Set(['claude-sonnet-
  *
  *   - Haiku (no effort dimension) → `undefined`; the rung is skipped gracefully.
  *   - The `effective` current effort is the explicit level, or — when unset — the CLI default:
- *     `xhigh` on xhigh-capable models (Opus 4.7/4.8, Sonnet 5, Fable 5, …), else `high`.
+ *     `xhigh` on xhigh-capable models (Opus 4.7/4.8/5, Sonnet 5, Fable 5, …), else `high`.
  *   - The target is the next power tier strictly above `effective`, capped at `max`: an explicit
  *     `low | medium | high` on an xhigh-capable model climbs to `xhigh`; `unset | xhigh` (and every
  *     tier on a non-xhigh-capable model) climbs to `max`; `max` is the ceiling → `undefined` (spent).
@@ -205,11 +247,15 @@ const claudeEffortRung = (model: string, currentEffort: string | undefined): str
  * Provider-aware target:
  *   - **claude-code** — model-aware ({@link claudeEffortRung}). Claude Code's own default effort is
  *     `xhigh` on xhigh-capable models, so the rung climbs to the next tier up (…→ `xhigh` → `max`),
- *     never re-stamping the implicit default. The shipped default posture (`claude-opus-4-8`, effort
+ *     never re-stamping the implicit default. The shipped default posture (`claude-opus-5`, effort
  *     unset) therefore escalates to `max` in a single step.
- *   - **github-copilot / openai-codex** — unchanged fixed target {@link EFFORT_ESCALATION_TARGET}
- *     (`high`); `unset` counts as escalatable (their CLI default sits ~medium), and `high | xhigh |
- *     max` are spent. `model` plays no role on this path.
+ *   - **github-copilot** — fixed target {@link EFFORT_ESCALATION_TARGET} (`high`); `unset` counts as
+ *     escalatable (its CLI default sits ~medium), and `high | xhigh | max` are spent. Non-OpenAI
+ *     models' effort semantics are opaque, so Copilot stays conservative rather than climbing further.
+ *   - **openai-codex** — fixed target {@link CODEX_EFFORT_ESCALATION_TARGET} (`xhigh`, universal
+ *     across the codex catalog since the vocabulary change); `unset` and a legacy `minimal` (retired,
+ *     pre-migration) count as escalatable, and `xhigh | max | ultra` are spent. `model` plays no role
+ *     on either the Copilot or Codex path.
  *
  * `currentEffort` is the resolved per-flow effort (`resolveEffort`/`resolveEffortForRow`), or
  * `undefined` for the CLI default. Pure; no I/O.
@@ -223,7 +269,11 @@ export const nextEffortRung = (
 ): string | undefined => {
   if (provider === undefined || !EFFORT_CAPABLE_PROVIDERS.has(provider)) return undefined;
   if (provider === 'claude-code') return claudeEffortRung(model, currentEffort);
-  // Copilot / Codex keep the original fixed-`high` semantics — see EFFORT_ESCALATION_TARGET.
-  if (currentEffort !== undefined && EFFORT_AT_OR_ABOVE_TARGET.has(currentEffort)) return undefined;
-  return EFFORT_ESCALATION_TARGET;
+  if (provider === 'github-copilot') {
+    if (currentEffort !== undefined && EFFORT_AT_OR_ABOVE_TARGET.has(currentEffort)) return undefined;
+    return EFFORT_ESCALATION_TARGET;
+  }
+  // openai-codex: xhigh is universal across the codex catalog; max/ultra are already above it.
+  if (currentEffort !== undefined && CODEX_EFFORT_AT_OR_ABOVE_TARGET.has(currentEffort)) return undefined;
+  return CODEX_EFFORT_ESCALATION_TARGET;
 };

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -54,10 +54,10 @@ const triggerLabel = (trigger: EscalationTrigger): string =>
  * At the top — before spending the same-model `nudge` — the policy tries a same-model EFFORT rung
  * (`escalate-effort`) when the provider/model exposes an effort dimension and the generator has
  * headroom. The target is provider-aware ({@link nextEffortRung}): Claude climbs its own tiers (…→
- * `xhigh` → `max`) because Claude Code's default is already `xhigh` on xhigh-capable models, while
- * Copilot/Codex step to a fixed `high`. A further failure then nudges, and a failure after the nudge
+ * `xhigh` → `max`) because Claude Code's default is already `xhigh` on xhigh-capable models;
+ * Copilot steps to a fixed `high`; Codex to a fixed `xhigh`. A further failure then nudges, and a failure after the nudge
  * tops out. The effort rung is what activates a live remedy for the shipped default posture
- * (`claude-opus-4-8`, effort unset → `max`, which sits at the top of the model ladder with no
+ * (`claude-opus-5`, effort unset → `max`, which sits at the top of the model ladder with no
  * stronger rung above it).
  *
  * Outputs (discriminated):
@@ -121,9 +121,9 @@ export interface DecideEscalationProps {
    * `undefined` for the CLI default. Read alongside {@link generatorProvider} and
    * {@link generatorModel} to decide whether the effort rung has headroom — the target is
    * provider/model-aware ({@link nextEffortRung}): Claude climbs its own tiers (unset on an
-   * xhigh-capable model → `max`), Copilot/Codex step to a fixed `high`, and a generator already at
-   * its ceiling falls through to the nudge. OPTIONAL for the same backward-compatibility reason as
-   * {@link generatorProvider}.
+   * xhigh-capable model → `max`), Copilot steps to a fixed `high`, Codex to a fixed `xhigh`, and a
+   * generator already at its ceiling falls through to the nudge. OPTIONAL for the same
+   * backward-compatibility reason as {@link generatorProvider}.
    */
   readonly generatorEffort?: string | undefined;
 }
@@ -180,10 +180,11 @@ export const decideEscalation = (props: DecideEscalationProps): EscalationDecisi
   // Cheapest remedy before the change-of-approach nudge: raise reasoning effort on the SAME model
   // when the provider/model exposes an effort dimension and there is headroom. The target is
   // provider/model-aware (nextEffortRung): Claude climbs its own tiers (unset on an xhigh-capable
-  // model → `max`, so the shipped default `claude-opus-4-8` gets a live escalation step instead of
-  // settling done-with-warning after one nudge), Copilot/Codex step to a fixed `high`. Skipped
-  // gracefully (falls through to the nudge) when the caller supplied no provider/effort context,
-  // the provider/model has no effort knob, or the generator is already at its ceiling.
+  // model → `max`, so the shipped default `claude-opus-5` gets a live escalation step instead of
+  // settling done-with-warning after one nudge), Copilot steps to a fixed `high`, Codex to a fixed
+  // `xhigh`. Skipped gracefully (falls through to the nudge) when the caller supplied no
+  // provider/effort context, the provider/model has no effort knob, or the generator is already
+  // at its ceiling.
   const effortTarget = nextEffortRung(props.generatorProvider, props.generatorModel, props.generatorEffort);
   if (effortTarget !== undefined) {
     return {

--- a/src/domain/entity/settings.ts
+++ b/src/domain/entity/settings.ts
@@ -34,13 +34,15 @@ const LogLevelSchema = z.enum(['silent', 'debug', 'info', 'warn', 'error']) sati
  */
 export type AiProvider = 'claude-code' | 'github-copilot' | 'openai-codex';
 
-/** The `claude-code` provider id — reused by the schema enum/literal and the legacy-row migration check. */
+/** Provider ids — reused by the schema enum/literals and the legacy-row migration checks below. */
 const PROVIDER_CLAUDE_CODE = 'claude-code';
+const PROVIDER_GITHUB_COPILOT = 'github-copilot';
+const PROVIDER_OPENAI_CODEX = 'openai-codex';
 
 const AiProviderSchema = z.enum([
   PROVIDER_CLAUDE_CODE,
-  'github-copilot',
-  'openai-codex',
+  PROVIDER_GITHUB_COPILOT,
+  PROVIDER_OPENAI_CODEX,
 ]) satisfies z.ZodType<AiProvider>;
 
 /**
@@ -48,10 +50,14 @@ const AiProviderSchema = z.enum([
  * provider's native enum at parse time (a Copilot-only level on a Claude row would surface as
  * a schema error). The unified global `ai.effort` accepts the superset; `resolveEffort` floors
  * it to a provider-supported level at read time.
+ *
+ * Codex now carries `xhigh` (all catalog models) plus `max` / `ultra` (5.6-family /
+ * sol-terra-only, CLI-enforced); `minimal` was retired by codex ≥ 0.145 and migrates to `low`
+ * at parse time (see {@link migrateStaleRow}).
  */
 const ClaudeEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max']);
 const CopilotEffortSchema = z.enum(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
-const CodexEffortSchema = z.enum(['minimal', 'low', 'medium', 'high']);
+const CodexEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
 
 /** Superset across providers. The global `ai.effort` accepts any of these; `resolveEffort` floors. */
 const GlobalEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh', 'max']);
@@ -74,13 +80,13 @@ const ClaudeFlowRowSchema = z.object({
 });
 
 const CopilotFlowRowSchema = z.object({
-  provider: z.literal('github-copilot'),
+  provider: z.literal(PROVIDER_GITHUB_COPILOT),
   model: CopilotModelSchema,
   effort: CopilotEffortSchema.optional(),
 });
 
 const CodexFlowRowSchema = z.object({
-  provider: z.literal('openai-codex'),
+  provider: z.literal(PROVIDER_OPENAI_CODEX),
   model: CodexModelSchema,
   effort: CodexEffortSchema.optional(),
 });
@@ -169,26 +175,49 @@ const seedLegacyCreatePrRow = (ai: unknown): unknown => {
   return { ...aiObj, createPr: { ...(refine as Record<string, unknown>) } };
 };
 
-/** Retired Claude model slug and its catalog successor — rewritten at parse time. */
-const RETIRED_CLAUDE_OPUS = 'claude-opus-4-7';
-const SUCCESSOR_CLAUDE_OPUS = 'claude-opus-4-8';
+/**
+ * Retired model slugs and their catalog successors, per provider — rewritten at parse time.
+ * Provider-guarded so a colliding custom string on another provider's row is never touched.
+ * (Same silence/idempotence policy as {@link promoteLegacyImplementRow}. Cite each retirement:
+ * `claude-opus-4-7` retired for `claude-opus-4-8`; Copilot delisted `claude-opus-4.6-fast` for
+ * `claude-opus-4.8-fast`; codex ≥ 0.145 dropped `gpt-5.2` / `gpt-5.3-codex` /
+ * `gpt-5.3-codex-spark` — `gpt-5.5` is the conservative successor and the default ladder climbs
+ * it to `gpt-5.6-sol` on plateau.)
+ */
+const RETIRED_MODEL_REMAPS: ReadonlyArray<{
+  readonly provider: AiProvider;
+  readonly from: string;
+  readonly to: string;
+}> = [
+  { provider: PROVIDER_CLAUDE_CODE, from: 'claude-opus-4-7', to: 'claude-opus-4-8' },
+  { provider: PROVIDER_GITHUB_COPILOT, from: 'claude-opus-4.6-fast', to: 'claude-opus-4.8-fast' },
+  { provider: PROVIDER_OPENAI_CODEX, from: 'gpt-5.2', to: 'gpt-5.5' },
+  { provider: PROVIDER_OPENAI_CODEX, from: 'gpt-5.3-codex', to: 'gpt-5.5' },
+  { provider: PROVIDER_OPENAI_CODEX, from: 'gpt-5.3-codex-spark', to: 'gpt-5.5' },
+];
 
-/** Rewrite a single row in place when it pins the retired Claude Opus model. */
-const migrateRetiredOpusRow = (row: unknown): unknown => {
+/** Codex retired the 'minimal' reasoning-effort level (codex CLI >= 0.145); 'low' succeeds it. */
+const RETIRED_CODEX_EFFORT = 'minimal';
+
+/** Rewrite one row: retired-model remap by (provider, model), then codex 'minimal' -> 'low'. */
+const migrateStaleRow = (row: unknown): unknown => {
   if (typeof row !== 'object' || row === null) return row;
-  const rowObj = row as Record<string, unknown>;
-  if (rowObj['provider'] === PROVIDER_CLAUDE_CODE && rowObj['model'] === RETIRED_CLAUDE_OPUS) {
-    return { ...rowObj, model: SUCCESSOR_CLAUDE_OPUS };
+  let next = row as Record<string, unknown>;
+  const remap = RETIRED_MODEL_REMAPS.find((r) => next['provider'] === r.provider && next['model'] === r.from);
+  if (remap !== undefined) next = { ...next, model: remap.to };
+  if (next['provider'] === PROVIDER_OPENAI_CODEX && next['effort'] === RETIRED_CODEX_EFFORT) {
+    next = { ...next, effort: 'low' };
   }
-  return row;
+  return next;
 };
 
 /**
- * Rewrite any AI row pinned to the now-removed Claude model `claude-opus-4-7` to its catalog
- * successor `claude-opus-4-8`. The settings schema accepts off-catalog model strings, so a
- * persisted `claude-opus-4-7` row LOADS fine — but the Claude adapter rejects non-catalog
- * models at spawn time with `InvalidStateError`. Rewriting at parse time keeps existing users
- * on a working model across the catalog change.
+ * Rewrite any AI row pinned to a retired model slug (see {@link RETIRED_MODEL_REMAPS}) to its
+ * catalog successor, and any codex row carrying the retired `minimal` effort level to `low`.
+ * The settings schema accepts off-catalog model strings, so a persisted retired-model row LOADS
+ * fine — but the adapter rejects non-catalog models at spawn time with `InvalidStateError`.
+ * Rewriting at parse time keeps existing users on a working model/effort across the catalog
+ * change.
  *
  * Covers the five flat rows (`refine` / `plan` / `readiness` / `ideate` / `createPr`) and the
  * nested `implement.{generator,evaluator}` pair. Runs at parse time without bumping
@@ -199,20 +228,20 @@ const migrateRetiredOpusRow = (row: unknown): unknown => {
  * Returns the input untouched for non-object / null shapes — it runs on raw `unknown` before
  * validation, so schema validation still surfaces the real error message for malformed input.
  */
-const migrateRetiredClaudeOpus = (ai: unknown): unknown => {
+const migrateStaleAiRows = (ai: unknown): unknown => {
   if (typeof ai !== 'object' || ai === null) return ai;
   const aiObj = ai as Record<string, unknown>;
   const next: Record<string, unknown> = { ...aiObj };
   for (const flow of ['refine', 'plan', 'readiness', 'ideate', 'createPr'] as const) {
-    if (flow in next) next[flow] = migrateRetiredOpusRow(next[flow]);
+    if (flow in next) next[flow] = migrateStaleRow(next[flow]);
   }
   const implement = next['implement'];
   if (typeof implement === 'object' && implement !== null) {
     const implObj = implement as Record<string, unknown>;
     next['implement'] = {
       ...implObj,
-      generator: migrateRetiredOpusRow(implObj['generator']),
-      evaluator: migrateRetiredOpusRow(implObj['evaluator']),
+      generator: migrateStaleRow(implObj['generator']),
+      evaluator: migrateStaleRow(implObj['evaluator']),
     };
   }
   return next;
@@ -220,12 +249,13 @@ const migrateRetiredClaudeOpus = (ai: unknown): unknown => {
 
 /**
  * Compose the parse-time preprocessors so they all fire on every parse. Order matters:
- * {@link migrateRetiredClaudeOpus} runs LAST so it sees the implement row already nested into
- * `{ generator, evaluator }` (so a legacy flat `claude-opus-4-7` implement row migrates both
- * roles) and the createPr row already seeded from refine (so a 4-7 seeded createPr migrates too).
+ * {@link migrateStaleAiRows} runs LAST so it sees the implement row already nested into
+ * `{ generator, evaluator }` (so a legacy flat retired-model/`minimal`-effort implement row
+ * migrates both roles) and the createPr row already seeded from refine (so a seeded createPr
+ * migrates too).
  */
 const promoteLegacyAiRows = (ai: unknown): unknown =>
-  migrateRetiredClaudeOpus(seedLegacyCreatePrRow(promoteLegacyImplementRow(ai)));
+  migrateStaleAiRows(seedLegacyCreatePrRow(promoteLegacyImplementRow(ai)));
 
 /**
  * Parse-time self-heal for the `maxTurns ≥ plateauThreshold` cross-knob invariant.

--- a/src/domain/value/settings-models/claude.ts
+++ b/src/domain/value/settings-models/claude.ts
@@ -8,14 +8,14 @@
  * mistyped CLI input is caught with `InvalidStateError` rather than dispatched as
  * `--model <bogus>`.
  *
- * `claude-fable-5` is the frontier tier above Opus 4.8; the `[1m]` suffix is Claude Code's
+ * `claude-fable-5` is the frontier tier above Opus 5; the `[1m]` suffix is Claude Code's
  * long-context (1M-token) variant syntax for the same model — a literal part of the `--model`
  * value, passed through verbatim (argv array, never a shell — the brackets cannot glob). Opus
  * ships a `[1m]` variant too: on large repos the long window avoids mid-session compaction,
  * which is the practical "better and faster" for deep implement runs. The `[1m]` and fable
  * entries are deliberate opt-in only: none is referenced by presets, defaults, or the built-in
  * escalation ladder — pick one per row, or extend `settings.harness.escalationMap` with a rung
- * such as `'claude-opus-4-8': 'claude-fable-5'`.
+ * such as `'claude-opus-5': 'claude-fable-5'`.
  *
  * `claude-sonnet-5` is the Sonnet-5 successor to Sonnet 4.6 and the default Sonnet across
  * presets / defaults / the escalation ladder; `claude-sonnet-4-6` is KEPT alongside it (both
@@ -24,6 +24,12 @@
  * no 200K default to opt out of), unlike Opus/Fable whose Claude-Code default is 200K and whose
  * `[1m]` suffix is the real 1M selector. The 1M figure is recorded in the context-window tables
  * against the bare id, not via a suffix.
+ *
+ * `claude-opus-5` is the Opus 4.8 successor at the same price and the **default Opus** across
+ * presets, new-install defaults, and the escalation ladder; natively 1M in Claude Code (default
+ * AND max) so — like `claude-sonnet-5` — it has **no `[1m]` variant**; 128K output; separate
+ * rate-limit bucket from Opus 4.x. `claude-opus-4-8` is kept so pinned configs work (and now
+ * carries a ladder rung to Opus 5).
  */
 export type ClaudeModel =
   | 'claude-haiku-4-5'
@@ -31,6 +37,7 @@ export type ClaudeModel =
   | 'claude-sonnet-5'
   | 'claude-opus-4-8'
   | 'claude-opus-4-8[1m]'
+  | 'claude-opus-5'
   | 'claude-fable-5'
   | 'claude-fable-5[1m]';
 
@@ -40,6 +47,7 @@ export const CLAUDE_MODELS: readonly ClaudeModel[] = [
   'claude-sonnet-5',
   'claude-opus-4-8',
   'claude-opus-4-8[1m]',
+  'claude-opus-5',
   'claude-fable-5',
   'claude-fable-5[1m]',
 ] as const;

--- a/src/domain/value/settings-models/codex.ts
+++ b/src/domain/value/settings-models/codex.ts
@@ -1,33 +1,36 @@
-// Verified against the `codex -m` picker (OpenAI Codex CLI v0.138.0).
-// Docs: https://github.com/openai/codex#model-selection — facts cross-checked against
-// https://developers.openai.com/codex/models
+// Verified against the live CLI model cache (codex CLI v0.145.0, `~/.codex/models_cache.json`,
+// 2026-07-26). Docs: https://github.com/openai/codex#model-selection — facts cross-checked
+// against https://developers.openai.com/codex/models
 
 /**
- * Models supported by the OpenAI Codex CLI adapter. Enumerated from the `codex -m`
- * picker (codex v0.138.0): `gpt-5.5` is the frontier default — the model `codex-only` runs
- * implement on and the top rung of the Codex escalation ladder; `gpt-5.4` is the strong
- * frontier coder one tier below it (where the economic preset starts implement before climbing
- * to `gpt-5.5` on a plateau); `gpt-5.4-mini` is the efficient/mini tier; `gpt-5.3-codex-spark`
- * is a text-only research preview surfaced to ChatGPT Pro accounts only. `gpt-5.2` and
- * `gpt-5.3-codex` are DEPRECATED for ChatGPT sign-in but kept in the allowlist because they
- * remain available via API-key auth — removing them would break pinned configs. The codex
- * backend serves models dynamically — new entries that appear in the picker after this list
- * was captured require a one-line update here. Domain-owned: persisted Settings reference
- * these identifiers; adapters consume them when invoking the CLI subprocess. The adapter
- * validates `AiSession.model` against this set and surfaces `InvalidStateError` for unknowns.
- * `codex-auto-review` is the synthetic model id the CLI uses for its review subcommand and is
- * kept here so review chains can name it.
+ * Models supported by the OpenAI Codex CLI adapter. `gpt-5.6-sol` is the flagship / top rung of
+ * the Codex escalation ladder; `gpt-5.6-terra` is the balanced everyday tier; `gpt-5.6-luna` is
+ * the most cost-efficient tier in the 5.6 family. `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` remain
+ * served for pinned configs. The 5.6 family requires codex CLI ≥ ~0.145 — older CLIs reject
+ * these ids with "requires a newer version of Codex". Bare `gpt-5.6` is an API-only alias
+ * rejected under ChatGPT auth — deliberately NOT listed here.
+ *
+ * `gpt-5.2`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark` are gone from the codex CLI entirely and
+ * were REMOVED from this catalog; persisted rows pinned to any of the three are silently
+ * remapped to `gpt-5.5` at parse time (see `domain/entity/settings.ts`).
+ *
+ * The codex backend serves models dynamically — new entries that appear in the picker after
+ * this list was captured require a one-line update here. Domain-owned: persisted Settings
+ * reference these identifiers; adapters consume them when invoking the CLI subprocess. The
+ * adapter validates `AiSession.model` against this set and surfaces `InvalidStateError` for
+ * unknowns. `codex-auto-review` is the synthetic model id the CLI uses for its review
+ * subcommand and is kept here so review chains can name it.
  */
 export type CodexModel =
-  'gpt-5.5' | 'gpt-5.4' | 'gpt-5.4-mini' | 'gpt-5.3-codex-spark' | 'gpt-5.3-codex' | 'gpt-5.2' | 'codex-auto-review';
+  'gpt-5.6-sol' | 'gpt-5.6-terra' | 'gpt-5.6-luna' | 'gpt-5.5' | 'gpt-5.4' | 'gpt-5.4-mini' | 'codex-auto-review';
 
 export const CODEX_MODELS: readonly CodexModel[] = [
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',
-  'gpt-5.3-codex-spark',
-  'gpt-5.3-codex',
-  'gpt-5.2',
   'codex-auto-review',
 ] as const;
 

--- a/src/domain/value/settings-models/context-window.ts
+++ b/src/domain/value/settings-models/context-window.ts
@@ -18,10 +18,10 @@
  *
  *  - **Claude (Anthropic)** — 200 000 for the 4.x line (Haiku 4.5 / Sonnet 4.6 / Opus 4.8).
  *    The `[1m]` suffix IS Claude Code's 1M-token long-context selector — the figure comes from
- *    the id itself, not a model card. Sonnet 5 (`claude-sonnet-5`) is the exception: it has NO
- *    `[1m]` variant because on the Anthropic API it ALWAYS runs at its native 1 000 000 window in
- *    Claude Code — so the 1M figure is keyed on the bare id, the first base id (not a `[1m]`
- *    selector) to carry a 1M window here.
+ *    the id itself, not a model card. Sonnet 5 (`claude-sonnet-5`) and Opus 5 (`claude-opus-5`)
+ *    are the exception: neither has a `[1m]` variant because on the Anthropic API both ALWAYS run
+ *    at their native 1 000 000 window in Claude Code — so the 1M figure is keyed on the bare id
+ *    rather than a `[1m]` selector for both.
  *  - **Copilot / Codex** — omitted; the CLIs do not surface per-model window sizes.
  *
  * Pure domain — no `node:*` I/O.
@@ -35,6 +35,8 @@ const CONTEXT_WINDOW: Readonly<Record<string, number>> = {
   // Sonnet 5 always runs at its native 1M window on the Anthropic API — no `[1m]` selector, so
   // the bare id carries the 1M figure directly.
   'claude-sonnet-5': 1_000_000,
+  // Opus 5 — natively 1M in Claude Code — no `[1m]` selector; the bare id carries the figure.
+  'claude-opus-5': 1_000_000,
   // `[1m]` is Claude Code's 1M-token long-context selector — the window IS the id suffix.
   'claude-opus-4-8[1m]': 1_000_000,
   'claude-fable-5[1m]': 1_000_000,

--- a/src/domain/value/settings-models/copilot.ts
+++ b/src/domain/value/settings-models/copilot.ts
@@ -1,4 +1,4 @@
-// Reconciled to GitHub's official supported-models doc (as of 2026-06-30).
+// Reconciled to GitHub's official supported-models doc (as of 2026-07-26).
 // Docs: https://docs.github.com/en/copilot/reference/ai-models/supported-models
 
 /**
@@ -7,21 +7,30 @@
  * adapter validates `AiSession.model` against this set and surfaces `InvalidStateError` for
  * unknowns. The default model is Claude Sonnet 4.5 (`claude-sonnet-4.5`).
  *
- * This catalog is reconciled to GitHub's official supported-models doc (as of 2026-06-30):
+ * This catalog is reconciled to GitHub's official supported-models doc (as of 2026-07-26):
  * https://docs.github.com/en/copilot/reference/ai-models/supported-models
  *
  * Anthropic's Claude Sonnet 5 (`claude-sonnet-5`) went GA for GitHub Copilot on 2026-06-30 and is
  * listed here; its slug carries no dot/date, so the Copilot dotted-lowercase form is identical to
  * the Claude-Code dash form (`claude-sonnet-5`) — see `escalation-map.ts` for the consequence.
+ * `claude-opus-5` joins `claude-sonnet-5` / `claude-fable-5` as an undotted shared-slug id
+ * identical to the Claude-Code id — same consequence, see `escalation-map.ts`.
+ *
+ * `gpt-5.6-sol` was verified working via the Copilot CLI (1.0.75). `claude-opus-5` is
+ * plan-gated (Pro+/Max/Business/Enterprise) and — per the existing passthrough-probe policy —
+ * fails at spawn with a clear error on gated accounts. `claude-opus-4.8-fast`,
+ * `gemini-3.6-flash`, and `kimi-k2.7-code` slugs are convention-derived from the doc's display
+ * names (could not be validated on the reference account).
  *
  * The Copilot CLI cannot enumerate its model catalog non-interactively (github/copilot-cli
  * issue #700), so the slugs below are mapped from the doc's display names through the
- * established dotted-lowercase convention. They are NOT verified against the live CLI.
+ * established dotted-lowercase convention. They are NOT verified against the live CLI (except
+ * where noted above).
  *
  * This list is a full official replacement: de-listed models are dropped rather than retained.
  * The per-session model-availability probe (a passthrough for Copilot in v1) is the intended
  * mechanism for hiding models a given account cannot use — not retaining superseded entries in
- * this static catalog.
+ * this static catalog. `claude-opus-4.6-fast` was delisted (replaced by `claude-opus-4.8-fast`).
  */
 export type CopilotModel =
   // OpenAI
@@ -31,13 +40,17 @@ export type CopilotModel =
   | 'gpt-5.4-mini'
   | 'gpt-5.4-nano'
   | 'gpt-5.5'
+  | 'gpt-5.6-sol'
+  | 'gpt-5.6-terra'
+  | 'gpt-5.6-luna'
   // Anthropic
   | 'claude-haiku-4.5'
   | 'claude-opus-4.5'
   | 'claude-opus-4.6'
-  | 'claude-opus-4.6-fast'
   | 'claude-opus-4.7'
   | 'claude-opus-4.8'
+  | 'claude-opus-4.8-fast'
+  | 'claude-opus-5'
   | 'claude-fable-5'
   | 'claude-sonnet-4.5'
   | 'claude-sonnet-4.6'
@@ -47,8 +60,11 @@ export type CopilotModel =
   | 'gemini-3-flash'
   | 'gemini-3.1-pro-preview'
   | 'gemini-3.5-flash'
+  | 'gemini-3.6-flash'
   // Microsoft
   | 'mai-code-1-flash'
+  // Moonshot
+  | 'kimi-k2.7-code'
   // Fine-tuned
   | 'raptor-mini-preview';
 
@@ -60,13 +76,17 @@ export const COPILOT_MODELS: readonly CopilotModel[] = [
   'gpt-5.4-mini',
   'gpt-5.4-nano',
   'gpt-5.5',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   // Anthropic
   'claude-haiku-4.5',
   'claude-opus-4.5',
   'claude-opus-4.6',
-  'claude-opus-4.6-fast',
   'claude-opus-4.7',
   'claude-opus-4.8',
+  'claude-opus-4.8-fast',
+  'claude-opus-5',
   'claude-fable-5',
   'claude-sonnet-4.5',
   'claude-sonnet-4.6',
@@ -76,8 +96,11 @@ export const COPILOT_MODELS: readonly CopilotModel[] = [
   'gemini-3-flash',
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',
+  'gemini-3.6-flash',
   // Microsoft
   'mai-code-1-flash',
+  // Moonshot
+  'kimi-k2.7-code',
   // Fine-tuned
   'raptor-mini-preview',
 ] as const;

--- a/src/domain/value/settings-models/effort.ts
+++ b/src/domain/value/settings-models/effort.ts
@@ -7,6 +7,11 @@
  * the same enums (Claude / Copilot / Codex variants); keeping the levels here lets every UI
  * surface read from the same array rather than re-declaring the literal list.
  *
+ * The Codex list is the provider-level superset — `minimal` was retired by codex ≥ 0.145
+ * (persisted rows are migrated to `low`); `max` exists only on the 5.6 family and `ultra` only
+ * on sol/terra (plan-gated to Plus+) — per-model narrowing is deliberately left to the codex CLI
+ * at spawn, matching the custom-model policy.
+ *
  * @public
  */
 
@@ -15,5 +20,5 @@ import type { AiProvider } from '@src/domain/entity/settings.ts';
 export const PROVIDER_EFFORT_LEVELS: Readonly<Record<AiProvider, readonly string[]>> = {
   'claude-code': ['low', 'medium', 'high', 'xhigh', 'max'],
   'github-copilot': ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
-  'openai-codex': ['minimal', 'low', 'medium', 'high'],
+  'openai-codex': ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
 };

--- a/src/domain/value/settings-models/suspended-models.ts
+++ b/src/domain/value/settings-models/suspended-models.ts
@@ -1,25 +1,26 @@
 /**
  * Single reversible kill-switch for models that are temporarily unusable server-side while still
- * carried in the provider catalogs. As of 2026-06-12 the `claude-fable-5` family (Fable 5 /
- * Mythos 5) is suspended by an Anthropic export-control directive; the bare `claude-fable-5`
- * string also matches the Copilot catalog entry (Anthropic-served via Copilot, so it is down too).
+ * carried in the provider catalogs. The list is deliberately retained as a mechanism even when
+ * EMPTY: the 2026-06-12 `claude-fable-5` family (Fable 5 / Mythos 5) Anthropic export-control
+ * suspension was lifted when Fable went GA (2026-07), so {@link SUSPENDED_MODELS} is currently
+ * empty — but the seam and its four consumers (two adapter guards in `claude/headless.ts` +
+ * `copilot/headless.ts`, and the two picker annotations in `flows-customize-picker.ts` +
+ * `settings-editor.tsx`) stay wired for the next incident.
  *
- * The catalog entries deliberately STAY in place: the suspension is described as temporary, and the
- * `settings` model fields accept any catalog id OR a custom string (`z.union([z.enum(...),
- * CustomModelStringSchema])`), so already-persisted configs that name a suspended model remain
- * schema-valid. Rather than churn the catalog, the adapters fail fast with a clear message and the
- * model pickers flag the entry — all gated on this one list.
+ * The catalog entries deliberately STAY in place during a suspension: it is described as
+ * temporary, and the `settings` model fields accept any catalog id OR a custom string
+ * (`z.union([z.enum(...), CustomModelStringSchema])`), so already-persisted configs that name a
+ * suspended model remain schema-valid. Rather than churn the catalog, the adapters fail fast
+ * with a clear message and the model pickers flag the entry — all gated on this one list.
  *
- * To fully restore a model: empty {@link SUSPENDED_MODELS} (or delete this module and its four
- * consumers — the two adapter guards in `claude/headless.ts` + `copilot/headless.ts`, and the two
- * picker annotations in `flows-customize-picker.ts` + `settings-editor.tsx`). Re-enabling is a
- * one-line revert.
+ * To suspend a model again: add its id(s) to {@link SUSPENDED_MODELS}. Re-enabling is a
+ * one-line revert (empty the array, as done here for Fable 5).
  *
  * Domain layer — pure, no I/O.
  *
  * @public
  */
-export const SUSPENDED_MODELS: readonly string[] = ['claude-fable-5', 'claude-fable-5[1m]'] as const;
+export const SUSPENDED_MODELS: readonly string[] = [] as const;
 
 /**
  * `true` when `s` names a temporarily-suspended model (see {@link SUSPENDED_MODELS}).
@@ -43,4 +44,4 @@ export const SUSPENSION_NOTE = 'suspended';
  * @public
  */
 export const suspendedModelMessage = (model: string): string =>
-  `'${model}' is temporarily suspended by Anthropic (2026-06-12 export-control directive on Fable 5 / Mythos 5) — pick another model until access is restored`;
+  `'${model}' is temporarily suspended by its provider — pick another model until access is restored`;

--- a/src/integration/ai/providers/_engine/ai-session.ts
+++ b/src/integration/ai/providers/_engine/ai-session.ts
@@ -38,7 +38,8 @@ export interface AiSession {
   /**
    * Effort / reasoning level the AI should run at, resolved by the launcher via
    * `resolveEffort(flowId, settings)`. Provider-native vocabulary (Claude:
-   * `low|medium|high|xhigh|max`; Copilot adds `none`; Codex: `minimal|low|medium|high`).
+   * `low|medium|high|xhigh|max`; Copilot adds `none`; Codex: `low|medium|high|xhigh|max|ultra`,
+   * with `max`/`ultra` model-narrowed by the CLI).
    * The adapter is responsible for translating this string into its CLI flag
    * (`--model-reasoning-effort` for Codex, etc.). Adapters that do not support a
    * reasoning flag MUST silently ignore the field — never surface an error for an

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -166,10 +166,12 @@ export const buildCodexArgs = (
     }
   }
   // Forward `session.effort` verbatim via `-c model_reasoning_effort=<value>`. Codex's
-  // documented levels are minimal | low | medium | high; the launcher floors xhigh/max to
-  // high in `resolveEffort` before reaching the adapter, so any string that arrives here
-  // should already be in-range. Codex itself rejects unknown levels — let it speak rather
-  // than re-validate here (mirrors the custom-model arm policy).
+  // documented levels are low | medium | high | xhigh | max | ultra; the launcher only floors
+  // a global `max` to `xhigh` in `resolveEffort` before reaching the adapter — an explicit
+  // per-row `max` (5.6-family only) or `ultra` (sol/terra-only, plan-gated) arrives here
+  // verbatim, with the codex CLI as final arbiter. Codex itself rejects unknown or
+  // model-incompatible levels — let it speak rather than re-validate here (mirrors the
+  // custom-model arm policy).
   if (session.effort !== undefined) {
     args.push('-c', `model_reasoning_effort=${session.effort}`);
   }

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -110,8 +110,8 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
       })
     );
   }
-  // Catalog-valid but temporarily suspended server-side (see suspended-models.ts). For Copilot
-  // this hits the Anthropic-served claude-fable-5 entry — fail fast with a clear message.
+  // Catalog-valid but temporarily suspended server-side (see suspended-models.ts) — the list is
+  // currently empty; the guard stays wired for the next incident.
   if (isSuspendedModel(session.model)) {
     return Result.error(
       new InvalidStateError({

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -2318,16 +2318,18 @@ describe('createImplementFlow — gen-eval loop', () => {
   // path produces a genuine second attempt; `maxAttempts === 1` collapses to one iteration;
   // an abort propagates verbatim with no extra iteration.
 
-  it('graduated ladder across attempts: sonnet plateaus → escalate to opus → opus plateaus → effort-bump to max → budget-exhausted preserves work', async () => {
+  it('graduated ladder across attempts: sonnet-5 plateaus → escalate to opus-5 → opus-5 plateaus → effort-bump to max → budget-exhausted preserves work', async () => {
     // maxAttempts 3 so the ladder can climb multiple rungs. Generator starts on a model
-    // (`claude-sonnet-4-6`) that HAS a default escalation rung (→ `claude-opus-4-8`). The graduated
-    // remedy ladder is spent cheapest-first per plateau: attempt 1 (sonnet) escalates to opus,
-    // attempt 2 (opus, top of the model ladder) raises reasoning effort on the SAME model (the
-    // effort rung, before the nudge). opus is xhigh-capable and Claude Code's own default is xhigh,
-    // so the rung climbs to `max` in a single step (a fixed `high` would be a no-op / downgrade),
-    // attempt 3 (opus at max effort) plateaus with the budget exhausted (attempts === maxAttempts) —
-    // a plateau never blocks, so the work is preserved (done-with-warning). The nudge is the NEXT
-    // rung after the effort bump, but the budget runs out first here, so it is never reached.
+    // (`claude-sonnet-5`) that HAS a default escalation rung (→ `claude-opus-5`, the true top of
+    // the dash-form ladder — `claude-opus-4-8` no longer tops out, it now carries a live rung to
+    // Opus 5). The graduated remedy ladder is spent cheapest-first per plateau: attempt 1 (sonnet-5)
+    // escalates to opus-5, attempt 2 (opus-5, top of the model ladder) raises reasoning effort on
+    // the SAME model (the effort rung, before the nudge). opus-5 is xhigh-capable and Claude Code's
+    // own default is xhigh, so the rung climbs to `max` in a single step (a fixed `high` would be a
+    // no-op / downgrade), attempt 3 (opus-5 at max effort) plateaus with the budget exhausted
+    // (attempts === maxAttempts) — a plateau never blocks, so the work is preserved
+    // (done-with-warning). The nudge is the NEXT rung after the effort bump, but the budget runs
+    // out first here, so it is never reached.
     const f = await buildFixture(1, 3);
     tracking(f);
     const sprintRepo = inMemorySprintRepo(f.sprint);
@@ -2363,9 +2365,9 @@ describe('createImplementFlow — gen-eval loop', () => {
       todoTasks: f.tasks,
       repositories: FAKE_REPOSITORIES,
       generatorProviderId: 'claude-code',
-      generatorModel: 'claude-sonnet-4-6',
+      generatorModel: 'claude-sonnet-5',
       evaluatorProviderId: 'claude-code',
-      evaluatorModel: 'claude-opus-4-8',
+      evaluatorModel: 'claude-opus-5',
       progressFile: absolutePath(f.progressFile),
       sprintDir: absolutePath(f.dir),
       memoryRoot: FAKE_MEMORY_ROOT,
@@ -2383,7 +2385,7 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(runner.status).toBe('completed');
 
     // Three attempts ran in ONE launch — the outer loop re-entered after each escalate/effort-bump
-    // kept the task in_progress. Attempt 1 escalated sonnet→opus, attempt 2 raised effort to max
+    // kept the task in_progress. Attempt 1 escalated sonnet-5→opus-5, attempt 2 raised effort to max
     // (same model), attempt 3 plateaued with the budget exhausted — a plateau never blocks, so the
     // work is preserved (done-with-warning). All three attempts recorded.
     const finalTask = taskRepo.tasks()[0];
@@ -2399,20 +2401,20 @@ describe('createImplementFlow — gen-eval loop', () => {
     const startEntries = runner.trace.filter((e) => e.elementName === `start-attempt-${String(finalTask?.id)}`);
     expect(startEntries).toHaveLength(3);
 
-    // The last MODEL transition is the sonnet→opus climb (the effort rung leaves the model fields
-    // untouched, and the budget exhausted before the nudge). The effort rung stamped
+    // The last MODEL transition is the sonnet-5→opus-5 climb (the effort rung leaves the model
+    // fields untouched, and the budget exhausted before the nudge). The effort rung stamped
     // `escalatedToEffort = max`. A plateau never blocks; the work is preserved (done-with-warning).
-    expect(finalTask?.escalatedFromModel).toBe('claude-sonnet-4-6');
-    expect(finalTask?.escalatedToModel).toBe('claude-opus-4-8');
+    expect(finalTask?.escalatedFromModel).toBe('claude-sonnet-5');
+    expect(finalTask?.escalatedToModel).toBe('claude-opus-5');
     expect(finalTask?.escalatedToEffort).toBe('max');
     expect(finalTask?.status).not.toBe('blocked');
 
-    // The generator climbed the ladder: attempt 1 ran on sonnet, later attempts ran on the
-    // escalated opus model — proof later iterations didn't just re-run identical work.
+    // The generator climbed the ladder: attempt 1 ran on sonnet-5, later attempts ran on the
+    // escalated opus-5 model — proof later iterations didn't just re-run identical work.
     const generatorSessions = provider.recordedSessions.filter((s) => s.role === 'generator');
     const generatorModels = generatorSessions.map((s) => s.model);
-    expect(generatorModels).toContain('claude-sonnet-4-6');
-    expect(generatorModels).toContain('claude-opus-4-8');
+    expect(generatorModels).toContain('claude-sonnet-5');
+    expect(generatorModels).toContain('claude-opus-5');
     // End-to-end proof the effort bump reached the actual spawn: at least one generator turn ran at
     // the escalated `max` effort (attempt 3, after the effort rung stamped `escalatedToEffort`).
     expect(generatorSessions.some((s) => s.effort === 'max')).toBe(true);

--- a/tests/integration/ai/providers/claude/claude-provider.test.ts
+++ b/tests/integration/ai/providers/claude/claude-provider.test.ts
@@ -671,15 +671,12 @@ describe('buildClaudeArgs — AiSession → CLI flag translation', () => {
   });
 
   it.each([['claude-fable-5'], ['claude-fable-5[1m]']])(
-    'rejects the suspended model %s with InvalidStateError(model-suspended)',
+    'builds args for the un-suspended fable model %s — the suspension was lifted at GA (2026-07)',
     (model) => {
-      const r = buildClaudeArgs(session({ model }));
-      expect(r.ok).toBe(false);
-      if (r.ok) return;
-      expect(r.error.code).toBe('invalid-state');
-      expect(r.error.currentState).toBe('model-suspended');
-      expect(r.error.message).toContain('suspended');
-      expect(r.error.message).toContain(`'${model}'`);
+      const args = unwrapArgs(session({ model }));
+      const idx = args.indexOf('--model');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(args[idx + 1]).toBe(model);
     }
   );
 

--- a/tests/integration/ai/providers/codex/codex-provider.test.ts
+++ b/tests/integration/ai/providers/codex/codex-provider.test.ts
@@ -107,7 +107,7 @@ const tempBodyFile = () => {
 const session = (overrides: Partial<AiSession> = {}): AiSession => ({
   prompt: PROMPT,
   cwd: CWD,
-  model: 'gpt-5.3-codex',
+  model: 'gpt-5.5',
   permissions: READ_ONLY,
   signalsFile: tempSignalsFile(),
   ...overrides,

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -620,14 +620,9 @@ describe('buildCopilotArgs — AiSession → CLI flag translation', () => {
     expect(r.error.message).toContain("'claude-haiku-4-5'");
   });
 
-  it('rejects the suspended claude-fable-5 with InvalidStateError(model-suspended)', () => {
-    const r = buildCopilotArgs(session({ model: 'claude-fable-5' }));
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.error.code).toBe('invalid-state');
-    expect(r.error.currentState).toBe('model-suspended');
-    expect(r.error.message).toContain('suspended');
-    expect(r.error.message).toContain("'claude-fable-5'");
+  it('builds args for the un-suspended claude-fable-5 — the suspension was lifted at GA (2026-07)', () => {
+    const args = unwrapArgs(session({ model: 'claude-fable-5' }));
+    expect(args).toContain('--model=claude-fable-5');
   });
 
   it('still builds args for a non-suspended copilot model (claude-opus-4.8)', () => {

--- a/tests/integration/application/flows/readiness/effort-resolution.test.ts
+++ b/tests/integration/application/flows/readiness/effort-resolution.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Readiness's per-tool effort resolution must stay pinned to the shared
+ * {@link clampEffortToProvider} clamp (`business/settings/resolve-effort.ts`) — a private local
+ * table previously diverged from it (codex floored `xhigh`/`max` to `high` here, while the shared
+ * clamp only floors `max` to `xhigh`).
+ */
+
+import { promises as fs } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { Result } from '@src/domain/result.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { ReadinessProbe, ReadinessProbeRegistry } from '@src/integration/ai/readiness/_engine/probe.ts';
+import { absentState } from '@src/integration/ai/readiness/_engine/state.ts';
+import type { ToolArtifacts } from '@src/integration/ai/readiness/_engine/tool-artifacts.ts';
+import type { InteractivePrompt } from '@src/business/interactive/prompt.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
+import { ValidationError } from '@src/domain/value/error/validation-error.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { AgentsMdProposalSignal } from '@src/domain/signal.ts';
+import type { AiSettings } from '@src/domain/entity/settings.ts';
+import { absolutePath, FIXED_NOW, isoTimestamp, makeProject, makeRepository } from '@tests/fixtures/domain.ts';
+import { createRunner } from '@src/application/chain/run/runner.ts';
+import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import { createFakeAiProvider } from '@tests/fixtures/fake-ai-provider.ts';
+import { createReadinessFlow } from '@src/application/flows/readiness/flow.ts';
+import { createEventBusLogger } from '@src/business/observability/event-bus-logger.ts';
+import { emptySkillSource, noopSkillsAdapter } from '@tests/fixtures/skills-fakes.ts';
+import { clampEffortToProvider } from '@src/business/settings/resolve-effort.ts';
+
+const FAKE_CWD = absolutePath('/tmp/ralph/fake-readiness-effort-cwd');
+
+const fakeProjectRepo = (project: Project): ProjectRepository =>
+  ({
+    async findById(id: ProjectId) {
+      if (project.id === id) return Result.ok(project);
+      return Result.error(new NotFoundError({ entity: 'project', id: String(id) }));
+    },
+    async save() {
+      return Result.ok(undefined);
+    },
+  }) as unknown as ProjectRepository;
+
+const absentProbes = (): ReadinessProbeRegistry =>
+  ({
+    codex: {
+      tool: 'codex',
+      async evaluate() {
+        return Result.ok(absentState(FIXED_NOW));
+      },
+    } satisfies ReadinessProbe<ToolArtifacts>,
+  }) as unknown as ReadinessProbeRegistry;
+
+const scriptedInteractive = (confirms: readonly boolean[]): InteractivePrompt => {
+  let idx = 0;
+  return {
+    async askText(): Promise<Result<string, DomainError>> {
+      return Result.error(new ValidationError({ field: 'fake', value: null, message: 'not scripted' }));
+    },
+    async askTextArea(): Promise<Result<string, DomainError>> {
+      return Result.error(new ValidationError({ field: 'fake', value: null, message: 'not scripted' }));
+    },
+    async askChoice<T>(): Promise<Result<T, DomainError>> {
+      return Result.error(new ValidationError({ field: 'fake', value: null, message: 'not scripted' })) as Result<
+        T,
+        DomainError
+      >;
+    },
+    async askConfirm(): Promise<Result<boolean, DomainError>> {
+      const value = confirms[idx];
+      idx += 1;
+      if (value === undefined)
+        return Result.error(new ValidationError({ field: 'fake', value: null, message: 'no scripted confirm' }));
+      return Result.ok(value);
+    },
+    async askMultiChoice<T>(): Promise<Result<readonly T[], DomainError>> {
+      return Result.ok([]);
+    },
+  };
+};
+
+const agentsMdProposal = (content: string): AgentsMdProposalSignal => ({
+  type: 'agents-md-proposal',
+  tag: 'claude-md',
+  content,
+  timestamp: IsoTimestamp.now(),
+});
+
+describe('readiness effort resolution mirrors the shared provider clamp', () => {
+  let tmpDir: string;
+  let repoPath: string;
+  let runsRoot: AbsolutePath;
+
+  beforeEach(async () => {
+    const raw = await fs.mkdtemp('/tmp/ralphctl-readiness-effort-test-');
+    tmpDir = await realpath(raw);
+    repoPath = join(tmpDir, 'repo-a');
+    await fs.mkdir(repoPath, { recursive: true });
+    const parsed = AbsolutePath.parse(join(tmpDir, 'runs'));
+    if (!parsed.ok) throw new Error('AbsolutePath.parse failed for runs dir');
+    runsRoot = parsed.value;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('a global codex `max` resolves to the shared clamp result (`xhigh`), not a stale local `high` floor', async () => {
+    const repository = makeRepository({ path: repoPath, name: 'repo-a' });
+    const project = makeProject({ repositories: [repository] });
+    const eventBus = createInMemoryEventBus();
+    const provider = createFakeAiProvider({
+      signals: { readiness: [agentsMdProposal('# repo-a — generated by AI\n')] },
+    });
+
+    const codexRow = { provider: 'openai-codex', model: 'gpt-5.4' } as const;
+    const ai: AiSettings = {
+      refine: codexRow,
+      plan: codexRow,
+      implement: { generator: codexRow, evaluator: codexRow },
+      readiness: codexRow,
+      ideate: codexRow,
+      createPr: codexRow,
+      effort: 'max',
+    };
+
+    const flow = createReadinessFlow(
+      {
+        projectRepo: fakeProjectRepo(project),
+        probes: absentProbes(),
+        providerFor: () => provider,
+        skillsAdapterFor: () => noopSkillsAdapter,
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        eventBus,
+        logger: createEventBusLogger({ eventBus, clock: () => isoTimestamp('2026-05-09T10:00:00.000Z') }),
+        interactive: scriptedInteractive([true]),
+        writeFile: async () => Result.ok(undefined),
+        clock: () => isoTimestamp('2026-05-09T10:00:00.000Z'),
+        skillSource: emptySkillSource,
+        runsRoot,
+      },
+      { projectId: project.id, cwd: FAKE_CWD, ai, providers: ['openai-codex'] }
+    );
+
+    const runner = createRunner({
+      id: 'r-effort-clamp',
+      element: flow,
+      initialCtx: { projectId: project.id, tools: [], entries: {} },
+    });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+    expect(provider.recordedSessions).toHaveLength(1);
+    // Pinned to the shared clamp so the two seams cannot silently diverge again.
+    expect(provider.recordedSessions[0]?.effort).toBe(clampEffortToProvider('max', 'openai-codex'));
+    expect(provider.recordedSessions[0]?.effort).toBe('xhigh');
+  });
+});

--- a/tests/integration/persistence/settings/json-settings-repository.test.ts
+++ b/tests/integration/persistence/settings/json-settings-repository.test.ts
@@ -31,14 +31,15 @@ describe('Settings defaults + schema', () => {
   });
 
   it("rejects an effort value outside the row provider's native vocabulary", () => {
-    // Codex does not expose `xhigh`; setting it on a codex row must fail at parse time.
+    // Codex does not expose `none` (a Copilot-only opt-out level); setting it on a codex row
+    // must fail at parse time.
     const bad = {
       ...DEFAULT_SETTINGS,
       ai: {
         ...DEFAULT_SETTINGS.ai,
         implement: {
-          generator: { provider: 'openai-codex' as const, model: 'gpt-5.3-codex', effort: 'xhigh' },
-          evaluator: { provider: 'openai-codex' as const, model: 'gpt-5.3-codex' },
+          generator: { provider: 'openai-codex' as const, model: 'gpt-5.5', effort: 'none' },
+          evaluator: { provider: 'openai-codex' as const, model: 'gpt-5.5' },
         },
       },
     };
@@ -98,11 +99,11 @@ describe('JsonSettingsRepository', () => {
     const codex: Settings = {
       schemaVersion: CURRENT_SCHEMA_VERSION,
       ai: {
-        refine: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
+        refine: { provider: 'openai-codex', model: 'gpt-5.6-terra' },
         plan: { provider: 'openai-codex', model: 'gpt-5.4' },
         implement: {
-          generator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
-          evaluator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
+          generator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
         },
         readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
         ideate: { provider: 'openai-codex', model: 'gpt-5.4-mini' },

--- a/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
+++ b/tests/unit/application/ui/tui/views/settings-view-model.escalation-map.test.ts
@@ -74,17 +74,26 @@ describe('escalation model helpers', () => {
 });
 
 describe('effectiveEscalationChains', () => {
-  it('renders the built-in haiku→sonnet→opus chain uncustomised with no overrides', () => {
+  it('renders the built-in haiku→sonnet-5→opus-5 chain uncustomised with no overrides', () => {
     const chains = effectiveEscalationChains({});
     const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
-    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-4-8']);
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-5']);
     expect(claude?.customised).toBe(false);
   });
 
+  it('renders the legacy sonnet-4-6→opus-4-8→opus-5 chain uncustomised with no overrides', () => {
+    const chains = effectiveEscalationChains({});
+    const legacy = chains.find((c) => c.models[0] === 'claude-sonnet-4-6');
+    expect(legacy?.models).toEqual(['claude-sonnet-4-6', 'claude-opus-4-8', 'claude-opus-5']);
+    expect(legacy?.customised).toBe(false);
+  });
+
   it('extends a chain through a user rung and marks it customised', () => {
-    const chains = effectiveEscalationChains({ 'claude-opus-4-8': 'claude-fable-5' });
+    // claude-opus-5 has no default rung — the documented opt-in promotion path
+    // (`'claude-opus-5': 'claude-fable-5'`) extends the dash-form ladder's real top.
+    const chains = effectiveEscalationChains({ 'claude-opus-5': 'claude-fable-5' });
     const claude = chains.find((c) => c.models[0] === 'claude-haiku-4-5');
-    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-4-8', 'claude-fable-5']);
+    expect(claude?.models).toEqual(['claude-haiku-4-5', 'claude-sonnet-5', 'claude-opus-5', 'claude-fable-5']);
     expect(claude?.customised).toBe(true);
   });
 

--- a/tests/unit/business/settings/implement-shape.test.ts
+++ b/tests/unit/business/settings/implement-shape.test.ts
@@ -31,11 +31,11 @@ describe('settings.ai.implement — nested generator/evaluator shape', () => {
   it('fresh-install defaults split implement across providers (generator=Claude, evaluator=Codex)', () => {
     expect(DEFAULT_SETTINGS.ai.implement.generator).toEqual({
       provider: 'claude-code',
-      model: 'claude-opus-4-8',
+      model: 'claude-opus-5',
     });
     expect(DEFAULT_SETTINGS.ai.implement.evaluator).toEqual({
       provider: 'openai-codex',
-      model: 'gpt-5.5',
+      model: 'gpt-5.6-sol',
     });
   });
 
@@ -191,5 +191,161 @@ describe('settings.ai — retired claude-opus-4-7 migration', () => {
     if (!parsed.success) return;
     const expectedRow = { provider: 'claude-code', model: 'claude-opus-4-8' };
     expect(parsed.data.ai.implement).toEqual({ generator: expectedRow, evaluator: expectedRow });
+  });
+
+  it('rewrites a copilot flat row pinned to the delisted claude-opus-4.6-fast to claude-opus-4.8-fast', () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        plan: { provider: 'github-copilot', model: 'claude-opus-4.6-fast' },
+        implement: nestedImplement,
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.plan).toEqual({ provider: 'github-copilot', model: 'claude-opus-4.8-fast' });
+    expect(parsed.data.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it.each(['gpt-5.3-codex', 'gpt-5.2', 'gpt-5.3-codex-spark'])(
+    'rewrites a codex flat row pinned to the removed %s to gpt-5.5',
+    (removedModel) => {
+      const stale = {
+        ...baseRecord,
+        ai: {
+          ...baseRecord.ai,
+          refine: { provider: 'openai-codex', model: removedModel },
+          implement: nestedImplement,
+        },
+      };
+      const parsed = SettingsSchema.safeParse(stale);
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+      expect(parsed.data.ai.refine).toEqual({ provider: 'openai-codex', model: 'gpt-5.5' });
+    }
+  );
+
+  it('leaves a Copilot row pinned to gpt-5.3-codex untouched — still a live Copilot catalog member', () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        // gpt-5.3-codex was removed from the codex catalog but GitHub still lists it for Copilot —
+        // the remap is codex-provider-guarded, so this row must survive untouched.
+        plan: { provider: 'github-copilot', model: 'gpt-5.3-codex' },
+        implement: nestedImplement,
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.plan).toEqual({ provider: 'github-copilot', model: 'gpt-5.3-codex' });
+  });
+
+  it('rewrites both nested implement roles pinned to the removed gpt-5.2', () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        implement: {
+          generator: { provider: 'openai-codex', model: 'gpt-5.2' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.2' },
+        },
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.generator.model).toBe('gpt-5.5');
+    expect(parsed.data.ai.implement.evaluator.model).toBe('gpt-5.5');
+  });
+});
+
+describe("settings.ai — retired codex effort 'minimal' migration", () => {
+  const nestedImplement = {
+    generator: { provider: 'claude-code', model: 'claude-opus-4-8' },
+    evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+  };
+
+  it("rewrites a flat codex row's effort 'minimal' to 'low' at parse time", () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+        implement: nestedImplement,
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.refine).toEqual({ provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' });
+  });
+
+  it("heals both nested implement roles pinned to codex effort 'minimal'", () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        implement: {
+          generator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+        },
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.implement.generator.effort).toBe('low');
+    expect(parsed.data.ai.implement.evaluator.effort).toBe('low');
+  });
+
+  it("promotes a legacy FLAT codex implement row with effort 'minimal' and heals both roles (ordering proof)", () => {
+    const legacyFlatStale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        implement: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+      },
+    };
+    const parsed = SettingsSchema.safeParse(legacyFlatStale);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const expectedRow = { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' };
+    expect(parsed.data.ai.implement).toEqual({ generator: expectedRow, evaluator: expectedRow });
+  });
+
+  it("leaves a codex row already at effort 'low' untouched (idempotence)", () => {
+    const stable = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
+        implement: nestedImplement,
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stable);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.ai.refine).toEqual({ provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' });
+  });
+
+  it('never rewrites effort on a claude-code row, even one carrying an off-vocabulary string', () => {
+    const stale = {
+      ...baseRecord,
+      ai: {
+        ...baseRecord.ai,
+        // Off-catalog custom string that happens to collide with the retired codex effort level —
+        // the effort migration is provider-guarded to openai-codex only.
+        readiness: { provider: 'claude-code', model: 'claude-sonnet-4-6', effort: 'minimal' },
+        implement: nestedImplement,
+      },
+    };
+    const parsed = SettingsSchema.safeParse(stale);
+    // claude-code's effort schema does not accept 'minimal' at all, so this row is expected to
+    // fail validation rather than being silently rewritten — proving the migration never touches it.
+    expect(parsed.success).toBe(false);
   });
 });

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -154,7 +154,8 @@ describe('presets', () => {
     // …while presets and the built-in escalation ladder deliberately do NOT reference it: the
     // catalog-top = ladder-top = preset-flagship invariant intentionally excludes the fable tier
     // until a deliberate flagship swap. Promoting it later means deleting this fence on purpose.
-    // The frontier family tops out at opus for exactly this reason (fable is export-suspended).
+    // The frontier family tops out at Opus 5 for exactly this reason — fable is 2x the Opus
+    // price, an operator spend decision, opt-in only via a per-row pick or an escalationMap rung.
     for (const preset of PRESET_NAMES) {
       const out = applyPreset(preset, DEFAULT_SETTINGS);
       for (const flow of FLOW_IDS) {
@@ -182,10 +183,10 @@ describe('presets', () => {
       out.ai.createPr.model,
     ];
     expect(models).not.toContain('gpt-5.3-codex');
-    expect(out.ai.implement.generator.model).toBe('gpt-5.5');
-    expect(out.ai.implement.evaluator.model).toBe('gpt-5.5');
-    expect(out.ai.implement.generator.effort).toBe('high');
-    expect(out.ai.implement.evaluator.effort).toBe('high');
+    expect(out.ai.implement.generator.model).toBe('gpt-5.6-sol');
+    expect(out.ai.implement.evaluator.model).toBe('gpt-5.6-sol');
+    expect(out.ai.implement.generator.effort).toBe('xhigh');
+    expect(out.ai.implement.evaluator.effort).toBe('xhigh');
   });
 
   it('isPresetName accepts all twenty preset names and rejects garbage', () => {
@@ -296,12 +297,11 @@ describe('presets', () => {
       }
     });
 
-    it('frontier presets stamp global ai.effort to max — except codex-frontier which floors to high', () => {
+    it('frontier presets stamp global ai.effort to max — codex-frontier included, the 5.6 flagship accepts max directly', () => {
       expect(applyPreset('mixed-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
       expect(applyPreset('claude-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
       expect(applyPreset('copilot-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
-      // Codex has no max/xhigh effort rung, so the global stays high to avoid implying a max row.
-      expect(applyPreset('codex-frontier', DEFAULT_SETTINGS).ai.effort).toBe('high');
+      expect(applyPreset('codex-frontier', DEFAULT_SETTINGS).ai.effort).toBe('max');
     });
 
     describe("'mixed' preset matrix", () => {
@@ -344,7 +344,7 @@ describe('presets', () => {
         expect(out.ai.effort).toBe('high');
         expect(out.ai.refine.model).toBe('claude-sonnet-5');
         expect(out.ai.refine.effort).toBeUndefined();
-        expect(out.ai.plan.model).toBe('claude-opus-4-8');
+        expect(out.ai.plan.model).toBe('claude-opus-5');
         expect(out.ai.plan.effort).toBe('xhigh');
         expect(out.ai.readiness.model).toBe('claude-haiku-4-5');
         expect(out.ai.readiness.effort).toBe('medium');
@@ -357,7 +357,7 @@ describe('presets', () => {
         // The novel property no other family has: generator weaker than evaluator.
         expect(out.ai.implement.generator.provider).toBe(out.ai.implement.evaluator.provider);
         expect(out.ai.implement.generator.model).toBe('claude-sonnet-5');
-        expect(out.ai.implement.evaluator.model).toBe('claude-opus-4-8');
+        expect(out.ai.implement.evaluator.model).toBe('claude-opus-5');
         expect(out.ai.implement.generator.model).not.toBe(out.ai.implement.evaluator.model);
         expect(out.ai.implement.generator.effort).toBe('high');
         expect(out.ai.implement.evaluator.effort).toBe('xhigh');
@@ -367,24 +367,25 @@ describe('presets', () => {
     describe("'codex-strong-gate' preset matrix — the narrowest gate", () => {
       const out = applyPreset('codex-strong-gate', DEFAULT_SETTINGS);
 
-      it('pairs a gpt-5.4 author with a gpt-5.5 evaluator one rung apart', () => {
+      it('pairs a gpt-5.6-terra author with a gpt-5.6-sol evaluator one default-ladder rung apart', () => {
         expect(out.ai.implement.generator.provider).toBe('openai-codex');
         expect(out.ai.implement.evaluator.provider).toBe('openai-codex');
-        expect(out.ai.implement.generator.model).toBe('gpt-5.4');
-        expect(out.ai.implement.evaluator.model).toBe('gpt-5.5');
-        // Codex never carries xhigh/max — both rows floor at high.
+        expect(out.ai.implement.generator.model).toBe('gpt-5.6-terra');
+        expect(out.ai.implement.evaluator.model).toBe('gpt-5.6-sol');
+        // Cheap author at high, strong gate at xhigh — the terra→sol rung is now live (xhigh is
+        // universal across the codex catalog since the vocabulary change).
         expect(out.ai.implement.generator.effort).toBe('high');
-        expect(out.ai.implement.evaluator.effort).toBe('high');
+        expect(out.ai.implement.evaluator.effort).toBe('xhigh');
       });
     });
 
     describe("'codex-fast' preset matrix", () => {
       const out = applyPreset('codex-fast', DEFAULT_SETTINGS);
 
-      it('leans on minimal effort for light flows and low effort for implement', () => {
-        expect(out.ai.refine.effort).toBe('minimal');
-        expect(out.ai.readiness.effort).toBe('minimal');
-        expect(out.ai.createPr.effort).toBe('minimal');
+      it('light flows inherit the global low (minimal was retired) and implement stays low', () => {
+        expect(out.ai.refine.effort).toBeUndefined();
+        expect(out.ai.readiness.effort).toBeUndefined();
+        expect(out.ai.createPr.effort).toBeUndefined();
         expect(out.ai.implement.generator.effort).toBe('low');
         expect(out.ai.implement.evaluator.effort).toBe('low');
       });
@@ -407,13 +408,13 @@ describe('presets', () => {
       });
     });
 
-    describe('frontier family tops out at opus / gpt-5.5 (never fable)', () => {
-      it('routes implement to the provider flagship at max effort (codex floored to high)', () => {
-        const cases: ReadonlyArray<[PresetName, string, 'max' | 'high']> = [
-          ['mixed-frontier', 'claude-opus-4-8', 'max'],
-          ['claude-frontier', 'claude-opus-4-8', 'max'],
+    describe('frontier family tops out at Opus 5 / gpt-5.6-sol (never fable)', () => {
+      it('routes implement to the provider flagship at max effort', () => {
+        const cases: ReadonlyArray<[PresetName, string, 'max']> = [
+          ['mixed-frontier', 'claude-opus-5', 'max'],
+          ['claude-frontier', 'claude-opus-5', 'max'],
           ['copilot-frontier', 'claude-opus-4.8', 'max'],
-          ['codex-frontier', 'gpt-5.5', 'high'],
+          ['codex-frontier', 'gpt-5.6-sol', 'max'],
         ];
         for (const [preset, model, effort] of cases) {
           const out = applyPreset(preset, DEFAULT_SETTINGS);
@@ -445,11 +446,10 @@ describe('presets', () => {
           }
         });
 
-        it('matches the effort matrix (implement+plan xhigh / codex high, readiness medium, refine+ideate unset)', () => {
-          const heavyEffort = provider === 'openai-codex' ? 'high' : 'xhigh';
-          expect(out.ai.implement.generator.effort).toBe(heavyEffort);
-          expect(out.ai.implement.evaluator.effort).toBe(heavyEffort);
-          expect(out.ai.plan.effort).toBe(heavyEffort);
+        it('matches the effort matrix (implement+plan xhigh across all three providers, readiness medium, refine+ideate unset)', () => {
+          expect(out.ai.implement.generator.effort).toBe('xhigh');
+          expect(out.ai.implement.evaluator.effort).toBe('xhigh');
+          expect(out.ai.plan.effort).toBe('xhigh');
           expect(out.ai.readiness.effort).toBe('medium');
           expect(out.ai.refine.effort).toBeUndefined();
           expect(out.ai.ideate.effort).toBeUndefined();

--- a/tests/unit/business/settings/resolve-agent-override.test.ts
+++ b/tests/unit/business/settings/resolve-agent-override.test.ts
@@ -58,19 +58,19 @@ describe('resolveAgentOverride', () => {
     expect(resolved).toEqual({ model: 'claude-sonnet-5', effort: 'max' });
   });
 
-  it('floors a binding-supplied xhigh to the codex provider ceiling', () => {
+  it('passes a binding-supplied xhigh through unclamped for codex (xhigh is now universal across the catalog)', () => {
     // A definition-bound effort still goes through the same provider floor as the
-    // global-default path — codex only accepts minimal|low|medium|high and rejects
-    // unknown levels, so an unclamped xhigh would fail every spawn for this role.
+    // global-default path — codex now accepts low|medium|high|xhigh|max|ultra, so xhigh
+    // passes through identity.
     const row = codexRow();
     const resolved = resolveAgentOverride(row, 'medium', { effort: 'xhigh' });
-    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
   });
 
-  it('floors a binding-supplied max to the codex provider ceiling', () => {
+  it('floors a binding-supplied max to the codex provider ceiling (xhigh)', () => {
     const row = codexRow();
     const resolved = resolveAgentOverride(row, 'medium', { effort: 'max' });
-    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
   });
 
   it('leaves a binding-supplied xhigh untouched on a claude-code row (identity)', () => {
@@ -85,9 +85,15 @@ describe('resolveAgentOverride', () => {
     expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'ultra-mega' });
   });
 
-  it('floors the global default to the codex provider ceiling when no definition/row effort is set', () => {
+  it('passes a global xhigh default through unclamped for codex when no definition/row effort is set', () => {
     const row = codexRow();
     const resolved = resolveAgentOverride(row, 'xhigh', undefined);
-    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'high' });
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
+  });
+
+  it('floors a global max default to xhigh for codex when no definition/row effort is set', () => {
+    const row = codexRow();
+    const resolved = resolveAgentOverride(row, 'max', undefined);
+    expect(resolved).toEqual({ model: 'gpt-5.5', effort: 'xhigh' });
   });
 });

--- a/tests/unit/business/settings/resolve-effort.test.ts
+++ b/tests/unit/business/settings/resolve-effort.test.ts
@@ -42,7 +42,7 @@ describe('resolveEffort', () => {
     expect(resolveEffort('refine', withGlobalEffort('high'))).toBe('high');
   });
 
-  it('floors a global effort to the codex provider ceiling (xhigh / max → high)', () => {
+  it('passes a global xhigh through unclamped for codex (xhigh is now universal across the catalog)', () => {
     // Set every row to codex so `resolveEffort` always sees the codex floor table.
     const codexEverywhere: Settings = {
       ...DEFAULT_SETTINGS,
@@ -51,19 +51,38 @@ describe('resolveEffort', () => {
         refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
         plan: { provider: 'openai-codex', model: 'gpt-5.5' },
         implement: {
-          generator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
-          evaluator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
+          generator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
         },
         readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
         ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
         createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
       },
     };
-    expect(resolveEffort('implement', codexEverywhere)).toBe('high');
-    expect(resolveEffort('plan', { ...codexEverywhere, ai: { ...codexEverywhere.ai, effort: 'max' } })).toBe('high');
+    expect(resolveEffort('implement', codexEverywhere)).toBe('xhigh');
     expect(resolveEffort('readiness', { ...codexEverywhere, ai: { ...codexEverywhere.ai, effort: 'medium' } })).toBe(
       'medium'
     );
+  });
+
+  it('floors a global max to xhigh for codex — only the 5.6 family accepts max, and this clamp has no model context', () => {
+    const codexEverywhere: Settings = {
+      ...DEFAULT_SETTINGS,
+      ai: {
+        effort: 'max',
+        refine: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+        plan: { provider: 'openai-codex', model: 'gpt-5.5' },
+        implement: {
+          generator: { provider: 'openai-codex', model: 'gpt-5.5' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.5' },
+        },
+        readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+        ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
+        createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
+      },
+    };
+    expect(resolveEffort('implement', codexEverywhere)).toBe('xhigh');
+    expect(resolveEffort('plan', codexEverywhere)).toBe('xhigh');
   });
 
   it('passes a global effort through identity for claude-code rows', () => {
@@ -74,20 +93,20 @@ describe('resolveEffort', () => {
     const settings: Settings = {
       ...DEFAULT_SETTINGS,
       ai: {
-        effort: 'xhigh',
-        refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'minimal' },
+        effort: 'max',
+        refine: { provider: 'openai-codex', model: 'gpt-5.4-mini', effort: 'low' },
         plan: { provider: 'openai-codex', model: 'gpt-5.5' },
         implement: {
-          generator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
-          evaluator: { provider: 'openai-codex', model: 'gpt-5.3-codex' },
+          generator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
+          evaluator: { provider: 'openai-codex', model: 'gpt-5.6-sol' },
         },
         readiness: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
         ideate: { provider: 'openai-codex', model: 'gpt-5.5' },
         createPr: { provider: 'openai-codex', model: 'gpt-5.4-mini' },
       },
     };
-    expect(resolveEffort('refine', settings)).toBe('minimal');
-    expect(resolveEffort('plan', settings)).toBe('high'); // floored from xhigh
+    expect(resolveEffort('refine', settings)).toBe('low');
+    expect(resolveEffort('plan', settings)).toBe('xhigh'); // floored from max
   });
 
   it('returns the per-flow value verbatim for the configured provider', () => {
@@ -96,9 +115,13 @@ describe('resolveEffort', () => {
 });
 
 describe('clampEffortToProvider', () => {
-  it('floors xhigh/max to high for codex', () => {
-    expect(clampEffortToProvider('xhigh', 'openai-codex')).toBe('high');
-    expect(clampEffortToProvider('max', 'openai-codex')).toBe('high');
+  it('passes xhigh through unclamped for codex but floors max to xhigh', () => {
+    expect(clampEffortToProvider('xhigh', 'openai-codex')).toBe('xhigh');
+    expect(clampEffortToProvider('max', 'openai-codex')).toBe('xhigh');
+  });
+
+  it('passes ultra through unclamped for codex — plan-gated, explicit-only, the CLI is the final arbiter', () => {
+    expect(clampEffortToProvider('ultra', 'openai-codex')).toBe('ultra');
   });
 
   it('passes effort through unchanged for claude-code and github-copilot', () => {

--- a/tests/unit/business/task/escalation-map.test.ts
+++ b/tests/unit/business/task/escalation-map.test.ts
@@ -17,6 +17,7 @@ import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
 import {
+  CODEX_EFFORT_ESCALATION_TARGET,
   DEFAULT_ESCALATION_MAP,
   EFFORT_ESCALATION_TARGET,
   escalationLadderCyclicFrom,
@@ -53,13 +54,27 @@ describe('DEFAULT_ESCALATION_MAP', () => {
     expect(DEFAULT_ESCALATION_MAP['claude-sonnet-4.6']).toBe('claude-opus-4.8');
   });
 
-  it('climbs the dash-form Claude-Code/Codex ladder via Sonnet 5 (haiku → sonnet-5 → opus)', () => {
+  it('climbs the dash-form Claude-Code/Codex ladder via Sonnet 5 (haiku → sonnet-5 → opus-5)', () => {
     expect(DEFAULT_ESCALATION_MAP['claude-haiku-4-5']).toBe('claude-sonnet-5');
-    expect(DEFAULT_ESCALATION_MAP['claude-sonnet-5']).toBe('claude-opus-4-8');
+    expect(DEFAULT_ESCALATION_MAP['claude-sonnet-5']).toBe('claude-opus-5');
   });
 
   it('retains the legacy claude-sonnet-4-6 → claude-opus-4-8 rung so pinned 4.6 configs still climb', () => {
     expect(DEFAULT_ESCALATION_MAP['claude-sonnet-4-6']).toBe('claude-opus-4-8');
+  });
+
+  it('gives pinned Opus-4.8 configs a live rung to the same-price successor (claude-opus-4-8 → claude-opus-5)', () => {
+    expect(DEFAULT_ESCALATION_MAP['claude-opus-4-8']).toBe('claude-opus-5');
+  });
+
+  it('climbs the codex 5.6 family within itself, chaining in from the old generation', () => {
+    expect(DEFAULT_ESCALATION_MAP['gpt-5.5']).toBe('gpt-5.6-sol');
+    expect(DEFAULT_ESCALATION_MAP['gpt-5.6-luna']).toBe('gpt-5.6-terra');
+    expect(DEFAULT_ESCALATION_MAP['gpt-5.6-terra']).toBe('gpt-5.6-sol');
+  });
+
+  it('does not steer the dot-form Copilot ladder into the plan-gated claude-opus-5', () => {
+    expect(DEFAULT_ESCALATION_MAP['claude-opus-4.8']).toBeUndefined();
   });
 });
 
@@ -183,9 +198,9 @@ describe('DEFAULT_ESCALATION_MAP — catalog lockstep (mechanizes the section 14
       .slice(0, 16);
 
   it('catalog fingerprints are unchanged — a failure means a model bump landed; run the model-bump audit', () => {
-    expect(fingerprint(CLAUDE_MODELS)).toBe('f49667dc324c37cc');
-    expect(fingerprint(CODEX_MODELS)).toBe('d0af18882f9e15ac');
-    expect(fingerprint(COPILOT_MODELS)).toBe('1f51a63b2cbf93f0');
+    expect(fingerprint(CLAUDE_MODELS)).toBe('7aa37ba5efb83173');
+    expect(fingerprint(CODEX_MODELS)).toBe('dce39d8df173e3d8');
+    expect(fingerprint(COPILOT_MODELS)).toBe('16647e8dcb879ea9');
   });
 });
 
@@ -231,19 +246,31 @@ describe('nextEffortRung', () => {
     expect(nextEffortRung('claude-code', HAIKU, 'low')).toBeUndefined();
   });
 
-  // ── Copilot / Codex keep the original fixed-`high` semantics; model plays no role. ──
+  // ── Copilot keeps the original fixed-`high` semantics; model plays no role. ──
 
-  it('copilot/codex escalate a fresh or below-target row to the fixed target `high`', () => {
+  it('copilot escalates a fresh or below-target row to the fixed target `high`', () => {
     expect(nextEffortRung('github-copilot', 'gpt-5.5', undefined)).toBe(EFFORT_ESCALATION_TARGET);
-    expect(nextEffortRung('openai-codex', 'gpt-5.5', undefined)).toBe(EFFORT_ESCALATION_TARGET);
     expect(nextEffortRung('github-copilot', 'gpt-5.5', 'low')).toBe(EFFORT_ESCALATION_TARGET);
-    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'minimal')).toBe(EFFORT_ESCALATION_TARGET);
   });
 
-  it('copilot/codex return undefined when already at/above the fixed target (no headroom)', () => {
+  it('copilot returns undefined when already at/above the fixed target (no headroom)', () => {
     expect(nextEffortRung('github-copilot', 'gpt-5.5', 'high')).toBeUndefined();
     expect(nextEffortRung('github-copilot', 'gpt-5.5', 'xhigh')).toBeUndefined();
-    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'high')).toBeUndefined();
+  });
+
+  // ── Codex targets the fixed `xhigh` rung — universal across the codex catalog since the
+  //    vocabulary change, so every codex preset (which stamps `high`) has a live rung. ──
+
+  it('codex escalates a fresh, below-target, or legacy `minimal` row to the fixed target `xhigh`', () => {
+    expect(nextEffortRung('openai-codex', 'gpt-5.6-sol', undefined)).toBe(CODEX_EFFORT_ESCALATION_TARGET);
+    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'high')).toBe(CODEX_EFFORT_ESCALATION_TARGET);
+    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'minimal')).toBe(CODEX_EFFORT_ESCALATION_TARGET);
+  });
+
+  it('codex returns undefined when already at/above the fixed target (no headroom)', () => {
+    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'xhigh')).toBeUndefined();
+    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'max')).toBeUndefined();
+    expect(nextEffortRung('openai-codex', 'gpt-5.5', 'ultra')).toBeUndefined();
   });
 
   it('returns undefined when no provider is resolvable (skips the rung gracefully)', () => {

--- a/tests/unit/business/task/escalation-policy-branches.test.ts
+++ b/tests/unit/business/task/escalation-policy-branches.test.ts
@@ -145,17 +145,19 @@ describe('decideEscalation — user-only and edge cases', () => {
 
   it('tops out only after a same-model nudge at the top of the ladder', () => {
     const base = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
-    const nudged = withEscalation(base, 'claude-opus-4-8', 'claude-opus-4-8');
+    // claude-opus-5 is the true top of the dash-form ladder — claude-opus-4-8 now carries a live
+    // rung to it, so the top-of-ladder / nudge / topped-out sequence must exercise opus-5.
+    const nudged = withEscalation(base, 'claude-opus-5', 'claude-opus-5');
     const decision = decideEscalation({
       task: nudged,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
     });
 
     expect(decision.kind).toBe('topped-out');
-    if (decision.kind === 'topped-out') expect(decision.model).toBe('claude-opus-4-8');
+    if (decision.kind === 'topped-out') expect(decision.model).toBe('claude-opus-5');
   });
 });
 

--- a/tests/unit/business/task/escalation-policy.test.ts
+++ b/tests/unit/business/task/escalation-policy.test.ts
@@ -68,7 +68,7 @@ describe('decideEscalation', () => {
     if (decision.kind === 'escalate') expect(decision.to).toBe('custom-frontier-model');
   });
 
-  it('climbs the ladder one rung per plateau: haiku → sonnet-5 → opus across successive plateaus', () => {
+  it('climbs the ladder one rung per plateau: haiku → sonnet-5 → opus-5 across successive plateaus', () => {
     // Rung 1: fresh task on haiku plateaus → escalate to the default Sonnet (Sonnet 5).
     const fresh = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const d1 = decideEscalation({
@@ -81,7 +81,8 @@ describe('decideEscalation', () => {
     expect(d1.kind).toBe('escalate');
     if (d1.kind === 'escalate') expect(d1.to).toBe('claude-sonnet-5');
 
-    // Rung 2: task already escalated to sonnet, now running on sonnet, plateaus → escalate to opus.
+    // Rung 2: task already escalated to sonnet, now running on sonnet, plateaus → escalate to the
+    // default Opus (Opus 5) — the same-price, strictly-better successor.
     const onSonnet = withEscalation(fresh, 'claude-haiku-4-5', 'claude-sonnet-5');
     const d2 = decideEscalation({
       task: onSonnet,
@@ -93,34 +94,34 @@ describe('decideEscalation', () => {
     expect(d2.kind).toBe('escalate');
     if (d2.kind === 'escalate') {
       expect(d2.from).toBe('claude-sonnet-5');
-      expect(d2.to).toBe('claude-opus-4-8');
+      expect(d2.to).toBe('claude-opus-5');
     }
 
-    // Top: re-stamped to opus, plateaus on opus (no higher rung, not yet nudged) → nudge.
-    const onOpus = withEscalation(onSonnet, 'claude-sonnet-4-6', 'claude-opus-4-8');
+    // Top: re-stamped to opus-5, plateaus on opus-5 (no higher rung, not yet nudged) → nudge.
+    const onOpus = withEscalation(onSonnet, 'claude-sonnet-5', 'claude-opus-5');
     const d3 = decideEscalation({
       task: onOpus,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
     });
     expect(d3.kind).toBe('nudge');
 
-    // After the top-of-ladder nudge (from === to === opus), a further plateau tops out.
-    const nudged = withEscalation(onOpus, 'claude-opus-4-8', 'claude-opus-4-8');
+    // After the top-of-ladder nudge (from === to === opus-5), a further plateau tops out.
+    const nudged = withEscalation(onOpus, 'claude-opus-5', 'claude-opus-5');
     const d4 = decideEscalation({
       task: nudged,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
     });
     expect(d4.kind).toBe('topped-out');
-    if (d4.kind === 'topped-out') expect(d4.model).toBe('claude-opus-4-8');
+    if (d4.kind === 'topped-out') expect(d4.model).toBe('claude-opus-5');
   });
 
-  it('returns nudge when the current model has no rung above (top of ladder, not yet nudged)', () => {
+  it('gives pinned Opus-4.8 configs a live model rung to the same-price Opus 5 successor', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const decision = decideEscalation({
       task,
@@ -129,8 +130,21 @@ describe('decideEscalation', () => {
       userMap: {},
       fallbackMaxAttempts: 3,
     });
+    expect(decision.kind).toBe('escalate');
+    if (decision.kind === 'escalate') expect(decision.to).toBe('claude-opus-5');
+  });
+
+  it('returns nudge when the current model has no rung above (top of ladder, not yet nudged)', () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const decision = decideEscalation({
+      task,
+      generatorModel: 'claude-opus-5',
+      flagOn: true,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+    });
     expect(decision.kind).toBe('nudge');
-    if (decision.kind === 'nudge') expect(decision.currentModel).toBe('claude-opus-4-8');
+    if (decision.kind === 'nudge') expect(decision.currentModel).toBe('claude-opus-5');
   });
 
   it('treats self-loop entries (from === to) as a nudge', () => {
@@ -235,12 +249,12 @@ describe('decideEscalation — same-model effort rung', () => {
     }
   });
 
-  it('(b) claude opus at explicit `high` → effort rung climbs to `xhigh` (headroom remains)', () => {
+  it('(b) claude opus-5 at explicit `high` → effort rung climbs to `xhigh` (headroom remains)', () => {
     // `high` is below the xhigh/max power tiers on an xhigh-capable model, so it still escalates —
     // to `xhigh` (the first power tier). A later plateau at `xhigh` would then climb to `max`.
     const decision = decideEscalation({
       task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
@@ -254,10 +268,10 @@ describe('decideEscalation — same-model effort rung', () => {
     }
   });
 
-  it('(b2) claude opus already at `max` → no headroom, falls through to the same-model nudge', () => {
+  it('(b2) claude opus-5 already at `max` → no headroom, falls through to the same-model nudge', () => {
     const decision = decideEscalation({
       task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
@@ -265,7 +279,7 @@ describe('decideEscalation — same-model effort rung', () => {
       generatorEffort: 'max',
     });
     expect(decision.kind).toBe('nudge');
-    if (decision.kind === 'nudge') expect(decision.currentModel).toBe('claude-opus-4-8');
+    if (decision.kind === 'nudge') expect(decision.currentModel).toBe('claude-opus-5');
   });
 
   it('(b3) claude Haiku (no effort dimension) → falls through to the same-model nudge', () => {
@@ -286,7 +300,7 @@ describe('decideEscalation — same-model effort rung', () => {
   it('(c) provider without a resolvable effort dimension → unchanged behaviour (nudge)', () => {
     const decision = decideEscalation({
       task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,
@@ -317,12 +331,12 @@ describe('decideEscalation — same-model effort rung', () => {
     // even when effort headroom exists — the nudge is the last remedy before preserving the work.
     const nudged = withEscalation(
       makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
-      'claude-opus-4-8',
-      'claude-opus-4-8'
+      'claude-opus-5',
+      'claude-opus-5'
     );
     const decision = decideEscalation({
       task: nudged,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       flagOn: true,
       userMap: {},
       fallbackMaxAttempts: 3,

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -351,8 +351,8 @@ describe('finalizeGenEvalUseCase', () => {
   it('plateau topped-out (nudged then plateaued again): verdict failed, plateau warning, no shouldFailAttempt, no blockedReason (preserves work)', async () => {
     // Mutant-kill: a mutant that drops the topped-out guard would incorrectly set shouldFailAttempt.
     const initial = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
-    // Task was nudged at the top of the ladder (from === to === opus); plateauing again tops out.
-    const stamped = recordTaskEscalation(initial, 'claude-opus-4-8', 'claude-opus-4-8');
+    // Task was nudged at the top of the ladder (from === to === opus-5); plateauing again tops out.
+    const stamped = recordTaskEscalation(initial, 'claude-opus-5', 'claude-opus-5');
     if (!stamped.ok) throw stamped.error;
     const bus = newBus();
     const events: Array<{ type: string }> = [];
@@ -367,7 +367,7 @@ describe('finalizeGenEvalUseCase', () => {
       logger: noopLogger,
       eventBus: bus,
       clock: fixedClock,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -395,15 +395,15 @@ describe('finalizeGenEvalUseCase', () => {
       logger: noopLogger,
       eventBus: bus,
       clock: fixedClock,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // Nudge: same model stamped (arms the directive + once-per-task cap), one more attempt granted.
     expect(result.value.verdict).toBe('failed');
     expect(result.value.warning).toEqual({ kind: 'plateau', dimensions: ['correctness'] }); // plateau warning attached
-    expect(result.value.task.escalatedFromModel).toBe('claude-opus-4-8');
-    expect(result.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(result.value.task.escalatedFromModel).toBe('claude-opus-5');
+    expect(result.value.task.escalatedToModel).toBe('claude-opus-5');
     expect(result.value.shouldFailAttempt).toBe(true);
     expect(result.value.blockedReason).toBeUndefined();
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
@@ -867,7 +867,7 @@ describe('finalizeGenEvalUseCase', () => {
 
   it('provider without a resolvable effort dimension → same-model nudge as before (no escalatedToEffort, no model bump)', async () => {
     // No generatorProvider passed → the policy can never return escalate-effort. Top-of-ladder
-    // opus falls through to the same-model nudge exactly as it did before the rung existed.
+    // opus-5 falls through to the same-model nudge exactly as it did before the rung existed.
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const bus = newBus();
     const events: Array<{ type: string }> = [];
@@ -882,21 +882,21 @@ describe('finalizeGenEvalUseCase', () => {
       logger: noopLogger,
       eventBus: bus,
       clock: fixedClock,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       // generatorProvider intentionally omitted.
     });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // Same-model nudge stamp (from === to), one more attempt granted, no effort stamp.
-    expect(result.value.task.escalatedFromModel).toBe('claude-opus-4-8');
-    expect(result.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(result.value.task.escalatedFromModel).toBe('claude-opus-5');
+    expect(result.value.task.escalatedToModel).toBe('claude-opus-5');
     expect(result.value.task.escalatedToEffort).toBeUndefined();
     expect(result.value.shouldFailAttempt).toBe(true);
     expect(events.some((e) => e.type === 'model-escalated')).toBe(false);
   });
 
   it('generator already at max effort → nudge (no headroom): no escalatedToEffort stamped', async () => {
-    // `max` is the top of Claude's effort ladder — the rung is spent, so a top-of-ladder opus
+    // `max` is the top of Claude's effort ladder — the rung is spent, so a top-of-ladder opus-5
     // plateau falls through to the same-model nudge (an explicit `high` would still climb to xhigh;
     // only the ceiling exhausts the rung). This is the wiring of `nextEffortRung` returning
     // undefined at the ceiling → the finalize leaf stamps no effort, only the same-model nudge.
@@ -911,7 +911,7 @@ describe('finalizeGenEvalUseCase', () => {
       logger: noopLogger,
       eventBus: newBus(),
       clock: fixedClock,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       generatorProvider: 'claude-code',
       generatorEffort: 'max',
     });
@@ -919,13 +919,13 @@ describe('finalizeGenEvalUseCase', () => {
     if (!result.ok) return;
     // No effort headroom → the top-of-ladder nudge (same-model stamp), never an effort bump.
     expect(result.value.task.escalatedToEffort).toBeUndefined();
-    expect(result.value.task.escalatedFromModel).toBe('claude-opus-4-8');
-    expect(result.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(result.value.task.escalatedFromModel).toBe('claude-opus-5');
+    expect(result.value.task.escalatedToModel).toBe('claude-opus-5');
     expect(result.value.shouldFailAttempt).toBe(true);
   });
 
   it('generator at explicit high effort → escalate-effort to xhigh (headroom on an xhigh-capable model)', async () => {
-    // opus is xhigh-capable, so an explicit `high` still has headroom: the rung climbs to `xhigh`
+    // opus-5 is xhigh-capable, so an explicit `high` still has headroom: the rung climbs to `xhigh`
     // (the raised effort is stamped for the next spawn; a later plateau at xhigh would reach max).
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
     const result = await finalizeGenEvalUseCase({
@@ -938,7 +938,7 @@ describe('finalizeGenEvalUseCase', () => {
       logger: noopLogger,
       eventBus: newBus(),
       clock: fixedClock,
-      generatorModel: 'claude-opus-4-8',
+      generatorModel: 'claude-opus-5',
       generatorProvider: 'claude-code',
       generatorEffort: 'high',
     });

--- a/tests/unit/domain/value/settings-models.test.ts
+++ b/tests/unit/domain/value/settings-models.test.ts
@@ -3,36 +3,43 @@ import { CODEX_MODELS, isCodexModel } from '@src/domain/value/settings-models/co
 import { COPILOT_MODELS, isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
 
 describe('settings-models / codex catalog', () => {
-  const added = ['gpt-5.3-codex-spark'] as const;
-  // Deprecated for ChatGPT sign-in but kept available via API-key auth — must not be dropped.
-  const keptDeprecated = ['gpt-5.2', 'gpt-5.3-codex'] as const;
+  // Verified against the live CLI model cache (codex CLI v0.145.0, 2026-07-26).
+  const kept = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'codex-auto-review'] as const;
+  const added = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'] as const;
+  // Gone from the codex CLI entirely — persisted rows are remapped to `gpt-5.5` at parse time.
+  const removed = ['gpt-5.2', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'] as const;
 
-  it('keeps all six previously-shipped entries plus the synthetic review id', () => {
-    for (const m of ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex', 'gpt-5.2', 'codex-auto-review']) {
+  it('keeps the previously-shipped entries plus the synthetic review id', () => {
+    for (const m of kept) {
       expect(CODEX_MODELS).toContain(m);
     }
   });
 
-  it('adds the new codex 0.138 research-preview model', () => {
+  it('adds the GPT-5.6 family from the 0.145.0 model cache', () => {
     for (const m of added) {
       expect(CODEX_MODELS).toContain(m);
       expect(isCodexModel(m)).toBe(true);
     }
   });
 
-  it('keeps the deprecated-but-API-valid models in the allowlist', () => {
-    for (const m of keptDeprecated) {
-      expect(isCodexModel(m)).toBe(true);
+  it('drops every model removed from the live CLI cache', () => {
+    for (const m of removed) {
+      expect(CODEX_MODELS).not.toContain(m);
+      expect(isCodexModel(m)).toBe(false);
     }
   });
 
   it('rejects unknown ids', () => {
     expect(isCodexModel('gpt-9000')).toBe(false);
   });
+
+  it('rejects the bare gpt-5.6 alias — API-only, deliberately absent', () => {
+    expect(isCodexModel('gpt-5.6')).toBe(false);
+  });
 });
 
 describe('settings-models / copilot catalog', () => {
-  // Reconciled to GitHub's official supported-models doc (as of 2026-06-10).
+  // Reconciled to GitHub's official supported-models doc (as of 2026-07-26).
   const official = [
     // OpenAI
     'gpt-5-mini',
@@ -41,13 +48,17 @@ describe('settings-models / copilot catalog', () => {
     'gpt-5.4-mini',
     'gpt-5.4-nano',
     'gpt-5.5',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
     // Anthropic
     'claude-haiku-4.5',
     'claude-opus-4.5',
     'claude-opus-4.6',
-    'claude-opus-4.6-fast',
     'claude-opus-4.7',
     'claude-opus-4.8',
+    'claude-opus-4.8-fast',
+    'claude-opus-5',
     'claude-fable-5',
     'claude-sonnet-4.5',
     'claude-sonnet-4.6',
@@ -57,8 +68,11 @@ describe('settings-models / copilot catalog', () => {
     'gemini-3-flash',
     'gemini-3.1-pro-preview',
     'gemini-3.5-flash',
+    'gemini-3.6-flash',
     // Microsoft
     'mai-code-1-flash',
+    // Moonshot
+    'kimi-k2.7-code',
     // Fine-tuned
     'raptor-mini-preview',
   ] as const;
@@ -75,6 +89,7 @@ describe('settings-models / copilot catalog', () => {
     'claude-sonnet-4',
     'gemini-3-pro-preview',
     'gemini-3-flash-preview',
+    'claude-opus-4.6-fast',
   ] as const;
 
   it('contains exactly the official supported-models list', () => {

--- a/tests/unit/domain/value/settings-models/suspended-models.test.ts
+++ b/tests/unit/domain/value/settings-models/suspended-models.test.ts
@@ -7,25 +7,21 @@ import {
 } from '@src/domain/value/settings-models/suspended-models.ts';
 
 describe('suspended-models', () => {
-  it('flags both fable ids as suspended', () => {
-    expect(isSuspendedModel('claude-fable-5')).toBe(true);
-    expect(isSuspendedModel('claude-fable-5[1m]')).toBe(true);
+  it('SUSPENDED_MODELS is empty — the kill-switch mechanism is deliberately retained with no active entries', () => {
+    expect(SUSPENDED_MODELS).toEqual([]);
   });
 
-  it('does not flag a live catalog model, a custom string, or empty', () => {
-    expect(isSuspendedModel('claude-opus-4-8')).toBe(false);
-    expect(isSuspendedModel('my-custom-model')).toBe(false);
+  it('does not flag any model as suspended (fable is un-suspended, GA again)', () => {
+    expect(isSuspendedModel('claude-fable-5')).toBe(false);
+    expect(isSuspendedModel('claude-fable-5[1m]')).toBe(false);
+    expect(isSuspendedModel('claude-opus-5')).toBe(false);
     expect(isSuspendedModel('')).toBe(false);
   });
 
-  it('SUSPENDED_MODELS contains exactly the two fable ids', () => {
-    expect([...SUSPENDED_MODELS].sort()).toEqual(['claude-fable-5', 'claude-fable-5[1m]']);
-  });
-
   it('message names the model and carries the suspension note tag', () => {
-    const msg = suspendedModelMessage('claude-fable-5');
-    expect(msg).toContain("'claude-fable-5'");
-    expect(msg).toContain(SUSPENSION_NOTE);
+    const msg = suspendedModelMessage('x');
+    expect(msg).toContain('x');
+    expect(msg).toContain('suspended');
     expect(SUSPENSION_NOTE).toBe('suspended');
   });
 });


### PR DESCRIPTION
## Summary

Brings all three provider catalogs, defaults, escalation ladders, effort vocabularies, migrations, docs, and tests up to date with the July 2026 model releases. Research was verified empirically where possible (live CLI probes, refreshed `~/.codex/models_cache.json` from codex 0.145.0, official GitHub supported-models docs).

### claude-code
- Add `claude-opus-5` — Opus 4.8's successor at the same price, natively 1M context (no `[1m]` variant, same precedent as Sonnet 5). New default Opus across defaults, presets, and ladder destinations.
- Unsuspend `claude-fable-5` (now GA) — kill-switch mechanism kept, list emptied. Fable stays opt-in only (2× Opus price): no preset row, no default rung; the `escalationMap` seam is the documented promotion path.

### openai-codex
- Add `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` (verified against the codex 0.145.0 model cache; `gpt-5.6-terra` probed end-to-end on ChatGPT auth). Bare `gpt-5.6` is API-only and deliberately excluded. **Requires codex CLI ≥ 0.145.**
- Remove `gpt-5.2` / `gpt-5.3-codex` / `gpt-5.3-codex-spark` (gone from the CLI) with a tolerant stored-settings remap.
- Effort vocabulary: `minimal` removed upstream; now `low..ultra` (`ultra` sol/terra-only, plan-gated — CLI is the arbiter). Stored `minimal` migrates to `low`; the provider clamp now floors only a global `max` to `xhigh`; codex effort-escalation rung target raised to `xhigh`.
- Frontier default `gpt-5.5` → `gpt-5.6-sol`; balanced tier `gpt-5.4` role → `gpt-5.6-terra` in presets.

### github-copilot
- Add `claude-opus-5`, `claude-opus-4.8-fast` (preview), `gpt-5.6-sol/terra/luna` (`gpt-5.6-sol` verified live), `gemini-3.6-flash`, `kimi-k2.7-code`. Delist `claude-opus-4.6-fast` with a remap to `claude-opus-4.8-fast`.
- Preset OPUS constant stays `claude-opus-4.8`: Opus 5 is plan-gated on Copilot (Pro+/Max/Business/Enterprise), so it's catalog + pin-only there.

### Cross-cutting
- Generalized the single-pair retired-model seam into a provider-guarded `RETIRED_MODEL_REMAPS` table (claude 4-7→4-8, copilot 4.6-fast→4.8-fast, three codex removals→gpt-5.5) + codex effort remap — all tolerant, silent, idempotent.
- Review gate caught and removed a duplicated codex effort-floor table in `readiness/flow.ts` (now calls the shared `clampEffortToProvider`, pinned by a new integration test).
- Catalog SHA-256 fingerprints recomputed; model-bump audit logged in HARNESS-PRINCIPLES.md.

## Verification
- `pnpm typecheck` clean · `pnpm lint` 0 errors (114/115 warnings under the ratchet) · `pnpm test` 4760/4760 across 525 files · prettier + knip clean.
- Multi-agent build: Fable design spec → Sonnet implementation (disjoint file ownership) → Opus 5 review gate (1 major + 10 minor findings, all fixed and re-gated PASS).

Unverifiable-by-probe Copilot slugs (`claude-opus-4.8-fast`, `gemini-3.6-flash`, `kimi-k2.7-code`) follow GitHub's established picker-name→slug convention and are flagged as such in MIGRATION.md.