### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to RalphCTL will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.17.0] - 2026-07-27
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
Promotes [Unreleased] to 0.17.0 (2026-07-27) and bumps package.json.

Ships two merged efforts:
- July 2026 provider model refresh (#265) — Opus 5 default, GPT-5.6 family, codex effort levels, Fable unsuspended (opt-in)
- Prompt-layer research audit (#266) — verified sources, contract fixes, SOTA hardening, RESEARCH-REFERENCES.md

Pre-release checks done: full verify green (4761/4761), `pnpm build` + cold bin smoke reports 0.17.0, dist prompt assets 1:1 with source, render smoke of implement/evaluate prompts shows zero leftover placeholders and all new prompt features present.

After merge: tag `v0.17.0` on the merge commit — the tag push triggers npm publish with provenance.