### PR TITLE
fix(contract): narrative signals use text, not body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to RalphCTL will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres
 to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Planning no longer fails when the AI names a narrative signal field `body`.** 0.17.0 added an "optional
+  signals" block to the plan and ideate prompts inviting `note` / `learning` / `decision` — but their
+  rendered `signals.json` example only showed the required payload, and the prose said "body capped at 500
+  chars". Models followed the prose and wrote `body` where the schema wants `text`. Because contract
+  validation is all-or-nothing, one wrong field on a throwaway commentary signal discarded the entire
+  file — including a complete, user-approved task plan — leaving the sprint in `draft` with no tasks and
+  no retry path. The plan and ideate contracts now demonstrate every narrative signal they accept (refine,
+  readiness, and the implement generator / evaluator gained their missing examples too), the misleading
+  prose is gone, and the validator rewrites `body` → `text` on those three kinds so a near-miss can never
+  sink a round again. Scoped to the narrative kinds: `body` stays untouched on `refined-ticket`,
+  `pr-content`, and `commit-message`, where it is a real field.
+
 ## [0.17.0] - 2026-07-27
 
 ### Added

--- a/src/application/flows/ideate/leaves/ideate.contract.ts
+++ b/src/application/flows/ideate/leaves/ideate.contract.ts
@@ -60,13 +60,33 @@ const EXAMPLE_TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
 /**
  * Representative ideate payload. The required `ideated-tickets` carries the AI-authored
  * combined refine + plan envelope as a JSON string in `outputJson` — opaque to the contract
- * validator (parsed downstream by `parseIdeateOutput`).
+ * validator (parsed downstream by `parseIdeateOutput`). The optional narrative signals
+ * (`decision` / `learning` / `note`) each carry their prose in a `text` field — NOT `body`.
+ * All shapes are shown here so the rendered `{{OUTPUT_CONTRACT_SECTION}}` is the authoritative
+ * source the AI copies, rather than relying on prose in the template that can drift from the
+ * schemas — a `decision` emitted with `body` fails whole-array validation and sinks an entire
+ * approved ideate session.
  */
 const ideateExampleSignals: readonly IdeateSignal[] = [
   {
     type: 'ideated-tickets',
     outputJson:
       '{"requirements":"# Export CSV\\n\\n## Problem\\n…","tasks":[{"name":"Wire endpoint","projectPath":"/abs/repo","steps":["…"],"verificationCriteria":["…"]}]}',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'decision',
+    text: 'Scoped export to CSV only for v1; XLSX deferred to a follow-up ticket.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'learning',
+    text: 'The repo runs its integration suite from a separate config; the root test command does not cover it.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'The user ruled out changing the existing download endpoint, so the new route is additive.',
     timestamp: EXAMPLE_TS,
   },
 ];

--- a/src/application/flows/implement/leaves/evaluator.contract.ts
+++ b/src/application/flows/implement/leaves/evaluator.contract.ts
@@ -138,6 +138,16 @@ const evaluatorExampleSignals: readonly EvaluatorSignal[] = [
     critique: 'Correctness: add edge-case handling for empty input at src/foo.ts:23.',
     timestamp: EXAMPLE_TS,
   },
+  {
+    type: 'learning',
+    text: 'The suite needs a built fixture; a cold checkout fails the C1 command for reasons unrelated to the task.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'C2 was checked by reading the call site — the criterion is manual, so no command was run.',
+    timestamp: EXAMPLE_TS,
+  },
 ];
 
 /**

--- a/src/application/flows/implement/leaves/generator.contract.ts
+++ b/src/application/flows/implement/leaves/generator.contract.ts
@@ -135,6 +135,16 @@ const generatorExampleSignals: readonly GeneratorSignal[] = [
     appliesTo: 'config / io layer',
     timestamp: EXAMPLE_TS,
   },
+  {
+    type: 'decision',
+    text: 'Centralised the parse in one helper rather than patching both call sites, to avoid future drift.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'Left the unrelated typo at src/baz.ts:8 alone — out of scope for this task.',
+    timestamp: EXAMPLE_TS,
+  },
   { type: 'task-verified', output: '$ <project test command>\n... 42 passed', timestamp: EXAMPLE_TS },
   {
     type: COMMIT_MESSAGE_KIND,

--- a/src/application/flows/plan/leaves/plan.contract.ts
+++ b/src/application/flows/plan/leaves/plan.contract.ts
@@ -62,13 +62,33 @@ const EXAMPLE_TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
 /**
  * Representative plan payload. The required `task-plan` carries the AI-authored task list as
  * a JSON string in `tasksJson` — opaque to the contract validator (parsed downstream by
- * `parsePlanOutput` against the task-import JSON Schema).
+ * `parsePlanOutput` against the task-import JSON Schema). The optional narrative signals
+ * (`decision` / `learning` / `note`) each carry their prose in a `text` field — NOT `body`.
+ * All shapes are shown here so the rendered `{{OUTPUT_CONTRACT_SECTION}}` is the authoritative
+ * source the AI copies, rather than relying on prose in the template that can drift from the
+ * schemas — a `decision` emitted with `body` fails whole-array validation and sinks an entire
+ * approved plan session.
  */
 const planExampleSignals: readonly PlanSignal[] = [
   {
     type: 'task-plan',
     tasksJson:
       '[{"name":"Wire export endpoint","ticketRef":"<ticket-uuid>","projectPath":"/abs/repo","steps":["..."],"verificationCriteria":["..."]}]',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'decision',
+    text: 'Split the export work into endpoint + serializer tasks so the shared file is owned by exactly one task.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'learning',
+    text: 'The repo runs its integration suite from a separate config; the root test command does not cover it.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'Two approved tickets touch the same route file; sequenced them via blockedBy rather than splitting the file.',
     timestamp: EXAMPLE_TS,
   },
 ];

--- a/src/application/flows/readiness/leaves/readiness.contract.ts
+++ b/src/application/flows/readiness/leaves/readiness.contract.ts
@@ -151,6 +151,16 @@ const readinessExampleSignals: readonly ReadinessSignal[] = [
     timestamp: EXAMPLE_TS,
   },
   { type: 'skill-suggestions', names: ['typescript-strict', 'code-style-conventions'], timestamp: EXAMPLE_TS },
+  {
+    type: 'learning',
+    text: 'The verify command lives in a workspace package script, not the repo root manifest.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'No lint config found, so the proposed verify skill covers typecheck + test only.',
+    timestamp: EXAMPLE_TS,
+  },
 ];
 
 /**

--- a/src/application/flows/refine/leaves/refine.contract.ts
+++ b/src/application/flows/refine/leaves/refine.contract.ts
@@ -151,6 +151,16 @@ const refineExampleSignals: readonly RefineSignal[] = [
     text: 'Scoped export to CSV only for v1; XLSX deferred to a follow-up ticket.',
     timestamp: EXAMPLE_TS,
   },
+  {
+    type: 'learning',
+    text: 'The export path already streams; the ticket must not assume an in-memory buffer.',
+    timestamp: EXAMPLE_TS,
+  },
+  {
+    type: 'note',
+    text: 'The user ruled column ordering out of scope — captured as a deferred item rather than an AC.',
+    timestamp: EXAMPLE_TS,
+  },
 ];
 
 /**

--- a/src/integration/ai/contract/_engine/validate-signals-file.ts
+++ b/src/integration/ai/contract/_engine/validate-signals-file.ts
@@ -140,7 +140,7 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
   // schema validation on a missable field is bad ergonomics for what the timestamp
   // ultimately drives (display-only). Stamp any signal missing `timestamp` at
   // validation time — spawn-time is within seconds of when the AI wrote the field.
-  const defaulted = defaultMissingTimestamps(inner);
+  const defaulted = renameNarrativeBodyToText(defaultMissingTimestamps(inner));
   const parsed = contract.signalsSchema.safeParse(defaulted);
   if (!parsed.success) {
     return Result.error(
@@ -158,6 +158,35 @@ export const validateSignalsFile = async <TSig extends AiSignal>(
 const describeJsonError = (cause: unknown): string => {
   if (cause instanceof Error) return cause.message;
   return String(cause);
+};
+
+/**
+ * Signal kinds whose prose lives in `text`. `body` is a real, required field on OTHER kinds
+ * (`refined-ticket`, `pr-content`, `commit-message`), so the alias rewrite below is scoped to
+ * this set rather than applied blind — renaming `body` on a `refined-ticket` would destroy it.
+ */
+const NARRATIVE_SIGNAL_KINDS = new Set(['learning', 'note', 'decision']);
+
+/**
+ * Be lenient on the `body` / `text` alias for the three narrative kinds. Every prompt invites
+ * the AI to emit optional `note` / `learning` / `decision` signals alongside the round's
+ * required payload, and models reach for `body` — the field name the neighbouring
+ * `refined-ticket` / `pr-content` signals actually use. Because the array parse is
+ * all-or-nothing, one such near-miss on a signal the harness only renders into `progress.md`
+ * would discard the round's real payload — for the interactive flows (plan / ideate), an
+ * entire user-approved session with no retry path. The rewrite fires only when `text` is
+ * absent and `body` is a string, so a correctly-shaped signal is never touched.
+ */
+const renameNarrativeBodyToText = (inner: unknown): unknown => {
+  if (!Array.isArray(inner)) return inner;
+  return inner.map((sig) => {
+    if (typeof sig !== 'object' || sig === null) return sig;
+    const s = sig as Record<string, unknown>;
+    if (typeof s.type !== 'string' || !NARRATIVE_SIGNAL_KINDS.has(s.type)) return sig;
+    if (typeof s.text === 'string' || typeof s.body !== 'string') return sig;
+    const { body, ...rest } = s;
+    return { ...rest, text: body };
+  });
 };
 
 const defaultMissingTimestamps = (inner: unknown): unknown => {

--- a/src/integration/ai/prompts/ideate/template.md
+++ b/src/integration/ai/prompts/ideate/template.md
@@ -258,11 +258,12 @@ The `outputJson` field is a JSON-encoded string. When decoded it has exactly two
 
 **Required signals:** exactly one `ideated-tickets`.
 
-**Optional signals** (emit when relevant):
+**Optional signals** (emit when relevant). Each carries its prose in a `text` field — never
+`body`; the output contract below shows the exact shape:
 
 - `note` — for status updates or observations worth surfacing.
 - `learning` — for non-obvious repo facts discovered during exploration.
-- `decision` — for architectural choices made during planning (body capped at 500 chars).
+- `decision` — for architectural choices made during planning.
 
 Emit nothing else. No prose responses, no explanatory comments outside the signals file.
 

--- a/src/integration/ai/prompts/plan/template.md
+++ b/src/integration/ai/prompts/plan/template.md
@@ -437,10 +437,11 @@ Once the user has answered "Approved, write it" in Step 4 AND every checklist it
 satisfied, write the `task-plan` signal into `signals.json` per the output contract below.
 The task array goes into the signal's `tasksJson` field as a JSON-encoded string.
 
-**Optional signals** (emit when relevant):
+**Optional signals** (emit when relevant). Each carries its prose in a `text` field — never
+`body`; the output contract below shows the exact shape:
 
 - `note` — for status updates or observations worth surfacing.
 - `learning` — for non-obvious repo facts discovered during exploration.
-- `decision` — for architectural choices made during planning (body capped at 500 chars).
+- `decision` — for architectural choices made during planning.
 
 {{OUTPUT_CONTRACT_SECTION}}

--- a/tests/e2e/flows/refine.test.ts
+++ b/tests/e2e/flows/refine.test.ts
@@ -650,9 +650,10 @@ describe('createRefineFlow — interactive', () => {
       schemaVersion: 1,
       signals: [
         { type: 'refined-ticket', body: refinedBody, timestamp: '2026-05-22T10:00:00.000Z' },
-        // Malformed: `decision` carries `body` where the schema wants `text`. The exact drift
-        // that previously discarded the whole refinement. Now it is dropped, not fatal.
-        { type: 'decision', body: 'wrong field', timestamp: '2026-05-22T10:00:00.000Z' },
+        // Malformed beyond recovery: a `decision` with no prose field the schema can use. The
+        // `body` near-miss is now rewritten to `text` upstream, so this case uses a shape that
+        // genuinely cannot be salvaged. Dropped, not fatal.
+        { type: 'decision', rationale: 'no text, no body', timestamp: '2026-05-22T10:00:00.000Z' },
       ],
     }));
 

--- a/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
+++ b/tests/integration/application/flows/refine/leaves/refine-contract.test.ts
@@ -212,15 +212,15 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
   // ── 2b. Resilience: valid refined-ticket + malformed auxiliary signal ──────────
   it('resilience: keeps the refinement when only auxiliary signals are malformed', async () => {
     await ensureUnitDir();
-    // One valid refined-ticket plus a malformed `decision` (carries `body` where the schema
-    // wants `text`). The lenient refine contract drops the decision and keeps the refinement.
+    // One valid refined-ticket plus an auxiliary `decision` with no recoverable prose field at
+    // all. The lenient refine contract drops the decision and keeps the refinement.
     await fs.writeFile(
       signalsFilePath(),
       JSON.stringify({
         schemaVersion: 1,
         signals: [
           refinedTicketSignal('## Refined\n\n- the essential body survives'),
-          { type: 'decision', body: 'wrong field — should be text', timestamp: '2026-05-22T10:00:00.000Z' },
+          { type: 'decision', rationale: 'no text, no body', timestamp: '2026-05-22T10:00:00.000Z' },
         ],
       }),
       'utf8'
@@ -241,6 +241,38 @@ describe('refineTicketInteractiveLeaf — audit-[09] contract', () => {
     const approved = result.value.ctx.refinedTickets?.[0];
     expect(approved?.status).toBe('approved');
     expect(approved?.requirements).toBe('## Refined\n\n- the essential body survives');
+  });
+
+  // ── 2c. Recovery: the `body` / `text` near-miss on an auxiliary signal ─────────
+  it('recovers a `decision` that carries `body` instead of `text` rather than dropping it', async () => {
+    await ensureUnitDir();
+    // `body` is the field the neighbouring refined-ticket signal uses, so models reach for it on
+    // the narrative kinds too. That near-miss used to cost the decision (here) or the entire
+    // round (plan / ideate, whose contracts are strict); the validator now rewrites it.
+    await fs.writeFile(
+      signalsFilePath(),
+      JSON.stringify({
+        schemaVersion: 1,
+        signals: [
+          refinedTicketSignal('## Refined\n\n- the essential body survives'),
+          { type: 'decision', body: 'wrong field — should be text', timestamp: '2026-05-22T10:00:00.000Z' },
+        ],
+      }),
+      'utf8'
+    );
+    const { events, eventBus } = captureBus();
+    const provider = fakeAi(async () => {});
+    const { ctx, ticket } = buildCtx();
+    const leaf = refineTicketInteractiveLeaf(buildDeps(provider, eventBus), ticket);
+
+    const result = await leaf.execute(ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const aiSignals = events.filter((e): e is AiSignalEvent => e.type === 'ai-signal');
+    expect(aiSignals.map((e) => e.signal.type)).toEqual(['refined-ticket', 'decision']);
+    const decision = aiSignals[1]?.signal;
+    expect(decision?.type === 'decision' ? decision.text : undefined).toBe('wrong field — should be text');
   });
 
   // ── 3. Malformed JSON ─────────────────────────────────────────────────────────

--- a/tests/unit/application/flows/contract-example-narrative-signals.test.ts
+++ b/tests/unit/application/flows/contract-example-narrative-signals.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { AiSignal } from '@src/domain/signal.ts';
+import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import type { AiOutputContract } from '@src/integration/ai/contract/_engine/types.ts';
+import { planOutputContract } from '@src/application/flows/plan/leaves/plan.contract.ts';
+import { ideateOutputContract } from '@src/application/flows/ideate/leaves/ideate.contract.ts';
+import { refineOutputContract } from '@src/application/flows/refine/leaves/refine.contract.ts';
+import { readinessOutputContract } from '@src/application/flows/readiness/leaves/readiness.contract.ts';
+import { generatorOutputContract } from '@src/application/flows/implement/leaves/generator.contract.ts';
+import { evaluatorOutputContract } from '@src/application/flows/implement/leaves/evaluator.contract.ts';
+import { detectScriptsOutputContract } from '@src/application/flows/detect-scripts/leaves/propose.contract.ts';
+import { detectSkillsOutputContract } from '@src/application/flows/detect-skills/leaves/propose.contract.ts';
+import { generatePrContentOutputContract } from '@src/application/flows/create-pr/leaves/generate-pr-content.contract.ts';
+import { reviewRoundOutputContract } from '@src/application/flows/review/leaves/review-round.contract.ts';
+
+/**
+ * The three narrative kinds every prompt invites as optional extras. They carry prose in
+ * `text` — unlike the neighbouring `refined-ticket` / `pr-content` / `commit-message` signals,
+ * which use `body`. A model that guesses `body` fails the whole-array parse and sinks the
+ * round's real payload; for the interactive flows that is a user-approved session lost with no
+ * retry path. The rendered `{{OUTPUT_CONTRACT_SECTION}}` is the only place the AI can read the
+ * right shape, so a contract that ACCEPTS a narrative kind must also DEMONSTRATE it.
+ */
+const NARRATIVE_KINDS = ['learning', 'note', 'decision'] as const;
+
+const isNarrative = (type: string): boolean => (NARRATIVE_KINDS as readonly string[]).includes(type);
+
+const EXAMPLE_TS = '2026-05-22T10:00:00.000Z' as IsoTimestamp;
+
+/**
+ * Structural view of a contract, erased of its per-leaf signal sub-union. `AiOutputContract`
+ * is invariant in `TSig` (the Zod schema appears in both positions), so a heterogeneous table
+ * cannot hold the concrete contracts directly.
+ */
+interface ContractProbe {
+  readonly signalsSchema: {
+    readonly safeParse: (value: unknown) => { readonly success: boolean; readonly data?: unknown };
+  };
+  readonly exampleSignals: readonly AiSignal[];
+}
+
+const probe = <TSig extends AiSignal>(contract: AiOutputContract<TSig>): ContractProbe => contract;
+
+const CONTRACTS: ReadonlyArray<readonly [string, ContractProbe]> = [
+  ['plan', probe(planOutputContract)],
+  ['ideate', probe(ideateOutputContract)],
+  ['refine', probe(refineOutputContract)],
+  ['readiness', probe(readinessOutputContract)],
+  ['implement/generator', probe(generatorOutputContract)],
+  ['implement/evaluator', probe(evaluatorOutputContract)],
+  ['detect-scripts', probe(detectScriptsOutputContract)],
+  ['detect-skills', probe(detectSkillsOutputContract)],
+  ['create-pr', probe(generatePrContentOutputContract)],
+  ['review', probe(reviewRoundOutputContract)],
+];
+
+/**
+ * Does the contract carry `kind` through to its validated output? Probed rather than
+ * introspected: the schemas carry `refine`d cardinality rules (exactly one `task-plan`, exactly
+ * one `ideated-tickets`, …), so the probe keeps the contract's own non-narrative example signals
+ * as the required payload and swaps in a single narrative candidate.
+ *
+ * "Carries through" — not merely "parses". The create-pr contract is deliberately tolerant: it
+ * DROPS stray narrative signals before validation rather than failing on them, so a probe that
+ * only checked `success` would demand examples for kinds that contract discards.
+ */
+const accepts = (contract: ContractProbe, kind: string): boolean => {
+  const payload = contract.exampleSignals.filter((s) => !isNarrative(s.type));
+  const result = contract.signalsSchema.safeParse([...payload, { type: kind, text: 'probe', timestamp: EXAMPLE_TS }]);
+  if (!result.success || !Array.isArray(result.data)) return false;
+  return result.data.some((s: unknown) => (s as { readonly type?: unknown }).type === kind);
+};
+
+describe('AI output contracts — narrative signal examples', () => {
+  it.each(CONTRACTS)('%s demonstrates every narrative kind it accepts', (_name, contract) => {
+    const shown = new Set(contract.exampleSignals.map((s) => s.type));
+    const missing = NARRATIVE_KINDS.filter((kind) => accepts(contract, kind) && !shown.has(kind));
+    expect(missing).toEqual([]);
+  });
+
+  it.each(CONTRACTS)('%s example signals round-trip through its own schema', (_name, contract) => {
+    expect(contract.signalsSchema.safeParse(contract.exampleSignals).success).toBe(true);
+  });
+
+  it.each(CONTRACTS)('%s never shows a narrative signal carrying `body`', (_name, contract) => {
+    const offenders = contract.exampleSignals
+      .filter((s) => isNarrative(s.type))
+      .filter((s) => 'body' in s)
+      .map((s) => s.type);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/integration/ai/contract/_engine/validate-signals-file.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/validate-signals-file.test.ts
@@ -7,14 +7,16 @@ import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { MigrationGapError } from '@src/domain/value/error/migration-gap-error.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
+import { brandSignalArray } from '@src/integration/ai/contract/_engine/brand-signal-array.ts';
 import { changeSignalSchema } from '@src/integration/ai/contract/_engine/signals/change/schema.ts';
+import { commitMessageSignalSchema } from '@src/integration/ai/contract/_engine/signals/commit-message/schema.ts';
 import { decisionSignalSchema } from '@src/integration/ai/contract/_engine/signals/decision/schema.ts';
 import type { AiOutputContract } from '@src/integration/ai/contract/_engine/types.ts';
 import {
   SIGNALS_FILE_MAX_BYTES,
   validateSignalsFile,
 } from '@src/integration/ai/contract/_engine/validate-signals-file.ts';
-import type { ChangeSignal, DecisionSignal } from '@src/domain/signal.ts';
+import type { ChangeSignal, CommitMessageSignal, DecisionSignal } from '@src/domain/signal.ts';
 
 const unwrapPath = (s: string): AbsolutePath => {
   const r = AbsolutePath.parse(s);
@@ -79,6 +81,82 @@ describe('validateSignalsFile', () => {
     expect(result.value).toHaveLength(2);
     expect(result.value[0]?.type).toBe('change');
     expect(result.value[1]?.type).toBe('decision');
+  });
+
+  it('rewrites `body` to `text` on a narrative signal so a near-miss does not sink the round', async () => {
+    // Regression: every prompt invites optional note/learning/decision signals, and models reach
+    // for `body` — the field name the neighbouring refined-ticket / pr-content / commit-message
+    // signals use. The array parse is all-or-nothing, so one such near-miss on a signal that only
+    // feeds progress.md used to discard the round's real payload (a whole approved plan session).
+    const path = join(tmp, 'signals.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        signals: [
+          { type: 'change', text: 'added foo', timestamp: '2026-05-22T10:00:00.000Z' },
+          { type: 'decision', body: 'we go with X', timestamp: '2026-05-22T10:00:01.000Z' },
+        ],
+      })
+    );
+
+    const result = await validateSignalsFile(unwrapPath(tmp), sampleContract);
+    if (!result.ok) throw new Error(`expected ok: ${result.error.message}`);
+    expect(result.value).toHaveLength(2);
+    const decision = result.value[1] as DecisionSignal & { readonly body?: string };
+    expect(decision.text).toBe('we go with X');
+    expect(decision.body).toBeUndefined();
+  });
+
+  it('leaves a narrative signal alone when it already carries `text`', async () => {
+    const path = join(tmp, 'signals.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        signals: [
+          { type: 'change', text: 'added foo', timestamp: '2026-05-22T10:00:00.000Z' },
+          { type: 'decision', text: 'canonical', body: 'stray', timestamp: '2026-05-22T10:00:01.000Z' },
+        ],
+      })
+    );
+
+    const result = await validateSignalsFile(unwrapPath(tmp), sampleContract);
+    if (!result.ok) throw new Error(`expected ok: ${result.error.message}`);
+    expect((result.value[1] as DecisionSignal).text).toBe('canonical');
+  });
+
+  it('does NOT rewrite `body` on a non-narrative signal that legitimately uses it', async () => {
+    // `body` is a real, required field on refined-ticket / pr-content / commit-message. A blanket
+    // rewrite would destroy them, so the alias is scoped to the three narrative kinds.
+    const contract: AiOutputContract<CommitMessageSignal> = {
+      schemaVersion: 1,
+      // Same brand bridge the real contracts use — Zod widens optional fields to `T | undefined`
+      // under exactOptionalPropertyTypes; the runtime check is the source of truth.
+      signalsSchema: brandSignalArray<CommitMessageSignal>(z.array(commitMessageSignalSchema)),
+      sidecars: [],
+      migrations: {},
+      exampleSignals: [],
+    };
+    const path = join(tmp, 'signals.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        signals: [
+          {
+            type: 'commit-message',
+            subject: 'feat: x',
+            body: 'why this',
+            timestamp: '2026-05-22T10:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    const result = await validateSignalsFile(unwrapPath(tmp), contract);
+    if (!result.ok) throw new Error(`expected ok: ${result.error.message}`);
+    expect(result.value[0]?.body).toBe('why this');
   });
 
   it('returns InvalidStateError when signals.json is missing', async () => {


### PR DESCRIPTION
## Problem

Planning sprint `2026-07-26` failed twice on 0.17.0. Both runs produced a complete, user-approved
3-task plan — and both were discarded.

The planner wrote four signals. The `task-plan` was valid. The other three (`decision`, `learning`,
`note`) carried their prose in `body`; the schemas require `text`. Contract validation is
all-or-nothing, so three throwaway commentary signals — the kind that only ever get appended to
`progress.md` — invalidated the whole file and took the task plan with them. Sprint stayed `draft`,
no `tasks.json`, no retry path for an interactive flow.

The planner had no way to get it right. `e495880f` (the 0.17.0 prompt audit) added an "optional
signals" block to the plan and ideate templates naming those three kinds, but:

- the rendered `{{OUTPUT_CONTRACT_SECTION}}` example only showed the required payload, and
- the prose read `decision — for architectural choices made during planning (body capped at 500 chars)`.

The model followed the prose. This is the same bug `41e24bc1` fixed for **refine**; plan and ideate
were never covered, and 0.17.0 re-armed the trigger.

## Fix

**Root cause — make the contract self-describing.** Plan and ideate contracts now demonstrate every
narrative kind they accept, so the prompt shows `"text"` verbatim instead of leaving the AI to guess.
The misleading "body" wording is gone from both templates.

**Safety net.** `validateSignalsFile` rewrites `body` → `text` on the three narrative kinds, mirroring
the existing missing-`timestamp` leniency. Scoped deliberately: `body` is a real required field on
`refined-ticket` / `pr-content` / `commit-message`, so a blanket rewrite would destroy them.

**Fence test.** A new grid asserts *accepts-implies-demonstrates* across all 10 contracts. It caught
the same gap in refine, readiness, and the implement generator / evaluator — all closed here. It also
pins that create-pr's deliberate tolerance (it drops stray narrative signals rather than failing) is
not mistaken for acceptance.

Two refine tests asserted the old "drop the malformed signal" behaviour. They now assert recovery,
plus a case proving a signal with no recoverable prose field is still dropped.

## Verification

Replayed against both real failed `signals.json` files from the sprint: each now validates and parses
into its 3 tasks.

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors, 114 warnings (under the 115 cap)
- `pnpm test` — 4795 passed
- `pnpm format:check` — clean
