### PR TITLE
chore(release): 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-28
+
 ### Fixed
 
 - **Planning no longer fails when the AI names a narrative signal field `body`.** 0.17.0 added an "optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.17.1
- Promote `## [Unreleased]` CHANGELOG section to `## [0.17.1]`

Patch release for #268 — planning no longer discards a user-approved task plan when the AI names a
narrative signal field `body` instead of `text`.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` (4795 passed) — green locally
- [ ] CI green