### PR TITLE
chore: full-repo audit campaign — verified fixes, resurrected lint fences, test backfill

### DIFF
--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -1,11 +1,15 @@
 # Reviewer Agent Memory
 
 - [feedback_review_scope.md](feedback_review_scope.md) — Reviewing full feature branches; check all new/changed files
-  top-to-bottom, run all four checks
+  top-to-bottom, run all four checks — plus the scratchpad-tsconfig recipe for scoped typechecks
+- [feedback_typecheck_probe.md](feedback_typecheck_probe.md) — Verifying a "compile-time forcing function" claim with a
+  scratchpad tsc probe when the workflow forbids pnpm typecheck (literal-widening → `never` trap)
 - [project_memory_ledger.md](project_memory_ledger.md) — Theme 6 procedural memory: append-only NDJSON ledger, distill
   sub-chain, attempt outer loop, task-graph validation
-- [project_windowed_list_review.md](project_windowed_list_review.md) — Windowed-list / ScrollRegion review findings: WindowedList dead export, new flaky windowing test, pick-sprint-view not migrated
+- [project_windowed_list_review.md](project_windowed_list_review.md) — Windowed-list / ScrollRegion findings + the headered-list migration hazard: re-attached headers escape the window, and suppressScrollArrows makes the overflow unreachable
 - [project_coalesced_buffer_review.md](project_coalesced_buffer_review.md) — CoalescedBuffer onCritical window-not-cleared bug + double-seed nit from 0.10.0 commit-storm fix
 - [project_esc_collapse_claim_seam.md](project_esc_collapse_claim_seam.md) — Wide Implement view Esc-collapse-before-pop: claimEscape suppresses pop, keymap collapses; undefined-sentinel ref establishes mount-time claim
 - [project_duplicate_codex_effort_clamp.md](project_duplicate_codex_effort_clamp.md) — RESOLVED: readiness's duplicate codex effort floor deleted + pinned by a test; watch for a new copy appearing outside resolve-effort.ts
 - [project_model_refresh_review_2026-07-26.md](project_model_refresh_review_2026-07-26.md) — Opus 5 / GPT-5.6 refresh review: what the catalog-fingerprint gate catches vs. where drift actually lands
+- [project_unwired_ratelimit_jitter.md](project_unwired_ratelimit_jitter.md) — RESOLVED: applyJitter now wired + test-pinned; durable lesson: knip can't flag test-only exports because tests are entry points
+- [project_eslint_sibling_isolation_dead.md](project_eslint_sibling_isolation_dead.md) — Sibling-isolation fences under src/integration/ai/** never fire; the later general integration block replaces the rule

--- a/.claude/agent-memory/reviewer/MEMORY.md
+++ b/.claude/agent-memory/reviewer/MEMORY.md
@@ -12,4 +12,4 @@
 - [project_duplicate_codex_effort_clamp.md](project_duplicate_codex_effort_clamp.md) — RESOLVED: readiness's duplicate codex effort floor deleted + pinned by a test; watch for a new copy appearing outside resolve-effort.ts
 - [project_model_refresh_review_2026-07-26.md](project_model_refresh_review_2026-07-26.md) — Opus 5 / GPT-5.6 refresh review: what the catalog-fingerprint gate catches vs. where drift actually lands
 - [project_unwired_ratelimit_jitter.md](project_unwired_ratelimit_jitter.md) — RESOLVED: applyJitter now wired + test-pinned; durable lesson: knip can't flag test-only exports because tests are entry points
-- [project_eslint_sibling_isolation_dead.md](project_eslint_sibling_isolation_dead.md) — Sibling-isolation fences under src/integration/ai/** never fire; the later general integration block replaces the rule
+- [project_eslint_sibling_isolation_dead.md](project_eslint_sibling_isolation_dead.md) — RESOLVED: dead fences fixed via mergeRestrictedImports composition + liveness suite; durable lesson: flat config replaces same-key rule entries, verify fences by probe

--- a/.claude/agent-memory/reviewer/feedback_review_scope.md
+++ b/.claude/agent-memory/reviewer/feedback_review_scope.md
@@ -1,6 +1,6 @@
 ---
 name: feedback_review_scope
-description: Review approach — full branch diff, all four tool checks, per-file deep read of new code
+description: Review approach — full branch diff, all four tool checks, per-file deep read of new code, and how to run scoped eslint/prettier/vitest/tsc when a full-repo check is off-limits
 metadata:
   type: feedback
 ---
@@ -14,3 +14,10 @@ rules manually for new integration paths (not just ESLint flags).
 **How to apply:** For every new file under `application/flows/_shared/`, manually scan its imports for references to
 sibling named flows (e.g. `readiness/flow.ts`). The ESLint rule only blocks imports FROM named FLOWS, not FROM
 `_shared`.
+
+**Scoped checks when a full `pnpm typecheck` is off-limits** (e.g. multi-agent campaigns where other packages are
+mid-edit): `npx eslint <files>`, `npx prettier --check <files>`, `npx vitest run <paths>` all scope cleanly. For types,
+write a throwaway tsconfig in the scratchpad that `extends` the repo tsconfig with `"include": []` + an explicit `files`
+list — it must also re-declare `typeRoots` (absolute, to the repo's `node_modules/@types`) and `paths` with ABSOLUTE
+values, because both resolve relative to the extending config's directory and silently break otherwise. Prefer this
+over `baseUrl` (TS 6 deprecation error).

--- a/.claude/agent-memory/reviewer/feedback_typecheck_probe.md
+++ b/.claude/agent-memory/reviewer/feedback_typecheck_probe.md
@@ -1,0 +1,24 @@
+---
+name: feedback-typecheck-probe
+description: How to verify a "compile-time forcing function" claim when the review workflow forbids running pnpm typecheck
+metadata:
+  type: feedback
+---
+
+When a fix claims a type-level guarantee (`satisfies`, mapped type, `Required<Pick<…>>`, branded type) and the review
+harness forbids `pnpm typecheck`, do NOT take the claim on faith and do NOT settle for the runtime tests — replicate the
+pattern in a scratchpad-only `.ts` file with a synthetic stand-in for the repo type and run `tsc` on it, including a
+NEGATIVE variant that should error.
+
+**Why:** these guards are load-bearing only if the inferred types come out as literals. A `satisfies` map whose property
+types widen to `string` silently degrades a derived key union to `never`, so the "forcing function" compiles no matter
+what while every runtime test still passes. Nothing in vitest can distinguish the two.
+
+**How to apply:** copy the repo's compilerOptions that change inference (`strict`, `exactOptionalPropertyTypes`,
+`noUncheckedIndexedAccess`, `target`, `verbatimModuleSyntax`); add `{"type":"module"}` package.json in the probe dir or
+`verbatimModuleSyntax` + NodeNext will report bogus TS1287 on every export; pass `--ignoreConfig` when naming files on
+the CLI next to a tsconfig.json. Assert BOTH directions — a positive (`const k: DerivedKey = 'realKey'` compiles, proving
+the union isn't `never`) and a negative (omit the field → expect the exact TSxxxx the docstring promises).
+
+Applies to any review under a "never run pnpm typecheck/lint/test" workflow — see [[feedback_review_scope]] for the
+normal, unrestricted pass.

--- a/.claude/agent-memory/reviewer/project_eslint_sibling_isolation_dead.md
+++ b/.claude/agent-memory/reviewer/project_eslint_sibling_isolation_dead.md
@@ -1,0 +1,30 @@
+---
+name: eslint-sibling-isolation-dead-under-integration
+description: Sibling-isolation ESLint fences under src/integration/ai/** are silently dead — the later general src/integration/** block replaces their no-restricted-imports value
+metadata:
+  type: project
+---
+
+The `siblingIsolationRule(...)` blocks in `eslint.config.ts` for
+`src/integration/ai/{prompts,providers,readiness,skills,agents}/<sibling>/` are **not enforced**. The
+general `{ files: ['src/integration/**/*.{ts,tsx}'] }` block is declared later in the flat-config array
+and sets its own `'no-restricted-imports'`; ESLint flat config **replaces** (never merges) a same-key
+rule entry, so the sibling patterns are wiped for every file under `src/integration/`.
+
+Verified empirically 2026-08-01 with `new Linter().verify(code, config, filename)`:
+a `providers/claude → providers/codex` import produces **no** diagnostic with the config as shipped,
+and produces the expected "Sibling-provider import violation" once **both** `src/integration/**` blocks
+are filtered out of the array. The equivalent fences for `src/business/<x>/` and
+`src/domain/repository/<x>/` are NOT affected (no later same-glob block overrides them);
+`src/application/flows/<x>/` is also fine (its sibling block is declared after the flows block).
+
+**Why:** discovered while reviewing the security-hygiene `node:child_process` fence, which added a
+second `src/integration/**` block. The new block did not cause this — it predates the change — but
+any future work that "adds a rule to the integration block" needs to know which of the two same-glob
+blocks actually wins.
+
+**How to apply:** treat CLAUDE.md's claim that sibling isolation under `integration/ai/` is
+ESLint-fenced as aspirational for that subtree — verify cross-sibling imports by hand in review until
+the config is fixed. Fixing it means folding the sibling patterns into the integration block (or
+declaring the sibling blocks after it). Related: [[project_duplicate_codex_effort_clamp]] for the
+same "a fence exists but doesn't fire" failure mode.

--- a/.claude/agent-memory/reviewer/project_eslint_sibling_isolation_dead.md
+++ b/.claude/agent-memory/reviewer/project_eslint_sibling_isolation_dead.md
@@ -1,30 +1,27 @@
 ---
 name: eslint-sibling-isolation-dead-under-integration
-description: Sibling-isolation ESLint fences under src/integration/ai/** are silently dead — the later general src/integration/** block replaces their no-restricted-imports value
+description: 'RESOLVED 2026-08-01: dead fences fixed via mergeRestrictedImports composition — durable lesson: flat config replaces same-key rule entries, so overlapping blocks must carry the union'
 metadata:
   type: project
 ---
 
-The `siblingIsolationRule(...)` blocks in `eslint.config.ts` for
-`src/integration/ai/{prompts,providers,readiness,skills,agents}/<sibling>/` are **not enforced**. The
-general `{ files: ['src/integration/**/*.{ts,tsx}'] }` block is declared later in the flat-config array
-and sets its own `'no-restricted-imports'`; ESLint flat config **replaces** (never merges) a same-key
-rule entry, so the sibling patterns are wiped for every file under `src/integration/`.
+RESOLVED: the dead fences were fixed the same day via `mergeRestrictedImports` in
+`eslint.config.ts` — every sibling-isolation block now composes its layer base back in
+(integration spawn-fenced rule / businessLayerRule / domainLayerRule / chainsLayerRule), and the
+five `integration/ai` sibling blocks moved after the general `src/integration/**` blocks so they
+win. Empirical probing found the blast radius was WIDER than first recorded: besides the five ai
+sibling isolations, the business I/O + composite-repository bans, the domain layer rule under
+`repository/<x>/`, and the chains no-concrete-adapters rule under `flows/<x>/` were all dead.
+Resurrecting the chains rule exposed 42 per-signal schema imports — all in per-leaf
+`*.contract.ts` files, which the audit-[09] contract sanctions, so the rule (not the code) was
+adjusted: `chainsContractFileRule` lifts only the schema ban for `*.contract.ts`.
 
-Verified empirically 2026-08-01 with `new Linter().verify(code, config, filename)`:
-a `providers/claude → providers/codex` import produces **no** diagnostic with the config as shipped,
-and produces the expected "Sibling-provider import violation" once **both** `src/integration/**` blocks
-are filtered out of the array. The equivalent fences for `src/business/<x>/` and
-`src/domain/repository/<x>/` are NOT affected (no later same-glob block overrides them);
-`src/application/flows/<x>/` is also fine (its sibling block is declared after the flows block).
+**Durable lesson (still true):** ESLint flat config REPLACES a same-key rule entry when a later
+block matches the same file — options never merge. Any block narrowing a broader glob silently
+wipes the broader block's same-key restrictions in both directions. The liveness suite in
+`tests/unit/eslint-config.test.ts` ("fence liveness under overlapping config blocks") probes
+every overlap with `Linter().verify`; extend it whenever a new no-restricted-imports block
+lands, and verify a "fence exists" claim by probe, not by reading the config.
 
-**Why:** discovered while reviewing the security-hygiene `node:child_process` fence, which added a
-second `src/integration/**` block. The new block did not cause this — it predates the change — but
-any future work that "adds a rule to the integration block" needs to know which of the two same-glob
-blocks actually wins.
-
-**How to apply:** treat CLAUDE.md's claim that sibling isolation under `integration/ai/` is
-ESLint-fenced as aspirational for that subtree — verify cross-sibling imports by hand in review until
-the config is fixed. Fixing it means folding the sibling patterns into the integration block (or
-declaring the sibling blocks after it). Related: [[project_duplicate_codex_effort_clamp]] for the
-same "a fence exists but doesn't fire" failure mode.
+Related: [[project_duplicate_codex_effort_clamp]] for the same "a fence exists but doesn't
+fire" failure mode.

--- a/.claude/agent-memory/reviewer/project_unwired_ratelimit_jitter.md
+++ b/.claude/agent-memory/reviewer/project_unwired_ratelimit_jitter.md
@@ -1,0 +1,19 @@
+---
+name: unwired-ratelimit-jitter
+description: 'RESOLVED 2026-08-01: applyJitter is now wired into run-with-rate-limit-retry.ts — durable lesson: knip cannot flag test-only exports because tests are entry points'
+metadata:
+  type: project
+---
+
+RESOLVED: `applyJitter` was wired into `handleRateLimitOutcome` in `run-with-rate-limit-retry.ts`
+(the `delayForRetry(...) → sleepCancellable(...)` hop) later the same day it was flagged, with an
+injectable `random` option on `RunWithRateLimitRetryOptions` and three pinning tests in
+`tests/unit/integration/ai/providers/_engine/run-with-rate-limit-retry.test.ts` (+20% / -20% /
+zero-delay fast path). 429 backoff is jittered production behaviour now.
+
+**Durable lesson (still true):** `pnpm deadcode` stays green for an export used only by tests,
+because `knip.json` lists `tests/**/*.test.ts` as entry points. "It has tests and knip is green"
+does NOT prove a production caller exists — grep `src/` for a non-test call site before citing a
+mechanism as shipped behaviour (release notes, PERFORMANCE.md, a harness review).
+
+Related: [[project_model_refresh_review_2026-07-26]]

--- a/.claude/agent-memory/reviewer/project_windowed_list_review.md
+++ b/.claude/agent-memory/reviewer/project_windowed_list_review.md
@@ -1,6 +1,6 @@
 ---
 name: project_windowed_list_review
-description: Key findings from the windowed-list / ScrollRegion suppressArrows review on ui-ux-stabilization branch
+description: Windowed-list / ScrollRegion review findings, plus the headered-list migration hazard (window bounds only the cursorable subset once headers are re-attached)
 metadata:
   type: project
 ---
@@ -13,9 +13,19 @@ Reviewed branch: ui-ux-stabilization (commit range against main).
 - `sprint-detail-view.windowing.test.tsx` is a NEW test added on this branch; the reviewer flagged it as flaky under full-suite load (used `tick(60)`), but three subsequent full-suite runs were green — treat as a latent timing risk, not a confirmed failure. `waitForViewReady` is the robust pattern if it ever flakes.
 - `progress-overlay.test.tsx` is the pre-existing known flaky test; unrelated to this branch.
 - `badge.tsx` became an unused file ON THIS BRANCH (its only consumer, `flows-view`, was dropped in the flow-clarity refactor); `knip` passes on `main`, so this WAS a branch regression of the deadcode invariant. RESOLVED: file + its DESIGN-SYSTEM row removed.
-- `pick-sprint-view` is NOT migrated to `useListWindow` — still uses index-based `computeWindow` + its own `useInput` arrows. RESOLVED the double-scroll by adding `suppressScrollArrows` to its `ViewShell`; the full `useListWindow` migration is still deferred.
+- `pick-sprint-view` WAS migrated to `useListWindow` (2026-08-01 fix campaign) — id-keyed cursor lives in `PickerRowList`; `pick-sprint-internals/window.ts`'s `computeWindow` then had zero production callers and survived only via the `@public` re-export + `tests/unit/.../pick-sprint-window.test.ts`.
 - `scroll-region.tsx` module comment referenced deleted `ListView, CardList` — RESOLVED (points at `useListWindow` now).
 - `suppressArrows` is implemented correctly: early return in the handler body (not `isActive: false`), so keys fall through to `useListWindow`'s handler.
+
+**Headered-list migration hazard (check this on every `useListWindow` migration of a grouped list):** the
+established pattern (`action-menu.tsx`, now `pick-sprint-internals/row-views.tsx`) windows over the _cursorable
+subset_ and re-attaches headers for rendering. That silently drops the "rendered height ≤ `visibleRows`" property
+the pre-migration `computeWindow(rows.length, …)` had, because each re-attached header adds lines on top of the
+window — and any "always render this header regardless of the window" exemption makes the overshoot unbounded in
+group count. It bites hard specifically because these views pass `suppressScrollArrows`, so `ScrollRegion`'s
+keyboard scroll is off and overflowed content is unreachable without a mouse. Cheap fix shape: keep `useListWindow`
+for cursor + keys over the cursorable subset, but derive the _render_ slice from
+`computeListWindow(rows.length, indexOfFocusedInRows, visibleRows)` over the full flat row list.
 
 **Why:** These facts are non-obvious from reading code alone and help future reviewer/implementer agents avoid false positives. The RESOLVED markers record that the pre-merge fix pass (PR #190) addressed each item.
 

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -510,7 +510,9 @@ of the stack — the leaf or use-case wrapping them catches and converts to `Res
 │           │           └── session-id.txt
 │           ├── feedback.md            ← human review feedback input (read by the review flow)
 │           ├── distill/               ← learning-distill AI session sandbox (opt-in at close)
-│           └── review/                ← apply-feedback per-round forensics
+│           ├── review/                ← apply-feedback per-round forensics
+│           ├── logs/setup/<repository-id>.log            ← full setup-script stdout/stderr per repo
+│           └── logs/verify/<task-id>/{pre,post}-attempt-<N>.log  ← full verify-script stdout/stderr per task per attempt
 └── state/
     └── locks/
         └── repo-<worktree-hash>.lock/ ← cross-process advisory lock directory (one per sprint, keyed by sha1 of the sprint dir path — implement and review share the same key)
@@ -518,7 +520,9 @@ of the stack — the leaf or use-case wrapping them catches and converts to `Res
 
 Path resolution lives in `src/application/bootstrap/storage-paths.ts` (`resolveStoragePaths`,
 `storagePathsFromRoot`, `ensureStorageRoots`). On-disk path helpers for the sprint subtree live in
-`src/integration/persistence/storage.ts`.
+`src/integration/persistence/storage.ts`. This tree is canonical — the abbreviated `<sprintDir>/`
+subtree in [diagrams/02-sprint-lifecycle.md § On-disk shape](./diagrams/02-sprint-lifecycle.md#on-disk-shape)
+mirrors it and should stay in sync.
 
 The `RALPHCTL_HOME` env var, when set to an absolute path, replaces the entire `<home>/.ralphctl` prefix.
 Used by integration tests that spawn real subprocesses, and by users who want a non-default data location.
@@ -626,18 +630,19 @@ EventBus events emitted by the chain runner / adapters (not parsed from AI outpu
 All domain errors extend `DomainError` (`src/domain/value/error/domain-error.ts`) and carry a machine-readable
 `code` plus optional `cause`. The error class is one of the few legitimate places `class` is allowed.
 
-| Class               | Folder                | Cause                                                                  |
-| ------------------- | --------------------- | ---------------------------------------------------------------------- |
-| `NotFoundError`     | `domain/value/error/` | Aggregate (project / sprint / ticket / task) not found by id           |
-| `ConflictError`     | `domain/value/error/` | Uniqueness or cardinality violation (e.g. duplicate slug, repo path)   |
-| `InvalidStateError` | `domain/value/error/` | Operation invalid for the entity's current status                      |
-| `ValidationError`   | `domain/value/error/` | Smart-constructor or schema validation failed (carries `field`/`path`) |
-| `ParseError`        | `domain/value/error/` | JSON / output parser rejection                                         |
-| `StorageError`      | `domain/value/error/` | Read/write failure in the persistence layer                            |
-| `RateLimitError`    | `domain/value/error/` | AI process rate-limited (wraps spawn outcome)                          |
-| `AbortError`        | `domain/value/error/` | User-initiated cancellation; propagates through chains                 |
-| `ProbeError`        | `domain/value/error/` | Readiness probe rejection                                              |
-| `MigrationGapError` | `domain/value/error/` | On-disk schemaVersion older than expected and no migration registered  |
+| Class               | Folder                | Cause                                                                                                                                                                                  |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NotFoundError`     | `domain/value/error/` | Aggregate (project / sprint / ticket / task) not found by id                                                                                                                           |
+| `ConflictError`     | `domain/value/error/` | Uniqueness or cardinality violation (e.g. duplicate slug, repo path)                                                                                                                   |
+| `InvalidStateError` | `domain/value/error/` | Operation invalid for the entity's current status                                                                                                                                      |
+| `ValidationError`   | `domain/value/error/` | Smart-constructor or schema validation failed (carries `field`/`path`)                                                                                                                 |
+| `ParseError`        | `domain/value/error/` | JSON / output parser rejection                                                                                                                                                         |
+| `StorageError`      | `domain/value/error/` | Read/write failure in the persistence layer                                                                                                                                            |
+| `RateLimitError`    | `domain/value/error/` | AI process rate-limited (wraps spawn outcome)                                                                                                                                          |
+| `AbortError`        | `domain/value/error/` | User-initiated cancellation; propagates through chains                                                                                                                                 |
+| `ProbeError`        | `domain/value/error/` | Readiness probe rejection                                                                                                                                                              |
+| `MigrationGapError` | `domain/value/error/` | On-disk schemaVersion older than expected and no migration registered                                                                                                                  |
+| `ProcessCrashError` | `domain/value/error/` | Transient AI-process death (watchdog kill, spawn failure, exit before `signals.json`) — retried within `maxAttempts` rather than blocked after one attempt, unlike `InvalidStateError` |
 
 ## Exit Codes
 

--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -6,7 +6,7 @@ most needs are already covered.
 
 Companion docs:
 
-- [REQUIREMENTS.md § UI Contract](./REQUIREMENTS.md#ui-contract) — the testable acceptance criteria.
+- [REQUIREMENTS.md § TUI](./REQUIREMENTS.md#tui) — the testable acceptance criteria.
 - [ARCHITECTURE.md § Terminal UI Layer](./ARCHITECTURE.md#terminal-ui-layer-srcapplicationui) — file layout and
   runtime wiring.
 - `src/application/ui/tui/theme/tokens.ts` — the tokens themselves, in code.

--- a/.claude/docs/REQUIREMENTS.md
+++ b/.claude/docs/REQUIREMENTS.md
@@ -286,7 +286,7 @@ Status flow: `draft → planned → active → review → done`.
 - [x] **Surface is deliberately smaller than the pre-TUI CLI** — interactive flows (refine / plan / ideate /
       implement / readiness / create-sprint) stay TUI-only. The CLI exposes only inspection commands +
       one-shot operations: `doctor`, `completion <shell>`, `export-context`, `export-requirements`, `create-pr`,
-      `agents {list}`, `settings {show,set,apply-preset}`, `project {list,show,remove}`,
+      `agents {list}`, `skills {list}`, `settings {show,set,apply-preset}`, `project {list,show,remove}`,
       `sprint {list,show,set-current,activate,close,remove,progress}`,
       `ticket {list,show,add,remove}`, `task {list,show,unblock}`,
       `runs {list,prune}`.

--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -46,11 +46,18 @@ fenced from business code by the layer rules.
 
 **Cross-platform process spawning** goes through `integration/io/cross-platform-spawn.ts`
 (`crossPlatformSpawn`, backed by `cross-spawn`) — the single primitive every external-CLI spawn
-(`claude` / `codex` / `gh` / `glab` / `git`, headless + interactive) delegates to. Never call
-`node:child_process.spawn` directly for a binary: on Node 24 Windows a bare spawn cannot launch the
-npm/winget `.cmd` shims, and `shell: true` mis-quotes arguments with spaces or `& | % "`. The
-exception is the setup/verify-script runner (`shell-script-runner.ts`), which intentionally keeps
-`shell: true` because it runs a user-authored command _string_, not a binary + args.
+(`claude` / `codex` / `gh` / `glab` / `git`, headless + interactive) delegates to, including
+`clipboard.ts` and `command-exists.ts`. Never call `node:child_process.spawn` directly for a
+binary: on Node 24 Windows a bare spawn cannot launch the npm/winget `.cmd` shims, and
+`shell: true` mis-quotes arguments with spaces or `& | % "`. There are two named exceptions: the
+setup/verify-script runner (`shell-script-runner.ts`), which intentionally keeps `shell: true`
+because it runs a user-authored command _string_, not a binary + args; and
+`os-notification-dispatcher.ts`, which uses promisified `execFile` for its buffered-stdout,
+reject-on-nonzero semantics against `osascript` / `notify-send` / `which`. An ESLint
+`no-restricted-imports` rule (`childProcessSpawnBan` in `eslint.config.ts`, scoped by
+`importNames` to the spawn/exec family) fences every other file under `src/integration/**` from
+importing `node:child_process`'s spawn functions directly, so the two-exception list above is
+enforced at lint time, not by convention.
 
 **`AbortError` is the one error chains propagate transparently.** User-initiated cancellation (Ctrl+C, the
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard

--- a/.claude/docs/diagrams/02-sprint-lifecycle.md
+++ b/.claude/docs/diagrams/02-sprint-lifecycle.md
@@ -71,6 +71,10 @@ state to revert.
 
 ## On-disk shape
 
+Mirrors [ARCHITECTURE.md § Storage layout](../ARCHITECTURE.md#storage-layout) — see there for the full tree
+(per-flow sandbox contents, `skills/`, `memory/`, lock directory, …); this is an abbreviated view of the
+`<sprintDir>/` subtree only.
+
 ```
 <dataRoot>/sprints/<id>--<slug>/
 ├── sprint.json          ← planning aggregate (tickets, status, project ref)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Corrective retry no longer burns resumed spawns on a harness-side I/O failure.** A read failure on an
+  already-written `signals.json` (e.g. a permission error) was misclassified as "the AI forgot to write the
+  file" and retried up to `harness.correctiveRetries` times with a misleading nudge before self-blocking with
+  the same error. Only genuinely re-promptable failures (missing file, invalid JSON, schema mismatch) are
+  retried now; a harness-side I/O fault self-blocks immediately.
+- **Sprint picker cursor no longer jumps away from a manually navigated row.** Toggling "hide done" (`f`)
+  could reshuffle the row list and snap the cursor back onto the currently-selected sprint instead of
+  staying on the row the user had navigated to.
+- **Plateau early-warning line no longer under-reports the longest stall streak** on tasks with more than 8
+  concurrently-failing grading dimensions — the generator's "K stalled round(s)" nudge could previously miss
+  a dimension that had actually stalled the longest.
+- **Interactive refine / plan / ideate / readiness sessions now honor a suspended model**, matching the
+  headless implement / evaluate guard. Dormant today (no models are currently suspended) but closes the gap
+  for the next incident — previously an interactive session on a suspended model would spawn and fail with an
+  opaque CLI error instead of a clear one.
+
+### Changed
+
+- **Sprint and project listing reads every entity file concurrently** instead of one at a time, speeding up
+  TUI and CLI startup for installations with many historical sprints or projects.
+- **Tightened the implement prompt's project-context-file rule** — secrets and credentials are now an
+  unconditional "never" with no exception; the existing declared-step exception still applies to slash
+  commands, hooks, MCP server config, and IDE settings.
+
 ## [0.17.1] - 2026-07-28
 
 ### Fixed

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -53,9 +53,17 @@ import type { ESLint, Linter } from 'eslint';
  *   AI may use I/O-bearing node:* modules — it owns the provider/template/skill I/O.
  */
 
-const restrictImports = (forbidden: readonly string[]): Linter.RuleEntry => [
+const restrictImports = (
+  forbidden: readonly string[],
+  extraPaths: readonly {
+    readonly name: string;
+    readonly importNames?: readonly string[];
+    readonly message: string;
+  }[] = []
+): Linter.RuleEntry => [
   'error',
   {
+    paths: extraPaths,
     patterns: forbidden.map((layer) => ({
       group: [`**/${layer}/**`],
       message: `Layer dependency violation: cannot import from '${layer}'.`,
@@ -72,6 +80,32 @@ const resultLibBan = {
   name: 'typescript-result',
   message:
     "Import `Result` from '@src/domain/result.ts' (the single re-export point) instead. The underlying `typescript-result` library may only be imported by that one file so the implementation can be swapped without churning callers.",
+} as const;
+
+/**
+ * `node:child_process`'s spawn-family functions are fenced to the sanctioned wrappers everywhere
+ * outside domain/business (which ban the whole module via `nodeIoBans` already). Every
+ * external-binary spawn routes through `integration/io/cross-platform-spawn.ts`
+ * (`crossPlatformSpawn`) — see SECURITY.md. Two named exceptions carry their own justification and
+ * are excluded from this rule instead of routed through the wrapper:
+ *   - `shell-script-runner.ts` — runs a user-authored shell command *string* and needs `shell: true`,
+ *     which `crossPlatformSpawn` intentionally does not support.
+ *   - `os-notification-dispatcher.ts` — needs the *promisified* `execFile` API: a single awaited
+ *     call that buffers stdout/stderr and rejects on a non-zero exit (used both to run
+ *     `osascript` / `notify-send` and to probe `which notify-send`), a shape `crossPlatformSpawn`'s
+ *     event-based `spawn` wrapper doesn't provide. (`spawn` does accept a `timeout` option, so a
+ *     wall-clock cap alone would not justify the exception — it's specifically the buffered,
+ *     promise-shaped result that's missing.)
+ *
+ * Scoped by `importNames` (not the whole module) so type-only imports (`ChildProcess`,
+ * `ChildProcessWithoutNullStreams`, `SpawnOptions`, …) — used all over the AI provider adapters for
+ * test-seam typing — stay unaffected.
+ */
+const childProcessSpawnBan = {
+  name: 'node:child_process',
+  importNames: ['spawn', 'execFile', 'exec', 'fork', 'execSync', 'spawnSync', 'execFileSync'],
+  message:
+    'Direct node:child_process spawn/exec imports are fenced outside the sanctioned wrappers — route external-binary spawns through integration/io/cross-platform-spawn.ts (crossPlatformSpawn). shell-script-runner.ts and os-notification-dispatcher.ts are the two named exceptions — see the rationale above this rule (childProcessSpawnBan in eslint.config.ts) and the header comment in each file.',
 } as const;
 
 /**
@@ -627,6 +661,21 @@ export default [
     files: ['src/integration/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': restrictImports(['application']),
+    },
+  },
+
+  // ── integration — node:child_process spawn/exec fence ───────────────────────
+  // Overrides the block above (same glob, declared later) to additionally ban raw spawn/exec
+  // imports everywhere under integration/ EXCEPT the two named exceptions, which keep the base
+  // layer-direction check only. See `childProcessSpawnBan` for the full rationale.
+  {
+    files: ['src/integration/**/*.{ts,tsx}'],
+    ignores: [
+      'src/integration/io/shell-script-runner.ts',
+      'src/integration/observability/os-notification-dispatcher.ts',
+    ],
+    rules: {
+      'no-restricted-imports': restrictImports(['application'], [childProcessSpawnBan]),
     },
   },
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -108,6 +108,15 @@ const childProcessSpawnBan = {
     'Direct node:child_process spawn/exec imports are fenced outside the sanctioned wrappers — route external-binary spawns through integration/io/cross-platform-spawn.ts (crossPlatformSpawn). shell-script-runner.ts and os-notification-dispatcher.ts are the two named exceptions — see the rationale above this rule (childProcessSpawnBan in eslint.config.ts) and the header comment in each file.',
 } as const;
 
+/** Base layer rule for src/integration/** — no imports from application. */
+const integrationLayerRule = restrictImports(['application']);
+
+/**
+ * The integration rule most files get: layer direction + the spawn/exec fence. Also the base
+ * the integration/ai sibling-isolation blocks compose over (see `mergeRestrictedImports`).
+ */
+const integrationSpawnFencedRule = restrictImports(['application'], [childProcessSpawnBan]);
+
 /**
  * Node modules that perform I/O or expose host-environment state. Banned in domain + business so
  * the product model stays portable + testable without a node runtime. Integration / ai may
@@ -164,6 +173,39 @@ const siblingIsolationRule = (
       })),
     },
   ];
+};
+
+/**
+ * Union several `no-restricted-imports` entries into one. ESLint flat config REPLACES a
+ * same-key rule entry wholesale when a later block matches the same file — options are never
+ * merged — so a block that narrows a broader glob (a sibling-isolation block inside a layer
+ * glob) silently wipes the broader block's restrictions for its files, and vice versa. Every
+ * narrower block therefore composes its own restrictions WITH the broader block's via this
+ * helper, so whichever entry survives carries the full set regardless of declaration order.
+ * Duplicate paths/patterns (e.g. `resultLibBan`, present in both inputs) are deduped so one
+ * violation reports once. The liveness suite in tests/unit/eslint-config.test.ts pins every
+ * overlap this composes.
+ */
+const mergeRestrictedImports = (...entries: readonly Linter.RuleEntry[]): Linter.RuleEntry => {
+  const paths: unknown[] = [];
+  const patterns: unknown[] = [];
+  const seen = new Set<string>();
+  const push = (bucket: unknown[], items: readonly unknown[] | undefined, tag: string): void => {
+    for (const item of items ?? []) {
+      const key = `${tag}:${JSON.stringify(item)}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        bucket.push(item);
+      }
+    }
+  };
+  for (const entry of entries) {
+    if (!Array.isArray(entry)) continue;
+    const options = entry[1] as { readonly paths?: readonly unknown[]; readonly patterns?: readonly unknown[] };
+    push(paths, options.paths, 'path');
+    push(patterns, options.patterns, 'pattern');
+  }
+  return ['error', { paths, patterns }] as Linter.RuleEntry;
 };
 
 const FLOWS = [
@@ -301,37 +343,53 @@ const businessLayerRule: Linter.RuleEntry = [
  * are picked by the composition root. Chain compositions speak only port-level vocabulary so
  * the provider can be swapped without changing flow code.
  */
+const chainsBasePatterns = [
+  { group: ['**/application/ui/**'], message: 'Chains may not import from UI.' },
+  { group: ['**/application/bootstrap/**'], message: 'Chains may not import from bootstrap.' },
+  {
+    group: PROVIDERS.map((p) => `**/integration/ai/providers/${p}/**`),
+    message:
+      'Chains may not import concrete provider adapters — depend on integration/ai/providers/_engine/ port instead. Bootstrap selects the concrete provider.',
+  },
+  {
+    group: READINESS_PROVIDERS.map((p) => `**/integration/ai/readiness/${p}/**`),
+    message:
+      'Chains may not import concrete readiness probes — depend on integration/ai/readiness/_engine/ port instead. Bootstrap wires concrete probes.',
+  },
+  {
+    group: [...SKILLS.map((s) => `**/integration/ai/skills/${s}/**`), '**/integration/ai/skills/adapter-factory.ts'],
+    message:
+      'Chains may not import concrete skill adapters / sources — depend on integration/ai/skills/_engine/ ports instead. Bootstrap selects concrete skills.',
+  },
+];
+
+/**
+ * Per-signal Zod schemas are private to the contract engine, with ONE sanctioned exception:
+ * per-leaf `*.contract.ts` files, which the audit-[09] contract makes the single composition
+ * point declaring which signals a leaf consumes. The contract-file config blocks below use
+ * `chainsContractFileRule` (this pattern omitted); everything else under flows/ gets
+ * `chainsLayerRule` (this pattern included).
+ */
+const chainsSignalSchemaBan = {
+  group: ['**/integration/ai/contract/_engine/signals/**'],
+  message:
+    'Chains may not import per-signal Zod schemas directly — go through the leaf contract (validateSignalsFile / renderSidecars / renderContractSection) under integration/ai/contract/_engine/. Per-signal schemas are private to the contract engine; a per-leaf *.contract.ts file is the one sanctioned import point.',
+};
+
 const chainsLayerRule: Linter.RuleEntry = [
   'error',
   {
     paths: [resultLibBan],
-    patterns: [
-      { group: ['**/application/ui/**'], message: 'Chains may not import from UI.' },
-      { group: ['**/application/bootstrap/**'], message: 'Chains may not import from bootstrap.' },
-      {
-        group: PROVIDERS.map((p) => `**/integration/ai/providers/${p}/**`),
-        message:
-          'Chains may not import concrete provider adapters — depend on integration/ai/providers/_engine/ port instead. Bootstrap selects the concrete provider.',
-      },
-      {
-        group: READINESS_PROVIDERS.map((p) => `**/integration/ai/readiness/${p}/**`),
-        message:
-          'Chains may not import concrete readiness probes — depend on integration/ai/readiness/_engine/ port instead. Bootstrap wires concrete probes.',
-      },
-      {
-        group: [
-          ...SKILLS.map((s) => `**/integration/ai/skills/${s}/**`),
-          '**/integration/ai/skills/adapter-factory.ts',
-        ],
-        message:
-          'Chains may not import concrete skill adapters / sources — depend on integration/ai/skills/_engine/ ports instead. Bootstrap selects concrete skills.',
-      },
-      {
-        group: ['**/integration/ai/contract/_engine/signals/**'],
-        message:
-          'Chains may not import per-signal Zod schemas directly — go through the leaf contract (validateSignalsFile / renderSidecars / renderContractSection) under integration/ai/contract/_engine/. Per-signal schemas are private to the contract engine.',
-      },
-    ],
+    patterns: [...chainsBasePatterns, chainsSignalSchemaBan],
+  },
+];
+
+/** The chains rule for per-leaf `*.contract.ts` files — everything except the schema ban. */
+const chainsContractFileRule: Linter.RuleEntry = [
+  'error',
+  {
+    paths: [resultLibBan],
+    patterns: chainsBasePatterns,
   },
 ];
 
@@ -493,81 +551,6 @@ export default [
     },
   },
 
-  // ── integration/ai/prompts/<x>/ — sibling-prompt isolation ───────────────────
-  // Each prompt is independent. Shared machinery lives under prompts/_engine/.
-  ...PROMPTS.map((active): Linter.Config => ({
-    files: [`src/integration/ai/prompts/${active}/**/*.{ts,tsx}`],
-    rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/integration/ai/prompts',
-        active,
-        PROMPTS,
-        ['_engine', '_partials'],
-        'prompt'
-      ),
-    },
-  })),
-
-  // ── integration/ai/providers/<x>/ — sibling-provider isolation ───────────────
-  // Each tool adapter is independent. Cross-tool sharing goes through providers/_engine/.
-  ...PROVIDERS.map((active): Linter.Config => ({
-    files: [`src/integration/ai/providers/${active}/**/*.{ts,tsx}`],
-    rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/integration/ai/providers',
-        active,
-        PROVIDERS,
-        ['_engine'],
-        'provider'
-      ),
-    },
-  })),
-
-  // ── integration/ai/readiness/<x>/ — sibling-readiness-probe isolation ────────
-  // Each per-tool readiness probe is independent. Cross-tool sharing goes through readiness/_engine/.
-  ...READINESS_PROVIDERS.map((active): Linter.Config => ({
-    files: [`src/integration/ai/readiness/${active}/**/*.{ts,tsx}`],
-    rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/integration/ai/readiness',
-        active,
-        READINESS_PROVIDERS,
-        ['_engine'],
-        'readiness probe'
-      ),
-    },
-  })),
-
-  // ── integration/ai/skills/<x>/ — sibling-skill isolation ─────────────────────
-  // Per-tool adapter directories (claude/codex/copilot) and skill-source directories
-  // (bundled/project) are all independent siblings. Cross-sibling sharing goes through
-  // skills/_engine/. The composition switch over the per-tool adapters lives at
-  // skills/adapter-factory.ts (directly under skills/, outside the sibling glob).
-  ...SKILLS.map((active): Linter.Config => ({
-    files: [`src/integration/ai/skills/${active}/**/*.{ts,tsx}`],
-    rules: {
-      'no-restricted-imports': siblingIsolationRule('**/integration/ai/skills', active, SKILLS, ['_engine'], 'skill'),
-    },
-  })),
-
-  // ── integration/ai/agents/<x>/ — sibling-agent-definition isolation ──────────
-  // Per-tool adapter directories (claude/codex/copilot) and definition-source directories
-  // (bundled/operator) are all independent siblings. Cross-sibling sharing goes through
-  // agents/_engine/. The composition switch over the per-tool adapters lives at
-  // agents/adapter-factory.ts (directly under agents/, outside the sibling glob).
-  ...AGENTS.map((active): Linter.Config => ({
-    files: [`src/integration/ai/agents/${active}/**/*.{ts,tsx}`],
-    rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/integration/ai/agents',
-        active,
-        AGENTS,
-        ['_engine'],
-        'agent definition'
-      ),
-    },
-  })),
-
   // ── integration/ai/** — port declarations must live in _engine/ ──────────────
   // Port-shaped names (`*Port`, `*Adapter`, `*Provider`, `*Sink`, `*Loader`, `*Probe`,
   // `*Reader`, `*Writer`, `*Renderer`, `*Detector`) define cross-tool contracts. They
@@ -628,12 +611,17 @@ export default [
   ...BUSINESS_SIBLINGS.map((active): Linter.Config => ({
     files: [`src/business/${active}/**/*.{ts,tsx}`],
     rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/business',
-        active,
-        BUSINESS_SIBLINGS,
-        ['_engine', '_shared', 'observability'],
-        'business module'
+      // Composed over the layer rule — this block wins over the src/business/** block above
+      // (same key, later declaration), so it must carry the layer bans too.
+      'no-restricted-imports': mergeRestrictedImports(
+        businessLayerRule,
+        siblingIsolationRule(
+          '**/business',
+          active,
+          BUSINESS_SIBLINGS,
+          ['_engine', '_shared', 'observability'],
+          'business module'
+        )
       ),
     },
   })),
@@ -643,12 +631,10 @@ export default [
   ...REPOSITORY_SIBLINGS.map((active): Linter.Config => ({
     files: [`src/domain/repository/${active}/**/*.{ts,tsx}`],
     rules: {
-      'no-restricted-imports': siblingIsolationRule(
-        '**/domain/repository',
-        active,
-        REPOSITORY_SIBLINGS,
-        ['_base'],
-        'repository module'
+      // Composed over the domain layer rule — same-key replacement, see mergeRestrictedImports.
+      'no-restricted-imports': mergeRestrictedImports(
+        domainLayerRule,
+        siblingIsolationRule('**/domain/repository', active, REPOSITORY_SIBLINGS, ['_base'], 'repository module')
       ),
     },
   })),
@@ -660,7 +646,7 @@ export default [
   {
     files: ['src/integration/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-imports': restrictImports(['application']),
+      'no-restricted-imports': integrationLayerRule,
     },
   },
 
@@ -675,9 +661,76 @@ export default [
       'src/integration/observability/os-notification-dispatcher.ts',
     ],
     rules: {
-      'no-restricted-imports': restrictImports(['application'], [childProcessSpawnBan]),
+      'no-restricted-imports': integrationSpawnFencedRule,
     },
   },
+
+  // ── integration/ai/<concept>/<x>/ — sibling isolation ────────────────────────
+  // Declared AFTER the two src/integration/** blocks above: flat config replaces a same-key
+  // rule entry per file (last matching block wins), so these must win for sibling files —
+  // and each entry composes the integration base back in via `mergeRestrictedImports` so the
+  // layer direction + spawn fence keep firing inside sibling directories.
+
+  // Each prompt is independent. Shared machinery lives under prompts/_engine/.
+  ...PROMPTS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/prompts/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': mergeRestrictedImports(
+        integrationSpawnFencedRule,
+        siblingIsolationRule('**/integration/ai/prompts', active, PROMPTS, ['_engine', '_partials'], 'prompt')
+      ),
+    },
+  })),
+
+  // Each tool adapter is independent. Cross-tool sharing goes through providers/_engine/.
+  ...PROVIDERS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/providers/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': mergeRestrictedImports(
+        integrationSpawnFencedRule,
+        siblingIsolationRule('**/integration/ai/providers', active, PROVIDERS, ['_engine'], 'provider')
+      ),
+    },
+  })),
+
+  // Each per-tool readiness probe is independent. Cross-tool sharing goes through readiness/_engine/.
+  ...READINESS_PROVIDERS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/readiness/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': mergeRestrictedImports(
+        integrationSpawnFencedRule,
+        siblingIsolationRule('**/integration/ai/readiness', active, READINESS_PROVIDERS, ['_engine'], 'readiness probe')
+      ),
+    },
+  })),
+
+  // Per-tool adapter directories (claude/codex/copilot) and skill-source directories
+  // (bundled/project) are all independent siblings. Cross-sibling sharing goes through
+  // skills/_engine/. The composition switch over the per-tool adapters lives at
+  // skills/adapter-factory.ts (directly under skills/, outside the sibling glob).
+  ...SKILLS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/skills/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': mergeRestrictedImports(
+        integrationSpawnFencedRule,
+        siblingIsolationRule('**/integration/ai/skills', active, SKILLS, ['_engine'], 'skill')
+      ),
+    },
+  })),
+
+  // Per-tool adapter directories (claude/codex/copilot) and definition-source directories
+  // (bundled/operator) are all independent siblings. Cross-sibling sharing goes through
+  // agents/_engine/. The composition switch over the per-tool adapters lives at
+  // agents/adapter-factory.ts (directly under agents/, outside the sibling glob).
+  ...AGENTS.map((active): Linter.Config => ({
+    files: [`src/integration/ai/agents/${active}/**/*.{ts,tsx}`],
+    rules: {
+      'no-restricted-imports': mergeRestrictedImports(
+        integrationSpawnFencedRule,
+        siblingIsolationRule('**/integration/ai/agents', active, AGENTS, ['_engine'], 'agent definition')
+      ),
+    },
+  })),
 
   // ── application ──────────────────────────────────────────────────────────────
   // Composition root + chain framework + flow compositions + UI runtime. May depend on
@@ -700,13 +753,40 @@ export default [
     },
   },
 
-  // ── application/flows/<x>/ — sibling-flow isolation ──────────────────────────
-  ...FLOWS.map((active): Linter.Config => ({
-    files: [`src/application/flows/${active}/**/*.{ts,tsx}`],
+  // ── application/flows/**/*.contract.ts — per-leaf signal contracts ──────────
+  // The audit-[09] sanctioned composition point for per-signal Zod schemas: the schema ban is
+  // lifted here (and only here); every other chains restriction still applies.
+  {
+    files: ['src/application/flows/**/*.contract.ts'],
     rules: {
-      'no-restricted-imports': siblingIsolationRule('**/application/flows', active, FLOWS, [], 'flow'),
+      'no-restricted-imports': chainsContractFileRule,
     },
-  })),
+  },
+
+  // ── application/flows/<x>/ — sibling-flow isolation ──────────────────────────
+  // Two blocks per flow: the second re-lifts the schema ban for that flow's *.contract.ts
+  // files (same-key replacement would otherwise re-impose it via the first block).
+  ...FLOWS.flatMap((active): Linter.Config[] => [
+    {
+      files: [`src/application/flows/${active}/**/*.{ts,tsx}`],
+      rules: {
+        // Composed over the chains rule — same-key replacement, see mergeRestrictedImports.
+        'no-restricted-imports': mergeRestrictedImports(
+          chainsLayerRule,
+          siblingIsolationRule('**/application/flows', active, FLOWS, [], 'flow')
+        ),
+      },
+    },
+    {
+      files: [`src/application/flows/${active}/**/*.contract.ts`],
+      rules: {
+        'no-restricted-imports': mergeRestrictedImports(
+          chainsContractFileRule,
+          siblingIsolationRule('**/application/flows', active, FLOWS, [], 'flow')
+        ),
+      },
+    },
+  ]),
 
   // ── tests ────────────────────────────────────────────────────────────────────
   // Tests wire every layer together — only the typescript-result rule applies.

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,6 @@
   "entry": ["tests/**/*.test.{ts,tsx}", "scripts/**/*.ts"],
   "project": ["src/**/*.{ts,tsx}"],
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": ["ralphctl", "where"],
+  "ignoreBinaries": ["ralphctl"],
   "tags": ["-public"]
 }

--- a/src/application/flows/_shared/memory/distill-propose.ts
+++ b/src/application/flows/_shared/memory/distill-propose.ts
@@ -4,6 +4,7 @@ import { Result } from '@src/domain/result.ts';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { RunInTerminal } from '@src/integration/io/run-in-terminal.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
+import { renderProjectToolingSection } from '@src/integration/ai/prompts/_engine/renderers/task.ts';
 import { buildDistillLearningsPrompt } from '@src/integration/ai/prompts/distill-learnings/definition.ts';
 import type { AssistantTool } from '@src/integration/ai/readiness/_engine/tool.ts';
 import { targetPathFor } from '@src/integration/ai/readiness/_engine/setup.ts';
@@ -157,14 +158,15 @@ const renderCandidateList = (candidates: readonly LearningRecord[]): string =>
 
 /**
  * Project the repository's known tooling into the prompt's `PROJECT_TOOLING` section — the only
- * place a package-manager command may appear. Falls back to an explicit "(none detected)" line so
- * the prompt copy never hardcodes an ecosystem's commands.
+ * place a package-manager command may appear. Delegates the empty-fallback rendering to
+ * {@link renderProjectToolingSection} (shared with the implement / evaluate prompts) so the
+ * fallback markup can't drift between the two renderers.
  */
 const renderProjectTooling = (repository: Repository): string => {
   const lines: string[] = [];
   if (repository.setupScript !== undefined) lines.push(`- Setup: ${repository.setupScript}`);
   if (repository.verifyScript !== undefined) lines.push(`- Verify: ${repository.verifyScript}`);
-  return lines.length > 0 ? lines.join('\n') : '(none detected)';
+  return renderProjectToolingSection(lines.length > 0 ? lines.join('\n') : undefined);
 };
 
 const safeReadText = async (path: string): Promise<string | undefined> => {

--- a/src/application/flows/implement/leaves/build-task-workspace.ts
+++ b/src/application/flows/implement/leaves/build-task-workspace.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
@@ -6,7 +5,6 @@ import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
-import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { buildImplementPrompt } from '@src/integration/ai/prompts/implement/definition.ts';
@@ -14,6 +12,7 @@ import { renderContractMd } from '@src/integration/ai/prompts/_engine/renderers/
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
 import { generatorOutputContract } from '@src/application/flows/implement/leaves/generator.contract.ts';
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 
 /**
@@ -43,6 +42,7 @@ import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 export interface BuildTaskWorkspaceLeafDeps {
   readonly templateLoader: TemplateLoader;
   readonly logger: Logger;
+  readonly writeFile: WriteFile;
 }
 
 export interface BuildTaskWorkspaceLeafOpts {
@@ -59,23 +59,6 @@ interface LeafInput {
 interface LeafOutput {
   readonly workspaceRoot: AbsolutePath;
 }
-
-const writeOrError = async (path: string, content: string): Promise<Result<void, StorageError>> => {
-  try {
-    await fs.mkdir(path.slice(0, path.lastIndexOf('/')), { recursive: true });
-    await fs.writeFile(path, content, 'utf8');
-    return Result.ok(undefined);
-  } catch (cause) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: `failed to write task workspace file: ${path}`,
-        path,
-        cause,
-      })
-    );
-  }
-};
 
 export const buildTaskWorkspaceLeaf = (
   deps: BuildTaskWorkspaceLeafDeps,
@@ -94,6 +77,10 @@ export const buildTaskWorkspaceLeaf = (
         if (!previewOutputDir.ok) return Result.error(previewOutputDir.error);
 
         const contractPath = join(workspaceRoot, 'contract.md');
+        const parsedContractPath = AbsolutePath.parse(contractPath);
+        if (!parsedContractPath.ok) return Result.error(parsedContractPath.error);
+        const parsedPromptPath = AbsolutePath.parse(join(workspaceRoot, 'prompt.md'));
+        if (!parsedPromptPath.ok) return Result.error(parsedPromptPath.error);
 
         // build-task-workspace materialises a static prompt.md as an audit artifact only —
         // the live generator leaf re-reads `progress.md` immediately before each spawn, so
@@ -110,13 +97,13 @@ export const buildTaskWorkspaceLeaf = (
         });
         if (!prompt.ok) return Result.error(prompt.error);
 
-        const wrotePrompt = await writeOrError(join(workspaceRoot, 'prompt.md'), String(prompt.value));
+        const wrotePrompt = await deps.writeFile(parsedPromptPath.value, String(prompt.value));
         if (!wrotePrompt.ok) return Result.error(wrotePrompt.error);
 
         // Persist the canonical contract sidecar — overwritten on every leaf run so it always
         // reflects the current task spec. The generator and evaluator both read this file
         // (their prompts cite `{{CONTRACT_PATH}}`), so the harness owns the writer.
-        const wroteContract = await writeOrError(contractPath, renderContractMd(input.task));
+        const wroteContract = await deps.writeFile(parsedContractPath.value, renderContractMd(input.task));
         if (!wroteContract.ok) return Result.error(wroteContract.error);
 
         log.debug('task workspace built', { taskId: input.task.id, workspaceRoot });

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -303,7 +303,7 @@ export const createPerTaskSubchain = (
             ]
           : []),
         buildTaskWorkspaceLeaf(
-          { templateLoader: deps.templateLoader, logger: deps.logger },
+          { templateLoader: deps.templateLoader, logger: deps.logger, writeFile: deps.writeFile },
           {
             sprintDir: opts.sprintDir,
             cwd: repo.path,

--- a/src/application/flows/implement/merge-wave.ts
+++ b/src/application/flows/implement/merge-wave.ts
@@ -5,85 +5,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { BranchOutcome } from '@src/application/chain/run/wave-scheduler.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { RepoExecConfig } from '@src/application/flows/implement/leaves/resolve-repo.ts';
-
-/**
- * Classification of every {@link ImplementCtx} field for the parallel-wave fan-in.
- *
- *  - `'sprint'`       — sprint-scoped invariant; carried straight from `base` (the ctx that
- *                       entered the wave). Same across every branch.
- *  - `'tasks'`        — the task list; the only field a wave actually mutates. Folded as a
- *                       task-keyed overlay of every branch's settled task copy onto `base.tasks`.
- *  - `'per-task'`     — single-slot state scoped to ONE in-flight task. Meaningless between waves
- *                       (each branch carried its own); reset to `undefined` in the merged ctx.
- *  - `'signal-accum'` — per-attempt signal accumulators. Likewise per-branch; reset to `undefined`.
- */
-type MergeClass = 'sprint' | 'tasks' | 'per-task' | 'signal-accum';
-
-// Named so the classification map reads as labels, not repeated string literals.
-const SPRINT = 'sprint' satisfies MergeClass;
-const TASKS = 'tasks' satisfies MergeClass;
-const PER_TASK = 'per-task' satisfies MergeClass;
-const SIGNAL_ACCUM = 'signal-accum' satisfies MergeClass;
-
-/**
- * THE exhaustiveness guard. A single object literal keyed over EVERY field of
- * {@link ImplementCtx}, `satisfies Record<keyof ImplementCtx, MergeClass>`. It is derived from the
- * interface, not a hand-maintained list: add a new field to `ImplementCtx` and this object stops
- * satisfying the constraint until the new field is classified here — a compile-time forcing
- * function so a future ctx field can never silently skip the merge/fork projection below.
- *
- * The merge/fork logic reads NOTHING from this object at runtime — it exists purely so the
- * classification is type-checked. The actual projection is hand-written below (and must be kept in
- * agreement with these labels), which is exactly the pairing the guard enforces.
- */
-const _exhaustive = {
-  // sprint-scoped → from base
-  sprintId: SPRINT,
-  sprint: SPRINT,
-  execution: SPRINT,
-  progressFile: SPRINT,
-  setupVerifiedRepoIdsThisRun: SPRINT,
-  // Loaded once in the prologue; every branch reads the same cross-sprint memory → run-scoped.
-  priorLearnings: SPRINT,
-  // task list → overlay
-  tasks: TASKS,
-  // per-task single-slot → undefined
-  taskWorkspaceRoot: PER_TASK,
-  currentTaskId: PER_TASK,
-  currentTask: PER_TASK,
-  genEvalTurn: PER_TASK,
-  currentRoundNum: PER_TASK,
-  lastEvaluation: PER_TASK,
-  plateauHistory: PER_TASK,
-  // Per-turn signal-kind distribution for the in-flight task's current gen-eval turn — meaningless
-  // between waves (each branch carries its own), reset to undefined in the merged ctx.
-  lastTurnActionCounts: PER_TASK,
-  lastExit: PER_TASK,
-  lastVerdict: PER_TASK,
-  lastBlockReason: PER_TASK,
-  lastWarning: PER_TASK,
-  lastShouldFailAttempt: PER_TASK,
-  lastVerifyResult: PER_TASK,
-  lastPreVerifyOutcome: PER_TASK,
-  priorPostVerifyOutcome: PER_TASK,
-  lastCommitSha: PER_TASK,
-  proposedCommitMessage: PER_TASK,
-  expectedBranch: PER_TASK,
-  priorGeneratorSessionId: PER_TASK,
-  priorEvaluatorSessionId: PER_TASK,
-  // signal accumulators → undefined
-  currentAttemptDecisions: SIGNAL_ACCUM,
-  currentAttemptChanges: SIGNAL_ACCUM,
-  currentAttemptLearnings: SIGNAL_ACCUM,
-  currentAttemptNotes: SIGNAL_ACCUM,
-  // Corrective-nudge tallies — same per-attempt lifecycle as the signal accumulators above.
-  currentAttemptGeneratorNudges: SIGNAL_ACCUM,
-  currentAttemptEvaluatorNudges: SIGNAL_ACCUM,
-} satisfies Record<keyof ImplementCtx, MergeClass>;
-
-// Reference the guard so it is not dead-code-eliminated / lint-flagged; its whole purpose is the
-// compile-time `satisfies` check above.
-void _exhaustive;
+import { projectSprintScopedFields } from '@src/application/flows/implement/sprint-scoped-projection.ts';
 
 /**
  * Whether a branch genuinely SETTLED its task, versus the scheduler killing it before it advanced.
@@ -111,7 +33,7 @@ const branchSettled = <TCtx>(outcome: BranchOutcome<TCtx>): boolean =>
  * `outcomes` produces an identical merged ctx. The reducer therefore needs no ordering guarantees
  * from the scheduler beyond "these outcomes all belong to the same wave."
  *
- *  - sprint-scoped fields → carried verbatim from `base`.
+ *  - sprint-scoped fields → carried verbatim from `base` via {@link projectSprintScopedFields}.
  *  - `tasks` → `base.tasks` with each settled branch's task copy overlaid by id; an unsettled
  *    (killed) branch contributes nothing, leaving its base task untouched for reset/re-run.
  *  - per-task + signal-accum fields → reset to `undefined`; they have no meaning between waves.
@@ -133,15 +55,7 @@ export const mergeImplementWave = (
   const tasks = base.tasks?.map((t) => byId.get(t.id) ?? t);
 
   return {
-    // sprint-scoped → base
-    sprintId: base.sprintId,
-    ...(base.sprint !== undefined ? { sprint: base.sprint } : {}),
-    ...(base.execution !== undefined ? { execution: base.execution } : {}),
-    ...(base.progressFile !== undefined ? { progressFile: base.progressFile } : {}),
-    ...(base.setupVerifiedRepoIdsThisRun !== undefined
-      ? { setupVerifiedRepoIdsThisRun: base.setupVerifiedRepoIdsThisRun }
-      : {}),
-    ...(base.priorLearnings !== undefined ? { priorLearnings: base.priorLearnings } : {}),
+    ...projectSprintScopedFields(base),
     // task list → overlay
     ...(tasks !== undefined ? { tasks } : {}),
     // per-task + signal-accum classes intentionally omitted → undefined in the merged ctx.
@@ -161,7 +75,8 @@ export const mergeImplementWave = (
  * pure place rather than splitting ctx-clearing from repo-redirection across the launcher.
  *
  * Projection:
- *  - sprint-scoped fields → carried from `base` (same sprint, execution, progress file).
+ *  - sprint-scoped fields → carried from `base` via {@link projectSprintScopedFields} (same sprint,
+ *    execution, progress file).
  *  - per-task single-slot + signal-accum classes → cleared (`undefined`); a fresh branch starts a
  *    fresh task with no carried per-attempt state.
  *  - `priorPostVerifyOutcome` → DROPPED (accepted cost): a parallel branch starts on its own
@@ -183,19 +98,8 @@ export const forkCtx = (
   worktreePath: AbsolutePath
 ): { readonly ctx: ImplementCtx; readonly repo: RepoExecConfig } => {
   const ctx: ImplementCtx = {
-    // sprint-scoped → base
-    sprintId: base.sprintId,
-    ...(base.sprint !== undefined ? { sprint: base.sprint } : {}),
-    ...(base.execution !== undefined ? { execution: base.execution } : {}),
-    ...(base.progressFile !== undefined ? { progressFile: base.progressFile } : {}),
+    ...projectSprintScopedFields(base),
     ...(base.tasks !== undefined ? { tasks: base.tasks } : {}),
-    // run-scoped (like `execution`): the set of repos this launch's setup verified survives the
-    // fork so a parallel branch's first pre-task-verify can also take the fresh-setup skip.
-    ...(base.setupVerifiedRepoIdsThisRun !== undefined
-      ? { setupVerifiedRepoIdsThisRun: base.setupVerifiedRepoIdsThisRun }
-      : {}),
-    // run-scoped cross-sprint memory: every branch's generator reads the same loaded ledger.
-    ...(base.priorLearnings !== undefined ? { priorLearnings: base.priorLearnings } : {}),
     // per-task + signal-accum classes cleared (omitted → undefined); `priorPostVerifyOutcome`
     // dropped (accepted cost). `expectedBranch` is intentionally NOT set here — see the docstring:
     // the branch element omits `branch-preflight`, so leaving it `undefined` is correct.

--- a/src/application/flows/implement/sprint-scoped-projection.ts
+++ b/src/application/flows/implement/sprint-scoped-projection.ts
@@ -1,0 +1,119 @@
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+
+/**
+ * Classification of every {@link ImplementCtx} field for the parallel-wave fan-in
+ * (`mergeImplementWave`) and per-branch fork (`forkCtx`) — both in `merge-wave.ts`.
+ *
+ *  - `'sprint'`       — sprint-scoped invariant; carried straight from `base` (the ctx that entered
+ *                       the wave / that a branch forked from). Same across every branch. Projected
+ *                       by {@link projectSprintScopedFields} below — the ONLY place either caller
+ *                       reads these fields off `base`.
+ *  - `'tasks'`        — the task list. `mergeImplementWave` folds it as a task-keyed overlay;
+ *                       `forkCtx` carries it straight through so per-task leaves can look up sibling
+ *                       deps. The two callers genuinely compute different values for it, so it is
+ *                       classified here (for the exhaustiveness check) but NOT part of the shared
+ *                       sprint-scoped projection.
+ *  - `'per-task'`     — single-slot state scoped to ONE in-flight task. Meaningless between waves
+ *                       (each branch carried its own); both callers reset it to `undefined` by
+ *                       omission.
+ *  - `'signal-accum'` — per-attempt signal accumulators. Likewise per-branch; reset to `undefined`.
+ */
+type MergeClass = 'sprint' | 'tasks' | 'per-task' | 'signal-accum';
+
+// Named so the classification map reads as labels, not repeated string literals.
+const SPRINT = 'sprint' satisfies MergeClass;
+const TASKS = 'tasks' satisfies MergeClass;
+const PER_TASK = 'per-task' satisfies MergeClass;
+const SIGNAL_ACCUM = 'signal-accum' satisfies MergeClass;
+
+/**
+ * THE exhaustiveness guard. A single object literal keyed over EVERY field of {@link ImplementCtx},
+ * `satisfies Record<keyof ImplementCtx, MergeClass>`. It is derived from the interface, not a
+ * hand-maintained list: add a new field to `ImplementCtx` and this object stops satisfying the
+ * constraint until the new field is classified here.
+ *
+ * Classifying a field `'sprint'` here is necessary but not, on its own, sufficient to make it
+ * project — see {@link SprintScopedKey} / {@link projectSprintScopedFields}, which is the part of
+ * the guard that actually forces the projection function to keep up with this classification.
+ */
+const CTX_FIELD_CLASS = {
+  // sprint-scoped → projected by projectSprintScopedFields
+  sprintId: SPRINT,
+  sprint: SPRINT,
+  execution: SPRINT,
+  progressFile: SPRINT,
+  setupVerifiedRepoIdsThisRun: SPRINT,
+  // Loaded once in the prologue; every branch reads the same cross-sprint memory → run-scoped.
+  priorLearnings: SPRINT,
+  // task list → each caller projects its own value (overlay vs straight carry)
+  tasks: TASKS,
+  // per-task single-slot → undefined
+  taskWorkspaceRoot: PER_TASK,
+  currentTaskId: PER_TASK,
+  currentTask: PER_TASK,
+  genEvalTurn: PER_TASK,
+  currentRoundNum: PER_TASK,
+  lastEvaluation: PER_TASK,
+  plateauHistory: PER_TASK,
+  // Per-turn signal-kind distribution for the in-flight task's current gen-eval turn — meaningless
+  // between waves (each branch carries its own), reset to undefined in the merged/forked ctx.
+  lastTurnActionCounts: PER_TASK,
+  lastExit: PER_TASK,
+  lastVerdict: PER_TASK,
+  lastBlockReason: PER_TASK,
+  lastWarning: PER_TASK,
+  lastShouldFailAttempt: PER_TASK,
+  lastVerifyResult: PER_TASK,
+  lastPreVerifyOutcome: PER_TASK,
+  priorPostVerifyOutcome: PER_TASK,
+  lastCommitSha: PER_TASK,
+  proposedCommitMessage: PER_TASK,
+  expectedBranch: PER_TASK,
+  priorGeneratorSessionId: PER_TASK,
+  priorEvaluatorSessionId: PER_TASK,
+  // signal accumulators → undefined
+  currentAttemptDecisions: SIGNAL_ACCUM,
+  currentAttemptChanges: SIGNAL_ACCUM,
+  currentAttemptLearnings: SIGNAL_ACCUM,
+  currentAttemptNotes: SIGNAL_ACCUM,
+  // Corrective-nudge tallies — same per-attempt lifecycle as the signal accumulators above.
+  currentAttemptGeneratorNudges: SIGNAL_ACCUM,
+  currentAttemptEvaluatorNudges: SIGNAL_ACCUM,
+} satisfies Record<keyof ImplementCtx, MergeClass>;
+
+// Reference the guard so it is not dead-code-eliminated / lint-flagged; its whole purpose is the
+// compile-time `satisfies` check above plus the `SprintScopedKey` type derived from it below.
+void CTX_FIELD_CLASS;
+
+/**
+ * Keys of {@link ImplementCtx} classified `'sprint'` in {@link CTX_FIELD_CLASS} — derived by mapped
+ * type over the classification object itself, never hand-listed, so it can't drift from it.
+ */
+type SprintScopedKey = {
+  [K in keyof typeof CTX_FIELD_CLASS]: (typeof CTX_FIELD_CLASS)[K] extends typeof SPRINT ? K : never;
+}[keyof typeof CTX_FIELD_CLASS];
+
+/**
+ * Project the sprint-scoped fields of `ctx` — carried verbatim across a wave merge
+ * (`mergeImplementWave`) or a per-branch fork (`forkCtx`): the same sprint, execution, progress
+ * file, and run-scoped setup/memory state applies to every branch of a wave and every wave of a run.
+ *
+ * The return type, `Required<Pick<ImplementCtx, SprintScopedKey>>`, is the actual compile-time
+ * forcing function the `_exhaustive`-style guard alone can't provide: EVERY field classified
+ * `'sprint'` above MUST be assigned explicitly below (present or not — each field's own type already
+ * allows `undefined`, `Required` only strips the *optional* modifier so the key can't be silently
+ * left out of the object literal). Reclassifying or adding a field to the `'sprint'` bucket widens
+ * `SprintScopedKey`, which breaks THIS function's return type until the new field is projected here.
+ * Because `mergeImplementWave` and `forkCtx` both build their sprint-scoped slice by calling this and
+ * only this, neither can drift out of sync with the classification, or with each other.
+ *
+ * @public
+ */
+export const projectSprintScopedFields = (ctx: ImplementCtx): Required<Pick<ImplementCtx, SprintScopedKey>> => ({
+  sprintId: ctx.sprintId,
+  sprint: ctx.sprint,
+  execution: ctx.execution,
+  progressFile: ctx.progressFile,
+  setupVerifiedRepoIdsThisRun: ctx.setupVerifiedRepoIdsThisRun,
+  priorLearnings: ctx.priorLearnings,
+});

--- a/src/application/ui/tui/components/action-menu.tsx
+++ b/src/application/ui/tui/components/action-menu.tsx
@@ -24,6 +24,7 @@ import React, { useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { useListWindow, OverflowRow } from '@src/application/ui/tui/components/windowed-list.tsx';
+import { listKeys } from '@src/application/ui/tui/runtime/keyboard-map.ts';
 
 export interface MenuItem {
   readonly id: string;
@@ -62,6 +63,18 @@ export interface ActionMenuProps {
 
 const isEnabled = (item: MenuItem): boolean => item.disabledReason === undefined;
 
+/**
+ * Single-character nav aliases reserved by the windowed-list contract (DESIGN-SYSTEM §6.4) —
+ * derived from `listKeys` so it can never drift from the actual `useListWindow` bindings. A
+ * `MenuItem.hotkey` on one of these would double-fire: `useListWindow`'s own `useInput` (mounted
+ * alongside this component's) moves the cursor on the same keystroke that `matchHotkey` would
+ * fire the item's `onSelect`. `matchHotkey` refuses to match them outright, so a future item
+ * defining `hotkey: 'j'` fails closed (hotkey silently inert) instead of double-firing.
+ */
+const RESERVED_NAV_KEYS: ReadonlySet<string> = new Set(
+  [...listKeys.up.keys, ...listKeys.down.keys].filter((k) => /^[a-z]$/.test(k))
+);
+
 /** Seed the cursor from `initialIndex` (index into the full items array). */
 const findInitialCursorId = (
   items: readonly MenuItem[],
@@ -75,9 +88,14 @@ const findInitialCursorId = (
   return enabledItems[0]?.id ?? '';
 };
 
-/** Hotkey match for the space-as-select / hotkey `useInput` handler (skips global hotkeys). */
-const matchHotkey = (items: readonly MenuItem[], input: string): MenuItem | undefined =>
-  items.find((it) => it.hotkey === input && it.globalHotkey !== true && isEnabled(it));
+/**
+ * Hotkey match for the space-as-select / hotkey `useInput` handler (skips global hotkeys and the
+ * reserved `j`/`k` list-nav aliases — see {@link RESERVED_NAV_KEYS}).
+ */
+const matchHotkey = (items: readonly MenuItem[], input: string): MenuItem | undefined => {
+  if (RESERVED_NAV_KEYS.has(input)) return undefined;
+  return items.find((it) => it.hotkey === input && it.globalHotkey !== true && isEnabled(it));
+};
 
 interface RenderRow {
   readonly item: MenuItem;

--- a/src/application/ui/tui/components/breadcrumb.tsx
+++ b/src/application/ui/tui/components/breadcrumb.tsx
@@ -127,7 +127,7 @@ export const Breadcrumb = (): React.JSX.Element => {
                 [S]
               </Text>
               {atLeast('md') && effectiveSprintStatus !== undefined && (
-                <Box marginLeft={1}>
+                <Box marginLeft={spacing.gutter}>
                   <StatusChip label={effectiveSprintStatus} kind={sprintStatusKind(effectiveSprintStatus)} />
                 </Box>
               )}

--- a/src/application/ui/tui/components/feedback-line.tsx
+++ b/src/application/ui/tui/components/feedback-line.tsx
@@ -65,7 +65,7 @@ export const FeedbackLine = ({ text }: FeedbackLineProps): React.JSX.Element | n
   if (typeof text === 'string') {
     const { color, body } = resolveStructured(text);
     return (
-      <Box paddingX={spacing.indent} marginTop={1}>
+      <Box paddingX={spacing.indent} marginTop={spacing.section}>
         <Text color={color}>{body}</Text>
       </Box>
     );
@@ -74,7 +74,7 @@ export const FeedbackLine = ({ text }: FeedbackLineProps): React.JSX.Element | n
   // Structured form
   const { glyph, color } = toneConfig(text.tone);
   return (
-    <Box paddingX={spacing.indent} marginTop={1}>
+    <Box paddingX={spacing.indent} marginTop={spacing.section}>
       <Text color={color}>
         {glyph.length > 0 ? `${glyph} ` : ''}
         {text.text}

--- a/src/application/ui/tui/prompts/confirm-prompt.tsx
+++ b/src/application/ui/tui/prompts/confirm-prompt.tsx
@@ -54,7 +54,7 @@ export const ConfirmPrompt = ({
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
       <ScrollableMessage message={message} />
-      <Box marginTop={1}>
+      <Box marginTop={spacing.section}>
         <Pill on={yes} label="Yes" />
         <Text> </Text>
         <Pill on={!yes} label="No" />

--- a/src/application/ui/tui/prompts/multi-select-prompt.tsx
+++ b/src/application/ui/tui/prompts/multi-select-prompt.tsx
@@ -171,7 +171,7 @@ export const MultiSelectPrompt = ({
       <Text color={inkColors.primary} bold>
         {glyphs.actionCursor} {message}
       </Text>
-      <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="column" marginTop={spacing.section}>
         {options.slice(start, end).map((opt, localIdx) => {
           const i = start + localIdx;
           const focused = i === cursor && opt.disabled !== true;

--- a/src/application/ui/tui/prompts/path-picker-prompt.tsx
+++ b/src/application/ui/tui/prompts/path-picker-prompt.tsx
@@ -306,11 +306,11 @@ export const PathPickerPrompt = ({
           <Text color={inkColors.error}>{error}</Text>
         </Box>
       )}
-      <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="column" marginTop={spacing.section}>
         <PathPickerRows rows={rows} start={start} end={end} cursor={cursor} />
       </Box>
       {typing ? (
-        <Box flexDirection="column" marginTop={1} paddingX={spacing.indent}>
+        <Box flexDirection="column" marginTop={spacing.section} paddingX={spacing.indent}>
           <Text dimColor>Type an absolute path (~/ allowed). Enter validates; esc returns to the picker.</Text>
           <TextPrompt
             message="Path"
@@ -320,7 +320,7 @@ export const PathPickerPrompt = ({
           />
         </Box>
       ) : (
-        <Box paddingX={spacing.indent} marginTop={1}>
+        <Box paddingX={spacing.indent} marginTop={spacing.section}>
           <Text dimColor>
             ↵ open/select · ⌫ up · esc cancel · ~ home · t type · . {showHidden ? 'hide' : 'show'} hidden
           </Text>

--- a/src/application/ui/tui/prompts/scrollable-message.tsx
+++ b/src/application/ui/tui/prompts/scrollable-message.tsx
@@ -70,7 +70,7 @@ export const ScrollableMessage = ({ message, ownsArrows = true }: ScrollableMess
         {glyphs.actionCursor} {header}
       </Text>
       {body.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
+        <Box flexDirection="column" marginTop={spacing.section}>
           <Box flexDirection="column" borderStyle="single" borderColor={inkColors.rule} paddingX={spacing.cardPadX}>
             {visible.map((line, i) => (
               <Text key={`body-${String(offset + i)}`}>{line.length === 0 ? ' ' : line}</Text>

--- a/src/application/ui/tui/prompts/select-prompt.tsx
+++ b/src/application/ui/tui/prompts/select-prompt.tsx
@@ -99,7 +99,7 @@ export const SelectPrompt = ({
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
       <ScrollableMessage message={message} ownsArrows={false} />
-      <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="column" marginTop={spacing.section}>
         {options.slice(start, end).map((opt, localIdx) => {
           const i = start + localIdx;
           const focused = i === cursor;

--- a/src/application/ui/tui/views/execute-view-internals/header-card.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/header-card.tsx
@@ -24,7 +24,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import { Card } from '@src/application/ui/tui/components/card.tsx';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
-import { glyphs, inkColors } from '@src/application/ui/tui/theme/tokens.ts';
+import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { resolveAttemptCoords, type TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import { contextWindowLabel } from '@src/domain/value/settings-models/context-window.ts';
@@ -180,7 +180,7 @@ const HeaderCardImpl = ({
             </>
           )}
           {isRunning && (
-            <Box marginLeft={2}>
+            <Box marginLeft={spacing.indent}>
               <Spinner active={isRunning} color={inkColors.info} label="live" />
             </Box>
           )}

--- a/src/application/ui/tui/views/execute-view-internals/implement-sidebar.tsx
+++ b/src/application/ui/tui/views/execute-view-internals/implement-sidebar.tsx
@@ -70,7 +70,7 @@ const TASK_STATUS_COLOR: Readonly<Record<TaskBucketStatus, string>> = {
 // ---------------------------------------------------------------------------
 
 const SidebarDivider = ({ width }: { readonly width: number }): React.JSX.Element => (
-  <Box paddingX={1} marginTop={spacing.gutter}>
+  <Box paddingX={spacing.gutter} marginTop={spacing.gutter}>
     <Text color={inkColors.rule}>{glyphs.sectionRule.repeat(Math.max(0, width - 2))}</Text>
   </Box>
 );

--- a/src/application/ui/tui/views/pick-sprint-internals/group-builder.ts
+++ b/src/application/ui/tui/views/pick-sprint-internals/group-builder.ts
@@ -1,15 +1,18 @@
 /**
- * Pure list-shaping helpers for the sprint picker: bucket sprints into project groups,
- * flatten the groups into the cursor-navigable row list, and walk that list to the next
- * cursorable index. Headers and overflow indicators are never cursor targets.
+ * Pure list-shaping helpers for the sprint picker: bucket sprints into project groups, flatten
+ * the groups into the cursor-navigable row list, and derive the id-keyed cursorable subset that
+ * feeds the shared `useListWindow` primitive. Headers are never cursor targets.
  */
 
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import {
+  type CreateActionRow,
   type FlatRow,
   type PickerData,
   type SprintGroup,
+  type SprintRow,
   UNKNOWN_PROJECT_KEY,
   UNKNOWN_PROJECT_LABEL,
 } from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
@@ -105,51 +108,31 @@ export const flatten = (groups: readonly SprintGroup[], includeCreate: boolean):
   return rows;
 };
 
-/** Indices of the rows the cursor is allowed to land on (sprint + create rows; never headers). */
-export const cursorableRowIndices = (rows: readonly FlatRow[]): readonly number[] => {
-  const indices: number[] = [];
-  for (let i = 0; i < rows.length; i += 1) {
-    const kind = rows[i]?.kind;
-    if (kind === 'sprint' || kind === 'create') indices.push(i);
-  }
-  return indices;
-};
+/** Sentinel id for the synthetic `+ Create new sprint` row — never collides with a real sprint id. */
+const CREATE_ROW_ID = '__create__';
 
-export const nextCursorableIndex = (rows: readonly FlatRow[], from: number, direction: 1 | -1): number => {
-  const candidates = cursorableRowIndices(rows);
-  if (candidates.length === 0) return from;
-  if (direction === 1) {
-    const next = candidates.find((i) => i > from);
-    return next ?? from;
-  }
-  // direction === -1
-  let prev = from;
-  for (const i of candidates) {
-    if (i < from) prev = i;
-    else break;
-  }
-  return prev === from && candidates.includes(from) ? from : prev;
-};
+/** Rows the cursor is allowed to land on (sprint + create rows; never headers). */
+export const cursorableRows = (rows: readonly FlatRow[]): ReadonlyArray<SprintRow | CreateActionRow> =>
+  rows.filter((r): r is SprintRow | CreateActionRow => r.kind !== 'header');
+
+/** Stable id for a cursorable row — the `getId` fed to `useListWindow`. */
+export const cursorableRowId = (row: SprintRow | CreateActionRow): string =>
+  row.kind === 'create' ? CREATE_ROW_ID : row.sprint.id;
 
 /**
- * Snap an arbitrary (clamped) target index to the nearest cursorable row, biased in `direction`.
- * Used by PageUp/PageDown, where a raw `cursor ± visibleRows` jump may land on a header or off the
- * end of the list. When the exact target is already cursorable it is returned unchanged; otherwise
- * we step toward the bias direction (Page**Down** prefers the next cursorable below, Page**Up** the
- * previous above), then fall back to the closest cursorable on the other side so a jump always
- * lands on a selectable row.
+ * Preferred landing id within `rows`: the row for `preferredSprintId` if present, else the first
+ * sprint row, else the first cursorable row (the synthetic create row), else `''`. Used to seed
+ * `useListWindow`'s `initialCursorId` — both on first mount (once the async load settles) and on
+ * an explicit scope-toggle remount — so "Enter is a one-keystroke confirm" pre-seeds onto the
+ * already-selected sprint whenever possible.
  */
-export const cursorableNear = (rows: readonly FlatRow[], target: number, direction: 1 | -1): number => {
-  const candidates = cursorableRowIndices(rows);
-  if (candidates.length === 0) return target;
-  if (candidates.includes(target)) return target;
-  const below = candidates.find((i) => i > target);
-  let above: number | undefined;
-  for (const i of candidates) {
-    if (i < target) above = i;
-    else break;
+export const preferredCursorId = (rows: readonly FlatRow[], preferredSprintId: SprintId | undefined): string => {
+  if (preferredSprintId !== undefined) {
+    const match = rows.find((r): r is SprintRow => r.kind === 'sprint' && r.sprint.id === preferredSprintId);
+    if (match !== undefined) return match.sprint.id;
   }
-  const preferred = direction === 1 ? below : above;
-  const fallback = direction === 1 ? above : below;
-  return preferred ?? fallback ?? target;
+  const firstSprint = rows.find((r): r is SprintRow => r.kind === 'sprint');
+  if (firstSprint !== undefined) return firstSprint.sprint.id;
+  const firstCreate = rows.find((r): r is CreateActionRow => r.kind === 'create');
+  return firstCreate !== undefined ? CREATE_ROW_ID : '';
 };

--- a/src/application/ui/tui/views/pick-sprint-internals/row-views.tsx
+++ b/src/application/ui/tui/views/pick-sprint-internals/row-views.tsx
@@ -1,60 +1,97 @@
 /**
- * Row presentation for the sprint picker. Pure render components — the orchestrator owns
- * cursor + window state; this file only knows how to draw a given row at a given focus state.
+ * Row presentation for the sprint picker. `PickerRowList` owns cursor + windowing via the shared
+ * `useListWindow` primitive (id-keyed on the cursorable subset — sprint + create rows); the row
+ * components below are pure presentation, driven entirely by props.
  */
 
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { sprintStatusKind, StatusChip } from '@src/application/ui/tui/components/status-chip.tsx';
+import { computeListWindow, OverflowRow, useListWindow } from '@src/application/ui/tui/components/windowed-list.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
-import type { FlatRow, HeaderRow } from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
-import { computeWindow } from '@src/application/ui/tui/views/pick-sprint-internals/window.ts';
+import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import {
+  type CreateActionRow,
+  type FlatRow,
+  type HeaderRow,
+  type SprintRow,
+} from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
+import { cursorableRowId, cursorableRows } from '@src/application/ui/tui/views/pick-sprint-internals/group-builder.ts';
 
-interface RowWindowViewProps {
+interface PickerRowListProps {
   readonly rows: readonly FlatRow[];
-  readonly cursor: number;
   readonly visibleRows: number;
-  readonly currentSprintId: string | undefined;
+  readonly active: boolean;
+  readonly initialCursorId: string;
+  readonly currentSprintId: SprintId | undefined;
+  readonly onSubmit: (row: SprintRow | CreateActionRow) => void;
 }
 
-export const RowWindowView = ({
+/**
+ * Windowed row list — id-keyed cursor via `useListWindow` over the cursorable subset (sprint +
+ * create rows) drives focus and keyboard handling. The RENDER slice is a separate window over
+ * the full flat row list (headers included), centred on the focused row's index in that full
+ * list, so the rendered height stays bounded by `visibleRows` regardless of how many group
+ * headers (empty or otherwise) sit inside or outside the window. This mirrors the pre-migration
+ * `computeWindow`-over-full-rows behaviour: a header only renders when it falls inside the
+ * slice, exactly like any other row — no exemption for empty groups.
+ */
+export const PickerRowList = ({
   rows,
-  cursor,
   visibleRows,
+  active,
+  initialCursorId,
   currentSprintId,
-}: RowWindowViewProps): React.JSX.Element => {
-  const window = useMemo(() => computeWindow(rows.length, cursor, visibleRows), [rows.length, cursor, visibleRows]);
-  const slice = rows.slice(window.start, window.end);
+  onSubmit,
+}: PickerRowListProps): React.JSX.Element => {
+  const items = useMemo(() => cursorableRows(rows), [rows]);
+
+  const { focusedItem } = useListWindow<SprintRow | CreateActionRow>({
+    items,
+    getId: cursorableRowId,
+    visibleRows,
+    active,
+    initialCursorId,
+    onSubmit,
+  });
+
+  const focusedId = focusedItem !== undefined ? cursorableRowId(focusedItem) : undefined;
+
+  // Index of the focused row within the FULL flat row list (headers included) — the anchor for
+  // the render window. Falls back to 0 when nothing is focused yet (e.g. list still empty).
+  const focusedRowIndex = useMemo(() => {
+    if (focusedId === undefined) return 0;
+    const idx = rows.findIndex((row) => row.kind !== 'header' && cursorableRowId(row) === focusedId);
+    return idx < 0 ? 0 : idx;
+  }, [rows, focusedId]);
+
+  const renderWindow = useMemo(
+    () => computeListWindow(rows.length, focusedRowIndex, visibleRows),
+    [rows.length, focusedRowIndex, visibleRows]
+  );
+
+  const renderRows = useMemo(
+    () => rows.slice(renderWindow.start, renderWindow.end),
+    [rows, renderWindow.start, renderWindow.end]
+  );
+
   return (
     <Box flexDirection="column">
-      {window.hiddenAbove > 0 && (
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>▲ {String(window.hiddenAbove)} more above</Text>
-        </Box>
-      )}
-      {slice.map((row, i) => {
-        const absoluteIndex = i + window.start;
-        if (row.kind === 'header') {
-          return <HeaderRowView key={`h-${row.groupKey}-${String(absoluteIndex)}`} row={row} />;
-        }
-        if (row.kind === 'create') {
-          return <CreateRowView key={`create-${String(absoluteIndex)}`} focused={absoluteIndex === cursor} />;
-        }
+      <OverflowRow direction="above" count={renderWindow.start} />
+      {renderRows.map((row) => {
+        if (row.kind === 'header') return <HeaderRowView key={`h-${row.groupKey}`} row={row} />;
+        if (row.kind === 'create') return <CreateRowView key="create" focused={focusedId === cursorableRowId(row)} />;
         return (
           <SprintRowView
             key={row.sprint.id}
             sprint={row.sprint}
-            focused={absoluteIndex === cursor}
+            focused={focusedId === row.sprint.id}
             isCurrent={currentSprintId === row.sprint.id}
           />
         );
       })}
-      {window.hiddenBelow > 0 && (
-        <Box paddingX={spacing.indent}>
-          <Text dimColor>▼ {String(window.hiddenBelow)} more below</Text>
-        </Box>
-      )}
+      <OverflowRow direction="below" count={rows.length - renderWindow.end} />
     </Box>
   );
 };

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -11,12 +11,19 @@
  * `setProject` + `setSprint` would briefly null the sprint cursor (setProject side effect)
  * and fire the persistence write twice.
  *
- * List shaping (group/flatten/cursor walk) lives under `pick-sprint-internals/`; this file is
- * the orchestrator that wires data → hooks → row presentation.
+ * Cursor + windowing are owned by the shared `useListWindow` primitive (id-keyed on the
+ * cursorable row subset — see `pick-sprint-internals/row-views.tsx`'s `PickerRowList`), not a
+ * bespoke index. The `t` scope toggle forces an explicit reseat to the preferred sprint by
+ * remounting `PickerRowList` (`key` includes `scopeAll`); the `f` done-filter does NOT remount,
+ * so a manually-navigated row that survives the filter keeps focus — `useListWindow`'s own
+ * id-resolution (snap to nearest survivor by prior index on eviction) handles the rest.
+ *
+ * List shaping (group/flatten/cursorable-subset) lives under `pick-sprint-internals/`; this file
+ * is the orchestrator that wires data → hooks → row presentation.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useInput, type Key } from 'ink';
+import React, { useMemo, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
 import { ViewShell } from '@src/application/ui/tui/components/view-shell.tsx';
 import { LoadErrorRow, LoadingRow } from '@src/application/ui/tui/components/async-rows.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
@@ -34,38 +41,25 @@ import type { Project } from '@src/domain/entity/project.ts';
 import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
-import type { FlatRow, PickerData } from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
+import type {
+  CreateActionRow,
+  FlatRow,
+  PickerData,
+  SprintRow,
+} from '@src/application/ui/tui/views/pick-sprint-internals/types.ts';
 import {
   buildGroups,
-  cursorableNear,
-  cursorableRowIndices,
   flatten,
-  nextCursorableIndex,
+  preferredCursorId,
 } from '@src/application/ui/tui/views/pick-sprint-internals/group-builder.ts';
 import {
   computeWindow,
   MIN_VISIBLE_ROWS,
   VERTICAL_CHROME_ROWS,
 } from '@src/application/ui/tui/views/pick-sprint-internals/window.ts';
-import { RowWindowView } from '@src/application/ui/tui/views/pick-sprint-internals/row-views.tsx';
+import { PickerRowList } from '@src/application/ui/tui/views/pick-sprint-internals/row-views.tsx';
 
 type Selection = ReturnType<typeof useSelection>;
-
-/**
- * Preferred cursor index within `rows`: the row for `preferredSprintId` if present, else the
- * first sprint row, else the first cursorable row (the synthetic create row), else 0. Shared by
- * the initial-mount seed and the scope-toggle reseat — both want the same "best landing spot"
- * rule, just against a (possibly different) row list.
- */
-const preferredCursorIndex = (rows: readonly FlatRow[], preferredSprintId: SprintId | undefined): number => {
-  if (preferredSprintId !== undefined) {
-    const i = rows.findIndex((r) => r.kind === 'sprint' && r.sprint.id === preferredSprintId);
-    if (i !== -1) return i;
-  }
-  const firstSprint = rows.findIndex((r) => r.kind === 'sprint');
-  if (firstSprint !== -1) return firstSprint;
-  return cursorableRowIndices(rows)[0] ?? 0;
-};
 
 interface UsePickerRowsResult {
   readonly state: AsyncLoadState<PickerData, unknown>;
@@ -78,8 +72,6 @@ interface UsePickerRowsResult {
   readonly hideDone: boolean;
   readonly setHideDone: React.Dispatch<React.SetStateAction<boolean>>;
   readonly toggleScope: () => void;
-  readonly cursor: number;
-  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
 }
 
 /**
@@ -145,39 +137,7 @@ const usePickerRows = (deps: AppDeps, selection: Selection): UsePickerRowsResult
     return flatten(buildGroups(data, selection.projectId, scopeAll), false).some((r) => r.kind === 'sprint');
   }, [hideDone, sprintCount, data, selection.projectId, scopeAll]);
 
-  // Pre-seed the cursor to the already-selected sprint so Enter is a one-keystroke confirm.
-  // Otherwise, prefer the first sprint row over the synthetic `+ create` row so users with
-  // existing sprints can still press Enter to pick the topmost one — the create row sits at
-  // the very top but is intentionally NOT the initial focus (the common case is "switch", not
-  // "create"). When the picker is completely empty (no sprints anywhere), the create row IS
-  // first cursorable, so the fallback still lands on it.
-  const initialIdx = useMemo(() => preferredCursorIndex(rows, selection.sprintId), [rows, selection.sprintId]);
-
-  const [cursor, setCursor] = useState<number>(initialIdx);
-  useEffect(() => {
-    setCursor((c) => {
-      if (rows.length === 0) return 0;
-      if (c >= rows.length) return Math.max(0, rows.length - 1);
-      // Snap cursor back onto a cursorable row if a re-group landed it on a header.
-      const focused = rows[c];
-      if (focused?.kind !== 'sprint' && focused?.kind !== 'create') {
-        return cursorableRowIndices(rows)[0] ?? c;
-      }
-      return c;
-    });
-  }, [rows]);
-  useEffect(() => {
-    setCursor(initialIdx);
-  }, [initialIdx]);
-
-  const toggleScope = (): void => {
-    const next = !scopeAll;
-    setScopeAll(next);
-    // Recompute the cursor: prefer the already-selected sprint, then the first sprint row,
-    // then the create row (only relevant on a totally empty picker).
-    const nextRows = flatten(buildGroups(visibleData, selection.projectId, next), includeCreate);
-    setCursor(preferredCursorIndex(nextRows, selection.sprintId));
-  };
+  const toggleScope = (): void => setScopeAll((v) => !v);
 
   return {
     state,
@@ -190,38 +150,7 @@ const usePickerRows = (deps: AppDeps, selection: Selection): UsePickerRowsResult
     hideDone,
     setHideDone,
     toggleScope,
-    cursor,
-    setCursor,
   };
-};
-
-/** Whether `input`/`key` is one of the six cursor-navigation keys (arrows, j/k, page, home/end). */
-const isNavigationInput = (input: string, key: Key): boolean =>
-  key.upArrow || key.downArrow || key.pageUp || key.pageDown || key.home || key.end || input === 'j' || input === 'k';
-
-/**
- * Resolve the cursor's next index for the six pure-navigation keys (arrows, j/k, page up/down,
- * home/end); `undefined` for any other key. Called from inside the `setCursor` updater (see
- * {@link usePickerInput}) so `cursor` is always the truly-latest committed state, not whatever
- * value the `useInput` closure captured at its last render.
- */
-const resolveArrowMove = (
-  rows: readonly FlatRow[],
-  cursor: number,
-  visibleRows: number,
-  input: string,
-  key: Key
-): number | undefined => {
-  if (key.upArrow || input === 'k') return nextCursorableIndex(rows, cursor, -1);
-  if (key.downArrow || input === 'j') return nextCursorableIndex(rows, cursor, 1);
-  if (key.pageUp) return cursorableNear(rows, Math.max(0, cursor - visibleRows), -1);
-  if (key.pageDown) return cursorableNear(rows, Math.min(rows.length - 1, cursor + visibleRows), 1);
-  if (key.home) return cursorableRowIndices(rows)[0] ?? 0;
-  if (key.end) {
-    const candidates = cursorableRowIndices(rows);
-    return candidates[candidates.length - 1] ?? cursor;
-  }
-  return undefined;
 };
 
 interface PickerBodyProps {
@@ -232,11 +161,14 @@ interface PickerBodyProps {
   readonly scopeAll: boolean;
   readonly hideDone: boolean;
   readonly rows: readonly FlatRow[];
-  readonly cursor: number;
   readonly visibleRows: number;
+  readonly listActive: boolean;
+  readonly initialCursorId: string;
+  readonly listKey: string;
   readonly currentSprintId: SprintId | undefined;
   readonly currentSprintLabel: string | undefined;
   readonly feedback: string | undefined;
+  readonly onRowSubmit: (row: SprintRow | CreateActionRow) => void;
 }
 
 /** Loading / error / empty / list-of-rows presentation — pure props in, no state of its own. */
@@ -248,11 +180,14 @@ const PickerBody = ({
   scopeAll,
   hideDone,
   rows,
-  cursor,
   visibleRows,
+  listActive,
+  initialCursorId,
+  listKey,
   currentSprintId,
   currentSprintLabel,
   feedback,
+  onRowSubmit,
 }: PickerBodyProps): React.JSX.Element =>
   helpOpen ? (
     <HelpOverlay />
@@ -294,7 +229,15 @@ const PickerBody = ({
           )}
         </Text>
       </Box>
-      <RowWindowView rows={rows} cursor={cursor} visibleRows={visibleRows} currentSprintId={currentSprintId} />
+      <PickerRowList
+        key={listKey}
+        rows={rows}
+        visibleRows={visibleRows}
+        active={listActive}
+        initialCursorId={initialCursorId}
+        currentSprintId={currentSprintId}
+        onSubmit={onRowSubmit}
+      />
       <Box marginTop={spacing.section} paddingX={spacing.indent}>
         <Text dimColor>
           {glyphs.bullet} ↵ use the highlighted sprint {glyphs.bullet} t toggle scope {glyphs.bullet} f{' '}
@@ -302,70 +245,12 @@ const PickerBody = ({
         </Text>
       </Box>
       {feedback !== undefined && (
-        <Box paddingX={spacing.indent} marginTop={1}>
+        <Box paddingX={spacing.indent} marginTop={spacing.section}>
           <Text color={inkColors.error}>{feedback}</Text>
         </Box>
       )}
     </Box>
   );
-
-interface UsePickerInputArgs {
-  readonly modalOpen: boolean;
-  readonly rows: readonly FlatRow[];
-  readonly cursor: number;
-  readonly visibleRows: number;
-  readonly setCursor: React.Dispatch<React.SetStateAction<number>>;
-  readonly pick: (sprint: Sprint) => void;
-  readonly launchCreateSprint: () => Promise<void>;
-  readonly toggleScope: () => void;
-  readonly setHideDone: React.Dispatch<React.SetStateAction<boolean>>;
-  readonly reload: () => void;
-}
-
-/**
- * Sole `useInput` registration for the picker — the six navigation keys resolve through
- * {@link resolveArrowMove}; everything else (confirm / scope toggle / done filter / create /
- * reload) is a flat one-branch-each dispatch.
- */
-const usePickerInput = ({
-  modalOpen,
-  rows,
-  cursor,
-  visibleRows,
-  setCursor,
-  pick,
-  launchCreateSprint,
-  toggleScope,
-  setHideDone,
-  reload,
-}: UsePickerInputArgs): void => {
-  useInput((input, key) => {
-    if (modalOpen) return;
-    if (isNavigationInput(input, key)) {
-      setCursor((c) => resolveArrowMove(rows, c, visibleRows, input, key) ?? c);
-      return;
-    }
-    if (key.return) {
-      const row = rows[cursor];
-      if (row?.kind === 'sprint') pick(row.sprint);
-      else if (row?.kind === 'create') void launchCreateSprint();
-      return;
-    }
-    if (input === 't') {
-      toggleScope();
-      return;
-    }
-    if (input === 'f') {
-      setHideDone((v) => !v);
-      return;
-    }
-    if (input === '+' || input === 'c') {
-      void launchCreateSprint();
-      return;
-    }
-    if (input === 'r') reload();
-  });
-};
 
 /**
  * Re-export of the windowing helper. Kept at this canonical path so the existing unit-test
@@ -383,20 +268,8 @@ export const PickSprintView = (): React.JSX.Element => {
   const ui = useUiState();
   const [feedback, setFeedback] = useState<string | undefined>(undefined);
 
-  const {
-    state,
-    reload,
-    data,
-    rows,
-    sprintCount,
-    hiddenByDoneFilter,
-    scopeAll,
-    hideDone,
-    setHideDone,
-    toggleScope,
-    cursor,
-    setCursor,
-  } = usePickerRows(deps, selection);
+  const { state, reload, data, rows, sprintCount, hiddenByDoneFilter, scopeAll, hideDone, setHideDone, toggleScope } =
+    usePickerRows(deps, selection);
 
   useViewHints([
     { keys: '↑/↓/j/k', label: 'move' },
@@ -436,18 +309,40 @@ export const PickSprintView = (): React.JSX.Element => {
     noProjectMessage: `${glyphs.cross} select a project first`,
   });
 
-  usePickerInput({
-    modalOpen: ui.modalOpen,
-    rows,
-    cursor,
-    visibleRows,
-    setCursor,
-    pick,
-    launchCreateSprint,
-    toggleScope,
-    setHideDone,
-    reload,
+  const onRowSubmit = (row: SprintRow | CreateActionRow): void => {
+    if (row.kind === 'sprint') pick(row.sprint);
+    else void launchCreateSprint();
+  };
+
+  // Non-navigation keys only — `PickerRowList`'s `useListWindow` owns ↑/↓/j/k/PgUp/PgDn/Home/End/Enter.
+  useInput((input) => {
+    if (ui.modalOpen) return;
+    if (input === 't') {
+      toggleScope();
+      return;
+    }
+    if (input === 'f') {
+      setHideDone((v) => !v);
+      return;
+    }
+    if (input === '+' || input === 'c') {
+      void launchCreateSprint();
+      return;
+    }
+    if (input === 'r') reload();
   });
+
+  // The preferred landing id — the already-selected sprint if present, else the first sprint,
+  // else the create row. Recomputed every render but only actually consumed by `useListWindow`
+  // at (re)mount time (see `listKey` below); it never forces a reseat on an already-mounted list.
+  const initialCursorId = useMemo(() => preferredCursorId(rows, selection.sprintId), [rows, selection.sprintId]);
+
+  // Remount the row list — and so its `useListWindow` cursor — on an explicit scope toggle (`t`)
+  // or when the persisted selection changes (covers the selection context arriving a tick after
+  // first render). This is the ONLY case that force-reseats onto `initialCursorId`; the `f`
+  // done-filter does NOT change this key, so a manually-navigated row that survives the filter
+  // keeps focus via `useListWindow`'s own id resolution (see the module doc comment above).
+  const listKey = `${String(scopeAll)}-${selection.sprintId ?? 'unseeded'}`;
 
   return (
     <ViewShell title="Pick a sprint" subtitle="Switch sprint (and project) in one step" suppressScrollArrows>
@@ -459,11 +354,14 @@ export const PickSprintView = (): React.JSX.Element => {
         scopeAll={scopeAll}
         hideDone={hideDone}
         rows={rows}
-        cursor={cursor}
         visibleRows={visibleRows}
+        listActive={!ui.modalOpen}
+        initialCursorId={initialCursorId}
+        listKey={listKey}
         currentSprintId={selection.sprintId}
         currentSprintLabel={selection.sprintLabel}
         feedback={feedback}
+        onRowSubmit={onRowSubmit}
       />
     </ViewShell>
   );

--- a/src/business/_shared/format-duration.ts
+++ b/src/business/_shared/format-duration.ts
@@ -1,0 +1,32 @@
+/**
+ * Human-readable duration formatting — shared by every renderer that reports an elapsed-time
+ * field (journal entries, round outcomes, …). Lives under `business/_shared/` per the business
+ * sibling-isolation rule's own allow-list (each `business/<module>/` is independent; `_shared/`
+ * is the sanctioned cross-module seam), rather than duplicated per module.
+ *
+ * Pure — same input always produces the same string.
+ */
+
+const EM_DASH = '—';
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+/** `undefined` → em-dash. Sub-second → milliseconds. Otherwise the coarsest unit that fits. */
+export const formatDuration = (ms: number | undefined): string => {
+  if (ms === undefined) return EM_DASH;
+  if (ms < 0) return `${String(ms)}ms`;
+  if (ms < MS_PER_SECOND) return `${String(ms)}ms`;
+  if (ms < MS_PER_MINUTE) {
+    return `${String(Math.floor(ms / MS_PER_SECOND))}s`;
+  }
+  if (ms < MS_PER_HOUR) {
+    const minutes = Math.floor(ms / MS_PER_MINUTE);
+    const seconds = Math.floor((ms % MS_PER_MINUTE) / MS_PER_SECOND);
+    return seconds > 0 ? `${String(minutes)}m ${String(seconds)}s` : `${String(minutes)}m`;
+  }
+  const hours = Math.floor(ms / MS_PER_HOUR);
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
+  return minutes > 0 ? `${String(hours)}h ${String(minutes)}m` : `${String(hours)}h`;
+};

--- a/src/business/sprint/render-journal-entry.ts
+++ b/src/business/sprint/render-journal-entry.ts
@@ -1,5 +1,6 @@
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { LearningEntry } from '@src/domain/signal.ts';
+import { formatDuration } from '@src/business/_shared/format-duration.ts';
 import { neutralizeProseHeadings } from '@src/business/sprint/journal-sanitize.ts';
 import { renderSectionHeader } from '@src/business/sprint/journal-structure.ts';
 
@@ -151,28 +152,6 @@ export interface JournalEntryInput {
 }
 
 const EM_DASH = '—';
-
-const MS_PER_SECOND = 1000;
-const MS_PER_MINUTE = 60 * MS_PER_SECOND;
-const MS_PER_HOUR = 60 * MS_PER_MINUTE;
-
-/** Human-readable duration. Mirrors the `render-round-outcome` formatter. */
-const formatDuration = (ms: number | undefined): string => {
-  if (ms === undefined) return EM_DASH;
-  if (ms < 0) return `${String(ms)}ms`;
-  if (ms < MS_PER_SECOND) return `${String(ms)}ms`;
-  if (ms < MS_PER_MINUTE) {
-    return `${String(Math.floor(ms / MS_PER_SECOND))}s`;
-  }
-  if (ms < MS_PER_HOUR) {
-    const minutes = Math.floor(ms / MS_PER_MINUTE);
-    const seconds = Math.floor((ms % MS_PER_MINUTE) / MS_PER_SECOND);
-    return seconds > 0 ? `${String(minutes)}m ${String(seconds)}s` : `${String(minutes)}m`;
-  }
-  const hours = Math.floor(ms / MS_PER_HOUR);
-  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
-  return minutes > 0 ? `${String(hours)}h ${String(minutes)}m` : `${String(hours)}h`;
-};
 
 const SHA_DISPLAY_LENGTH = 7;
 

--- a/src/business/task/dimension-trajectory.ts
+++ b/src/business/task/dimension-trajectory.ts
@@ -75,7 +75,10 @@ export const composeDimensionTrajectory = (input: DimensionTrajectoryInput): str
 
   const fixed = sortedLimited([...priorFailed].filter((d) => !latestFailed.has(d)));
   const newlyFailing = sortedLimited([...latestFailed].filter((d) => !priorFailed.has(d)));
-  const stillFailing = sortedLimited([...latestFailed].filter((d) => priorFailed.has(d)));
+  // Keep the FULL (untruncated) still-failing set for the stall-streak computation below — only the
+  // rendered bullet lines apply the MAX_DIMENSIONS_PER_CLASS display cap.
+  const stillFailingAll = [...latestFailed].filter((d) => priorFailed.has(d));
+  const stillFailing = sortedLimited(stillFailingAll);
 
   const lines: string[] = [];
 
@@ -94,9 +97,11 @@ export const composeDimensionTrajectory = (input: DimensionTrajectoryInput): str
 
   // Budget-pressure line: the loop plateaus after `plateauThreshold` consecutive stalled rounds.
   // Fire the warning one round early (the longest still-failing streak has reached
-  // `plateauThreshold - 1`) so the generator can change approach before the harness gives up.
+  // `plateauThreshold - 1`) so the generator can change approach before the harness gives up. Uses
+  // `stillFailingAll` (untruncated) — a dimension sorted out of the rendered bullets by the display
+  // cap can still hold the true longest stall and must not be silently dropped from this check.
   const threshold = Math.max(2, Math.trunc(input.plateauThreshold));
-  const longestStall = stillFailing.reduce((max, d) => Math.max(max, consecutiveFailing(history, d)), 0);
+  const longestStall = stillFailingAll.reduce((max, d) => Math.max(max, consecutiveFailing(history, d)), 0);
   const pressure =
     longestStall >= threshold - 1
       ? [

--- a/src/business/task/render-round-outcome.ts
+++ b/src/business/task/render-round-outcome.ts
@@ -1,5 +1,6 @@
 import type { Attempt, Evaluation } from '@src/domain/entity/attempt.ts';
 import type { DimensionScore, EvaluationSignal } from '@src/domain/signal.ts';
+import { formatDuration } from '@src/business/_shared/format-duration.ts';
 
 /**
  * Render an `outcome.md` for a single settled gen-eval round.
@@ -180,25 +181,3 @@ const formatFailedDimensions = (evaluation: EvaluationSignal | undefined): strin
 
 const SHA_DISPLAY_LENGTH = 7;
 const shortSha = (sha: string): string => sha.slice(0, SHA_DISPLAY_LENGTH);
-
-const MS_PER_SECOND = 1000;
-const MS_PER_MINUTE = 60 * MS_PER_SECOND;
-const MS_PER_HOUR = 60 * MS_PER_MINUTE;
-
-/** Human-readable duration. Mirrors `render-progress-markdown.ts`'s formatter for consistency. */
-const formatDuration = (ms: number | undefined): string => {
-  if (ms === undefined) return EM_DASH;
-  if (ms < 0) return `${String(ms)}ms`;
-  if (ms < MS_PER_SECOND) return `${String(ms)}ms`;
-  if (ms < MS_PER_MINUTE) {
-    return `${String(Math.floor(ms / MS_PER_SECOND))}s`;
-  }
-  if (ms < MS_PER_HOUR) {
-    const minutes = Math.floor(ms / MS_PER_MINUTE);
-    const seconds = Math.floor((ms % MS_PER_MINUTE) / MS_PER_SECOND);
-    return seconds > 0 ? `${String(minutes)}m ${String(seconds)}s` : `${String(minutes)}m`;
-  }
-  const hours = Math.floor(ms / MS_PER_HOUR);
-  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
-  return minutes > 0 ? `${String(hours)}h ${String(minutes)}m` : `${String(hours)}h`;
-};

--- a/src/integration/ai/agents/_engine/parse-agent-definition.ts
+++ b/src/integration/ai/agents/_engine/parse-agent-definition.ts
@@ -2,8 +2,12 @@
  * Shared agent-definition parsing helpers — the frontmatter split + naive-YAML reader that
  * every agent-definition source backed by an on-disk Markdown file consumes.
  *
- * Reuses the same flat `key: value` frontmatter shape as SKILL.md — a real YAML lib lands only
- * when an agent definition needs nested / multiline frontmatter.
+ * Reuses the same flat `key: value` frontmatter shape as SKILL.md, so the generic split/YAML/
+ * error-code primitives live in the shared `skills/_engine/frontmatter.ts` module rather than
+ * being duplicated here — this reaches into skills' `_engine/` via the documented cross-concept
+ * `_engine`-to-`_engine` import seam. A real YAML lib lands only when an agent definition needs
+ * nested / multiline frontmatter. This module re-exports `errorCode` so existing agent-source
+ * callers (`bundled/source.ts`, `operator/source.ts`) are unaffected.
  *
  * `parseAgentDefinition` validates against {@link AgentDefinitionFrontmatterSchema} and asserts
  * frontmatter `name` matches the source name. The `label` parameter tailors the error message
@@ -14,58 +18,9 @@ import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AgentDefinition } from '@src/integration/ai/agents/_engine/agent-definition.ts';
 import { AgentDefinitionFrontmatterSchema } from '@src/integration/ai/agents/_engine/agent-definition.ts';
+import { errorCode, parseSimpleYaml, splitFrontmatter } from '@src/integration/ai/skills/_engine/frontmatter.ts';
 
-/**
- * Split an agent-definition file body into frontmatter + content. The frontmatter block is the
- * first `---` … `---` pair starting at the file's first non-whitespace line; everything after
- * the closing fence is the body. Returns the body verbatim when no frontmatter is present —
- * callers then validate frontmatter separately.
- *
- * @public
- */
-export const splitFrontmatter = (raw: string): { readonly frontmatter: string; readonly body: string } => {
-  const trimmed = raw.replace(/^\uFEFF/u, ''); // strip UTF-8 BOM
-  if (!trimmed.startsWith('---')) return { frontmatter: '', body: trimmed };
-  const closing = trimmed.indexOf('\n---', 3);
-  if (closing === -1) return { frontmatter: '', body: trimmed };
-  const frontmatter = trimmed.slice(3, closing).trim();
-  const afterClose = trimmed.slice(closing + 4); // skip "\n---"
-  // Strip every blank line after the closing fence so the body is clean. Stripping only ONE
-  // line-end would keep the standard blank separator line inside the body, and each
-  // parse → render round-trip (render re-inserts the separator) would grow the file by one
-  // blank line.
-  const body = afterClose.replace(/^(?:\r?\n)+/, '');
-  return { frontmatter, body };
-};
-
-/**
- * Naive YAML key:value parser — keys are simple identifiers, values are strings or single-quoted
- * strings without escapes. Frontmatter we control is always this shape, so a full YAML parser
- * is overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
- *
- * @public
- */
-export const parseSimpleYaml = (input: string): Record<string, string> => {
-  const result: Record<string, string> = {};
-  for (const line of input.split('\n')) {
-    const stripped = line.trim();
-    if (stripped.length === 0 || stripped.startsWith('#')) continue;
-    const colon = stripped.indexOf(':');
-    if (colon === -1) continue;
-    const key = stripped.slice(0, colon).trim();
-    let value = stripped.slice(colon + 1).trim();
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-    else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-    result[key] = value;
-  }
-  return result;
-};
-
-/** Narrow an unknown caught value to a Node `fs` error code without leaking `any`. @public */
-export const errorCode = (cause: unknown): string | undefined =>
-  typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string'
-    ? cause.code
-    : undefined;
+export { errorCode };
 
 /**
  * Parse an already-read agent-definition file body into the canonical {@link AgentDefinition}

--- a/src/integration/ai/contract/_engine/corrective-retry.ts
+++ b/src/integration/ai/contract/_engine/corrective-retry.ts
@@ -2,7 +2,7 @@ import { ZodError } from 'zod';
 import { Result } from '@src/domain/result.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
-import { ErrorCode } from '@src/domain/value/error/error-code.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import type { AiSignal } from '@src/domain/signal.ts';
@@ -88,16 +88,27 @@ export interface CorrectiveRetryDeps {
 /**
  * A contract failure is *correctable by re-prompting* when the AI could plausibly fix it on a
  * follow-up turn: it forgot to write the file, wrote invalid JSON, or wrote the wrong shape.
+ * This is an ALLOW-list of the three shapes {@link validateSignalsFile}'s own docstring names as
+ * genuinely re-promptable — `InvalidStateError` (signals-missing) and `ParseError` (invalid-json
+ * / schema-mismatch, its only two subcodes). Fail CLOSED by construction: any future
+ * `DomainError` variant `validateSignalsFile` starts returning defaults to "not correctable"
+ * (straight to self-block) instead of silently being retried until someone remembers to add it
+ * to a deny-list — which is exactly how a harness-side `StorageError` (EACCES, EISDIR, transient
+ * I/O — nothing the AI wrote caused it) used to slip through as "correctable" and burn up to
+ * `correctiveRetries` wasted resumed spawns on a corrective prompt that could never fix it.
  *
- * NOT correctable, so we skip the retry and let the caller self-block immediately:
+ * NOT correctable, so we skip the retry and let the caller self-block immediately — everything
+ * outside the two classes above, notably:
  *   - `Aborted` — user cancel; the retry would race the teardown and the corrective spawn would
  *     just re-abort. AbortError must propagate transparently (CLAUDE.md §AbortError).
  *   - `RateLimit` — the adapter already exhausted its 429 retries; re-spawning re-hits the wall.
  *   - `MigrationGap` — an on-disk version older than the contract with a missing migration step;
  *     the AI cannot fix a harness-side migration gap by re-emitting signals.
+ *   - `StorageError` — a harness-side I/O fault (EACCES, EISDIR, …) reading the file the AI
+ *     already wrote; re-emitting the same content will not change whether the harness can read it.
  */
 const isCorrectableContractError = (err: DomainError): boolean =>
-  err.code !== ErrorCode.Aborted && err.code !== ErrorCode.RateLimit && err.code !== ErrorCode.MigrationGap;
+  err instanceof InvalidStateError || err instanceof ParseError;
 
 /**
  * Build the corrective message body, gated by error class. Zod issue lists exist ONLY for
@@ -214,6 +225,18 @@ export const validateSignalsFileWithCorrectiveRetry = async <TSig extends AiSign
       return Result.ok({ signals: revalidated.value, nudgeCount: attempt });
     }
     lastErr = revalidated.error;
+    // A nudge can turn a correctable failure into a non-correctable one (e.g. the AI's rewrite
+    // replaced signals.json with a directory, or a transient StorageError appears on re-read) —
+    // re-check every round, not just before the loop starts, so a shape that stopped being
+    // correctable self-blocks immediately instead of burning the remaining nudges.
+    if (!isCorrectableContractError(lastErr)) {
+      log.warn('corrective retry produced a non-correctable error — self-blocking without a further nudge', {
+        outputDir: String(deps.outputDir),
+        attempt,
+        error: lastErr.message,
+      });
+      return Result.error(lastErr);
+    }
   }
 
   log.warn('corrective retries exhausted — self-blocking', {

--- a/src/integration/ai/prompts/_engine/build-prompt.ts
+++ b/src/integration/ai/prompts/_engine/build-prompt.ts
@@ -11,6 +11,23 @@ import type { ParameterSpec, PromptDefinition } from '@src/integration/ai/prompt
 export type BuildPromptError = StorageError | ParseError | ValidationError;
 
 /**
+ * A parameter can never share a placeholder with an auto-loaded partial slot — `buildPrompt`
+ * populates `values` from partials first, so a colliding parameter would silently clobber the
+ * partial's rendered content instead of failing loudly. Returns the first collision found (a
+ * `[field, placeholder]` pair), or `undefined` when there is none. Definition-authoring bug,
+ * caught once up front rather than left to whichever field happens to iterate last.
+ */
+const findPartialParameterCollision = <TInput extends object>(
+  def: PromptDefinition<TInput>,
+  partialPlaceholders: ReadonlySet<string>
+): readonly [field: string, placeholder: string] | undefined => {
+  for (const [field, rawSpec] of Object.entries(def.parameters) as Array<[string, ParameterSpec<unknown>]>) {
+    if (partialPlaceholders.has(rawSpec.placeholder)) return [field, rawSpec.placeholder];
+  }
+  return undefined;
+};
+
+/**
  * Generic prompt builder. Reads a `PromptDefinition` and a typed input bag, loads the
  * template + any partials, validates each input field via its spec, runs substitution, and
  * brands the result as `Prompt` after `assertTemplateKeysFilled` confirms every placeholder
@@ -37,6 +54,22 @@ export const buildPrompt = async <TInput extends object>(
 
   const values: Record<string, string> = {};
   const partialBodies: string[] = [];
+  const partialPlaceholders = new Set<string>(def.partials !== undefined ? Object.keys(def.partials) : []);
+
+  const collision = findPartialParameterCollision(def, partialPlaceholders);
+  if (collision !== undefined) {
+    const [field, placeholder] = collision;
+    return Result.error(
+      new ValidationError({
+        field,
+        value: placeholder,
+        message:
+          `buildPrompt(${def.templateName}): parameter '${field}' declares placeholder ` +
+          `{{${placeholder}}}, which collides with an auto-loaded partial slot of the same ` +
+          `name — rename one of them.`,
+      })
+    );
+  }
 
   // Auto-loaded partials. Bodies are trimmed so trailing whitespace from the partial file
   // doesn't bleed into the rendered prompt. The bodies are also kept for the template-side

--- a/src/integration/ai/prompts/implement/template.md
+++ b/src/integration/ai/prompts/implement/template.md
@@ -133,9 +133,11 @@ repository now, trust the repository and record the conflict as a `learning` sig
     measurably raises cost without improving agent success.
   - Be specific and verifiable. "Use 2-space indentation" beats "format properly".
   - Stay under 200 lines, max 7 H2 sections, no H4+. Adherence degrades past these limits.
-  - Never embed slash commands, hooks, MCP server config, IDE settings, secrets, or credentials —
-    except when a declared step explicitly calls for adding one of these items to the project context
-    file. Those artefacts otherwise have dedicated homes and do not belong there.
+  - Never embed secrets or credentials — those belong in `.env` files or a secret manager, never a
+    committed context file, with no exception.
+  - Never embed slash commands, hooks, MCP server config, or IDE settings — except when a declared
+    step explicitly calls for adding one of these items to the project context file. Those artefacts
+    otherwise have dedicated homes and do not belong there.
 
 </constraints>
 

--- a/src/integration/ai/providers/_engine/rate-limit-backoff.ts
+++ b/src/integration/ai/providers/_engine/rate-limit-backoff.ts
@@ -13,6 +13,13 @@
  *
  * `sleepCancellable` short-circuits on `abortSignal` so Ctrl-C / TUI cancel doesn't have to
  * wait two hours for the in-flight retry timer.
+ *
+ * `delayForRetry` stays a pure function of `retryIndex` — two branches at the same retry index
+ * get the identical base delay by design (that's what the "matches the documented 1m → 5m →
+ * 30m → 2h sequence" test pins). {@link applyJitter} is the paired primitive a caller applies to
+ * that base delay before sleeping, so concurrent parallel branches sharing one account-level
+ * rate limit disperse their wake times instead of retrying in lockstep and re-tripping the same
+ * limit their synchronized burst of 429s just hit.
  */
 
 const ONE_MINUTE = 60_000;
@@ -30,6 +37,25 @@ export const delayForRetry = (retryIndex: number, schedule: readonly number[] = 
   if (retryIndex < 1) return 0;
   const clamped = Math.min(retryIndex - 1, schedule.length - 1);
   return schedule[clamped] ?? 0;
+};
+
+/** Proportional jitter window applied by {@link applyJitter} — +/- 20% of the base delay. */
+export const JITTER_RATIO = 0.2;
+
+/**
+ * Spread a base delay by up to {@link JITTER_RATIO} in either direction so concurrent callers
+ * that computed the SAME base delay (e.g. several parallel branches hitting the same
+ * account-level rate limit at essentially the same instant) don't wake and retry in lockstep.
+ *
+ * `random` is an injectable `[0, 1)` source, defaulting to `Math.random` — tests pin a fake
+ * (e.g. `() => 0`, `() => 0.999999`) to assert the exact jittered bound instead of asserting on
+ * live randomness. `delayMs <= 0` (the "no wait" sentinel `delayForRetry` returns past the
+ * defensive `retryIndex < 1` guard) passes through unchanged — there is nothing to disperse.
+ */
+export const applyJitter = (delayMs: number, random: () => number = Math.random): number => {
+  if (delayMs <= 0) return delayMs;
+  const spread = delayMs * JITTER_RATIO;
+  return Math.round(delayMs - spread + random() * spread * 2);
 };
 
 /**

--- a/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
+++ b/src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts
@@ -9,6 +9,7 @@ import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attem
 import type { ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import type { SessionId } from '@src/integration/ai/providers/_engine/session-id.ts';
 import {
+  applyJitter,
   DEFAULT_BACKOFF_SCHEDULE,
   delayForRetry,
   sleepCancellable,
@@ -52,6 +53,12 @@ export interface RunWithRateLimitRetryOptions {
   readonly rateLimitRetries: number;
   /** Wait schedule between retries. Defaults to {@link DEFAULT_BACKOFF_SCHEDULE}. */
   readonly backoffSchedule?: readonly number[];
+  /**
+   * `[0, 1)` source for the {@link applyJitter} spread on each backoff wait, defaulting to
+   * `Math.random`. Injectable so tests pin the exact jittered delay instead of asserting on
+   * live randomness.
+   */
+  readonly random?: () => number;
   readonly eventBus: EventBus;
   /**
    * Short provider tag for log lines / banner ids (`'claude'` / `'codex'` / `'copilot'`). Keeps
@@ -107,6 +114,7 @@ interface HandleRateLimitOutcomeParams {
   readonly maxAttempts: number;
   readonly schedule: readonly number[];
   readonly error: RateLimitError;
+  readonly random?: (() => number) | undefined;
 }
 
 /**
@@ -132,6 +140,7 @@ const handleRateLimitOutcome = async ({
   maxAttempts,
   schedule,
   error,
+  random,
 }: HandleRateLimitOutcomeParams): Promise<RateLimitOutcomeResult> => {
   const bannerId = `rate-limit-${providerSlug}-${error.sessionId ?? String(attemptIdx + 1)}`;
   eventBus.publish({
@@ -152,7 +161,9 @@ const handleRateLimitOutcome = async ({
   if (attemptIdx >= maxAttempts - 1) {
     return { type: 'continue', session: nextSession };
   }
-  const delayMs = delayForRetry(attemptIdx + 1, schedule);
+  // Jitter disperses concurrent branches that computed the SAME base delay off a shared
+  // account-level limit, so they don't wake and re-collide in lockstep.
+  const delayMs = applyJitter(delayForRetry(attemptIdx + 1, schedule), random ?? Math.random);
   if (delayMs <= 0) {
     return { type: 'continue', session: nextSession };
   }
@@ -253,6 +264,7 @@ export const runWithRateLimitRetry = async (
         maxAttempts,
         schedule,
         error: outcome.error,
+        random: opts.random,
       });
       if (result.type === 'aborted') {
         return Result.error(result.error) as Result<ProviderOutput, DomainError>;

--- a/src/integration/ai/providers/_engine/truncate-debug-field.ts
+++ b/src/integration/ai/providers/_engine/truncate-debug-field.ts
@@ -19,7 +19,7 @@
  */
 export const truncateField = (value: string | undefined, max = 120): string | undefined => {
   if (value === undefined || value === null) return undefined;
-  if (value.length === 0) return undefined;
+  if (value.trim().length === 0) return undefined;
   if (value.length <= max) return value;
   return `${value.slice(0, max)}…`;
 };

--- a/src/integration/ai/providers/_engine/validate-model.ts
+++ b/src/integration/ai/providers/_engine/validate-model.ts
@@ -1,0 +1,59 @@
+import { Result } from '@src/domain/result.ts';
+import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/settings-models/suspended-models.ts';
+
+/**
+ * Shared catalog-membership + suspension check for every provider adapter entrypoint (headless
+ * `build*Args` and interactive `run`, × claude / copilot / codex — six call sites). Each used to
+ * hand-roll its own two-step "known model, then not suspended" guard; the headless adapters did
+ * both steps, but the interactive claude/copilot adapters only checked catalog membership and
+ * silently skipped the suspension check, so a model suspended AFTER an incident (the mechanism
+ * `suspended-models.ts` is deliberately kept wired for) would fail fast with an actionable
+ * message under implement/evaluate but spawn and fail opaquely under refine/plan/ideate/readiness
+ * on the identical model. One helper makes that drift structurally impossible to reintroduce.
+ *
+ * Suspension is keyed by model id (see `suspended-models.ts`) and today only ever names
+ * Anthropic-family ids, so wiring this into the Codex adapters too is harmless — `isSuspendedModel`
+ * simply never matches a `gpt-*` id; the call still earns its keep there as the one catalog-
+ * membership check.
+ *
+ * `opts.entity` / `opts.attemptedAction` feed straight into the returned {@link InvalidStateError}
+ * so error provenance is unchanged from each adapter's pre-existing inline check. `opts.notKnownMessage`
+ * lets each call site keep its own user-facing wording (`'claude-provider: …'` vs
+ * `'interactive-claude: …'`) rather than homogenising copy as a side effect of this refactor.
+ */
+export interface ValidateModelOptions {
+  readonly entity: string;
+  readonly attemptedAction: string;
+  readonly notKnownMessage: string;
+}
+
+export const validateModel = (
+  model: string,
+  isKnownModel: (s: string) => boolean,
+  opts: ValidateModelOptions
+): Result<void, InvalidStateError> => {
+  if (!isKnownModel(model)) {
+    return Result.error(
+      new InvalidStateError({
+        entity: opts.entity,
+        currentState: 'model-validation',
+        attemptedAction: opts.attemptedAction,
+        message: opts.notKnownMessage,
+      })
+    );
+  }
+  // Catalog-valid but temporarily suspended server-side — fail fast with a clear message rather
+  // than dispatching a --model the provider will reject opaquely.
+  if (isSuspendedModel(model)) {
+    return Result.error(
+      new InvalidStateError({
+        entity: opts.entity,
+        currentState: 'model-suspended',
+        attemptedAction: opts.attemptedAction,
+        message: suspendedModelMessage(model),
+      })
+    );
+  }
+  return Result.ok(undefined);
+};

--- a/src/integration/ai/providers/claude/headless.ts
+++ b/src/integration/ai/providers/claude/headless.ts
@@ -5,10 +5,10 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
 import type { ClaudeProviderDeps } from '@src/integration/ai/providers/_engine/claude-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
-import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/settings-models/suspended-models.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { createClaudeStreamParser } from '@src/integration/ai/providers/claude/parse-stream.ts';
 import type { ClaudeStreamLine } from '@src/integration/ai/providers/_engine/claude-stream.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
@@ -274,28 +274,12 @@ const disallowedToolsFor = (p: SessionPermissions): readonly string[] => {
  * for unknowns; `Result.ok(args)` otherwise.
  */
 export const buildClaudeArgs = (session: AiSession): Result<readonly string[], InvalidStateError> => {
-  if (!isClaudeModel(session.model)) {
-    return Result.error(
-      new InvalidStateError({
-        entity: PROVIDER_NAME,
-        currentState: 'model-validation',
-        attemptedAction: 'build argv',
-        message: `claude-provider: '${session.model}' is not a known Claude model`,
-      })
-    );
-  }
-  // Catalog-valid but temporarily suspended server-side (see suspended-models.ts) — fail fast
-  // with a clear message rather than dispatching a --model the provider will reject opaquely.
-  if (isSuspendedModel(session.model)) {
-    return Result.error(
-      new InvalidStateError({
-        entity: PROVIDER_NAME,
-        currentState: 'model-suspended',
-        attemptedAction: 'build argv',
-        message: suspendedModelMessage(session.model),
-      })
-    );
-  }
+  const validated = validateModel(session.model, isClaudeModel, {
+    entity: PROVIDER_NAME,
+    attemptedAction: 'build argv',
+    notKnownMessage: `claude-provider: '${session.model}' is not a known Claude model`,
+  });
+  if (!validated.ok) return Result.error(validated.error);
   // `-p` is the print-mode flag — without it `claude` launches its interactive TUI and the
   // stdin-piped prompt is silently discarded. v1 hit the same gotcha; mirror the fix here.
   // `--verbose` is required alongside `--output-format stream-json` in non-interactive `-p`

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -18,6 +18,7 @@ import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.t
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { uuidv7 } from '@src/domain/value/uuid7.ts';
 
 /**
@@ -71,16 +72,12 @@ export const createInteractiveClaudeProvider = (deps: InteractiveClaudeDeps): In
 
   return {
     async run(input: InteractiveAiProviderInput) {
-      if (!isClaudeModel(input.model)) {
-        return Result.error(
-          new InvalidStateError({
-            entity: PROVIDER,
-            currentState: 'model-validation',
-            attemptedAction: 'run',
-            message: `interactive-claude: '${input.model}' is not a known Claude model`,
-          })
-        );
-      }
+      const validated = validateModel(input.model, isClaudeModel, {
+        entity: PROVIDER,
+        attemptedAction: 'run',
+        notKnownMessage: `interactive-claude: '${input.model}' is not a known Claude model`,
+      });
+      if (!validated.ok) return Result.error(validated.error);
 
       // Read the prompt file in Node.js so its content can be passed as a direct argv
       // element to claude. This avoids the bash $(cat ...) expansion that broke on Windows

--- a/src/integration/ai/providers/codex/headless.ts
+++ b/src/integration/ai/providers/codex/headless.ts
@@ -10,9 +10,10 @@ import type { CodexProviderDeps } from '@src/integration/ai/providers/_engine/co
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
-import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
 import { DEFAULT_RATE_LIMIT_RE } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import { truncateField } from '@src/integration/ai/providers/_engine/truncate-debug-field.ts';
@@ -138,16 +139,12 @@ export const buildCodexArgs = (
   session: AiSession,
   opts: BuildCodexArgsOpts
 ): Result<readonly string[], InvalidStateError> => {
-  if (!isCodexModel(session.model)) {
-    return Result.error(
-      new InvalidStateError({
-        entity: PROVIDER_NAME,
-        currentState: 'model-validation',
-        attemptedAction: 'build argv',
-        message: `codex-provider: '${session.model}' is not a known Codex model`,
-      })
-    );
-  }
+  const validated = validateModel(session.model, isCodexModel, {
+    entity: PROVIDER_NAME,
+    attemptedAction: 'build argv',
+    notKnownMessage: `codex-provider: '${session.model}' is not a known Codex model`,
+  });
+  if (!validated.ok) return Result.error(validated.error);
   const perms = sandboxFor(session.permissions);
   if (!perms.ok) return Result.error(perms.error);
 

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -17,6 +17,7 @@ import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.t
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 
 /**
  * Interactive `codex` adapter. Spawns the Codex CLI with `stdio: 'inherit'` so the user sees
@@ -64,16 +65,12 @@ export const createInteractiveCodexProvider = (deps: InteractiveCodexDeps): Inte
 
   return {
     async run(input: InteractiveAiProviderInput) {
-      if (!isCodexModel(input.model)) {
-        return Result.error(
-          new InvalidStateError({
-            entity: PROVIDER,
-            currentState: 'model-validation',
-            attemptedAction: 'run',
-            message: `interactive-codex: '${input.model}' is not a known Codex model`,
-          })
-        );
-      }
+      const validated = validateModel(input.model, isCodexModel, {
+        entity: PROVIDER,
+        attemptedAction: 'run',
+        notKnownMessage: `interactive-codex: '${input.model}' is not a known Codex model`,
+      });
+      if (!validated.ok) return Result.error(validated.error);
 
       // Read the prompt file in Node.js so its content can be passed as a direct argv
       // element to codex. This avoids the bash $(cat ...) expansion that broke on Windows

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -9,10 +9,10 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
 import type { CopilotProviderDeps } from '@src/integration/ai/providers/_engine/copilot-provider-deps.ts';
 import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
-import { isSuspendedModel, suspendedModelMessage } from '@src/domain/value/settings-models/suspended-models.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { createCopilotStreamParser } from '@src/integration/ai/providers/copilot/parse-stream.ts';
 import type { CopilotStreamLine, CopilotUsage } from '@src/integration/ai/providers/_engine/copilot-stream.ts';
 import { type ProviderSpawn, defaultProviderSpawn } from '@src/integration/ai/providers/_engine/spawn.ts';
@@ -100,28 +100,14 @@ const PROVIDER_NAME = 'copilot-provider';
  * {@link CopilotModel}; surfaces `InvalidStateError` for unknowns.
  */
 export const buildCopilotArgs = (session: AiSession): Result<readonly string[], InvalidStateError> => {
-  if (!isCopilotModel(session.model)) {
-    return Result.error(
-      new InvalidStateError({
-        entity: PROVIDER_NAME,
-        currentState: 'model-validation',
-        attemptedAction: 'build argv',
-        message: `copilot-provider: '${session.model}' is not a known Copilot model`,
-      })
-    );
-  }
   // Catalog-valid but temporarily suspended server-side (see suspended-models.ts) — the list is
   // currently empty; the guard stays wired for the next incident.
-  if (isSuspendedModel(session.model)) {
-    return Result.error(
-      new InvalidStateError({
-        entity: PROVIDER_NAME,
-        currentState: 'model-suspended',
-        attemptedAction: 'build argv',
-        message: suspendedModelMessage(session.model),
-      })
-    );
-  }
+  const validated = validateModel(session.model, isCopilotModel, {
+    entity: PROVIDER_NAME,
+    attemptedAction: 'build argv',
+    notKnownMessage: `copilot-provider: '${session.model}' is not a known Copilot model`,
+  });
+  if (!validated.ok) return Result.error(validated.error);
   // `--autopilot` is required for autonomous continuation; without it Copilot may pause
   // between actions in non-interactive mode and never finish the turn. v1's working headless
   // adapter sets this flag too — keeping the patterns aligned across versions.

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -18,6 +18,7 @@ import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.t
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
+import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { uuidv7 } from '@src/domain/value/uuid7.ts';
 
 /**
@@ -60,16 +61,12 @@ export const createInteractiveCopilotProvider = (deps: InteractiveCopilotDeps): 
 
   return {
     async run(input: InteractiveAiProviderInput) {
-      if (!isCopilotModel(input.model)) {
-        return Result.error(
-          new InvalidStateError({
-            entity: PROVIDER,
-            currentState: 'model-validation',
-            attemptedAction: 'run',
-            message: `interactive-copilot: '${input.model}' is not a known Copilot model`,
-          })
-        );
-      }
+      const validated = validateModel(input.model, isCopilotModel, {
+        entity: PROVIDER,
+        attemptedAction: 'run',
+        notKnownMessage: `interactive-copilot: '${input.model}' is not a known Copilot model`,
+      });
+      if (!validated.ok) return Result.error(validated.error);
 
       let prompt: string;
       try {

--- a/src/integration/ai/skills/_engine/frontmatter.ts
+++ b/src/integration/ai/skills/_engine/frontmatter.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared flat-frontmatter parsing primitives — the frontmatter split + naive-YAML reader that
+ * every Markdown-with-frontmatter format this codebase reads is built on: SKILL.md
+ * (`./parse-skill.ts`'s `parseSkill`) and agent-definition Markdown
+ * (`agents/_engine/parse-agent-definition.ts`'s `parseAgentDefinition`). Both formats use the
+ * identical flat `key: value` frontmatter shape, so one implementation serves both — a real
+ * YAML lib lands only when either format needs nested / multiline frontmatter.
+ *
+ * Lives under `skills/_engine/` (rather than a new top-level `integration/ai/_engine/`) so the
+ * existing cross-concept `_engine`-to-`_engine` import seam applies unchanged: `agents/_engine/`
+ * reaches in here exactly the way `readiness/_engine/` already reaches into `providers/_engine/`
+ * and `prompts/_engine/`.
+ */
+
+/**
+ * Split a frontmatter-fenced Markdown file body into frontmatter + content. The frontmatter
+ * block is the first `---` … `---` pair starting at the file's first non-whitespace line;
+ * everything after the closing fence is the body. Returns the body verbatim when no frontmatter
+ * is present — callers then validate frontmatter separately.
+ *
+ * @public
+ */
+export const splitFrontmatter = (raw: string): { readonly frontmatter: string; readonly body: string } => {
+  const trimmed = raw.replace(/^\uFEFF/u, ''); // strip UTF-8 BOM
+  if (!trimmed.startsWith('---')) return { frontmatter: '', body: trimmed };
+  const closing = trimmed.indexOf('\n---', 3);
+  if (closing === -1) return { frontmatter: '', body: trimmed };
+  const frontmatter = trimmed.slice(3, closing).trim();
+  const afterClose = trimmed.slice(closing + 4); // skip "\n---"
+  // Strip every blank line after the closing fence so the body is clean. Stripping only ONE
+  // line-end would keep the standard blank separator line inside the body, and each
+  // parse → render round-trip (render re-inserts the separator) would grow the file by one
+  // blank line.
+  const body = afterClose.replace(/^(?:\r?\n)+/, '');
+  return { frontmatter, body };
+};
+
+/**
+ * Naive YAML key:value parser — keys are simple identifiers, values are strings or single-quoted
+ * strings without escapes. Frontmatter we control is always this shape, so a full YAML parser
+ * is overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
+ *
+ * @public
+ */
+export const parseSimpleYaml = (input: string): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const line of input.split('\n')) {
+    const stripped = line.trim();
+    if (stripped.length === 0 || stripped.startsWith('#')) continue;
+    const colon = stripped.indexOf(':');
+    if (colon === -1) continue;
+    const key = stripped.slice(0, colon).trim();
+    let value = stripped.slice(colon + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+    else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+    result[key] = value;
+  }
+  return result;
+};
+
+/** Narrow an unknown caught value to a Node `fs` error code without leaking `any`. @public */
+export const errorCode = (cause: unknown): string | undefined =>
+  typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string'
+    ? cause.code
+    : undefined;

--- a/src/integration/ai/skills/_engine/parse-skill.ts
+++ b/src/integration/ai/skills/_engine/parse-skill.ts
@@ -2,10 +2,11 @@
  * Shared SKILL.md parsing helpers — the canonical frontmatter split + naive-YAML reader + body
  * extraction that every {@link SkillSource} backed by on-disk `SKILL.md` folders consumes.
  *
- * Extracted from `bundled/source.ts` so the bundled source and the operator source
- * (`operator/source.ts`) share one parse implementation byte-for-byte. The frontmatter we
- * author is always flat `key: value` lines, so a full YAML parser is overkill (and adds a dep);
- * a real YAML lib lands only when a skill needs nested / multiline frontmatter.
+ * The generic split/YAML/error-code primitives live in `./frontmatter.ts` — shared byte-for-byte
+ * with `agents/_engine/parse-agent-definition.ts`, which reaches into this module's sibling via
+ * the documented cross-concept `_engine`-to-`_engine` import seam (both formats use the same
+ * flat `key: value` frontmatter shape). This module re-exports `errorCode` so existing skill-
+ * source callers (`bundled/source.ts`, `operator/source.ts`, `phase/*.ts`) are unaffected.
  *
  * `parseSkill` validates against {@link SkillFrontmatterSchema} and asserts frontmatter `name`
  * matches the on-disk folder name per the Agent Skills spec. The `label` parameter tailors the
@@ -14,60 +15,11 @@
 
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { errorCode, parseSimpleYaml, splitFrontmatter } from '@src/integration/ai/skills/_engine/frontmatter.ts';
 import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import { SkillFrontmatterSchema } from '@src/integration/ai/skills/_engine/skill.ts';
 
-/**
- * Split a SKILL.md body into frontmatter + content. The frontmatter block is the first
- * `---` … `---` pair starting at the file's first non-whitespace line; everything after the
- * closing fence is the body. Returns the body verbatim when no frontmatter is present —
- * callers then validate frontmatter separately.
- *
- * @public
- */
-export const splitFrontmatter = (raw: string): { readonly frontmatter: string; readonly body: string } => {
-  const trimmed = raw.replace(/^\uFEFF/u, ''); // strip UTF-8 BOM
-  if (!trimmed.startsWith('---')) return { frontmatter: '', body: trimmed };
-  const closing = trimmed.indexOf('\n---', 3);
-  if (closing === -1) return { frontmatter: '', body: trimmed };
-  const frontmatter = trimmed.slice(3, closing).trim();
-  const afterClose = trimmed.slice(closing + 4); // skip "\n---"
-  // Strip every blank line after the closing fence so the body is clean. Stripping only ONE
-  // line-end would keep the standard blank separator line inside the body, and each
-  // parse → render round-trip (render re-inserts the separator) would grow the file by one
-  // blank line.
-  const body = afterClose.replace(/^(?:\r?\n)+/, '');
-  return { frontmatter, body };
-};
-
-/**
- * Naive YAML key:value parser — keys are simple identifiers, values are strings or single-quoted
- * strings without escapes. Frontmatter we control is always this shape, so a full YAML parser
- * is overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
- *
- * @public
- */
-export const parseSimpleYaml = (input: string): Record<string, string> => {
-  const result: Record<string, string> = {};
-  for (const line of input.split('\n')) {
-    const stripped = line.trim();
-    if (stripped.length === 0 || stripped.startsWith('#')) continue;
-    const colon = stripped.indexOf(':');
-    if (colon === -1) continue;
-    const key = stripped.slice(0, colon).trim();
-    let value = stripped.slice(colon + 1).trim();
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-    else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-    result[key] = value;
-  }
-  return result;
-};
-
-/** Narrow an unknown caught value to a Node `fs` error code without leaking `any`. @public */
-export const errorCode = (cause: unknown): string | undefined =>
-  typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string'
-    ? cause.code
-    : undefined;
+export { errorCode };
 
 /**
  * Parse an already-read SKILL.md body into the canonical {@link Skill} record. Split from the

--- a/src/integration/io/clipboard.ts
+++ b/src/integration/io/clipboard.ts
@@ -22,8 +22,8 @@
  * Spawn is injected so unit tests can script stdin / exit codes deterministically.
  */
 
-import { spawn as nodeSpawn } from 'node:child_process';
 import { Result } from '@src/domain/result.ts';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 import type { Spawn } from '@src/integration/io/spawn.ts';
 
 /** Sentinel error tag so callers can branch on the cause without parsing strings. */
@@ -128,7 +128,7 @@ const runHelper = (spawn: Spawn, helper: HelperCommand, text: string): Promise<R
 
 /** @public */
 export interface CreateCopyToClipboardOptions {
-  /** Override `node:child_process.spawn` in tests. */
+  /** Override `crossPlatformSpawn` in tests. */
   readonly spawn?: Spawn;
   /** Override `process.platform` in tests. */
   readonly platform?: NodeJS.Platform;
@@ -143,7 +143,7 @@ export interface CreateCopyToClipboardOptions {
  * invocation so the TUI hotkey can surface "clipboard unavailable" without spawning anything.
  */
 export const createCopyToClipboard = (opts: CreateCopyToClipboardOptions = {}): CopyToClipboard => {
-  const spawn = opts.spawn ?? (nodeSpawn as Spawn);
+  const spawn = opts.spawn ?? (crossPlatformSpawn as unknown as Spawn);
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
   const helpers = resolveHelpers({ platform, env });

--- a/src/integration/io/command-exists.ts
+++ b/src/integration/io/command-exists.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts';
 
 /**
  * Check whether a named executable resolves on the current `PATH`. Cross-platform — the single
@@ -28,8 +28,8 @@ export const commandExists = (name: string): Promise<boolean> =>
   new Promise((resolve) => {
     const child =
       process.platform === 'win32'
-        ? spawn('where', [name], { stdio: 'ignore' })
-        : spawn('sh', ['-c', 'command -v "$0"', name], { stdio: 'ignore' });
+        ? crossPlatformSpawn('where', [name], { stdio: 'ignore' })
+        : crossPlatformSpawn('sh', ['-c', 'command -v "$0"', name], { stdio: 'ignore' });
     let settled = false;
     const settle = (value: boolean): void => {
       if (settled) return;

--- a/src/integration/io/file-locker.ts
+++ b/src/integration/io/file-locker.ts
@@ -32,7 +32,14 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 
 const DEFAULT_RETRY_DELAY_MS = 50;
 const DEFAULT_MAX_RETRIES = 100;
-const DEFAULT_STALE_AFTER_MS = 30_000;
+/**
+ * Default crash-reclaim latency (ms). Exported as the single source of truth for any consumer
+ * that needs to reason about "is a `proper-lockfile`-heartbeated lock still fresh" without
+ * constructing a `FileLocker` — e.g. `data-migration/lock-guard.ts`'s `anyLockHeld`, which must
+ * treat a lock as HELD using the exact same window the locker itself uses, or the migration's
+ * notion of "held" silently diverges from the locker's notion of "live".
+ */
+export const DEFAULT_STALE_AFTER_MS = 30_000;
 // `proper-lockfile` does not enforce a floor, but a too-small `stale` would let a lock be judged
 // stale between heartbeats. Keep a sane floor and refresh well inside the window (see below).
 const STALE_LOWER_BOUND_MS = 2_000;

--- a/src/integration/observability/os-notification-dispatcher.ts
+++ b/src/integration/observability/os-notification-dispatcher.ts
@@ -22,6 +22,13 @@
  *
  * Platform detection is done once at adapter construction time via `os.platform()`. Tests inject
  * a fake `platform()` to exercise each branch without depending on the host OS.
+ *
+ * This file is one of two named, sanctioned exceptions to the repo-wide
+ * `node:child_process` spawn/exec fence (`childProcessSpawnBan` in `eslint.config.ts`; the other
+ * is `shell-script-runner.ts`) — it needs the *promisified* `execFile` API (a single awaited call
+ * that buffers stdout/stderr and rejects on a non-zero exit), a shape
+ * `integration/io/cross-platform-spawn.ts` doesn't provide since it only wraps the event-based
+ * `spawn`.
  */
 
 import { execFile as execFileCb } from 'node:child_process';

--- a/src/integration/persistence/data-migration/lock-guard.ts
+++ b/src/integration/persistence/data-migration/lock-guard.ts
@@ -2,21 +2,23 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { listDir } from '@src/integration/io/fs.ts';
+import { DEFAULT_STALE_AFTER_MS } from '@src/integration/io/file-locker.ts';
 
 const LOCKS_SUBDIR = 'locks';
 
 /**
  * How fresh a lock's mtime must be to count as HELD. `proper-lockfile` heartbeats a live holder's
- * lock directory (default stale window 30s, refreshed ~3×), so a genuinely-held lock always has an
- * mtime within the stale window. A crashed holder stops heartbeating and its mtime ages past it; we
- * deliberately use a generous window (matching the file-locker default) so we never start a migration
- * that races a long-running implement flow, while still ignoring a stale crash-leftover lock.
+ * lock directory (default stale window {@link DEFAULT_STALE_AFTER_MS}, refreshed ~3×), so a
+ * genuinely-held lock always has an mtime within the stale window. A crashed holder stops
+ * heartbeating and its mtime ages past it; we deliberately reuse the same generous window the
+ * file-locker itself uses so we never start a migration that races a long-running implement flow,
+ * while still ignoring a stale crash-leftover lock.
  *
- * MUST stay in sync with `DEFAULT_STALE_AFTER_MS` in `integration/io/file-locker.ts` (currently 30_000):
- * if the locker's stale window changes, this one must move with it, or the migration's notion of "held"
- * diverges from the locker's notion of "live".
+ * Imported (not re-declared) so this can never drift from the locker's actual stale-reclaim
+ * window — a caller passing a non-default `staleAfterMs` to `createFileLocker` is a separate,
+ * narrower gap this alone doesn't close (see the audit note in the file-locker module).
  */
-const HELD_WITHIN_MS = 30_000;
+const HELD_WITHIN_MS: number = DEFAULT_STALE_AFTER_MS;
 
 /**
  * Whether ANY advisory flow lock is currently HELD under `<stateRoot>/locks/`. The migration's

--- a/src/integration/persistence/project/repository.ts
+++ b/src/integration/persistence/project/repository.ts
@@ -42,38 +42,53 @@ const reconcileStaleProjectSiblings = async (root: AbsolutePath, id: string, can
   }
 };
 
-export const createFsProjectRepository = (deps: FsProjectRepositoryDeps): ProjectRepository => {
-  const list = async (): Promise<Result<readonly Project[], StorageError>> => {
-    const dir = projectsDir(deps.root);
-    const entries = await listDir(dir);
-    if (!entries.ok) return Result.error(entries.error);
+/**
+ * Lists every project under `<root>/projects/`. Extracted to module scope (rather than nested in
+ * the factory) purely to keep `createFsProjectRepository`'s own line count in check —
+ * behaviourally it is the repo's `list()`.
+ */
+const listProjects = async (root: AbsolutePath): Promise<Result<readonly Project[], StorageError>> => {
+  const dir = projectsDir(root);
+  const entries = await listDir(dir);
+  if (!entries.ok) return Result.error(entries.error);
 
-    const jsonFiles = entries.value.filter((f) => f.endsWith('.json')).sort();
-    const items: Project[] = [];
-    // Dedupe by project id: if a legacy bare `<id>.json` and a slugged `<id>--<slug>.json` transiently
-    // coexist (a crash between save's write + stale-sibling cleanup), the list must not show the project
-    // twice. The slugged (canonical) name wins EXPLICITLY — sort order cannot arbitrate here: `-` < `.`
-    // in ASCII puts `<id>--<slug>.json` before `<id>.json`, so the bare (stale) file is read last.
-    const byId = new Map<string, Project>();
-    const canonicalIds = new Set<string>();
-    for (const file of jsonFiles) {
+  const jsonFiles = entries.value.filter((f) => f.endsWith('.json')).sort();
+  // Read every project file concurrently — each read is an independent disk round-trip, and
+  // Promise.all preserves the input array's order regardless of settle order, so the sorted
+  // order established above survives untouched.
+  const reads = await Promise.all(
+    jsonFiles.map(async (file) => {
       const path = `${dir}/${file}`;
-      const json = await readJson(path);
-      if (!json.ok) {
-        if (json.error instanceof NotFoundError) continue; // race: file deleted between list and read
-        return Result.error(json.error);
-      }
-      const decoded = decode(fromJsonProject, json.value, { entity: 'project', path });
-      if (!decoded.ok) return Result.error(decoded.error);
-      const id = String(decoded.value.id);
-      const isCanonical = file.includes('--');
-      if (!isCanonical && canonicalIds.has(id)) continue; // slugged sibling already read — it wins
-      byId.set(id, decoded.value);
-      if (isCanonical) canonicalIds.add(id);
+      return { file, path, json: await readJson(path) };
+    })
+  );
+
+  const items: Project[] = [];
+  // Dedupe by project id: if a legacy bare `<id>.json` and a slugged `<id>--<slug>.json` transiently
+  // coexist (a crash between save's write + stale-sibling cleanup), the list must not show the project
+  // twice. The slugged (canonical) name wins EXPLICITLY — sort order cannot arbitrate here: `-` < `.`
+  // in ASCII puts `<id>--<slug>.json` before `<id>.json`, so the bare (stale) file is read last.
+  const byId = new Map<string, Project>();
+  const canonicalIds = new Set<string>();
+  for (const { file, path, json } of reads) {
+    if (!json.ok) {
+      if (json.error instanceof NotFoundError) continue; // race: file deleted between list and read
+      return Result.error(json.error);
     }
-    items.push(...byId.values());
-    return Result.ok(items);
-  };
+    const decoded = decode(fromJsonProject, json.value, { entity: 'project', path });
+    if (!decoded.ok) return Result.error(decoded.error);
+    const id = String(decoded.value.id);
+    const isCanonical = file.includes('--');
+    if (!isCanonical && canonicalIds.has(id)) continue; // slugged sibling already read — it wins
+    byId.set(id, decoded.value);
+    if (isCanonical) canonicalIds.add(id);
+  }
+  items.push(...byId.values());
+  return Result.ok(items);
+};
+
+export const createFsProjectRepository = (deps: FsProjectRepositoryDeps): ProjectRepository => {
+  const list = (): Promise<Result<readonly Project[], StorageError>> => listProjects(deps.root);
 
   return {
     async findById(id) {

--- a/src/integration/persistence/sprint/repository.ts
+++ b/src/integration/persistence/sprint/repository.ts
@@ -92,40 +92,55 @@ const reconcileSprintDir = async (root: AbsolutePath, id: string, canonicalDir: 
   }
 };
 
-export const createFsSprintRepository = (deps: FsSprintRepositoryDeps): SprintRepository => {
-  const list = async (): Promise<Result<readonly Sprint[], StorageError>> => {
-    const dir = sprintsDir(deps.root);
-    const entries = await listDir(dir);
-    if (!entries.ok) return Result.error(entries.error);
+/**
+ * Lists every sprint under `<root>/sprints/`. Extracted to module scope (rather than nested in the
+ * factory) purely to keep `createFsSprintRepository`'s own line count in check — behaviourally it
+ * is the repo's `list()`.
+ */
+const listSprints = async (root: AbsolutePath): Promise<Result<readonly Sprint[], StorageError>> => {
+  const dir = sprintsDir(root);
+  const entries = await listDir(dir);
+  if (!entries.ok) return Result.error(entries.error);
 
-    // Sort by the leading id (split on `--`) so chronological UUIDv7 order survives the slug
-    // suffix — a `<id>--zzz` dir must still sort by its id, not the whole name.
-    const sortedEntries = [...entries.value].sort((a, b) => parseIdFromName(a).localeCompare(parseIdFromName(b)));
-    const items: Sprint[] = [];
-    // Dedupe by sprint id: if a legacy bare `<id>/` and a slugged `<id>--<slug>/` dir transiently
-    // coexist (a crash between reconcile's rename + cleanup), the list must not show the sprint twice.
-    // The slugged (canonical) entry wins EXPLICITLY — the id-only comparator above returns 0 for the
-    // colliding pair, so sort order (stable sort over unspecified readdir order) cannot arbitrate.
-    const byId = new Map<string, Sprint>();
-    const canonicalIds = new Set<string>();
-    for (const entry of sortedEntries) {
+  // Sort by the leading id (split on `--`) so chronological UUIDv7 order survives the slug
+  // suffix — a `<id>--zzz` dir must still sort by its id, not the whole name.
+  const sortedEntries = [...entries.value].sort((a, b) => parseIdFromName(a).localeCompare(parseIdFromName(b)));
+  // Read every entry's sprint.json concurrently — each read is an independent disk round-trip,
+  // and Promise.all preserves the input array's order regardless of settle order, so the
+  // chronological order established above survives untouched.
+  const reads = await Promise.all(
+    sortedEntries.map(async (entry) => {
       const path = `${dir}/${entry}/sprint.json`;
-      const json = await readJson(path);
-      if (!json.ok) {
-        if (json.error instanceof NotFoundError) continue; // race or stray dir without sprint.json
-        return Result.error(json.error);
-      }
-      const decoded = decode((input) => fromJsonSprint(input, path), json.value, { entity: 'sprint', path });
-      if (!decoded.ok) return Result.error(decoded.error);
-      const id = String(decoded.value.id);
-      const isCanonical = entry.includes('--');
-      if (!isCanonical && canonicalIds.has(id)) continue; // slugged sibling already read — it wins
-      byId.set(id, decoded.value);
-      if (isCanonical) canonicalIds.add(id);
+      return { entry, path, json: await readJson(path) };
+    })
+  );
+
+  const items: Sprint[] = [];
+  // Dedupe by sprint id: if a legacy bare `<id>/` and a slugged `<id>--<slug>/` dir transiently
+  // coexist (a crash between reconcile's rename + cleanup), the list must not show the sprint twice.
+  // The slugged (canonical) entry wins EXPLICITLY — the id-only comparator above returns 0 for the
+  // colliding pair, so sort order (stable sort over unspecified readdir order) cannot arbitrate.
+  const byId = new Map<string, Sprint>();
+  const canonicalIds = new Set<string>();
+  for (const { entry, path, json } of reads) {
+    if (!json.ok) {
+      if (json.error instanceof NotFoundError) continue; // race or stray dir without sprint.json
+      return Result.error(json.error);
     }
-    items.push(...byId.values());
-    return Result.ok(items);
-  };
+    const decoded = decode((input) => fromJsonSprint(input, path), json.value, { entity: 'sprint', path });
+    if (!decoded.ok) return Result.error(decoded.error);
+    const id = String(decoded.value.id);
+    const isCanonical = entry.includes('--');
+    if (!isCanonical && canonicalIds.has(id)) continue; // slugged sibling already read — it wins
+    byId.set(id, decoded.value);
+    if (isCanonical) canonicalIds.add(id);
+  }
+  items.push(...byId.values());
+  return Result.ok(items);
+};
+
+export const createFsSprintRepository = (deps: FsSprintRepositoryDeps): SprintRepository => {
+  const list = (): Promise<Result<readonly Sprint[], StorageError>> => listSprints(deps.root);
 
   return {
     async findById(id) {

--- a/tests/integration/ai/prompts/_engine/build-prompt.test.ts
+++ b/tests/integration/ai/prompts/_engine/build-prompt.test.ts
@@ -164,6 +164,27 @@ describe('buildPrompt — error paths', () => {
     if (result.ok) expect(result.value).toContain('{{ROUND_NUMBER}}');
   });
 
+  it('returns ValidationError when a parameter placeholder collides with a partial slot key', async () => {
+    // A parameter's placeholder must never share a name with an auto-loaded partial slot —
+    // buildPrompt populates `values` from partials first, then parameters, so a collision would
+    // silently clobber the partial's rendered content with the parameter's value instead of
+    // failing loudly. This pins the collision as a construction-time ValidationError.
+    await writePromptTemplate(dir, 'greeting', '{{NAME}}\n');
+    await fs.mkdir(join(String(dir), '_partials'), { recursive: true });
+    await fs.writeFile(join(String(dir), '_partials', 'name-partial.md'), 'PARTIAL BODY\n');
+
+    const collidingDef: PromptDefinition<SimpleParams> = {
+      ...simpleDef,
+      partials: { NAME: 'name-partial' },
+    };
+    const result = await buildPrompt(createFsTemplateLoader(dir), collidingDef, { name: 'Ada' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain('NAME');
+    }
+  });
+
   it('returns ParseError when the template carries a placeholder the manifest does not declare', async () => {
     // Template references {{UNKNOWN}} but the def has no spec for it — drift detected at the
     // template-side assertTemplateKeysFilled fence.

--- a/tests/integration/ai/prompts/implement/definition.test.ts
+++ b/tests/integration/ai/prompts/implement/definition.test.ts
@@ -89,6 +89,25 @@ describe('implementPromptDef — completeness', () => {
     }
   });
 
+  it('never licenses an exception for the secrets/credentials rule in the AI context-file constraints', async () => {
+    // The context-file constraint block DOES carve out a "when a declared step calls for it"
+    // exception for slash commands / hooks / MCP config / IDE settings — those have a legitimate
+    // "document it here on purpose" use case. Secrets and credentials never do: a committed
+    // context file is git-tracked, so embedding one is a real exposure. This pins that rule as
+    // exception-free so a future prose rewrite (e.g. the project's "absolute rules name their
+    // exception" style pass) can't silently regrant the exception to this specific clause.
+    const path = `${String(defaultTemplatesDir())}/implement/template.md`;
+    const template = await fs.readFile(path, 'utf8');
+    const flattened = template.replace(/\s+/g, ' ');
+    const secretsClauses = flattened.match(/[^.]*\b(?:secrets|credentials)\b[^.]*\./gi) ?? [];
+    expect(secretsClauses.length).toBeGreaterThan(0);
+    for (const clause of secretsClauses) {
+      expect(clause, `clause mentioning secrets/credentials must stay exception-free: "${clause}"`).not.toMatch(
+        /\bexcept\b/i
+      );
+    }
+  });
+
   it('declares the documented harness signals the implement response is expected to carry', () => {
     // Aligned with `generator.contract.ts` accepted union: narrative fan-out (`change`,
     // `decision`, `learning`, `note`) + lifecycle signals (`task-verified`, `task-complete`,

--- a/tests/integration/ai/providers/claude/interactive.test.ts
+++ b/tests/integration/ai/providers/claude/interactive.test.ts
@@ -1,11 +1,22 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { createInteractiveClaudeProvider } from '@src/integration/ai/providers/claude/interactive.ts';
 import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+
+// `SUSPENDED_MODELS` ships empty (see suspended-models.ts) — mock it so the suspended-model
+// regression test below (interactive adapters used to skip this check entirely, unlike the
+// headless adapters) can exercise the guard without waiting for a real suspension incident.
+// Every OTHER test in this file spawns `CLAUDE_MODELS[0]`, so the mock targets `CLAUDE_MODELS[1]`
+// exclusively to avoid perturbing them.
+vi.mock('@src/domain/value/settings-models/suspended-models.ts', () => ({
+  isSuspendedModel: (s: string) => s === CLAUDE_MODELS[1],
+  suspendedModelMessage: (m: string) =>
+    `'${m}' is temporarily suspended by its provider — pick another model until access is restored`,
+}));
 
 interface CapturingSpawnState {
   readonly spawn: InteractiveSpawn;
@@ -59,6 +70,23 @@ describe('createInteractiveClaudeProvider', () => {
     if (r.ok) return;
     expect(r.error.code).toBe('invalid-state');
     expect(r.error.message).toContain("'gpt-5'");
+  });
+
+  it('rejects a suspended-but-catalog-known model with InvalidStateError, without spawning — the headless adapter enforces this guard and interactive must match', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls } = makeSpawn();
+    const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+    const r = await provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: CLAUDE_MODELS[1]!,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('invalid-state');
+    expect(r.error.message).toContain('temporarily suspended');
+    expect(calls).toHaveLength(0);
   });
 
   it('returns StorageError when the prompt file cannot be read', async () => {

--- a/tests/integration/ai/providers/copilot/interactive.test.ts
+++ b/tests/integration/ai/providers/copilot/interactive.test.ts
@@ -1,11 +1,22 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
 import { createInteractiveCopilotProvider } from '@src/integration/ai/providers/copilot/interactive.ts';
 import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+
+// `SUSPENDED_MODELS` ships empty (see suspended-models.ts) — mock it so the suspended-model
+// regression test below (interactive adapters used to skip this check entirely, unlike the
+// headless adapters) can exercise the guard without waiting for a real suspension incident.
+// Every OTHER test in this file spawns `COPILOT_MODELS[0]`, so the mock targets
+// `COPILOT_MODELS[1]` exclusively to avoid perturbing them.
+vi.mock('@src/domain/value/settings-models/suspended-models.ts', () => ({
+  isSuspendedModel: (s: string) => s === COPILOT_MODELS[1],
+  suspendedModelMessage: (m: string) =>
+    `'${m}' is temporarily suspended by its provider — pick another model until access is restored`,
+}));
 
 interface CapturingSpawnState {
   readonly spawn: InteractiveSpawn;
@@ -58,6 +69,23 @@ describe('createInteractiveCopilotProvider', () => {
     if (r.ok) return;
     expect(r.error.code).toBe('invalid-state');
     expect(r.error.message).toContain("'claude-haiku-4-5'");
+  });
+
+  it('rejects a suspended-but-catalog-known model with InvalidStateError, without spawning — the headless adapter enforces this guard and interactive must match', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls } = makeSpawn();
+    const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+    const r = await provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: COPILOT_MODELS[1]!,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('invalid-state');
+    expect(r.error.message).toContain('temporarily suspended');
+    expect(calls).toHaveLength(0);
   });
 
   it('spawns copilot directly with --add-dir=<path>, --model=<model>, --allow-all-tools, and -i <prompt content>', async () => {

--- a/tests/integration/application/flows/_shared/memory/distill-propose.test.ts
+++ b/tests/integration/application/flows/_shared/memory/distill-propose.test.ts
@@ -89,4 +89,19 @@ describe('distillProposeLeaf — abort signal threading', () => {
     expect(result.ok).toBe(true);
     expect(sink.input?.abortSignal).toBe(controller.signal);
   });
+
+  it('renders the same "(none detected)" PROJECT_TOOLING fallback markdown as the implement/evaluate renderer', async () => {
+    // Pins distill-propose's local renderProjectTooling to the same italic fallback markup as
+    // renderProjectToolingSection (task.ts) — the two renderers must not drift apart.
+    const sink: { input?: InteractiveAiProviderInput } = {};
+    const leaf = distillProposeLeaf(buildDeps(fakeAi(sink)), 'claude-code');
+
+    const result = await leaf.execute(buildCtx());
+    expect(result.ok).toBe(true);
+
+    const promptPath = join(String(distillRoot), 'claude-code', 'prompt.md');
+    const promptBody = await fs.readFile(promptPath, 'utf8');
+    expect(promptBody).toContain('_(none detected)_');
+    expect(promptBody).not.toMatch(/(?<!_)\(none detected\)(?!_)/);
+  });
 });

--- a/tests/integration/application/flows/implement/leaves/build-task-workspace.test.ts
+++ b/tests/integration/application/flows/implement/leaves/build-task-workspace.test.ts
@@ -4,10 +4,14 @@ import { join } from 'node:path';
 import { realpath } from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { absolutePath, makeTodoTask } from '@tests/fixtures/domain.ts';
+import { Result } from '@src/domain/result.ts';
 import type { VerificationCriterion } from '@src/domain/entity/task.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { WriteFile } from '@src/business/io/write-file.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import { buildTaskWorkspaceLeaf } from '@src/application/flows/implement/leaves/build-task-workspace.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import { createAtomicWriteFile } from '@src/integration/io/write-file-atomic.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 describe('buildTaskWorkspaceLeaf', () => {
@@ -27,7 +31,11 @@ describe('buildTaskWorkspaceLeaf', () => {
     const cwd = absolutePath(dir);
     const progressFile = absolutePath(join(dir, 'progress.md'));
     const leaf = buildTaskWorkspaceLeaf(
-      { templateLoader: createFsTemplateLoader(defaultTemplatesDir()), logger: noopLogger },
+      {
+        templateLoader: createFsTemplateLoader(defaultTemplatesDir()),
+        logger: noopLogger,
+        writeFile: createAtomicWriteFile(),
+      },
       { sprintDir, cwd, progressFile },
       task.id
     );
@@ -112,6 +120,38 @@ describe('buildTaskWorkspaceLeaf', () => {
     expect(contractAfter).toContain('# v2-name');
     expect(contractAfter).toContain('fresh criterion');
     expect(contractAfter).not.toContain('old criterion');
+  });
+
+  it('writes both files through the injected WriteFile port, not raw fs', async () => {
+    const task = {
+      ...makeTodoTask({ name: 'ported-write' }),
+      verificationCriteria: [] as readonly VerificationCriterion[],
+    };
+    const sprintDir = absolutePath(dir);
+    const cwd = absolutePath(dir);
+    const progressFile = absolutePath(join(dir, 'progress.md'));
+    const calls: Array<{ readonly path: AbsolutePath; readonly content: string }> = [];
+    const fakeWriteFile: WriteFile = (path, content) => {
+      calls.push({ path, content });
+      return Promise.resolve(Result.ok(undefined));
+    };
+    const leaf = buildTaskWorkspaceLeaf(
+      { templateLoader: createFsTemplateLoader(defaultTemplatesDir()), logger: noopLogger, writeFile: fakeWriteFile },
+      { sprintDir, cwd, progressFile },
+      task.id
+    );
+
+    const result = await leaf.execute({
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+    } satisfies ImplementCtx);
+
+    expect(result.ok).toBe(true);
+    const root = join(dir, 'implement', String(task.id));
+    expect(calls.map((c) => c.path).sort()).toEqual([join(root, 'contract.md'), join(root, 'prompt.md')].sort());
+    // Nothing hit the real filesystem — proof the leaf no longer shells out to raw fs itself.
+    await expect(fs.access(join(root, 'prompt.md'))).rejects.toThrow();
+    await expect(fs.access(join(root, 'contract.md'))).rejects.toThrow();
   });
 
   it('fails fast when ctx.tasks does not contain the task', async () => {

--- a/tests/integration/application/ui/tui/components/action-menu-hotkeys.test.tsx
+++ b/tests/integration/application/ui/tui/components/action-menu-hotkeys.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ActionMenu — hotkey vs windowed-list nav-alias guard.
+ *
+ * `useListWindow` (mounted alongside ActionMenu's own hotkey `useInput`) binds `j`/`k` as the
+ * vim-alias for cursor move (DESIGN-SYSTEM §6.4). If a `MenuItem` ever declared `hotkey: 'j'` (or
+ * `'k'`), Ink would fire BOTH handlers for the same keystroke: the cursor moves AND the
+ * hotkeyed item's `onSelect` fires. `matchHotkey` must refuse to match these two reserved chars
+ * regardless of what a `MenuItem` declares, so the keystroke behaves as pure navigation.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionMenu, type MenuItem } from '@src/application/ui/tui/components/action-menu.tsx';
+import { DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+
+describe('ActionMenu — reserved nav-alias hotkey guard', () => {
+  it('a MenuItem hotkeyed to "j" never fires onSelect from the "j" keystroke — only the cursor moves', async () => {
+    const alphaSelect = vi.fn();
+    const betaSelect = vi.fn();
+    const gammaSelect = vi.fn();
+    const items: readonly MenuItem[] = [
+      { id: 'alpha', label: 'Alpha', onSelect: alphaSelect },
+      // Pathological: a future menu item hotkeyed to the reserved "down" nav alias.
+      { id: 'beta', label: 'Beta', onSelect: betaSelect, hotkey: 'j' },
+      { id: 'gamma', label: 'Gamma', onSelect: gammaSelect },
+    ];
+    const r = render(<ActionMenu items={items} active />);
+    await tick(30);
+
+    r.stdin.write('j');
+    await tick(30);
+
+    // Cursor moved down onto Beta (same as pressing the down-arrow / DOWN key would).
+    expect(r.lastFrame() ?? '').toMatch(/▸\s*Beta/);
+    // Neither item's onSelect fired — "j" is nav-only, never a hotkey trigger.
+    expect(alphaSelect).not.toHaveBeenCalled();
+    expect(betaSelect).not.toHaveBeenCalled();
+    expect(gammaSelect).not.toHaveBeenCalled();
+
+    r.unmount();
+  });
+
+  it('"j" and DOWN move the cursor identically when no item claims it as a hotkey', async () => {
+    const items: readonly MenuItem[] = [
+      { id: 'alpha', label: 'Alpha', onSelect: (): void => undefined },
+      { id: 'beta', label: 'Beta', onSelect: (): void => undefined },
+    ];
+    const r = render(<ActionMenu items={items} active />);
+    await tick(30);
+    r.stdin.write(DOWN);
+    await tick(30);
+    const viaArrow = r.lastFrame() ?? '';
+    r.unmount();
+
+    const r2 = render(<ActionMenu items={items} active />);
+    await tick(30);
+    r2.stdin.write('j');
+    await tick(30);
+    const viaJ = r2.lastFrame() ?? '';
+    r2.unmount();
+
+    expect(viaJ).toBe(viaArrow);
+  });
+
+  it('a non-reserved hotkey still fires onSelect directly, without moving the cursor first', async () => {
+    const gammaSelect = vi.fn();
+    const items: readonly MenuItem[] = [
+      { id: 'alpha', label: 'Alpha', onSelect: (): void => undefined },
+      { id: 'beta', label: 'Beta', onSelect: (): void => undefined },
+      { id: 'gamma', label: 'Gamma', onSelect: gammaSelect, hotkey: 'z' },
+    ];
+    const r = render(<ActionMenu items={items} active />);
+    await tick(30);
+
+    r.stdin.write('z');
+    await tick(30);
+
+    expect(gammaSelect).toHaveBeenCalledTimes(1);
+
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
@@ -189,6 +189,50 @@ describe('PickSprintView', () => {
     expect(result.lastFrame() ?? '').toContain('live sprint');
   });
 
+  it('f key does not teleport the cursor off a manually-navigated row onto the selected sprint', async () => {
+    // Regression test for the index-based cursor teleport: a `done` sprint sorts BETWEEN the
+    // user's manually-navigated row and the globally-selected sprint, so filtering it out shifts
+    // every row below it up by one. An id-keyed cursor must stay on the row the user is looking
+    // at; an index-keyed cursor previously snapped back onto the selected sprint whenever that
+    // shift changed the selected sprint's own row index.
+    const SID_LIVE_NEW = sprintId('01900000-0000-7000-8000-000000030000');
+    const SID_CLOSED_MID = sprintId('01900000-0000-7000-8000-000000020000');
+    const SID_LIVE_OLD = sprintId('01900000-0000-7000-8000-000000010000');
+    const sprints = [
+      makeSprint({ id: SID_LIVE_NEW, projectId: PID_A, name: 'live-new sprint' }),
+      makeSprint({ id: SID_CLOSED_MID, projectId: PID_A, name: 'closed-mid sprint', status: 'done' }),
+      makeSprint({ id: SID_LIVE_OLD, projectId: PID_A, name: 'live-old sprint' }),
+    ];
+    const { result } = renderView(<PickSprintView />, {
+      deps: stubDeps(sprints, [projectAlpha]),
+      initial: { id: 'pick-sprint' },
+      // The currently-selected sprint is the OLDEST row (last in the newest-first list) — the
+      // initial cursor pre-seeds there.
+      selection: {
+        projectId: PID_A,
+        projectLabel: 'Alpha Project',
+        sprintId: SID_LIVE_OLD,
+        sprintLabel: 'live-old sprint',
+      },
+    });
+    await waitFor(() => expect(result.lastFrame() ?? '').toContain('closed-mid sprint'));
+    // Confirm the pre-seed landed on the selected sprint before navigating away from it.
+    expect(focusedLine(result.lastFrame() ?? '')).toContain('live-old sprint');
+
+    // Navigate up past the done sprint onto the newest sprint — two rows above the selection.
+    result.stdin.write('k');
+    await tick(20);
+    result.stdin.write('k');
+    await waitFor(() => expect(focusedLine(result.lastFrame() ?? '')).toContain('live-new sprint'));
+
+    // Hiding done sprints removes `closed-mid sprint` and shifts every row below it up by one —
+    // exactly the condition that used to desync an index-based cursor. Focus must stay put.
+    result.stdin.write('f');
+    await waitFor(() => expect(result.lastFrame() ?? '').not.toContain('closed-mid sprint'));
+    expect(focusedLine(result.lastFrame() ?? '')).toContain('live-new sprint');
+    expect(focusedLine(result.lastFrame() ?? '')).not.toContain('live-old sprint');
+  });
+
   it('empty state names the f escape hatch when the filter hid every sprint in scope', async () => {
     const sprints = [makeSprint({ id: SID_A2, projectId: PID_A, name: 'closed sprint', status: 'done' })];
     const { result } = renderView(<PickSprintView />, {
@@ -366,5 +410,35 @@ describe('PickSprintView', () => {
       expect(frame).toContain('Gamma Project');
       expect(frame).toContain('no sprints');
     });
+  });
+
+  it('render height stays bounded by the visible window even with many empty project groups in scope', async () => {
+    // `scopeAll` (the default) pre-seeds a header for every known project, including empty ones.
+    // Twenty empty projects — sorted alphabetically after the current (Alpha) project — comfortably
+    // exceed the ~12-row window a 24-row test terminal allows. With the cursor pre-seeded onto
+    // Alpha's newest sprint (near the top of the full row list), only the empty groups that fall
+    // inside that window should render; a group sorted near the bottom must not.
+    const manyEmptyProjects = Array.from({ length: 20 }, (_unused, i) => {
+      const n = String(i + 1).padStart(2, '0');
+      return makeProject({
+        id: projectId(`01900000-0000-7000-8000-0000000e00${n}`),
+        displayName: `Empty${n}`,
+        slug: `empty-${n}`,
+      });
+    });
+    const sprints = [
+      makeSprint({ id: SID_A1, projectId: PID_A, name: 'alpha sprint one' }),
+      makeSprint({ id: SID_A2, projectId: PID_A, name: 'alpha sprint two' }),
+    ];
+    const { result } = renderView(<PickSprintView />, {
+      deps: stubDeps(sprints, [projectAlpha, ...manyEmptyProjects]),
+      initial: { id: 'pick-sprint' },
+      selection: { projectId: PID_A, projectLabel: 'Alpha Project' },
+    });
+    // Cursor pre-seeds onto the newest Alpha sprint — the second row in the full flat row list.
+    await waitFor(() => expect(focusedLine(result.lastFrame() ?? '')).toContain('alpha sprint two'));
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Empty01');
+    expect(frame).not.toContain('Empty20');
   });
 });

--- a/tests/integration/persistence/data-migration/apply.test.ts
+++ b/tests/integration/persistence/data-migration/apply.test.ts
@@ -13,11 +13,13 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { recordingWriteFile } from '@tests/fixtures/recording-write-file.ts';
 import { dryRun } from '@src/integration/persistence/data-migration/dry-run.ts';
-import { apply, type ApplyCtx } from '@src/integration/persistence/data-migration/apply.ts';
-import { readDataVersion } from '@src/integration/persistence/data-migration/version-marker.ts';
+import { apply, type ApplyCtx, type ApplyWriteFile } from '@src/integration/persistence/data-migration/apply.ts';
+import { DATA_VERSION_FILENAME, readDataVersion } from '@src/integration/persistence/data-migration/version-marker.ts';
 import { resolveSprintDir, resolveProjectPath } from '@src/integration/persistence/storage.ts';
 import { ProjectId } from '@src/domain/value/id/project-id.ts';
 import { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -286,6 +288,84 @@ describe('apply — crash safety', () => {
     expect((await readDataVersion(absolutePath(dataRoot))).dataVersion).toBe(2);
     await expect(fs.stat(join(dataRoot, 'sprints', `${a}--one`))).resolves.toBeTruthy();
     await expect(fs.stat(join(dataRoot, 'sprints', `${b}--two`))).resolves.toBeTruthy();
+  });
+
+  it('a merge ledger write that throws ⇒ marker NOT stamped, legacy memory dir survives ⇒ a clean re-run finishes', async () => {
+    const row = (id: string, text: string): string => `${JSON.stringify({ v: 1, id, text, promotedAt: null })}\n`;
+    const pid = freshId();
+    await seedLegacyProject(dataRoot, pid, 'alpha');
+    // Both-dirs present so the dry-run classifies this project's memory as a MERGE, not a plain rename.
+    await seedNewMemory(dataRoot, pid, 'alpha', row('a', 'from slugged A'));
+    await seedLegacyMemory(dataRoot, pid, row('c', 'from legacy C'));
+
+    const report = await dryRun(absolutePath(dataRoot));
+    expect(report.merges).toHaveLength(1);
+
+    // Simulate a real I/O fault writing the merged ledger — the module docstring's crash-safety
+    // contract ("a real I/O fault STOPS before the stamp") applies to this write exactly like a
+    // rename. The legacy dir must still be gone-only-after-a-durable-write, so it must survive.
+    const failingWriteFile: ApplyWriteFile = async (path, content) => {
+      if (String(path).endsWith('learnings.ndjson')) {
+        return Result.error(new StorageError({ subCode: 'io', message: 'simulated EACCES', path: String(path) }));
+      }
+      return writer.fn(path, content);
+    };
+
+    const failed = await apply(absolutePath(dataRoot), report, { ...ctx(), writeFile: failingWriteFile });
+
+    expect(failed.kind).toBe('failed');
+    if (failed.kind === 'failed') expect(failed.error).toBeInstanceOf(StorageError);
+    // The marker was NOT stamped — a re-run must resume.
+    expect((await readDataVersion(absolutePath(dataRoot))).dataVersion).toBe(1);
+    // The legacy memory dir is untouched: `mergeOne` only removes it AFTER a durable write, so a
+    // crash here must leave the legacy records on disk for the next run to re-merge.
+    await expect(fs.stat(join(dataRoot, 'memory', pid))).resolves.toBeTruthy();
+    await expect(fs.stat(join(dataRoot, 'memory', pid, 'learnings.ndjson'))).resolves.toBeTruthy();
+
+    // Re-run with a working writer → the merge completes (idempotently re-unioning) and stamps.
+    const resume = await apply(absolutePath(dataRoot), await dryRun(absolutePath(dataRoot)), ctx());
+    expect(resume.kind).toBe('ok');
+    expect((await readDataVersion(absolutePath(dataRoot))).dataVersion).toBe(2);
+    await expect(fs.stat(join(dataRoot, 'memory', pid))).rejects.toThrow();
+    await expect(fs.stat(join(dataRoot, 'memory', `${pid}--alpha`))).resolves.toBeTruthy();
+    const merged = writer.read(absolutePath(join(dataRoot, 'memory', `${pid}--alpha`, 'learnings.ndjson'))) ?? '';
+    const ids = merged
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => (JSON.parse(l) as { id: string }).id);
+    expect(ids.sort()).toEqual(['a', 'c']);
+  });
+
+  it('a marker stamp write that throws ⇒ marker NOT stamped even though every rename already landed ⇒ a clean re-run stamps', async () => {
+    const sid = freshId();
+    await seedLegacySprint(dataRoot, sid, 'beta');
+
+    const report = await dryRun(absolutePath(dataRoot));
+
+    // Simulate a crash writing the FINAL version marker — the one raw `fs.writeFile` call site in
+    // the data-migration module (version-marker.ts). Every rename above has already landed for real.
+    const realWriteFile = fs.writeFile.bind(fs);
+    const writeFileSpy = vi.spyOn(fs, 'writeFile').mockImplementation((async (path: string, data: string) => {
+      if (path.endsWith(DATA_VERSION_FILENAME)) {
+        throw Object.assign(new Error('simulated ENOSPC'), { code: 'ENOSPC' });
+      }
+      return realWriteFile(path, data, 'utf8');
+    }) as typeof fs.writeFile);
+
+    const failed = await apply(absolutePath(dataRoot), report, ctx());
+    writeFileSpy.mockRestore();
+
+    expect(failed.kind).toBe('failed');
+    if (failed.kind === 'failed') expect(failed.error).toBeInstanceOf(StorageError);
+    // The marker was NOT stamped — still v1, even though the rename below already completed for real.
+    expect((await readDataVersion(absolutePath(dataRoot))).dataVersion).toBe(1);
+    await expect(fs.stat(join(dataRoot, 'sprints', `${sid}--beta`))).resolves.toBeTruthy();
+
+    // Re-run: every rename is now an idempotent no-op skip; only the stamp needs to land.
+    const resume = await runFull();
+    expect(resume.kind).toBe('ok');
+    if (resume.kind === 'ok') expect(resume.applied.every((a) => a.status === 'skipped')).toBe(true);
+    expect((await readDataVersion(absolutePath(dataRoot))).dataVersion).toBe(2);
   });
 });
 

--- a/tests/integration/persistence/data-migration/lock-guard.test.ts
+++ b/tests/integration/persistence/data-migration/lock-guard.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { anyLockHeld } from '@src/integration/persistence/data-migration/lock-guard.ts';
+import { DEFAULT_STALE_AFTER_MS } from '@src/integration/io/file-locker.ts';
 
 let stateRoot: string;
 
@@ -48,6 +49,25 @@ describe('anyLockHeld', () => {
   it('ignores non-.lock entries', async () => {
     await fs.mkdir(locksDir(), { recursive: true });
     await fs.writeFile(join(locksDir(), 'README.txt'), 'x', 'utf8');
+    expect(await anyLockHeld(absolutePath(stateRoot))).toBe(false);
+  });
+
+  // Pins the held-window to `file-locker.ts`'s actual DEFAULT_STALE_AFTER_MS (not a duplicated
+  // literal) so the two constants can never silently drift apart again — see the shared
+  // source-of-truth note on DEFAULT_STALE_AFTER_MS.
+  it('treats a lock as held right up to file-locker.ts DEFAULT_STALE_AFTER_MS, stale just past it', async () => {
+    const justWithin = join(locksDir(), 'repo-just-within.lock');
+    await fs.mkdir(justWithin, { recursive: true });
+    const withinMtime = new Date(Date.now() - (DEFAULT_STALE_AFTER_MS - 1_000));
+    await fs.utimes(justWithin, withinMtime, withinMtime);
+    expect(await anyLockHeld(absolutePath(stateRoot))).toBe(true);
+
+    await fs.rm(justWithin, { recursive: true, force: true });
+
+    const justPast = join(locksDir(), 'repo-just-past.lock');
+    await fs.mkdir(justPast, { recursive: true });
+    const pastMtime = new Date(Date.now() - (DEFAULT_STALE_AFTER_MS + 1_000));
+    await fs.utimes(justPast, pastMtime, pastMtime);
     expect(await anyLockHeld(absolutePath(stateRoot))).toBe(false);
   });
 });

--- a/tests/integration/persistence/project/repository.test.ts
+++ b/tests/integration/persistence/project/repository.test.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
@@ -91,6 +91,48 @@ describe('createFsProjectRepository', () => {
     if (all.ok) {
       const expectedOrder = [a.id, b.id, c.id].sort();
       expect(all.value.map((p) => p.id)).toEqual(expectedOrder);
+    }
+  });
+
+  it('reads project files concurrently while preserving id-asc list order', async () => {
+    const repo = createFsProjectRepository({ root });
+    const a = makeProject({ id: ProjectId.generate(), slug: 'a' });
+    const b = makeProject({ id: ProjectId.generate(), slug: 'b' });
+    const c = makeProject({ id: ProjectId.generate(), slug: 'c' });
+    const expectedOrder = [a.id, b.id, c.id].sort();
+    await repo.save(a);
+    await repo.save(b);
+    await repo.save(c);
+
+    // Make the FIRST file in sort order settle LAST and hold every read briefly. A sequential
+    // implementation never overlaps (maxInFlight stays 1); an implementation that pushes results
+    // in completion order (rather than preserving array position) would also misorder the first
+    // entry. Only true concurrent reads via Promise.all satisfy both assertions below.
+    const firstId = expectedOrder[0];
+    const firstProject = [a, b, c].find((p) => p.id === firstId);
+    if (firstProject === undefined) throw new Error('expected a matching project');
+    const delayedPath = projectFile(root, firstProject.id, firstProject.slug);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const realReadFile = fs.readFile.bind(fs);
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation((async (path: string, encoding: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, path === delayedPath ? 20 : 5));
+      try {
+        return await realReadFile(path, encoding as BufferEncoding);
+      } finally {
+        inFlight -= 1;
+      }
+    }) as typeof fs.readFile);
+
+    try {
+      const all = await repo.list();
+      if (!all.ok) throw new Error('list failed');
+      expect(all.value.map((p) => p.id)).toEqual(expectedOrder);
+      expect(maxInFlight).toBeGreaterThan(1);
+    } finally {
+      readFileSpy.mockRestore();
     }
   });
 

--- a/tests/integration/persistence/sprint/repository.test.ts
+++ b/tests/integration/persistence/sprint/repository.test.ts
@@ -261,6 +261,49 @@ describe('createFsSprintRepository', () => {
     expect(all.value.filter((s) => s.id === sprint.id)).toHaveLength(1);
   });
 
+  it('reads sprint.json files concurrently while preserving id-asc list order and NotFound tolerance', async () => {
+    const repo = createFsSprintRepository({ root });
+    const a = makeDraftSprintBundle({ slug: 'a' }).sprint;
+    await new Promise((r) => setTimeout(r, 5)); // ensure UUIDv7 timestamps differ
+    const b = makeDraftSprintBundle({ slug: 'b' }).sprint;
+    await new Promise((r) => setTimeout(r, 5));
+    const c = makeDraftSprintBundle({ slug: 'c' }).sprint;
+    await repo.save(a);
+    await repo.save(b);
+    await repo.save(c);
+    // A stray file alongside the per-sprint dirs — proves the NotFound/ENOTDIR tolerance also
+    // survives running the reads concurrently, not just sequentially.
+    await fs.writeFile(`${String(root)}/sprints/.DS_Store`, 'Mac Finder metadata\n');
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const aPath = sprintFile(root, a.id, a.slug);
+    const realReadFile = fs.readFile.bind(fs);
+    // Every sprint.json read holds briefly before resolving, and `a` (which sorts FIRST) is held
+    // LONGEST. A sequential implementation never overlaps (maxInFlight stays 1); an implementation
+    // that pushes results in completion order (rather than preserving array position) would also
+    // put `a` last. Only true concurrent reads via Promise.all satisfy both assertions below.
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation((async (path: string, encoding: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, path === aPath ? 20 : 5));
+      try {
+        return await realReadFile(path, encoding as BufferEncoding);
+      } finally {
+        inFlight -= 1;
+      }
+    }) as typeof fs.readFile);
+
+    try {
+      const all = await repo.list();
+      if (!all.ok) throw new Error('list failed');
+      expect(all.value.map((s) => s.id)).toEqual([a.id, b.id, c.id]);
+      expect(maxInFlight).toBeGreaterThan(1);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
   it('list parses the id from the leading --segment of a mixed (legacy + slugged) dir set', async () => {
     const repo = createFsSprintRepository({ root });
     const a = makeDraftSprintBundle({ slug: 'a' }).sprint;

--- a/tests/unit/application/flows/_shared/with-repo-lock.test.ts
+++ b/tests/unit/application/flows/_shared/with-repo-lock.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+import { Result } from '@src/domain/result.ts';
+import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { AppEvent } from '@src/business/observability/events.ts';
+import type { EventBus } from '@src/business/observability/event-bus.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import type { Element } from '@src/application/chain/element.ts';
+import { leaf } from '@src/application/chain/build/leaf.ts';
+import type { FileLocker } from '@src/integration/io/file-locker.ts';
+import { withRepoLock } from '@src/application/flows/_shared/with-repo-lock.ts';
+
+import { absolutePath } from '@tests/fixtures/domain.ts';
+
+interface Ctx {
+  readonly value: string;
+}
+
+const spyEventBus = (): { readonly bus: EventBus; readonly events: AppEvent[] } => {
+  const events: AppEvent[] = [];
+  return {
+    events,
+    bus: {
+      publish(event) {
+        events.push(event);
+      },
+      subscribe() {
+        return () => {};
+      },
+    },
+  };
+};
+
+/** A trivial ok leaf, so `withRepoLock`'s inner-passthrough plumbing is real chain code, not a stub. */
+const okInner = (): Element<Ctx> =>
+  leaf<Ctx, Ctx, Ctx>('inner-ok', {
+    input: (ctx) => ctx,
+    useCase: { execute: async (input) => Result.ok({ ...input, value: 'ran' }) },
+    output: (_ctx, out) => out,
+  });
+
+/** A leaf that records whether the signal it observed was aborted at call time. */
+const signalObservingInner = (observed: { aborted?: boolean }): Element<Ctx> =>
+  leaf<Ctx, Ctx, Ctx>('inner-observer', {
+    input: (ctx) => ctx,
+    useCase: {
+      execute: async (input, signal) => {
+        observed.aborted = signal?.aborted ?? false;
+        return Result.ok(input);
+      },
+    },
+    output: (_ctx, out) => out,
+  });
+
+const opts = (fileLocker: FileLocker, eventBus: EventBus): Parameters<typeof withRepoLock>[0] => ({
+  fileLocker,
+  locksRoot: absolutePath('/locks'),
+  worktreePath: absolutePath('/repos/main'),
+  eventBus,
+});
+
+/**
+ * A `FileLocker` stub that always "acquires" and hands `fn` the given signal. Declares its own
+ * generic `T` on the method (shadowing the interface's) and casts the result — without this,
+ * `Result.ok(await fn(signal))` infers as `Ok<Awaited<T>>`, which tsc rejects against the
+ * interface's `Promise<Result<T, StorageError>>` for the unresolved generic `T`.
+ */
+const okLocker = (signal: AbortSignal): FileLocker => ({
+  withLock: async <T>(_path: AbsolutePath, fn: (signal: AbortSignal) => Promise<T>) =>
+    Result.ok(await fn(signal)) as Result<T, StorageError>,
+});
+
+describe('withRepoLock', () => {
+  it('exposes the wrapped inner element via `children` for TUI plan-walking (flattenLeaves)', () => {
+    const inner = okInner();
+    const fileLocker = okLocker(new AbortController().signal);
+    const { bus } = spyEventBus();
+
+    const wrapped = withRepoLock(opts(fileLocker, bus), inner);
+
+    expect(wrapped.name).toBe('with-repo-lock(inner-ok)');
+    expect(wrapped.children).toStrictEqual([inner]);
+  });
+
+  it('acquires the lock, runs the inner chain, and bubbles its ctx/trace through on success', async () => {
+    const inner = okInner();
+    let capturedPath: AbsolutePath | undefined;
+    const fileLocker: FileLocker = {
+      withLock: async <T>(path: AbsolutePath, fn: (signal: AbortSignal) => Promise<T>) => {
+        capturedPath = path;
+        return Result.ok(await fn(new AbortController().signal)) as Result<T, StorageError>;
+      },
+    };
+    const { bus, events } = spyEventBus();
+
+    const result = await withRepoLock(opts(fileLocker, bus), inner).execute({ value: 'start' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.ctx).toStrictEqual({ value: 'ran' });
+      expect(result.value.trace.map((e) => e.elementName)).toStrictEqual(['inner-ok']);
+    }
+    // Lock key is a deterministic hash of the worktree path — the locker sees a real path, not the ctx.
+    expect(capturedPath).toBeDefined();
+    expect(String(capturedPath)).toMatch(/^\/locks\/repo-[0-9a-f]{16}\.lock$/);
+    // Success never publishes a banner.
+    expect(events).toStrictEqual([]);
+  });
+
+  it('releases the lock even when the inner chain fails — bubbles the inner failure unwrapped, no banner', async () => {
+    const failingInner: Element<Ctx> = leaf<Ctx, Ctx, Ctx>('inner-failing', {
+      input: (ctx) => ctx,
+      useCase: {
+        execute: async () => Result.error(new StorageError({ subCode: 'io', message: 'boom' })),
+      },
+      output: (_ctx, out) => out,
+    });
+    const fileLocker = okLocker(new AbortController().signal);
+    const { bus, events } = spyEventBus();
+
+    const result = await withRepoLock(opts(fileLocker, bus), failingInner).execute({ value: 'start' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBeInstanceOf(StorageError);
+      expect(result.error.trace.map((e) => `${e.elementName}:${e.status}`)).toStrictEqual(['inner-failing:failed']);
+    }
+    // The inner's own failure is bubbled unwrapped — only a genuine ACQUIRE failure publishes the banner.
+    expect(events).toStrictEqual([]);
+  });
+
+  it('when lock acquisition itself fails, publishes a warn banner and fails with the locker StorageError', async () => {
+    const inner = okInner();
+    const acquireError = new StorageError({ subCode: 'lock', message: 'failed to acquire lock after 100 retries' });
+    const fileLocker: FileLocker = { withLock: async () => Result.error(acquireError) };
+    const { bus, events } = spyEventBus();
+
+    const result = await withRepoLock(opts(fileLocker, bus), inner).execute({ value: 'start' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.error).toBe(acquireError);
+      expect(result.error.trace).toStrictEqual([
+        {
+          elementName: 'with-repo-lock(inner-ok)',
+          status: 'failed',
+          durationMs: expect.any(Number),
+          error: acquireError,
+        },
+      ]);
+    }
+    expect(events).toHaveLength(1);
+    const banner = events[0];
+    expect(banner?.type).toBe('banner-show');
+    if (banner?.type === 'banner-show') {
+      expect(banner.tier).toBe('warn');
+      expect(banner.id).toMatch(/^lock-\/locks\/repo-[0-9a-f]{16}\.lock$/);
+      expect(banner.cause).toMatch(/^\/locks\/repo-[0-9a-f]{16}\.lock$/);
+    }
+    // The inner element never ran — it never gets to record its own trace entry.
+    expect(inner.name).toBe('inner-ok'); // sanity: same inner instance, untouched
+  });
+
+  it('merges a compromised lock signal into the inner chain so it tears down as an AbortError', async () => {
+    const observed: { aborted?: boolean } = {};
+    const inner = signalObservingInner(observed);
+    // Simulate FileLocker handing back an ALREADY-fired lock-compromised signal — the inner chain
+    // must observe it as aborted via `combineAbortSignals`, exactly as a live lock takeover would.
+    const compromised = new AbortController();
+    compromised.abort(new Error('lock compromised'));
+    const fileLocker = okLocker(compromised.signal);
+    const { bus, events } = spyEventBus();
+
+    const result = await withRepoLock(opts(fileLocker, bus), inner).execute({ value: 'start' });
+
+    // The inner leaf's own `checkAborted` guard fires before its use case runs, so the use case body
+    // (which would have recorded `observed.aborted = false`) never executes.
+    expect(observed.aborted).toBeUndefined();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.trace.map((e) => `${e.elementName}:${e.status}`)).toStrictEqual(['inner-observer:aborted']);
+    }
+    // A compromised-mid-run lock is not an acquire failure — no banner.
+    expect(events).toStrictEqual([]);
+  });
+
+  it('merges the host abort signal with the lock signal — a host-level abort tears the inner chain down too', async () => {
+    const observed: { aborted?: boolean } = {};
+    const inner = signalObservingInner(observed);
+    const fileLocker = okLocker(new AbortController().signal);
+    const { bus } = spyEventBus();
+    const host = new AbortController();
+    host.abort(new Error('user cancelled'));
+
+    const result = await withRepoLock(opts(fileLocker, bus), inner).execute({ value: 'start' }, host.signal);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.trace.map((e) => `${e.elementName}:${e.status}`)).toStrictEqual(['inner-observer:aborted']);
+    }
+  });
+
+  it('forwards progressive onTrace calls from the inner chain untouched', async () => {
+    const inner = okInner();
+    const fileLocker = okLocker(new AbortController().signal);
+    const { bus } = spyEventBus();
+    const traced: string[] = [];
+
+    await withRepoLock(opts(fileLocker, bus), inner).execute({ value: 'start' }, undefined, (entry) => {
+      traced.push(entry.elementName);
+    });
+
+    expect(traced).toStrictEqual(['inner-ok']);
+  });
+});

--- a/tests/unit/application/flows/implement/merge-wave.test.ts
+++ b/tests/unit/application/flows/implement/merge-wave.test.ts
@@ -262,26 +262,64 @@ describe('forkCtx', () => {
 });
 
 /**
- * Compile-time guard demonstration. `mergeImplementWave`'s `_exhaustive` object is
- * `satisfies Record<keyof ImplementCtx, MergeClass>`. Adding a new field to `ImplementCtx` WITHOUT
- * classifying it in that object is a TYPE ERROR (the object stops satisfying the constraint), so a
- * future ctx field can never silently bypass the merge/fork projection.
+ * Compile-time guard demonstration. `mergeImplementWave` and `forkCtx` both build their
+ * sprint-scoped slice by spreading `projectSprintScopedFields(base)` (see
+ * `sprint-scoped-projection.ts`) — the ONLY place either function reads a `'sprint'`-classified
+ * field off `base`. That module's internal `CTX_FIELD_CLASS` object is
+ * `satisfies Record<keyof ImplementCtx, MergeClass>`, so adding a new `ImplementCtx` field without
+ * classifying it there is a TYPE ERROR (classification is exhaustive).
  *
- * The block below documents what a deliberately-unclassified field would look like. It cannot be
- * left uncommented in a green suite (by design it would fail typecheck), so it is preserved here as
- * the contract record:
+ * Classification alone is not enough to force the PROJECTION to keep up (every `ImplementCtx` field
+ * except `sprintId` is optional, so a hand-written return object can legally omit an optional key)
+ * — which is exactly the gap this guard closes. `projectSprintScopedFields` declares its return
+ * type as `Required<Pick<ImplementCtx, SprintScopedKey>>`, where `SprintScopedKey` is derived by
+ * mapped type from the fields classified `'sprint'`. `Required<>` strips the optional modifier, so
+ * every sprint-scoped key MUST be explicitly present in the returned object literal — omitting one
+ * is a compile error, not a silently-accepted gap.
  *
- *   // In ctx.ts, adding:  readonly someNewField?: string | undefined;
- *   // …without adding `someNewField: '…'` to `_exhaustive` produces, at `pnpm typecheck`:
- *   //   error TS2353 / TS2741: Property 'someNewField' is missing in type '…'
- *   //   but required in type 'Record<keyof ImplementCtx, MergeClass>'.
+ * The block below documents what happens if a NEW field is classified `'sprint'` but the projection
+ * function is not updated to assign it. It cannot be left uncommented in a green suite (by design it
+ * would fail typecheck), so it is preserved here as the contract record:
+ *
+ *   // In ctx.ts, adding:                readonly someNewField?: string | undefined;
+ *   // In sprint-scoped-projection.ts's CTX_FIELD_CLASS, classifying:  someNewField: SPRINT,
+ *   // …without adding `someNewField: ctx.someNewField` to `projectSprintScopedFields`'s return
+ *   // object produces, at `pnpm typecheck`:
+ *   //   error TS2741: Property 'someNewField' is missing in type '{ sprintId: …; … }' but
+ *   //   required in type 'Required<Pick<ImplementCtx, SprintScopedKey>>'.
  *
  * This `expectTypeOf`-free note is the test surface for the guard — the actual enforcement is the
- * `satisfies` in merge-wave.ts, verified every `pnpm typecheck`.
+ * `Required<Pick<…>>` return type in sprint-scoped-projection.ts, verified every `pnpm typecheck`.
  */
 describe('exhaustiveness guard (compile-time)', () => {
-  it('is enforced by the satisfies Record<keyof ImplementCtx, MergeClass> in merge-wave.ts', () => {
+  it('is enforced by projectSprintScopedFields returning Required<Pick<ImplementCtx, SprintScopedKey>>', () => {
     // Runtime no-op: the guarantee is structural (typecheck-time), asserted by the doc above.
     expect(true).toBe(true);
+  });
+
+  it('both mergeImplementWave and forkCtx carry an unset sprint-scoped field through as undefined, not a stale prior value', () => {
+    // `setupVerifiedRepoIdsThisRun` / `priorLearnings` are deliberately left unset on this base
+    // (unlike makeBaseCtx, which always populates every sprint-scoped field) to exercise the
+    // projection's handling of an absent optional field through the shared helper.
+    const t1 = makeTodoTask();
+    const base: ImplementCtx = {
+      sprintId: sprint.id,
+      sprint,
+      execution: makeExecution(sprint.id),
+      progressFile: absolutePath('/sprints/s1/progress.md'),
+      tasks: [t1],
+    };
+
+    const merged = mergeImplementWave(base, []);
+    const { ctx: forked } = forkCtx(
+      base,
+      { path: absolutePath('/repos/main'), name: 'main-repo' },
+      absolutePath('/repos/.worktrees/wt-1')
+    );
+
+    expect(merged.setupVerifiedRepoIdsThisRun).toBeUndefined();
+    expect(merged.priorLearnings).toBeUndefined();
+    expect(forked.setupVerifiedRepoIdsThisRun).toBeUndefined();
+    expect(forked.priorLearnings).toBeUndefined();
   });
 });

--- a/tests/unit/application/flows/implement/sprint-scoped-projection.test.ts
+++ b/tests/unit/application/flows/implement/sprint-scoped-projection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
+import { projectSprintScopedFields } from '@src/application/flows/implement/sprint-scoped-projection.ts';
+
+import { absolutePath, makeExecution, makePlannedSprint } from '@tests/fixtures/domain.ts';
+
+const sprint = makePlannedSprint();
+
+describe('projectSprintScopedFields', () => {
+  it('carries every sprint-scoped field from ctx', () => {
+    const ctx: ImplementCtx = {
+      sprintId: sprint.id,
+      sprint,
+      execution: makeExecution(sprint.id),
+      progressFile: absolutePath('/sprints/s1/progress.md'),
+      setupVerifiedRepoIdsThisRun: [],
+      priorLearnings: [],
+    };
+
+    const projected = projectSprintScopedFields(ctx);
+
+    expect(projected).toStrictEqual({
+      sprintId: ctx.sprintId,
+      sprint: ctx.sprint,
+      execution: ctx.execution,
+      progressFile: ctx.progressFile,
+      setupVerifiedRepoIdsThisRun: ctx.setupVerifiedRepoIdsThisRun,
+      priorLearnings: ctx.priorLearnings,
+    });
+  });
+
+  it('projects an unset optional field as an explicitly-present undefined key (Required<>, not omission)', () => {
+    // The `Required<Pick<...>>` return type is the type-level forcing function (see merge-wave.test.ts's
+    // "exhaustiveness guard" block): every sprint-scoped key must be assigned, present or not.
+    const ctx: ImplementCtx = { sprintId: sprint.id };
+
+    const projected = projectSprintScopedFields(ctx);
+
+    expect('sprint' in projected).toBe(true);
+    expect(projected.sprint).toBeUndefined();
+  });
+
+  it('never includes a non-sprint-scoped field (tasks / per-task / signal-accum classes)', () => {
+    const ctx: ImplementCtx = { sprintId: sprint.id, currentTaskId: undefined, tasks: [] };
+
+    const projected = projectSprintScopedFields(ctx);
+
+    expect('tasks' in projected).toBe(false);
+    expect('currentTaskId' in projected).toBe(false);
+  });
+});

--- a/tests/unit/application/flows/review/flow-shape.test.ts
+++ b/tests/unit/application/flows/review/flow-shape.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Element } from '@src/application/chain/element.ts';
+import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import type { ReviewDeps } from '@src/application/flows/review/deps.ts';
+import { createReviewFlow, type CreateReviewFlowOpts } from '@src/application/flows/review/flow.ts';
+
+import { absolutePath } from '@tests/fixtures/domain.ts';
+
+/**
+ * Topology fence for the review chain — mirrors the construction-only pattern the other AI-driven
+ * flows use (readiness/flow-shape.test.ts, implement/flow-shape.test.ts, …): flatten the element
+ * tree in DFS order and assert on the name list. No leaf ever executes, so every dep can be an
+ * inert cast — `createReviewFlow` never reads a dep field eagerly (unlike implement's
+ * `config.harness.*` read), it only closes over them inside leaf factories and, for `deps.distill`,
+ * calls `createDistillStep` — which itself only stores its `deps`/`opts` in closure, never invokes
+ * them at construction (see `distill-step.ts`). Locks in the loop + guard + optional-distill-splice
+ * composition `flow.ts`'s own doc comment describes, so a future reorder fails fast and clearly.
+ */
+const names = <T>(el: Element<T>): readonly string[] => [el.name, ...(el.children ?? []).flatMap((c) => names(c))];
+
+const stubDeps = (opts: { readonly withDistill?: boolean } = {}): ReviewDeps =>
+  ({
+    ...(opts.withDistill === true ? { distill: { deps: {}, opts: {} } } : {}),
+  }) as unknown as ReviewDeps;
+
+const makeOpts = (): CreateReviewFlowOpts => ({
+  sprintId: SprintId.generate(),
+  sprintDir: absolutePath('/sprints/s1'),
+  reviewRoot: absolutePath('/sprints/s1/review'),
+  commitCwd: absolutePath('/repos/main'),
+  additionalRoots: [absolutePath('/repos/main')],
+  repositoriesBlock: '- main-repo',
+  feedbackFile: absolutePath('/sprints/s1/feedback.md'),
+});
+
+describe('createReviewFlow — chain-topology fence', () => {
+  it('builds the exact leaf topology, in order, when no distill step is wired', () => {
+    expect(names(createReviewFlow(stubDeps(), makeOpts()))).toStrictEqual([
+      'with-repo-lock(review)',
+      'review',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'ensure-feedback-file',
+      'review-loop',
+      'review-round',
+      'review-settled',
+      'review-settle',
+      'transition-sprint-to-done',
+    ]);
+  });
+
+  it('splices distill-learnings-step into review-settle, immediately BEFORE the done transition, when deps.distill is present', () => {
+    expect(names(createReviewFlow(stubDeps({ withDistill: true }), makeOpts()))).toStrictEqual([
+      'with-repo-lock(review)',
+      'review',
+      'load-and-assert-sprint',
+      'load-sprint',
+      'assert-sprint-status',
+      'ensure-feedback-file',
+      'review-loop',
+      'review-round',
+      'review-settled',
+      'review-settle',
+      'distill-learnings-step',
+      'transition-sprint-to-done',
+    ]);
+  });
+
+  it('wraps the WHOLE chain in exactly one with-repo-lock, never inside review-settle or the loop body', () => {
+    const top = createReviewFlow(stubDeps(), makeOpts());
+
+    expect(top.name).toBe('with-repo-lock(review)');
+    expect(top.children?.length).toBe(1);
+    const chain = top.children?.[0];
+    expect(chain?.name).toBe('review');
+
+    // Only the top node's name carries the `with-repo-lock(...)` wrapper — it never recurs deeper.
+    expect(names(top).filter((n) => n.startsWith('with-repo-lock('))).toStrictEqual(['with-repo-lock(review)']);
+  });
+
+  it('exposes review-loop wrapping exactly one review-round body (the loop primitive never unrolls iterations at construction)', () => {
+    const chain = createReviewFlow(stubDeps(), makeOpts()).children?.[0];
+    const loopNode = chain?.children?.find((c) => c.name === 'review-loop');
+
+    expect(loopNode?.children?.length).toBe(1);
+    expect(loopNode?.children?.[0]?.name).toBe('review-round');
+  });
+
+  it('gates BOTH the transition and the optional distill step behind the SAME review-settled guard', () => {
+    const chain = createReviewFlow(stubDeps({ withDistill: true }), makeOpts()).children?.[0];
+    const guardNode = chain?.children?.find((c) => c.name === 'review-settled');
+    const settleBody = guardNode?.children?.[0];
+
+    expect(settleBody?.name).toBe('review-settle');
+    expect(settleBody?.children?.map((c) => c.name)).toStrictEqual([
+      'distill-learnings-step',
+      'transition-sprint-to-done',
+    ]);
+  });
+});

--- a/tests/unit/application/session/session.test.ts
+++ b/tests/unit/application/session/session.test.ts
@@ -35,4 +35,86 @@ describe('session-context', () => {
     expect(outerSeen).toBe('outer');
     expect(innerSeen).toBe('inner');
   });
+
+  // The chain runner's wave scheduler (`wave-scheduler.ts`) launches multiple `runWithSession(...)`
+  // calls genuinely CONCURRENTLY — interleaved on the microtask queue via `Promise.race` over an
+  // in-flight pool — not merely nested/sequential like the case above. Every downstream
+  // `logger.info` / `publishSignal` call inside a branch relies on `currentSessionId()` resolving to
+  // THAT branch's id even while sibling branches' async work is interleaved. This pins that
+  // guarantee without real timers: each branch yields to the microtask queue several times via
+  // `await Promise.resolve()`, so sibling branches' continuations genuinely interleave with it —
+  // Node drains the microtask queue in strict FIFO order, so this interleaving is fully
+  // deterministic (no reliance on `setTimeout` / OS scheduling / which branch "wins").
+  it('resolves each of several CONCURRENTLY interleaved branches to its own id, never a sibling’s', async () => {
+    const branchIds = ['branch-a', 'branch-b', 'branch-c', 'branch-d', 'branch-e'] as const;
+    const observedBySession = new Map<string, string[]>();
+
+    const interleavingWork = async (sessionId: string): Promise<void> => {
+      const observed: string[] = [];
+      observedBySession.set(sessionId, observed);
+      for (let step = 0; step < 5; step += 1) {
+        // Yield to the microtask queue so sibling branches get a chance to run interleaved with
+        // this one before it resumes — the exact scenario a shared mutable variable (instead of
+        // AsyncLocalStorage) would fail.
+        await Promise.resolve();
+        observed.push(currentSessionId() ?? 'MISSING');
+      }
+    };
+
+    await Promise.all(branchIds.map((id) => runWithSession(id, () => interleavingWork(id))));
+
+    // Every branch observed ONLY its own id at every one of its interleaved steps.
+    for (const id of branchIds) {
+      expect(observedBySession.get(id)).toStrictEqual([id, id, id, id, id]);
+    }
+    // No leakage into the ambient (non-session) scope once every concurrent branch has settled.
+    expect(currentSessionId()).toBeUndefined();
+  });
+
+  // Mirrors `wave-scheduler.ts`'s actual concurrency shape (`.claude/docs/HARNESS-PRINCIPLES.md`
+  // §7-adjacent parallel-implement machinery): a bounded pool of in-flight branches, `Promise.race`d
+  // to admit the next queued branch as soon as a slot frees up. Branches have DIFFERENT lifetimes
+  // (varying step counts), so slots turn over unevenly and branches genuinely overlap arbitrarily —
+  // not in lockstep like the fixed-size `Promise.all` above. Still fully deterministic: no real
+  // timers, only microtask yields and `Promise.race`, whose settlement order Node resolves the same
+  // way every run for a given code shape.
+  it('keeps every branch on its own id as a bounded `Promise.race` pool (mirroring the wave scheduler) turns slots over', async () => {
+    const queue = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'] as const;
+    const stepsFor: Record<(typeof queue)[number], number> = { p1: 3, p2: 1, p3: 2, p4: 4, p5: 1, p6: 2 };
+    const observed = new Map<string, string[]>();
+    const POOL_SIZE = 3;
+
+    const runBranch = async (id: (typeof queue)[number]): Promise<void> => {
+      await runWithSession(id, async () => {
+        const seen: string[] = [];
+        observed.set(id, seen);
+        for (let step = 0; step < stepsFor[id]; step += 1) {
+          await Promise.resolve();
+          seen.push(currentSessionId() ?? 'MISSING');
+        }
+      });
+    };
+
+    const pending = new Set<Promise<void>>();
+    let nextIdx = 0;
+    const admitNext = (): void => {
+      if (nextIdx >= queue.length) return;
+      const id = queue[nextIdx]!;
+      nextIdx += 1;
+      const p: Promise<void> = runBranch(id).then(() => {
+        pending.delete(p);
+      });
+      pending.add(p);
+    };
+
+    for (let i = 0; i < POOL_SIZE; i += 1) admitNext();
+    while (pending.size > 0) {
+      await Promise.race(pending);
+      admitNext();
+    }
+
+    for (const id of queue) {
+      expect(observed.get(id)).toStrictEqual(Array.from({ length: stepsFor[id] }, () => id));
+    }
+  });
 });

--- a/tests/unit/business/_shared/format-duration.test.ts
+++ b/tests/unit/business/_shared/format-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from '@src/business/_shared/format-duration.ts';
+
+// Canonical duration-formatting suite — the single implementation shared by
+// business/sprint/render-journal-entry.ts and business/task/render-round-outcome.ts, which used
+// to each define an identical formatDuration + MS_PER_* constants copy.
+
+describe('formatDuration', () => {
+  it('renders an em-dash for undefined', () => {
+    expect(formatDuration(undefined)).toBe('—');
+  });
+
+  it('renders sub-second durations in milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('renders negative durations in milliseconds verbatim', () => {
+    expect(formatDuration(-5)).toBe('-5ms');
+  });
+
+  it('renders sub-minute durations in whole seconds', () => {
+    expect(formatDuration(1000)).toBe('1s');
+    expect(formatDuration(1500)).toBe('1s');
+    expect(formatDuration(59_000)).toBe('59s');
+  });
+
+  it('renders sub-hour durations as minutes, dropping the seconds when zero', () => {
+    expect(formatDuration(60_000)).toBe('1m');
+    expect(formatDuration(5_000 + 60_000)).toBe('1m 5s');
+    expect(formatDuration(3_599_000)).toBe('59m 59s');
+  });
+
+  it('renders hour-plus durations as hours, dropping the minutes when zero', () => {
+    expect(formatDuration(3_600_000)).toBe('1h');
+    expect(formatDuration(3_600_000 + 5 * 60_000)).toBe('1h 5m');
+  });
+});

--- a/tests/unit/business/task/dimension-trajectory.test.ts
+++ b/tests/unit/business/task/dimension-trajectory.test.ts
@@ -109,4 +109,22 @@ describe('composeDimensionTrajectory', () => {
     const b = composeDimensionTrajectory({ history, plateauThreshold: 3, roundNum: 2, maxTurns: 5 });
     expect(a).toBe(b);
   });
+
+  it('computes the longest stall streak over the FULL still-failing set, not the display-truncated one', () => {
+    // 'longStall' has been failing since round 1 (streak 3 by the latest turn). Eight more
+    // dimensions ('a'..'h') only start failing at round 2, so by the latest turn they only have a
+    // streak of 2. Sorted alphabetically, 'a'..'h' sort BEFORE 'longStall' — the display cap
+    // (MAX_DIMENSIONS_PER_CLASS = 8) keeps exactly 'a'..'h' and drops 'longStall' from the rendered
+    // "still failing" bullets. The budget-pressure line must still reflect 'longStall''s streak of 3,
+    // not the truncated set's max of 2.
+    const eightDims = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const history = [turn(['longStall']), turn(['longStall', ...eightDims]), turn(['longStall', ...eightDims])];
+
+    // threshold 4 → pressure fires at streak >= 3. The truncated set's max streak (2, from 'a'..'h')
+    // would NOT fire it; only 'longStall''s untruncated streak of 3 does.
+    const out = composeDimensionTrajectory({ history, plateauThreshold: 4, roundNum: 3, maxTurns: 8 });
+
+    expect(out).toContain('stalled round(s)');
+    expect(out).toContain('3 stalled round(s)');
+  });
 });

--- a/tests/unit/eslint-config.test.ts
+++ b/tests/unit/eslint-config.test.ts
@@ -118,3 +118,172 @@ describe('node:child_process spawn/exec fence', () => {
     expect(isRestrictedImportError(messages)).toBe(false);
   });
 });
+
+/**
+ * Liveness probes for every no-restricted-imports fence. ESLint flat config REPLACES a
+ * same-key rule entry when a later block matches the same file — it never merges options —
+ * so a block that narrows a broader glob silently wipes the broader block's restrictions
+ * (and vice versa) unless the surviving entry carries the union of both. These probes pin
+ * that every fence actually fires in the directories where two blocks overlap; each one was
+ * dead (or is the still-live control) when the composition flaw was found.
+ */
+describe('fence liveness under overlapping config blocks', () => {
+  const linter = new Linter();
+  const config = eslintConfig as LinterTypes.Config[];
+
+  const restrictedMessages = (code: string, filename: string): string =>
+    linter
+      .verify(code, config, filename)
+      .filter((m) => m.ruleId === 'no-restricted-imports')
+      .map((m) => m.message)
+      .join('\n');
+
+  const AI_FAMILIES = [
+    { constant: 'PROMPTS', root: 'src/integration/ai/prompts' },
+    { constant: 'PROVIDERS', root: 'src/integration/ai/providers' },
+    { constant: 'READINESS_PROVIDERS', root: 'src/integration/ai/readiness' },
+    { constant: 'SKILLS', root: 'src/integration/ai/skills' },
+    { constant: 'AGENTS', root: 'src/integration/ai/agents' },
+  ] as const;
+
+  for (const { constant, root } of AI_FAMILIES) {
+    describe(`${root}/<sibling>/`, () => {
+      const [a, b] = constantFromEslintConfig(constant);
+
+      it('sibling isolation fires', () => {
+        expect(
+          restrictedMessages(
+            `import { x } from '@${root}/${b!}/thing.ts';\nexport const y = x;\n`,
+            `${root}/${a!}/probe.ts`
+          )
+        ).toMatch(/Sibling-/);
+      });
+
+      it('the integration layer rule survives in a sibling directory', () => {
+        expect(
+          restrictedMessages(
+            "import { x } from '@src/application/registry.ts';\nexport const y = x;\n",
+            `${root}/${a!}/probe.ts`
+          )
+        ).toMatch(/Layer dependency violation/);
+      });
+
+      it('the node:child_process spawn fence survives in a sibling directory', () => {
+        expect(
+          restrictedMessages(
+            "import { spawn } from 'node:child_process';\nexport const y = spawn;\n",
+            `${root}/${a!}/probe.ts`
+          )
+        ).toMatch(/child_process/);
+      });
+    });
+  }
+
+  describe('src/business/<sibling>/', () => {
+    const [a, b] = constantFromEslintConfig('BUSINESS_SIBLINGS');
+
+    it('sibling isolation fires', () => {
+      expect(
+        restrictedMessages(
+          `import { x } from '@src/business/${b!}/thing.ts';\nexport const y = x;\n`,
+          `src/business/${a!}/probe.ts`
+        )
+      ).toMatch(/Sibling-business/);
+    });
+
+    it('the I/O-bearing node module ban survives in a sibling directory', () => {
+      expect(
+        restrictedMessages(
+          "import { readFileSync } from 'node:fs';\nexport const y = readFileSync;\n",
+          `src/business/${a!}/probe.ts`
+        )
+      ).toMatch(/I\/O-bearing/);
+    });
+
+    it('the composite *Repository ban survives in a sibling directory', () => {
+      expect(
+        restrictedMessages(
+          "import { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';\nexport const y = 0;\n",
+          `src/business/${a!}/probe.ts`
+        )
+      ).toMatch(/slim sub-ports/);
+    });
+  });
+
+  describe('src/domain/repository/<sibling>/', () => {
+    const [a, b] = constantFromEslintConfig('REPOSITORY_SIBLINGS');
+
+    it('sibling isolation fires', () => {
+      expect(
+        restrictedMessages(
+          `import { x } from '@src/domain/repository/${b!}/thing.ts';\nexport const y = x;\n`,
+          `src/domain/repository/${a!}/probe.ts`
+        )
+      ).toMatch(/Sibling-repository/);
+    });
+
+    it('the domain layer rule survives in a sibling directory', () => {
+      expect(
+        restrictedMessages(
+          "import { readFileSync } from 'node:fs';\nexport const y = readFileSync;\n",
+          `src/domain/repository/${a!}/probe.ts`
+        )
+      ).toMatch(/I\/O-bearing|Layer dependency violation/);
+    });
+  });
+
+  describe('src/application/flows/<flow>/', () => {
+    const [a, b] = constantFromEslintConfig('FLOWS');
+
+    it('sibling isolation fires', () => {
+      expect(
+        restrictedMessages(
+          `import { x } from '@src/application/flows/${b!}/flow.ts';\nexport const y = x;\n`,
+          `src/application/flows/${a!}/probe.ts`
+        )
+      ).toMatch(/Sibling-flow/);
+    });
+
+    it('the no-concrete-adapters chains rule survives in a sibling directory', () => {
+      expect(
+        restrictedMessages(
+          "import { x } from '@src/integration/ai/providers/claude/headless.ts';\nexport const y = x;\n",
+          `src/application/flows/${a!}/probe.ts`
+        )
+      ).toMatch(/concrete provider adapters/);
+    });
+
+    it('bans per-signal schema imports from ordinary flow code', () => {
+      expect(
+        restrictedMessages(
+          "import { x } from '@src/integration/ai/contract/_engine/signals/note/schema.ts';\nexport const y = x;\n",
+          `src/application/flows/${a!}/leaves/probe.ts`
+        )
+      ).toMatch(/per-signal Zod schemas/);
+    });
+
+    it('lifts the schema ban for per-leaf *.contract.ts files — the audit-[09] composition point', () => {
+      expect(
+        restrictedMessages(
+          "import { x } from '@src/integration/ai/contract/_engine/signals/note/schema.ts';\nexport const y = x;\n",
+          `src/application/flows/${a!}/leaves/probe.contract.ts`
+        )
+      ).toBe('');
+    });
+
+    it('keeps sibling isolation and the concrete-adapter ban inside *.contract.ts files', () => {
+      expect(
+        restrictedMessages(
+          `import { x } from '@src/application/flows/${b!}/flow.ts';\nexport const y = x;\n`,
+          `src/application/flows/${a!}/leaves/probe.contract.ts`
+        )
+      ).toMatch(/Sibling-flow/);
+      expect(
+        restrictedMessages(
+          "import { x } from '@src/integration/ai/providers/claude/headless.ts';\nexport const y = x;\n",
+          `src/application/flows/${a!}/leaves/probe.contract.ts`
+        )
+      ).toMatch(/concrete provider adapters/);
+    });
+  });
+});

--- a/tests/unit/eslint-config.test.ts
+++ b/tests/unit/eslint-config.test.ts
@@ -2,6 +2,9 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import type { Linter as LinterTypes } from 'eslint';
+import eslintConfig from '../../eslint.config.ts';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const ESLINT_CONFIG_PATH = join(REPO_ROOT, 'eslint.config.ts');
@@ -60,5 +63,58 @@ describe('eslint.config.ts constants ↔ src/ directory parity', () => {
 
   it('REPOSITORY_SIBLINGS matches src/domain/repository/<sibling>/ (excluding underscore-prefixed)', () => {
     expect(constantFromEslintConfig('REPOSITORY_SIBLINGS')).toEqual(directorySiblings('src/domain/repository', ['_']));
+  });
+});
+
+describe('node:child_process spawn/exec fence', () => {
+  const linter = new Linter();
+  const config = eslintConfig as LinterTypes.Config[];
+
+  const isRestrictedImportError = (messages: readonly LinterTypes.LintMessage[]): boolean =>
+    messages.some((m) => m.ruleId === 'no-restricted-imports');
+
+  it('flags a raw spawn import outside the sanctioned wrappers', () => {
+    const messages = linter.verify(
+      "import { spawn } from 'node:child_process';\nexport const x = () => spawn('echo', []);\n",
+      config,
+      'src/integration/io/some-new-adapter.ts'
+    );
+    expect(isRestrictedImportError(messages)).toBe(true);
+  });
+
+  it('flags a raw execFile import outside the sanctioned wrappers', () => {
+    const messages = linter.verify(
+      "import { execFile } from 'node:child_process';\nexport const x = execFile;\n",
+      config,
+      'src/integration/scm/some-new-adapter.ts'
+    );
+    expect(isRestrictedImportError(messages)).toBe(true);
+  });
+
+  it('does not flag shell-script-runner.ts, the documented shell:true exception', () => {
+    const messages = linter.verify(
+      "import { spawn } from 'node:child_process';\nexport const x = () => spawn('sh', ['-c', 'echo hi'], { shell: true });\n",
+      config,
+      'src/integration/io/shell-script-runner.ts'
+    );
+    expect(isRestrictedImportError(messages)).toBe(false);
+  });
+
+  it('does not flag os-notification-dispatcher.ts, the documented promisified-execFile exception', () => {
+    const messages = linter.verify(
+      "import { execFile } from 'node:child_process';\nexport const x = execFile;\n",
+      config,
+      'src/integration/observability/os-notification-dispatcher.ts'
+    );
+    expect(isRestrictedImportError(messages)).toBe(false);
+  });
+
+  it('does not flag type-only ChildProcess imports anywhere under integration/', () => {
+    const messages = linter.verify(
+      "import { type ChildProcess } from 'node:child_process';\nexport type X = ChildProcess;\n",
+      config,
+      'src/integration/ai/providers/claude/some-adapter.ts'
+    );
+    expect(isRestrictedImportError(messages)).toBe(false);
   });
 });

--- a/tests/unit/integration/ai/agents/parse-agent-definition.test.ts
+++ b/tests/unit/integration/ai/agents/parse-agent-definition.test.ts
@@ -1,25 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseAgentDefinition, splitFrontmatter } from '@src/integration/ai/agents/_engine/parse-agent-definition.ts';
+import { parseAgentDefinition } from '@src/integration/ai/agents/_engine/parse-agent-definition.ts';
 
-describe('splitFrontmatter', () => {
-  it('splits frontmatter from a body that follows immediately after the closing fence', () => {
-    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\nbody line\n');
-    expect(frontmatter).toBe('name: x');
-    expect(body).toBe('body line\n');
-  });
-
-  it('strips the blank separator line after the closing fence', () => {
-    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\n\nbody line\n');
-    expect(frontmatter).toBe('name: x');
-    expect(body).toBe('body line\n');
-  });
-
-  it('returns the body verbatim when no frontmatter is present', () => {
-    const { frontmatter, body } = splitFrontmatter('just a body\n');
-    expect(frontmatter).toBe('');
-    expect(body).toBe('just a body\n');
-  });
-});
+// splitFrontmatter / parseSimpleYaml / errorCode moved to the shared
+// tests/unit/integration/ai/skills/frontmatter.test.ts suite — this file now tests
+// parseAgentDefinition's own validation behavior on top of that shared parsing.
 
 describe('parseAgentDefinition', () => {
   it('parses a valid agent definition round-trip', () => {

--- a/tests/unit/integration/ai/contract/_engine/corrective-retry.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/corrective-retry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,7 @@ import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import { MigrationGapError } from '@src/domain/value/error/migration-gap-error.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { changeSignalSchema } from '@src/integration/ai/contract/_engine/signals/change/schema.ts';
@@ -290,5 +291,58 @@ describe('validateSignalsFileWithCorrectiveRetry', () => {
     expect(result.ok).toBe(false);
     expect(calls).toBe(0);
     if (!result.ok) expect(result.error).toBeInstanceOf(MigrationGapError);
+  });
+
+  it('skips the retry entirely on a non-correctable StorageError (harness-side I/O fault) from the FIRST validate', async () => {
+    // A directory at signals.json's path reproduces a real StorageError (EISDIR is neither
+    // ENOENT nor ENOTDIR, so validateSignalsFile falls into its generic read-failure branch)
+    // without relying on a permission trick that behaves differently as root. Re-prompting the
+    // AI to "write signals.json" cannot fix a harness-side path collision it did not cause.
+    mkdirSync(signalsPath);
+    let calls = 0;
+    const result = await validateSignalsFileWithCorrectiveRetry(
+      {
+        outputDir: unwrapPath(tmp),
+        logger: noopLogger,
+        correctiveRetries: 2,
+        selfContainedContext: 'OUTPUT CONTRACT SECTION (self-contained)',
+        reinvoke: async () => {
+          calls += 1;
+          return Result.ok(undefined);
+        },
+      },
+      contract
+    );
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(0);
+    if (!result.ok) expect(result.error).toBeInstanceOf(StorageError);
+  });
+
+  it('self-blocks WITHOUT a further nudge when a later revalidation turns non-correctable (StorageError) mid-loop', async () => {
+    // First validate: correctable schema-mismatch → one nudge fires. The corrective spawn's
+    // rewrite leaves a directory at signals.json's path instead of a file (e.g. a confused
+    // AI turn) → the SECOND validateSignalsFile call hits the same EISDIR StorageError. The
+    // loop must not spend a second nudge re-prompting for something re-emitting content can't
+    // fix — `calls` must stay at 1, not reach `correctiveRetries` (2).
+    writeFileSync(signalsPath, BAD_SHAPE);
+    let calls = 0;
+    const result = await validateSignalsFileWithCorrectiveRetry(
+      {
+        outputDir: unwrapPath(tmp),
+        logger: noopLogger,
+        correctiveRetries: 2,
+        selfContainedContext: 'OUTPUT CONTRACT SECTION (self-contained)',
+        reinvoke: async () => {
+          calls += 1;
+          rmSync(signalsPath, { recursive: true, force: true });
+          mkdirSync(signalsPath);
+          return Result.ok(undefined);
+        },
+      },
+      contract
+    );
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(1);
+    if (!result.ok) expect(result.error).toBeInstanceOf(StorageError);
   });
 });

--- a/tests/unit/integration/ai/providers/_engine/rate-limit-backoff.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/rate-limit-backoff.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_BACKOFF_SCHEDULE,
+  JITTER_RATIO,
+  applyJitter,
   delayForRetry,
   sleepCancellable,
 } from '@src/integration/ai/providers/_engine/rate-limit-backoff.ts';
@@ -34,6 +36,45 @@ describe('delayForRetry', () => {
 
   it('default schedule matches the documented "1m → 5m → 30m → 2h" sequence', () => {
     expect(DEFAULT_BACKOFF_SCHEDULE).toEqual([60_000, 5 * 60_000, 30 * 60_000, 2 * 60 * 60_000]);
+  });
+});
+
+describe('applyJitter', () => {
+  it('passes non-positive delays through unchanged (nothing to disperse)', () => {
+    expect(applyJitter(0)).toBe(0);
+    expect(applyJitter(-5)).toBe(-5);
+  });
+
+  it('is a deterministic function of the injected random source, not live Math.random', () => {
+    // random() = 0 → the minimum of the jitter window (delay - spread).
+    expect(applyJitter(1000, () => 0)).toBe(1000 - 1000 * JITTER_RATIO);
+    // random() = 1 → the maximum of the jitter window (delay + spread). Real Math.random()
+    // never returns exactly 1, but the injected fake can, pinning the exact upper bound.
+    expect(applyJitter(1000, () => 1)).toBe(1000 + 1000 * JITTER_RATIO);
+    // random() = 0.5 → the midpoint, i.e. the unjittered base delay.
+    expect(applyJitter(1000, () => 0.5)).toBe(1000);
+  });
+
+  it('stays within +/- JITTER_RATIO of the base delay for any random() in [0, 1)', () => {
+    const base = 60_000;
+    for (const r of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.999]) {
+      const jittered = applyJitter(base, () => r);
+      expect(jittered).toBeGreaterThanOrEqual(base * (1 - JITTER_RATIO));
+      expect(jittered).toBeLessThanOrEqual(base * (1 + JITTER_RATIO));
+    }
+  });
+
+  it('two callers with the SAME base delay disperse when their random() draws differ (the lockstep fix)', () => {
+    const base = delayForRetry(1);
+    const branchA = applyJitter(base, () => 0.1);
+    const branchB = applyJitter(base, () => 0.9);
+    expect(branchA).not.toBe(branchB);
+  });
+
+  it('defaults to Math.random when no source is injected', () => {
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    expect(applyJitter(1000)).toBe(1000);
+    spy.mockRestore();
   });
 });
 

--- a/tests/unit/integration/ai/providers/_engine/run-with-rate-limit-retry.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/run-with-rate-limit-retry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
+import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
+import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
+import type { ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
+import { runWithRateLimitRetry } from '@src/integration/ai/providers/_engine/run-with-rate-limit-retry.ts';
+import { FULL_AUTO } from '@src/integration/ai/providers/_engine/session-permissions.ts';
+import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import { absolutePath } from '@tests/fixtures/domain.ts';
+
+const session = (): AiSession => ({
+  prompt: 'prompt-body',
+  cwd: absolutePath('/tmp/retry-loop-test-repo'),
+  model: 'test-model',
+  permissions: FULL_AUTO,
+  signalsFile: absolutePath('/tmp/retry-loop-test-repo/signals.json'),
+});
+
+const successOutput = (): ProviderOutput => ({
+  signalsFile: absolutePath('/tmp/retry-loop-test-repo/signals.json'),
+  exitCode: 0,
+});
+
+/** One rate-limited attempt, then success — forces exactly one backoff wait. */
+const attemptOnceThenSucceed = (): ((s: AiSession) => Promise<AttemptOutcome>) => {
+  let calls = 0;
+  return (): Promise<AttemptOutcome> => {
+    calls++;
+    return Promise.resolve(
+      calls === 1
+        ? { kind: 'rate-limit', error: new RateLimitError({ subCode: 'spawn-stderr', message: 'rate limit' }) }
+        : { kind: 'success', output: successOutput() }
+    );
+  };
+};
+
+describe('runWithRateLimitRetry backoff jitter', () => {
+  it('spreads the backoff wait by +20% when the injected random source returns 1', async () => {
+    const cap = createCapturingBus();
+    const out = await runWithRateLimitRetry({
+      session: session(),
+      rateLimitRetries: 1,
+      backoffSchedule: [10],
+      eventBus: cap.bus,
+      providerSlug: 'claude',
+      providerName: 'claude-test',
+      random: () => 1,
+      attempt: attemptOnceThenSucceed(),
+    });
+    expect(out.ok).toBe(true);
+    // applyJitter(10, () => 1) = round(10 - 2 + 1 * 4) = 12 — an un-jittered loop logs 10.
+    const wait = cap.logs.find((l) => /waiting \d+ms before retry/.test(l.message));
+    expect(wait?.message).toContain('waiting 12ms');
+  });
+
+  it('spreads the backoff wait by -20% when the injected random source returns 0', async () => {
+    const cap = createCapturingBus();
+    const out = await runWithRateLimitRetry({
+      session: session(),
+      rateLimitRetries: 1,
+      backoffSchedule: [10],
+      eventBus: cap.bus,
+      providerSlug: 'claude',
+      providerName: 'claude-test',
+      random: () => 0,
+      attempt: attemptOnceThenSucceed(),
+    });
+    expect(out.ok).toBe(true);
+    expect(cap.logs.find((l) => /waiting \d+ms before retry/.test(l.message))?.message).toContain('waiting 8ms');
+  });
+
+  it('keeps the zero-delay fast path un-jittered so test schedules of [0] never sleep', async () => {
+    const cap = createCapturingBus();
+    const out = await runWithRateLimitRetry({
+      session: session(),
+      rateLimitRetries: 1,
+      backoffSchedule: [0],
+      eventBus: cap.bus,
+      providerSlug: 'claude',
+      providerName: 'claude-test',
+      random: () => 1,
+      attempt: attemptOnceThenSucceed(),
+    });
+    expect(out.ok).toBe(true);
+    expect(cap.logs.some((l) => /waiting \d+ms before retry/.test(l.message))).toBe(false);
+  });
+});

--- a/tests/unit/integration/ai/providers/_engine/truncate-debug-field.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/truncate-debug-field.test.ts
@@ -32,4 +32,13 @@ describe('truncateField', () => {
   it('returns undefined for empty string input', () => {
     expect(truncateField('')).toBeUndefined();
   });
+
+  it('returns undefined for whitespace-only input, matching the documented contract', () => {
+    expect(truncateField('   ')).toBeUndefined();
+    expect(truncateField('\n\t ')).toBeUndefined();
+  });
+
+  it('does NOT trim a string that has non-whitespace content — only the whitespace-only case is special-cased', () => {
+    expect(truncateField('  hello  ')).toBe('  hello  ');
+  });
 });

--- a/tests/unit/integration/ai/providers/_engine/validate-model.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/validate-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `SUSPENDED_MODELS` is empty in the shipped catalog (see suspended-models.ts) — the mechanism
+// is deliberately kept wired for the next incident, so the only way to exercise the suspended
+// branch is to mock the module. `isKnownModel` stays real per-call; only suspension is faked.
+vi.mock('@src/domain/value/settings-models/suspended-models.ts', () => ({
+  isSuspendedModel: (s: string) => s === 'suspended-model',
+  suspendedModelMessage: (m: string) =>
+    `'${m}' is temporarily suspended by its provider — pick another model until access is restored`,
+}));
+
+const { validateModel } = await import('@src/integration/ai/providers/_engine/validate-model.ts');
+
+describe('validateModel', () => {
+  const isKnown = (s: string): boolean => s === 'known-model' || s === 'suspended-model';
+
+  it('returns ok for a catalog-known, non-suspended model', () => {
+    const result = validateModel('known-model', isKnown, {
+      entity: 'test-provider',
+      attemptedAction: 'build argv',
+      notKnownMessage: 'not known',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns InvalidStateError (currentState model-validation) for an unknown model, using the caller-supplied message', () => {
+    const result = validateModel('typo-model', isKnown, {
+      entity: 'test-provider',
+      attemptedAction: 'build argv',
+      notKnownMessage: "test-provider: 'typo-model' is not a known model",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-state');
+    expect(result.error.currentState).toBe('model-validation');
+    expect(result.error.entity).toBe('test-provider');
+    expect(result.error.message).toBe("test-provider: 'typo-model' is not a known model");
+  });
+
+  it('returns InvalidStateError (currentState model-suspended) for a catalog-known but suspended model', () => {
+    const result = validateModel('suspended-model', isKnown, {
+      entity: 'test-provider',
+      attemptedAction: 'run',
+      notKnownMessage: 'not known',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-state');
+    expect(result.error.currentState).toBe('model-suspended');
+    expect(result.error.message).toContain('temporarily suspended');
+  });
+
+  it('checks catalog membership BEFORE suspension — an unknown model never reaches the suspension check', () => {
+    // 'unknown-and-not-in-catalog' is neither known nor in the mocked suspended set, so this
+    // only proves ordering when combined with the next assertion's shared predicate; the real
+    // guard here is that a model failing isKnownModel always surfaces model-validation, never
+    // model-suspended, even if it happened to also be suspended.
+    const result = validateModel('suspended-model', () => false, {
+      entity: 'test-provider',
+      attemptedAction: 'run',
+      notKnownMessage: 'not known',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.currentState).toBe('model-validation');
+  });
+});

--- a/tests/unit/integration/ai/skills/frontmatter.test.ts
+++ b/tests/unit/integration/ai/skills/frontmatter.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { errorCode, parseSimpleYaml, splitFrontmatter } from '@src/integration/ai/skills/_engine/frontmatter.ts';
+
+// Canonical frontmatter-parsing suite — the single implementation both SKILL.md sources
+// (skills/_engine/parse-skill.ts) and agent-definition sources (agents/_engine/parse-agent-
+// definition.ts) build on. Consolidates what used to be two byte-identical, independently
+// maintained partial suites (one per concept) so a regression in either concept's behaviour is
+// caught here once instead of drifting silently.
+
+describe('splitFrontmatter', () => {
+  it('splits frontmatter from a body that follows immediately after the closing fence', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\nbody line\n');
+    expect(frontmatter).toBe('name: x');
+    expect(body).toBe('body line\n');
+  });
+
+  it('strips the blank separator line after the closing fence (standard SKILL.md shape)', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\n\nbody line\n');
+    expect(frontmatter).toBe('name: x');
+    expect(body).toBe('body line\n');
+  });
+
+  it('strips CRLF blank lines after the closing fence', () => {
+    const { body } = splitFrontmatter('---\r\nname: x\r\n---\r\n\r\nbody line\r\n');
+    expect(body).toBe('body line\r\n');
+  });
+
+  it('strips a leading UTF-8 BOM before detecting the opening fence', () => {
+    const { frontmatter, body } = splitFrontmatter('﻿---\nname: x\n---\nbody line\n');
+    expect(frontmatter).toBe('name: x');
+    expect(body).toBe('body line\n');
+  });
+
+  it('does not accumulate blank lines across parse → render round-trips', () => {
+    // Mirror the render shape from filesystem-skills-adapter: fence + ONE blank separator + body.
+    const render = (frontmatter: string, content: string): string =>
+      `---\n${frontmatter}\n---\n\n${content.replace(/\s+$/u, '')}\n`;
+
+    const once = splitFrontmatter(render('name: x', 'body line'));
+    const twice = splitFrontmatter(render(once.frontmatter, once.body));
+    expect(twice.body).toBe(once.body);
+    expect(twice.body.startsWith('\n')).toBe(false);
+  });
+
+  it('returns the body verbatim when no frontmatter is present', () => {
+    const { frontmatter, body } = splitFrontmatter('just a body\n');
+    expect(frontmatter).toBe('');
+    expect(body).toBe('just a body\n');
+  });
+
+  it('returns the body verbatim when the opening fence has no closing fence', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\nno closing fence\n');
+    expect(frontmatter).toBe('');
+    expect(body).toBe('---\nname: x\nno closing fence\n');
+  });
+});
+
+describe('parseSimpleYaml', () => {
+  it('parses flat key: value lines', () => {
+    expect(parseSimpleYaml('name: x\ndescription: does a thing')).toEqual({
+      name: 'x',
+      description: 'does a thing',
+    });
+  });
+
+  it('strips matching double or single quotes around a value', () => {
+    expect(parseSimpleYaml('a: "quoted"\nb: \'single\'')).toEqual({ a: 'quoted', b: 'single' });
+  });
+
+  it('skips blank lines and comment lines', () => {
+    expect(parseSimpleYaml('a: 1\n\n# a comment\nb: 2')).toEqual({ a: '1', b: '2' });
+  });
+
+  it('skips lines with no colon', () => {
+    expect(parseSimpleYaml('not a kv line\na: 1')).toEqual({ a: '1' });
+  });
+});
+
+describe('errorCode', () => {
+  it('reads the code off a Node-style fs error', () => {
+    expect(errorCode({ code: 'ENOENT' })).toBe('ENOENT');
+  });
+
+  it('returns undefined for a value with no string code property', () => {
+    expect(errorCode(new Error('boom'))).toBeUndefined();
+    expect(errorCode('not an object')).toBeUndefined();
+    expect(errorCode(null)).toBeUndefined();
+    expect(errorCode({ code: 42 })).toBeUndefined();
+  });
+});

--- a/tests/unit/integration/ai/skills/parse-skill.test.ts
+++ b/tests/unit/integration/ai/skills/parse-skill.test.ts
@@ -1,38 +1,39 @@
 import { describe, expect, it } from 'vitest';
-import { splitFrontmatter } from '@src/integration/ai/skills/_engine/parse-skill.ts';
+import { parseSkill } from '@src/integration/ai/skills/_engine/parse-skill.ts';
 
-describe('splitFrontmatter', () => {
-  it('splits frontmatter from a body that follows immediately after the closing fence', () => {
-    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\nbody line\n');
-    expect(frontmatter).toBe('name: x');
-    expect(body).toBe('body line\n');
+// splitFrontmatter / parseSimpleYaml / errorCode moved to the shared
+// tests/unit/integration/ai/skills/frontmatter.test.ts suite — this file now tests parseSkill's
+// own validation behavior on top of that shared parsing.
+
+describe('parseSkill', () => {
+  it('parses a valid skill round-trip', () => {
+    const raw = '---\nname: alignment\ndescription: Confirm scope before diving into work.\n---\nBody text.\n';
+    const result = parseSkill('bundled skill', '/path/alignment/SKILL.md', 'alignment', raw);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        name: 'alignment',
+        description: 'Confirm scope before diving into work.',
+        content: 'Body text.\n',
+      });
+    }
   });
 
-  it('strips the blank separator line after the closing fence (standard SKILL.md shape)', () => {
-    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\n\nbody line\n');
-    expect(frontmatter).toBe('name: x');
-    expect(body).toBe('body line\n');
+  it('returns a parse StorageError when the description is missing', () => {
+    const raw = '---\nname: alignment\n---\nBody text.\n';
+    const result = parseSkill('bundled skill', '/path/alignment/SKILL.md', 'alignment', raw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.subCode).toBe('parse');
+    }
   });
 
-  it('strips CRLF blank lines after the closing fence', () => {
-    const { body } = splitFrontmatter('---\r\nname: x\r\n---\r\n\r\nbody line\r\n');
-    expect(body).toBe('body line\r\n');
-  });
-
-  it('does not accumulate blank lines across parse → render round-trips', () => {
-    // Mirror the render shape from filesystem-skills-adapter: fence + ONE blank separator + body.
-    const render = (frontmatter: string, content: string): string =>
-      `---\n${frontmatter}\n---\n\n${content.replace(/\s+$/u, '')}\n`;
-
-    const once = splitFrontmatter(render('name: x', 'body line'));
-    const twice = splitFrontmatter(render(once.frontmatter, once.body));
-    expect(twice.body).toBe(once.body);
-    expect(twice.body.startsWith('\n')).toBe(false);
-  });
-
-  it('returns the body verbatim when no frontmatter is present', () => {
-    const { frontmatter, body } = splitFrontmatter('just a body\n');
-    expect(frontmatter).toBe('');
-    expect(body).toBe('just a body\n');
+  it('returns a parse StorageError when the frontmatter name does not match the folder name', () => {
+    const raw = '---\nname: other\ndescription: Some description.\n---\nBody text.\n';
+    const result = parseSkill('bundled skill', '/path/alignment/SKILL.md', 'alignment', raw);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.subCode).toBe('parse');
+    }
   });
 });


### PR DESCRIPTION
Multi-agent audit + fix campaign over the whole repo (10 finder dimensions → adversarial verification → 8 review-gated fix packages).

## Fixes
- **corrective-retry**: correctable contract errors are now an explicit allow-list — a harness-side `StorageError` self-blocks immediately instead of burning up to 5 resumed spawns on a misleading nudge
- **validate-model**: one shared catalog+suspension guard across all six provider entrypoints (interactive adapters were skipping the suspended-model check)
- **rate-limit backoff**: ±20% jitter so parallel branches don't retry in lockstep (injectable random, test-pinned)
- **TUI**: pick-sprint cursor no longer teleports when the done-filter reshapes rows (migrated to the shared id-based `useListWindow`); ActionMenu hotkeys can't shadow j/k nav aliases; spacing literals → tokens
- **ESLint fences**: flat-config same-key replacement had silently killed 9 fence families (ai sibling isolation, business I/O bans, chains adapter ban, …) — now composed via `mergeRestrictedImports` and pinned by a 37-probe liveness suite; per-leaf `*.contract.ts` named as the sanctioned per-signal schema import point
- **security/hygiene**: `node:child_process` lint fence with two named exceptions, single lock-staleness constant, atomic workspace writes, exception-free secrets rule in the implement prompt

## Improvements
- Deduped frontmatter parsing (skills/agents) and duration formatting; type-forced sprint-scoped ctx projection; parallelized repository `list()` reads
- Test backfill: with-repo-lock behavior, migration fault paths, AsyncLocalStorage concurrency, review flow fence
- Docs sync: 4 confirmed drift findings fixed, changelog updated

## Verification
- typecheck / lint (0 errors, 114 warnings — one under the 115 ratchet) / 4,890 tests in 535 files / knip / prettier all green
- every fix package passed an independent review gate; each fix is pinned by a test that fails without it
- ⏳ manual TUI smoke test pending before merge

https://claude.ai/code/session_01CsnTu4KZxcX3vH6MtEyME8