### PR TITLE
Add phase-aware effort defaults and evaluator escalation lockstep

### DIFF
--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -17,7 +17,10 @@ provider's native vocabulary.
 
 **Effort resolution** at every AI-spawning leaf (`src/business/settings/resolve-effort.ts`): per-flow
 `ai.<flow>.effort` wins; otherwise the global `ai.effort` floored to the row's provider ceiling;
-otherwise the provider CLI's default. Codex accepts `low..ultra` — from the **global** value, `max` floors
+otherwise, for `plan` and `ideate` only, a shipped default of `high` (floored to the row's provider
+ceiling) — deliberately the lowest-precedence layer, below the global default, so an operator who has
+set `ai.effort` keeps that deliberate choice untouched; otherwise the provider CLI's default. Codex
+accepts `low..ultra` — from the **global** value, `max` floors
 to `xhigh` (only the GPT-5.6 family accepts `max`); `ultra` (sol/terra-only, plan-gated) is reachable only
 via an explicit per-flow effort; `minimal` no longer exists — persisted rows migrate to `low` at parse
 time. The implement generator's resolved effort also feeds the escalation policy's same-model effort rung,

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -147,7 +147,14 @@ spawn, and the next plateau sees the raised effort. Fires once for the shipped d
 single step) and is strictly bounded generally — the stamped effort climbs monotonically to the terminal
 `max`, from which the rung is spent and falls through to the nudge. Skipped gracefully — straight to the
 nudge — when the provider/model has no effort knob (e.g. Claude Haiku) or the generator is already at its
-ceiling.
+ceiling. The EVALUATOR gets the same effort rung in lockstep, computed independently: whenever the
+generator's `escalate-effort` fires, `decideEscalation` also calls `nextEffortRung` against the
+evaluator's OWN provider/model/effort triple (never copied from the generator's target) and, when it
+returns a target, stamps `Task.escalatedToEvaluatorEffort` alongside `escalatedToEffort` in the same
+persist. The evaluator's MODEL never changes — only its reasoning effort advances, at the same attempt
+boundary as the generator's rung. Absent when the caller supplies no evaluator context, the evaluator
+provider/model has no effort dimension, or the evaluator is already at its own ceiling; it never fires
+independently of the generator's own `escalate-effort` event.
 (3) **change-of-approach nudge** — a single same-model **"change your approach" directive**
 (`{{PLATEAU_DIRECTIVE_SECTION}}` in the implement prompt) stamped `escalatedFromModel === escalatedToModel`.
 The directive is gated on that same-model marker, NOT on a model bump: a bump hands the stronger model the
@@ -174,12 +181,13 @@ of that implicit `xhigh`. A further plateau (opus already at `max`, rung spent) 
 then settles done-with-warning. See `AI-SETTINGS.md § Default escalation posture` for how to also activate a
 live MODEL ladder (economic presets or a custom escalationMap rung).
 
-Escalation is generator-only by design — the evaluator's model is held constant across the task so the
-scoring rubric does not shift mid-task, which would make plateau detection meaningless. `Task`'s
-`escalatedFromModel` / `escalatedToModel` (model bump / nudge marker) and `escalatedToEffort` (effort rung)
-fields are re-stampable and hold the MOST-RECENT transition; the cost ceiling is enforced by the ladder top
-plus `maxAttempts` (each escalate / effort-bump / nudge fails the running attempt, consuming budget), not by
-a once-per-task cap. A non-passing exit with no attempt budget left, or after the top-of-ladder nudge,
+The evaluator's MODEL stays frozen for the whole task — the scoring rubric must not shift mid-task, which
+would make plateau detection meaningless — but its EFFORT now advances in lockstep with the generator's
+effort rung (see bullet (2) above). `Task`'s `escalatedFromModel` / `escalatedToModel` (model bump / nudge
+marker), `escalatedToEffort` (generator effort rung), and `escalatedToEvaluatorEffort` (evaluator effort
+rung) fields are re-stampable and hold the MOST-RECENT transition; the cost ceiling is enforced by the
+ladder top plus `maxAttempts` (each escalate / effort-bump / nudge fails the running attempt, consuming
+budget), not by a once-per-task cap. A non-passing exit with no attempt budget left, or after the top-of-ladder nudge,
 preserves the work (done-with-warning) — never blocks.
 Cross-provider escalation (e.g. `claude-opus-5` → `gpt-5.6-sol`) is intentionally deferred — switching
 providers mid-task carries auth / context / tool-availability hazards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`plan` and `ideate` now default to `high` reasoning effort.** Both flows shape everything downstream of
+  them, so they get the deeper default out of the box. It ranks below `settings.ai.effort` and below a
+  per-flow effort — an operator who has set either keeps exactly what they chose — and clamps to the
+  provider's ceiling where `high` isn't available. Every other flow resolves as before.
+- **A plateau now raises the evaluator's reasoning effort in lockstep with the generator's.** When the
+  same-model effort rung fires, the evaluator's own ladder is consulted independently — against its own
+  provider, model, and current effort, never copied from the generator's target — and bumped if it has
+  headroom, so grading rigor keeps pace with a strengthening generator instead of falling behind it. The
+  evaluator's model is never escalated, only its effort, and the plateau banner names both bumps.
 - **Sprint and project listing reads every entity file concurrently** instead of one at a time, speeding up
   TUI and CLI startup for installations with many historical sprints or projects.
 - **Tightened the implement prompt's project-context-file rule** — secrets and credentials are now an

--- a/src/application/flows/implement/leaves/evaluator.ts
+++ b/src/application/flows/implement/leaves/evaluator.ts
@@ -325,11 +325,13 @@ const buildEvaluatorPrompt = async (
  */
 const makeEvaluatorReinvoke =
   (
-    deps: Pick<EvaluatorLeafDeps, 'provider' | 'cwd' | 'sprintDir' | 'model' | 'effort'>,
+    deps: Pick<EvaluatorLeafDeps, 'provider' | 'cwd' | 'sprintDir' | 'model'>,
     args: {
       readonly workspaceRoot: AbsolutePath;
       readonly roundNum: number;
       readonly signalsFile: AbsolutePath;
+      /** Effort the initial spawn ran at (`task.escalatedToEvaluatorEffort ?? deps.effort`) — the corrective respawn matches it. */
+      readonly effectiveEffort: string | undefined;
       readonly priorEvaluatorSessionId: SessionId | undefined;
       readonly signal: AbortSignal | undefined;
     }
@@ -355,7 +357,7 @@ const makeEvaluatorReinvoke =
         args.signalsFile,
         'evaluator',
         resume,
-        deps.effort,
+        args.effectiveEffort,
         args.signal,
         bodyFile.ok ? bodyFile.value : undefined
       )
@@ -407,6 +409,12 @@ const makeEvaluatorCallEvaluate =
     const initialBodyFile = AbsolutePath.parse(
       roundBodyPath(args.input.workspaceRoot, args.input.roundNum, 'evaluator')
     );
+    // Per-task evaluator-EFFORT escalation: the escalation policy's lockstep bump stamps
+    // `escalatedToEvaluatorEffort` (computed against the evaluator's own ladder, never copied from
+    // the generator's target) when it fires alongside the generator's same-model effort rung.
+    // Prefer it over the configured `deps.effort` at spawn — the MODEL always stays `deps.model`,
+    // unconditionally, on both this spawn and the corrective respawn below.
+    const effectiveEffort = task.escalatedToEvaluatorEffort ?? deps.effort;
     const spawn = await deps.provider.generate(
       implementSession(
         args.input.workspaceRoot,
@@ -417,7 +425,7 @@ const makeEvaluatorCallEvaluate =
         args.signalsFile,
         'evaluator',
         args.input.priorEvaluatorSessionId,
-        deps.effort,
+        effectiveEffort,
         args.signal,
         initialBodyFile.ok ? initialBodyFile.value : undefined
       )
@@ -452,6 +460,7 @@ const makeEvaluatorCallEvaluate =
           workspaceRoot: args.input.workspaceRoot,
           roundNum: args.input.roundNum,
           signalsFile: args.signalsFile,
+          effectiveEffort,
           priorEvaluatorSessionId: args.input.priorEvaluatorSessionId,
           signal: args.signal,
         }),

--- a/src/application/flows/implement/leaves/finalize-gen-eval.ts
+++ b/src/application/flows/implement/leaves/finalize-gen-eval.ts
@@ -29,6 +29,13 @@ import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
  * policy's same-model effort rung: the leaf forwards the provider plus `task.escalatedToEffort ??
  * configured` so a top-of-ladder plateau raises reasoning effort before spending the nudge. Absent
  * (a provider with no effort dimension, or a caller that never wired them) → the rung is skipped.
+ *
+ * `configuredEvaluatorProvider` / `configuredEvaluatorModel` / `configuredEvaluatorEffort` are the
+ * same triple for the EVALUATOR role, mirroring the generator resolution order
+ * (`task.escalatedToEvaluatorEffort ?? configured`) so the policy's lockstep evaluator bump is
+ * computed against the evaluator's own, already-raised effort rather than re-firing on a stale
+ * baseline. The evaluator MODEL is never escalated, so `configuredEvaluatorModel` rides straight
+ * through with no task-field override.
  */
 export interface FinalizeGenEvalLeafDeps {
   readonly taskRepo: UpdateTask;
@@ -44,6 +51,9 @@ export interface FinalizeGenEvalLeafDeps {
   readonly configuredGeneratorModel: string;
   readonly configuredGeneratorProvider?: AiProvider;
   readonly configuredGeneratorEffort?: string;
+  readonly configuredEvaluatorProvider?: AiProvider;
+  readonly configuredEvaluatorModel?: string;
+  readonly configuredEvaluatorEffort?: string;
 }
 
 interface FinalizeInput {
@@ -54,6 +64,9 @@ interface FinalizeInput {
   readonly generatorModel: string;
   readonly generatorProvider?: AiProvider;
   readonly generatorEffort?: string;
+  readonly evaluatorProvider?: AiProvider;
+  readonly evaluatorModel?: string;
+  readonly evaluatorEffort?: string;
 }
 
 export const finalizeGenEvalLeaf = (deps: FinalizeGenEvalLeafDeps, taskId: TaskId): Element<ImplementCtx> =>
@@ -73,6 +86,9 @@ export const finalizeGenEvalLeaf = (deps: FinalizeGenEvalLeafDeps, taskId: TaskI
           generatorModel: input.generatorModel,
           ...(input.generatorProvider !== undefined ? { generatorProvider: input.generatorProvider } : {}),
           ...(input.generatorEffort !== undefined ? { generatorEffort: input.generatorEffort } : {}),
+          ...(input.evaluatorProvider !== undefined ? { evaluatorProvider: input.evaluatorProvider } : {}),
+          ...(input.evaluatorModel !== undefined ? { evaluatorModel: input.evaluatorModel } : {}),
+          ...(input.evaluatorEffort !== undefined ? { evaluatorEffort: input.evaluatorEffort } : {}),
         }),
     },
     input: (ctx) => {
@@ -100,6 +116,10 @@ export const finalizeGenEvalLeaf = (deps: FinalizeGenEvalLeafDeps, taskId: TaskI
       // configured`) so the policy sees the effort the just-finished attempt actually ran at — a
       // prior effort bump reads back as the raised level, stopping the effort rung from re-firing.
       const generatorEffort = ctx.currentTask.escalatedToEffort ?? deps.configuredGeneratorEffort;
+      // Evaluator effort mirrors the same resolution order — a prior lockstep bump reads back as
+      // the raised level, so the ladder advances one step per event instead of re-firing. The
+      // evaluator MODEL is never escalated, so `configuredEvaluatorModel` rides through unchanged.
+      const evaluatorEffort = ctx.currentTask.escalatedToEvaluatorEffort ?? deps.configuredEvaluatorEffort;
       return {
         task: ctx.currentTask,
         sprintId: ctx.sprintId,
@@ -110,6 +130,11 @@ export const finalizeGenEvalLeaf = (deps: FinalizeGenEvalLeafDeps, taskId: TaskI
           ? { generatorProvider: deps.configuredGeneratorProvider }
           : {}),
         ...(generatorEffort !== undefined ? { generatorEffort } : {}),
+        ...(deps.configuredEvaluatorProvider !== undefined
+          ? { evaluatorProvider: deps.configuredEvaluatorProvider }
+          : {}),
+        ...(deps.configuredEvaluatorModel !== undefined ? { evaluatorModel: deps.configuredEvaluatorModel } : {}),
+        ...(evaluatorEffort !== undefined ? { evaluatorEffort } : {}),
       };
     },
     output: (ctx, out) => {

--- a/src/application/flows/implement/leaves/per-task-subchain.ts
+++ b/src/application/flows/implement/leaves/per-task-subchain.ts
@@ -412,6 +412,13 @@ export const createPerTaskSubchain = (
                 // `nextEffortRung` skips gracefully for any non-effort provider or model.
                 configuredGeneratorProvider: opts.generator.providerId as AiProvider,
                 ...(opts.generator.effort !== undefined ? { configuredGeneratorEffort: opts.generator.effort } : {}),
+                // Same lockstep wiring for the EVALUATOR role: the policy computes its bump
+                // independently against this triple, never copying the generator's target. The
+                // evaluator MODEL is never escalated, but it still rides through so `nextEffortRung`
+                // can classify the evaluator's own effort ladder.
+                configuredEvaluatorProvider: opts.evaluator.providerId as AiProvider,
+                configuredEvaluatorModel: opts.evaluator.model,
+                ...(opts.evaluator.effort !== undefined ? { configuredEvaluatorEffort: opts.evaluator.effort } : {}),
               },
               taskId
             ),

--- a/src/application/ui/tui/views/flows-customize-picker.ts
+++ b/src/application/ui/tui/views/flows-customize-picker.ts
@@ -158,8 +158,8 @@ const defaultRowFor = (flowId: string, settings: Settings): AiFlowSettings | und
 
 const labelKeepDefault = (value: string | undefined): string => `Keep default (${value ?? 'unset'})`;
 
-const formatRow = (row: AiFlowSettings, globalEffort: Settings['ai']['effort']): string => {
-  const resolved = resolveEffortForRow(row, globalEffort);
+const formatRow = (row: AiFlowSettings, globalEffort: Settings['ai']['effort'], flow: FlowId): string => {
+  const resolved = resolveEffortForRow(row, globalEffort, flow);
   return `${row.provider} / ${row.model} / ${resolved ?? 'auto'}`;
 };
 
@@ -263,10 +263,11 @@ const pickEffortStep = async (
   globalEffort: Settings['ai']['effort'],
   effectiveProvider: AiProvider,
   providerChanged: boolean,
-  modelChanged: boolean
+  modelChanged: boolean,
+  flow: FlowId
 ): Promise<string | undefined> => {
   const effortCatalog = PROVIDER_EFFORT_LEVELS[effectiveProvider];
-  const resolvedRowEffort = resolveEffortForRow(defaultRow, globalEffort);
+  const resolvedRowEffort = resolveEffortForRow(defaultRow, globalEffort, flow);
   const effortDefaultLabel = computeEffortDefaultLabel(
     defaultRow,
     globalEffort,
@@ -314,7 +315,8 @@ const customizeRow = async (
   header: string,
   defaultRow: AiFlowSettings,
   globalEffort: Settings['ai']['effort'],
-  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined
+  availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
+  flow: FlowId
 ): Promise<NonNullable<LaunchExtras['override']> | undefined> => {
   const providerStep = await pickProviderStep(interactive, header, defaultRow);
   if (providerStep === undefined) return undefined;
@@ -338,7 +340,8 @@ const customizeRow = async (
     globalEffort,
     effectiveProvider,
     providerChanged,
-    modelChanged
+    modelChanged,
+    flow
   );
   if (effortValue === undefined) return undefined;
 
@@ -377,10 +380,10 @@ export interface RunCustomizePickerArgs {
  * current defaults are. For implement we render both gen and eval; for everything else we
  * render the single resolved row.
  */
-const buildPickerHeader = (flowId: string, flowTitle: string, settings: Settings): string =>
+const buildPickerHeader = (flowId: string, flowTitle: string, settings: Settings, aiFlow: FlowId): string =>
   flowId === 'implement'
-    ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort)}`
-    : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort)}`;
+    ? `${flowTitle} — current defaults:\n  generator: ${formatRow(settings.ai.implement.generator, settings.ai.effort, aiFlow)}\n  evaluator: ${formatRow(settings.ai.implement.evaluator, settings.ai.effort, aiFlow)}`
+    : `${flowTitle} — current default: ${formatRow(defaultRowFor(flowId, settings)!, settings.ai.effort, aiFlow)}`;
 
 /** Human label for a skill candidate's origin, shown next to its name in the skills checklist. */
 const originLabel = (origin: SkillCandidate['origin']): string => {
@@ -501,7 +504,8 @@ const runImplementCustomize = async (
   flowTitle: string,
   settings: Settings,
   availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
-  skillsStepInput: SkillsStepInput
+  skillsStepInput: SkillsStepInput,
+  aiFlow: FlowId
 ): Promise<CustomizePickerResult> => {
   const roles: readonly AiImplementRole[] = ['generator', 'evaluator'];
   const collected: {
@@ -511,7 +515,7 @@ const runImplementCustomize = async (
   for (const role of roles) {
     const row = role === 'generator' ? settings.ai.implement.generator : settings.ai.implement.evaluator;
     const roleHeader = `${header}\n\nRole: ${role}`;
-    const result = await customizeRow(interactive, roleHeader, row, settings.ai.effort, availableModelsFor);
+    const result = await customizeRow(interactive, roleHeader, row, settings.ai.effort, availableModelsFor, aiFlow);
     if (result === undefined) return { kind: 'cancel' };
     if (Object.keys(result).length > 0) collected[role] = result;
   }
@@ -552,11 +556,12 @@ const runSingleRowCustomize = async (
   flowTitle: string,
   settings: Settings,
   availableModelsFor: ((provider: AiProvider) => Promise<readonly string[]>) | undefined,
-  skillsStepInput: SkillsStepInput
+  skillsStepInput: SkillsStepInput,
+  aiFlow: FlowId
 ): Promise<CustomizePickerResult> => {
   const defaultRow = defaultRowFor(flowId, settings);
   if (defaultRow === undefined) return { kind: 'defaults' };
-  const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor);
+  const override = await customizeRow(interactive, header, defaultRow, settings.ai.effort, availableModelsFor, aiFlow);
   if (override === undefined) return { kind: 'cancel' };
 
   const candidates = await effectiveSkillCandidates(
@@ -595,7 +600,7 @@ export const runCustomizePicker = async ({
   const aiFlow = aiFlowIdForPicker(flowId);
   if (aiFlow === undefined) return { kind: 'defaults' };
 
-  const header = buildPickerHeader(flowId, flowTitle, settings);
+  const header = buildPickerHeader(flowId, flowTitle, settings, aiFlow);
 
   const action = await interactive.askChoice<'start' | 'customize' | 'cancel'>(
     `${header}\n\nWhat would you like to do?`,
@@ -613,8 +618,17 @@ export const runCustomizePicker = async ({
     ...(rebuildSkillCandidates !== undefined ? { rebuild: rebuildSkillCandidates } : {}),
   };
   if (flowId === 'implement') {
-    return runImplementCustomize(interactive, header, flowTitle, settings, availableModelsFor, skillsStepInput);
+    return runImplementCustomize(interactive, header, flowTitle, settings, availableModelsFor, skillsStepInput, aiFlow);
   }
 
-  return runSingleRowCustomize(interactive, header, flowId, flowTitle, settings, availableModelsFor, skillsStepInput);
+  return runSingleRowCustomize(
+    interactive,
+    header,
+    flowId,
+    flowTitle,
+    settings,
+    availableModelsFor,
+    skillsStepInput,
+    aiFlow
+  );
 };

--- a/src/business/settings/resolve-effort.ts
+++ b/src/business/settings/resolve-effort.ts
@@ -2,12 +2,27 @@ import { type AiFlowSettings, type AiProvider, primaryFlowRow, type Settings } f
 import type { FlowId } from '@src/domain/value/flow-id.ts';
 
 /**
+ * Shipped per-flow effort default, consulted only when neither the row nor the global effort
+ * is set. Deliberately narrow — `plan` and `ideate` only — since every other flow must keep
+ * resolving to `undefined` (CLI default) exactly as it does today. Passed through
+ * {@link clampEffortToProvider} at the call site so a provider that caps below `high` still
+ * resolves to its highest supported level instead of an invalid value.
+ */
+const FLOW_DEFAULT_EFFORT: Partial<Record<FlowId, 'high'>> = {
+  plan: 'high',
+  ideate: 'high',
+};
+
+/**
  * Resolve the effort level the AI provider adapter should request for one flow.
  *
  * Resolution order:
  *   1. Per-flow `settings.ai[flow].effort` if explicitly set.
  *   2. Global `settings.ai.effort`, floored to the flow's provider ceiling.
- *   3. `undefined` — the adapter falls back to the CLI's built-in default.
+ *   3. The flow's shipped default effort (see {@link FLOW_DEFAULT_EFFORT}), floored to the
+ *      flow's provider ceiling — deliberately BELOW the global default: an operator who set
+ *      `ai.effort` has made a deliberate choice, and the shipped default must not override it.
+ *   4. `undefined` — the adapter falls back to the CLI's built-in default.
  *
  * Floor table (per provider): the global effort vocabulary is the Claude superset
  * (`low | medium | high | xhigh | max`). Each provider may not expose every level, so a
@@ -19,7 +34,7 @@ import type { FlowId } from '@src/domain/value/flow-id.ts';
  */
 export const resolveEffort = (flow: FlowId, settings: Settings): string | undefined => {
   const row = primaryFlowRow(settings.ai, flow);
-  return resolveEffortForRow(row, settings.ai.effort);
+  return resolveEffortForRow(row, settings.ai.effort, flow);
 };
 
 /**
@@ -27,14 +42,22 @@ export const resolveEffort = (flow: FlowId, settings: Settings): string | undefi
  * value rather than looking the row up through {@link primaryFlowRow}. Used by the implement
  * launcher to resolve effort per role (generator / evaluator) when the two roles may carry
  * different providers and effort floors.
+ *
+ * `flow` is optional and consulted only for the third resolution layer (the shipped per-flow
+ * default) — existing two-argument call sites (`resolveAgentOverride`, and through it the
+ * implement launcher) are unaffected, since `implement` carries no entry in
+ * {@link FLOW_DEFAULT_EFFORT} regardless.
  */
 export const resolveEffortForRow = (
   row: AiFlowSettings,
-  globalEffort: Settings['ai']['effort']
+  globalEffort: Settings['ai']['effort'],
+  flow?: FlowId
 ): string | undefined => {
   if (row.effort !== undefined) return row.effort;
-  if (globalEffort === undefined) return undefined;
-  return _floorForProvider(globalEffort, row.provider);
+  if (globalEffort !== undefined) return _floorForProvider(globalEffort, row.provider);
+  const flowDefault = flow !== undefined ? FLOW_DEFAULT_EFFORT[flow] : undefined;
+  if (flowDefault !== undefined) return clampEffortToProvider(flowDefault, row.provider);
+  return undefined;
 };
 
 /**

--- a/src/business/task/escalation-policy.ts
+++ b/src/business/task/escalation-policy.ts
@@ -90,7 +90,21 @@ const triggerLabel = (trigger: EscalationTrigger): string =>
  */
 export type EscalationDecision =
   | { readonly kind: 'escalate'; readonly from: string; readonly to: string }
-  | { readonly kind: 'escalate-effort'; readonly model: string; readonly from: string; readonly to: string }
+  | {
+      readonly kind: 'escalate-effort';
+      readonly model: string;
+      readonly from: string;
+      readonly to: string;
+      /**
+       * The evaluator's own same-model effort bump, fired in lockstep with the generator's rung
+       * above — computed independently against the evaluator's OWN provider/model/effort triple
+       * via {@link nextEffortRung}, never copied from the generator's `from`/`to`. Absent when the
+       * caller supplied no evaluator context, the evaluator provider/model has no effort dimension,
+       * or the evaluator is already at its own effort ceiling. The evaluator MODEL is never part of
+       * this — only reasoning effort.
+       */
+      readonly evaluator?: { readonly from: string; readonly to: string };
+    }
   | { readonly kind: 'nudge'; readonly currentModel: string }
   | { readonly kind: 'flag-off' }
   | { readonly kind: 'topped-out'; readonly model: string }
@@ -126,6 +140,28 @@ export interface DecideEscalationProps {
    * backward-compatibility reason as {@link generatorProvider}.
    */
   readonly generatorEffort?: string | undefined;
+  /**
+   * Provider the EVALUATOR role runs on — read only to compute the evaluator half of an
+   * `escalate-effort` decision ({@link EscalationDecision} `evaluator`). The evaluator's model
+   * never changes, so this is consulted purely for the effort-dimension lookup, independent of
+   * {@link generatorProvider}. OPTIONAL: a caller that omits it (or supplies `undefined`) gets no
+   * `evaluator` field on the decision — the pre-lockstep behaviour is unchanged.
+   */
+  readonly evaluatorProvider?: AiProvider | undefined;
+  /**
+   * The model the evaluator role spawns with — fixed for the whole task (never escalated). Read
+   * alongside {@link evaluatorProvider} so {@link nextEffortRung} can classify the evaluator's own
+   * effort ladder (e.g. Claude's model-aware xhigh/max split). OPTIONAL for the same reason as
+   * {@link evaluatorProvider}.
+   */
+  readonly evaluatorModel?: string | undefined;
+  /**
+   * The evaluator's currently-resolved reasoning effort, or `undefined` for the CLI default. Read
+   * alongside {@link evaluatorProvider} / {@link evaluatorModel} to decide whether the EVALUATOR'S
+   * OWN effort rung has headroom — computed independently of {@link generatorEffort}, never copied
+   * from it. OPTIONAL for the same reason as {@link evaluatorProvider}.
+   */
+  readonly evaluatorEffort?: string | undefined;
 }
 
 /**
@@ -187,11 +223,23 @@ export const decideEscalation = (props: DecideEscalationProps): EscalationDecisi
   // at its ceiling.
   const effortTarget = nextEffortRung(props.generatorProvider, props.generatorModel, props.generatorEffort);
   if (effortTarget !== undefined) {
+    // Lockstep evaluator bump: computed independently against the evaluator's OWN provider/model/
+    // effort triple — never copied from the generator's target. Absent when the caller supplied no
+    // evaluator context or the evaluator has no headroom left (already at its own ceiling).
+    const evaluatorEffortTarget =
+      props.evaluatorModel !== undefined
+        ? nextEffortRung(props.evaluatorProvider, props.evaluatorModel, props.evaluatorEffort)
+        : undefined;
+    const evaluatorCarry =
+      evaluatorEffortTarget !== undefined
+        ? { evaluator: { from: props.evaluatorEffort ?? 'default', to: evaluatorEffortTarget } }
+        : {};
     return {
       kind: 'escalate-effort',
       model: props.generatorModel,
       from: props.generatorEffort ?? 'default',
       to: effortTarget,
+      ...evaluatorCarry,
     };
   }
   // Top of the ladder, no effort headroom, not yet nudged. Grant one more attempt on the same model
@@ -362,12 +410,19 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
       // the escalation model fields are NOT stamped (leaving them untouched keeps the same-model
       // change-of-approach marker for the LATER nudge accurate) and no `model-escalated` event fires
       // — the banner names the effort bump so the operator sees the remedy. The generator leaf reads
-      // the raised effort on the next attempt; this policy half only announces the decision.
+      // the raised effort on the next attempt; this policy half only announces the decision. Neither
+      // the generator nor the evaluator model fields are stamped here — the evaluator effort stamp
+      // (when `decision.evaluator` is present) happens in the caller (finalize-gen-eval), alongside
+      // the generator's, in the same `taskRepo.update` persist.
+      const evaluatorClause =
+        decision.evaluator !== undefined
+          ? `; evaluator effort: ${decision.evaluator.from} → ${decision.evaluator.to}`
+          : '';
       eventBus.publish({
         type: BANNER_SHOW_EVENT,
         id: bannerId,
         tier: 'info',
-        message: `raised generator effort on '${decision.model}': ${decision.from} → ${decision.to}`,
+        message: `raised generator effort on '${decision.model}': ${decision.from} → ${decision.to}${evaluatorClause}`,
         cause,
         at: now,
       });
@@ -377,6 +432,9 @@ export const applyEscalation = (props: ApplyEscalationProps): Result<ApplyEscala
         from: decision.from,
         to: decision.to,
         reason: trigger,
+        ...(decision.evaluator !== undefined
+          ? { evaluatorFrom: decision.evaluator.from, evaluatorTo: decision.evaluator.to }
+          : {}),
       });
       return Result.ok({ task });
     }

--- a/src/business/task/finalize-gen-eval.ts
+++ b/src/business/task/finalize-gen-eval.ts
@@ -4,7 +4,7 @@ import type { Logger } from '@src/business/observability/logger.ts';
 import type { AttemptWarning } from '@src/domain/entity/attempt.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
 import type { InProgressTask } from '@src/domain/entity/task.ts';
-import { recordTaskEffortEscalation } from '@src/domain/entity/task-settle.ts';
+import { recordTaskEffortEscalation, recordTaskEvaluatorEffortEscalation } from '@src/domain/entity/task-settle.ts';
 import type { UpdateTask } from '@src/domain/repository/task/update-task.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
@@ -93,6 +93,26 @@ export interface FinalizeGenEvalProps {
    * to {@link decideEscalation} alongside {@link generatorProvider}; OPTIONAL for the same reason.
    */
   readonly generatorEffort?: string | undefined;
+  /**
+   * Provider the EVALUATOR role runs on — forwarded to {@link decideEscalation} so the same-model
+   * EFFORT rung can compute the evaluator's OWN lockstep bump (never copied from the generator's
+   * target). OPTIONAL: absent → no `evaluator` field on an `escalate-effort` decision, unchanged
+   * from the generator-only behaviour. The leaf resolves it from the configured evaluator row.
+   */
+  readonly evaluatorProvider?: AiProvider | undefined;
+  /**
+   * The model the evaluator role spawns with — fixed for the whole task, never escalated. Read
+   * alongside {@link evaluatorProvider} so the policy can classify the evaluator's own effort
+   * ladder. OPTIONAL for the same reason as {@link evaluatorProvider}.
+   */
+  readonly evaluatorModel?: string | undefined;
+  /**
+   * The evaluator's currently-resolved reasoning effort (`task.escalatedToEvaluatorEffort ??
+   * configured`), or `undefined` for the CLI default — mirrors {@link generatorEffort}'s
+   * resolution order so a prior evaluator effort bump is reflected here and the policy stops
+   * re-firing the rung. OPTIONAL for the same reason as {@link evaluatorProvider}.
+   */
+  readonly evaluatorEffort?: string | undefined;
   readonly eventBus: EventBus;
   readonly clock: () => IsoTimestamp;
 }
@@ -194,6 +214,11 @@ const resolveEscalatableRemedy = (
     // returns `escalate-effort` and behaves exactly as before.
     generatorProvider: props.generatorProvider,
     generatorEffort: props.generatorEffort,
+    // Evaluator lockstep context — same optionality: absent context means the policy never
+    // returns an `evaluator` field on the decision.
+    evaluatorProvider: props.evaluatorProvider,
+    evaluatorModel: props.evaluatorModel,
+    evaluatorEffort: props.evaluatorEffort,
   });
   const applied = applyEscalation({
     task: props.task,
@@ -216,6 +241,13 @@ const resolveEscalatableRemedy = (
     const stamped = recordTaskEffortEscalation(task, decision.to);
     if (!stamped.ok) return Result.error(stamped.error);
     task = stamped.value;
+    // Evaluator's lockstep bump — stamped right beside the generator's so both land in the single
+    // `taskRepo.update` persist below. Absent when the policy found no evaluator headroom.
+    if (decision.evaluator !== undefined) {
+      const evaluatorStamped = recordTaskEvaluatorEffortEscalation(task, decision.evaluator.to);
+      if (!evaluatorStamped.ok) return Result.error(evaluatorStamped.error);
+      task = evaluatorStamped.value;
+    }
   }
   // A model escalation, a same-model effort bump, and a same-model nudge each grant one more
   // attempt: fail the running attempt so the task stays in_progress and the outer loop re-enters

--- a/src/domain/entity/task-lifecycle.ts
+++ b/src/domain/entity/task-lifecycle.ts
@@ -64,6 +64,8 @@ export const unblockTask = (task: Task): Result<TodoTask, InvalidStateError> => 
     // The raised effort is a per-run remedy like the model bump — a clean restart drops it so the
     // fresh run begins on the configured effort again.
     escalatedToEffort: _effort,
+    // Evaluator-side counterpart of the effort remedy above — same clean-restart rationale.
+    escalatedToEvaluatorEffort: _evaluatorEffort,
     // A clean restart drops the prior run's per-criterion verdicts too — a freshly-planned task
     // carries no k-of-N history; stale verdicts would mislead the next run's checklist.
     criteriaVerdicts: _verdicts,
@@ -74,6 +76,7 @@ export const unblockTask = (task: Task): Result<TodoTask, InvalidStateError> => 
   void _from;
   void _to;
   void _effort;
+  void _evaluatorEffort;
   void _verdicts;
   return Result.ok({ ...rest, status: 'todo', attempts: [] });
 };

--- a/src/domain/entity/task-settle.ts
+++ b/src/domain/entity/task-settle.ts
@@ -87,6 +87,9 @@ export const markTaskDone = (task: Task, now: IsoTimestamp): Result<DoneTask, In
     ...(guard.value.escalatedFromModel !== undefined ? { escalatedFromModel: guard.value.escalatedFromModel } : {}),
     ...(guard.value.escalatedToModel !== undefined ? { escalatedToModel: guard.value.escalatedToModel } : {}),
     ...(guard.value.escalatedToEffort !== undefined ? { escalatedToEffort: guard.value.escalatedToEffort } : {}),
+    ...(guard.value.escalatedToEvaluatorEffort !== undefined
+      ? { escalatedToEvaluatorEffort: guard.value.escalatedToEvaluatorEffort }
+      : {}),
     status: 'done',
     attempts,
     finalAttemptN: verified.n,
@@ -176,4 +179,20 @@ export const recordTaskEffortEscalation = (
   const to = parseRequiredString('task.escalatedToEffort', toEffort);
   if (!to.ok) return Result.error(to.error);
   return Result.ok({ ...task, escalatedToEffort: to.value });
+};
+
+/**
+ * Stamp the same-model EVALUATOR effort escalation onto an `in_progress` task — the evaluator-side
+ * counterpart of {@link recordTaskEffortEscalation}. The evaluator's model never changes, so only
+ * {@link InProgressTask.escalatedToEvaluatorEffort} is recorded; the evaluator leaf reads it on the
+ * next attempt to spawn at the raised reasoning effort. Validates the effort string is non-empty;
+ * the cost ceiling is policy-enforced (the evaluator's own effort ladder), not here.
+ */
+export const recordTaskEvaluatorEffortEscalation = (
+  task: InProgressTask,
+  toEffort: string
+): Result<InProgressTask, ValidationError> => {
+  const to = parseRequiredString('task.escalatedToEvaluatorEffort', toEffort);
+  if (!to.ok) return Result.error(to.error);
+  return Result.ok({ ...task, escalatedToEvaluatorEffort: to.value });
 };

--- a/src/domain/entity/task.ts
+++ b/src/domain/entity/task.ts
@@ -113,6 +113,15 @@ interface TaskBase extends Entity<TaskId> {
    * role is never affected.
    */
   readonly escalatedToEffort?: string;
+  /**
+   * Reasoning-effort level the next attempt's evaluator leaf must spawn with — the evaluator-side
+   * counterpart of {@link escalatedToEffort}. Stamped by the escalation policy's same-model EFFORT
+   * rung alongside the generator stamp, computed independently against the evaluator's OWN
+   * provider/model ladder (never copied from the generator's target). Effort only — the evaluator
+   * MODEL never changes, so this field has no `escalatedToModel`-shaped counterpart. The evaluator
+   * leaf prefers this value over the configured evaluator effort when present.
+   */
+  readonly escalatedToEvaluatorEffort?: string;
 }
 
 export interface TodoTask extends TaskBase {

--- a/src/integration/persistence/task/task.schema.ts
+++ b/src/integration/persistence/task/task.schema.ts
@@ -92,6 +92,9 @@ const TaskBaseShape = {
   // Same-model effort-rung override. Optional on read so `tasks.json` files written before the
   // field existed load unchanged (a missing value heals to `undefined`). Never planner-authored.
   escalatedToEffort: z.string().optional(),
+  // Evaluator-side counterpart of escalatedToEffort — same tolerant-read rationale. The evaluator
+  // MODEL never escalates, so there is no evaluator equivalent of escalatedToModel.
+  escalatedToEvaluatorEffort: z.string().optional(),
 };
 
 const TodoTaskSchema = z.object({ ...TaskBaseShape, status: z.literal('todo') });

--- a/tests/integration/application/flows/implement/leaves/evaluator.test.ts
+++ b/tests/integration/application/flows/implement/leaves/evaluator.test.ts
@@ -6,7 +6,7 @@ import type { HarnessSignal } from '@src/domain/signal.ts';
 import { createFakeAiProvider } from '@tests/fixtures/fake-ai-provider.ts';
 import { createFsTemplateLoader, defaultTemplatesDir } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
 import { absolutePath, FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@tests/fixtures/domain.ts';
-import { recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
+import { recordTaskEscalation, recordTaskEvaluatorEffortEscalation } from '@src/domain/entity/task-settle.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
 import { emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
@@ -131,6 +131,44 @@ describe('evaluatorLeaf', () => {
     };
     await leaf.execute(ctx);
     expect(deps.provider.recordedSessions[0]?.model).toBe('evaluator-model-fixed');
+  });
+
+  it('uses task.escalatedToEvaluatorEffort as the spawn effort when the task carries an evaluator effort escalation', async () => {
+    // Evaluator lockstep effort bump: the model is unchanged (no escalatedToModel), but the raised
+    // effort must reach the spawn. Without the leaf preferring `escalatedToEvaluatorEffort`, the
+    // bump the escalation policy granted would never take effect.
+    const initial = makeInProgressTaskWithRunningAttempt();
+    const stamped = recordTaskEvaluatorEffortEscalation(initial, 'high');
+    if (!stamped.ok) throw stamped.error;
+    const task = stamped.value;
+    const deps = buildDeps();
+    const leaf = evaluatorLeaf({ ...deps, model: 'evaluator-model-fixed', effort: 'medium' }, task.id);
+    const ctx: ImplementCtx = {
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+      currentTask: task,
+      currentRoundNum: 1,
+      taskWorkspaceRoot: root.root,
+    };
+    await leaf.execute(ctx);
+    expect(deps.provider.recordedSessions[0]?.effort).toBe('high');
+    // Model stays the configured value — the effort rung never touches the evaluator model.
+    expect(deps.provider.recordedSessions[0]?.model).toBe('evaluator-model-fixed');
+  });
+
+  it('falls back to the configured evaluator effort when the task has no escalatedToEvaluatorEffort', async () => {
+    const task = makeInProgressTaskWithRunningAttempt();
+    const deps = buildDeps();
+    const leaf = evaluatorLeaf({ ...deps, model: 'evaluator-model-fixed', effort: 'medium' }, task.id);
+    const ctx: ImplementCtx = {
+      sprintId: task.id as unknown as ImplementCtx['sprintId'],
+      tasks: [task],
+      currentTask: task,
+      currentRoundNum: 1,
+      taskWorkspaceRoot: root.root,
+    };
+    await leaf.execute(ctx);
+    expect(deps.provider.recordedSessions[0]?.effort).toBe('medium');
   });
 
   // Abort wire (keystone for #1/#5): the evaluator, like the generator, must carry the chain's

--- a/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.customize-picker.test.tsx
@@ -25,6 +25,7 @@ import { Result } from '@src/domain/result.ts';
 import type { Choice, InteractivePrompt } from '@src/business/interactive/prompt.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { resolveEffort } from '@src/business/settings/resolve-effort.ts';
 import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
@@ -156,6 +157,14 @@ const driveSettings = (overrides: Partial<Settings['ai']> = {}): Settings => ({
 
 const SIMPLE_FLOWS = ['refine', 'plan', 'readiness', 'ideate'] as const;
 
+/**
+ * Effort step's Keep-default label for a simple flow's resolved default under DEFAULT_SETTINGS.
+ * `plan` / `ideate` carry a shipped `high` default (see `resolve-effort.ts`); the others still
+ * resolve to `undefined`, rendered as 'auto'.
+ */
+const keepDefaultEffortLabel = (flowId: (typeof SIMPLE_FLOWS)[number]): string =>
+  `Keep default (${resolveEffort(flowId, DEFAULT_SETTINGS) ?? 'auto'})`;
+
 describe('runCustomizePicker — single-row flows (refine / plan / readiness / ideate)', () => {
   for (const flowId of SIMPLE_FLOWS) {
     describe(`flow=${flowId}`, () => {
@@ -184,10 +193,10 @@ describe('runCustomizePicker — single-row flows (refine / plan / readiness / i
           // provider step: Keep default — exact label matches the row's default provider id
           { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
           { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].model})` },
-          // The default row carries no per-flow effort and DEFAULT_SETTINGS has no global
-          // effort either, so resolveEffortForRow returns undefined and Keep default's label
-          // renders 'unset'.
-          { action: 'pick', choice: 'Keep default (auto)' },
+          // The default row carries no per-flow effort, so the label shows whatever
+          // resolveEffort resolves to under DEFAULT_SETTINGS (the shipped per-flow default for
+          // plan/ideate, 'auto' for everything else).
+          { action: 'pick', choice: keepDefaultEffortLabel(flowId) },
         ]);
         const result = await runCustomizePicker({
           interactive,
@@ -233,7 +242,7 @@ describe('runCustomizePicker — single-row flows (refine / plan / readiness / i
           { action: 'pick', choice: 'Customize for this run…' },
           { action: 'pick', choice: `Keep default (${DEFAULT_SETTINGS.ai[flowId].provider})` },
           { action: 'pick', choice: otherModel },
-          { action: 'pick', choice: 'Keep default (auto)' },
+          { action: 'pick', choice: keepDefaultEffortLabel(flowId) },
         ]);
         const result = await runCustomizePicker({
           interactive,

--- a/tests/integration/persistence/task/repository.test.ts
+++ b/tests/integration/persistence/task/repository.test.ts
@@ -6,7 +6,11 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
-import { recordTaskEffortEscalation, recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
+import {
+  recordTaskEffortEscalation,
+  recordTaskEscalation,
+  recordTaskEvaluatorEffortEscalation,
+} from '@src/domain/entity/task-settle.ts';
 import { join } from 'node:path';
 import { createFsTaskRepository } from '@src/integration/persistence/task/repository.ts';
 import { sprintsDir } from '@src/integration/persistence/storage.ts';
@@ -140,6 +144,29 @@ describe('createFsTaskRepository', () => {
     const reloaded = await repo.findById(sprintId, legacy.id);
     if (!reloaded.ok) throw new Error('expected ok');
     expect(reloaded.value.escalatedToEffort).toBeUndefined();
+  });
+
+  it('round-trips escalatedToEvaluatorEffort across save → load (evaluator lockstep resume path)', async () => {
+    const repo = createFsTaskRepository({ root });
+    const inProgress = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const bumped = recordTaskEvaluatorEffortEscalation(inProgress, 'high');
+    if (!bumped.ok) throw bumped.error;
+    await repo.saveAll(sprintId, [bumped.value]);
+
+    const reloaded = await repo.findById(sprintId, bumped.value.id);
+    if (!reloaded.ok) throw new Error('expected ok');
+    expect(reloaded.value.escalatedToEvaluatorEffort).toBe('high');
+  });
+
+  it('loads a legacy tasks.json entry without escalatedToEvaluatorEffort unchanged (tolerant additive field)', async () => {
+    const repo = createFsTaskRepository({ root });
+    // A task saved before the field existed carries no escalatedToEvaluatorEffort — it must load fine.
+    const legacy = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    await repo.saveAll(sprintId, [legacy]);
+
+    const reloaded = await repo.findById(sprintId, legacy.id);
+    if (!reloaded.ok) throw new Error('expected ok');
+    expect(reloaded.value.escalatedToEvaluatorEffort).toBeUndefined();
   });
 
   it('surfaces a non-array tasks file as StorageError(parse)', async () => {

--- a/tests/unit/business/settings/resolve-effort.test.ts
+++ b/tests/unit/business/settings/resolve-effort.test.ts
@@ -17,9 +17,26 @@ const withPerFlowEffort = (flow: 'refine' | 'plan' | 'readiness' | 'ideate', eff
 });
 
 describe('resolveEffort', () => {
-  it('returns undefined when neither per-flow nor global effort is set', () => {
+  it('resolves plan and ideate to the shipped high default when neither the row nor the global effort is set', () => {
+    expect(resolveEffort('plan', DEFAULT_SETTINGS)).toBe('high');
+    expect(resolveEffort('ideate', DEFAULT_SETTINGS)).toBe('high');
+  });
+
+  it('leaves every other flow resolving to undefined when neither the row nor the global effort is set', () => {
     expect(resolveEffort('refine', DEFAULT_SETTINGS)).toBeUndefined();
-    expect(resolveEffort('plan', DEFAULT_SETTINGS)).toBeUndefined();
+    expect(resolveEffort('readiness', DEFAULT_SETTINGS)).toBeUndefined();
+    expect(resolveEffort('createPr', DEFAULT_SETTINGS)).toBeUndefined();
+    expect(resolveEffort('implement', DEFAULT_SETTINGS)).toBeUndefined();
+  });
+
+  it('an explicit global effort wins over the new plan/ideate flow default', () => {
+    expect(resolveEffort('plan', withGlobalEffort('low'))).toBe('low');
+    expect(resolveEffort('ideate', withGlobalEffort('medium'))).toBe('medium');
+  });
+
+  it('an explicit per-flow row effort wins over the new plan/ideate flow default', () => {
+    expect(resolveEffort('plan', withPerFlowEffort('plan', 'low'))).toBe('low');
+    expect(resolveEffort('ideate', withPerFlowEffort('ideate', 'medium'))).toBe('medium');
   });
 
   it('returns the per-flow value when set, ignoring the global', () => {

--- a/tests/unit/business/task/escalation-policy.test.ts
+++ b/tests/unit/business/task/escalation-policy.test.ts
@@ -347,6 +347,130 @@ describe('decideEscalation — same-model effort rung', () => {
   });
 });
 
+describe('decideEscalation — evaluator lockstep effort bump', () => {
+  it('computes the evaluator target from its OWN provider/model/effort — not copied from the generator target', () => {
+    // Generator: shipped default (opus, effort unset) → climbs to `max` (Claude xhigh-capable).
+    // Evaluator: a DIFFERENT provider/model (Copilot) → climbs to a DIFFERENT target (`high`). If the
+    // evaluator field were ever copied from the generator's `to`, this would assert `max` and fail.
+    const generatorRow = DEFAULT_SETTINGS.ai.implement.generator;
+    const decision = decideEscalation({
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      generatorModel: generatorRow.model,
+      flagOn: true,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+      generatorProvider: generatorRow.provider,
+      generatorEffort: resolveEffort('implement', DEFAULT_SETTINGS),
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(decision.kind).toBe('escalate-effort');
+    if (decision.kind !== 'escalate-effort') return;
+    expect(decision.to).toBe('max');
+    expect(decision.evaluator).toEqual({ from: 'default', to: 'high' });
+  });
+
+  it('is absent on a plain model escalate — no evaluator context leaks onto a `escalate` decision', () => {
+    const decision = decideEscalation({
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      generatorModel: 'claude-sonnet-4-6',
+      flagOn: true,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(decision.kind).toBe('escalate');
+    expect('evaluator' in decision).toBe(false);
+  });
+
+  it('is absent on a same-model nudge (generator has no effort headroom of its own)', () => {
+    // Claude Haiku has no effort dimension, so the GENERATOR rung never fires (falls through to
+    // nudge) even though evaluator context is supplied — the evaluator bump only rides the
+    // generator's OWN escalate-effort event, never fires independently.
+    const decision = decideEscalation({
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      generatorModel: 'claude-haiku-4-5',
+      flagOn: true,
+      userMap: { 'claude-haiku-4-5': 'claude-haiku-4-5' },
+      fallbackMaxAttempts: 3,
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(decision.kind).toBe('nudge');
+    expect('evaluator' in decision).toBe(false);
+  });
+
+  it('is absent on flag-off', () => {
+    const decision = decideEscalation({
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      generatorModel: 'claude-opus-5',
+      flagOn: false,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(decision.kind).toBe('flag-off');
+    expect('evaluator' in decision).toBe(false);
+  });
+
+  it('is absent when the evaluator is already at its own effort ceiling, even while the generator rung fires', () => {
+    const decision = decideEscalation({
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      // Top of the model ladder (no outbound rung) so the generator hits the effort rung, not a
+      // model climb — `claude-opus-4-8` would climb to `claude-opus-5` instead.
+      generatorModel: 'claude-opus-5',
+      flagOn: true,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'claude-code',
+      evaluatorModel: 'claude-opus-5',
+      evaluatorEffort: 'max',
+    });
+    expect(decision.kind).toBe('escalate-effort');
+    if (decision.kind !== 'escalate-effort') return;
+    // The generator still climbed (max headroom) — only the evaluator half is missing.
+    expect(decision.to).toBe('max');
+    expect(decision.evaluator).toBeUndefined();
+  });
+
+  it('a single-step Copilot evaluator ladder jumps to `high` once and stays there on a later round', () => {
+    const base = {
+      task: makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 }),
+      // Top of the model ladder so the generator's own rung is the effort rung both rounds.
+      generatorModel: 'claude-opus-5',
+      flagOn: true,
+      userMap: {},
+      fallbackMaxAttempts: 3,
+      generatorProvider: 'claude-code' as const,
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot' as const,
+      evaluatorModel: 'gpt-5.5',
+    };
+    const first = decideEscalation({ ...base, evaluatorEffort: undefined });
+    expect(first.kind).toBe('escalate-effort');
+    if (first.kind === 'escalate-effort') expect(first.evaluator).toEqual({ from: 'default', to: 'high' });
+
+    // A later round reads the raised effort back — Copilot's single-step ladder has no rung above
+    // `high`, so the evaluator field disappears (spent) even though the generator's own effort rung
+    // fires again on a different model.
+    const second = decideEscalation({ ...base, evaluatorEffort: 'high' });
+    expect(second.kind).toBe('escalate-effort');
+    if (second.kind === 'escalate-effort') expect(second.evaluator).toBeUndefined();
+  });
+});
+
 describe('applyEscalation', () => {
   it('on escalate: stamps task, publishes model-escalated event and info banner', () => {
     const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });

--- a/tests/unit/business/task/finalize-gen-eval.test.ts
+++ b/tests/unit/business/task/finalize-gen-eval.test.ts
@@ -951,6 +951,158 @@ describe('finalizeGenEvalUseCase', () => {
     expect(result.value.shouldFailAttempt).toBe(true);
   });
 
+  // ── Evaluator lockstep effort bump (activated via evaluatorProvider/evaluatorModel/evaluatorEffort) ──
+
+  it('escalate-effort with evaluator context: both escalatedToEffort and escalatedToEvaluatorEffort land in the same persist', async () => {
+    const generatorRow = DEFAULT_SETTINGS.ai.implement.generator;
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const persisted: Array<{ escalatedToEffort: string | undefined; escalatedToEvaluatorEffort: string | undefined }> =
+      [];
+    const repo: UpdateTask = {
+      async update(_sprintId, t) {
+        persisted.push({
+          escalatedToEffort: t.escalatedToEffort,
+          escalatedToEvaluatorEffort: t.escalatedToEvaluatorEffort,
+        });
+        return Result.ok(undefined);
+      },
+    };
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 5 }),
+      taskRepo: repo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: generatorRow.model,
+      generatorProvider: generatorRow.provider,
+      generatorEffort: resolveEffort('implement', DEFAULT_SETTINGS),
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.task.escalatedToEffort).toBe('max');
+    expect(result.value.task.escalatedToEvaluatorEffort).toBe('high');
+    // Both landed together in the single persist call — no separate write for the evaluator field.
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toEqual({ escalatedToEffort: 'max', escalatedToEvaluatorEffort: 'high' });
+  });
+
+  it('plain model escalate: escalatedToEvaluatorEffort is NOT stamped even when evaluator context is supplied', async () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 5 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: 'claude-sonnet-4-6',
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.task.escalatedToModel).toBe('claude-opus-4-8');
+    expect(result.value.task.escalatedToEvaluatorEffort).toBeUndefined();
+  });
+
+  it('top-of-ladder nudge: escalatedToEvaluatorEffort is NOT stamped even when evaluator context is supplied', async () => {
+    // Generator has no effort dimension (Haiku) → falls through to the nudge; the evaluator bump
+    // only rides the generator's OWN escalate-effort event, so it stays unstamped here too. A
+    // self-loop user-map entry keeps Haiku at the top of ITS ladder (the default map would
+    // otherwise climb it to Sonnet, which is escalatable and not what this test exercises).
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: async () => ({
+        maxTurns: 5,
+        escalateOnPlateau: true,
+        escalationMap: { 'claude-haiku-4-5': 'claude-haiku-4-5' },
+        maxAttempts: 5,
+      }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: 'claude-haiku-4-5',
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.task.escalatedFromModel).toBe('claude-haiku-4-5');
+    expect(result.value.task.escalatedToModel).toBe('claude-haiku-4-5');
+    expect(result.value.task.escalatedToEvaluatorEffort).toBeUndefined();
+  });
+
+  it('flag-off: escalatedToEvaluatorEffort is NOT stamped even when evaluator context is supplied', async () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: false, maxAttempts: 5 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: 'claude-opus-5',
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'github-copilot',
+      evaluatorModel: 'gpt-5.5',
+      evaluatorEffort: undefined,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.task.escalatedToEvaluatorEffort).toBeUndefined();
+    expect(result.value.shouldFailAttempt).toBeUndefined();
+  });
+
+  it('evaluator already at its own effort ceiling: generator still escalates, evaluator field absent, no evaluator stamp', async () => {
+    const task = makeInProgressTaskWithRunningAttempt({ maxAttempts: 5 });
+    const result = await finalizeGenEvalUseCase({
+      task,
+      sprintId,
+      exit: { kind: 'plateau', dimensions: ['correctness'] },
+      turnsUsed: 3,
+      readConfig: cfg({ escalateOnPlateau: true, maxAttempts: 5 }),
+      taskRepo: okRepo,
+      logger: noopLogger,
+      eventBus: newBus(),
+      clock: fixedClock,
+      generatorModel: 'claude-opus-5',
+      generatorProvider: 'claude-code',
+      generatorEffort: undefined,
+      evaluatorProvider: 'claude-code',
+      evaluatorModel: 'claude-opus-5',
+      evaluatorEffort: 'max',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.task.escalatedToEffort).toBe('max');
+    expect(result.value.task.escalatedToEvaluatorEffort).toBeUndefined();
+  });
+
   it('forwards a StorageError from the repo', async () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const failing: UpdateTask = {

--- a/tests/unit/domain/entity/task-lifecycle.test.ts
+++ b/tests/unit/domain/entity/task-lifecycle.test.ts
@@ -5,7 +5,11 @@ import {
   markTaskBlocked,
   unblockTask,
 } from '@src/domain/entity/task-lifecycle.ts';
-import { recordTaskEffortEscalation, recordTaskEscalation } from '@src/domain/entity/task-settle.ts';
+import {
+  recordTaskEffortEscalation,
+  recordTaskEscalation,
+  recordTaskEvaluatorEffortEscalation,
+} from '@src/domain/entity/task-settle.ts';
 import { applyCriteriaVerdicts } from '@src/domain/entity/task-criteria.ts';
 import type { BlockedTask } from '@src/domain/entity/task.ts';
 import { makeInProgressTaskWithRunningAttempt, makeTodoTask } from '@tests/fixtures/domain.ts';
@@ -73,7 +77,10 @@ describe('unblockTask — clean restart (drops block fields, resets budget + esc
     // Also carry a raised effort — the effort rung's per-run remedy must reset too.
     const effortEscalated = recordTaskEffortEscalation(escalated.value, 'high');
     if (!effortEscalated.ok) throw effortEscalated.error;
-    const blocked = markTaskBlocked(effortEscalated.value, 'attempt budget exhausted', 'own');
+    // And the evaluator's own lockstep effort bump — same clean-restart rationale.
+    const evaluatorEffortEscalated = recordTaskEvaluatorEffortEscalation(effortEscalated.value, 'high');
+    if (!evaluatorEffortEscalated.ok) throw evaluatorEffortEscalated.error;
+    const blocked = markTaskBlocked(evaluatorEffortEscalated.value, 'attempt budget exhausted', 'own');
     if (!blocked.ok) throw blocked.error;
     expect(blocked.value.attempts.length).toBeGreaterThan(0);
 
@@ -85,6 +92,7 @@ describe('unblockTask — clean restart (drops block fields, resets budget + esc
     expect((back.value as unknown as Record<string, unknown>)['escalatedFromModel']).toBeUndefined();
     expect((back.value as unknown as Record<string, unknown>)['escalatedToModel']).toBeUndefined();
     expect((back.value as unknown as Record<string, unknown>)['escalatedToEffort']).toBeUndefined();
+    expect((back.value as unknown as Record<string, unknown>)['escalatedToEvaluatorEffort']).toBeUndefined();
     // The cap itself (a planning field) survives — only the consumed budget resets.
     expect(back.value.maxAttempts).toBe(3);
   });


### PR DESCRIPTION
Raises default reasoning effort for `plan` and `ideate` flows to `high`, and binds evaluator reasoning effort to generator escalation so both advance in lockstep during plateaus — ensuring consistent scoring rigor as the generator model strengthens.

## Changes

- **Phase-aware defaults**: `plan` and `ideate` flows default to `high` effort (below global setting, so operator choices are preserved) — all other flows resolve via global setting or CLI default as before.
- **Evaluator effort escalation**: when the generator's same-model effort rung fires, the evaluator's own effort ladder is consulted independently; if there's headroom, a parallel bump is stamped and propagated.
- **Task persistence**: new `escalatedToEvaluatorEffort` field tracks the evaluator's raised effort, computed against the evaluator's own provider/model ceiling (never copied from the generator's target).
- **UI**: customize picker now threads flow context through effort resolution, and displays phase-aware defaults correctly.
- **Escalation decision**: `escalate-effort` decisions now carry an optional `evaluator` subfield naming the evaluator's own from/to effort transition.

## Test plan

- [ ] Unit tests for `resolveEffort` verify phase-aware defaults rank below global setting.
- [ ] Unit tests for `escalationPolicy.decideEscalation` verify independent evaluator effort rung with headroom detection.
- [ ] Unit tests for `finalize-gen-eval` verify evaluator context is threaded and effort stamp is written.
- [ ] Manually run an implement flow with both generator and evaluator configured; trigger a plateau and confirm the banner names both effort bumps.
- [ ] Manually run `plan` and `ideate` flows with no explicit effort setting; confirm they resolve to `high` (or provider ceiling below that).
- [ ] Manually run plan/ideate with an explicit global effort; confirm the global overrides the phase default.

Closes #257
Closes #256