### PR TITLE
chore(release): 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-02
+
 ### Fixed
 
 - **Corrective retry no longer burns resumed spawns on a harness-side I/O failure.** A read failure on an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, and OpenAI Codex across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.18.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.18.0]`

Ships the post-0.17.1 work: the full-repo audit campaign (#270), phase-aware effort defaults (#257), and evaluator escalation lockstep (#256). Minor bump — `plan` / `ideate` now default to `high` reasoning effort, a user-visible behaviour change.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally (4,908 tests / 535 files, lint 0 err / 115 warn at the ratchet)
- [x] Manual TUI smoke — a live sprint was driven end-to-end off this base (plan → implement → gen-eval → PR), shipping as #272
- [ ] CI green