### PR TITLE
docs(readme): rebalance provider sections, simplify diagrams; fix dead OpenCode default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ to [Semantic Versioning](https://semver.org/).
     and for CI jobs without secrets.
   - **It aggregates other providers.** Model ids are namespaced as `<provider>/<model>` (e.g.
     `opencode/big-pickle` on the free tier), and the reachable set depends on which upstream providers you
-    have authenticated via `opencode providers`. The model picker asks the CLI (`opencode models`) instead
+    have authenticated via `opencode providers login`. The model picker asks the CLI (`opencode models`) instead
     of reading a fixed list, so authenticating a provider makes its models selectable with no ralphctl
     upgrade.
 
@@ -53,6 +53,12 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The OpenCode free-tier default no longer points at a model that refuses every request.**
+  `opencode/north-mini-code-free` returns an upstream `401` while its free-tier siblings serve normally, and
+  it was the shipped light-tier default in both the per-provider defaults and the `opencode-only` preset — so
+  a first run on OpenCode's free tier failed on every flow. The default is now
+  `opencode/deepseek-v4-flash-free`. Note that `opencode models` still lists ids that no longer serve, so
+  enumeration is not a health check; if a free-tier model starts failing, pick another from that list.
 - **Interactive AI sessions now honor the configured reasoning effort.** `refine`, `plan`, `ideate`, and
   the learning-distill step all hand the terminal over to an interactive AI session, and that path
   silently dropped `effort` for all three provider CLIs — a `high` or `xhigh` setting had no effect once

--- a/README.md
+++ b/README.md
@@ -25,26 +25,9 @@ repositories.**
 
 > _"I'm helping!"_ — Ralph Wiggum
 
-> [!TIP]
-> **New: [OpenCode](#opencode) support — run ralphctl on whatever model you want.** OpenCode is a
-> vendor-neutral CLI that fronts 75+ providers and local runtimes, so adding it effectively opens the harness
-> to Anthropic, OpenAI, Google, Bedrock, Azure, OpenRouter, Groq, DeepSeek, Mistral, and local Ollama /
-> LM Studio / llama.cpp — with your own keys, or none at all.
->
-> ```bash
-> npm install -g ralphctl opencode-ai
-> ralphctl settings set ai.implement.generator.provider opencode
-> ralphctl settings set ai.implement.generator.model    <provider>/<model>
-> ```
-
 > [!NOTE]
-> **Active development.** New features and polish ship regularly. Four backends are supported — Claude Code,
-> GitHub Copilot CLI, OpenAI Codex CLI, and OpenCode, the last of which brings any model it can reach.
-> Pick one per flow or mix them, in one command, from 21 presets across five families (`standard`, `economic`,
-> `strong-gate`, `fast`, `frontier`), each in `mixed` / `claude-only` / `copilot-only` / `codex-only`
-> variants, plus a standalone `opencode-only`.
-> Upgrades are best-effort: install the latest version, redo your config, proceed.
-> See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
+> **Active development.** New features and polish ship regularly. Upgrades are best-effort: install the
+> latest version, redo your config, proceed. See [Upgrading](#upgrading) and [CHANGELOG](./CHANGELOG.md).
 
 ---
 
@@ -158,24 +141,18 @@ ralphctl settings set ai.implement.evaluator.model    <model-id>
 
 ```mermaid
 flowchart LR
-    A[Create sprint] --> B[Add tickets]
-    B --> C[Refine<br>WHAT]
-    C --> D[Plan<br>HOW]
-    D --> E[Implement<br>loop]
-    E --> F[Review<br>loop]
-    F --> G([done])
+    A[Create sprint] --> B[Add tickets] --> C[Refine] --> D[Plan] --> E[Implement] --> F[Review] --> G[Done]
 
-    C -.- c1[AI clarifies<br>requirements with you]
-    D -.- d1[AI builds<br>the task graph]
-    E -.- e1[AI implements +<br>AI reviews each task]
-    F -.- f1[you steer revisions,<br>close to done]
-
-    classDef note fill:none,stroke:none
-    class c1,d1,e1,f1 note
+    classDef you fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef ai fill:#ecfdf5,stroke:#10b981,color:#052e16
+    classDef end_ fill:#f1f5f9,stroke:#94a3b8,color:#0f172a
+    class A,B you
+    class C,D,E,F ai
+    class G end_
 ```
 
-The first two steps are yours; from **Refine** onward ralphctl drives, with approval gates where your judgement
-matters.
+The first two steps are yours (blue); from **Refine** onward ralphctl drives (green), with approval gates where
+your judgement matters.
 
 **Refine** is implementation-agnostic: the AI clarifies requirements with you, ticket by ticket, and flips each one from
 `pending` to `approved`. **Plan** requires every ticket approved — the AI explores the affected repos and generates a
@@ -190,16 +167,27 @@ The loop inside **Implement** is what separates a ralph harness from a bare `whi
 independent reviewer before the harness moves on:
 
 ```mermaid
-flowchart TB
-    T[Next task in dependency order] --> G[Generator writes the change]
-    G --> E{Evaluator reviews it<br>against the task spec}
-    E -->|passes| V{Verify script}
-    E -->|fails| C[Critique fed back<br>to the generator]
-    C --> G
-    V -->|green| D([Task done])
-    V -->|red| C
-    C -.->|budget exhausted| B([Task flagged blocked])
+flowchart LR
+    T[Next task] --> G[Generator] --> E{Evaluator}
+    E -->|pass| V{Verify}
+    E -->|fail| R[Retry]
+    V -->|green| D[Done]
+    V -->|red| R
+    R --> G
+    R -.->|attempts exhausted| B[Blocked]
+
+    classDef work fill:#ecfdf5,stroke:#10b981,color:#052e16
+    classDef gate fill:#fefce8,stroke:#eab308,color:#422006
+    classDef ok fill:#f1f5f9,stroke:#94a3b8,color:#0f172a
+    classDef bad fill:#fef2f2,stroke:#ef4444,color:#450a0a
+    class T,G,R work
+    class E,V gate
+    class D ok
+    class B bad
 ```
+
+Either gate can send the task back: a failed review or a red verify both return to the generator with the
+critique attached, up to `harness.maxAttempts` times.
 
 Key properties:
 
@@ -219,106 +207,41 @@ For the full architectural picture see [`.claude/docs/ARCHITECTURE.md`](./.claud
 
 ## Providers
 
-ralphctl drives four AI coding CLIs. Choose one per flow — or mix them, say plan with one and implement with
-another — through a [preset](#configuration) or per-row settings. Three bind you to a vendor;
-[OpenCode](#opencode) fronts 75+ providers and local runtimes, so between them the harness reaches essentially
-any model you can get an API key for.
+ralphctl drives four AI coding CLIs. All four run every flow and are supported first-class. Pick one per
+flow — or mix them, say plan with one and implement with another — through a [preset](#configuration) or
+per-row settings.
 
-| Provider                                  | CLI        | Status | Auth to get started | Headless permission mapping                                                                     | Native context file               |
-| ----------------------------------------- | ---------- | ------ | ------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------- |
-| **Claude Code** (`claude-code`)           | `claude`   | Stable | Anthropic account   | `--permission-mode bypassPermissions` + per-tool deny list                                      | `CLAUDE.md` at repo root          |
-| **GitHub Copilot CLI** (`github-copilot`) | `copilot`  | Stable | GitHub Copilot seat | `--autopilot --max-autopilot-continues=200` + `--allow-all` (per-tool deny list when read-only) | `.github/copilot-instructions.md` |
-| **OpenAI Codex CLI** (`openai-codex`)     | `codex`    | Stable | ChatGPT / OpenAI    | `-s workspace-write` (topology-scoped)                                                          | `AGENTS.md`                       |
-| **OpenCode** (`opencode`)                 | `opencode` | Stable | any (or none)       | `--auto` (topology-scoped)                                                                      | `AGENTS.md`                       |
+| Provider                                  | CLI        | Install                              | Auth                  | Context file                      |
+| ----------------------------------------- | ---------- | ------------------------------------ | --------------------- | --------------------------------- |
+| **Claude Code** (`claude-code`)           | `claude`   | `npm i -g @anthropic-ai/claude-code` | Anthropic account     | `CLAUDE.md`                       |
+| **GitHub Copilot CLI** (`github-copilot`) | `copilot`  | `npm i -g @github/copilot`           | GitHub Copilot seat   | `.github/copilot-instructions.md` |
+| **OpenAI Codex CLI** (`openai-codex`)     | `codex`    | `npm i -g @openai/codex`             | ChatGPT / OpenAI      | `AGENTS.md`                       |
+| **OpenCode** (`opencode`)                 | `opencode` | `npm i -g opencode-ai`               | your own key, or none | `AGENTS.md`                       |
 
-Claude Code has the most end-to-end mileage inside the harness — it's the most battle-tested — but Copilot, Codex, and
-OpenCode run every flow and are supported first-class, with correspondingly less real-world mileage than Claude Code.
-Bundled skill injection and `bodyFile` forensic capture work on all four backends; only the on-disk skills directory
-differs (`.claude/` / `.github/` / `.agents/` / `.opencode/`). One difference worth knowing: Codex's sandbox has only
-two modes (read-only / workspace-write), so path scope (cwd + `--add-dir`) is its fine-grained safety envelope rather
-than a per-tool deny list. Parallel execution is provider-agnostic — it works with whichever provider each implement
-role is configured to use. Hit a rough edge with any provider? Please [open an
-issue](https://github.com/lukas-grigis/ralphctl/issues).
+**Which one?**
 
-<a id="opencode"></a>
+- **Claude Code** — the most end-to-end mileage inside the harness, and the reference the others are checked
+  against. Per-tool deny lists mean read-only flows are CLI-enforced.
+- **GitHub Copilot CLI** — no extra billing relationship if you already have a seat. Also supports per-tool
+  deny lists, so read-only flows are CLI-enforced.
+- **OpenAI Codex CLI** — a natural fit inside the ChatGPT/OpenAI ecosystem. Its sandbox has two modes only,
+  so path scope is the fine-grained safety envelope.
+- **OpenCode** — vendor-neutral: it fronts 75+ providers and local runtimes on a bring-your-own-key model, so
+  you can run a specific model, a local model, or no account at all.
 
-### OpenCode — bring any model
+Bundled skill injection and forensic capture work on all four; only the on-disk skills directory differs
+(`.claude/` / `.github/` / `.agents/` / `.opencode/`). Parallel execution is provider-agnostic. Claude Code
+has the most real-world mileage simply because it came first — the others are equally supported, with
+correspondingly less of it.
 
-The first three backends each bind you to one vendor. [OpenCode](https://opencode.ai/) doesn't: it is a
-vendor-neutral CLI that fronts **75+ model providers** (via [Models.dev](https://models.dev/)) plus local
-runtimes, on a bring-your-own-key model. Adding it to ralphctl means the harness is no longer limited to the
-three vendors it ships adapters for.
+📖 **[Full provider reference →](./docs/providers.md)** — permission mapping per backend, per-provider setup,
+model ids, mixing backends, and known limitations.
 
-| Want to run…               | With OpenCode                                                   |
-| -------------------------- | --------------------------------------------------------------- |
-| A frontier hosted model    | Anthropic, OpenAI, Google Vertex, Bedrock, Azure — your own key |
-| An aggregator              | OpenRouter, Together, Groq, Hugging Face                        |
-| A specialist or open model | DeepSeek, Mistral, xAI, and the rest of the Models.dev catalog  |
-| Something entirely local   | Ollama, LM Studio, llama.cpp — no data leaves your machine      |
-| Nothing at all set up yet  | OpenCode's own free tier — no account, no key                   |
+Hit a rough edge with any provider? Please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
 
-```bash
-npm install -g opencode-ai
-opencode providers                  # connect Anthropic / OpenAI / Ollama / … with your own keys
-opencode models                     # list every id now reachable
-
-ralphctl settings set ai.implement.generator.provider opencode
-ralphctl settings set ai.implement.generator.model    <provider>/<model>
-```
-
-Model ids are namespaced `<provider>/<model>`, and can carry more than two segments — OpenRouter ids are three
-(`openrouter/moonshotai/kimi-k2`) because the vendor id itself contains a slash, and a custom provider you
-declare yourself can nest just as deep (`myprovider/vendor/slashed-model`). ralphctl doesn't validate against a
-fixed list; it asks the CLI (`opencode models`) for whatever is reachable, so authenticating — or declaring — a
-new provider in OpenCode makes its models selectable in ralphctl immediately, with no ralphctl upgrade and no
-catalog PR. That is the practical difference: **new models become usable the day they land upstream.**
-
-The division of responsibility is deliberate: OpenCode owns authentication, base URLs, and the provider adapter
-package; ralphctl only stores a model id string. ralphctl has no provider or credential configuration of its
-own — everything upstream of the model id lives in OpenCode's config, including a project-level `opencode.json`
-in your repository's working directory, which `opencode models` honours — so per-repo model configuration works
-today with no ralphctl-side setup.
-
-Worked example — wiring up OpenRouter:
-
-```bash
-opencode auth login                       # add your OpenRouter key (or edit opencode.json directly)
-opencode models | grep openrouter         # confirm the ids you now have reachable
-ralphctl settings set ai.implement.generator.provider opencode
-ralphctl settings set ai.implement.generator.model    openrouter/moonshotai/kimi-k2
-```
-
-Mix freely — nothing forces a whole sprint onto one backend. A local model can draft while a frontier model
-reviews:
-
-```bash
-ralphctl settings set ai.implement.generator.provider opencode
-ralphctl settings set ai.implement.generator.model    ollama/<your-local-model>
-ralphctl settings set ai.implement.evaluator.provider claude-code
-ralphctl settings set ai.implement.evaluator.model    claude-opus-5
-```
-
-There is also a zero-auth path if you just want to see the harness run: `ralphctl settings apply-preset
-opencode-only` uses OpenCode's free tier, which needs no credentials at all. Handy for a first look or a CI
-job without secrets — the free-tier models are community models, so point OpenCode at a real provider before
-judging output quality.
-
-**Current limitations, stated plainly.** The adapter is covered by unit and integration tests, same as the
-other three backends, but it has less real-world mileage — please [report anything
-rough](https://github.com/lukas-grigis/ralphctl/issues). `opencode run` has no read-only mode, so a read-only
-flow is not sandboxed by the CLI (the session directory is the boundary, as it already is for OpenAI Codex). It
-also has no flag to grant write access to just one extra directory — permission is all-or-nothing. ralphctl
-writes its `signals.json` results file into a directory outside the project folder, so it passes `--auto` on
-effectively every headless run; without it the AI would sit blocked waiting for an approval that never arrives.
-The practical consequence, same as Codex: on OpenCode the project/session directory is the real safety
-boundary, not the CLI's permission gate. Effort is forwarded only on the headless `run` path (`--variant`); the
-interactive TUI path never receives it. Plateau escalation also skips the effort rung for OpenCode, because the
-accepted `--variant` levels belong to whichever upstream vendor is behind your model id — set `effort`
-explicitly on the row if your model supports it.
-
-One-shot configuration for any provider: `ralphctl settings apply-preset <name>` where `<name>` is one of
-21 presets — `standard`, `economic`, `strong-gate`, `fast`, and `frontier` families, each in
-`mixed` / `claude-only` / `copilot-only` / `codex-only` variants, plus `opencode-only`.
+One-shot configuration: `ralphctl settings apply-preset <name>` where `<name>` is one of 21 presets —
+`standard`, `economic`, `strong-gate`, `fast`, and `frontier` families, each in `mixed` / `claude-only` /
+`copilot-only` / `codex-only` variants, plus `opencode-only`.
 
 ---
 
@@ -340,9 +263,8 @@ One-shot configuration for any provider: `ralphctl settings apply-preset <name>`
   first — the crashed attempt is settled as aborted (kept in history) and a fresh attempt opens automatically
 - **Pair or let it run** — work alongside your AI agent interactively, or let it execute unattended
 - **Zero-memorization start** — run `ralphctl` with no args for a guided menu
-- **Run any model** — the OpenCode backend fronts 75+ providers and local runtimes (Ollama, LM Studio,
-  llama.cpp), so the harness isn't limited to the three vendors it ships adapters for — and its free tier lets you
-  try the whole loop with no account at all
+- **Bring your own model** — four backends to choose from, one of which (OpenCode) is vendor-neutral, so the
+  harness reaches hosted, aggregated, and local models alike
 
 ---
 
@@ -551,6 +473,7 @@ Run `ralphctl <command> --help` for flag-level detail.
 | Resource                                         | Description                                              |
 | ------------------------------------------------ | -------------------------------------------------------- |
 | [Architecture](./ARCHITECTURE.md)                | Data models, harness loop, file storage, error reference |
+| [Providers](./docs/providers.md)                 | Per-backend setup, permission mapping, model ids, limits |
 | [Adding a provider](./docs/adding-a-provider.md) | Extension guide: wire a new AI CLI into the harness      |
 | [Requirements](./.claude/docs/REQUIREMENTS.md)   | Acceptance criteria and feature checklist                |
 | [Contributing](./CONTRIBUTING.md)                | Dev setup, code style, PR process                        |

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ flowchart LR
     class B bad
 ```
 
-Either gate can send the task back: a failed review or a red verify both return to the generator with the
-critique attached, up to `harness.maxAttempts` times.
+Both gates send the task back, but they spend different budgets: a failed review re-runs the generator
+_within_ the same attempt (up to `harness.maxTurns` turns), while a red verify fails the attempt outright and
+opens a fresh one (up to `harness.maxAttempts`, after which the task is flagged `blocked`).
 
 Key properties:
 
@@ -195,7 +196,8 @@ Key properties:
   Opt-in parallelism (`concurrency.maxParallelTasks` > 1) runs independent tasks within a dependency wave concurrently,
   each in its own git worktree folded onto one branch — default stays serial
 - **Generator-evaluator cycle** — an independent AI reviewer checks each task; if it fails, the generator gets the
-  critique and iterates (up to `harness.maxAttempts` tries before the task is flagged `blocked`)
+  critique and iterates (up to `harness.maxTurns` turns per attempt, across at most `harness.maxAttempts`
+  attempts before the task is flagged `blocked`)
 - **Context persistence** — sprint state, branch, progress history, and per-task context survive across sessions;
   interrupted runs resume automatically
 - **Multi-repo support** — one sprint can span several repositories with per-repo setup and verify scripts
@@ -220,14 +222,18 @@ per-row settings.
 
 **Which one?**
 
-- **Claude Code** — the most end-to-end mileage inside the harness, and the reference the others are checked
-  against. Per-tool deny lists mean read-only flows are CLI-enforced.
-- **GitHub Copilot CLI** — no extra billing relationship if you already have a seat. Also supports per-tool
-  deny lists, so read-only flows are CLI-enforced.
+- **Claude Code** — read-only flows deny the edit, shell and network tools at the CLI level, the finest-grained
+  gate of the four.
+- **GitHub Copilot CLI** — no extra billing relationship if you already have a seat. Read-only flows deny the
+  shell tool; file writes stay open, bounded by path scope.
 - **OpenAI Codex CLI** — a natural fit inside the ChatGPT/OpenAI ecosystem. Its sandbox has two modes only,
   so path scope is the fine-grained safety envelope.
 - **OpenCode** — vendor-neutral: it fronts 75+ providers and local runtimes on a bring-your-own-key model, so
   you can run a specific model, a local model, or no account at all.
+
+On every backend the `Write` tool stays open by design — the harness's `signals.json` lands through it — so
+path scope (cwd + mounted roots) is always part of the safety envelope. See the
+[provider reference](./docs/providers.md#permission-model-per-backend) for the exact mapping.
 
 Bundled skill injection and forensic capture work on all four; only the on-disk skills directory differs
 (`.claude/` / `.github/` / `.agents/` / `.opencode/`). Parallel execution is provider-agnostic. Claude Code

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,173 @@
+# Providers
+
+ralphctl drives four AI coding CLIs. All four run every flow and are supported first-class. Pick one per
+flow — or mix them, say plan with one and implement with another — through a preset or per-row settings.
+
+This page is the detailed reference. The [README](../README.md#providers) has the summary.
+
+## At a glance
+
+| Provider                                  | CLI        | Install                              | Auth                  | Context file                      | Skills directory |
+| ----------------------------------------- | ---------- | ------------------------------------ | --------------------- | --------------------------------- | ---------------- |
+| **Claude Code** (`claude-code`)           | `claude`   | `npm i -g @anthropic-ai/claude-code` | Anthropic account     | `CLAUDE.md`                       | `.claude/`       |
+| **GitHub Copilot CLI** (`github-copilot`) | `copilot`  | `npm i -g @github/copilot`           | GitHub Copilot seat   | `.github/copilot-instructions.md` | `.github/`       |
+| **OpenAI Codex CLI** (`openai-codex`)     | `codex`    | `npm i -g @openai/codex`             | ChatGPT / OpenAI      | `AGENTS.md`                       | `.agents/`       |
+| **OpenCode** (`opencode`)                 | `opencode` | `npm i -g opencode-ai`               | your own key, or none | `AGENTS.md`                       | `.opencode/`     |
+
+Bundled skill injection and `bodyFile` forensic capture work on all four. Parallel execution is
+provider-agnostic — it works with whichever provider each implement role is configured to use.
+
+## Permission model per backend
+
+Each CLI exposes a different vocabulary for "let the agent work without asking". ralphctl maps its own
+permission model onto whatever the backend offers:
+
+| Provider           | Headless mapping                                                                                | Fine-grained gate?                |
+| ------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
+| **Claude Code**    | `--permission-mode bypassPermissions` + per-tool deny list                                      | Yes — per-tool deny list          |
+| **GitHub Copilot** | `--autopilot --max-autopilot-continues=200` + `--allow-all` (per-tool deny list when read-only) | Yes — per-tool deny list          |
+| **OpenAI Codex**   | `-s workspace-write` (topology-scoped)                                                          | No — two sandbox modes only       |
+| **OpenCode**       | `--auto` (topology-scoped)                                                                      | No — permission is all-or-nothing |
+
+For Codex and OpenCode, **path topology is the safety envelope** rather than a per-tool deny list. Codex's
+sandbox has only two modes (read-only / workspace-write), so the cwd plus `--add-dir` set defines the scope.
+OpenCode has no per-directory grant at all, and ralphctl writes its `signals.json` results file outside the
+project folder, so it passes `--auto` on effectively every headless run — without it the agent would sit
+blocked waiting for an approval that never arrives. In both cases the session directory is the real boundary.
+
+## Claude Code
+
+The most end-to-end mileage inside the harness — the most battle-tested backend, and the reference
+implementation the others are checked against.
+
+```bash
+npm i -g @anthropic-ai/claude-code
+ralphctl settings apply-preset claude-only
+```
+
+Full per-tool deny lists mean read-only flows are genuinely sandboxed by the CLI, not just by path scope.
+Reads `CLAUDE.md` at the repo root as its native context file; ralphctl's readiness flow writes it.
+
+## GitHub Copilot CLI
+
+Runs every flow, backed by your GitHub Copilot seat.
+
+```bash
+npm i -g @github/copilot
+ralphctl settings apply-preset copilot-only
+```
+
+Autopilot mode is capped at 200 continues per session. Like Claude Code it supports a per-tool deny list, so
+read-only flows are CLI-enforced. Reads `.github/copilot-instructions.md`.
+
+A model showing as "not available" is usually plan gating on your Copilot subscription, not an invalid model
+id — check what your seat includes before assuming a bug.
+
+## OpenAI Codex CLI
+
+Runs every flow, backed by ChatGPT or an OpenAI account.
+
+```bash
+npm i -g @openai/codex
+ralphctl settings apply-preset codex-only
+```
+
+The sandbox has exactly two modes, so every ralphctl profile maps to `workspace-write` — `codex exec`
+read-only blocks every write including `signals.json`, which the harness needs. Path scope is therefore the
+fine-grained safety envelope. Reads `AGENTS.md`.
+
+## OpenCode
+
+The other three each bind you to one vendor. [OpenCode](https://opencode.ai/) doesn't: it's a vendor-neutral
+CLI that fronts **75+ model providers** (via [Models.dev](https://models.dev/)) plus local runtimes, on a
+bring-your-own-key model.
+
+```bash
+npm i -g opencode-ai
+opencode providers        # connect Anthropic / OpenAI / Ollama / … with your own keys
+opencode models           # list every id now reachable
+
+ralphctl settings set ai.implement.generator.provider opencode
+ralphctl settings set ai.implement.generator.model    <provider>/<model>
+```
+
+| Want to run…               | With OpenCode                                                   |
+| -------------------------- | --------------------------------------------------------------- |
+| A frontier hosted model    | Anthropic, OpenAI, Google Vertex, Bedrock, Azure — your own key |
+| An aggregator              | OpenRouter, Together, Groq, Hugging Face                        |
+| A specialist or open model | DeepSeek, Mistral, xAI, and the rest of the Models.dev catalog  |
+| Something entirely local   | Ollama, LM Studio, llama.cpp — no data leaves your machine      |
+| Nothing at all set up yet  | OpenCode's own free tier — no account, no key                   |
+
+### Model ids
+
+Ids are namespaced `<provider>/<model>` and can carry more than two segments — OpenRouter ids are three
+(`openrouter/moonshotai/kimi-k2`) because the vendor id itself contains a slash, and a custom provider you
+declare yourself can nest just as deep (`myprovider/vendor/slashed-model`).
+
+ralphctl doesn't validate against a fixed list; it asks the CLI (`opencode models`) for whatever is reachable,
+so authenticating — or declaring — a new provider in OpenCode makes its models selectable in ralphctl
+immediately, with no ralphctl upgrade and no catalog PR. **New models become usable the day they land
+upstream.**
+
+The division of responsibility is deliberate: OpenCode owns authentication, base URLs, and the provider
+adapter package; ralphctl only stores a model id string. There is no ralphctl-side provider or credential
+configuration — including a project-level `opencode.json` in your repository's working directory, which
+`opencode models` honours, so per-repo model configuration works with no ralphctl-side setup.
+
+### Worked example — OpenRouter
+
+```bash
+opencode auth login                       # add your OpenRouter key (or edit opencode.json directly)
+opencode models | grep openrouter         # confirm the ids you now have reachable
+ralphctl settings set ai.implement.generator.provider opencode
+ralphctl settings set ai.implement.generator.model    openrouter/moonshotai/kimi-k2
+```
+
+### Mixing backends
+
+Nothing forces a whole sprint onto one backend. A local model can draft while a frontier model reviews:
+
+```bash
+ralphctl settings set ai.implement.generator.provider opencode
+ralphctl settings set ai.implement.generator.model    ollama/<your-local-model>
+ralphctl settings set ai.implement.evaluator.provider claude-code
+ralphctl settings set ai.implement.evaluator.model    claude-opus-5
+```
+
+### Zero-auth path
+
+`ralphctl settings apply-preset opencode-only` uses OpenCode's free tier, which needs no credentials at all —
+handy for a first look or a CI job without secrets. The free-tier models are community models, so point
+OpenCode at a real provider before judging output quality.
+
+The free tier rotates as OpenCode swaps models in and out, and individual models occasionally stop serving
+(an upstream `401` on one id while others answer fine). If a free-tier model fails, list what's currently
+reachable and pick another:
+
+```bash
+opencode models | grep free
+```
+
+### OpenCode limitations
+
+- `opencode run` has no read-only mode, so a read-only flow is not sandboxed by the CLI — the session
+  directory is the boundary, as it already is for OpenAI Codex.
+- No flag to grant write access to just one extra directory; permission is all-or-nothing.
+- Reasoning effort is forwarded only on the headless `run` path (`--variant`); the interactive TUI path
+  never receives it.
+- Plateau escalation skips the effort rung, because the accepted `--variant` levels belong to whichever
+  upstream vendor is behind your model id. Set `effort` explicitly on the row if your model supports it.
+
+## Choosing between them
+
+- **Want the most proven path?** Claude Code.
+- **Already have a Copilot seat?** GitHub Copilot CLI — no extra billing relationship.
+- **Live in the ChatGPT/OpenAI ecosystem?** OpenAI Codex CLI.
+- **Want a specific model, a local model, or no account at all?** OpenCode.
+
+Hit a rough edge with any provider? Please [open an issue](https://github.com/lukas-grigis/ralphctl/issues).
+
+## Adding a new provider
+
+See [adding-a-provider.md](./adding-a-provider.md).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,18 +22,24 @@ provider-agnostic — it works with whichever provider each implement role is co
 Each CLI exposes a different vocabulary for "let the agent work without asking". ralphctl maps its own
 permission model onto whatever the backend offers:
 
-| Provider           | Headless mapping                                                                                | Fine-grained gate?                |
-| ------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
-| **Claude Code**    | `--permission-mode bypassPermissions` + per-tool deny list                                      | Yes — per-tool deny list          |
-| **GitHub Copilot** | `--autopilot --max-autopilot-continues=200` + `--allow-all` (per-tool deny list when read-only) | Yes — per-tool deny list          |
-| **OpenAI Codex**   | `-s workspace-write` (topology-scoped)                                                          | No — two sandbox modes only       |
-| **OpenCode**       | `--auto` (topology-scoped)                                                                      | No — permission is all-or-nothing |
+| Provider           | Headless mapping (full-auto)           | Read-only mapping                             | Fine-grained gate?                |
+| ------------------ | -------------------------------------- | --------------------------------------------- | --------------------------------- |
+| **Claude Code**    | `--permission-mode bypassPermissions`  | `--disallowedTools` on edit / shell / network | Yes — per-tool deny list          |
+| **GitHub Copilot** | `--autopilot` + `--allow-all`          | `--allow-all-tools --deny-tool=shell`         | Partial — shell deny only         |
+| **OpenAI Codex**   | `-s workspace-write` (topology-scoped) | same — two sandbox modes only                 | No — two sandbox modes only       |
+| **OpenCode**       | `--auto` (topology-scoped)             | same — no read-only mode                      | No — permission is all-or-nothing |
 
-For Codex and OpenCode, **path topology is the safety envelope** rather than a per-tool deny list. Codex's
-sandbox has only two modes (read-only / workspace-write), so the cwd plus `--add-dir` set defines the scope.
-OpenCode has no per-directory grant at all, and ralphctl writes its `signals.json` results file outside the
-project folder, so it passes `--auto` on effectively every headless run — without it the agent would sit
-blocked waiting for an approval that never arrives. In both cases the session directory is the real boundary.
+**The `Write` tool is never denied, on any backend.** The harness's contract envelope (`signals.json`) lands
+through it, so path scope — cwd plus the mounted roots (`--add-dir` and equivalents) — is always part of the
+safety envelope, not an alternative to the deny list. Claude Code denies the tools that modify _existing_
+files (`Edit` / `MultiEdit` / `NotebookEdit`) plus shell and network; Copilot denies only `shell`; Codex and
+OpenCode have no per-tool gate at all.
+
+For Codex and OpenCode, **path topology is the whole safety envelope**. Codex's sandbox has only two modes
+(read-only / workspace-write), so the cwd plus `--add-dir` set defines the scope. OpenCode has no
+per-directory grant at all, and ralphctl writes `signals.json` outside the project folder, so it passes
+`--auto` on effectively every headless run — without it the agent would sit blocked waiting for an approval
+that never arrives. In both cases the session directory is the real boundary.
 
 ## Claude Code
 
@@ -45,8 +51,9 @@ npm i -g @anthropic-ai/claude-code
 ralphctl settings apply-preset claude-only
 ```
 
-Full per-tool deny lists mean read-only flows are genuinely sandboxed by the CLI, not just by path scope.
-Reads `CLAUDE.md` at the repo root as its native context file; ralphctl's readiness flow writes it.
+The finest-grained gate of the four: read-only flows deny the edit, shell and network tools at the CLI level.
+`Write` stays open by design so `signals.json` can land, bounded by cwd + `--add-dir`. Reads `CLAUDE.md` at
+the repo root as its native context file; ralphctl's readiness flow writes it.
 
 ## GitHub Copilot CLI
 
@@ -57,8 +64,9 @@ npm i -g @github/copilot
 ralphctl settings apply-preset copilot-only
 ```
 
-Autopilot mode is capped at 200 continues per session. Like Claude Code it supports a per-tool deny list, so
-read-only flows are CLI-enforced. Reads `.github/copilot-instructions.md`.
+ralphctl passes `--max-autopilot-continues=200` per spawn, raising Copilot's default budget of 5. Its deny
+list is coarser than Claude Code's: a read-only flow denies `shell` only, so file writes remain available and
+path scope (cwd + `--add-dir`) is what bounds them. Reads `.github/copilot-instructions.md`.
 
 A model showing as "not available" is usually plan gating on your Copilot subscription, not an invalid model
 id — check what your seat includes before assuming a bug.
@@ -84,7 +92,8 @@ bring-your-own-key model.
 
 ```bash
 npm i -g opencode-ai
-opencode providers        # connect Anthropic / OpenAI / Ollama / … with your own keys
+opencode providers login  # connect Anthropic / OpenAI / Ollama / … with your own keys
+opencode providers list   # see what is currently connected
 opencode models           # list every id now reachable
 
 ralphctl settings set ai.implement.generator.provider opencode

--- a/src/business/settings/defaults.ts
+++ b/src/business/settings/defaults.ts
@@ -14,9 +14,15 @@ const CLAUDE_OPUS = 'claude-opus-5';
 const GPT_5_MINI = 'gpt-5-mini';
 const GPT_5_4_MINI = 'gpt-5.4-mini';
 const GPT_5_6_SOL = 'gpt-5.6-sol';
-/** OpenCode free-tier picks — the general-purpose tier and the light/code-oriented tier. */
+/**
+ * OpenCode free-tier picks — the general-purpose tier and the light/code-oriented tier.
+ *
+ * The free tier rotates and individual ids go dark upstream (a 401 on one model while its
+ * siblings answer fine). Both picks here were live-probed against opencode-ai v1.18.15 on
+ * 2026-08-08; re-probe with `opencode models` before changing them.
+ */
 const OPENCODE_BIG = 'opencode/big-pickle';
-const OPENCODE_MINI = 'opencode/north-mini-code-free';
+const OPENCODE_MINI = 'opencode/deepseek-v4-flash-free';
 
 /**
  * Per-provider, per-flow default model picks. Used by the welcome flow when the user picks a

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -89,7 +89,10 @@ const CODEX = 'openai-codex';
 const OPENCODE = 'opencode';
 /** OpenCode free-tier picks — see the note on OPENCODE_ONLY. */
 const OPENCODE_BIG = 'opencode/big-pickle';
-const OPENCODE_MINI = 'opencode/north-mini-code-free';
+// The free tier rotates and individual ids go dark upstream (a 401 on one model while its
+// siblings answer fine). Both picks here were live-probed against opencode-ai v1.18.15 on
+// 2026-08-08; re-probe with `opencode models` before changing them.
+const OPENCODE_MINI = 'opencode/deepseek-v4-flash-free';
 const OPUS = 'claude-opus-5';
 const SONNET = 'claude-sonnet-5';
 const HAIKU = 'claude-haiku-4-5';

--- a/src/domain/value/settings-models/opencode.ts
+++ b/src/domain/value/settings-models/opencode.ts
@@ -24,6 +24,12 @@
  * The free tier rotates as OpenCode swaps in new community models — entries that disappear
  * upstream simply stop being offered by the probe, so a stale line here degrades to a picker
  * entry the CLI rejects, never a crash.
+ *
+ * Catalog membership means "advertised", NOT "known-healthy": a listed id can still fail at
+ * invocation with an upstream `401` while its siblings serve normally (observed for
+ * `opencode/north-mini-code-free` on opencode-ai v1.18.15, 2026-08-08). `opencode models` keeps
+ * listing such ids, so enumeration is not a liveness check — health-probe before promoting an
+ * id to a shipped default.
  */
 export type OpencodeModel =
   | 'opencode/big-pickle'

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
 import { SettingsSchema } from '@src/domain/entity/settings.ts';
-import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import { DEFAULT_SETTINGS, defaultAiSettingsForProvider } from '@src/business/settings/defaults.ts';
 import { FLOW_IDS } from '@src/domain/value/flow-id.ts';
 import { applyPreset, isPresetName, PRESET_NAMES, type PresetName } from '@src/business/settings/presets.ts';
 import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
@@ -110,6 +110,28 @@ describe('presets', () => {
         for (const row of rows) {
           const guard = modelGuardFor(row.provider);
           expect(guard(row.model), `${preset}/${flow}: ${row.provider} → ${row.model}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  // Sibling of the preset check above, for the OTHER table of harness-authored model ids.
+  // `defaultAiSettingsForProvider` feeds the welcome flow and `settings-set-provider`, so an
+  // off-catalog id here ships a first-run config the adapter would reject. defaults.ts was
+  // previously unguarded even though the catalog docstring claimed otherwise.
+  //
+  // Scope: this asserts catalog MEMBERSHIP, not upstream health — a cataloged id that starts
+  // returning 401 (as `opencode/north-mini-code-free` did) still passes. Liveness cannot be
+  // unit-tested; health-probe free-tier ids by hand before shipping one as a default.
+  it('every model in the per-provider defaults is a member of its provider catalog', () => {
+    const providers: readonly AiProvider[] = ['claude-code', 'github-copilot', 'openai-codex', 'opencode'];
+    for (const provider of providers) {
+      const ai = defaultAiSettingsForProvider(provider);
+      for (const flow of FLOW_IDS) {
+        const rows = flow === 'implement' ? [ai.implement.generator, ai.implement.evaluator] : [ai[flow]];
+        for (const row of rows) {
+          const guard = modelGuardFor(row.provider);
+          expect(guard(row.model), `defaults[${provider}]/${flow}: ${row.provider} → ${row.model}`).toBe(true);
         }
       }
     }


### PR DESCRIPTION
## Why

Two unrelated problems, found while attempting the OpenCode manual smoke run.

**1. A shipped default pointed at a dead model.** `opencode/north-mini-code-free` returns an upstream `401` while its free-tier siblings serve normally (7 of 8 catalog models probed healthy). It was the light-tier default in *both* `defaults.ts` and `presets.ts`, so a first run on `opencode-only` failed on every flow. Repointed to `opencode/deepseek-v4-flash-free`, live-probed against opencode-ai v1.18.15.

Not a ralphctl bug in itself — bare `opencode run` reproduces it — but shipping it as the default was.

**2. The README had become OpenCode-dominated.** OpenCode had a `[!TIP]` callout above the fold *plus* an ~80-line dedicated section, while Claude Code / Copilot / Codex got one table row each.

## What changed

- **Provider balance** — one uniform four-row table, one equal-length bullet per provider. Deep per-backend detail moved to a new `docs/providers.md`. Mention counts went from a heavy OpenCode skew to roughly even across the four. This follows how comparable multi-provider tools (LiteLLM, Aider) present provider support: identical formatting, link out for depth.
- **Diagrams** — removed the hidden-annotation-node hack (`classDef note fill:none,stroke:none`), which rendered as stray broken-looking text. Collapsed the implement loop's two swooping back-edges into one join. Every `classDef` now pins a text color so both GitHub themes stay readable. Both diagrams were rendered and visually checked, not just syntax-checked.
- **README is 607 → ~530 lines.**

## Review fixes

An adversarial review raised 20 findings; 11 were rejected on verification, 9 confirmed and fixed. The substantive ones were factual errors in prose I had just written:

- **Copilot read-only is not CLI-enforced beyond shell.** The adapter passes `--allow-all-tools --deny-tool=shell` — file writes stay open. The docs had grouped Copilot with Claude Code.
- **Claude Code leaves `Write` open too** (the `signals.json` envelope lands through it), so "genuinely sandboxed, not just path scope" was too strong. Now states plainly that path scope is part of the envelope on *every* backend.
- **The gen-eval back-edge is bounded by `harness.maxTurns` per attempt, not `harness.maxAttempts`** — a red verify burns an attempt, a failed review re-runs the generator within one. The new prose had merged the two budgets; the pre-existing bullet had the same conflation and is fixed too.
- **`opencode providers` is a command group**; the connecting verb is `providers login`.
- **`defaultAiSettingsForProvider` was unguarded** against the model catalogs even though the catalog docstring claimed otherwise — now covered by a test. Scope is deliberately membership, not liveness: a cataloged id that starts returning 401 still passes, which is why the catalog docstring now records that enumeration is not a health check.

## Verification

`pnpm typecheck` clean · `pnpm lint` at its existing 1-warning cap · `pnpm format:check` clean · **5345 tests pass** (one new). Mermaid re-rendered after the edits.

## Not included

No release. The manual OpenCode TUI smoke run still has not passed end-to-end — the terminal handover works, but the run died on the upstream 401 before `signals.json` was written — so the README continues to claim test coverage only, not live end-to-end verification.

https://claude.ai/code/session_017iha7faWkaPwxybKmRvbwi