### PR TITLE
fix(providers): stop passing prompt bodies in argv

### DIFF
--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -82,6 +82,19 @@ reject-on-nonzero semantics against `osascript` / `notify-send` / `which`. An ES
 importing `node:child_process`'s spawn functions directly, so the two-exception list above is
 enforced at lint time, not by convention.
 
+**A prompt body never travels in argv.** Every adapter writes the rendered prompt to a file and passes the
+CLI a POINTER at that file (`providers/_engine/prompt-pointer.ts`) — headless claude / codex / opencode pipe
+it through stdin instead, which is equivalent for this purpose. Argv is capped at 32,767 bytes on Windows
+(and 8,191 once a `.cmd` shim routes through `cmd.exe`, where the excess is silently TRUNCATED rather than
+reported), well under what a rendered harness prompt reaches — a plan session on Windows died with
+`spawn ENAMETOOLONG` before the CLI started. The one exception is a CLI that cannot be given access to the
+prompt file: OpenCode has no `--add-dir`, so when the prompt lives outside `cwd` the engine inlines the body
+and warns, because a session that cannot read its own brief fails more quietly than a large argv does. Two
+earlier answers to this are on the rejected list and must not return: a `bash -lc "… $(cat promptFile)"`
+wrapper (cannot execute `.cmd` shims, mangles Windows backslash paths, silently dropped the Copilot seed)
+and `shell: true` for binary+args (mis-quotes spaces and `& | % "`). `providers/_engine/argv-budget.ts`
+carries the limits and turns an overflow into a named, non-retryable error instead of a bare errno.
+
 **`AbortError` is the one error chains propagate transparently.** User-initiated cancellation (Ctrl+C, the
 TUI abort hotkey) flows through every wrapper without being absorbed by guards or fallbacks. Anywhere a guard
 or fallback catches errors, it MUST exempt `AbortError`. The chain's `AbortSignal` is now threaded all the

--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -90,9 +90,9 @@ reported), well under what a rendered harness prompt reaches — a plan session 
 `spawn ENAMETOOLONG` before the CLI started. Each adapter grants its CLI read access to the prompt file's
 directory and nothing wider — `--add-dir` for claude / copilot / codex, and for OpenCode (which has no such
 flag) a path-scoped `external_directory` grant injected as `OPENCODE_CONFIG_CONTENT`, which MERGES into the
-operator's own config rather than replacing it. The engine keeps an inline-body fallback for a CLI that can
-be granted nothing at all — no adapter needs it today — because a session that cannot read its own brief
-fails more quietly than a large argv does. Two
+operator's own config rather than replacing it. There is no inline-body fallback: a CLI that can be granted
+no access at all does not belong on this port, since inlining the body for it would just relocate the same
+overflow. Reject such an adapter where it is declared. Two
 earlier answers to this are on the rejected list and must not return: a `bash -lc "… $(cat promptFile)"`
 wrapper (cannot execute `.cmd` shims, mangles Windows backslash paths, silently dropped the Copilot seed)
 and `shell: true` for binary+args (mis-quotes spaces and `& | % "`). `providers/_engine/argv-budget.ts`

--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -87,9 +87,12 @@ CLI a POINTER at that file (`providers/_engine/prompt-pointer.ts`) — headless 
 it through stdin instead, which is equivalent for this purpose. Argv is capped at 32,767 bytes on Windows
 (and 8,191 once a `.cmd` shim routes through `cmd.exe`, where the excess is silently TRUNCATED rather than
 reported), well under what a rendered harness prompt reaches — a plan session on Windows died with
-`spawn ENAMETOOLONG` before the CLI started. The one exception is a CLI that cannot be given access to the
-prompt file: OpenCode has no `--add-dir`, so when the prompt lives outside `cwd` the engine inlines the body
-and warns, because a session that cannot read its own brief fails more quietly than a large argv does. Two
+`spawn ENAMETOOLONG` before the CLI started. Each adapter grants its CLI read access to the prompt file's
+directory and nothing wider — `--add-dir` for claude / copilot / codex, and for OpenCode (which has no such
+flag) a path-scoped `external_directory` grant injected as `OPENCODE_CONFIG_CONTENT`, which MERGES into the
+operator's own config rather than replacing it. The engine keeps an inline-body fallback for a CLI that can
+be granted nothing at all — no adapter needs it today — because a session that cannot read its own brief
+fails more quietly than a large argv does. Two
 earlier answers to this are on the rejected list and must not return: a `bash -lc "… $(cat promptFile)"`
 wrapper (cannot execute `.cmd` shims, mangles Windows backslash paths, silently dropped the Copilot seed)
 and `shell: true` for binary+args (mis-quotes spaces and `& | % "`). `providers/_engine/argv-budget.ts`

--- a/.claude/skills/claude-integration/SKILL.md
+++ b/.claude/skills/claude-integration/SKILL.md
@@ -43,6 +43,13 @@ import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engin
   its own UI); the TUI's alt-screen state is suspended and restored on the way back. Used by `refine` /
   `plan` / `ideate` / `readiness` flows that need a human at the keyboard.
 
+**Prompt delivery — never the body in argv.** Headless claude / codex / opencode pipe the prompt through
+stdin. Interactive cannot (stdin piping flips these CLIs out of interactive mode) and neither can copilot
+headless (that CLI has no stdin prompt path), so those write the prompt to a file and pass a POINTER at it —
+`_engine/prompt-pointer.ts`. Argv caps at 32,767 bytes on Windows and a rendered plan prompt clears that on
+its own; inlining it produced `spawn ENAMETOOLONG` before the CLI ever started. `_engine/argv-budget.ts`
+names an overflow in the error rather than leaving a bare errno.
+
 ## File-based provider contract
 
 ralphctl does NOT parse stdout for signals or session IDs. Instead, every spawn passes paths to two files:
@@ -59,7 +66,8 @@ The per-spawn audit / sandbox layout is:
 
 ```
 <sprintDir>/<flow>/<unit>/rounds/<N>/{generator,evaluator}/
-├── prompt.md           ← rendered prompt (input)
+├── prompt.md           ← rendered prompt (input); the CLI is pointed at this file, not handed its text
+├── copilot-prompt.md   ← copilot headless only: the exact prompt that spawn was given
 ├── signals.json        ← parsed structured signals (output, provider-written)
 ├── session-id.txt      ← provider's session id (output)
 └── evaluation.md       ← rendered evaluator verdict (evaluator role only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **AI sessions no longer die with `spawn ENAMETOOLONG` on Windows.** The rendered prompt was passed to the
+  CLI as a command-line argument, and Windows caps a command line at 32,767 characters — which a plan or
+  refine prompt reaches on its own once a sprint has some history behind it. The session failed before the
+  CLI had started, with nothing in the error pointing at the cause. The prompt now stays in the file the
+  harness already writes and the CLI is pointed at it, so command-line size no longer tracks prompt size.
+  Affected every interactive flow (`plan`, `refine`, `ideate`, learning-distill) on all four providers, plus
+  headless GitHub Copilot. Two related failures were fixed alongside it: a spawn that failed synchronously —
+  which is how Windows reports this — escaped as an unhandled exception instead of failing the round, and an
+  oversized command line was retried until the attempt budget ran out even though every retry rebuilt the
+  same command. There is one deliberate carve-out: OpenCode can only read files under its project directory,
+  so when the prompt lives elsewhere (`ideate`, learning-distill) it is still passed inline, with a warning
+  in the log.
 - **The OpenCode free-tier default no longer points at a model that refuses every request.**
   `opencode/north-mini-code-free` returns an upstream `401` while its free-tier siblings serve normally, and
   it was the shipped light-tier default in both the per-provider defaults and the `opencode-only` preset — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,9 @@ to [Semantic Versioning](https://semver.org/).
   headless GitHub Copilot. Two related failures were fixed alongside it: a spawn that failed synchronously —
   which is how Windows reports this — escaped as an unhandled exception instead of failing the round, and an
   oversized command line was retried until the attempt budget ran out even though every retry rebuilt the
-  same command. There is one deliberate carve-out: OpenCode can only read files under its project directory,
-  so when the prompt lives elsewhere (`ideate`, learning-distill) it is still passed inline, with a warning
-  in the log.
+  same command. OpenCode needed one extra step, since it has no `--add-dir` and refuses paths outside its
+  project directory: it is now granted read access to the prompt file's directory alone, layered onto your
+  own OpenCode config rather than replacing it.
 - **The OpenCode free-tier default no longer points at a model that refuses every request.**
   `opencode/north-mini-code-free` returns an upstream `401` while its free-tier siblings serve normally, and
   it was the shipped light-tier default in both the per-provider defaults and the `opencode-only` preset — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ to [Semantic Versioning](https://semver.org/).
   oversized command line was retried until the attempt budget ran out even though every retry rebuilt the
   same command. OpenCode needed one extra step, since it has no `--add-dir` and refuses paths outside its
   project directory: it is now granted read access to the prompt file's directory alone, layered onto your
-  own OpenCode config rather than replacing it.
+  own OpenCode config rather than replacing it. Copilot in headless mode gets the same treatment, since it
+  is the one CLI that cannot take a prompt on stdin.
 - **The OpenCode free-tier default no longer points at a model that refuses every request.**
   `opencode/north-mini-code-free` returns an upstream `401` while its free-tier siblings serve normally, and
   it was the shipped light-tier default in both the per-provider defaults and the `opencode-only` preset — so

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -187,6 +187,18 @@ the full shape):
   on clean exit **and** on signals-present recovery, so a watchdog SIGTERM that landed after the
   agent finished still counts as success.
 
+### Prompt delivery — keep the body out of argv
+
+`stdin: session.prompt` above is not a stylistic choice. A Windows command line caps at 32,767
+bytes (8,191 once an npm/winget `.cmd` shim routes through `cmd.exe`, where the excess is silently
+truncated instead of reported), and a rendered harness prompt clears that on its own — passing the
+body as an argument produced `spawn ENAMETOOLONG` before the CLI had started.
+
+So: pipe the prompt through stdin when your CLI accepts it. When it does not — the interactive
+port cannot, since piping stdin flips most CLIs out of interactive mode — write the prompt to a
+file and pass a pointer at it with `buildPromptPointer(path)` from
+`_engine/prompt-pointer.ts`, and make sure the file's directory is among the roots you mount.
+
 Companion file `src/integration/ai/providers/_engine/gemini-provider-deps.ts` declares the
 composition-root inputs (`rateLimitRetries`, `eventBus`, and the test seams `spawn?` / `command?`
 / `idleMs?` / `backoffSchedule?`). Copy `claude-provider-deps.ts` and rename. It lives in

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -37,9 +37,11 @@ OpenCode have no per-tool gate at all.
 
 For Codex and OpenCode, **path topology is the whole safety envelope**. Codex's sandbox has only two modes
 (read-only / workspace-write), so the cwd plus `--add-dir` set defines the scope. OpenCode has no
-per-directory grant at all, and ralphctl writes `signals.json` outside the project folder, so it passes
-`--auto` on effectively every headless run — without it the agent would sit blocked waiting for an approval
-that never arrives. In both cases the session directory is the real boundary.
+`--add-dir` flag; its per-directory grants live in config instead (`permission.external_directory`), and
+ralphctl writes `signals.json` outside the project folder. Interactive sessions get exactly one such grant,
+scoped to the directory holding the prompt file and layered onto your own config. Headless runs still pass
+`--auto` — without it the agent would sit blocked waiting for an approval that never arrives. In both cases
+the session directory is the real boundary.
 
 ## Claude Code
 

--- a/src/integration/ai/providers/_engine/argv-budget.ts
+++ b/src/integration/ai/providers/_engine/argv-budget.ts
@@ -20,13 +20,17 @@
  */
 
 /** `CreateProcessW` `lpCommandLine` ceiling, including the terminating null. */
-export const WINDOWS_COMMAND_LINE_LIMIT = 32_767;
+const WINDOWS_COMMAND_LINE_LIMIT = 32_767;
 
 /**
  * `cmd.exe` ceiling. Not enforced here — it is the SILENT band, so there is no error to classify —
  * but it is the number the hint quotes when explaining why staying well under the ceiling matters.
  */
-export const CMD_EXE_COMMAND_LINE_LIMIT = 8_191;
+const CMD_EXE_COMMAND_LINE_LIMIT = 8_191;
+
+/** Best-effort errno for any thrown or emitted spawn cause, including a non-`Error` rejection. */
+export const errnoOf = (cause: unknown): string | undefined =>
+  cause instanceof Error ? ((cause as NodeJS.ErrnoException).code ?? cause.name) : undefined;
 
 /** Total bytes a command line occupies: the binary, every argument, and one separator each. */
 export const argvByteLength = (command: string, args: readonly string[]): number =>
@@ -46,7 +50,8 @@ export const isArgvOverflow = (errno: string | undefined, argvBytes: number): bo
  * points at the prompt file, because an oversized argv on this codebase means a prompt body leaked
  * back into it.
  */
-export const argvOverflowHint = (argvBytes: number, promptFile?: string): string =>
-  `command line is ${String(argvBytes)} bytes, past the ${String(WINDOWS_COMMAND_LINE_LIMIT)}-byte Windows limit ` +
-  `(${String(CMD_EXE_COMMAND_LINE_LIMIT)} when a .cmd shim routes through cmd.exe) — the prompt body belongs in ` +
-  `${promptFile ?? 'a file the CLI reads'}, not in argv`;
+export const argvOverflowHint = (argvBytes?: number, promptFile?: string): string =>
+  `command line is past the ${String(WINDOWS_COMMAND_LINE_LIMIT)}-byte Windows limit` +
+  `${argvBytes === undefined ? '' : ` (measured ${String(argvBytes)} bytes)`}` +
+  ` (${String(CMD_EXE_COMMAND_LINE_LIMIT)} when a .cmd shim routes through cmd.exe) — ` +
+  `the prompt body belongs in ${promptFile ?? 'a file the CLI reads'}, not in argv`;

--- a/src/integration/ai/providers/_engine/argv-budget.ts
+++ b/src/integration/ai/providers/_engine/argv-budget.ts
@@ -1,0 +1,52 @@
+/**
+ * Argv-size accounting shared by the interactive engine and the headless spawn classifier.
+ *
+ * Windows caps a process command line at 32,767 characters including the terminating null
+ * (`CreateProcessW` / `lpCommandLine`), and `cmd.exe` — which `cross-spawn` routes through when it
+ * resolves an npm / winget `.cmd` shim — caps at 8,191. The two fail differently, and the second
+ * one is the nastier of the pair:
+ *
+ *  - above 32,767 the spawn fails outright and Node surfaces `ENAMETOOLONG` (win32) or `E2BIG`
+ *    (darwin / linux);
+ *  - between 8,191 and 32,767 `CreateProcess` SUCCEEDS and `cmd.exe` silently truncates, so the
+ *    child starts with a mangled command line and no error is raised anywhere.
+ *
+ * Nothing here can prevent the silent band — only keeping prompt bodies out of argv does that (see
+ * `prompt-pointer.ts`). What this module provides is the diagnosis: a byte count for the message,
+ * and a predicate that recognises an overflow even when the errno is unhelpful. Overflow does not
+ * always arrive as `ENAMETOOLONG`; the same condition has been observed surfacing as
+ * `ERROR_INVALID_PARAMETER` on Windows, so the byte count is checked alongside the errno rather
+ * than trusting the errno alone.
+ */
+
+/** `CreateProcessW` `lpCommandLine` ceiling, including the terminating null. */
+export const WINDOWS_COMMAND_LINE_LIMIT = 32_767;
+
+/**
+ * `cmd.exe` ceiling. Not enforced here — it is the SILENT band, so there is no error to classify —
+ * but it is the number the hint quotes when explaining why staying well under the ceiling matters.
+ */
+export const CMD_EXE_COMMAND_LINE_LIMIT = 8_191;
+
+/** Total bytes a command line occupies: the binary, every argument, and one separator each. */
+export const argvByteLength = (command: string, args: readonly string[]): number =>
+  args.reduce((total, arg) => total + Buffer.byteLength(arg, 'utf8') + 1, Buffer.byteLength(command, 'utf8'));
+
+/**
+ * Whether a spawn failure is an argv / command-line overflow. Matches the two errnos the kernels
+ * raise, plus any failure at all once the assembled command line is already past the Windows
+ * ceiling — at that size no other explanation is more likely, and the errno cannot be relied on.
+ */
+export const isArgvOverflow = (errno: string | undefined, argvBytes: number): boolean =>
+  errno === 'ENAMETOOLONG' || errno === 'E2BIG' || argvBytes >= WINDOWS_COMMAND_LINE_LIMIT;
+
+/**
+ * The actionable half of an overflow message. Names the measured size against the ceiling it
+ * breached so the next occurrence identifies itself instead of arriving as a bare errno — and
+ * points at the prompt file, because an oversized argv on this codebase means a prompt body leaked
+ * back into it.
+ */
+export const argvOverflowHint = (argvBytes: number, promptFile?: string): string =>
+  `command line is ${String(argvBytes)} bytes, past the ${String(WINDOWS_COMMAND_LINE_LIMIT)}-byte Windows limit ` +
+  `(${String(CMD_EXE_COMMAND_LINE_LIMIT)} when a .cmd shim routes through cmd.exe) — the prompt body belongs in ` +
+  `${promptFile ?? 'a file the CLI reads'}, not in argv`;

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -5,7 +5,7 @@ import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import { pathExists } from '@src/integration/io/fs.ts';
-import { argvOverflowHint, isArgvOverflow } from '@src/integration/ai/providers/_engine/argv-budget.ts';
+import { argvOverflowHint, errnoOf, isArgvOverflow } from '@src/integration/ai/providers/_engine/argv-budget.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
 
@@ -197,9 +197,9 @@ export const classifySpawnFailure = (
   cause: NodeJS.ErrnoException,
   argvBytes?: number
 ): AttemptOutcome => {
-  const errno = cause.code ?? cause.name;
+  const errno = errnoOf(cause);
   if (isArgvOverflow(errno, argvBytes ?? 0)) {
-    const hint = argvOverflowHint(argvBytes ?? 0);
+    const hint = argvOverflowHint(argvBytes);
     return {
       kind: 'error',
       error: new InvalidStateError({

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -5,6 +5,7 @@ import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import { pathExists } from '@src/integration/io/fs.ts';
+import { argvOverflowHint, isArgvOverflow } from '@src/integration/ai/providers/_engine/argv-budget.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
 
@@ -100,6 +101,12 @@ export interface ClassifySpawnExitInput {
      * branch — a spawn error means the child never ran, so `code` / `signal` carry no signal.
      */
     readonly spawnError?: NodeJS.ErrnoException;
+    /**
+     * Size of the command line that was attempted, when the caller measured it. Lets the spawn-
+     * error branch recognise an argv overflow whose errno is unhelpful — the same condition has
+     * been seen surfacing as `ERROR_INVALID_PARAMETER` rather than `ENAMETOOLONG`.
+     */
+    readonly argvBytes?: number;
   };
   readonly stderr: string;
   /**
@@ -166,19 +173,53 @@ const classifyPreExit = ({ session, exit, providerName }: ClassifySpawnExitInput
   }
 
   if (exit.spawnError !== undefined) {
-    const errno = exit.spawnError.code ?? exit.spawnError.name;
-    return {
-      kind: 'error',
-      error: new ProcessCrashError({
-        entity: providerName,
-        state: 'spawn-failed',
-        message: `${providerName}: spawn failed: ${errno} — ${exit.spawnError.message}`,
-        hint: 'verify the provider CLI is installed and on PATH',
-      }),
-    };
+    return classifySpawnFailure(providerName, exit.spawnError, exit.argvBytes);
   }
 
   return undefined;
+};
+
+/**
+ * Turn a spawn-level failure into an outcome. Shared by the pre-exit branch above and by the
+ * synchronous-throw path in `runProviderAttempt` — `cross-spawn` raises an oversized command line
+ * synchronously on Windows, so a classifier that only handled the async `'error'` event would let
+ * exactly this bug escape as an unhandled exception.
+ *
+ * An argv overflow is NOT transient: the same command line is assembled on every attempt, so a
+ * retryable `ProcessCrash` would burn the whole budget re-spawning something that can never fit.
+ * It is also not a PATH problem, so the default hint would send an operator looking in the wrong
+ * place. Non-retryable config error instead, carrying the measured size.
+ *
+ * @public
+ */
+export const classifySpawnFailure = (
+  providerName: ProviderName,
+  cause: NodeJS.ErrnoException,
+  argvBytes?: number
+): AttemptOutcome => {
+  const errno = cause.code ?? cause.name;
+  if (isArgvOverflow(errno, argvBytes ?? 0)) {
+    const hint = argvOverflowHint(argvBytes ?? 0);
+    return {
+      kind: 'error',
+      error: new InvalidStateError({
+        entity: providerName,
+        currentState: 'spawn-failed',
+        attemptedAction: 'complete generation',
+        message: `${providerName}: spawn failed: ${errno} — ${hint}`,
+        hint,
+      }),
+    };
+  }
+  return {
+    kind: 'error',
+    error: new ProcessCrashError({
+      entity: providerName,
+      state: 'spawn-failed',
+      message: `${providerName}: spawn failed: ${errno} — ${cause.message}`,
+      hint: 'verify the provider CLI is installed and on PATH',
+    }),
+  };
 };
 
 /**

--- a/src/integration/ai/providers/_engine/interactive-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/interactive-ai-provider.ts
@@ -12,8 +12,11 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
  * caller reads that file separately after `run` resolves.
  *
  * The prompt is delivered as a file path ({@link InteractiveAiProviderInput.promptFile}) — the
- * caller writes the rendered prompt to disk first, then the AI is told to read it. This
- * mirrors how interactive coding-assistant CLIs prefer file inputs over giant CLI args.
+ * caller writes the rendered prompt to disk first, then the AI is told to read it. Adapters put a
+ * pointer at that file in the CLI's prompt slot; the body itself must not travel as an argument,
+ * because argv is capped (32,767 bytes on Windows) well below what a rendered harness prompt
+ * reaches. `_engine/prompt-pointer.ts` owns that contract, including the one CLI that cannot
+ * always be given access to the file.
  *
  * Result semantics:
  *  - `Result.ok({ sessionId? })` — AI exited cleanly. Caller reads `outputFile`. The

--- a/src/integration/ai/providers/_engine/interactive-ai-provider.ts
+++ b/src/integration/ai/providers/_engine/interactive-ai-provider.ts
@@ -15,8 +15,8 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
  * caller writes the rendered prompt to disk first, then the AI is told to read it. Adapters put a
  * pointer at that file in the CLI's prompt slot; the body itself must not travel as an argument,
  * because argv is capped (32,767 bytes on Windows) well below what a rendered harness prompt
- * reaches. `_engine/prompt-pointer.ts` owns that contract, including the one CLI that cannot
- * always be given access to the file.
+ * reaches. `_engine/prompt-pointer.ts` owns that contract, including how each adapter grants its
+ * CLI access to the file it is pointed at.
  *
  * Result semantics:
  *  - `Result.ok({ sessionId? })` — AI exited cleanly. Caller reads `outputFile`. The

--- a/src/integration/ai/providers/_engine/interactive-spawn.ts
+++ b/src/integration/ai/providers/_engine/interactive-spawn.ts
@@ -13,7 +13,18 @@ import { crossPlatformSpawn } from '@src/integration/io/cross-platform-spawn.ts'
 export type InteractiveSpawn = (
   command: string,
   args: readonly string[],
-  options: { readonly stdio: 'inherit'; readonly cwd: string }
+  options: {
+    readonly stdio: 'inherit';
+    readonly cwd: string;
+    /**
+     * Extra environment entries layered over the harness's own `process.env`, for CLIs that take
+     * launch configuration through the environment rather than through flags. OpenCode is the
+     * only one today: it has no `--add-dir`, so the directory grant that lets it read the prompt
+     * file arrives as `OPENCODE_CONFIG_CONTENT`. Absent for every other adapter, which then
+     * inherits the parent environment untouched.
+     */
+    readonly env?: Readonly<Record<string, string>>;
+  }
 ) => ChildProcess;
 
 /**
@@ -21,9 +32,16 @@ export type InteractiveSpawn = (
  * on Windows and the positional prompt arg (which may contain spaces / shell metacharacters) is
  * escaped correctly without a shell. Each interactive adapter carried a byte-identical local copy;
  * this is the one shared impl. Tests inject a fake `spawn` to avoid launching a real binary.
+ *
+ * `env` is LAYERED over `process.env` rather than replacing it — a child launched with a bare
+ * override would lose PATH, HOME, and the provider's own credential variables.
  */
 export const defaultInteractiveSpawn: InteractiveSpawn = (command, args, options) =>
-  crossPlatformSpawn(command, args, { stdio: options.stdio, cwd: options.cwd });
+  crossPlatformSpawn(command, args, {
+    stdio: options.stdio,
+    cwd: options.cwd,
+    ...(options.env !== undefined ? { env: { ...process.env, ...options.env } } : {}),
+  });
 
 /** Default prompt-file reader shared by the interactive adapters (tests inject a fake `readFile`). */
 export const defaultReadFile = (path: string): Promise<string> => fs.readFile(path, 'utf8');

--- a/src/integration/ai/providers/_engine/interactive-spawn.ts
+++ b/src/integration/ai/providers/_engine/interactive-spawn.ts
@@ -17,8 +17,10 @@ export type InteractiveSpawn = (
     readonly stdio: 'inherit';
     readonly cwd: string;
     /**
-     * Extra environment entries layered over the harness's own `process.env`, for CLIs that take
-     * launch configuration through the environment rather than through flags. OpenCode is the
+     * Extra environment entries for a CLI that takes launch configuration through the environment
+     * rather than through flags. These are OVERRIDES — merging them over `process.env` is
+     * {@link defaultInteractiveSpawn}'s job, so a test fake sees exactly what the adapter declared
+     * rather than the whole merged environment. OpenCode is the
      * only one today: it has no `--add-dir`, so the directory grant that lets it read the prompt
      * file arrives as `OPENCODE_CONFIG_CONTENT`. Absent for every other adapter, which then
      * inherits the parent environment untouched.

--- a/src/integration/ai/providers/_engine/prompt-pointer.ts
+++ b/src/integration/ai/providers/_engine/prompt-pointer.ts
@@ -43,12 +43,14 @@ const isWithin = (root: string, candidate: string): boolean => {
  * is, because a CLI that cannot read the path fails by starting an empty session rather than by
  * erroring, which is far harder to diagnose than the overflow it replaced.
  *
- * `mountsRoots` is true for the CLIs that take `--add-dir` (claude / copilot / codex): the engine
- * mounts `dirname(promptFile)` for them, so the file is always reachable. OpenCode has no
- * `--add-dir` equivalent — its single positional project directory is the whole topology — so for
- * it the prompt file has to live under `cwd` on its own. It does for plan and refine (both run
- * with the per-run sandbox as cwd) and does not for ideate or memory-distill (both run with a
- * repository as cwd), which is why this is a runtime check rather than a per-provider constant.
+ * `mountsRoots` says the adapter has some way to grant its CLI access to the prompt file's
+ * directory, whatever that mechanism is: `--add-dir` for claude / copilot / codex, and a scoped
+ * `external_directory` config grant for OpenCode, which has no such flag. All four can today, so
+ * the second arm is a safety net rather than a live path — it exists so a future adapter for a CLI
+ * that cannot be granted anything degrades to a working (if large) argv instead of opening a
+ * session that silently has no instructions. `cwd` is a per-run sandbox for plan and refine but a
+ * repository for ideate and memory-distill, so where the prompt sits relative to it is a runtime
+ * question, not a per-provider constant.
  */
 export const isPromptFileReachable = (cwd: string, promptFile: string, mountsRoots: boolean): boolean =>
   mountsRoots || isWithin(cwd, promptFile);

--- a/src/integration/ai/providers/_engine/prompt-pointer.ts
+++ b/src/integration/ai/providers/_engine/prompt-pointer.ts
@@ -1,0 +1,54 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+
+/**
+ * How a rendered prompt reaches an interactive AI CLI: as a POINTER to the file the harness
+ * already wrote, never as the body itself.
+ *
+ * The body used to travel as a plain argv element, which put every interactive session one long
+ * `PRIOR_PROGRESS` section away from `spawn ENAMETOOLONG` on Windows — the plan template alone is
+ * ~22 KB before a single substitution, against a 32,767-byte command line (see `argv-budget.ts`).
+ * A pointer is a fixed ~250 bytes regardless of prompt size, so argv size stops tracking prompt
+ * size at all.
+ *
+ * Two earlier answers to the same problem are on the rejected list and must not come back:
+ * `bash -lc "claude … \"$(cat promptFile)\""` (Windows backslash paths do not survive `cat` inside
+ * bash, bash cannot execute the npm / winget `.cmd` shims, and it silently dropped the seed on
+ * Copilot) and `shell: true` for binary+args (mis-quotes arguments containing spaces or `& | % "`).
+ * The pointer needs neither — it is an ordinary argument to a directly-spawned binary.
+ */
+
+/**
+ * The argv element handed to the CLI in place of the prompt body.
+ *
+ * Deliberately ONE line: on Windows `cross-spawn` folds every argument into a single
+ * `cmd.exe /d /s /c "…"` string when it resolves a `.cmd` shim, and an embedded CR/LF there is a
+ * command separator rather than text. The path is passed absolute — `cwd` is the per-run sandbox
+ * for some flows and the repository for others, so a relative path would resolve differently
+ * depending on which flow launched the session.
+ */
+export const buildPromptPointer = (promptFile: string): string =>
+  `Your complete instructions for this session are in the file ${promptFile}. Read that entire file first, before any other action, then carry out exactly what it says — it is the full brief, already written to disk, so there is nothing further to wait for or ask about.`;
+
+/** Case-fold only where the filesystem does, so a `C:\Users` / `c:\users` mismatch is not a miss. */
+const forCompare = (path: string): string => (process.platform === 'win32' ? path.toLowerCase() : path);
+
+/** Whether `candidate` resolves to a location inside `root` (a path equal to the root does not count). */
+const isWithin = (root: string, candidate: string): boolean => {
+  const rel = relative(forCompare(resolve(root)), forCompare(resolve(candidate)));
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+};
+
+/**
+ * Whether the CLI will actually be able to open the prompt file — the pointer is only safe when it
+ * is, because a CLI that cannot read the path fails by starting an empty session rather than by
+ * erroring, which is far harder to diagnose than the overflow it replaced.
+ *
+ * `mountsRoots` is true for the CLIs that take `--add-dir` (claude / copilot / codex): the engine
+ * mounts `dirname(promptFile)` for them, so the file is always reachable. OpenCode has no
+ * `--add-dir` equivalent — its single positional project directory is the whole topology — so for
+ * it the prompt file has to live under `cwd` on its own. It does for plan and refine (both run
+ * with the per-run sandbox as cwd) and does not for ideate or memory-distill (both run with a
+ * repository as cwd), which is why this is a runtime check rather than a per-provider constant.
+ */
+export const isPromptFileReachable = (cwd: string, promptFile: string, mountsRoots: boolean): boolean =>
+  mountsRoots || isWithin(cwd, promptFile);

--- a/src/integration/ai/providers/_engine/prompt-pointer.ts
+++ b/src/integration/ai/providers/_engine/prompt-pointer.ts
@@ -1,14 +1,18 @@
-import { isAbsolute, relative, resolve } from 'node:path';
-
 /**
  * How a rendered prompt reaches an interactive AI CLI: as a POINTER to the file the harness
- * already wrote, never as the body itself.
+ * already wrote, never as the body.
  *
  * The body used to travel as a plain argv element, which put every interactive session one long
  * `PRIOR_PROGRESS` section away from `spawn ENAMETOOLONG` on Windows — the plan template alone is
  * ~22 KB before a single substitution, against a 32,767-byte command line (see `argv-budget.ts`).
  * A pointer is a fixed ~250 bytes regardless of prompt size, so argv size stops tracking prompt
  * size at all.
+ *
+ * Every adapter grants its CLI read access to the pointer's directory and nothing wider:
+ * `--add-dir` for claude / copilot / codex, and a path-scoped `external_directory` config grant for
+ * OpenCode, which has no such flag. A CLI that could be granted nothing at all has no place in this
+ * port — inlining the body for it would just move the same overflow one layer down — so it should
+ * be rejected where the adapter is declared, not quietly handed an unbounded command line.
  *
  * Two earlier answers to the same problem are on the rejected list and must not come back:
  * `bash -lc "claude … \"$(cat promptFile)\""` (Windows backslash paths do not survive `cat` inside
@@ -28,29 +32,3 @@ import { isAbsolute, relative, resolve } from 'node:path';
  */
 export const buildPromptPointer = (promptFile: string): string =>
   `Your complete instructions for this session are in the file ${promptFile}. Read that entire file first, before any other action, then carry out exactly what it says — it is the full brief, already written to disk, so there is nothing further to wait for or ask about.`;
-
-/** Case-fold only where the filesystem does, so a `C:\Users` / `c:\users` mismatch is not a miss. */
-const forCompare = (path: string): string => (process.platform === 'win32' ? path.toLowerCase() : path);
-
-/** Whether `candidate` resolves to a location inside `root` (a path equal to the root does not count). */
-const isWithin = (root: string, candidate: string): boolean => {
-  const rel = relative(forCompare(resolve(root)), forCompare(resolve(candidate)));
-  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
-};
-
-/**
- * Whether the CLI will actually be able to open the prompt file — the pointer is only safe when it
- * is, because a CLI that cannot read the path fails by starting an empty session rather than by
- * erroring, which is far harder to diagnose than the overflow it replaced.
- *
- * `mountsRoots` says the adapter has some way to grant its CLI access to the prompt file's
- * directory, whatever that mechanism is: `--add-dir` for claude / copilot / codex, and a scoped
- * `external_directory` config grant for OpenCode, which has no such flag. All four can today, so
- * the second arm is a safety net rather than a live path — it exists so a future adapter for a CLI
- * that cannot be granted anything degrades to a working (if large) argv instead of opening a
- * session that silently has no instructions. `cwd` is a per-run sandbox for plan and refine but a
- * repository for ideate and memory-distill, so where the prompt sits relative to it is a runtime
- * question, not a per-provider constant.
- */
-export const isPromptFileReachable = (cwd: string, promptFile: string, mountsRoots: boolean): boolean =>
-  mountsRoots || isWithin(cwd, promptFile);

--- a/src/integration/ai/providers/_engine/resolve-roots.ts
+++ b/src/integration/ai/providers/_engine/resolve-roots.ts
@@ -18,12 +18,25 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
  * De-duplication is by exact string equality on the `AbsolutePath` brand. Order is
  * preserved: caller-declared roots first, outputDir last when it adds new value.
  */
-export const resolveWritableRoots = (session: AiSession): readonly AbsolutePath[] => {
-  const declared = session.additionalRoots ?? [];
-  if (session.outputDir === undefined) return declared;
-  const cwdStr = String(session.cwd);
-  const outputStr = String(session.outputDir);
-  if (outputStr === cwdStr) return declared;
-  if (declared.some((r) => String(r) === outputStr)) return declared;
-  return [...declared, session.outputDir];
+export const resolveWritableRoots = (session: AiSession): readonly AbsolutePath[] =>
+  appendRoot(session.additionalRoots ?? [], session.outputDir, String(session.cwd));
+
+/**
+ * Append one more root unless it adds nothing — it is `cwd` (implicitly mounted) or already
+ * declared. Exported because an adapter can have a root of its own to mount that the session does
+ * not know about: copilot headless writes the prompt file the CLI is pointed at, and that
+ * directory has to be readable. Keeping the "worth mounting" rule in one place stops each such
+ * adapter from open-coding its own copy.
+ *
+ * @public
+ */
+export const appendRoot = (
+  roots: readonly AbsolutePath[],
+  candidate: AbsolutePath | undefined,
+  cwd: string
+): readonly AbsolutePath[] => {
+  if (candidate === undefined) return roots;
+  const value = String(candidate);
+  if (value === cwd || roots.some((r) => String(r) === value)) return roots;
+  return [...roots, candidate];
 };

--- a/src/integration/ai/providers/_engine/run-interactive-session.ts
+++ b/src/integration/ai/providers/_engine/run-interactive-session.ts
@@ -11,8 +11,13 @@ import {
   defaultInteractiveSpawn,
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
-import { argvByteLength, argvOverflowHint, isArgvOverflow } from '@src/integration/ai/providers/_engine/argv-budget.ts';
-import { buildPromptPointer, isPromptFileReachable } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
+import {
+  argvByteLength,
+  argvOverflowHint,
+  errnoOf,
+  isArgvOverflow,
+} from '@src/integration/ai/providers/_engine/argv-budget.ts';
+import { buildPromptPointer } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
 import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
@@ -93,14 +98,6 @@ export interface InteractiveProviderSpec {
    */
   readonly supportsSessionId: boolean;
   /**
-   * Whether the CLI can be handed directory roots (`--add-dir` or equivalent), which decides
-   * whether the prompt file is reachable from wherever the harness put it. Claude / Copilot /
-   * Codex can; OpenCode cannot — its single positional project directory is the whole topology —
-   * so it only sees a prompt file that already lives under `cwd`. Drives the pointer-vs-body
-   * decision in {@link isPromptFileReachable}.
-   */
-  readonly mountsRoots: boolean;
-  /**
    * Environment entries this CLI needs at launch, layered over the harness's own environment.
    * Present only for a CLI configured through the environment rather than through flags —
    * OpenCode, which receives its prompt-directory grant this way because it has no `--add-dir`.
@@ -128,32 +125,12 @@ const dedupeRoots = (input: InteractiveAiProviderInput): readonly string[] => {
 };
 
 /**
- * Decide what occupies the CLI's prompt slot. Normally the pointer; the body only when the CLI
- * could not open the file it points at, which today means OpenCode running with the prompt outside
- * `cwd` (ideate, memory-distill). The fallback is warned about rather than silent — it is the one
- * remaining path where a large prompt can still overflow argv, so an operator hitting the limit
- * there gets the size in the log rather than only an errno at spawn time.
+ * Read the rendered prompt off disk, mapping any read failure to a `StorageError`.
+ *
+ * The contents are discarded — the CLI reads the file itself. This is a pre-flight: it turns a
+ * missing, unreadable, or permission-denied prompt file into a clear error BEFORE the terminal is
+ * handed over, which a `stat`-based existence check would not (it passes on EACCES).
  */
-const resolvePromptArg = (
-  deps: InteractiveProviderDeps,
-  spec: InteractiveProviderSpec,
-  input: InteractiveAiProviderInput,
-  body: string
-): string => {
-  const promptFile = String(input.promptFile);
-  if (isPromptFileReachable(String(input.cwd), promptFile, spec.mountsRoots)) return buildPromptPointer(promptFile);
-
-  deps.eventBus.publish({
-    type: 'log',
-    level: 'warn',
-    message: `${spec.providerName}: prompt file is outside the session's only readable root — passing the prompt inline (${String(Buffer.byteLength(body, 'utf8'))} bytes)`,
-    meta: { promptFile, cwd: String(input.cwd) },
-    at: IsoTimestamp.now(),
-  });
-  return body;
-};
-
-/** Read the rendered prompt off disk, mapping any read failure to a `StorageError`. */
 const readPrompt = async (
   readFile: (path: string) => Promise<string>,
   input: InteractiveAiProviderInput,
@@ -178,33 +155,38 @@ const readPrompt = async (
  * is not enough to recognise it (the same condition has been seen arriving as
  * `ERROR_INVALID_PARAMETER`), so the measured byte count decides too.
  */
-const describeSpawnFailure = (providerName: string, cause: unknown, argvBytes: number, promptFile: string): string => {
-  const errno = cause instanceof Error ? ((cause as NodeJS.ErrnoException).code ?? cause.name) : undefined;
-  if (!isArgvOverflow(errno, argvBytes)) return `${providerName}: failed to spawn — ${messageOf(cause)}`;
-  return `${providerName}: failed to spawn — ${messageOf(cause)} — ${argvOverflowHint(argvBytes, promptFile)}`;
+const spawnFailure = (
+  providerName: string,
+  cause: unknown,
+  command: string,
+  args: readonly string[],
+  promptFile: string
+): StorageError => {
+  const argvBytes = argvByteLength(command, args);
+  const overflow = isArgvOverflow(errnoOf(cause), argvBytes) ? ` — ${argvOverflowHint(argvBytes, promptFile)}` : '';
+  return new StorageError({
+    subCode: 'io',
+    message: `${providerName}: failed to spawn — ${messageOf(cause)}${overflow}`,
+    cause,
+  });
 };
 
-/** Hand the terminal to the CLI. A throwing spawn (missing binary, EACCES) becomes a `StorageError`. */
+/**
+ * Hand the terminal to the CLI. A throwing spawn (missing binary, EACCES, a command line the OS
+ * refuses) surfaces the raw cause; the caller turns it into a `StorageError` so the two spawn
+ * failure paths — this throw and the async `'error'` event — report identically.
+ */
 const spawnSession = (
   spawnFn: InteractiveSpawn,
   command: string,
   args: readonly string[],
-  input: InteractiveAiProviderInput,
-  providerName: string,
+  cwd: string,
   env: Readonly<Record<string, string>> | undefined
-): Result<ChildProcess, StorageError> => {
+): Result<ChildProcess, unknown> => {
   try {
-    return Result.ok(
-      spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd), ...(env !== undefined ? { env } : {}) })
-    );
+    return Result.ok(spawnFn(command, args, { stdio: 'inherit', cwd, ...(env !== undefined ? { env } : {}) }));
   } catch (cause) {
-    return Result.error(
-      new StorageError({
-        subCode: 'io',
-        message: describeSpawnFailure(providerName, cause, argvByteLength(command, args), String(input.promptFile)),
-        cause,
-      })
-    );
+    return Result.error(cause);
   }
 };
 
@@ -299,13 +281,10 @@ export const createInteractiveProvider = (
       });
       if (!validated.ok) return Result.error(validated.error);
 
-      // Read-through even though the body no longer reaches argv: it is the pre-flight that turns
-      // a missing / unreadable prompt file into a clear error before the terminal is handed over,
-      // and it supplies the body for the unreachable-file fallback below.
       const prompt = await readPrompt(readFile, input, spec.providerName);
       if (!prompt.ok) return Result.error(prompt.error);
 
-      const promptArg = resolvePromptArg(deps, spec, input, prompt.value);
+      const promptArg = buildPromptPointer(String(input.promptFile));
       const sessionId = spec.supportsSessionId ? newSessionId() : undefined;
       const args = spec.buildArgs(input, { promptArg, roots: dedupeRoots(input), sessionId });
 
@@ -321,8 +300,10 @@ export const createInteractiveProvider = (
         at: IsoTimestamp.now(),
       });
 
-      const spawned = spawnSession(spawnFn, command, args, input, spec.providerName, spec.buildEnv?.(input));
-      if (!spawned.ok) return Result.error(spawned.error);
+      const spawned = spawnSession(spawnFn, command, args, String(input.cwd), spec.buildEnv?.(input));
+      if (!spawned.ok) {
+        return Result.error(spawnFailure(spec.providerName, spawned.error, command, args, String(input.promptFile)));
+      }
 
       const exit = await awaitExit(spawned.value, input.abortSignal);
 
@@ -336,18 +317,7 @@ export const createInteractiveProvider = (
       // A late spawn failure outranks the synthetic `-1`, but not an abort — a user cancel that
       // races the child's teardown must still propagate as AbortError.
       if (exit.spawnError !== undefined && input.abortSignal?.aborted !== true) {
-        return Result.error(
-          new StorageError({
-            subCode: 'io',
-            message: describeSpawnFailure(
-              spec.providerName,
-              exit.spawnError,
-              argvByteLength(command, args),
-              String(input.promptFile)
-            ),
-            cause: exit.spawnError,
-          })
-        );
+        return Result.error(spawnFailure(spec.providerName, exit.spawnError, command, args, String(input.promptFile)));
       }
 
       const failure = classifyExit(spec.providerName, input.abortSignal, exit.code);

--- a/src/integration/ai/providers/_engine/run-interactive-session.ts
+++ b/src/integration/ai/providers/_engine/run-interactive-session.ts
@@ -11,6 +11,8 @@ import {
   defaultInteractiveSpawn,
   defaultReadFile,
 } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+import { argvByteLength, argvOverflowHint, isArgvOverflow } from '@src/integration/ai/providers/_engine/argv-budget.ts';
+import { buildPromptPointer, isPromptFileReachable } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
 import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
@@ -32,20 +34,32 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  * small ways (one skipped the suspension check, one hardcoded its own name in an error) precisely
  * because the skeleton was copied rather than shared.
  *
- * The prompt is read in Node and handed to the CLI as a plain argv element rather than through a
- * `bash -lc "… $(cat promptFile)"` wrapper. That wrapper broke on Windows twice over: Git Bash
- * cannot execute the `.cmd` shims npm/winget install, and Windows backslash paths do not survive
- * bash path resolution inside a command string. Spawning the binary directly through
- * `crossPlatformSpawn` resolves the shim and escapes a prompt containing spaces or `& | % "`
- * without a shell.
+ * The prompt travels as a POINTER to the file the caller already rendered — a fixed-size argv
+ * element naming the path — not as the body. Passing the body inlined argv size to prompt size,
+ * and the interactive templates outgrew the Windows command-line ceiling: a plan session died with
+ * `spawn ENAMETOOLONG` before Claude ever started. See `prompt-pointer.ts` for the pointer and
+ * `argv-budget.ts` for the limits. The one exception is a CLI that cannot be given access to the
+ * prompt file (OpenCode with a prompt outside `cwd`), which falls back to the inlined body with a
+ * warning rather than opening a session that can read nothing.
+ *
+ * The binary is spawned directly through `crossPlatformSpawn`, which resolves the npm / winget
+ * `.cmd` shims and escapes arguments containing spaces or `& | % "` without a shell. Neither a
+ * `bash -lc "… $(cat promptFile)"` wrapper nor `shell: true` may come back: the first cannot
+ * execute `.cmd` shims, mangles Windows backslash paths inside `$(cat …)`, and silently dropped
+ * the seeded prompt on Copilot; the second mis-quotes exactly the arguments listed above.
  *
  * Pause-the-host (Ink) is not the adapter's responsibility — that lives in the leaf, which wraps
  * `interactiveAi.run(...)` in `runInTerminal(...)`. Keeping the adapter pure means it behaves the
  * same under the TUI, the plain CLI, and tests.
  */
 export interface InteractiveSessionContext {
-  /** Prompt-file contents, already read from disk. */
-  readonly prompt: string;
+  /**
+   * What goes in the CLI's prompt slot: normally a short pointer at `input.promptFile`
+   * ({@link buildPromptPointer}), and only when that file would be unreachable — OpenCode with a
+   * prompt outside `cwd` — the prompt body itself. Adapters place it verbatim; the decision is the
+   * engine's so no adapter can reintroduce an unbounded argv element on its own.
+   */
+  readonly promptArg: string;
   /**
    * Directory roots to mount, de-duplicated and ordered: `cwd`, then any `additionalRoots`, then
    * the directories holding `outputFile` and `promptFile`. Each CLI spells the flag differently
@@ -78,6 +92,14 @@ export interface InteractiveProviderSpec {
    * absence as non-fatal.
    */
   readonly supportsSessionId: boolean;
+  /**
+   * Whether the CLI can be handed directory roots (`--add-dir` or equivalent), which decides
+   * whether the prompt file is reachable from wherever the harness put it. Claude / Copilot /
+   * Codex can; OpenCode cannot — its single positional project directory is the whole topology —
+   * so it only sees a prompt file that already lives under `cwd`. Drives the pointer-vs-body
+   * decision in {@link isPromptFileReachable}.
+   */
+  readonly mountsRoots: boolean;
   /** Assemble the CLI's argv from the caller's input plus the shared session context. */
   readonly buildArgs: (input: InteractiveAiProviderInput, context: InteractiveSessionContext) => readonly string[];
 }
@@ -99,6 +121,32 @@ const dedupeRoots = (input: InteractiveAiProviderInput): readonly string[] => {
   return [...new Set(all)];
 };
 
+/**
+ * Decide what occupies the CLI's prompt slot. Normally the pointer; the body only when the CLI
+ * could not open the file it points at, which today means OpenCode running with the prompt outside
+ * `cwd` (ideate, memory-distill). The fallback is warned about rather than silent — it is the one
+ * remaining path where a large prompt can still overflow argv, so an operator hitting the limit
+ * there gets the size in the log rather than only an errno at spawn time.
+ */
+const resolvePromptArg = (
+  deps: InteractiveProviderDeps,
+  spec: InteractiveProviderSpec,
+  input: InteractiveAiProviderInput,
+  body: string
+): string => {
+  const promptFile = String(input.promptFile);
+  if (isPromptFileReachable(String(input.cwd), promptFile, spec.mountsRoots)) return buildPromptPointer(promptFile);
+
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'warn',
+    message: `${spec.providerName}: prompt file is outside the session's only readable root — passing the prompt inline (${String(Buffer.byteLength(body, 'utf8'))} bytes)`,
+    meta: { promptFile, cwd: String(input.cwd) },
+    at: IsoTimestamp.now(),
+  });
+  return body;
+};
+
 /** Read the rendered prompt off disk, mapping any read failure to a `StorageError`. */
 const readPrompt = async (
   readFile: (path: string) => Promise<string>,
@@ -118,42 +166,63 @@ const readPrompt = async (
   }
 };
 
+/**
+ * Describe a spawn failure. An argv overflow gets named as such — it used to surface as a bare
+ * `failed to spawn — spawn ENAMETOOLONG` with nothing pointing at the cause, and the errno alone
+ * is not enough to recognise it (the same condition has been seen arriving as
+ * `ERROR_INVALID_PARAMETER`), so the measured byte count decides too.
+ */
+const describeSpawnFailure = (providerName: string, cause: unknown, argvBytes: number, promptFile: string): string => {
+  const errno = cause instanceof Error ? ((cause as NodeJS.ErrnoException).code ?? cause.name) : undefined;
+  if (!isArgvOverflow(errno, argvBytes)) return `${providerName}: failed to spawn — ${messageOf(cause)}`;
+  return `${providerName}: failed to spawn — ${messageOf(cause)} — ${argvOverflowHint(argvBytes, promptFile)}`;
+};
+
 /** Hand the terminal to the CLI. A throwing spawn (missing binary, EACCES) becomes a `StorageError`. */
 const spawnSession = (
   spawnFn: InteractiveSpawn,
   command: string,
   args: readonly string[],
-  cwd: string,
+  input: InteractiveAiProviderInput,
   providerName: string
 ): Result<ChildProcess, StorageError> => {
   try {
-    return Result.ok(spawnFn(command, args, { stdio: 'inherit', cwd }));
+    return Result.ok(spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd) }));
   } catch (cause) {
     return Result.error(
       new StorageError({
         subCode: 'io',
-        message: `${providerName}: failed to spawn — ${messageOf(cause)}`,
+        message: describeSpawnFailure(providerName, cause, argvByteLength(command, args), String(input.promptFile)),
         cause,
       })
     );
   }
 };
 
+/** How a session ended: an exit code, or the spawn-level failure that arrived asynchronously. */
+interface SessionExit {
+  readonly code: number | null;
+  readonly spawnError?: unknown;
+}
+
 /**
  * Run the child to completion under the abort kill-ladder. A `stdio: 'inherit'` child is
  * unreachable once spawned (the harness keeps no reference past `run`), so a TUI-side cancel can't
  * stop it — the caller's abort signal drives a SIGTERM → grace → SIGKILL ladder instead, and the
  * cleanup runs on normal exit so a reused AbortController never fires kill against a dead pid.
- * An `error` event (spawn-level failure after launch) maps to `-1`.
+ *
+ * An `error` event is a spawn-level failure that surfaced after launch rather than as a throw. Its
+ * cause is carried out rather than collapsed into the `-1` code alone: an argv overflow can arrive
+ * on either path, and reporting one of them as `session exited with code -1` hid the real cause.
  */
-const awaitExit = async (child: ChildProcess, abortSignal: AbortSignal | undefined): Promise<number | null> => {
+const awaitExit = async (child: ChildProcess, abortSignal: AbortSignal | undefined): Promise<SessionExit> => {
   const stopAbortKill = attachAbortKill(child, abortSignal);
-  const exitCode = await new Promise<number | null>((resolve) => {
-    child.on('close', (code) => resolve(code));
-    child.on('error', () => resolve(-1));
+  const exit = await new Promise<SessionExit>((resolve) => {
+    child.on('close', (code) => resolve({ code }));
+    child.on('error', (cause) => resolve({ code: -1, spawnError: cause }));
   });
   stopAbortKill();
-  return exitCode;
+  return exit;
 };
 
 /**
@@ -221,11 +290,15 @@ export const createInteractiveProvider = (
       });
       if (!validated.ok) return Result.error(validated.error);
 
+      // Read-through even though the body no longer reaches argv: it is the pre-flight that turns
+      // a missing / unreadable prompt file into a clear error before the terminal is handed over,
+      // and it supplies the body for the unreachable-file fallback below.
       const prompt = await readPrompt(readFile, input, spec.providerName);
       if (!prompt.ok) return Result.error(prompt.error);
 
+      const promptArg = resolvePromptArg(deps, spec, input, prompt.value);
       const sessionId = spec.supportsSessionId ? newSessionId() : undefined;
-      const args = spec.buildArgs(input, { prompt: prompt.value, roots: dedupeRoots(input), sessionId });
+      const args = spec.buildArgs(input, { promptArg, roots: dedupeRoots(input), sessionId });
 
       deps.eventBus.publish({
         type: 'log',
@@ -239,19 +312,36 @@ export const createInteractiveProvider = (
         at: IsoTimestamp.now(),
       });
 
-      const spawned = spawnSession(spawnFn, command, args, String(input.cwd), spec.providerName);
+      const spawned = spawnSession(spawnFn, command, args, input, spec.providerName);
       if (!spawned.ok) return Result.error(spawned.error);
 
-      const exitCode = await awaitExit(spawned.value, input.abortSignal);
+      const exit = await awaitExit(spawned.value, input.abortSignal);
 
       deps.eventBus.publish({
         type: 'log',
         level: 'info',
-        message: `${spec.providerName}: session exited (code=${String(exitCode ?? 'null')})`,
+        message: `${spec.providerName}: session exited (code=${String(exit.code ?? 'null')})`,
         at: IsoTimestamp.now(),
       });
 
-      const failure = classifyExit(spec.providerName, input.abortSignal, exitCode);
+      // A late spawn failure outranks the synthetic `-1`, but not an abort — a user cancel that
+      // races the child's teardown must still propagate as AbortError.
+      if (exit.spawnError !== undefined && input.abortSignal?.aborted !== true) {
+        return Result.error(
+          new StorageError({
+            subCode: 'io',
+            message: describeSpawnFailure(
+              spec.providerName,
+              exit.spawnError,
+              argvByteLength(command, args),
+              String(input.promptFile)
+            ),
+            cause: exit.spawnError,
+          })
+        );
+      }
+
+      const failure = classifyExit(spec.providerName, input.abortSignal, exit.code);
       if (failure !== undefined) return Result.error(failure);
 
       if (sessionId === undefined) return Result.ok({});

--- a/src/integration/ai/providers/_engine/run-interactive-session.ts
+++ b/src/integration/ai/providers/_engine/run-interactive-session.ts
@@ -100,6 +100,12 @@ export interface InteractiveProviderSpec {
    * decision in {@link isPromptFileReachable}.
    */
   readonly mountsRoots: boolean;
+  /**
+   * Environment entries this CLI needs at launch, layered over the harness's own environment.
+   * Present only for a CLI configured through the environment rather than through flags —
+   * OpenCode, which receives its prompt-directory grant this way because it has no `--add-dir`.
+   */
+  readonly buildEnv?: (input: InteractiveAiProviderInput) => Readonly<Record<string, string>>;
   /** Assemble the CLI's argv from the caller's input plus the shared session context. */
   readonly buildArgs: (input: InteractiveAiProviderInput, context: InteractiveSessionContext) => readonly string[];
 }
@@ -184,10 +190,13 @@ const spawnSession = (
   command: string,
   args: readonly string[],
   input: InteractiveAiProviderInput,
-  providerName: string
+  providerName: string,
+  env: Readonly<Record<string, string>> | undefined
 ): Result<ChildProcess, StorageError> => {
   try {
-    return Result.ok(spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd) }));
+    return Result.ok(
+      spawnFn(command, args, { stdio: 'inherit', cwd: String(input.cwd), ...(env !== undefined ? { env } : {}) })
+    );
   } catch (cause) {
     return Result.error(
       new StorageError({
@@ -312,7 +321,7 @@ export const createInteractiveProvider = (
         at: IsoTimestamp.now(),
       });
 
-      const spawned = spawnSession(spawnFn, command, args, input, spec.providerName);
+      const spawned = spawnSession(spawnFn, command, args, input, spec.providerName, spec.buildEnv?.(input));
       if (!spawned.ok) return Result.error(spawned.error);
 
       const exit = await awaitExit(spawned.value, input.abortSignal);

--- a/src/integration/ai/providers/_engine/run-provider-attempt.ts
+++ b/src/integration/ai/providers/_engine/run-provider-attempt.ts
@@ -11,7 +11,12 @@ import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { contextWindowFor } from '@src/integration/ai/providers/_engine/context-window.ts';
 import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
-import { classifySpawnExit, type ProviderName } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import {
+  classifySpawnExit,
+  classifySpawnFailure,
+  type ProviderName,
+} from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import { argvByteLength } from '@src/integration/ai/providers/_engine/argv-budget.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 
 export type { ProviderName };
@@ -241,15 +246,26 @@ const createSuccessHandler =
 export const runProviderAttempt = async (input: ProviderAttemptInput): Promise<AttemptOutcome> => {
   const { spawnFn, command, args, session, resolveOn, rateLimitRe, providerName, providerSlug, eventBus } = input;
 
-  const child = spawnFn(command, args, {
-    stdio: ['pipe', 'pipe', 'pipe'] as const,
-    cwd: String(session.cwd),
-  });
+  const argvBytes = argvByteLength(command, args);
+
+  // `crossPlatformSpawn` throws synchronously for a command line the OS refuses outright — an
+  // oversized argv on Windows arrives this way, not as an `'error'` event — so an uncaught call
+  // here would take the whole process down instead of failing the attempt.
+  let child;
+  try {
+    child = spawnFn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'] as const,
+      cwd: String(session.cwd),
+    });
+  } catch (cause) {
+    return classifySpawnFailure(providerName, cause as NodeJS.ErrnoException, argvBytes);
+  }
+
   const stderrTail = createBoundedTail(STDERR_TAIL_CAP);
   const watchdogBannerId = `watchdog-${providerSlug}-${String(child.pid ?? 'unknown')}`;
   const idle = createIdleTelemetry(input, watchdogBannerId);
 
-  const { code, signal } = await runHeadlessSpawn({
+  const { code, signal, spawnError } = await runHeadlessSpawn({
     child,
     onStdout: (chunk) => {
       input.onStdoutChunk(chunk);
@@ -269,7 +285,9 @@ export const runProviderAttempt = async (input: ProviderAttemptInput): Promise<A
   const stdoutTail = input.getStdoutTail();
   return classifySpawnExit({
     session,
-    exit: { code, signal },
+    // `spawnError` was previously dropped here, which left the classifier's spawn-error branch
+    // unreachable from this path — a missing binary read as a plain non-zero exit.
+    exit: { code, signal, argvBytes, ...(spawnError !== undefined ? { spawnError } : {}) },
     stderr: stderrTail.value(),
     rateLimitRe,
     ...(stdoutTail !== undefined && stdoutTail.length > 0 ? { stdoutTail } : {}),

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -32,7 +32,6 @@ export const createInteractiveClaudeProvider = (deps: InteractiveProviderDeps): 
       modelCatalogLabel: 'Claude',
       isKnownModel: isClaudeModel,
       supportsSessionId: true,
-      mountsRoots: true,
       buildArgs: (input, { promptArg, roots, sessionId }) => [
         ...roots.flatMap((p) => ['--add-dir', p]),
         '--model',

--- a/src/integration/ai/providers/claude/interactive.ts
+++ b/src/integration/ai/providers/claude/interactive.ts
@@ -11,7 +11,11 @@ import { isClaudeModel } from '@src/domain/value/settings-models/claude.ts';
  *
  *   claude --add-dir <cwd> --add-dir <dirname(outputFile)> [--add-dir <extra>...]
  *          --model <model> --permission-mode acceptEdits --session-id <uuid>
- *          [--effort <level>] <prompt>
+ *          [--effort <level>] <pointer at promptFile>
+ *
+ * The prompt slot carries a pointer at the rendered prompt file, never its body — see
+ * `_engine/prompt-pointer.ts`. `--add-dir` mounts the file's directory, so the pointer always
+ * resolves.
  *
  * Permission strategy: `acceptEdits` auto-approves the `Edit` / `Write` tools — but only for paths
  * inside one of the `--add-dir` roots, which is why the engine mounts the prompt / output
@@ -28,7 +32,8 @@ export const createInteractiveClaudeProvider = (deps: InteractiveProviderDeps): 
       modelCatalogLabel: 'Claude',
       isKnownModel: isClaudeModel,
       supportsSessionId: true,
-      buildArgs: (input, { prompt, roots, sessionId }) => [
+      mountsRoots: true,
+      buildArgs: (input, { promptArg, roots, sessionId }) => [
         ...roots.flatMap((p) => ['--add-dir', p]),
         '--model',
         input.model,
@@ -38,7 +43,7 @@ export const createInteractiveClaudeProvider = (deps: InteractiveProviderDeps): 
         // Forward the resolved effort verbatim — the CLI rejects unknown levels itself, so
         // re-validating here would only duplicate its catalog (mirrors the headless adapter).
         ...(input.effort !== undefined ? ['--effort', input.effort] : []),
-        prompt,
+        promptArg,
       ],
     },
     deps

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -35,7 +35,6 @@ export const createInteractiveCodexProvider = (deps: InteractiveProviderDeps): I
       modelCatalogLabel: 'Codex',
       isKnownModel: isCodexModel,
       supportsSessionId: false,
-      mountsRoots: true,
       buildArgs: (input, { promptArg, roots }) => [
         '--cd',
         String(input.cwd),

--- a/src/integration/ai/providers/codex/interactive.ts
+++ b/src/integration/ai/providers/codex/interactive.ts
@@ -9,7 +9,11 @@ import { isCodexModel } from '@src/domain/value/settings-models/codex.ts';
  * optional positional prompt — `codex "explain this codebase"`.
  *
  *   codex --cd <cwd> --add-dir <root>... --model <model> -s workspace-write -a never
- *         [-c model_reasoning_effort=<level>] <prompt>
+ *         [-c model_reasoning_effort=<level>] <pointer at promptFile>
+ *
+ * The positional prompt slot carries a pointer at the rendered prompt file, never its body — see
+ * `_engine/prompt-pointer.ts`. `--add-dir` mounts the file's directory, so the pointer always
+ * resolves.
  *
  * `-s workspace-write -a never` matches Claude's `--permission-mode acceptEdits` intent: writes
  * inside a mounted root run without a confirmation step, so the AI can drop its answer in
@@ -31,7 +35,8 @@ export const createInteractiveCodexProvider = (deps: InteractiveProviderDeps): I
       modelCatalogLabel: 'Codex',
       isKnownModel: isCodexModel,
       supportsSessionId: false,
-      buildArgs: (input, { prompt, roots }) => [
+      mountsRoots: true,
+      buildArgs: (input, { promptArg, roots }) => [
         '--cd',
         String(input.cwd),
         ...roots.flatMap((p) => ['--add-dir', p]),
@@ -45,7 +50,7 @@ export const createInteractiveCodexProvider = (deps: InteractiveProviderDeps): I
         // levels itself, so re-validating here would only duplicate its catalog (mirrors the
         // headless adapter).
         ...(input.effort !== undefined ? ['-c', `model_reasoning_effort=${input.effort}`] : []),
-        prompt,
+        promptArg,
       ],
     },
     deps

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { buildPromptPointer } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
@@ -10,7 +11,7 @@ import {
 } from '@src/integration/ai/providers/_engine/bounded-tail.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { HeadlessProviderDeps } from '@src/integration/ai/providers/_engine/headless-provider-deps.ts';
-import { resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
+import { appendRoot, resolveWritableRoots } from '@src/integration/ai/providers/_engine/resolve-roots.ts';
 import type { SessionPermissions } from '@src/integration/ai/providers/_engine/session-permissions.ts';
 import type { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -193,18 +194,17 @@ export const buildCopilotArgs = (
     // prompts which `--no-ask-user` turns into refusals.
     args.push('--allow-all-tools', '--deny-tool=shell');
   }
-  // Auto-mount `outputDir` so signals.json can land via the write tool. See resolve-roots.ts.
-  const roots = resolveWritableRoots(session).map((r) => String(r));
-  // …and the prompt file's directory, or the pointer would name a path the read tool may not open.
-  // Usually already mounted (it is `outputDir` for most callers); mounting twice is harmless, so
-  // dedupe rather than assume.
-  const promptDir = promptFile === undefined ? undefined : dirname(promptFile);
-  const mounted =
-    promptDir === undefined || promptDir === String(session.cwd) || roots.includes(promptDir)
-      ? roots
-      : [...roots, promptDir];
-  for (const root of mounted) {
-    args.push(`--add-dir=${root}`);
+  // Auto-mount `outputDir` so signals.json can land via the write tool (see resolve-roots.ts), and
+  // the prompt file's directory, or the pointer would name a path the read tool may not open. The
+  // two are usually the same directory, which `appendRoot` folds out.
+  const promptDir = promptFile === undefined ? undefined : AbsolutePath.parse(dirname(promptFile));
+  const roots = appendRoot(
+    resolveWritableRoots(session),
+    promptDir?.ok === true ? promptDir.value : undefined,
+    String(session.cwd)
+  );
+  for (const root of roots) {
+    args.push(`--add-dir=${String(root)}`);
   }
   args.push('-p', promptFile === undefined ? session.prompt : buildPromptPointer(promptFile));
   return Result.ok(args);
@@ -307,8 +307,13 @@ const createOnLine =
  */
 const createCopilotAttempt = (deps: HeadlessProviderDeps, spawnFn: ProviderSpawn, command: string) => {
   return async (attemptSession: AiSession) => {
+    // Validate before writing: an unknown / suspended model fails argv construction, and paying
+    // for an mkdir + atomic write for a spawn that never happens would leave a stray artifact.
+    const dryRun = buildCopilotArgs(attemptSession);
+    if (!dryRun.ok) return { kind: 'error' as const, error: dryRun.error };
+
     const promptFile = await materializeCopilotPrompt(deps, attemptSession);
-    const built = buildCopilotArgs(attemptSession, promptFile);
+    const built = promptFile === undefined ? dryRun : buildCopilotArgs(attemptSession, promptFile);
     if (!built.ok) return { kind: 'error' as const, error: built.error };
 
     const parser = createCopilotStreamParser();

--- a/src/integration/ai/providers/copilot/headless.ts
+++ b/src/integration/ai/providers/copilot/headless.ts
@@ -1,4 +1,7 @@
+import { dirname, join } from 'node:path';
 import { Result } from '@src/domain/result.ts';
+import { buildPromptPointer } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
+import { writeTextAtomic } from '@src/integration/io/fs.ts';
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import {
   FORENSIC_BODY_TAIL_CAP,
@@ -38,14 +41,20 @@ import {
  *   | permissions read-only (no edit, no shell)             | `--allow-all-tools --deny-tool=shell`              |
  *   | resume: <id>                                          | `--resume=<id>`                                    |
  *   | effort: <level>                                       | `--effort=<level>`                                 |
- *   | prompt                                                | argv: `-p <prompt>`                                |
+ *   | prompt                                                | file + argv: `-p <pointer at that file>`           |
  *
  * Resume note: current Copilot CLI accepts `--resume[=VALUE]` with `-p` / `--prompt`.
  * The adapter forwards {@link AiSession.resume} when present so headless runs can re-attach
  * to a prior session id.
  *
- * Copilot's prompt is passed as a CLI argument (`-p <text>`) rather than piped via stdin.
- * Argv length is the OS limit (~2MB on macOS); revisit if a chain hits it.
+ * Copilot is the one CLI of the four with no stdin prompt path — the sibling adapters pipe the
+ * body in, and `--prompt-file` is an open, unimplemented request upstream (copilot-cli#3398). So
+ * the adapter writes the prompt to `copilot-prompt.md` next to `signals.json`, mounts that
+ * directory, and passes a POINTER at the file in `-p`. Passing the body itself capped every
+ * headless run at the platform command line — 32,767 bytes on Windows, which a harness prompt
+ * clears easily, and the failure arrives as an opaque `spawn ENAMETOOLONG`. If the file cannot be
+ * written the adapter warns and falls back to the inlined body: a large argv is a risk, a session
+ * with no prompt at all is a certainty. See `_engine/prompt-pointer.ts` and `_engine/argv-budget.ts`.
  *
  * Read-only permission denies `shell` only — the `write` tool stays open because the
  * audit-[09] contract requires the AI to land `signals.json` in `outputDir` via Copilot's
@@ -96,11 +105,47 @@ const isFullAuto = (p: SessionPermissions): boolean => p.autoApprove && p.canMod
 
 const PROVIDER_NAME = 'copilot-provider';
 
+/** Filename the adapter writes the prompt to. Distinct from the flow-written `prompt.md` in the
+ * same directory, which stays the record of what the round was asked to do — this one tracks what
+ * THIS spawn was handed, and a corrective re-invocation legitimately overwrites it. */
+const COPILOT_PROMPT_FILENAME = 'copilot-prompt.md';
+
+/**
+ * Put the prompt on disk so argv only has to carry a pointer. Lands next to `signals.json`, which
+ * is where the flow's own per-run artifacts live and is inside a mounted root for every caller.
+ *
+ * Returns `undefined` when the write fails — the caller then inlines the body, so a full disk
+ * degrades a run's Windows headroom rather than failing it outright.
+ */
+const materializeCopilotPrompt = async (
+  deps: HeadlessProviderDeps,
+  session: AiSession
+): Promise<string | undefined> => {
+  const path = join(dirname(String(session.signalsFile)), COPILOT_PROMPT_FILENAME);
+  const wrote = await writeTextAtomic(path, session.prompt);
+  if (wrote.ok) return path;
+
+  deps.eventBus.publish({
+    type: 'log',
+    level: 'warn',
+    message: `${PROVIDER_NAME}: could not write ${COPILOT_PROMPT_FILENAME} — passing the prompt inline (${String(Buffer.byteLength(session.prompt, 'utf8'))} bytes)`,
+    meta: { path, error: wrote.error.message },
+    at: IsoTimestamp.now(),
+  });
+  return undefined;
+};
+
 /**
  * Build the argv for one Copilot invocation. Validates `session.model` is a known
  * {@link CopilotModel}; surfaces `InvalidStateError` for unknowns.
+ *
+ * `promptFile` is the path {@link materializeCopilotPrompt} produced; when it is absent the prompt
+ * body goes into argv as it did historically.
  */
-export const buildCopilotArgs = (session: AiSession): Result<readonly string[], InvalidStateError> => {
+export const buildCopilotArgs = (
+  session: AiSession,
+  promptFile?: string
+): Result<readonly string[], InvalidStateError> => {
   // Catalog-valid but temporarily suspended server-side (see suspended-models.ts) — the list is
   // currently empty; the guard stays wired for the next incident.
   const validated = validateModel(session.model, isCopilotModel, {
@@ -149,10 +194,19 @@ export const buildCopilotArgs = (session: AiSession): Result<readonly string[], 
     args.push('--allow-all-tools', '--deny-tool=shell');
   }
   // Auto-mount `outputDir` so signals.json can land via the write tool. See resolve-roots.ts.
-  for (const root of resolveWritableRoots(session)) {
-    args.push(`--add-dir=${String(root)}`);
+  const roots = resolveWritableRoots(session).map((r) => String(r));
+  // …and the prompt file's directory, or the pointer would name a path the read tool may not open.
+  // Usually already mounted (it is `outputDir` for most callers); mounting twice is harmless, so
+  // dedupe rather than assume.
+  const promptDir = promptFile === undefined ? undefined : dirname(promptFile);
+  const mounted =
+    promptDir === undefined || promptDir === String(session.cwd) || roots.includes(promptDir)
+      ? roots
+      : [...roots, promptDir];
+  for (const root of mounted) {
+    args.push(`--add-dir=${root}`);
   }
-  args.push('-p', session.prompt);
+  args.push('-p', promptFile === undefined ? session.prompt : buildPromptPointer(promptFile));
   return Result.ok(args);
 };
 
@@ -253,7 +307,8 @@ const createOnLine =
  */
 const createCopilotAttempt = (deps: HeadlessProviderDeps, spawnFn: ProviderSpawn, command: string) => {
   return async (attemptSession: AiSession) => {
-    const built = buildCopilotArgs(attemptSession);
+    const promptFile = await materializeCopilotPrompt(deps, attemptSession);
+    const built = buildCopilotArgs(attemptSession, promptFile);
     if (!built.ok) return { kind: 'error' as const, error: built.error };
 
     const parser = createCopilotStreamParser();
@@ -272,8 +327,8 @@ const createCopilotAttempt = (deps: HeadlessProviderDeps, spawnFn: ProviderSpawn
       args: built.value,
       session: attemptSession,
       resolveOn: 'exit',
-      // Copilot reads the prompt from -p argv (no stdin payload); omitting `stdin` causes
-      // runProviderAttempt to close the child's stdin immediately.
+      // Copilot takes its prompt from `-p` argv, not stdin (no stdin payload exists on this CLI);
+      // omitting `stdin` causes runProviderAttempt to close the child's stdin immediately.
       rateLimitRe: DEFAULT_RATE_LIMIT_RE,
       onStdoutChunk: (chunk) => {
         parser.feed(chunk, onLine);

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -33,7 +33,6 @@ export const createInteractiveCopilotProvider = (deps: InteractiveProviderDeps):
       modelCatalogLabel: 'Copilot',
       isKnownModel: isCopilotModel,
       supportsSessionId: true,
-      mountsRoots: true,
       buildArgs: (input, { promptArg, roots, sessionId }) => [
         ...roots.map((p) => `--add-dir=${p}`),
         `--model=${input.model}`,

--- a/src/integration/ai/providers/copilot/interactive.ts
+++ b/src/integration/ai/providers/copilot/interactive.ts
@@ -5,12 +5,16 @@ import { isCopilotModel } from '@src/domain/value/settings-models/copilot.ts';
 
 /**
  * Interactive `copilot` adapter. Spawns the GitHub Copilot CLI with `stdio: 'inherit'` so the user
- * sees the TUI directly. Copilot's interactive form takes a pre-seeded prompt via `-i PROMPT`, and
- * the prompt content is passed directly as argv — the earlier `bash -lc "… $(cat …)"` form
- * silently dropped the seed for some users (the TUI opened at an empty input box).
+ * sees the TUI directly. Copilot's interactive form takes a pre-seeded prompt via `-i PROMPT`,
+ * passed directly as argv — the earlier `bash -lc "… $(cat …)"` form silently dropped the seed for
+ * some users (the TUI opened at an empty input box).
  *
  *   copilot --add-dir=<root>... --model=<model> --allow-all-tools --session-id=<uuid>
- *           [--effort=<level>] -i <prompt>
+ *           [--effort=<level>] -i <pointer at promptFile>
+ *
+ * What that argv element carries is a pointer at the rendered prompt file, never its body — see
+ * `_engine/prompt-pointer.ts`. `--add-dir` mounts the file's directory, so the pointer always
+ * resolves.
  *
  * `--add-dir` / `--model` / `--session-id` / `--effort` are equals-only per the CLI reference;
  * passing them space-separated leaves the parser without a bound value.
@@ -29,7 +33,8 @@ export const createInteractiveCopilotProvider = (deps: InteractiveProviderDeps):
       modelCatalogLabel: 'Copilot',
       isKnownModel: isCopilotModel,
       supportsSessionId: true,
-      buildArgs: (input, { prompt, roots, sessionId }) => [
+      mountsRoots: true,
+      buildArgs: (input, { promptArg, roots, sessionId }) => [
         ...roots.map((p) => `--add-dir=${p}`),
         `--model=${input.model}`,
         '--allow-all-tools',
@@ -38,7 +43,7 @@ export const createInteractiveCopilotProvider = (deps: InteractiveProviderDeps):
         // re-validating here would only duplicate its catalog (mirrors the headless adapter).
         ...(input.effort !== undefined ? [`--effort=${input.effort}`] : []),
         '-i',
-        prompt,
+        promptArg,
       ],
     },
     deps

--- a/src/integration/ai/providers/opencode/interactive.ts
+++ b/src/integration/ai/providers/opencode/interactive.ts
@@ -7,7 +7,7 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * Interactive `opencode` adapter. Spawns the OpenCode TUI with `stdio: 'inherit'` so the user
  * chats directly.
  *
- *   opencode <cwd> --model <provider/model> --prompt <prompt>
+ *   opencode <cwd> --model <provider/model> --prompt <pointer at promptFile, or the body>
  *
  * OpenCode's default command takes the project directory as its positional argument (`opencode
  * [project]`) rather than a `--cd`-style flag, and starts the TUI. Unlike codex there is no
@@ -26,7 +26,13 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * `domain/value/settings-models/opencode.ts`.
  *
  * There is no `--add-dir` equivalent, so `roots` cannot be mounted — the single positional
- * project directory is the whole topology. Session ids are minted by OpenCode itself and only
+ * project directory is the whole topology, which is what `mountsRoots: false` declares. The
+ * consequence is that OpenCode only gets the prompt POINTER when the prompt file already lives
+ * under `cwd` (plan, refine); with a repository as cwd (ideate, memory-distill) the file is
+ * unreachable and the engine falls back to the inlined body with a warning, since a session that
+ * cannot read its own brief is worse than a large argv. See `_engine/prompt-pointer.ts`.
+ *
+ * Session ids are minted by OpenCode itself and only
  * surface on the `run` JSON stream (not on the TUI path), so `supportsSessionId` stays false and
  * subscribers fall back to the runner's session id, matching the codex adapter.
  *
@@ -40,7 +46,8 @@ export const createInteractiveOpencodeProvider = (deps: InteractiveProviderDeps)
       modelCatalogLabel: 'OpenCode',
       isKnownModel: isOpencodeModelIdShape,
       supportsSessionId: false,
-      buildArgs: (input, { prompt }) => [String(input.cwd), '--model', input.model, '--prompt', prompt],
+      mountsRoots: false,
+      buildArgs: (input, { promptArg }) => [String(input.cwd), '--model', input.model, '--prompt', promptArg],
     },
     deps
   );

--- a/src/integration/ai/providers/opencode/interactive.ts
+++ b/src/integration/ai/providers/opencode/interactive.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from 'node:path';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { InteractiveProviderDeps } from '@src/integration/ai/providers/_engine/interactive-provider-deps.ts';
 import { createInteractiveProvider } from '@src/integration/ai/providers/_engine/run-interactive-session.ts';
@@ -7,7 +8,8 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * Interactive `opencode` adapter. Spawns the OpenCode TUI with `stdio: 'inherit'` so the user
  * chats directly.
  *
- *   opencode <cwd> --model <provider/model> --prompt <pointer at promptFile, or the body>
+ *   OPENCODE_CONFIG_CONTENT=<grant for dirname(promptFile)> \
+ *     opencode <cwd> --model <provider/model> --prompt <pointer at promptFile>
  *
  * OpenCode's default command takes the project directory as its positional argument (`opencode
  * [project]`) rather than a `--cd`-style flag, and starts the TUI. Unlike codex there is no
@@ -25,19 +27,43 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * `opencode providers` auth state and cannot be known statically. See the note on
  * `domain/value/settings-models/opencode.ts`.
  *
- * There is no `--add-dir` equivalent, so `roots` cannot be mounted — the single positional
- * project directory is the whole topology, which is what `mountsRoots: false` declares. The
- * consequence is that OpenCode only gets the prompt POINTER when the prompt file already lives
- * under `cwd` (plan, refine); with a repository as cwd (ideate, memory-distill) the file is
- * unreachable and the engine falls back to the inlined body with a warning, since a session that
- * cannot read its own brief is worse than a large argv. See `_engine/prompt-pointer.ts`.
+ * There is no `--add-dir` FLAG, so anything outside the positional project directory is refused —
+ * OpenCode auto-rejects it as `permission requested: external_directory (…)`. That matters because
+ * `cwd` is a repository for ideate and memory-distill, which puts the prompt file outside it. The
+ * equivalent grant is a config entry rather than a flag, so {@link buildOpencodeEnv} injects one
+ * scoped to the prompt file's directory (see below) and `mountsRoots` is true: the prompt POINTER
+ * is always readable and the body never has to ride argv.
  *
- * Session ids are minted by OpenCode itself and only
- * surface on the `run` JSON stream (not on the TUI path), so `supportsSessionId` stays false and
- * subscribers fall back to the runner's session id, matching the codex adapter.
+ * `roots` beyond that directory are still NOT mounted — a caller's `additionalRoots` are silently
+ * dropped on this adapter, which the port contract says should surface an `InvalidStateError`
+ * instead. Pre-existing, and now fixable by the same mechanism; deliberately left alone here so a
+ * spawn-safety fix does not quietly widen what an OpenCode session can read.
  *
- * Docs: https://opencode.ai/docs/cli/
+ * Session ids are minted by OpenCode itself and only surface on the `run` JSON stream (not on the
+ * TUI path), so `supportsSessionId` stays false and subscribers fall back to the runner's session
+ * id, matching the codex adapter.
+ *
+ * Docs: https://opencode.ai/docs/cli/, https://opencode.ai/docs/permissions/
  */
+
+/**
+ * The one directory grant OpenCode needs: read access to the prompt file the harness wrote.
+ *
+ * `OPENCODE_CONFIG_CONTENT` is MERGED into the operator's own config rather than replacing it
+ * (documented precedence: remote → global → OPENCODE_CONFIG → project → .opencode →
+ * OPENCODE_CONFIG_CONTENT), so their models, agents, and instructions survive the session — only a
+ * conflicting `external_directory` rule is overridden.
+ *
+ * The grant is deliberately narrow: `*` stays denied and only the prompt file's own directory is
+ * allowed, which is the closest analogue to the `--add-dir` scoping the other three CLIs get.
+ * Verified against opencode-ai v1.18.15: the allowed directory reads, a sibling directory is
+ * refused, and the operator's pre-existing rules remain in the merged rule set.
+ */
+export const buildOpencodeEnv = (promptDir: string): Readonly<Record<string, string>> => ({
+  OPENCODE_CONFIG_CONTENT: JSON.stringify({
+    permission: { external_directory: { '*': 'deny', [join(promptDir, '*')]: 'allow' } },
+  }),
+});
 export const createInteractiveOpencodeProvider = (deps: InteractiveProviderDeps): InteractiveAiProvider =>
   createInteractiveProvider(
     {
@@ -46,7 +72,8 @@ export const createInteractiveOpencodeProvider = (deps: InteractiveProviderDeps)
       modelCatalogLabel: 'OpenCode',
       isKnownModel: isOpencodeModelIdShape,
       supportsSessionId: false,
-      mountsRoots: false,
+      mountsRoots: true,
+      buildEnv: (input) => buildOpencodeEnv(dirname(String(input.promptFile))),
       buildArgs: (input, { promptArg }) => [String(input.cwd), '--model', input.model, '--prompt', promptArg],
     },
     deps

--- a/src/integration/ai/providers/opencode/interactive.ts
+++ b/src/integration/ai/providers/opencode/interactive.ts
@@ -5,6 +5,38 @@ import { createInteractiveProvider } from '@src/integration/ai/providers/_engine
 import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/opencode.ts';
 
 /**
+ * The one directory grant OpenCode needs: read access to the prompt file the harness wrote.
+ *
+ * `OPENCODE_CONFIG_CONTENT` is MERGED into the operator's own config rather than replacing it
+ * (documented precedence: remote → global → OPENCODE_CONFIG → project → .opencode →
+ * OPENCODE_CONFIG_CONTENT), so their models, agents, and instructions survive the session — only a
+ * conflicting `external_directory` rule is overridden.
+ *
+ * The grant is deliberately narrow: `*` stays denied and only the prompt file's own directory is
+ * allowed, which is the closest analogue to the `--add-dir` scoping the other three CLIs get.
+ * Verified against opencode-ai v1.18.15: the allowed directory reads, a sibling directory is
+ * refused, and the operator's pre-existing rules remain in the merged rule set.
+ *
+ * Both separator spellings are granted on Windows. The rules are globs, where a backslash is
+ * conventionally an escape character, and the path OpenCode tests may be normalised to forward
+ * slashes before matching — a pattern that fails to match would not error, it would open a session
+ * whose only instruction is a path it is not allowed to read. A key that matches nothing is inert,
+ * so granting both costs nothing and removes the guess. (This is the one part of the mechanism
+ * that could not be verified on the platform it matters for.)
+ */
+export const buildOpencodeEnv = (promptDir: string): Readonly<Record<string, string>> => ({
+  OPENCODE_CONFIG_CONTENT: JSON.stringify({
+    permission: {
+      external_directory: {
+        '*': 'deny',
+        [join(promptDir, '*')]: 'allow',
+        // Identical to the key above on POSIX (so it collapses to one), a second spelling on Windows.
+        [`${promptDir.replaceAll('\\', '/')}/*`]: 'allow',
+      },
+    },
+  }),
+});
+/**
  * Interactive `opencode` adapter. Spawns the OpenCode TUI with `stdio: 'inherit'` so the user
  * chats directly.
  *
@@ -31,8 +63,8 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * OpenCode auto-rejects it as `permission requested: external_directory (…)`. That matters because
  * `cwd` is a repository for ideate and memory-distill, which puts the prompt file outside it. The
  * equivalent grant is a config entry rather than a flag, so {@link buildOpencodeEnv} injects one
- * scoped to the prompt file's directory (see below) and `mountsRoots` is true: the prompt POINTER
- * is always readable and the body never has to ride argv.
+ * scoped to the prompt file's directory ({@link buildOpencodeEnv}), so the prompt POINTER is
+ * always readable and the body never has to ride argv.
  *
  * `roots` beyond that directory are still NOT mounted — a caller's `additionalRoots` are silently
  * dropped on this adapter, which the port contract says should surface an `InvalidStateError`
@@ -46,24 +78,6 @@ import { isOpencodeModelIdShape } from '@src/domain/value/settings-models/openco
  * Docs: https://opencode.ai/docs/cli/, https://opencode.ai/docs/permissions/
  */
 
-/**
- * The one directory grant OpenCode needs: read access to the prompt file the harness wrote.
- *
- * `OPENCODE_CONFIG_CONTENT` is MERGED into the operator's own config rather than replacing it
- * (documented precedence: remote → global → OPENCODE_CONFIG → project → .opencode →
- * OPENCODE_CONFIG_CONTENT), so their models, agents, and instructions survive the session — only a
- * conflicting `external_directory` rule is overridden.
- *
- * The grant is deliberately narrow: `*` stays denied and only the prompt file's own directory is
- * allowed, which is the closest analogue to the `--add-dir` scoping the other three CLIs get.
- * Verified against opencode-ai v1.18.15: the allowed directory reads, a sibling directory is
- * refused, and the operator's pre-existing rules remain in the merged rule set.
- */
-export const buildOpencodeEnv = (promptDir: string): Readonly<Record<string, string>> => ({
-  OPENCODE_CONFIG_CONTENT: JSON.stringify({
-    permission: { external_directory: { '*': 'deny', [join(promptDir, '*')]: 'allow' } },
-  }),
-});
 export const createInteractiveOpencodeProvider = (deps: InteractiveProviderDeps): InteractiveAiProvider =>
   createInteractiveProvider(
     {
@@ -72,7 +86,6 @@ export const createInteractiveOpencodeProvider = (deps: InteractiveProviderDeps)
       modelCatalogLabel: 'OpenCode',
       isKnownModel: isOpencodeModelIdShape,
       supportsSessionId: false,
-      mountsRoots: true,
       buildEnv: (input) => buildOpencodeEnv(dirname(String(input.promptFile))),
       buildArgs: (input, { promptArg }) => [String(input.cwd), '--model', input.model, '--prompt', promptArg],
     },

--- a/tests/fixtures/interactive-spawn-fake.ts
+++ b/tests/fixtures/interactive-spawn-fake.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+
+/**
+ * Capturing `InteractiveSpawn` fake shared by the interactive-adapter suites and the shared-engine
+ * suite. Each of those files carried its own byte-identical copy, which drifted the moment one of
+ * them needed to observe something new — so the fake records everything an adapter can pass
+ * (including `env`) and can emit either ending (`close` or a spawn-level `error`), rather than each
+ * suite seeing only the half its file happened to grow.
+ *
+ * `env` is recorded as handed to the spawn — the merge over `process.env` belongs to
+ * `defaultInteractiveSpawn`, and a fake that pre-merged it would hide what the adapter declared.
+ *
+ * @public
+ */
+export interface InteractiveSpawnCall {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/** @public */
+export interface CapturingInteractiveSpawn {
+  readonly spawn: InteractiveSpawn;
+  readonly calls: readonly InteractiveSpawnCall[];
+  /** End the most recent session with an exit code, as a real child's `close` event would. */
+  readonly emitExit: (code: number | null) => void;
+  /** Fail the most recent session at spawn level (the async `'error'` event). */
+  readonly emitError: (cause: Error) => void;
+}
+
+/** @public */
+export const makeInteractiveSpawn = (): CapturingInteractiveSpawn => {
+  const calls: InteractiveSpawnCall[] = [];
+  const last = {
+    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
+  };
+
+  const spawn: InteractiveSpawn = (command, args, options) => {
+    calls.push({ command, args, cwd: options.cwd, ...(options.env !== undefined ? { env: options.env } : {}) });
+    const child = new EventEmitter() as unknown as ChildProcess & {
+      emit: (event: string, ...args: unknown[]) => boolean;
+    };
+    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
+    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
+    last.child = child;
+    return child;
+  };
+
+  return {
+    spawn,
+    calls,
+    emitExit: (code) => {
+      setTimeout(() => last.child?.emit('close', code), 0);
+    },
+    emitError: (cause) => {
+      setTimeout(() => last.child?.emit('error', cause), 0);
+    },
+  };
+};

--- a/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
+++ b/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
@@ -272,6 +272,52 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     }
   });
 
+  it('an argv overflow is a NON-retryable config error, not a retryable crash', async () => {
+    // The same command line is rebuilt on every attempt, so retrying an oversized argv burns the
+    // whole budget on a spawn that can never succeed — and the missing-binary hint would send an
+    // operator looking down the wrong path entirely.
+    const session = baseSession();
+    const spawnError = Object.assign(new Error('spawn ENAMETOOLONG'), {
+      code: 'ENAMETOOLONG',
+    }) as NodeJS.ErrnoException;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: null, signal: null, spawnError, argvBytes: 120_000 },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error.code).toBe('invalid-state');
+      expect(outcome.error.message).toContain('120000 bytes');
+      expect(outcome.error.message).toContain('not in argv');
+    }
+  });
+
+  it('treats any spawn failure past the Windows ceiling as an overflow, whatever the errno says', async () => {
+    // Windows does not document which error code CreateProcessW sets for an oversized command
+    // line, and the same condition has been reported as ERROR_INVALID_PARAMETER — so the measured
+    // size decides, not the errno alone.
+    const session = baseSession();
+    const spawnError = Object.assign(new Error('spawn UNKNOWN'), { code: 'UNKNOWN' }) as NodeJS.ErrnoException;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: null, signal: null, spawnError, argvBytes: 40_000 },
+      stderr: '',
+      rateLimitRe: RATE_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') expect(outcome.error.code).toBe('invalid-state');
+  });
+
   it('rate-limit detected in stdoutTail (not stderr) when the provider reports quota on stdout', async () => {
     // FINDING 3 — claude's `-p stream-json` mode reports quota in the stdout result envelope, not
     // on stderr. The classifier must scan stderr + stdoutTail so the throttle trips the backoff.

--- a/tests/integration/ai/providers/_engine/interactive-spawn.test.ts
+++ b/tests/integration/ai/providers/_engine/interactive-spawn.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defaultInteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+
+// Spawns a real `node` child, because the property under test is what the OS-level environment
+// looks like from inside that child — a fake spawn could only re-assert the code's own spread.
+
+const tempDirs: string[] = [];
+const makeTempDir = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), 'ralphctl-spawn-env-'));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(async (dir) => rm(dir, { recursive: true, force: true })));
+});
+
+const runNode = async (script: string, env?: Readonly<Record<string, string>>): Promise<number | null> => {
+  const child = defaultInteractiveSpawn(process.execPath, ['-e', script], {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+    ...(env !== undefined ? { env } : {}),
+  });
+  return new Promise((resolve) => child.on('close', resolve));
+};
+
+describe('defaultInteractiveSpawn', () => {
+  it('layers the supplied env over the parent environment instead of replacing it', async () => {
+    // A bare `env` override would strip PATH / HOME and every provider credential variable from
+    // the child — the CLI would start without its own auth. OPENCODE_CONFIG_CONTENT has to arrive
+    // as an addition, not a substitution.
+    const dir = await makeTempDir();
+    const out = join(dir, 'env.json');
+    const code = await runNode(
+      `require('fs').writeFileSync(${JSON.stringify(out)}, JSON.stringify({ injected: process.env.RALPHCTL_TEST_INJECTED, path: process.env.PATH }))`,
+      { RALPHCTL_TEST_INJECTED: 'yes' }
+    );
+
+    expect(code).toBe(0);
+    const seen = JSON.parse(await readFile(out, 'utf8')) as { injected?: string; path?: string };
+    expect(seen.injected).toBe('yes');
+    expect(seen.path).toBe(process.env['PATH']);
+  });
+
+  it('leaves the environment untouched when no override is supplied', async () => {
+    const dir = await makeTempDir();
+    const out = join(dir, 'env.json');
+    const code = await runNode(
+      `require('fs').writeFileSync(${JSON.stringify(out)}, JSON.stringify({ injected: process.env.RALPHCTL_TEST_INJECTED ?? null }))`
+    );
+
+    expect(code).toBe(0);
+    const seen = JSON.parse(await readFile(out, 'utf8')) as { injected: string | null };
+    expect(seen.injected).toBeNull();
+  });
+});

--- a/tests/integration/ai/providers/_engine/run-interactive-session.test.ts
+++ b/tests/integration/ai/providers/_engine/run-interactive-session.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
 import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+import { argvByteLength } from '@src/integration/ai/providers/_engine/argv-budget.ts';
 import {
   createInteractiveProvider,
   type InteractiveProviderSpec,
@@ -23,6 +24,7 @@ interface CapturingSpawnState {
   readonly spawn: InteractiveSpawn;
   readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
   readonly emitExit: (code: number | null) => void;
+  readonly emitError: (cause: Error) => void;
 }
 
 const makeSpawn = (): CapturingSpawnState => {
@@ -46,6 +48,9 @@ const makeSpawn = (): CapturingSpawnState => {
     emitExit: (code) => {
       setTimeout(() => last.child?.emit('close', code), 0);
     },
+    emitError: (cause) => {
+      setTimeout(() => last.child?.emit('error', cause), 0);
+    },
   };
 };
 
@@ -64,12 +69,13 @@ const spec = (overrides: Partial<InteractiveProviderSpec> = {}): InteractiveProv
   modelCatalogLabel: 'Stub',
   isKnownModel: (m) => m === MODEL || m === 'suspended-model',
   supportsSessionId: true,
-  buildArgs: (input, { prompt, roots, sessionId }) => [
+  mountsRoots: true,
+  buildArgs: (input, { promptArg, roots, sessionId }) => [
     ...roots.flatMap((p) => ['--add-dir', p]),
     '--model',
     input.model,
     ...(sessionId !== undefined ? ['--session-id', sessionId] : []),
-    prompt,
+    promptArg,
   ],
   ...overrides,
 });
@@ -265,6 +271,116 @@ describe('createInteractiveProvider', () => {
     expect(r.value.sessionId).toBeUndefined();
     expect(calls[0]!.args).not.toContain('fixed-session-id');
     await expect(readFileFs(join(dir, 'session-id.txt'), 'utf8')).rejects.toThrow();
+  });
+
+  it('passes a pointer at the prompt file, never the prompt body', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
+
+    const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
+    emitExit(0);
+    await runPromise;
+
+    const args = calls[0]!.args;
+    expect(args.at(-1)).toContain(String(PROMPT_FILE));
+    expect(args).not.toContain(STUB_PROMPT);
+  });
+
+  it('keeps argv small no matter how large the prompt is', async () => {
+    // The regression that motivated the pointer: a rendered plan prompt blew the 32,767-byte
+    // Windows command line and the session died with `spawn ENAMETOOLONG` before the CLI started.
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const hugePrompt = 'x'.repeat(200_000);
+    const provider = createInteractiveProvider(spec(), {
+      eventBus: cap.bus,
+      spawn,
+      readFile: () => Promise.resolve(hugePrompt),
+    });
+
+    const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
+    emitExit(0);
+    await runPromise;
+
+    const call = calls[0]!;
+    expect(argvByteLength(call.command, call.args)).toBeLessThan(2_000);
+  });
+
+  it('falls back to the inlined body, with a warning, when the CLI cannot reach the prompt file', async () => {
+    // OpenCode's shape: no `--add-dir`, so only a prompt file under `cwd` is readable. Handing it
+    // an unreachable path would open a session that silently has no instructions — worse than a
+    // large argv, which at least fails loudly.
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveProvider(spec({ mountsRoots: false }), {
+      eventBus: cap.bus,
+      spawn,
+      readFile: stubReadFile,
+    });
+
+    const runPromise = provider.run({
+      cwd: absolutePath('/tmp/some-repo'),
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: MODEL,
+    });
+    emitExit(0);
+    await runPromise;
+
+    expect(calls[0]!.args).toContain(STUB_PROMPT);
+    expect(cap.logs.map((e) => e.message).join('\n')).toContain('passing the prompt inline');
+  });
+
+  it('uses the pointer for a root-less CLI when the prompt file sits under cwd', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveProvider(spec({ mountsRoots: false }), {
+      eventBus: cap.bus,
+      spawn,
+      readFile: stubReadFile,
+    });
+
+    const promptFile = absolutePath(join(String(CWD), 'prompt.md'));
+    const runPromise = provider.run({ cwd: CWD, promptFile, outputFile: OUTPUT_FILE, model: MODEL });
+    emitExit(0);
+    await runPromise;
+
+    expect(calls[0]!.args.at(-1)).toContain(String(promptFile));
+    expect(calls[0]!.args).not.toContain(STUB_PROMPT);
+  });
+
+  it('names an argv overflow in the spawn error instead of surfacing a bare errno', async () => {
+    const cap = createCapturingBus();
+    const overflow = Object.assign(new Error('spawn ENAMETOOLONG'), { code: 'ENAMETOOLONG' });
+    const provider = createInteractiveProvider(spec(), {
+      eventBus: cap.bus,
+      spawn: () => {
+        throw overflow;
+      },
+      readFile: stubReadFile,
+    });
+
+    const r = await provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toContain('past the 32767-byte Windows limit');
+    expect(r.error.message).toContain(String(PROMPT_FILE));
+  });
+
+  it('reports a spawn failure that arrives as an async error event, not as exit code -1', async () => {
+    const cap = createCapturingBus();
+    const { spawn, emitError } = makeSpawn();
+    const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
+
+    const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
+    emitError(Object.assign(new Error('spawn E2BIG'), { code: 'E2BIG' }));
+    const r = await runPromise;
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('storage-error');
+    expect(r.error.message).toContain('failed to spawn');
+    expect(r.error.message).toContain('past the 32767-byte Windows limit');
   });
 
   it('publishes a start and an exit log naming the provider', async () => {

--- a/tests/integration/ai/providers/_engine/run-interactive-session.test.ts
+++ b/tests/integration/ai/providers/_engine/run-interactive-session.test.ts
@@ -1,12 +1,10 @@
-import { EventEmitter } from 'node:events';
 import { mkdtemp, readFile as readFileFs, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { ChildProcess } from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
-import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
+import { makeInteractiveSpawn } from '@tests/fixtures/interactive-spawn-fake.ts';
 import { argvByteLength } from '@src/integration/ai/providers/_engine/argv-budget.ts';
 import {
   createInteractiveProvider,
@@ -19,40 +17,6 @@ vi.mock('@src/domain/value/settings-models/suspended-models.ts', () => ({
   isSuspendedModel: (s: string) => s === 'suspended-model',
   suspendedModelMessage: (m: string) => `'${m}' is temporarily suspended by its provider`,
 }));
-
-interface CapturingSpawnState {
-  readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
-  readonly emitExit: (code: number | null) => void;
-  readonly emitError: (cause: Error) => void;
-}
-
-const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
-  const last = {
-    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
-  };
-  const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd });
-    const child = new EventEmitter() as unknown as ChildProcess & {
-      emit: (event: string, ...args: unknown[]) => boolean;
-    };
-    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
-    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
-    last.child = child;
-    return child;
-  };
-  return {
-    spawn,
-    calls,
-    emitExit: (code) => {
-      setTimeout(() => last.child?.emit('close', code), 0);
-    },
-    emitError: (cause) => {
-      setTimeout(() => last.child?.emit('error', cause), 0);
-    },
-  };
-};
 
 const STUB_PROMPT = 'Do the thing.';
 const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
@@ -69,7 +33,6 @@ const spec = (overrides: Partial<InteractiveProviderSpec> = {}): InteractiveProv
   modelCatalogLabel: 'Stub',
   isKnownModel: (m) => m === MODEL || m === 'suspended-model',
   supportsSessionId: true,
-  mountsRoots: true,
   buildArgs: (input, { promptArg, roots, sessionId }) => [
     ...roots.flatMap((p) => ['--add-dir', p]),
     '--model',
@@ -94,7 +57,7 @@ afterEach(async () => {
 describe('createInteractiveProvider', () => {
   it('rejects an unknown model with InvalidStateError, without spawning', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls } = makeSpawn();
+    const { spawn, calls } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const r = await provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: 'nope' });
@@ -107,7 +70,7 @@ describe('createInteractiveProvider', () => {
 
   it('rejects a suspended-but-catalog-known model with InvalidStateError, without spawning', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls } = makeSpawn();
+    const { spawn, calls } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const r = await provider.run({
@@ -125,7 +88,7 @@ describe('createInteractiveProvider', () => {
 
   it('returns StorageError when the prompt file cannot be read, without spawning', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls } = makeSpawn();
+    const { spawn, calls } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), {
       eventBus: cap.bus,
       spawn,
@@ -143,7 +106,7 @@ describe('createInteractiveProvider', () => {
 
   it('returns StorageError when the spawn itself throws', async () => {
     const cap = createCapturingBus();
-    const throwingSpawn: InteractiveSpawn = () => {
+    const throwingSpawn = (): never => {
       throw new Error('spawn stub-cli ENOENT');
     };
     const provider = createInteractiveProvider(spec(), {
@@ -162,7 +125,7 @@ describe('createInteractiveProvider', () => {
 
   it('returns InvalidStateError when the session exits non-zero', async () => {
     const cap = createCapturingBus();
-    const { spawn, emitExit } = makeSpawn();
+    const { spawn, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
@@ -179,7 +142,7 @@ describe('createInteractiveProvider', () => {
     // The engine must classify this as AbortError — the one error chains propagate transparently —
     // not the generic session-exit InvalidStateError a downstream guard could catch and continue.
     const cap = createCapturingBus();
-    const { spawn, emitExit } = makeSpawn();
+    const { spawn, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
     const controller = new AbortController();
 
@@ -201,7 +164,7 @@ describe('createInteractiveProvider', () => {
 
   it('folds duplicate roots and orders them cwd, additionalRoots, output dir, prompt dir', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const extraRepo = absolutePath('/tmp/engine-sibling-repo');
@@ -224,7 +187,7 @@ describe('createInteractiveProvider', () => {
   it('pre-generates a session id, passes it to the CLI, and mirrors it next to the output file', async () => {
     const dir = await makeTempDir();
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), {
       eventBus: cap.bus,
       spawn,
@@ -250,7 +213,7 @@ describe('createInteractiveProvider', () => {
   it('leaves the session id unset and writes no sidechannel file when the CLI has no launch-time override', async () => {
     const dir = await makeTempDir();
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec({ supportsSessionId: false }), {
       eventBus: cap.bus,
       spawn,
@@ -275,7 +238,7 @@ describe('createInteractiveProvider', () => {
 
   it('passes a pointer at the prompt file, never the prompt body', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
@@ -291,7 +254,7 @@ describe('createInteractiveProvider', () => {
     // The regression that motivated the pointer: a rendered plan prompt blew the 32,767-byte
     // Windows command line and the session died with `spawn ENAMETOOLONG` before the CLI started.
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const hugePrompt = 'x'.repeat(200_000);
     const provider = createInteractiveProvider(spec(), {
       eventBus: cap.bus,
@@ -305,49 +268,6 @@ describe('createInteractiveProvider', () => {
 
     const call = calls[0]!;
     expect(argvByteLength(call.command, call.args)).toBeLessThan(2_000);
-  });
-
-  it('falls back to the inlined body, with a warning, when the CLI cannot reach the prompt file', async () => {
-    // OpenCode's shape: no `--add-dir`, so only a prompt file under `cwd` is readable. Handing it
-    // an unreachable path would open a session that silently has no instructions — worse than a
-    // large argv, which at least fails loudly.
-    const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveProvider(spec({ mountsRoots: false }), {
-      eventBus: cap.bus,
-      spawn,
-      readFile: stubReadFile,
-    });
-
-    const runPromise = provider.run({
-      cwd: absolutePath('/tmp/some-repo'),
-      promptFile: PROMPT_FILE,
-      outputFile: OUTPUT_FILE,
-      model: MODEL,
-    });
-    emitExit(0);
-    await runPromise;
-
-    expect(calls[0]!.args).toContain(STUB_PROMPT);
-    expect(cap.logs.map((e) => e.message).join('\n')).toContain('passing the prompt inline');
-  });
-
-  it('uses the pointer for a root-less CLI when the prompt file sits under cwd', async () => {
-    const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
-    const provider = createInteractiveProvider(spec({ mountsRoots: false }), {
-      eventBus: cap.bus,
-      spawn,
-      readFile: stubReadFile,
-    });
-
-    const promptFile = absolutePath(join(String(CWD), 'prompt.md'));
-    const runPromise = provider.run({ cwd: CWD, promptFile, outputFile: OUTPUT_FILE, model: MODEL });
-    emitExit(0);
-    await runPromise;
-
-    expect(calls[0]!.args.at(-1)).toContain(String(promptFile));
-    expect(calls[0]!.args).not.toContain(STUB_PROMPT);
   });
 
   it('names an argv overflow in the spawn error instead of surfacing a bare errno', async () => {
@@ -370,7 +290,7 @@ describe('createInteractiveProvider', () => {
 
   it('reports a spawn failure that arrives as an async error event, not as exit code -1', async () => {
     const cap = createCapturingBus();
-    const { spawn, emitError } = makeSpawn();
+    const { spawn, emitError } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
@@ -385,7 +305,7 @@ describe('createInteractiveProvider', () => {
 
   it('publishes a start and an exit log naming the provider', async () => {
     const cap = createCapturingBus();
-    const { spawn, emitExit } = makeSpawn();
+    const { spawn, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveProvider(spec(), { eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });

--- a/tests/integration/ai/providers/claude/interactive.test.ts
+++ b/tests/integration/ai/providers/claude/interactive.test.ts
@@ -1,46 +1,14 @@
-import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import { makeInteractiveSpawn } from '@tests/fixtures/interactive-spawn-fake.ts';
 import { CLAUDE_MODELS } from '@src/domain/value/settings-models/claude.ts';
 import { createInteractiveClaudeProvider } from '@src/integration/ai/providers/claude/interactive.ts';
-import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 
 // The session skeleton this adapter delegates to — model validation, prompt-file reads, spawn
 // failures, abort precedence, the exit-code branch, the session-id sidechannel — is covered once
 // in tests/integration/ai/providers/_engine/run-interactive-session.test.ts. What stays here is
 // the part that is genuinely Claude-specific: the argv it builds.
-
-interface CapturingSpawnState {
-  readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
-  readonly emitExit: (code: number | null) => void;
-}
-
-const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
-  const last = {
-    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
-  };
-  const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd });
-    const child = new EventEmitter() as unknown as ChildProcess & {
-      emit: (event: string, ...args: unknown[]) => boolean;
-    };
-    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
-    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
-    last.child = child;
-    return child;
-  };
-  return {
-    spawn,
-    calls,
-    emitExit: (code) => {
-      setTimeout(() => last.child?.emit('close', code), 0);
-    },
-  };
-};
 
 const STUB_PROMPT = 'You are helping refine a ticket. Do X.';
 const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
@@ -52,7 +20,7 @@ const CWD = absolutePath('/tmp/claude-interactive-cwd');
 describe('createInteractiveClaudeProvider', () => {
   it('rejects a model outside the Claude catalog with InvalidStateError', async () => {
     const cap = createCapturingBus();
-    const { spawn } = makeSpawn();
+    const { spawn } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
     const r = await provider.run({
       cwd: CWD,
@@ -69,7 +37,7 @@ describe('createInteractiveClaudeProvider', () => {
 
   it('spawns claude directly (no bash wrapper) and passes a prompt-file pointer as positional arg', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
@@ -102,7 +70,7 @@ describe('createInteractiveClaudeProvider', () => {
 
   it('forwards the resolved effort as --effort <level>, and omits the flag when unset', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const withEffort = provider.run({
@@ -136,7 +104,7 @@ describe('createInteractiveClaudeProvider', () => {
     // `acceptEdits` only auto-approves writes inside `--add-dir` roots, so without mounting the
     // prompt / output dirs the user is hit by "Create file?" prompts mid-refine.
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const sprintRefinementDir = '/Users/x/.ralphctl/data/sprints/abc/refinement/foo';
@@ -162,7 +130,7 @@ describe('createInteractiveClaudeProvider', () => {
 
   it('keeps caller-supplied additionalRoots and folds duplicates with the auto-mounted dirs', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const extraRepo = absolutePath('/Users/x/repos/sibling-repo');
@@ -188,7 +156,7 @@ describe('createInteractiveClaudeProvider', () => {
 
   it('passes a pre-generated session id via --session-id <uuid>', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveClaudeProvider({
       eventBus: cap.bus,
       spawn,

--- a/tests/integration/ai/providers/claude/interactive.test.ts
+++ b/tests/integration/ai/providers/claude/interactive.test.ts
@@ -67,7 +67,7 @@ describe('createInteractiveClaudeProvider', () => {
     expect(r.error.message).toContain('Claude model');
   });
 
-  it('spawns claude directly (no bash wrapper) and passes prompt content as positional arg', async () => {
+  it('spawns claude directly (no bash wrapper) and passes a prompt-file pointer as positional arg', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
     const provider = createInteractiveClaudeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
@@ -88,12 +88,12 @@ describe('createInteractiveClaudeProvider', () => {
     const args = calls[0]!.args;
     expect(args).toContain('--model');
     expect(args).toContain(CLAUDE_MODELS[0]!);
-    // --permission-mode and prompt content are present as raw argv elements.
     expect(args).toContain('--permission-mode');
     expect(args).toContain('acceptEdits');
-    expect(args).toContain(STUB_PROMPT);
-    // The prompt is the trailing positional so claude reads it as the opening message.
-    expect(args.at(-1)).toBe(STUB_PROMPT);
+    // The trailing positional is claude's opening message: a pointer at the prompt file, never
+    // the body — inlining it capped every session at the platform command-line limit.
+    expect(args.at(-1)).toContain(String(PROMPT_FILE));
+    expect(args).not.toContain(STUB_PROMPT);
     // No -lc / bash remnants.
     expect(args).not.toContain('-lc');
     expect(args).not.toContain('bash');

--- a/tests/integration/ai/providers/codex/interactive.test.ts
+++ b/tests/integration/ai/providers/codex/interactive.test.ts
@@ -1,46 +1,14 @@
-import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import { makeInteractiveSpawn } from '@tests/fixtures/interactive-spawn-fake.ts';
 import { CODEX_MODELS } from '@src/domain/value/settings-models/codex.ts';
 import { createInteractiveCodexProvider } from '@src/integration/ai/providers/codex/interactive.ts';
-import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 
 // The session skeleton this adapter delegates to — model validation, prompt-file reads, spawn
 // failures, abort precedence, the exit-code branch — is covered once in
 // tests/integration/ai/providers/_engine/run-interactive-session.test.ts. What stays here is the
 // part that is genuinely Codex-specific: the argv it builds.
-
-interface CapturingSpawnState {
-  readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
-  readonly emitExit: (code: number | null) => void;
-}
-
-const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
-  const last = {
-    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
-  };
-  const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd });
-    const child = new EventEmitter() as unknown as ChildProcess & {
-      emit: (event: string, ...args: unknown[]) => boolean;
-    };
-    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
-    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
-    last.child = child;
-    return child;
-  };
-  return {
-    spawn,
-    calls,
-    emitExit: (code) => {
-      setTimeout(() => last.child?.emit('close', code), 0);
-    },
-  };
-};
 
 const STUB_PROMPT = 'Refine this Codex task.';
 const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
@@ -52,7 +20,7 @@ const CWD = absolutePath('/tmp/codex-interactive-cwd');
 describe('createInteractiveCodexProvider', () => {
   it('rejects a model outside the Codex catalog with InvalidStateError', async () => {
     const cap = createCapturingBus();
-    const { spawn } = makeSpawn();
+    const { spawn } = makeInteractiveSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
     const r = await provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: 'gpt-4.1' });
     expect(r.ok).toBe(false);
@@ -64,7 +32,7 @@ describe('createInteractiveCodexProvider', () => {
 
   it('spawns codex directly (no bash wrapper) with --cd, --add-dir, -s, -a, and a prompt-file pointer', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
@@ -99,7 +67,7 @@ describe('createInteractiveCodexProvider', () => {
 
   it('forwards the resolved effort as -c model_reasoning_effort=<level>, and omits it when unset', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const withEffort = provider.run({
@@ -130,7 +98,7 @@ describe('createInteractiveCodexProvider', () => {
 
   it('emits --add-dir for cwd, every additionalRoot, and the prompt / output dirs (deduped)', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const repoA = absolutePath('/tmp/codex-repo-a');
@@ -160,7 +128,7 @@ describe('createInteractiveCodexProvider', () => {
 
   it('leaves sessionId unset — codex accepts no harness-supplied id at launch', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({

--- a/tests/integration/ai/providers/codex/interactive.test.ts
+++ b/tests/integration/ai/providers/codex/interactive.test.ts
@@ -62,7 +62,7 @@ describe('createInteractiveCodexProvider', () => {
     expect(r.error.message).toContain('Codex model');
   });
 
-  it('spawns codex directly (no bash wrapper) with --cd, --add-dir, -s, -a, and prompt content', async () => {
+  it('spawns codex directly (no bash wrapper) with --cd, --add-dir, -s, -a, and a prompt-file pointer', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
     const provider = createInteractiveCodexProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
@@ -89,8 +89,9 @@ describe('createInteractiveCodexProvider', () => {
     expect(args).toContain('workspace-write');
     expect(args).toContain('-a');
     expect(args).toContain('never');
-    expect(args).toContain(STUB_PROMPT);
-    expect(args.at(-1)).toBe(STUB_PROMPT);
+    // Trailing positional is a pointer at the prompt file, never the body — see prompt-pointer.ts.
+    expect(args.at(-1)).toContain(String(PROMPT_FILE));
+    expect(args).not.toContain(STUB_PROMPT);
     // No bash remnants.
     expect(args).not.toContain('-lc');
     expect(calls[0]!.cwd).toBe(String(CWD));

--- a/tests/integration/ai/providers/copilot/copilot-provider.test.ts
+++ b/tests/integration/ai/providers/copilot/copilot-provider.test.ts
@@ -687,10 +687,51 @@ describe('buildCopilotArgs — AiSession → CLI flag translation', () => {
     expect(unwrapArgs(session()).some((s) => s.startsWith('--effort'))).toBe(false);
   });
 
-  it('emits the prompt as the trailing -p argv pair', () => {
+  it('classifies a synchronous spawn throw instead of letting it escape the attempt', async () => {
+    // cross-spawn raises an oversized command line synchronously on Windows, and the spawn call
+    // used to sit outside any try/catch — the exception escaped runProviderAttempt and would have
+    // taken the process down rather than failing the round.
+    const cap = createCapturingBus();
+    const provider = createCopilotProvider({
+      rateLimitRetries: 0,
+      eventBus: cap.bus,
+      spawn: () => {
+        throw Object.assign(new Error('spawn ENAMETOOLONG'), { code: 'ENAMETOOLONG' });
+      },
+    });
+
+    const out = await provider.generate(session());
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect(out.error.message).toContain('spawn failed');
+    expect(out.error.message).toContain('not in argv');
+  });
+
+  it('inlines the prompt on -p only when no prompt file could be written', () => {
     const args = unwrapArgs(session());
     const idx = args.indexOf('-p');
     expect(idx).toBeGreaterThanOrEqual(0);
     expect(args[idx + 1]).toBe(PROMPT as unknown as string);
+  });
+
+  it('writes the prompt to disk and passes -p a pointer at it, mounting its directory', async () => {
+    // Copilot is the one CLI with no stdin prompt path, so the body used to ride argv — which
+    // capped every headless run at the platform command line and died as `spawn ENAMETOOLONG`
+    // on Windows.
+    const cap = createCapturingBus();
+    const sess = session();
+    const { spawn, calls } = makeSpawn([{ stdoutChunks: ['{"session_id":"sess-1"}\n'], exitCode: 0 }]);
+    const provider = createCopilotProvider({ rateLimitRetries: 0, eventBus: cap.bus, spawn });
+
+    await provider.generate(sess);
+
+    const promptFile = join(dirname(String(sess.signalsFile)), 'copilot-prompt.md');
+    await expect(fs.readFile(promptFile, 'utf8')).resolves.toBe(PROMPT as unknown as string);
+
+    const args = calls[0]!.args;
+    const idx = args.indexOf('-p');
+    expect(args[idx + 1]).toContain(promptFile);
+    expect(args).not.toContain(PROMPT as unknown as string);
+    expect(args).toContain(`--add-dir=${dirname(promptFile)}`);
   });
 });

--- a/tests/integration/ai/providers/copilot/interactive.test.ts
+++ b/tests/integration/ai/providers/copilot/interactive.test.ts
@@ -66,7 +66,7 @@ describe('createInteractiveCopilotProvider', () => {
     expect(r.error.message).toContain('Copilot model');
   });
 
-  it('spawns copilot directly with --add-dir=<path>, --model=<model>, --allow-all-tools, and -i <prompt content>', async () => {
+  it('spawns copilot directly with --add-dir=<path>, --model=<model>, --allow-all-tools, and -i <prompt pointer>', async () => {
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
     const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
@@ -97,11 +97,13 @@ describe('createInteractiveCopilotProvider', () => {
     expect(args).toContain('--allow-all-tools');
     expect(args).not.toContain('--deny-tool=write');
     expect(args).not.toContain('--allow-tool=write');
-    // Prompt content is passed as a single argv to -i (no bash, no command substitution —
-    // matches v1's working adapter and avoids shell-quoting failure modes).
+    // A pointer at the prompt file rides `-i` as a single argv element (no bash, no command
+    // substitution — matches v1's working adapter and avoids shell-quoting failure modes). The
+    // body stays on disk so argv size does not track prompt size.
     const iIndex = args.indexOf('-i');
     expect(iIndex).toBeGreaterThanOrEqual(0);
-    expect(args[iIndex + 1]).toBe(PROMPT_CONTENT);
+    expect(args[iIndex + 1]).toContain(String(PROMPT_FILE));
+    expect(args).not.toContain(PROMPT_CONTENT);
     expect(calls[0]!.cwd).toBe(String(CWD));
   });
 

--- a/tests/integration/ai/providers/copilot/interactive.test.ts
+++ b/tests/integration/ai/providers/copilot/interactive.test.ts
@@ -1,46 +1,14 @@
-import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import { makeInteractiveSpawn } from '@tests/fixtures/interactive-spawn-fake.ts';
 import { COPILOT_MODELS } from '@src/domain/value/settings-models/copilot.ts';
 import { createInteractiveCopilotProvider } from '@src/integration/ai/providers/copilot/interactive.ts';
-import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 
 // The session skeleton this adapter delegates to — model validation, prompt-file reads, spawn
 // failures, abort precedence, the exit-code branch, the session-id sidechannel — is covered once
 // in tests/integration/ai/providers/_engine/run-interactive-session.test.ts. What stays here is
 // the part that is genuinely Copilot-specific: the argv it builds.
-
-interface CapturingSpawnState {
-  readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
-  readonly emitExit: (code: number | null) => void;
-}
-
-const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
-  const last = {
-    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
-  };
-  const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd });
-    const child = new EventEmitter() as unknown as ChildProcess & {
-      emit: (event: string, ...args: unknown[]) => boolean;
-    };
-    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
-    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
-    last.child = child;
-    return child;
-  };
-  return {
-    spawn,
-    calls,
-    emitExit: (code) => {
-      setTimeout(() => last.child?.emit('close', code), 0);
-    },
-  };
-};
 
 const PROMPT_FILE = absolutePath('/tmp/copilot-prompt.md');
 const OUTPUT_FILE = absolutePath('/tmp/copilot-output.md');
@@ -51,7 +19,7 @@ const stubReadFile = (): Promise<string> => Promise.resolve(PROMPT_CONTENT);
 describe('createInteractiveCopilotProvider', () => {
   it('rejects a model outside the Copilot catalog with InvalidStateError', async () => {
     const cap = createCapturingBus();
-    const { spawn } = makeSpawn();
+    const { spawn } = makeInteractiveSpawn();
     const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
     const r = await provider.run({
       cwd: CWD,
@@ -68,7 +36,7 @@ describe('createInteractiveCopilotProvider', () => {
 
   it('spawns copilot directly with --add-dir=<path>, --model=<model>, --allow-all-tools, and -i <prompt pointer>', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
@@ -109,7 +77,7 @@ describe('createInteractiveCopilotProvider', () => {
 
   it('forwards the resolved effort as --effort=<level>, and omits the flag when unset', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const withEffort = provider.run({
@@ -136,7 +104,7 @@ describe('createInteractiveCopilotProvider', () => {
 
   it('auto-mounts dirname(outputFile) and dirname(promptFile) for harness-controlled writes', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCopilotProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
@@ -157,7 +125,7 @@ describe('createInteractiveCopilotProvider', () => {
 
   it('passes a pre-generated session id via --session-id=<uuid>', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveCopilotProvider({
       eventBus: cap.bus,
       spawn,

--- a/tests/integration/ai/providers/opencode/interactive.test.ts
+++ b/tests/integration/ai/providers/opencode/interactive.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
@@ -15,17 +15,27 @@ import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/int
 
 interface CapturingSpawnState {
   readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{ readonly command: string; readonly args: readonly string[]; readonly cwd: string }>;
+  readonly calls: ReadonlyArray<{
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly env?: Readonly<Record<string, string>>;
+  }>;
   readonly emitExit: (code: number | null) => void;
 }
 
 const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
+  const calls: Array<{
+    command: string;
+    args: readonly string[];
+    cwd: string;
+    env?: Readonly<Record<string, string>>;
+  }> = [];
   const last = {
     child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
   };
   const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd });
+    calls.push({ command, args, cwd: options.cwd, ...(options.env !== undefined ? { env: options.env } : {}) });
     const child = new EventEmitter() as unknown as ChildProcess & {
       emit: (event: string, ...args: unknown[]) => boolean;
     };
@@ -65,28 +75,30 @@ describe('createInteractiveOpencodeProvider', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]!.command).toBe('opencode');
     // Order is load-bearing: `opencode [project]` takes the directory positionally, and the
-    // rendered prompt (which carries the audit-[09] contract section) rides --prompt.
-    //
-    // Body inlined here because PROMPT_FILE sits outside CWD and OpenCode has no --add-dir to
-    // mount it with — the pointer would name a path this session cannot open. See the sibling
-    // test for the reachable case.
-    expect(calls[0]!.args).toEqual([String(CWD), '--model', MODEL, '--prompt', STUB_PROMPT]);
+    // rendered prompt (which carries the audit-[09] contract section) rides --prompt — as a
+    // pointer at the prompt file, never the body.
+    expect(calls[0]!.args.slice(0, 4)).toEqual([String(CWD), '--model', MODEL, '--prompt']);
+    expect(calls[0]!.args.at(-1)).toContain(String(PROMPT_FILE));
+    expect(calls[0]!.args).not.toContain(STUB_PROMPT);
     expect(calls[0]!.cwd).toBe(String(CWD));
   });
 
-  it('passes a pointer instead of the body when the prompt file sits inside the project directory', async () => {
+  it('grants read access to the prompt directory only, since OpenCode has no --add-dir', async () => {
+    // Without this the CLI auto-rejects the pointer target as `permission requested:
+    // external_directory` and the session opens with no instructions — PROMPT_FILE lives outside
+    // CWD for ideate and memory-distill. The grant is scoped: everything else stays denied.
     const cap = createCapturingBus();
     const { spawn, calls, emitExit } = makeSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
-    // The plan / refine shape: cwd IS the per-run sandbox that holds prompt.md.
-    const promptFile = absolutePath(join(String(CWD), 'prompt.md'));
-    const runPromise = provider.run({ cwd: CWD, promptFile, outputFile: OUTPUT_FILE, model: MODEL });
+    const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
     emitExit(0);
     await runPromise;
 
-    expect(calls[0]!.args.at(-1)).toContain(String(promptFile));
-    expect(calls[0]!.args).not.toContain(STUB_PROMPT);
+    const config: unknown = JSON.parse(calls[0]!.env!['OPENCODE_CONFIG_CONTENT']!);
+    expect(config).toEqual({
+      permission: { external_directory: { '*': 'deny', [join(dirname(String(PROMPT_FILE)), '*')]: 'allow' } },
+    });
   });
 
   it('drops effort — --variant is `run`-only and the yargs-strict TUI command would exit 1', async () => {

--- a/tests/integration/ai/providers/opencode/interactive.test.ts
+++ b/tests/integration/ai/providers/opencode/interactive.test.ts
@@ -1,57 +1,15 @@
-import { EventEmitter } from 'node:events';
 import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
 import { createCapturingBus } from '@tests/fixtures/capturing-event-bus.ts';
+import { makeInteractiveSpawn } from '@tests/fixtures/interactive-spawn-fake.ts';
 import { OPENCODE_MODELS } from '@src/domain/value/settings-models/opencode.ts';
 import { createInteractiveOpencodeProvider } from '@src/integration/ai/providers/opencode/interactive.ts';
-import type { InteractiveSpawn } from '@src/integration/ai/providers/_engine/interactive-spawn.ts';
 
 // The session skeleton this adapter delegates to — model validation, prompt-file reads, spawn
 // failures, abort precedence, the exit-code branch — is covered once in
 // tests/integration/ai/providers/_engine/run-interactive-session.test.ts. What stays here is the
 // part that is genuinely OpenCode-specific: the argv it builds.
-
-interface CapturingSpawnState {
-  readonly spawn: InteractiveSpawn;
-  readonly calls: ReadonlyArray<{
-    readonly command: string;
-    readonly args: readonly string[];
-    readonly cwd: string;
-    readonly env?: Readonly<Record<string, string>>;
-  }>;
-  readonly emitExit: (code: number | null) => void;
-}
-
-const makeSpawn = (): CapturingSpawnState => {
-  const calls: Array<{
-    command: string;
-    args: readonly string[];
-    cwd: string;
-    env?: Readonly<Record<string, string>>;
-  }> = [];
-  const last = {
-    child: undefined as (ChildProcess & { emit: (event: string, ...args: unknown[]) => boolean }) | undefined,
-  };
-  const spawn: InteractiveSpawn = (command, args, options) => {
-    calls.push({ command, args, cwd: options.cwd, ...(options.env !== undefined ? { env: options.env } : {}) });
-    const child = new EventEmitter() as unknown as ChildProcess & {
-      emit: (event: string, ...args: unknown[]) => boolean;
-    };
-    // `attachAbortKill` calls `child.kill` on abort — the fake needs it to be callable.
-    (child as unknown as { kill: () => boolean }).kill = (): boolean => true;
-    last.child = child;
-    return child;
-  };
-  return {
-    spawn,
-    calls,
-    emitExit: (code) => {
-      setTimeout(() => last.child?.emit('close', code), 0);
-    },
-  };
-};
 
 const STUB_PROMPT = 'Refine this OpenCode task.';
 const stubReadFile = (): Promise<string> => Promise.resolve(STUB_PROMPT);
@@ -64,7 +22,7 @@ const MODEL = OPENCODE_MODELS[0]!;
 describe('createInteractiveOpencodeProvider', () => {
   it('spawns opencode with the project directory positional first, then --model and --prompt', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
@@ -88,22 +46,30 @@ describe('createInteractiveOpencodeProvider', () => {
     // external_directory` and the session opens with no instructions — PROMPT_FILE lives outside
     // CWD for ideate and memory-distill. The grant is scoped: everything else stays denied.
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });
     emitExit(0);
     await runPromise;
 
-    const config: unknown = JSON.parse(calls[0]!.env!['OPENCODE_CONFIG_CONTENT']!);
-    expect(config).toEqual({
-      permission: { external_directory: { '*': 'deny', [join(dirname(String(PROMPT_FILE)), '*')]: 'allow' } },
-    });
+    const config = JSON.parse(calls[0]!.env!['OPENCODE_CONFIG_CONTENT']!) as {
+      permission: { external_directory: Record<string, string> };
+    };
+    const rules = config.permission.external_directory;
+    expect(rules['*']).toBe('deny');
+    expect(rules[join(dirname(String(PROMPT_FILE)), '*')]).toBe('allow');
+    // Every allowed key names the prompt directory (in one separator spelling or the other, since
+    // a backslash glob may not match a path OpenCode normalised) — nothing wider slips in.
+    const promptDir = dirname(String(PROMPT_FILE)).replaceAll('\\', '/');
+    for (const [pattern, action] of Object.entries(rules)) {
+      if (action === 'allow') expect(pattern.replaceAll('\\', '/')).toBe(`${promptDir}/*`);
+    }
   });
 
   it('drops effort — --variant is `run`-only and the yargs-strict TUI command would exit 1', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({
@@ -123,7 +89,7 @@ describe('createInteractiveOpencodeProvider', () => {
 
   it('rejects a bare model id that is missing the provider namespace', async () => {
     const cap = createCapturingBus();
-    const { spawn } = makeSpawn();
+    const { spawn } = makeInteractiveSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const r = await provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: 'gpt-5.5' });
@@ -135,7 +101,7 @@ describe('createInteractiveOpencodeProvider', () => {
 
   it('leaves sessionId unset — opencode mints its own and only surfaces it on the run stream', async () => {
     const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeSpawn();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
     const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
 
     const runPromise = provider.run({ cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: MODEL });

--- a/tests/integration/ai/providers/opencode/interactive.test.ts
+++ b/tests/integration/ai/providers/opencode/interactive.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import { absolutePath } from '@tests/fixtures/domain.ts';
@@ -65,8 +66,27 @@ describe('createInteractiveOpencodeProvider', () => {
     expect(calls[0]!.command).toBe('opencode');
     // Order is load-bearing: `opencode [project]` takes the directory positionally, and the
     // rendered prompt (which carries the audit-[09] contract section) rides --prompt.
+    //
+    // Body inlined here because PROMPT_FILE sits outside CWD and OpenCode has no --add-dir to
+    // mount it with — the pointer would name a path this session cannot open. See the sibling
+    // test for the reachable case.
     expect(calls[0]!.args).toEqual([String(CWD), '--model', MODEL, '--prompt', STUB_PROMPT]);
     expect(calls[0]!.cwd).toBe(String(CWD));
+  });
+
+  it('passes a pointer instead of the body when the prompt file sits inside the project directory', async () => {
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeSpawn();
+    const provider = createInteractiveOpencodeProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+
+    // The plan / refine shape: cwd IS the per-run sandbox that holds prompt.md.
+    const promptFile = absolutePath(join(String(CWD), 'prompt.md'));
+    const runPromise = provider.run({ cwd: CWD, promptFile, outputFile: OUTPUT_FILE, model: MODEL });
+    emitExit(0);
+    await runPromise;
+
+    expect(calls[0]!.args.at(-1)).toContain(String(promptFile));
+    expect(calls[0]!.args).not.toContain(STUB_PROMPT);
   });
 
   it('drops effort — --variant is `run`-only and the yargs-strict TUI command would exit 1', async () => {


### PR DESCRIPTION
A Windows user on v0.18.0 hit `interactive-claude: failed to spawn — spawn ENAMETOOLONG` running **plan**. The prompt was passed as a single command-line argument, and Windows caps a command line at 32,767 bytes — which the plan template (~22 KB before substitutions, plus up to 160 KB of `PRIOR_PROGRESS` on a 1M-window model) clears easily. The session died before the CLI started, and nothing in the error pointed at why.

## What changed

The prompt stays in the `prompt.md` the harness already writes; argv carries a fixed ~250-byte pointer at it. A 38 KB prompt now produces a 554-byte command line. Applied to all four interactive adapters and to Copilot headless — the one headless adapter that also used argv, since that CLI has no stdin prompt path (`--prompt-file` is [copilot-cli#3398](https://github.com/github/copilot-cli/issues/3398), open and unimplemented).

Each adapter grants its CLI read access to the prompt file's directory and nothing wider. OpenCode has no `--add-dir`, so it gets a path-scoped `external_directory` grant via `OPENCODE_CONFIG_CONTENT`, which merges into the operator's own config rather than replacing it.

Two pre-existing defects on the same path, both found while implementing:

- A synchronous spawn throw — which is how Windows reports this — escaped `runProviderAttempt` uncaught instead of failing the round.
- `spawnError` was dropped at the classifier call site, leaving that branch unreachable; an oversized argv was classified as a *retryable* crash with the hint "verify the CLI is on PATH", so it burned the whole attempt budget rebuilding the identical command.

## Verification

`/verify` green (5360 tests), lint at its existing cap, knip clean. Beyond that:

- The pointer wording was run against the real `claude` binary — it read the file and executed the instructions. A green unit suite cannot prove that part.
- The OpenCode grant was run against the real `opencode` binary (v1.18.15): the allowed directory reads, a sibling directory is refused, and the operator's pre-existing rules survive in the merged rule set.
- New regression test: a 200 KB prompt still yields a command line under a fixed byte bound.
- One test spawns a real `node` child to prove `env` is layered over `process.env` — a bare override would strip PATH and every provider credential.

**Not verified:** the interactive TTY handoff end-to-end (needs a human at the keyboard; the stdio path itself is unchanged), Copilot headless (no Copilot auth in this checkout — test-covered but unsmoked), and the Windows glob-separator spelling in the OpenCode grant. That last one is why both separator forms are granted: a non-matching pattern would not error, it would open a session that cannot read its only instruction.

## Follow-up

#278 — OpenCode interactive silently drops `additionalRoots`, which the port contract says should raise `InvalidStateError`. Pre-existing, now fixable with this same mechanism, deliberately left out so a spawn-safety fix does not quietly widen what an OpenCode session can read.

https://claude.ai/code/session_01VLHUDzJCQ45gotzdBP4pJw