### PR TITLE
ci: coverage floors over the TUI, asset-aware dist smoke, changelog gate before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+      # knip — exits 0 on a clean tree. Needs no build output (its entry points are
+      # tests/ + scripts/ over src/), so it runs before Build.
+      - name: Dead code (knip)
+        run: pnpm deadcode
+
       - name: Build
         run: pnpm build
 
@@ -58,13 +63,35 @@ jobs:
       - name: Verify dist works from arbitrary cwd
         run: cd /tmp && node $GITHUB_WORKSPACE/dist/cli.mjs --version
 
+      # `--version` is answered by commander before `bootstrapCli` ever runs, so it never
+      # reaches `runBundleIntegrityCheck` and never touches a single bundled asset — the
+      # 0.15.0 fresh-install failure walked straight past that gate. `skills list` /
+      # `agents list` boot the real composition root (bootstrapCli → wire →
+      # runBundleIntegrityCheck) and then read every bundled SKILL.md / agent .md back
+      # through `resolveBundledRoot`, which is the resolver that actually broke. No AI CLI
+      # and no network are involved; every write is confined to RALPHCTL_HOME.
+      # `out=$(cmd)` + `printf | grep`, never `cmd | grep`: the default shell is `bash -e`
+      # WITHOUT pipefail, so a pipe would swallow a non-zero exit from the CLI.
+      - name: Verify dist boots a real subcommand (bundle integrity)
+        env:
+          RALPHCTL_HOME: ${{ runner.temp }}/ralphctl-dist-smoke
+        run: |
+          skills=$(node dist/cli.mjs skills list)
+          printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
+          agents=$(node dist/cli.mjs agents list)
+          printf '%s\n' "$agents" | grep -q '^ralphctl-evaluator'
+
       - name: Verify npm pack installs correctly
+        env:
+          RALPHCTL_HOME: ${{ runner.temp }}/ralphctl-pack-smoke
         run: |
           TARBALL=$(pnpm pack --pack-destination /tmp 2>/dev/null | tail -1)
           cd /tmp && mkdir -p ralphctl-smoke && cd ralphctl-smoke
           npm init -y
           npm install "$TARBALL"
           ./node_modules/.bin/ralphctl --version
+          skills=$(./node_modules/.bin/ralphctl skills list)
+          printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
 
   # Reproducibility gate. The fast `check` job above runs against whatever
   # node_modules the pnpm cache restores; that path can pass even when the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,55 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      # Tag / version / changelog gates run FIRST: none of them needs node_modules, and a bad
+      # tag or a missing release-notes heading should fail in seconds rather than after a full
+      # install + test + build. Critically, they must all pass BEFORE `Publish to npm` — an npm
+      # publish is irreversible, so nothing that can reject the release may run after it.
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # No git-log fallback: a commit-subject dump is not release notes, and silently
+      # substituting one hid the real defect (nobody wrote the changelog section) until after
+      # the package was already public. Missing heading and empty body are separate messages
+      # because they have separate fixes.
+      - name: Extract and validate changelog section
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::No '## [${VERSION}]' heading in CHANGELOG.md — write the release notes before tagging."
+            exit 1
+          fi
+          # `marker` is matched as a literal-prefix string (index(...) == 1) rather than a
+          # regex — `## [x.y.z]` contains `[`/`]` regex metacharacters that would otherwise
+          # turn the marker into a single-char class and silently match nothing.
+          SECTION=$(awk -v marker="## [${VERSION}]" '
+            index($0, marker) == 1 { found=1; next }
+            found && substr($0, 1, 4) == "## [" { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$(printf '%s' "$SECTION" | tr -d '[:space:]')" ]; then
+            echo "::error file=CHANGELOG.md::The '## [${VERSION}]' section is empty — write the release notes before tagging."
+            exit 1
+          fi
+
+          {
+            echo "notes<<EOF"
+            echo "$SECTION"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - run: pnpm install --frozen-lockfile
 
       - name: Format check
@@ -41,8 +90,13 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test
+      - name: Dead code (knip)
+        run: pnpm deadcode
+
+      # `pnpm coverage`, not `pnpm test`: the release must run the same regression floors CI
+      # gates PRs on, otherwise a release can ship coverage CI would have rejected.
+      - name: Test (with coverage thresholds)
+        run: pnpm coverage
 
       - name: Build
         run: pnpm build
@@ -50,58 +104,21 @@ jobs:
       - name: Verify dist
         run: node dist/cli.mjs --version
 
-      - name: Verify tag matches package.json version
+      # Mirrors ci.yml — `--version` never reaches `runBundleIntegrityCheck`, so it cannot
+      # catch a broken bundled-asset layout. The release gate must not be weaker than CI.
+      - name: Verify dist boots a real subcommand (bundle integrity)
+        env:
+          RALPHCTL_HOME: ${{ runner.temp }}/ralphctl-dist-smoke
         run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
+          skills=$(node dist/cli.mjs skills list)
+          printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
+          agents=$(node dist/cli.mjs agents list)
+          printf '%s\n' "$agents" | grep -q '^ralphctl-evaluator'
 
       - name: Publish to npm
         run: pnpm publish --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Extract changelog section
-        id: changelog
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Extract the section for this version from CHANGELOG.md.
-          # `marker` is matched as a literal-prefix string (index(...) == 1) rather than a
-          # regex — `## [x.y.z]` contains `[`/`]` regex metacharacters that would otherwise
-          # turn the marker into a single-char class and silently match nothing.
-          SECTION=$(awk -v marker="## [${VERSION}]" '
-            index($0, marker) == 1 { found=1; next }
-            found && substr($0, 1, 4) == "## [" { exit }
-            found { print }
-          ' CHANGELOG.md)
-
-          if [ -z "$SECTION" ]; then
-            # Fallback to git log if no changelog section found
-            PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed -n '2p')
-            CURRENT_TAG="${GITHUB_REF_NAME}"
-            if [ -n "$PREV_TAG" ]; then
-              SECTION=$(git log "${PREV_TAG}..${CURRENT_TAG}" \
-                --pretty=format:"- %s ([%h](https://github.com/${{ github.repository }}/commit/%H))" \
-                --no-merges)
-            else
-              SECTION=$(git log "${CURRENT_TAG}" \
-                --pretty=format:"- %s ([%h](https://github.com/${{ github.repository }}/commit/%H))" \
-                --no-merges)
-            fi
-          fi
-
-          {
-            echo "notes<<EOF"
-            echo "$SECTION"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,18 +13,31 @@ export default defineConfig({
       reporter: ['text', 'html', 'json-summary', 'lcov'],
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
-      exclude: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**', 'src/application/ui/**'],
-      // Regression floor — set ~1% below the 2026-08-14 baseline (post the provider
-      // conformance suite + plan-critic + first-run-bundle test lift). Baseline measured
-      // at that date:
-      //   statements 91.04 · branches 81.13 · functions 96.78 · lines 94.03.
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**'],
+      // Regression floors, measured 2026-08-17 with `src/application/ui/**` INCLUDED in
+      // coverage — the exclude that used to hide the primary surface (TUI + CLI, 237 files)
+      // is gone, so the whole tree now has a floor. Measured that day:
+      //   whole tree  statements 87.27 · branches 77.16 · functions 91.46 · lines 90.06
+      //   non-UI      statements 91.04 · branches 81.13 · functions 96.78 · lines 94.03
+      //   UI          statements 81.25 · branches 71.31 · functions 84.24 · lines 83.69
+      // Three tiers rather than one lowered global number: v8-over-Ink coverage is noisier
+      // than pure logic, so the UI tier gets its own lower floor while the logic tier keeps
+      // the strict floor it has always had (90/80/96/93 — unchanged).
+      // NOTE: vitest applies the GLOBAL thresholds to every file even when glob keys are
+      // present — the globs ADD floors, they do not partition — so the global row must be
+      // the whole-tree number, not the non-UI one.
+      // Glob matching is on the path relative to the vitest root, so the POSIX separators
+      // below only match on POSIX runners; on Windows an empty coverage map reads as 100%,
+      // i.e. the glob tiers degrade to vacuously-pass, never to a false failure. CI is ubuntu.
       // Raise these in lockstep with new tests; do NOT tighten retroactively in a commit
       // that isn't adding tests.
       thresholds: {
-        statements: 90,
-        branches: 80,
-        functions: 96,
-        lines: 93,
+        statements: 86,
+        branches: 75,
+        functions: 90,
+        lines: 88,
+        '!src/application/ui/**': { statements: 90, branches: 80, functions: 96, lines: 93 },
+        'src/application/ui/**': { statements: 79, branches: 69, functions: 82, lines: 82 },
       },
     },
     // Two projects so the heavy TUI render tests can run with file-level serialisation


### PR DESCRIPTION
Council-selected hardening of the CI and release gates. Three files, no runtime code.

- **Coverage**: drop the `src/application/ui/**` exclude (237 files, ~34% of src had no regression floor); three-tier thresholds — global 86/75/90/88, non-UI unchanged at 90/80/96/93, UI 79/69/82/82 — all 1–2pp under freshly measured values.
- **Dist/pack smoke**: boot `skills list` + `agents list` under a throwaway `RALPHCTL_HOME` so `runBundleIntegrityCheck` actually runs — `--version` short-circuits before `bootstrapCli`, which is how the 0.15.0 fresh-install break shipped undetected. Negative control verified: with `dist/prompts` removed, `--version` exits 0 while `skills list` exits 1.
- **Release order**: changelog extraction + validation hoisted above npm publish; silent git-log fallback replaced with two hard failures (`::error` annotations); release test step aligned to `pnpm coverage`.
- **CI gate**: `pnpm deadcode` (knip) added to the check job and release.

Required status-check contexts untouched (`check` / `coverage` / `cold-install` job names match `setup-required-checks.sh`). Full gate green locally: 5598/5598 tests, lint `--max-warnings 0`, knip, format.

https://claude.ai/code/session_01PHikH4LdejozJdjzTzhPes