### PR TITLE
fix: maintenance-council hardening sweep

### DIFF
--- a/.claude/agent-memory/docs-keeper/MEMORY.md
+++ b/.claude/agent-memory/docs-keeper/MEMORY.md
@@ -14,3 +14,7 @@
   diff both `<tag>..origin/main` and `origin/main..HEAD` — squash-merged PRs can lack a changelog line
 - [reference_opencode_headless_vs_interactive.md](reference_opencode_headless_vs_interactive.md) — SECURITY.md's
   OpenCode paragraphs mix headless (`--auto`) and interactive (`buildOpencodeEnv` config grant) — don't conflate
+- [reference_provider_fanout_registries.md](reference_provider_fanout_registries.md) — Provider fan-out is
+  `Record<AiProvider,…>` tables, not switches; regenerate the list by grep, never hand-maintain
+- [reference_entity_symbol_names_drift.md](reference_entity_symbol_names_drift.md) — ARCHITECTURE § Data Models
+  entity mutator/field names rot silently; table of the 2026-08-18 renames

--- a/.claude/agent-memory/docs-keeper/reference_entity_symbol_names_drift.md
+++ b/.claude/agent-memory/docs-keeper/reference_entity_symbol_names_drift.md
@@ -1,0 +1,26 @@
+---
+name: reference-entity-symbol-names-drift
+description: ARCHITECTURE § Data Models names entity mutators/fields that get renamed in code without a doc edit — grep every named symbol before trusting the section
+metadata:
+  type: reference
+---
+
+`.claude/docs/ARCHITECTURE.md § Data Models` is the section agents are pointed at for entity
+shapes, and it accumulates symbol names that no longer exist. Every name in it is a claim —
+`grep -rn "<symbol>" src` before repeating one.
+
+Renames caught in the 2026-08-18 audit (all had ZERO hits in `src/`):
+
+| Doc said                                               | Reality                                                                                                                                                                                         |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `affectedRepositories`                                 | never existed — repo targeting is `Task.repositoryId` vs `project.repositories`                                                                                                                 |
+| `refineTicket` (Sprint mutator)                        | `replaceTicket` (`refineTicketUseCase` is the business use case, different thing)                                                                                                               |
+| `activate` / `transitionToReview` / `transitionToDone` | `activateSprint` / `transitionSprintToReview` / `transitionSprintToDone`                                                                                                                        |
+| `Ticket.requirementStatus`                             | `Ticket.status` (`pending → approved`), body in `requirements`                                                                                                                                  |
+| `Attempt.recoveryContext`                              | `Attempt.recovering?: RecoveryContext`                                                                                                                                                          |
+| `resolveProjectFile`                                   | `resolveProjectPath` (`integration/persistence/storage.ts`)                                                                                                                                     |
+| `runDoctor()`                                          | `useSystemStatus().refreshDoctor()` (`runtime/system-status-context.tsx`)                                                                                                                       |
+| `appendLearningsAndMirror`                             | `appendMemoryRecords` + `mirrorLearningsMd` — and the mirror is LAZY, rendered only at sprint close (`refreshMemoryMirrorLeaf`) and distill (`stampPromotedLeaf`), never on the hot append path |
+
+Paired sections that repeat these names and must be edited together: `WORKFLOWS.md § Two-phase
+planning` (ticket status + repo selection) and `PERFORMANCE.md § learning ledger`.

--- a/.claude/agent-memory/docs-keeper/reference_provider_fanout_registries.md
+++ b/.claude/agent-memory/docs-keeper/reference_provider_fanout_registries.md
@@ -1,0 +1,31 @@
+---
+name: reference-provider-fanout-registries
+description: Widening the AiProvider union breaks ~15 total Record<AiProvider,…> tables plus one exhaustive switch — regenerate the list mechanically, never hand-maintain it
+metadata:
+  type: reference
+---
+
+Provider fan-out is registry-shaped, not switch-shaped. `docs/adding-a-provider.md` and root
+`ARCHITECTURE.md` both describe "the compiler routes you to every place that must change" — the
+places are total `Record<AiProvider, …>` tables, and the list rots the moment anyone adds one.
+
+Regenerate rather than trust the doc:
+
+```bash
+grep -rn 'Record<AiProvider' src | grep -v Partial   # the total tables (compile errors)
+grep -rn 'Partial<Record<AiProvider' src             # graceful-degradation registries (NOT errors)
+```
+
+The only remaining exhaustive `switch` on `AiProvider` is `toolForProvider`
+(`src/integration/ai/readiness/_engine/tool.ts`). Widening `AssistantTool` additionally forces its
+inverse `providerForTool` (same file) and `pickExistingContextPath`
+(`src/application/flows/readiness/leaves/propose.ts`).
+
+Gotcha: `PROVIDER_BINARY` / `PROVIDER_INSTALL_GUIDANCE` in `integration/system/detect-cli.ts` are
+one-line projections OF `PROVIDER_TRAITS`, but each is still its own total record — they do break
+the build. Two separate `PROVIDER_LABEL` tables exist (`flows/doctor/probe-helpers.ts` and
+`ui/shared/launch/readiness.ts`); documenting only one is the easy miss.
+
+Also drifts in pairs with provider counts: root `ARCHITECTURE.md § The provider boundary`,
+`README.md` headline/badges, `docs/adding-a-provider.md` union + `z.enum` examples. See
+[[project-high-drift-areas]].

--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -1,5 +1,13 @@
 # Implementer Memory
 
+- [project_root_session_id_nested_runners.md](project_root_session_id_nested_runners.md) — nested runners shadow
+  currentSessionId(): TUI-keyed chainSessionId must use the new rootSessionId(); + router.reset(entry) is now
+  required, and guard's single body-named `skipped` entry is what marks a dependency-blocked task
+
+- [project_runner_aborted_event_error_seam.md](project_runner_aborted_event_error_seam.md) — RunnerEvent
+  'aborted' carries an error ONLY for in-chain aborts (never for caller abort()/sibling kill); wave-scheduler
+  captures it on BOTH failed+aborted to stop the schedule instead of launching later waves
+
 - [project_settings_default_flip_surfaces.md](project_settings_default_flip_surfaces.md) — flipping a
   settings.harness default: 6 untested prose restatements (settings.ts JSDoc, TUI HARNESS_HINTS, 5 docs) +
   the optional per-preset harness pin seam in applyPreset
@@ -42,7 +50,7 @@
 - [project_implement_role_meta_sidecar.md](project_implement_role_meta_sidecar.md) — stamp-role-meta leaves persist
   per-round AI attribution to rounds/<N>/<role>/meta.json; preStampedRoundNum ctx seam isolates round claiming
 - [project_recoverable_turn_error_policy.md](project_recoverable_turn_error_policy.md) — gen-eval turn errors block the
-  task (self-blocked exit) instead of aborting the run; Aborted/RateLimit still propagate; via isRecoverableTurnError
+  task (self-blocked exit) instead of aborting the run; Aborted/RateLimit propagate; ProcessCrash → crashed retry (both roles)
 - [project_provider_stream_session_fields.md](project_provider_stream_session_fields.md) — empirical session-id/usage
   JSONL field names: codex thread_id on thread.started; copilot sessionId on result record
 - [project_session_als_fenced_from_integration.md](project_session_als_fenced_from_integration.md) — currentSessionId()
@@ -64,7 +72,7 @@
 - [project_attempt_scoped_ctx_reset_seam.md](project_attempt_scoped_ctx_reset_seam.md) — implement attempt-scoped ctx
   resets split across start-attempt (entry: verdict/session) vs progress-journal (exit: GENERATOR_HINTS accumulators)
 - [project_structured_verify_gates.md](project_structured_verify_gates.md) — WS3 per-module verify gates: precedence,
-  multi-gate VerifyRun representation, gitDiffFootprint seam, fail-fast post / all-run pre asymmetry, run-ALL fallback
+  multi-gate VerifyRun, gitDiffFootprint seam, fail-fast post / all-run pre asymmetry, coveredAllGates carry flag
 - [project_detect_scripts_verify_gates_signal.md](project_detect_scripts_verify_gates_signal.md) — T9 verify-gates signal:
   ONE signal carrying gates[] (not per-gate), .nonempty() schema, additive to verify-script, needed RepositoryUpdate wiring
 - [project_run_scoped_ctx_marker_fences.md](project_run_scoped_ctx_marker_fences.md) — a run-scoped ImplementCtx field
@@ -105,3 +113,12 @@
   AppDeps.providerSpawn must be forwarded at BOTH launcher rebuild sites (implement bypasses
   buildLaunchAdapters); scripted beats dispatch off the rounds/<N>/<role>/signals.json path scraped from
   the prompt — anchor the regex on the whole tail or it locks onto the template's `<outputDir>` prose
+- [project_path_traversal_test_sandbox.md](project_path_traversal_test_sandbox.md) — test-first traversal
+  regressions really escape the tmp fixture; nest session under a per-run root so the asserted escape
+  target stays unique, or the pre-fix artifact poisons the post-fix assertion
+- [project_tui_row_windowing_and_key_test_gotchas.md](project_tui_row_windowing_and_key_test_gotchas.md) — row-count
+  windowing needs 1 entry == 1 terminal row (pre-wrap, not truncate-end); ink-testing stdin batches a whole
+  written string into ONE useInput call; stub terminal is 100x24
+- [project_release_gate_seams.md](project_release_gate_seams.md) — release/CI gates: vitest FORCE_COLOR pin (never
+  add NO_COLOR), `npm init -y --prefix` writes into CWD (nearly corrupted package.json pre-publish), runCli's
+  reportFatal terminal frame (AbortError handled not re-thrown), `prompts list` as the prompt-resolver dist gate

--- a/.claude/agent-memory/implementer/project_path_traversal_test_sandbox.md
+++ b/.claude/agent-memory/implementer/project_path_traversal_test_sandbox.md
@@ -1,0 +1,20 @@
+---
+name: path-traversal-test-sandbox
+description: Writing a failing path-traversal regression test first really escapes the tmp sandbox — nest the session dir under a per-run root or the post-fix assertion is poisoned by the artifact the pre-fix run wrote
+metadata:
+  type: project
+---
+
+Test-first on a path-traversal defect: the failing run genuinely writes outside the fixture. A name
+like `../../../../tmp/pwned` under a `mkdtemp` session dir landed a real `SKILL.md` in
+`$TMPDIR/tmp/pwned`, which then made the post-fix `expect(existsSync(escapeTarget)).toBe(false)`
+assertion fail forever until the artifact was deleted by hand.
+
+**Why:** traversal targets that leave the unique `mkdtemp` dir resolve to a SHARED path, so the
+escape assertion is not run-isolated — a leftover from any earlier run (or from the vulnerable code
+itself) masks a regression in both directions.
+
+**How to apply:** for any traversal regression test, build the fixture as `root = mkdtemp(...)` +
+`session = root/repo`, and pick traversal depths that resolve back inside `root` (`../escape`,
+`../../../escape-far`). The escape is still real (outside `session`) but the asserted path stays
+unique per run. Related: [[project_slugged_data_layout_resolver]].

--- a/.claude/agent-memory/implementer/project_recoverable_turn_error_policy.md
+++ b/.claude/agent-memory/implementer/project_recoverable_turn_error_policy.md
@@ -12,6 +12,10 @@ remaining todo task. To stop one bad AI turn from taking down the entire impleme
 
 - `Aborted` / `RateLimit` codes → still `Result.error` (propagate, abort the run). Aborted = user cancel (CLAUDE.md
   transparent-propagation rule); RateLimit = adapter already exhausted 429 retries.
+- `ProcessCrash` (watchdog kill / spawn crash / non-zero exit with no signals.json) → `crashed` exit on BOTH roles
+  (evaluator parity landed 2026-08-18; it was generator-only before). `crashed` retries within `maxAttempts` and
+  deliberately leaves `lastBlockReason` unset, so the commit-task guard stays open and the retry starts from the
+  generator's committed work. `EvaluatorTurnExit` carries the member too (subset of `GenEvalExit`).
 - everything else (ParseError schema/json, InvalidStateError signals-missing / spawn-exit-N, MigrationGapError) →
   `Result.ok` with a `self-blocked` exit. The validator's message is preserved in the block reason.
 

--- a/.claude/agent-memory/implementer/project_release_gate_seams.md
+++ b/.claude/agent-memory/implementer/project_release_gate_seams.md
@@ -1,0 +1,45 @@
+---
+name: release-gate-seams
+description: Release/CI gate seams — vitest FORCE_COLOR pin, CLI terminal error frame, npm-pack prefix trap, and the prompts-list resolver gate
+metadata:
+  type: project
+---
+
+Four seams around the release/CI gates (hardened 2026-08-18, branch `chore/maintenance-hardening`).
+
+**1. Colour is PINNED in `vitest.config.ts`, per project (`env: { FORCE_COLOR: '0' }`).**
+**Why:** every TUI assertion is a plain-substring check on `lastFrame()`; an ambient `FORCE_COLOR`
+(Claude Code exports `FORCE_COLOR=3`) makes chalk split those substrings with SGR codes and 27
+assertions across 13 files went red on a pristine tree. Never add `NO_COLOR: '1'` alongside it —
+`useNoColor()` reads NO_COLOR to swap in the shape-glyph fallback, so pinning it suite-wide would
+run every test through the fallback path and neuter `tasks-panel-no-color.test.tsx`.
+**How to apply:** shared `stripAnsi` lives in `tests/integration/application/ui/tui/_harness.tsx`
+(use it for width/geometry assertions). `ci.yml`'s `cold-install` job runs `pnpm test` with
+`FORCE_COLOR: 3` on purpose — it is the only job that does, and it is the CI-side canary.
+
+**2. `npm init -y --prefix <dir>` IGNORES `--prefix` and writes package.json into the CWD.**
+**Why:** running it from the repo root appended `main` + `directories` to ralphctl's own
+package.json. In a release workflow that runs moments before `pnpm publish`, that is a corrupted
+publish.
+**How to apply:** in any pack/install smoke, write the stub by hand
+(`printf '{"name":"…","version":"0.0.0","private":true}\n' > "$SMOKE"/package.json`) then
+`npm install --prefix "$SMOKE" "$TARBALL"`. The stub is still load-bearing — with no package.json
+at the prefix npm walks up and installs into the repo tree.
+
+**3. `runCli` owns the CLI's terminal error frame** (`reportFatal` in `report-cli-error.ts`).
+**Why:** `bootstrapCli`'s pre-flights throw plain `Error`s; uncaught they print a source excerpt
+from the bundled `dist/cli-<hash>.mjs` plus a stack — worst on `doctor`, the command you run
+because something is already broken. `AbortError` is HANDLED there (exit 130), deliberately not
+re-thrown: the propagation rule targets mid-chain guards, and this is the last frame.
+**How to apply:** stack stays behind `RALPHCTL_DEBUG_TRACE`. Settings validation messages render
+compact `path: message` issue lists (`formatIssues`), never raw `ZodError.message` — the one-line
+stderr frame is worthless if `<message>` is a 40-line JSON dump.
+
+**4. `ralphctl prompts list` exists as a GATE, not a feature.**
+**Why:** there are four independent copies of the beside-the-module bundle probe; `skills list` /
+`agents list` / bundle-integrity walk three of them, and `fs-template-loader`'s copy falls back
+SILENTLY to the package root. A `dist/prompts/` rename passes every old smoke green while all 21
+prompt assets are unreadable (verified empirically). `prompts list` loads every body, so it exits 1.
+**How to apply:** the inventory is `_engine/bundled-templates.ts`, fenced against the on-disk tree
+by `tests/integration/ai/prompts/_engine/bundled-templates.test.ts` — a new prompt dir must join
+the list or that test fails. `ci.yml` + `release.yml` grep `^implement` from its output.

--- a/.claude/agent-memory/implementer/project_root_session_id_nested_runners.md
+++ b/.claude/agent-memory/implementer/project_root_session_id_nested_runners.md
@@ -1,0 +1,45 @@
+---
+name: root-session-id-nested-runners
+description: Nested runners shadow currentSessionId(); anything the TUI keys by SESSION (token-usage chainSessionId) must read rootSessionId() — plus the two other TUI-runtime seams fixed alongside it (router.reset explicit entry, guard-skipped task-body bucket status)
+metadata:
+  type: project
+---
+
+`src/application/session/session.ts` now stores `{ sessionId, rootSessionId }`. `runWithSession`
+SHADOWS `sessionId` (innermost wins — per-branch logger / signal attribution needs that) but
+INHERITS `rootSessionId` from the enclosing scope. `rootSessionId()` is the new export.
+
+**Why:** the parallel implement path runs one `createRunner({ id: 'task-<taskId>' })` per task
+inside the host runner's scope (plus prologue/epilogue sub-runners), and `runner.ts` wraps every
+`element.execute()` in `runWithSession(opts.id, …)`. So every generator/evaluator spawn stamped
+`chainSessionId` with `task-<uuid>`, while the Execute view does a plain
+`useTokenUsage(bus).get(hostRunnerId)` — the token/context readout was blank for the whole run on
+any `maxParallelTasks > 1` sprint. Threading the host id as data would have meant 6+ layers
+(ParallelImplementConfig → buildWaveBranches → PerTaskSubchainOpts → attempt-body → gen-eval-loop
+→ run-role-turn); the ALS root fixes every stamper at once and future nested runners for free.
+
+**How to apply:** anything keyed by BRANCH (logs, per-task signals) keeps `currentSessionId()`;
+anything keyed by SESSION as the TUI sees it uses `rootSessionId()`. The 5 `chainSessionId`
+stampers converted: `implement/leaves/{implement-session,reproduce,best-of-n-candidate,
+best-of-n-selection}.ts` + `_shared/signals-session.ts`. `review-round.ts` and
+`create-pr/leaves/generate-pr-content-leaf.ts` still read `currentSessionId()` — correct today
+(single runner, root === current), but convert them if either flow ever nests. Integration still
+cannot import the helper at all — see [[session-als-fenced-from-integration]].
+
+Two sibling TUI-runtime facts from the same batch:
+
+- `RouterApi.reset(entry)` no longer accepts a bare call. The old optional form fell back to the
+  FROZEN `initial` prop, so `h` / `D` on a first-run session re-mounted `welcome` /
+  `create-project`. WelcomeView's seed is now gated on `settingsRepo.exists()` (disk-backed), not
+  just its per-instance `useRef` — a re-mount used to re-run `applyPreset`, which replaces the
+  whole `ai` section over the user's Settings edits. Gotcha for tests: the settings-apply-preset
+  FLOW itself calls `detectInstalledProviders()`, so a seeding run counts 2 detect calls, not 1.
+- `guard` emits exactly ONE synthetic `skipped` trace entry, named after its BODY element. For a
+  dependency-blocked task that means only `dependency-gate-<id>` (completed) +
+  `task-body-<id>` (skipped) — no failed/aborted entry, no terminal leaf — so
+  `resolveStatusFromSubSteps` returned `running` forever and pinned the header/card cursor.
+  Fixed by a `task-body`-named skipped check (`BucketOptions.bodySubstepName`, defaulted like
+  `terminalSubstepName`) — NOT by "any skipped substep", because `reproduce-guard` /
+  `quarantine-blocked-diff-guard` skip routinely inside a healthy task. The cursor scans now share
+  `isInFlightBucket` (running|pending) from `bucket-task-signals.ts`; `tasksDone` still counts
+  only `completed` on purpose (a blocked task is not a pass, so `2/3` stays non-green).

--- a/.claude/agent-memory/implementer/project_runner_aborted_event_error_seam.md
+++ b/.claude/agent-memory/implementer/project_runner_aborted_event_error_seam.md
@@ -1,0 +1,31 @@
+---
+name: runner-aborted-event-error-seam
+description: RunnerEvent 'aborted' carries an optional error ONLY for in-chain aborts (not caller abort()); wave-scheduler keys on it to stop the schedule
+metadata:
+  type: project
+---
+
+`RunnerEvent` (src/application/chain/run/runner.ts) has TWO kinds of abort that used to be
+indistinguishable to any subscriber: the caller killed the run (`abort()` / outer signal /
+fatal-sibling kill), or the CHAIN ITSELF settled with an `aborted`-coded error. The runner now
+emits `{ type: 'aborted', error }` for the second kind only (via the `settleAborted(error?)` helper;
+`abortRequested` gates the field off, and `abortError` is retained so late-subscriber replay is
+lossless).
+
+**Why:** `createRunner` routes ANY `aborted`-coded error to the `aborted` terminal and never emits
+`failed`, so the wave scheduler's `capturedError` (only fed from `failed`) stayed `null` for a
+branch whose own chain aborted. `classify` early-returned, `stopLaunching` stayed false, and
+`runWaves` returned `Result.ok` — so an operator answering "abort" at an in-branch prompt
+(verify-execution red-baseline gate, preflight-task, post-task-verify, or any
+`InkInteractivePrompt` cancel, all of which build an AbortError with the outer signal untouched)
+was silently downgraded to "this one task did not settle" while later waves kept spending
+generator/evaluator sessions. Fixed 2026-08-18 in the maintenance-hardening batch.
+
+**How to apply:** Any new above-the-chain orchestrator that reads runner terminals must capture
+`event.error` on BOTH `failed` and `aborted` — an aborted event WITHOUT an error means "I killed
+this branch", so ignoring it there is what keeps fatal-sibling / outer-signal kills from
+double-reporting (first-fatal-wins still keeps a RateLimitError ahead of the synthesized abort).
+Do NOT synthesize `new AbortError({ elementName: branch.id })` in the scheduler instead — that
+loses the operator's reason string, which is what the TUI rail and `chain.log` display. See
+[[chain-runner-containment-boundary]] for the adjacent raw-throw abort path (it now forwards the
+thrown AbortError through the same helper).

--- a/.claude/agent-memory/implementer/project_structured_verify_gates.md
+++ b/.claude/agent-memory/implementer/project_structured_verify_gates.md
@@ -30,6 +30,14 @@ feat/gen-eval-speed (Phase 3, tasks T8/T10/T11/T12; 2026-06-10).
   `git diff --name-only HEAD` ∪ `git ls-files --others --exclude-standard` (untracked, de-duped). post-task
   -verify calls it ONLY when structured gates are configured. CRITICAL fallback: footprint error OR empty →
   `computeScope` returns `undefined` → run ALL gates (never silently skip), logged.
+- **Carry-baseline coverage flag (2026-08-18 fix):** a diff-scoped post `success` is NOT whole-tree evidence.
+  `runPostVerifyGates` returns `coveredAllGates = scope === undefined`; it rides `LeafOutput` →
+  `ctx.priorPostVerifyOutcome.{cwd,outcome,coveredAllGates}` and `isCarriedGreenForThisCwd` now requires
+  `coveredAllGates === true`. Absent flag (older ctx) = NOT covered → run the real gate. Without it, a gate
+  already red OUTSIDE task N's footprint mis-attributes as `regressed` on task N+1 (burns the T6 retry,
+  quarantines a correct diff, and bypasses both the `baseline-broken` hatch and the persisted
+  `baselineBrokenPolicy: 'proceed'` amnesty, since the recorded pre reads `success`). Serial path only —
+  `forkCtx` drops the field on the parallel path.
 - **Scope filtering ONLY applies when `opts.verifyGates` is present + non-empty** — the legacy single catch-all
   gate skips the git probe entirely (it matches every path anyway).
 - post-task-verify leaf now needs `gitRunner` in its Deps (wired from `deps.gitRunner` in per-task-subchain.ts).

--- a/.claude/agent-memory/implementer/project_tui_row_windowing_and_key_test_gotchas.md
+++ b/.claude/agent-memory/implementer/project_tui_row_windowing_and_key_test_gotchas.md
@@ -1,0 +1,31 @@
+---
+name: tui-row-windowing-and-key-test-gotchas
+description: Row-count windowing invariant for the document overlays + two ink-testing-library gotchas (batched stdin writes, 100x24 stub terminal) that silently make TUI keyboard tests pass for the wrong reason
+metadata:
+  type: project
+---
+
+Two things that cost real debugging time on the TUI hardening batch (2026-08-18).
+
+**1. `stdin.write('draft')` arrives at `useInput` as ONE input string, not five keystrokes.**
+A handler that matches `input === 'd'` never fires for a batched write, so a test that types a whole
+word "passes" against the buggy code. Write one character per call with a `tick()` between them when
+the behaviour under test is a single-key handler racing a prompt.
+
+**Why:** the `StatusBanner` `d`-dismiss gate regression test passed before the fix was applied; the
+batched write had sailed past the very bug it was meant to reproduce.
+
+**How to apply:** any test asserting "typing X does / does not trigger single-letter hotkey Y" must
+write char-by-char. Batched writes are fine only when asserting the resulting buffer contents.
+
+**2. ink-testing-library's stdout stub reports `columns = 100` and NO `rows`** — `useTerminalSize`
+falls back to 24. Derive expected viewport numbers from those two, don't guess.
+
+**3. Row-count windowing invariant.** Any surface that slices `lines[offset, offset + bodyRows]` and
+derives `maxOffset` from `lines.length` needs one array entry == one terminal row. Artifacts
+(`evaluation.md` critique, `progress.md` note) are written one paragraph per line, so the entry count
+and the painted row count diverge — `maxOffset` collapses to 0, `useDocumentScroll` early-returns on
+every key, the footer disappears and the tail is unreachable. Fix is pre-wrap (not `truncate-end`
+alone, which loses prose in a read-only prose viewer); `truncate-end` stays as the backstop.
+
+Related: [[project_view_hint_single_source]], [[project_trustworthy_firstrun_waves12_2026-08-14]].

--- a/.claude/agent-memory/tester/MEMORY.md
+++ b/.claude/agent-memory/tester/MEMORY.md
@@ -23,9 +23,13 @@ if (!r.ok) expect(r.error.code).toBe('not-found');
 ### Branded value objects
 
 ```typescript
-const path = AbsolutePath.trustString('/code');
-const sprintId = SprintId.trustString('20260429-120000-demo');
-const taskId = TaskId.trustString('abcdef01');
+// `parse()` is the ONLY constructor — there is no `trustString` (verified 2026-08-18).
+const absPath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`invalid path ${p}`);
+  return r.value;
+};
+const sprintId = '01933fbb-2222-7000-8000-0000000000aa' as unknown as SprintId;
 const slug = Slug.parse('demo');
 if (!slug.ok) throw slug.error;
 ```
@@ -34,7 +38,7 @@ if (!slug.ok) throw slug.error;
 
 ```typescript
 function uniqueRoot(): AbsolutePath {
-  return AbsolutePath.trustString(
+  return absPath(
     join(
       tmpdir(),
       `ralphctl-<module>-${String(process.pid)}-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`
@@ -54,7 +58,7 @@ if (process.platform === 'win32') return;
 
 - **No module-level `vi.mock`** for integration tests — they use real implementations with temp dirs (exception: mocking node builtins like `node:fs/promises` to inject specific error codes deterministically, where real filesystem cannot reproduce the exact error code reliably)
 - **`vi.mock('node:fs/promises', ...)` for named-import injection**: ESM named imports bind at link time, so `vi.spyOn` on the namespace object only intercepts namespace-qualified calls (e.g. `fs.readFile()`), not already-bound local `readFile` identifiers. `vi.mock` hoisting replaces the entire module factory before any import is evaluated — the only reliable seam for named-import interception. Put this in a SEPARATE test file so it doesn't affect co-located real-fs tests.
-- `AbsolutePath.trustString()` bypasses the VO validator for test paths (use only when you own the value)
+- **`trustString` does not exist anywhere in `src/`** (verified 2026-08-18 — the note that claimed otherwise was stale). Branded VOs expose `parse()` (and `generate()` on the id VOs). In tests either use the shared `@tests/fixtures/domain.ts` helpers (`absolutePath(...)`) or wrap locally: `const absPath = (p: string): AbsolutePath => { const r = AbsolutePath.parse(p); if (!r.ok) throw new Error(`invalid path ${p}`); return r.value; }`. Ids are commonly cast: `'…' as unknown as SprintId`.
 - Domain entity creation via static factory: `Task.create({...})` returns `Result<Task, ValidationError>`
 
 ## Gotchas
@@ -80,3 +84,5 @@ if (process.platform === 'win32') return;
 - [meta-run-flow-failure-arcs.md](meta-run-flow-failure-arcs.md) — implement-failure/review-failure arcs; RateLimitError yields 'failed' not 'aborted'
 - [progress-overlay-flake-elimination.md](progress-overlay-flake-elimination.md) — SEEDED sentinel + waitFor pattern to eliminate flaky ink-testing-library overlay/scroll tests
 - [full-stack-e2e-wiring.md](full-stack-e2e-wiring.md) — full-stack e2e wiring: implement launcher bypasses app.deps.provider, TUI mount plumbing, sprint pre-setup
+- [waitfor-loud-timeout-contract.md](waitfor-loud-timeout-contract.md) — ONE predicate waiter (`waitForPredicate`, throws on timeout) + the control-probe settle pattern for "empty is also the first frame" hooks
+- [plateau-detector-subordination.md](plateau-detector-subordination.md) — entropy/diversity leaves can never fire in the composed gen-eval loop; where the mutual-exclusion fences live

--- a/.claude/agent-memory/tester/plateau-detector-subordination.md
+++ b/.claude/agent-memory/tester/plateau-detector-subordination.md
@@ -1,0 +1,37 @@
+---
+name: plateau-detector-subordination
+description: entropy-check / loop-diversity-check can never fire through the composed gen-eval loop — their firing unit tests are isolated-unit contracts only; fence tests pin the mutual exclusion
+metadata:
+  type: project
+---
+
+# The two bolt-on plateau detectors are unreachable in the composed loop
+
+**Fact.** `loopDiversityCheckLeaf` and `entropyCheckLeaf` fire only when
+`ctx.lastExit === undefined` AND `windowIsHardStall(window)`. `windowIsHardStall` is true exactly
+when `classifyPlateauWindow` says `'stalled'` — which is exactly the case where
+`computePlateauVerdict` returns `{kind:'plateau'}`, which `run-evaluator-turn` turns into an exit
+that the evaluator leaf (one/two elements EARLIER in the same `gen-eval-turn` sequential) merges
+onto `ctx.lastExit`. The two conditions are mutually exclusive by construction, so a
+`source: 'entropy'` / `source: 'diversity'` exit is not reachable in production.
+
+**Why it matters:** the unit tests' "firing" cases pin a ctx state the real loop never presents.
+Left undocumented they read as behavioural guarantees. `settings.harness.entropyPlateauDetector`
+is a user-facing knob with nil e2e effect, and `outcome-stats`' `bySource.diversity` /
+`bySource.entropy` buckets are always zero. HARNESS-PRINCIPLES §6 lists both leaves as
+removal-with-measurement candidates.
+
+**How to apply:**
+
+- Fences that lock this (do not weaken them):
+  - `tests/unit/.../entropy-check.test.ts` and `loop-diversity-check.test.ts` each end with a
+    `— subordination to the calibrated predicate` describe: for the file's own stalled-window
+    fixture it asserts `windowIsHardStall(window) === true` AND
+    `computePlateauVerdict(window.slice(0,-1), current).kind === 'plateau'`, plus a no-op case
+    fed the ctx the loop really hands over (`lastExit: {kind:'plateau', source:'threshold'}`).
+  - `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` →
+    "attributes a genuine stall to the calibrated 'threshold' detector, not to a bolt-on".
+- If someone proposes deleting the leaves, the knob and the two `bySource` buckets go with them.
+  That is a production decision, not a test-side one.
+
+Related: [[gen-eval-turn-step-order-fence]], [[gen-eval-exit-mapping]].

--- a/.claude/agent-memory/tester/waitfor-loud-timeout-contract.md
+++ b/.claude/agent-memory/tester/waitfor-loud-timeout-contract.md
@@ -1,0 +1,42 @@
+---
+name: waitfor-loud-timeout-contract
+description: TUI suite has ONE predicate waiter (waitForPredicate in _wait.ts) that throws on timeout; plus the settle-marker pattern for hooks whose "empty" state is also their first frame
+metadata:
+  type: project
+---
+
+# TUI async-wait helpers after the 2026-08-18 consolidation
+
+**Fact.** `tests/integration/application/ui/tui/_wait.ts` owns BOTH waiters and both throw on
+expiry (3000ms ceiling, 15ms poll, double-`setImmediate` settle):
+
+- `waitFor(check: () => void | Promise<void>)` — assertion form; rethrows the last `expect` error.
+- `waitForPredicate(predicate: () => boolean, { timeout?, interval?, label? })` — boolean form;
+  throws `waitForPredicate: <label> never became true within Nms`.
+
+`_keys.ts` is key bytes + `tick` ONLY. It used to export a same-named `waitFor` that `return`ed
+silently on a 1000ms expiry; 36 files / ~200 call sites were migrated off it.
+
+**Why:** a silent timeout produces either a misleading downstream failure or (when the wait _was_
+the only check) a vacuously green test. Two such tests existed in `skills-view.test.tsx`.
+
+**How to apply:**
+
+- New polling waits use `waitForPredicate` and pass a `label` — the label IS the failure message.
+- Never re-add a silent-timeout waiter, and never give two waiters the same name again.
+- Flipping to loud immediately exposed two tests whose `waitForViewReady` extra-predicate had gone
+  stale against renamed view copy (`'Display name'` → `Project display name`,
+  `'Repository path'` → `Repository directory`). When a `waitForViewReady` extra predicate starts
+  failing, suspect stale COPY first — dump `result.lastFrame()` to a file (vitest swallows
+  `console.log` in this project) rather than guessing.
+
+## Settle-marker pattern for "empty is also the first frame"
+
+`useRunForensics` seeds `[]` and fills it after an async `fs.stat` pass, so
+`waitFor(frame.includes('NONE'))` is satisfied at t≈0 — the negative tests asserted the PRE-effect
+render. Fix (see `run-forensics.test.tsx`): render a **control probe** in the same tree that is
+guaranteed to resolve and prints `CONTROL:<n>`; wait for `CONTROL:[1-9]`, add a small grace tick,
+then assert over the WHOLE render history (`seen.every((s) => s.length === 0)`), not `seen.at(-1)`.
+Any leak at any tick fails. Mutation-verified: negating the hook's `enabled` gate turns it red.
+
+Related: [[gen-eval-turn-step-order-fence]], [[progress-overlay-flake-elimination]].

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ list does not lose the sprint plan.
 
 **`<id>--<slug>` naming.** Entity directories and files are named `<id>--<slug>` (a uuidv7 prefix followed by
 a double-hyphen and a kebab handle) — human-readable and still chronologically sortable. Resolvers are
-tolerant: `resolveProjectFile`, `resolveSprintDir`, and `resolveMemoryDir` in
+tolerant: `resolveProjectPath`, `resolveSprintDir`, and `resolveMemoryDir` in
 `src/integration/persistence/storage.ts` scan the parent directory and prefer the slugged form over a legacy
 bare `<id>` form, so old data directories continue to work without manual intervention. Write-side path builders
 always produce the canonical `<id>--<slug>` name.
@@ -557,20 +557,22 @@ and the non-obvious mutators.
   present and non-empty), `setupSkill`, `verifySkill`, and `suggestedSkills` — names persisted by
   `offerSkillSuggestionsLeaf` in the readiness flow).
 - **`Sprint`** (`sprint.ts`) — identified by `SprintId`; lifecycle `draft → planned → active → review → done`; carries
-  `projectId`, nested `Ticket[]`, `affectedRepositories` (absolute paths). Mutators: `addTicket`, `refineTicket`,
-  `removeTicket`, `planSprint(draft → planned)`, `activate`, `transitionToReview`, `transitionToDone`.
+  `projectId` and nested `Ticket[]`. It holds **no** repo list — which repo a unit of work targets rides on
+  `Task.repositoryId`, resolved against `project.repositories`. Mutators: `addTicket`, `replaceTicket`,
+  `removeTicket`, `planSprint(draft → planned)`, `activateSprint`, `transitionSprintToReview`,
+  `transitionSprintToDone`, plus `revertSprintToActive` (review → active, used by task unblock).
 - **`SprintExecution`** (`sprint-execution.ts`) — identified by the parent `SprintId`; carries `branch`,
   `pullRequestUrl`, `setupRanAt` (array of `SetupRun` — one structured entry per repo per chain run,
   outcome: `success` / `failed` / `spawn-error` / `skipped`). Separate from `Sprint` so runtime-mutating
   fields don't collide with planning writes.
-- **`Ticket`** (nested inside `Sprint`) — identified by `TicketId`; `requirementStatus: pending → approved`
-  flipped by the refine flow.
+- **`Ticket`** (nested inside `Sprint`) — identified by `TicketId`; `status: pending → approved` flipped by the
+  refine flow, which also fills the `requirements` body that `ApprovedTicket` requires.
 - **`Task`** (`task.ts`) — identified by `TaskId`; status `todo | in_progress | done | blocked`; references
   `Sprint` via `ticketId` and DAG edges via `dependsOn` (array of `TaskId`; the planner emits them as
   `blockedBy` and `parseTaskList` resolves them onto `dependsOn`). Carries an `attempts[]` history — each
   `Attempt` has `evaluation`, `verification`, `attribution` (`clean` / `regressed` / `baseline-broken` /
   `fixed-baseline` from pre/post verify-script comparison), optional `abortCause` (`AbortCause` discriminated
-  union), and optional `recoveryContext` (resume-from-aborted metadata). `BlockedTask` adds a structural
+  union), and optional `recovering` (a `RecoveryContext` — resume-from-aborted metadata). `BlockedTask` adds a structural
   `blockKind: 'upstream' | 'own'` discriminant — `'upstream'` when the `dependency-gate` parked the task
   because a prerequisite was not `done`; `'own'` for evaluator / verify / budget failures. New code reads
   `isUpstreamBlocked(task)` (checks `blockKind`) — never the `blockedReason` string prefix. Legacy
@@ -709,8 +711,8 @@ Cross-cutting TUI features:
   runner with status + age.
 - **Schema-driven settings panel** — rows iterate the `SettingsSchema`; the prompt kind is derived from value
   type. Edits save immediately.
-- **Doctor view** — runs `runDoctor()` on mount; renders per-check status rows + an aggregate result card.
-  `!` opens it from anywhere.
+- **Doctor view** — calls the shared `useSystemStatus` provider's `refreshDoctor()` on mount (and again on `r`);
+  renders per-check status rows + an aggregate result card. `!` opens it from anywhere.
 - **Execute view is responsive** — three-column (flow-steps rail / tasks-stream / context) at `xl` (≥180),
   two-column at `lg` (≥140), compact-rail at `md` (100–139), single-column below `md`. The rail is fixed
   28 cols below `xl`; at `xl`+ it grows fluidly up to 56 cols via `resolveRailWidth`. All width decisions use

--- a/.claude/docs/KERNEL-DESIGN.md
+++ b/.claude/docs/KERNEL-DESIGN.md
@@ -244,6 +244,11 @@ The final returned `Trace` is the union of those emissions. Live UIs subscribe v
   - Failure: `started → step* → failed`
   - Aborted pre-run: `aborted` only (no `started`)
   - Aborted mid-run: `started → step* → aborted`
+  - The `aborted` event carries an `error` **only** when the abort originated inside the chain (the element
+    returned or threw an `aborted`-coded error — e.g. the operator answered "abort" at an in-chain prompt).
+    A caller-driven `abort()` (Ctrl-C, outer signal, fatal-sibling kill) omits it. `runWaves` keys on that
+    distinction to tell "this branch's operator aborted the run" (fatal — stop the schedule, return the
+    error verbatim, launch no later wave) from "I killed this branch".
 - **Late-subscriber replay**: a listener added after a terminal state receives every recorded `step` event
   plus the matching terminal event. UI re-attach is lossless.
 - **Trace ring buffer**: `runner.trace` is capped at `MAX_TRACE_ENTRIES = 5_000` (defined and enforced in
@@ -357,6 +362,7 @@ sequential('implement', [
       activateSprintLeaf,
       loadSprintExecutionLeaf,
       loadTasksLeaf,
+      loadLearningsLeaf, // cross-sprint procedural memory (read side) → ctx.priorLearnings
       resolveBranchLeaf, // assign + checkout the sprint branch first
       sequential('working-tree-clean-checks', cleanLeaves), // hard-abort if any repo is dirty
       appendJournalSeparatorLeaf, // appends the 'activated' separator to the append-only progress.md journal
@@ -368,8 +374,11 @@ sequential('implement', [
       ),
       saveTasksLeaf,
       guard(
-        'transition-sprint-to-review-when-any-done',
-        (ctx) => ctx.tasks?.some((t) => t.status === 'done'),
+        // Every task settled (`done`/`blocked`) AND ≥1 done — see `shouldTransitionToReview`
+        // in implement/flow.ts. A bare `some(done)` would flip a partial sprint into review
+        // mid-run; an all-blocked run stays `active` so the operator can fix and re-run.
+        'transition-sprint-to-review-when-settled',
+        (ctx) => shouldTransitionToReview(ctx.tasks),
         sequential('transition-to-review-and-journal', [
           transitionSprintToReviewLeaf,
           appendJournalSeparatorLeaf, // appends the 'review' separator to the progress.md journal

--- a/.claude/docs/MANUAL-TEST-PLAYBOOK.md
+++ b/.claude/docs/MANUAL-TEST-PLAYBOOK.md
@@ -405,6 +405,90 @@ fail with a clear provider error — not a silent hang or an empty `signals.json
 
 ---
 
+## Scenario 17 — plateau calibration honours `plateauThreshold`
+
+**Setup:** a sprint with one task carrying a verification criterion the generator cannot satisfy (e.g. "the
+verify script exits 0" against a script that always exits 1), so the gen-eval loop genuinely stalls.
+
+```bash
+ralphctl settings set harness.plateauThreshold 3
+ralphctl settings show | grep entropyPlateauDetector   # expect false — the entropy detector is opt-in
+```
+
+1. Run Implement on that sprint and watch the Execute view's step rail
+2. **Expected:** neither `loop-diversity-check` nor `entropy-check` exits the loop before turn 3 — both
+   window from `plateauThreshold`, so an earlier exit is the regression this scenario exists to catch
+3. **Expected:** when the plateau does fire, the banner names the escalation (model rung, or the effort rung
+   for both generator **and** evaluator) — not a bare "plateau"
+4. `ralphctl settings set harness.entropyPlateauDetector true`, re-run — **expected:** the entropy detector
+   now participates, and still cannot end an attempt on a single turn
+5. **Pass condition:** `ralphctl runs stats --sprint <id>` reports the plateau under the source that actually
+   fired (`threshold` / `diversity` / `entropy`), and the escalation rung shows as resolved or fell-through
+
+---
+
+## Scenario 18 — outcome rollup: `runs stats`, the sprint card, and next steps
+
+**18a — CLI rollup:**
+
+1. `ralphctl runs stats` on a data root with at least one sprint holding a mix of done / blocked tasks
+2. **Expected:** outcome mix, first-pass rate, attempts-to-done, plateau-by-source, escalation efficacy, the
+   regression taxonomy (`clean` / `fixed-baseline` / `baseline-broken` / unattributed), warnings broken out by
+   kind, and per-criterion pass rates — each rate labelled with the denominator it quotes
+3. `ralphctl runs stats --json` — **expected:** the same numbers as raw JSON, stable key order (diff two runs)
+4. `ralphctl runs stats --sprint <id> --project <id>` — **expected:** refused, the two are mutually exclusive
+5. `RALPHCTL_HOME=/tmp/ralphctl-empty-$RANDOM ralphctl runs stats` — **expected:** the one-line
+   "no sprints yet" notice, exit 0, no stack trace; the same command with `--json` still emits a well-formed
+   all-zero report
+
+**18b — sprint outcome card:**
+
+1. Open a `review` sprint's detail view — **expected:** the outcome card renders between the next-phase card
+   and the tickets section, with the same numbers `runs stats --sprint <id>` prints
+2. Open a `draft` or `active` sprint — **expected:** no card at all (nothing to report before an attempt ran)
+3. On a sprint where an attempt was attributed `baseline-broken` or `regressed` — **expected:** the card takes
+   the error tone
+
+**18c — next steps / post-mortem:**
+
+1. Let a flow run to completion — **expected:** the settled result card ends with a `Next steps` block naming
+   the recommended flow and the key that launches it; the settled hint row reads
+   `↵ home · r re-run · g progress` (plus `v evaluation` when the focused task has a verdict)
+2. Press `r` — **expected:** it returns to Flows, which re-checks triggers against the sprint's status **now**
+   (a sprint that advanced during the run offers the next flow, not a stale repeat)
+3. Cancel a run with `Ctrl+C` — **expected:** a `Post-mortem` block lists only artifacts that actually exist on
+   disk (`progress.md`, trace, verify logs, sprint dir); a `create-sprint` that failed before creating a sprint
+   shows no paths rather than a guessed one
+4. **Pass condition:** Home and Flows recommend the same next action for the same sprint, in every state —
+   including `review` (two flows offered) and `done` (points at the pull request)
+
+---
+
+## Scenario 19 — evaluation verdict surface
+
+**Setup:** a sprint with at least one task whose latest attempt has an evaluator verdict (a failed round is the
+interesting case), plus one task that has never been evaluated.
+
+**19a — TUI overlay:**
+
+1. In the Execute view's tasks panel, focus the evaluated task and press `v`
+2. **Expected:** a read-only overlay opens on that attempt's `evaluation.md` — critique plus each dimension's
+   pass / fail / n-a with its finding and any command output; the same scroll chords as the `g` progress
+   overlay; `Esc` or `v` closes it
+3. Focus the never-evaluated task — **expected:** the `v` hint is disabled, and pressing `v` does nothing
+4. Repeat from a sprint-detail task row — **expected:** identical overlay, identical keys
+5. On a task whose record predates the artifact, or whose workspace was pruned — **expected:** it degrades to
+   the one-line verdict, never an error
+
+**19b — CLI reader:**
+
+1. `ralphctl task evaluation <taskId> --sprint <id>`
+2. **Expected:** the attempt / verdict / path header goes to **stderr**, the artifact body to stdout — so
+   `ralphctl task evaluation <taskId> > verdict.md` yields exactly the file
+3. **Pass condition:** the body matches what the overlay rendered for the same task
+
+---
+
 ## Known issues (file under here, link the fix commit)
 
 - (none currently)

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -226,7 +226,10 @@ times per task (harness pre + post + generator in-turn + evaluator in-turn). The
   A footprint probe failure or an empty footprint falls back to running all gates — a gate is never silently
   skipped. A monorepo task touching one module no longer pays every other module's suite on every verify pass.
   The legacy single `verifyScript` normalises to one catch-all `pathPrefix: ''` gate — non-gated repos are
-  byte-for-byte the prior behaviour.
+  byte-for-byte the prior behaviour. A diff-scoped green post does NOT license the next task's carry-baseline
+  pre-verify skip (`ctx.priorPostVerifyOutcome.coveredAllGates`): its `success` only covers the gates that
+  ran, so a gate already red outside that footprint would otherwise mis-attribute as `regressed` on the next
+  task. Only an unscoped run — legacy script or the run-ALL fallback — carries as a whole-tree baseline.
 - **`settings.harness.skipPreVerifyOnFreshSetup`** (default `false`) — skip the FIRST pre-task verify of a run
   when this launch's own setup script already proved the tree green. The skip synthesizes the same green
   `VerifyRun` shape the carry-baseline path produces, so the `PRE_VERIFY_RESULTS` block and attribution fold
@@ -289,10 +292,12 @@ repoName, taskKind, sprintId, taskId, timestamp, promotedAt }`; `id` is a stable
 `sha1(repo|taskKind|normalize(text))[:16]` dedup key and `promotedAt` is `null` on write.
 `text` is the Insight (required); `context` (when/why it arose) and `appliesTo` (where it applies) are optional and
 render as indented `Context:` / `Applies to:` sub-bullets in `progress.md` and the distilled `## Learnings (ralphctl)`
-section. A **`learnings.md` human-readable mirror** is written alongside the NDJSON ledger on every append and
-promote (`appendLearningsAndMirror` in `ledger-writer.ts`); `stamp-promoted` also regenerates it after
+section. A **`learnings.md` human-readable mirror** sits alongside the NDJSON ledger, rendered by
+`mirrorLearningsMd` (`ledger-writer.ts`). It is regenerated **lazily** — never on the hot per-attempt append
+path (`appendMemoryRecords`, which only appends + bounds), but at the two checkpoints a human is about to
+browse it: sprint close (`refreshMemoryMirrorLeaf`) and the distill flow's `stampPromotedLeaf` after
 compaction. The mirror is best-effort — a write failure is logged, the NDJSON append already landed, and the
-mirror self-heals on the next write. A one-syscall byte-ceiling guard (`LEDGER_HARD_CEILING_BYTES = 50 MB`,
+mirror self-heals on the next render. A one-syscall byte-ceiling guard (`LEDGER_HARD_CEILING_BYTES = 50 MB`,
 `ledgerExceedsCeiling` in `read-ledger.ts`) prevents loading a pathologically large ledger — an over-ceiling
 file is rotated to `.bak` and the mirror render is skipped rather than overwriting a real `learnings.md` with
 an empty view. At sprint close — BOTH the explicit `close-sprint` flow and the `review` flow's auto-done path —
@@ -313,14 +318,14 @@ Resolution uses the `SkillSource.getByName` lookup on the bundled source.
 
 ## Environment variables
 
-| Variable                     | Default        | Range / values   | Purpose                                                          |
-| ---------------------------- | -------------- | ---------------- | ---------------------------------------------------------------- |
-| `RALPHCTL_HOME`              | `~/.ralphctl/` | absolute path    | Override application root (data + config + state)                |
-| `RALPHCTL_SKIP_LEGACY_CHECK` | unset          | any truthy value | Bypass the v0.6.x legacy-layout detector at boot                 |
-| `RALPHCTL_DEBUG_TRACE`       | unset          | any truthy value | Enable `<sprintDir>/events.ndjson` debug sink (no-op when unset) |
-| `RALPHCTL_NO_TUI`            | unset          | any truthy value | Suppress implicit interactive prompts inside the implement flow  |
-| `NO_COLOR`                   | unset          | any truthy value | Suppress ANSI colors                                             |
-| `CI`                         | auto-detected  | any truthy value | Suppress implicit interactive prompts inside the implement flow  |
+| Variable                     | Default        | Range / values   | Purpose                                                                                                                                                           |
+| ---------------------------- | -------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RALPHCTL_HOME`              | `~/.ralphctl/` | absolute path    | Override application root (data + config + state)                                                                                                                 |
+| `RALPHCTL_SKIP_LEGACY_CHECK` | unset          | any truthy value | Bypass the v0.6.x legacy-layout detector at boot                                                                                                                  |
+| `RALPHCTL_DEBUG_TRACE`       | unset          | any truthy value | Enable `<sprintDir>/events.ndjson` debug sink (no-op when unset); also prints the full stack when a CLI invocation fails at the top level (`report-cli-error.ts`) |
+| `RALPHCTL_NO_TUI`            | unset          | any truthy value | Suppress implicit interactive prompts inside the implement flow                                                                                                   |
+| `NO_COLOR`                   | unset          | any truthy value | Suppress ANSI colors                                                                                                                                              |
+| `CI`                         | auto-detected  | any truthy value | Suppress implicit interactive prompts inside the implement flow                                                                                                   |
 
 ## Diagnosing an OOM (heap snapshot)
 

--- a/.claude/docs/SECURITY.md
+++ b/.claude/docs/SECURITY.md
@@ -131,6 +131,9 @@ Claude / Copilot / Codex only auto-discover their context file
 `.github/skills/` / `.agents/skills/`), agents, and `.mcp.json` from cwd — not from `--add-dir` roots.
 Harness-authored skills land in `<repo>/<parentDir>/skills/ralphctl-*/` and the skills adapter appends one
 wildcard line to `.git/info/exclude` on first install so they never appear in `git status` or `git add -A`.
+The line goes to the **common** git dir (`$GIT_COMMON_DIR`, resolved through the worktree gitdir's `commondir`
+file) — `info/` is a shared path in git, so a per-worktree copy would be silently ignored and the parallel
+implement path would commit harness-authored skills into the user's branch.
 
 **Refine and plan are the exceptions — their AI sessions run in the per-sprint unit root.**
 Refine's session is rooted at `<sprintDir>/refinement/<ticket-slug>/`; plan's at

--- a/.claude/docs/WORKFLOWS.md
+++ b/.claude/docs/WORKFLOWS.md
@@ -32,9 +32,10 @@ short-circuit still reopens). Without this, an unblocked task on a review sprint
 Implement is gated out and only Review / Close remain.
 
 **Two-phase planning.** **Refine** (`refine` chain) is implementation-agnostic per-ticket clarification —
-no repo exploration; ticket `requirementStatus` flips `pending → approved`. **Plan** (`plan` chain) requires
-every ticket `approved`; repo selection runs inside the chain and persists on `Sprint.affectedRepositories`
-(absolute paths); AI generates `tasks.json` atomically and the sprint transitions `draft → planned`.
+no repo exploration; ticket `status` flips `pending → approved`. **Plan** (`plan` chain) requires
+every ticket `approved`; every project repository is mounted as an equal `--add-dir` root, and repo
+selection lands per task as `Task.repositoryId` (resolved against `project.repositories`) — the sprint
+itself stores no repo list; AI generates `tasks.json` atomically and the sprint transitions `draft → planned`.
 **Ideate** combines both in a single AI session for low-stakes work.
 
 **Plan's approval gate is split from the AI hand-off.** `call-planner-interactive` stops at the proposal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
       # runBundleIntegrityCheck) and then read every bundled SKILL.md / agent .md back
       # through `resolveBundledRoot`, which is the resolver that actually broke. No AI CLI
       # and no network are involved; every write is confined to RALPHCTL_HOME.
+      # `prompts list` covers the OTHER half: prompts are 21 of the 36 bundled assets and every
+      # AI flow depends on them, but `fs-template-loader.ts` carries its own copy of the
+      # beside-the-module probe and falls back SILENTLY to the package root — a bundle with a
+      # broken `dist/prompts/` layout passes `skills list` / `agents list` / bundle-integrity and
+      # still serves no prompts. The command loads every template body, so a bad layout exits 1.
       # `out=$(cmd)` + `printf | grep`, never `cmd | grep`: the default shell is `bash -e`
       # WITHOUT pipefail, so a pipe would swallow a non-zero exit from the CLI.
       - name: Verify dist boots a real subcommand (bundle integrity)
@@ -80,6 +85,8 @@ jobs:
           printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
           agents=$(node dist/cli.mjs agents list)
           printf '%s\n' "$agents" | grep -q '^ralphctl-evaluator'
+          prompts=$(node dist/cli.mjs prompts list)
+          printf '%s\n' "$prompts" | grep -q '^implement'
 
       - name: Verify npm pack installs correctly
         env:
@@ -125,7 +132,16 @@ jobs:
       - name: Lint (cold)
         run: pnpm lint
 
+      # `FORCE_COLOR: 3` is deliberate, and this is the only job that sets it. Ink/chalk decide
+      # colour from the worker env and every TUI assertion is a plain-substring check against
+      # `lastFrame()`, so an ambient FORCE_COLOR used to turn 27 assertions red on a pristine tree
+      # for anyone whose terminal exports it (Claude Code does) while CI — which never sets it —
+      # stayed green. `vitest.config.ts` now pins `FORCE_COLOR=0` per project; running one job with
+      # the hostile value makes a future ambient-colour-sensitive assertion fail here rather than
+      # only on developer and agent machines.
       - name: Test (cold)
+        env:
+          FORCE_COLOR: 3
         run: pnpm test
 
   coverage:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,38 @@ jobs:
           printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
           agents=$(node dist/cli.mjs agents list)
           printf '%s\n' "$agents" | grep -q '^ralphctl-evaluator'
+          prompts=$(node dist/cli.mjs prompts list)
+          printf '%s\n' "$prompts" | grep -q '^implement'
+
+      # Not redundant with the step above, and the last gate before the irreversible publish:
+      # `node dist/cli.mjs` resolves commander / react / ink / zod / cross-spawn / proper-lockfile /
+      # typescript-result from the REPO's node_modules (tsup leaves every dependency external), so a
+      # runtime dep demoted to devDependencies — or anything the `files` allowlist drops — boots fine
+      # on the runner and then fails on every real `npm i ralphctl`. Only a pack + install into a
+      # clean prefix exercises that resolution, the bin link and the packaging layer.
+      # `npm i --prefix <abs path>`, never `cd && npm i`. The stub package.json at the prefix is
+      # load-bearing — without one npm walks up and installs into the repo tree — and it is written
+      # by hand rather than by `npm init -y`, which ignores `--prefix` and would rewrite the repo's
+      # OWN package.json moments before publish. Packing to /tmp keeps the .tgz outside the workspace
+      # so it cannot be swept into the tarball `pnpm publish` builds.
+      - name: Verify npm pack installs correctly
+        env:
+          RALPHCTL_HOME: ${{ runner.temp }}/ralphctl-pack-smoke
+        run: |
+          TARBALL=$(pnpm pack --pack-destination /tmp 2>/dev/null | tail -1)
+          SMOKE=/tmp/ralphctl-release-smoke
+          mkdir -p "$SMOKE"
+          printf '{"name":"ralphctl-release-smoke","version":"0.0.0","private":true}\n' > "$SMOKE"/package.json
+          npm install --prefix "$SMOKE" "$TARBALL"
+          BIN="$SMOKE"/node_modules/.bin/ralphctl
+          version=$("$BIN" --version)
+          printf '%s\n' "$version" | grep -qF "${{ steps.version.outputs.version }}"
+          skills=$("$BIN" skills list)
+          printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
+          agents=$("$BIN" agents list)
+          printf '%s\n' "$agents" | grep -q '^ralphctl-evaluator'
+          prompts=$("$BIN" prompts list)
+          printf '%s\n' "$prompts" | grep -q '^implement'
 
       - name: Publish to npm
         run: pnpm publish --no-git-checks --provenance

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,8 +23,10 @@ flowchart LR
 `node:child_process`, `node:http`). Only `integration/` does I/O. Only `application/` may import from
 anywhere.
 
-This is not a convention you have to trust — it is checked. `eslint.config.ts` carries 15
-`no-restricted-imports` rule blocks that fail the build on a wrong-direction import. The same config
+This is not a convention you have to trust — it is checked. `eslint.config.ts` carries a
+`no-restricted-imports` rule block per fenced boundary, each failing the build on a wrong-direction
+import — one per layer, plus narrower fences for the chain kernel, contract files, and the
+`integration/ai/<concept>/` siblings. The same config
 bans `class` outside `domain/value/error/`, bans barrel files (`export *`), and keeps each adapter
 directory under `integration/ai/<concept>/` isolated from its siblings (shared code goes through an
 explicit `_engine/` sub-namespace). A layering violation is a red build, not a review comment.
@@ -48,7 +50,7 @@ ticket  --refine-->  approved ticket  --plan-->  tasks.json (a DAG)  --implement
   emits a `signals.json` file. A separate evaluator agent grades that work against the task's criteria
   and the verify-script result. The evaluator defaults to skepticism — an out-of-the-box LLM judge
   approves bad work, so its prompt names concrete failure modes and forces a fail on any floor-dimension
-  miss (correctness / completeness / safety / consistency).
+  miss (correctness / completeness / safety / consistency / robustness).
 
 Two nested loops drive implement (`src/application/flows/implement/`). The inner loop runs
 generator → evaluator turns until the evaluator signals a terminal exit or the `maxTurns` budget is hit.
@@ -91,14 +93,17 @@ these primitives, never as a sixth one.
 
 ## The provider boundary
 
-Claude Code, GitHub Copilot, and Codex sit behind one port: `HeadlessAiProvider.generate(session)`
+Claude Code, GitHub Copilot, Codex, and OpenCode sit behind one port:
+`HeadlessAiProvider.generate(session)`
 (`src/integration/ai/providers/_engine/headless-ai-provider.ts`). The caller hands over an `AiSession`
 (`.../ai-session.ts`) that describes **intent** — prompt, working directory, model tier, permissions,
 the path to write `signals.json`, an optional resume id — and nothing about any specific CLI. Each
-adapter under `src/integration/ai/providers/{claude,codex,copilot}/` is the only place that translates
-that intent into its CLI's concrete flags and parses its output stream. The composition root picks one
-adapter per flow in `src/application/bootstrap/provider-factory.ts`. Adding a fourth provider is a new
-adapter directory and one factory case — see [docs/adding-a-provider.md](./docs/adding-a-provider.md).
+adapter under `src/integration/ai/providers/{claude,codex,copilot,opencode}/` is the only place that
+translates that intent into its CLI's concrete flags and parses its output stream. The composition root
+picks one adapter per flow in `src/application/bootstrap/provider-factory.ts`, where `HEADLESS_FACTORIES`
+is a total `Record<AiProvider, …>` — widening the union without a row is a compile error. Adding another
+provider is a new adapter directory plus that one registry row (and the sibling registries the compiler
+names) — see [docs/adding-a-provider.md](./docs/adding-a-provider.md).
 
 ## Why it's built this way
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ to [Semantic Versioning](https://semver.org/).
   attempt / verdict / path header on stderr so `> verdict.md` yields exactly the artifact.
   Older sprints stay readable: a task whose record predates the artifact, or whose workspace has been
   pruned, degrades to the one-line verdict it shows today — never an error.
+- **`ralphctl prompts list`** — renders every bundled prompt template through the real runtime
+  resolver and reports what loaded, so a broken bundle is visible before it breaks a run. CI now
+  runs it against the built package on every push, and the release workflow packs and installs the
+  tarball and smokes the binary before anything is published.
 
 ### Changed
 
@@ -128,6 +132,44 @@ to [Semantic Versioning](https://semver.org/).
   other repos with no error surfaced. It now grants every root the engine resolved, and a root that
   can't be expressed as a permission pattern (glob metacharacters in the path) fails the session with
   a named error instead of starting one that can't see what it was asked to.
+- **Aborting a parallel run now actually stops it.** Answering "abort" at an in-run prompt used to be
+  swallowed by the wave scheduler — in-flight sibling tasks kept running and every later wave still
+  launched fresh AI sessions. The abort now stops new launches, cancels in-flight siblings, and
+  surfaces the operator's abort reason verbatim in the rail and chain log.
+- **A turn that merely _talked about_ rate limits no longer costs you half an hour.** Rate-limit
+  detection scanned the assistant's own prose, so a non-zero exit on a task about throttling could
+  match "429" in conversation, discard a fully landed `signals.json`, and sleep the backoff (~36
+  minutes at the deepest rung). Stdout now only matches real throttle markers, and a landed signals
+  envelope counts as proof the turn worked — it is recovered instead of thrown away.
+- **An unreachable OpenCode `provider/model` id fails fast.** It used to classify as a retryable
+  crash and burn the whole attempt budget on a config typo; it now stops immediately and names the
+  id and the catalog that rejected it.
+- **Worktree runs no longer commit the bundled skills.** The `ralphctl-*` exclude line was written to
+  a per-worktree path git never reads; it now resolves the common git dir, so installed skills stay
+  out of your commits.
+- **AI-suggested skill names can no longer escape the skills directory.** `skill-suggestions` names
+  are validated to a safe slug shape at the contract boundary — separators, `..`, and absolute paths
+  are dropped before any filesystem path is built from them.
+- **An evaluator process crash retries instead of terminally blocking the task.** A watchdog kill or
+  spawn crash during the evaluator turn now consumes an attempt and retries within `maxAttempts`,
+  matching how the generator side has handled the same failures since 0.14.
+- **A diff-scoped verify pass no longer masquerades as a full-tree green baseline.** Passing gates
+  scoped to the task's diff was recorded as whole-tree evidence, so a pre-existing red gate elsewhere
+  later blocked the next task as a false `regressed`. Baseline provenance now records what the run
+  actually covered.
+- **Unblocking a task gives it a genuinely clean restart** — the transient best-of-N grant no longer
+  rides along, so the first retry attempt runs one generator session, not N.
+- **TUI truthfulness fixes.** A dependency-blocked task no longer renders as the active running task
+  for the rest of the run; parallel runs now show live token usage and context-window state (nested
+  runners had re-scoped the session id the meter was keyed on); and on a first-run session `h`/`D`
+  no longer bounce back to the Welcome screen and silently re-stamp the AI preset.
+- **Overlay and key-handling fixes.** The evaluation overlay windows by rendered row, so a critique
+  with long wrapped lines scrolls instead of overflowing the viewport; the Welcome error state's
+  `esc` hint now works; and the status banner's `d` dismiss no longer fires while a prompt owns the
+  keyboard.
+- **CLI errors are one line, not a stack.** A malformed `settings.json` (or any unexpected failure)
+  prints `ralphctl: <message>` with a debug-env hint instead of dumping a raw Node stack from the
+  minified bundle.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ export RALPHCTL_HOME="/path/to/custom/dir"
 | ---------------------------- | -------------- | ---------------------------------------------------- |
 | `RALPHCTL_HOME`              | `~/.ralphctl/` | Override application root (data + config + state)    |
 | `RALPHCTL_SKIP_LEGACY_CHECK` | unset          | Bypass the v0.6.x legacy-layout detector at boot     |
+| `RALPHCTL_DEBUG_TRACE`       | unset          | Write a `<sprintDir>/events.ndjson` debug trace      |
 | `RALPHCTL_NO_TUI`            | unset          | Suppress implicit interactive prompts in `implement` |
 | `NO_COLOR`                   | unset          | Suppress ANSI colors                                 |
 | `CI`                         | auto-detected  | Suppress implicit interactive prompts in `implement` |
@@ -439,6 +440,8 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 | `ralphctl settings set <key> <value>`   | Set a single settings key                                                                                                                                                     |
 | `ralphctl settings apply-preset <name>` | Stamp the entire `ai` section — 21 presets: `standard` / `economic` / `strong-gate` / `fast` / `frontier` families, each in `mixed` / `*-only` variants, plus `opencode-only` |
 | `ralphctl completion <shell>`           | Print shell tab-completion script                                                                                                                                             |
+| `ralphctl agents list`                  | List bundled + operator agent definitions and the implement role each is bound to                                                                                             |
+| `ralphctl skills list`                  | List bundled + manually-dropped skills — tier, enabled flows, provenance                                                                                                      |
 
 ### Project & Sprint Inspection
 
@@ -455,6 +458,7 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 | `ralphctl ticket list / show <id>`    | Inspect tickets                                                                     |
 | `ralphctl ticket remove <id>`         | Remove a ticket from a draft sprint                                                 |
 | `ralphctl task list / show <id>`      | Inspect tasks (planning generates them)                                             |
+| `ralphctl task evaluation <id>`       | Print the latest evaluator verdict (`evaluation.md`) for the task's last attempt    |
 | `ralphctl task unblock <id>`          | Reset a blocked task to `todo`                                                      |
 
 ### Sprint Lifecycle
@@ -475,10 +479,11 @@ readiness / create sprint) stay TUI-only by design. The CLI exposes inspection +
 
 ### Maintenance
 
-| Command                                                                                    | Description                                     |
-| ------------------------------------------------------------------------------------------ | ----------------------------------------------- |
-| `ralphctl runs list [--flow <name>]`                                                       | List per-run forensic artifacts grouped by flow |
-| `ralphctl runs prune [--older-than 7d] [--keep-last <n>] [--flow <name>] [--dry-run] [-y]` | Delete per-run forensic artifacts               |
+| Command                                                                                    | Description                                                                          |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `ralphctl runs list [--flow <name>]`                                                       | List per-run forensic artifacts grouped by flow                                      |
+| `ralphctl runs stats [--sprint <id>] [--project <id>] [--since <date>] [--json]`           | Harness outcome rollup — outcome mix, first-pass rate, plateaus, escalation efficacy |
+| `ralphctl runs prune [--older-than 7d] [--keep-last <n>] [--flow <name>] [--dry-run] [-y]` | Delete per-run forensic artifacts                                                    |
 
 Run `ralphctl <command> --help` for flag-level detail.
 

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -46,20 +46,34 @@ Add the provider to one union and the compiler will route you to every place tha
 Start in `src/domain/entity/settings.ts`:
 
 ```ts
-export type AiProvider = 'claude-code' | 'github-copilot' | 'openai-codex' | 'google-gemini';
+export type AiProvider = 'claude-code' | 'github-copilot' | 'openai-codex' | 'opencode' | 'google-gemini';
 ```
 
 This is additive — existing settings files still parse, so no `CURRENT_SCHEMA_VERSION` bump and
-no migration. But it breaks compilation at three **exhaustive switches with no `default`**, each
-of which you now have to extend:
+no migration. But it breaks compilation everywhere provider-keyed static data lives, because the
+tree registers that data as **total `Record<AiProvider, …>` tables** rather than switches: a
+missing key is a type error at the table, not a runtime fall-through. Regenerate the current list
+whenever you start:
 
-- `createAiProvider` in `src/application/bootstrap/provider-factory.ts` (`const exhaustive: never = row`)
-- `toolForProvider` in `src/integration/ai/readiness/_engine/tool.ts`
-- `createSkillsAdapter` in `src/integration/ai/skills/adapter-factory.ts`
+```bash
+grep -rn 'Record<AiProvider' src | grep -v Partial
+```
 
-And one **total record** that won't compile until you add a key:
+Today that is fifteen tables plus the registry in `wire.ts` (typed through
+`ModelAvailabilityProbeRegistry`), grouped by layer:
 
-- `MODEL_AVAILABILITY_PROBES: Record<AiProvider, …>` in `src/application/bootstrap/wire.ts`
+| Layer         | Table                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`      | `PROVIDER_EFFORT_LEVELS` (`value/settings-models/effort.ts`)                                                                                                                                                                                                                                                                                                                                                     |
+| `business`    | `DEFAULT_MODELS_BY_PROVIDER` (`settings/defaults.ts`)                                                                                                                                                                                                                                                                                                                                                            |
+| `integration` | `PROVIDER_BINARY` + `PROVIDER_INSTALL_GUIDANCE` (`system/detect-cli.ts`), `PROVIDER_TRAITS` (`ai/providers/_engine/provider-traits.ts`), `AGENT_ADAPTERS` (`ai/agents/adapter-factory.ts`), `SKILLS_ADAPTERS` (`ai/skills/adapter-factory.ts`), `OPERATOR_PROVIDER_DIR` (`ai/skills/operator/source.ts`)                                                                                                         |
+| `application` | `HEADLESS_FACTORIES` (`bootstrap/provider-factory.ts`), `INTERACTIVE_FACTORIES` (`bootstrap/interactive-provider-factory.ts`), `MODEL_AVAILABILITY_PROBES` (`bootstrap/wire.ts`), `PROVIDER_AUTH_CHECK` (`flows/doctor/provider-auth.ts`), `PROVIDER_LABEL` (`flows/doctor/probe-helpers.ts` and `ui/shared/launch/readiness.ts` — two separate tables), `PRESET_FOR_PROVIDER` (`ui/tui/views/welcome-view.tsx`) |
+
+One **exhaustive `switch` with no `default`** also breaks: `toolForProvider` in
+`src/integration/ai/readiness/_engine/tool.ts`. If your CLI reads its own context file you will
+additionally widen the `AssistantTool` union, which forces its inverse `providerForTool` (same
+file) and `pickExistingContextPath` in
+`src/application/flows/readiness/leaves/propose.ts`.
 
 Follow the red squiggles. The sections below are those errors in dependency order.
 
@@ -94,6 +108,7 @@ const AiProviderSchema = z.enum([
   'claude-code',
   'github-copilot',
   'openai-codex',
+  'opencode',
   'google-gemini',
 ]) satisfies z.ZodType<AiProvider>;
 
@@ -242,29 +257,31 @@ silently. A truly empty stream yields `body=''`, `sessionId=undefined` — a wel
 never a throw. Keep body capture O(1) or O(N) accumulated (a single reassigned string, or
 `lines.push()` + `join`); never per-line string concatenation.
 
-## 5. The factory arm
+## 5. The factory row
 
-`src/application/bootstrap/provider-factory.ts`, in the `switch (row.provider)`:
+`src/application/bootstrap/provider-factory.ts`, in the `HEADLESS_FACTORIES` table:
 
 ```ts
-case
-'google-gemini'
-:
-return createGeminiProvider({
-  rateLimitRetries: deps.harnessConfig.rateLimitRetries,
-  idleMs: deps.harnessConfig.idleWatchdogMs,
-  eventBus: deps.eventBus,
-  ...(deps.spawn !== undefined ? { spawn: deps.spawn } : {}),
-});
+const HEADLESS_FACTORIES: Readonly<Record<AiProvider, (deps: HeadlessProviderDeps) => HeadlessAiProvider>> = {
+  'claude-code': createClaudeProvider,
+  'github-copilot': createCopilotProvider,
+  'openai-codex': createCodexProvider,
+  opencode: createOpencodeProvider,
+  'google-gemini': createGeminiProvider,
+};
 ```
 
-This carries only operational concerns (retry budget, idle watchdog, log sink, test spawn seam).
-Model tier flows per call via `AiSession`, never through the factory.
+`createAiProvider` then hands every factory the same operational deps (retry budget, idle
+watchdog, event bus, test spawn seam), so your row is a bare reference — no per-provider call
+site to keep in sync. Model tier flows per call via `AiSession`, never through the factory.
+`INTERACTIVE_FACTORIES` in `interactive-provider-factory.ts` is the same shape for the
+interactive port.
 
-## 6. The rest of the surface (the forced arms)
+## 6. The rest of the surface (the forced rows)
 
-These exist because the new union member broke an exhaustive switch or a total record. They are
-small and mostly boilerplate.
+These exist because the new union member left a total record short a key, or broke the one
+exhaustive switch. They are small and mostly boilerplate — work the compiler's list top to
+bottom.
 
 - **Availability probe** — `src/integration/ai/providers/gemini/model-availability-probe.ts`.
   Start with a passthrough (copy `copilot/model-availability-probe.ts`): it returns the catalog
@@ -276,17 +293,36 @@ small and mostly boilerplate.
   `AssistantTool` variant, a `readiness/gemini/probe.ts` + `readiness/gemini/artifacts.ts` (copy
   `readiness/codex/`), and register `geminiProbe` in `wire.ts`'s `PROBES`. `PROBES` is a
   `Partial` record, so a missing probe degrades gracefully (readiness just does nothing for that
-  provider) — but `toolForProvider` is exhaustive and **must** get its arm to compile.
+  provider) — but `toolForProvider`, its inverse `providerForTool`, and
+  `pickExistingContextPath` (`flows/readiness/leaves/propose.ts`) are exhaustive and **must** get
+  their arms to compile.
 
-- **Skills** — `createSkillsAdapter` in `skills/adapter-factory.ts` must return an adapter for
-  `google-gemini`. The on-disk shape is identical across providers (Agent Skills `SKILL.md`
-  folders); only the parent directory differs. Add `skills/gemini/adapter.ts` that delegates to
-  `createFilesystemSkillsAdapter` with your directory (e.g. `.gemini/skills/`), copying
-  `skills/codex/adapter.ts`.
+- **Skills and agents** — `SKILLS_ADAPTERS` in `skills/adapter-factory.ts` and `AGENT_ADAPTERS`
+  in `agents/adapter-factory.ts` each need a row. The on-disk shape is identical across providers
+  (Agent Skills `SKILL.md` folders); only the parent directory differs. Add
+  `skills/gemini/adapter.ts` that delegates to `createFilesystemSkillsAdapter` with your directory
+  (e.g. `.gemini/skills/`), copying `skills/codex/adapter.ts`, and name that directory again in
+  `OPERATOR_PROVIDER_DIR` (`skills/operator/source.ts`) so operator-authored skills resolve.
+
+- **Traits, effort, defaults** — `PROVIDER_TRAITS` (`providers/_engine/provider-traits.ts`) is the
+  one object literal holding per-provider static data (binary, install guidance, context-file
+  target, skills / agents parent dirs, wire tag, model catalog, effort-forwarding flag);
+  `PROVIDER_EFFORT_LEVELS` (`domain/value/settings-models/effort.ts`) declares your CLI's native
+  effort vocabulary, and `DEFAULT_MODELS_BY_PROVIDER` (`business/settings/defaults.ts`) the
+  per-flow default model rows.
+
+- **Detection and doctor** — `PROVIDER_BINARY` + `PROVIDER_INSTALL_GUIDANCE`
+  (`integration/system/detect-cli.ts`) drive the PATH pre-flight and the install hint; both are
+  one-line projections of your `PROVIDER_TRAITS` row, but each is its own total record and each
+  needs its key. `PROVIDER_AUTH_CHECK` (`flows/doctor/provider-auth.ts`) is the doctor's auth
+  probe — when your CLI exposes no non-interactive auth verb use `kind: 'none'` with a `reason`,
+  which reports as `unknown` rather than guessing. Two `PROVIDER_LABEL` tables
+  (`flows/doctor/probe-helpers.ts`, `ui/shared/launch/readiness.ts`) carry the display name.
 
 - **Settings TUI** — the picker reads the `AiProvider` union, so your provider appears once the
-  schema includes it. Check `src/application/ui/tui/views/ai-row.tsx` and `preset-bar.tsx` for any
-  hardcoded provider labels or preset rows you want to surface.
+  schema includes it. `PRESET_FOR_PROVIDER` (`ui/tui/views/welcome-view.tsx`) maps it to the
+  first-run preset; check `ai-row.tsx` and `preset-bar.tsx` for hardcoded labels or preset rows
+  you want to surface.
 
 ## 7. Tests
 
@@ -321,39 +357,49 @@ Be honest with yourself about where the real work is:
 | `_engine/gemini-provider-deps.ts`        | boilerplate — copy `claude-provider-deps.ts`                                                  |
 | `gemini/headless.ts` (`buildGeminiArgs`) | **provider-specific** — your CLI's flags, permission mapping, rate-limit/stale-resume regexes |
 | `gemini/parse-stream.ts`                 | **provider-specific** — your CLI's stdout shape                                               |
-| `provider-factory.ts` arm                | boilerplate — one `case`                                                                      |
+| `provider-factory.ts` row                | boilerplate — one `HEADLESS_FACTORIES` entry                                                  |
 | `model-availability-probe.ts`            | boilerplate to start (passthrough); provider-specific only if you build real narrowing        |
 | readiness probe + artifacts              | mostly boilerplate — copy a sibling, change the context-file name                             |
 | `skills/gemini/adapter.ts`               | boilerplate — delegate to `createFilesystemSkillsAdapter`                                     |
 | tests                                    | copy a sibling suite, adjust fixtures                                                         |
 
 The two files you actually think hard about are `headless.ts` and the stream parser. Everything
-else is following the compiler from one exhaustive switch to the next.
+else is following the compiler from one missing record key to the next.
 
 ## Files at a glance
 
-A headless provider that compiles and runs the loop: ~6 files
-(`settings-models/<p>.ts`, `settings.ts`, `_engine/<p>-provider-deps.ts`, `<p>/headless.ts`,
-`<p>/parse-stream.ts`, `provider-factory.ts`) plus the two compiler-forced one-liners
-(`model-availability-probe.ts` + its `wire.ts` registry entry, and the `toolForProvider` /
-`createSkillsAdapter` arms).
+The files you author are few — the count comes from the provider-keyed registries the compiler
+forces you through. New code is six files (`settings-models/<p>.ts`,
+`_engine/<p>-provider-deps.ts`, `<p>/headless.ts`, `<p>/parse-stream.ts`,
+`<p>/model-availability-probe.ts`, `skills/<p>/adapter.ts`) plus tests; everything else is a
+one-line row in an existing table.
 
 Full parity with the built-in four — readiness context-file support, a skills directory,
-availability filtering, and the test suites — lands around **14 files**:
+availability filtering, and the test suites — lands around **24 files**:
 
 1. `src/domain/value/settings-models/gemini.ts` — _new_
 2. `src/domain/entity/settings.ts` — _edit_ (union, enum, effort/model/row schemas, discriminated union)
-3. `src/integration/ai/providers/_engine/gemini-provider-deps.ts` — _new_
-4. `src/integration/ai/providers/gemini/headless.ts` — _new_
-5. `src/integration/ai/providers/gemini/parse-stream.ts` — _new_ (or fold inline)
-6. `src/integration/ai/providers/gemini/model-availability-probe.ts` — _new_ (passthrough)
-7. `src/application/bootstrap/provider-factory.ts` — _edit_ (factory arm)
-8. `src/application/bootstrap/wire.ts` — _edit_ (`MODEL_AVAILABILITY_PROBES` + `PROBES`)
-9. `src/integration/ai/readiness/_engine/tool.ts` — _edit_ (`AssistantTool` + `toolForProvider`)
-10. `src/integration/ai/readiness/gemini/probe.ts` — _new_
-11. `src/integration/ai/readiness/gemini/artifacts.ts` — _new_
-12. `src/integration/ai/skills/adapter-factory.ts` — _edit_ (skills arm)
-13. `src/integration/ai/skills/gemini/adapter.ts` — _new_
-14. tests under `tests/integration/ai/providers/gemini/` and `tests/unit/…` — _new_
+3. `src/domain/value/settings-models/effort.ts` — _edit_ (`PROVIDER_EFFORT_LEVELS`)
+4. `src/business/settings/defaults.ts` — _edit_ (`DEFAULT_MODELS_BY_PROVIDER`)
+5. `src/integration/ai/providers/_engine/gemini-provider-deps.ts` — _new_
+6. `src/integration/ai/providers/_engine/provider-traits.ts` — _edit_ (`PROVIDER_TRAITS`)
+7. `src/integration/ai/providers/gemini/headless.ts` — _new_
+8. `src/integration/ai/providers/gemini/parse-stream.ts` — _new_ (or fold inline)
+9. `src/integration/ai/providers/gemini/model-availability-probe.ts` — _new_ (passthrough)
+10. `src/integration/system/detect-cli.ts` — _edit_ (`PROVIDER_BINARY` + `PROVIDER_INSTALL_GUIDANCE`)
+11. `src/integration/ai/readiness/_engine/tool.ts` — _edit_ (`AssistantTool` + `toolForProvider` + `providerForTool`)
+12. `src/integration/ai/readiness/gemini/probe.ts` — _new_
+13. `src/integration/ai/readiness/gemini/artifacts.ts` — _new_
+14. `src/integration/ai/skills/adapter-factory.ts` — _edit_ (`SKILLS_ADAPTERS`)
+15. `src/integration/ai/skills/gemini/adapter.ts` — _new_
+16. `src/integration/ai/skills/operator/source.ts` — _edit_ (`OPERATOR_PROVIDER_DIR`)
+17. `src/integration/ai/agents/adapter-factory.ts` — _edit_ (`AGENT_ADAPTERS`)
+18. `src/application/bootstrap/provider-factory.ts` — _edit_ (`HEADLESS_FACTORIES`)
+19. `src/application/bootstrap/interactive-provider-factory.ts` — _edit_ (`INTERACTIVE_FACTORIES`)
+20. `src/application/bootstrap/wire.ts` — _edit_ (`MODEL_AVAILABILITY_PROBES` + `PROBES`)
+21. `src/application/flows/doctor/provider-auth.ts` + `probe-helpers.ts` — _edit_ (auth check + label)
+22. `src/application/flows/readiness/leaves/propose.ts` — _edit_ (only when you widen `AssistantTool`)
+23. `src/application/ui/shared/launch/readiness.ts` + `ui/tui/views/welcome-view.tsx` — _edit_ (label + first-run preset)
+24. tests under `tests/integration/ai/providers/gemini/` and `tests/unit/…` — _new_
 
 See also `CONTRIBUTING.md` — open an issue first, keep the PR focused, all checks pass.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Lukas Grigis",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukas-grigis/ralphctl.git"
+    "url": "git+https://github.com/lukas-grigis/ralphctl.git"
   },
   "bugs": {
     "url": "https://github.com/lukas-grigis/ralphctl/issues"
@@ -30,7 +30,7 @@
     "generator-evaluator"
   ],
   "bin": {
-    "ralphctl": "./dist/cli.mjs"
+    "ralphctl": "dist/cli.mjs"
   },
   "files": [
     "dist/",

--- a/src/application/chain/run/runner.ts
+++ b/src/application/chain/run/runner.ts
@@ -15,13 +15,20 @@ export type RunnerStatus = 'idle' | 'running' | 'completed' | 'failed' | 'aborte
  *  Failed run:      `started` → zero or more `step` → `failed`
  *  Aborted pre-run: `aborted` only (no `started`)
  *  Aborted mid-run: `started` → zero or more `step` → `aborted`
+ *
+ * `aborted` carries an `error` ONLY when the abort originated INSIDE the chain — the element
+ * returned (or threw) an `aborted`-coded error of its own, e.g. the operator answered "abort" at an
+ * in-chain prompt. A caller-driven `abort()` (Ctrl-C, an outer signal, a fatal-sibling kill) omits
+ * it: the caller already knows it cancelled, and there is no branch error to propagate. The wave
+ * scheduler relies on exactly that distinction to tell "this branch's operator aborted the run"
+ * from "I killed this branch".
  */
 export type RunnerEvent<TCtx> =
   | { readonly type: 'started' }
   | { readonly type: 'step'; readonly entry: TraceEntry }
   | { readonly type: 'completed'; readonly ctx: TCtx }
   | { readonly type: 'failed'; readonly error: DomainError }
-  | { readonly type: 'aborted' };
+  | { readonly type: 'aborted'; readonly error?: DomainError };
 
 export type RunnerListener<TCtx> = (event: RunnerEvent<TCtx>) => void;
 
@@ -86,6 +93,8 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
   const trace: TraceEntry[] = [];
   let startPromise: Promise<void> | null = null;
   let failureError: DomainError | null = null;
+  /** The chain's own `aborted`-coded error, when the abort came from INSIDE the chain. */
+  let abortError: DomainError | null = null;
   let abortRequested = false;
 
   const isTerminal = (): boolean => status === 'completed' || status === 'failed' || status === 'aborted';
@@ -101,6 +110,20 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
     }
   };
 
+  const abortedEvent = (): RunnerEvent<TCtx> =>
+    abortError === null ? { type: 'aborted' } : { type: 'aborted', error: abortError };
+
+  /**
+   * Enter the `aborted` terminal. `error` is the chain's own abort error, if any; it is dropped
+   * when the abort was caller-driven (`abort()` / outer signal), because then the cancellation is
+   * the caller's, not a branch failure to hand back up.
+   */
+  const settleAborted = (error?: DomainError): void => {
+    status = 'aborted';
+    abortError = abortRequested || error === undefined ? null : error;
+    emit(abortedEvent());
+  };
+
   const replayTo = (listener: RunnerListener<TCtx>): void => {
     try {
       for (const entry of trace) listener({ type: 'step', entry });
@@ -112,7 +135,7 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
           if (failureError) listener({ type: 'failed', error: failureError });
           break;
         case 'aborted':
-          listener({ type: 'aborted' });
+          listener(abortedEvent());
           break;
         default:
           break;
@@ -152,10 +175,10 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
       }
       error = result.error.error;
     } catch (cause) {
-      // An abort thrown raw (rather than returned as a Result) must still travel the abort path.
+      // An abort thrown raw (rather than returned as a Result) must still travel the abort path —
+      // carrying the thrown error, so an in-chain abort stays distinguishable from a caller kill.
       if (cause instanceof Error && (cause as { code?: unknown }).code === ErrorCode.Aborted) {
-        status = 'aborted';
-        emit({ type: 'aborted' });
+        settleAborted(cause as DomainError);
         return;
       }
       // Log loudly so a programmer-error throw stays visible even though it no longer crashes.
@@ -175,8 +198,7 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
     // Distinguish caller-driven abort from underlying failures. A user who called `abort()`
     // always gets the 'aborted' status regardless of which error code surfaced.
     if (abortRequested || error.code === ErrorCode.Aborted) {
-      status = 'aborted';
-      emit({ type: 'aborted' });
+      settleAborted(error);
       return;
     }
 
@@ -212,8 +234,7 @@ export const createRunner = <TCtx>(opts: RunnerOptions<TCtx>): Runner<TCtx> => {
       if (abortRequested) return;
       abortRequested = true;
       if (status === 'idle') {
-        status = 'aborted';
-        emit({ type: 'aborted' });
+        settleAborted();
         return;
       }
       if (isTerminal()) return;

--- a/src/application/chain/run/wave-scheduler.ts
+++ b/src/application/chain/run/wave-scheduler.ts
@@ -93,7 +93,12 @@ interface BranchRun<TCtx> {
   readonly runner: Runner<TCtx>;
   /** Resolves to this same run when the runner reaches a terminal state. Never rejects. */
   readonly settled: Promise<BranchRun<TCtx>>;
-  /** The `failed`-event error, captured off the runner's stream; `null` for a clean / aborted run. */
+  /**
+   * The terminal error captured off the runner's stream: the `failed` event's error, or the
+   * `aborted` event's error when the abort originated INSIDE the branch chain. `null` for a clean
+   * run and for a runner WE killed (fatal sibling / outer signal), whose `aborted` event carries
+   * no error.
+   */
   capturedError: DomainError | null;
 }
 
@@ -117,11 +122,13 @@ interface BranchRun<TCtx> {
  * Failure contract (CLAUDE.md "AbortError is the one error chains propagate transparently"):
  *  - A NON-fatal branch failure is absorbed: siblings keep running, the error is captured in that
  *    branch's {@link BranchOutcome} (`status: 'failed'`) for the reducer to record as a block.
- *  - **Abort:** when `signal` aborts, forward it into every in-flight branch via
- *    `runner.abort()`, await all branches to settle (`Promise.allSettled` semantics — `settled`
- *    never rejects) so each branch's chain runs its own cleanup (e.g. worktree teardown), then
- *    return `Result.error({ error: AbortError, trace })` VERBATIM — the AbortError is never folded
- *    into a per-branch "blocked" outcome.
+ *  - **Abort:** when `signal` aborts — OR when a branch's own chain settles with an `aborted`-coded
+ *    error (the operator answered "abort" at an in-branch prompt, with no outer signal) — forward
+ *    it into every in-flight branch via `runner.abort()`, await all branches to settle
+ *    (`Promise.allSettled` semantics — `settled` never rejects) so each branch's chain runs its own
+ *    cleanup (e.g. worktree teardown), then return `Result.error({ error: AbortError, trace })`
+ *    VERBATIM — the AbortError is never folded into a per-branch "blocked" outcome, and no later
+ *    wave is launched.
  *  - **Rate-limit:** an exhausted-retry `rate-limit` in one branch is fatal. With
  *    `onFatal: 'drain'` (default) the in-flight siblings finish and then the rest of the wave is
  *    not launched; with `onFatal: 'kill'` the siblings are aborted immediately. Either way the
@@ -319,6 +326,12 @@ const createBranchRun = <TCtx>(branch: WaveBranch<TCtx>, base: TCtx): BranchRun<
 
   const unsub = runner.subscribe((event) => {
     if (event.type === 'failed') run.capturedError = event.error;
+    // An `aborted` event carrying an error means the BRANCH's own chain aborted (e.g. the operator
+    // answered "abort" at an in-branch prompt) while the outer signal never fired. Capture it so
+    // `classify` sees a fatal `aborted` and tears the schedule down instead of silently reading the
+    // branch as "did not settle" and launching the rest of the wave — and every later wave. A kill
+    // WE issued carries no error, so this stays a no-op for fatal-sibling / outer-signal aborts.
+    else if (event.type === 'aborted' && event.error !== undefined) run.capturedError = event.error;
   });
 
   // start() resolves when the run reaches a terminal state; detach the listener then, resolve to

--- a/src/application/flows/_shared/signals-session.ts
+++ b/src/application/flows/_shared/signals-session.ts
@@ -2,7 +2,7 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { READ_ONLY } from '@src/integration/ai/providers/_engine/session-permissions.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
-import { currentSessionId } from '@src/application/session/session.ts';
+import { rootSessionId } from '@src/application/session/session.ts';
 
 export interface ReadOnlySignalsSessionOpts {
   /** Working directory the AI session opens in — the repository (or repo-derived) path. */
@@ -29,11 +29,13 @@ export interface ReadOnlySignalsSessionOpts {
  * session at call time (omitted when invoked outside one, e.g. a bare test).
  */
 export const readOnlySignalsSession = (opts: ReadOnlySignalsSessionOpts): AiSession => {
-  // `currentSessionId()` is read inside the leaf's execute scope (the runner wraps it in
+  // `rootSessionId()` is read inside the leaf's execute scope (the runner wraps it in
   // `runWithSession`) and threaded onto the session as DATA so the headless adapter can key
   // the token-usage event by the runner id without importing the application session helper
-  // across the layer boundary. Undefined out of session scope → the spread omits it.
-  const chainSessionId = currentSessionId();
+  // across the layer boundary. ROOT, not current: a nested / branch runner shadows the current
+  // id, and the TUI looks the map up by the id it mounted the session with. Undefined out of
+  // session scope → the spread omits it.
+  const chainSessionId = rootSessionId();
   return {
     prompt: opts.prompt,
     cwd: opts.cwd,

--- a/src/application/flows/implement/ctx.ts
+++ b/src/application/flows/implement/ctx.ts
@@ -108,14 +108,23 @@ export interface ImplementCtx {
    */
   readonly lastPreVerifyOutcome?: VerifyRunOutcome | undefined;
   /**
-   * Outcome + cwd of the most recent post-task-verify run. Read by the NEXT task's
-   * pre-task-verify leaf to decide whether the carried baseline can stand in for re-running
-   * the script (short-circuits when `outcome === 'success'`, the cwd matches, and the
-   * working tree is clean per `git status --porcelain`). Survives `settle-attempt` — that
-   * leaf clears per-attempt fields but this field carries across tasks. Undefined before
-   * the first post-task-verify of a sprint.
+   * Outcome + cwd + gate coverage of the most recent post-task-verify run. Read by the NEXT
+   * task's pre-task-verify leaf to decide whether the carried baseline can stand in for
+   * re-running the script (short-circuits when `outcome === 'success'`, `coveredAllGates` is
+   * `true`, the cwd matches, and the working tree is clean per `git status --porcelain`).
+   * Survives `settle-attempt` — that leaf clears per-attempt fields but this field carries
+   * across tasks. Undefined before the first post-task-verify of a sprint.
+   *
+   * `coveredAllGates` is what makes the carry sound under structured `verifyGates`: post-verify
+   * runs only the gates the attempt's diff footprint touched, so its aggregate `'success'` means
+   * "every EXECUTED gate passed", NOT "the tree is green". Carrying a diff-scoped green as a
+   * whole-tree baseline would let the next task's pre-verify synthesize a green it never
+   * measured — and a gate that was already red outside that footprint then reads as `regressed`
+   * on the next task that touches it. An absent flag (a ctx from before this field existed)
+   * counts as NOT covered: demote to running the real gate rather than assume coverage.
    */
-  readonly priorPostVerifyOutcome?: { readonly cwd: AbsolutePath; readonly outcome: VerifyRunOutcome } | undefined;
+  readonly priorPostVerifyOutcome?:
+    { readonly cwd: AbsolutePath; readonly outcome: VerifyRunOutcome; readonly coveredAllGates?: boolean } | undefined;
   /**
    * Repository ids whose setup script SUCCEEDED during THIS launch's `setup-script-runner` leaf.
    * Distinct from `SprintExecution.setupRanAt` (which persists across launches/resumes): this

--- a/src/application/flows/implement/flow.ts
+++ b/src/application/flows/implement/flow.ts
@@ -143,6 +143,7 @@ export interface CreateImplementFlowOpts {
  *         activate-sprint,
  *         load-sprint-execution,
  *         load-tasks,
+ *         load-learnings,                  // cross-sprint procedural memory (read side) → ctx.priorLearnings
  *         resolve-branch,                  // assigns ralphctl/<id> on first run, persists, checks out
  *         working-tree-clean-checks,       // one per repo: hard-abort if dirty (no recovery menu)
  *         progress-journal-activate,       // separator line in progress.md
@@ -222,8 +223,9 @@ export interface CreateImplementFlowOpts {
  * Build the prologue segment — everything from `load-and-assert-sprint` through `preflight-tasks`,
  * the once-per-run setup that runs BEFORE any task executes:
  *
- *   load-and-assert-sprint → activate → load-execution → load-tasks → resolve-branch →
- *   working-tree-clean-checks → progress-journal-activate → setup-script-runner → preflight-tasks
+ *   load-and-assert-sprint → activate → load-execution → load-tasks → load-learnings →
+ *   resolve-branch → working-tree-clean-checks → progress-journal-activate → setup-script-runner →
+ *   preflight-tasks
  *
  * Returned as `sequential('implement-prologue', [...])` so the parallel launcher can run it
  * once on a dedicated runner under the held lock before fanning the task waves out. The serial

--- a/src/application/flows/implement/leaves/best-of-n-candidate.ts
+++ b/src/application/flows/implement/leaves/best-of-n-candidate.ts
@@ -17,7 +17,7 @@ import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
 import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import { FULL_AUTO } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import { currentSessionId } from '@src/application/session/session.ts';
+import { rootSessionId } from '@src/application/session/session.ts';
 import type { SessionId } from '@src/integration/ai/providers/_engine/session-id.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { buildImplementPrompt } from '@src/integration/ai/prompts/implement/definition.ts';
@@ -98,7 +98,7 @@ const buildCandidateSession = (opts: {
   readonly bodyFile: AbsolutePath;
   readonly abortSignal: AbortSignal | undefined;
 }): AiSession => {
-  const chainSessionId = currentSessionId();
+  const chainSessionId = rootSessionId();
   return {
     prompt: opts.prompt,
     cwd: opts.cwd,

--- a/src/application/flows/implement/leaves/best-of-n-selection.ts
+++ b/src/application/flows/implement/leaves/best-of-n-selection.ts
@@ -16,7 +16,7 @@ import type { ImplementDeps } from '@src/application/flows/implement/deps.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import { READ_ONLY } from '@src/integration/ai/providers/_engine/session-permissions.ts';
 import type { SessionId } from '@src/integration/ai/providers/_engine/session-id.ts';
-import { currentSessionId } from '@src/application/session/session.ts';
+import { rootSessionId } from '@src/application/session/session.ts';
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import { buildSelectCandidatePrompt } from '@src/integration/ai/prompts/select-candidate/definition.ts';
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
@@ -125,7 +125,7 @@ const buildJudgeSession = (opts: {
   readonly bodyFile: AbsolutePath;
   readonly abortSignal: AbortSignal | undefined;
 }): AiSession => {
-  const chainSessionId = currentSessionId();
+  const chainSessionId = rootSessionId();
   return {
     prompt: opts.prompt,
     cwd: opts.cwd,

--- a/src/application/flows/implement/leaves/implement-session.ts
+++ b/src/application/flows/implement/leaves/implement-session.ts
@@ -4,7 +4,7 @@ import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session
 import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
 import type { SessionId } from '@src/integration/ai/providers/_engine/session-id.ts';
 import { FULL_AUTO } from '@src/integration/ai/providers/_engine/session-permissions.ts';
-import { currentSessionId } from '@src/application/session/session.ts';
+import { rootSessionId } from '@src/application/session/session.ts';
 
 /**
  * Per-call AiSession profile for implement and evaluate calls. The session "plugs onto" the
@@ -68,12 +68,15 @@ export const implementSession = (
   // with `signals-missing`.
   const outputDir = AbsolutePath.parse(dirname(String(signalsFile)));
   // Read the chain/runner session id HERE — this helper is invoked from inside the
-  // generator/evaluator leaf's `execute(...)`, which the runner wraps in `runWithSession`,
-  // so `currentSessionId()` returns the active runner id. Threaded onto the session as DATA
-  // so the headless adapter can stamp it onto the token-usage event WITHOUT importing the
+  // generator/evaluator leaf's `execute(...)`, which the runner wraps in `runWithSession`.
+  // `rootSessionId()` (NOT `currentSessionId()`) is deliberate: on the parallel path each task
+  // runs on its own branch runner whose scope shadows the current id with `task-<taskId>`, and
+  // the Execute view keys its token-usage map by the HOST runner id — stamping the branch id
+  // filed every event under a key nothing ever looks up. Threaded onto the session as DATA so
+  // the headless adapter can stamp it onto the token-usage event WITHOUT importing the
   // application session helper across the layer boundary. Undefined when no session scope is
   // active (e.g. a direct unit-test call) → the spread below omits the field.
-  const chainSessionId = currentSessionId();
+  const chainSessionId = rootSessionId();
   return {
     prompt,
     cwd: repoPath,

--- a/src/application/flows/implement/leaves/post-task-verify.ts
+++ b/src/application/flows/implement/leaves/post-task-verify.ts
@@ -162,6 +162,16 @@ interface LeafOutput {
    */
   readonly rawOutput: string;
   readonly spawnErrorMessage?: string;
+  /**
+   * True iff this run executed EVERY configured gate — i.e. the legacy single-script path, or a
+   * structured-gates run that fell back to the unscoped all-gates set. False when the run was
+   * diff-scoped (a subset of the gates) or short-circuited entirely (zero-turn skip).
+   *
+   * Carried onto `ctx.priorPostVerifyOutcome` because a scoped run's aggregate `'success'` only
+   * proves "every EXECUTED gate passed" — it is NOT whole-tree evidence, so it must not license
+   * the next task's carry-baseline short-circuit. See the field docs on `ImplementCtx`.
+   */
+  readonly coveredAllGates: boolean;
 }
 
 /**
@@ -263,7 +273,9 @@ const buildZeroTurnSkippedResult = (deps: Pick<PostTaskVerifyLeafDeps, 'clock'>,
     durationMs: 0,
     outcome: 'skipped',
   };
-  return { task, run: skipped, rawOutput: '' };
+  // No gate ran at all, so this is not whole-tree evidence. The `'skipped'` outcome already
+  // blocks the next task's carry (it requires `'success'`); the flag keeps the two consistent.
+  return { task, run: skipped, rawOutput: '', coveredAllGates: false };
 };
 
 /**
@@ -274,16 +286,19 @@ const buildZeroTurnSkippedResult = (deps: Pick<PostTaskVerifyLeafDeps, 'clock'>,
  * (all-run subset = the one gate). When gates ARE configured we compute the footprint and pass it
  * as scope; fail-fast stops at the first red scoped gate. CRITICAL fallback: a footprint failure
  * or an empty result runs ALL gates (scope undefined) — we never silently skip a gate.
+ *
+ * Reports `coveredAllGates` alongside the run so the caller can record WHETHER this outcome is
+ * whole-tree evidence: only an unscoped run (legacy single script, or the run-ALL fallback) is.
  */
 const runPostVerifyGates = async (
   deps: PostTaskVerifyLeafDeps,
   opts: PostTaskVerifyLeafOpts,
   signal?: AbortSignal
-): Promise<RunVerifyScriptOutput> => {
+): Promise<RunVerifyScriptOutput & { readonly coveredAllGates: boolean }> => {
   const gates = normalizeVerifyGates(opts.verifyScript, opts.verifyGates);
   const usingStructuredGates = opts.verifyGates !== undefined && opts.verifyGates.length > 0;
   const scope = usingStructuredGates ? await computeScope(deps, opts.cwd) : undefined;
-  return runVerifyGatesUseCase({
+  const out = await runVerifyGatesUseCase({
     cwd: opts.cwd,
     phase: 'post',
     gates,
@@ -302,6 +317,7 @@ const runPostVerifyGates = async (
       }),
     logger: deps.logger,
   });
+  return { ...out, coveredAllGates: scope === undefined };
 };
 
 /** Fallback `WriteFile` for callers that don't (yet) wire the port — same atomic adapter either way. */
@@ -439,7 +455,7 @@ const createPostTaskVerifyExecute =
       return Result.ok(buildZeroTurnSkippedResult(deps, input.task));
     }
 
-    const { run, rawOutput, spawnErrorMessage } = await runPostVerifyGates(deps, opts, signal);
+    const { run, rawOutput, spawnErrorMessage, coveredAllGates } = await runPostVerifyGates(deps, opts, signal);
 
     // Cancellation propagates verbatim. `runVerifyScriptUseCase` folds a runner
     // `Result.error` into a `spawn-error` row, so the abort would otherwise be swallowed as an
@@ -468,6 +484,7 @@ const createPostTaskVerifyExecute =
       task: recorded.value.task,
       run,
       rawOutput,
+      coveredAllGates,
       ...(spawnErrorMessage !== undefined ? { spawnErrorMessage } : {}),
       ...(recorded.value.attribution !== undefined ? { attribution: recorded.value.attribution } : {}),
     });
@@ -545,12 +562,13 @@ const projectLeafOutput = (ctx: ImplementCtx, out: LeafOutput, opts: PostTaskVer
     currentTask: out.task,
     tasks,
     lastVerifyResult: verifyResult,
-    // Carry the (cwd, outcome) tuple onto ctx so the NEXT task's pre-task-verify can
-    // short-circuit when this post ran green AND its working tree is still clean. The
-    // pre-task-verify leaf re-checks the tree itself via `git status --porcelain` — this
-    // field only asserts "the script ran here and got this outcome." Survives
-    // `settle-attempt` (which clears per-attempt fields only).
-    priorPostVerifyOutcome: { cwd: opts.cwd, outcome: out.run.outcome },
+    // Carry the (cwd, outcome, coverage) tuple onto ctx so the NEXT task's pre-task-verify can
+    // short-circuit when this post ran green over EVERY gate AND its working tree is still
+    // clean. The pre-task-verify leaf re-checks the tree itself via `git status --porcelain` —
+    // this field only asserts "these gates ran here and got this outcome." `coveredAllGates`
+    // is false for a diff-scoped run, whose green says nothing about the gates it skipped.
+    // Survives `settle-attempt` (which clears per-attempt fields only).
+    priorPostVerifyOutcome: { cwd: opts.cwd, outcome: out.run.outcome, coveredAllGates: out.coveredAllGates },
     ...(blockReason !== undefined ? { lastBlockReason: blockReason } : {}),
     ...(grantRetry ? { lastShouldFailAttempt: true } : {}),
   };

--- a/src/application/flows/implement/leaves/pre-task-verify-internals/verify-execution.ts
+++ b/src/application/flows/implement/leaves/pre-task-verify-internals/verify-execution.ts
@@ -63,13 +63,25 @@ const askRedBaselineDecision = async (
 const isInteractive = (env: PreTaskVerifyEnvironment): boolean => env.isStdinTty && !env.isCi && !env.isNoTui;
 
 /**
- * True iff the previous task's post-task-verify ran green on this same cwd (carried from
- * `input.priorPostVerifyOutcome`). Drives {@link tryCarryBaselineShortCircuit} AND gates
- * {@link tryFreshSetupShortCircuit} — the two short-circuits never overlap; once a task has
- * post-verified green, the carry path owns the subsequent skip.
+ * True iff the previous task's post-task-verify ran green over EVERY configured gate on this same
+ * cwd (carried from `input.priorPostVerifyOutcome`). Drives {@link tryCarryBaselineShortCircuit}
+ * AND gates {@link tryFreshSetupShortCircuit} — the two short-circuits never overlap; once a task
+ * has post-verified green, the carry path owns the subsequent skip.
+ *
+ * The `coveredAllGates` requirement is what keeps the carry sound under structured `verifyGates`:
+ * post-verify runs `fail-fast` SCOPED to the attempt's diff footprint, so its aggregate
+ * `'success'` only means "every EXECUTED gate passed". Standing in for the full baseline on that
+ * evidence would synthesize a green pre nothing measured, and a gate that was already red outside
+ * the previous task's footprint would then attribute as `'regressed'` on this task — blaming the
+ * AI for a baseline it never touched, burning the bounded red-verify retry, and bypassing both the
+ * `baseline-broken` escape hatch and the operator's persisted `baselineBrokenPolicy: 'proceed'`
+ * amnesty (both keyed on a RECORDED red pre). An absent flag (ctx written before the field existed)
+ * counts as NOT covered — demote to running the real gate rather than assume coverage.
  */
 export const isCarriedGreenForThisCwd = (input: LeafInput, cwd: AbsolutePath): boolean =>
-  input.priorPostVerifyOutcome?.outcome === 'success' && String(input.priorPostVerifyOutcome.cwd) === String(cwd);
+  input.priorPostVerifyOutcome?.outcome === 'success' &&
+  input.priorPostVerifyOutcome.coveredAllGates === true &&
+  String(input.priorPostVerifyOutcome.cwd) === String(cwd);
 
 /**
  * Carry-baseline short-circuit. When the previous task on this same cwd post-verified green and

--- a/src/application/flows/implement/leaves/pre-task-verify.ts
+++ b/src/application/flows/implement/leaves/pre-task-verify.ts
@@ -161,11 +161,17 @@ export interface LeafInput {
   readonly execution: SprintExecution;
   /**
    * Carried from `ctx.priorPostVerifyOutcome` — the previous task's post-task-verify result
-   * (cwd + outcome). Drives the carry-baseline short-circuit: when `outcome === 'success'`
-   * and the cwd matches `opts.cwd` and the working tree is clean, the leaf returns a
-   * synthetic green {@link VerifyRun} without spawning the verify script.
+   * (cwd + outcome + gate coverage). Drives the carry-baseline short-circuit: when
+   * `outcome === 'success'` AND that run executed every configured gate (`coveredAllGates`)
+   * and the cwd matches `opts.cwd` and the working tree is clean, the leaf returns a synthetic
+   * green {@link VerifyRun} without spawning the verify script. A diff-scoped post run (or a
+   * ctx from before the flag existed) is not whole-tree evidence and falls through.
    */
-  readonly priorPostVerifyOutcome?: { readonly cwd: AbsolutePath; readonly outcome: VerifyRunOutcome };
+  readonly priorPostVerifyOutcome?: {
+    readonly cwd: AbsolutePath;
+    readonly outcome: VerifyRunOutcome;
+    readonly coveredAllGates?: boolean;
+  };
   /**
    * The in-flight task's repository id (`ctx.currentTask.repositoryId`). Matched against
    * {@link LeafInput.setupVerifiedRepoIds} to decide the fresh-setup skip — keyed on repo id, not

--- a/src/application/flows/implement/leaves/reproduce.ts
+++ b/src/application/flows/implement/leaves/reproduce.ts
@@ -20,7 +20,7 @@ import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts'
 import type { TemplateLoader } from '@src/integration/ai/prompts/_engine/template-loader.ts';
 import type { ShellScriptRunner } from '@src/integration/io/shell-script-runner.ts';
 import { writeTextAtomic } from '@src/integration/io/fs.ts';
-import { currentSessionId } from '@src/application/session/session.ts';
+import { rootSessionId } from '@src/application/session/session.ts';
 import { deriveTaskKind } from '@src/business/task/derive-task-kind.ts';
 import { buildReproducePrompt } from '@src/integration/ai/prompts/reproduce/definition.ts';
 import { renderContractSectionFor } from '@src/integration/ai/contract/_engine/render-contract-section.ts';
@@ -186,7 +186,7 @@ const buildReproduceSession = (opts: {
   readonly bodyFile: AbsolutePath;
   readonly abortSignal: AbortSignal | undefined;
 }): AiSession => {
-  const chainSessionId = currentSessionId();
+  const chainSessionId = rootSessionId();
   return {
     prompt: opts.prompt,
     cwd: opts.cwd,

--- a/src/application/flows/readiness/leaves/offer-skill-suggestions.ts
+++ b/src/application/flows/readiness/leaves/offer-skill-suggestions.ts
@@ -5,7 +5,7 @@ import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
 import type { SkillSource } from '@src/integration/ai/skills/_engine/skill-source.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
-import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import { SkillNameSchema, type Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import type { AssistantTool } from '@src/integration/ai/readiness/_engine/tool.ts';
 import type { Element } from '@src/application/chain/element.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
@@ -32,7 +32,9 @@ import type { ReadinessCtx } from '@src/application/flows/readiness/ctx.ts';
  * suggested skills, so the operator is never prompted to install anything off a rejected round.
  *
  * Empty / undefined suggestions, a missing repository path, or a declined proposal make the
- * leaf a logged no-op.
+ * leaf a logged no-op. A suggestion that is not a bare kebab-case skill name is dropped with a
+ * warning before the prompt — the name becomes a directory under the operator's repo, so a
+ * traversing or newline-bearing name must never reach `askConfirm` or the adapter.
  *
  * Like {@link installReadinessSkillsLeaf}, installs go through the BARE-name adapter path: the
  * folders are deliberately project-tracked (no `ralphctl-` prefix, no `.git/info/exclude`
@@ -117,7 +119,16 @@ const offerSkillSuggestionsUseCase = async (
     return Result.ok(undefined);
   }
 
+  // Suggestions are AI-authored strings that become both a directory name under the repo and the
+  // body of the confirm prompt. The wire schema already drops out-of-shape names; re-check here so
+  // a name that reached ctx another way can neither escape the repo via `join` nor spoof the
+  // operator's confirm message with an embedded newline. Dropping is silent-but-logged: a
+  // malformed suggestion is advisory noise, not a reason to fail the readiness round.
   for (const name of input.suggestions) {
+    if (!SkillNameSchema.safeParse(name).success) {
+      log.warn(`dropping malformed skill suggestion ${JSON.stringify(name)} — not a kebab-case skill name`);
+      continue;
+    }
     const offered = await offerOne(deps, log, repoPath, name);
     if (!offered.ok) return Result.error(offered.error);
   }

--- a/src/application/session/session.ts
+++ b/src/application/session/session.ts
@@ -15,15 +15,41 @@ import { AsyncLocalStorage } from 'node:async_hooks';
  * The chain runner enters the scope around `element.execute(...)`. Any async work inherited
  * via `await` stays inside the same store. Outside any chain (one-shot CLI commands, doctor),
  * `currentSessionId()` returns `undefined` and consumers treat the stream as untagged.
+ *
+ * Scopes NEST (parallel implement runs one branch runner per task inside the host runner's
+ * scope, plus prologue / epilogue sub-runners), so the store carries two ids: `sessionId` is
+ * innermost-wins (per-branch attribution) and `rootSessionId` is the outermost runner id
+ * (what the TUI keys a whole session by). See {@link rootSessionId}.
  */
 
 interface SessionStore {
   readonly sessionId: string;
+  /** Outermost `runWithSession` id of this scope chain — see {@link rootSessionId}. */
+  readonly rootSessionId: string;
 }
 
 const storage = new AsyncLocalStorage<SessionStore>();
 
+/**
+ * Enter a session scope. Nesting is legitimate — the parallel implement path runs each task on
+ * its own branch runner inside the host runner's scope, and the prologue / epilogue segments run
+ * on sub-runners — so an entered scope SHADOWS `sessionId` (innermost wins, which is what
+ * per-branch logger / signal attribution needs) while INHERITING `rootSessionId` from the scope
+ * it was entered from.
+ */
 export const runWithSession = <T>(sessionId: string, fn: () => Promise<T> | T): Promise<T> | T =>
-  storage.run({ sessionId }, fn);
+  storage.run({ sessionId, rootSessionId: storage.getStore()?.rootSessionId ?? sessionId }, fn);
 
 export const currentSessionId = (): string | undefined => storage.getStore()?.sessionId;
+
+/**
+ * The OUTERMOST runner id of the active scope — the id a nested runner inherits rather than
+ * replaces. Use this (not {@link currentSessionId}) for anything the TUI keys on by SESSION
+ * rather than by branch: the Execute view is mounted with the host runner's id, so a
+ * `token-usage` event stamped with a branch id (`task-<taskId>`) can never be looked up.
+ *
+ * On the serial path — one runner, no nesting — this equals `currentSessionId()`.
+ *
+ * @public
+ */
+export const rootSessionId = (): string | undefined => storage.getStore()?.rootSessionId;

--- a/src/application/ui/cli/bootstrap.ts
+++ b/src/application/ui/cli/bootstrap.ts
@@ -55,7 +55,14 @@ export const bootstrapCli = async (): Promise<CliBootstrap> => {
 
   const settingsRepo = createJsonSettingsRepository({ configRoot: paths.value.configRoot });
   const settings = await settingsRepo.load();
-  if (!settings.ok) throw new Error(`settings: ${settings.error.message}`);
+  // The repair hint is the actionable half of a bad-settings failure ("fix or delete
+  // settings.json …"), and this throw is the only thing the terminal reporter in
+  // `report-cli-error.ts` gets to print — drop it and the operator is told what is broken but not
+  // what to do about it.
+  if (!settings.ok) {
+    const hint = 'hint' in settings.error && settings.error.hint !== undefined ? ` (${settings.error.hint})` : '';
+    throw new Error(`settings: ${settings.error.message}${hint}`);
+  }
 
   const deps = wire({ storage: paths.value, settings: settings.value });
 

--- a/src/application/ui/cli/cli.ts
+++ b/src/application/ui/cli/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { flowRegistry } from '@src/application/registry.ts';
 import { launchTui } from '@src/application/ui/tui/launch.ts';
 import { parseImplementRoleOverrides } from '@src/application/ui/cli/parse-implement-role-overrides.ts';
+import { reportFatal } from '@src/application/ui/cli/report-cli-error.ts';
 import { registerExportRequirementsCommand } from '@src/application/ui/cli/commands/export-requirements.ts';
 import { registerExportContextCommand } from '@src/application/ui/cli/commands/export-context.ts';
 import { registerCreatePrCommand } from '@src/application/ui/cli/commands/create-pr.ts';
@@ -16,6 +17,7 @@ import { registerTaskCommand } from '@src/application/ui/cli/commands/task.ts';
 import { registerRunsCommand } from '@src/application/ui/cli/commands/runs.ts';
 import { registerAgentsCommand } from '@src/application/ui/cli/commands/agents.ts';
 import { registerSkillsCommand } from '@src/application/ui/cli/commands/skills.ts';
+import { registerPromptsCommand } from '@src/application/ui/cli/commands/prompts.ts';
 import { CLI_METADATA } from '@src/business/version/cli-metadata.ts';
 
 /**
@@ -107,6 +109,16 @@ export const runCli = async (argv: readonly string[]): Promise<void> => {
   registerRunsCommand(program);
   registerAgentsCommand(program);
   registerSkillsCommand(program);
+  registerPromptsCommand(program);
 
-  await program.parseAsync([...argv]);
+  // Terminal frame for the whole CLI: every `bootstrapCli` pre-flight throws a plain `Error`, and
+  // command actions can throw too. Uncaught, those reach Node's crash handler and print a source
+  // excerpt from the bundled `dist/cli-<hash>.mjs` plus a full stack. `reportFatal` turns that into
+  // one actionable stderr line (stack behind `RALPHCTL_DEBUG_TRACE`) — see its doc comment for why
+  // `AbortError` is handled here instead of re-thrown.
+  try {
+    await program.parseAsync([...argv]);
+  } catch (err) {
+    reportFatal(err);
+  }
 };

--- a/src/application/ui/cli/commands/prompts.ts
+++ b/src/application/ui/cli/commands/prompts.ts
@@ -1,0 +1,73 @@
+import type { Command } from 'commander';
+import { bootstrapCli } from '@src/application/ui/cli/bootstrap.ts';
+import { fail } from '@src/application/ui/cli/report-cli-error.ts';
+import {
+  BUNDLED_PROMPT_PARTIALS,
+  BUNDLED_PROMPT_TEMPLATES,
+} from '@src/integration/ai/prompts/_engine/bundled-templates.ts';
+
+type PromptKind = 'template' | 'partial';
+
+interface LoadedPrompt {
+  readonly name: string;
+  readonly kind: PromptKind;
+  readonly bytes: number;
+}
+
+const formatPromptLine = (loaded: LoadedPrompt): string =>
+  `${loaded.name.padEnd(26)}  ${loaded.kind.padEnd(8)}  ${String(loaded.bytes).padStart(6)} bytes`;
+
+/**
+ * Load every bundled prompt asset through the wired `TemplateLoader` and print one line each.
+ * The listing is the point but the LOAD is the gate: an empty body or a missing file is a failed
+ * install, so both fail the command rather than printing a zero-byte row.
+ */
+const listPromptsAction = async (): Promise<void> => {
+  const { deps } = await bootstrapCli();
+
+  const requested: readonly LoadedPrompt[] = [
+    ...BUNDLED_PROMPT_TEMPLATES.map((name) => ({ name, kind: 'template' as const, bytes: 0 })),
+    ...BUNDLED_PROMPT_PARTIALS.map((name) => ({ name, kind: 'partial' as const, bytes: 0 })),
+  ];
+
+  const loaded: LoadedPrompt[] = [];
+  for (const entry of requested) {
+    const body = await deps.templateLoader.load(entry.name);
+    if (!body.ok) {
+      fail(body.error.message);
+      return;
+    }
+    if (body.value.trim().length === 0) {
+      fail(`prompt template '${entry.name}' resolved to an empty file — the install is incomplete`);
+      return;
+    }
+    loaded.push({ ...entry, bytes: body.value.length });
+  }
+
+  for (const entry of loaded.sort((a, b) => a.name.localeCompare(b.name))) {
+    process.stdout.write(`${formatPromptLine(entry)}\n`);
+  }
+};
+
+/**
+ * Register the `prompts` command group.
+ *
+ *   ralphctl prompts list
+ *
+ * Inspection surface for the bundled prompt templates — and, deliberately, the only
+ * non-interactive command that exercises the prompt-template resolver end to end. Prompts are the
+ * largest bundled asset class and every AI flow depends on them, but their resolver
+ * (`fs-template-loader.ts`) is a separate copy of the beside-the-module probe from the ones
+ * `skills list` / `agents list` / `bundle-integrity` walk, and it falls back silently. Without a
+ * command that reads a template back out of the built bundle, the CI + release dist smokes stay
+ * green on an install whose prompts are all unreadable — the 0.15.0 failure class, scoped to
+ * prompts. The workflows grep this command's output for exactly that reason.
+ */
+export const registerPromptsCommand = (program: Command): void => {
+  const prompts = program.command('prompts').description('inspect the bundled prompt templates');
+
+  prompts
+    .command('list')
+    .description('load every bundled prompt template + partial and list its name, kind and size')
+    .action(listPromptsAction);
+};

--- a/src/application/ui/cli/report-cli-error.ts
+++ b/src/application/ui/cli/report-cli-error.ts
@@ -1,3 +1,6 @@
+import { RALPHCTL_DEBUG_TRACE_ENV } from '@src/application/bootstrap/wire.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+
 /**
  * Shared CLI failure reporter — every command action ends a failed branch with
  * `fail(message); return;` (or `return <value>;` in a helper with a non-`void` return type)
@@ -7,5 +10,48 @@
  */
 export const fail = (message: string): void => {
   process.stderr.write(`error: ${message}\n`);
+  process.exitCode = 1;
+};
+
+/** Cancellation exit code — 128 + SIGINT, the shell convention. */
+const EXIT_INTERRUPTED = 130;
+
+/**
+ * Terminal-frame reporter for anything that escapes a command action — chiefly the pre-flight
+ * throws in `bootstrapCli` (storage-paths / ensure-roots / settings / bundle-integrity), which
+ * are the failures an operator hits when the install or the config is broken. Without this, Node's
+ * uncaught-exception handler prints a source excerpt from the bundled `dist/cli-<hash>.mjs`, a full
+ * commander stack and a `Node.js v<x>` footer — the exact output `ralphctl doctor` must not produce
+ * when doctor is the command you run BECAUSE something is wrong. Mirrors the TUI's equivalent
+ * (`tui/launch.ts`).
+ *
+ * `AbortError` is handled here rather than re-thrown. The propagation rule ("a guard or fallback
+ * that catches errors must exempt AbortError") exists so a mid-chain catch cannot swallow
+ * cancellation and let an inner layer keep going; this is the process boundary, there is nothing
+ * left to propagate to, and a re-throw would reproduce the raw crash banner this reporter exists to
+ * prevent. Do not "fix" it back into a re-throw.
+ *
+ * The stack stays available behind `RALPHCTL_DEBUG_TRACE` — the same flag that turns on the
+ * chain.log debug sink — so maintainers keep the detail without inflicting it on operators.
+ *
+ * @public
+ */
+export const reportFatal = (err: unknown): void => {
+  if (err instanceof AbortError) {
+    process.stderr.write('ralphctl: cancelled\n');
+    process.exitCode = EXIT_INTERRUPTED;
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`ralphctl: ${message.trim()}\n`);
+
+  const debug = process.env[RALPHCTL_DEBUG_TRACE_ENV];
+  if (typeof debug === 'string' && debug.length > 0 && err instanceof Error && err.stack !== undefined) {
+    process.stderr.write(`${err.stack}\n`);
+  } else {
+    process.stderr.write(`ralphctl: re-run with ${RALPHCTL_DEBUG_TRACE_ENV}=1 for the full stack\n`);
+  }
+
   process.exitCode = 1;
 };

--- a/src/application/ui/tui/components/evaluation-overlay.tsx
+++ b/src/application/ui/tui/components/evaluation-overlay.tsx
@@ -18,7 +18,7 @@
  * even when its prose is not.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import { Spinner } from '@src/application/ui/tui/components/spinner.tsx';
@@ -36,6 +36,10 @@ import {
   overlayBodyRows,
   useDocumentScroll,
 } from '@src/application/ui/tui/components/overlay-internals/use-document-scroll.ts';
+import {
+  overlayBodyColumns,
+  wrapRow,
+} from '@src/application/ui/tui/components/overlay-internals/wrap-document-rows.ts';
 import {
   useEvaluationFile,
   type EvaluationFileState,
@@ -91,6 +95,11 @@ const buildBodyModel = (state: EvaluationFileState): EvaluationBodyModel => {
   }
 };
 
+/** Re-key one projected row onto a wrapped fragment of itself, keeping its styling verbatim. */
+const withText =
+  (line: EvaluationLineSpec) =>
+  (text: string): EvaluationLineSpec => ({ ...line, text });
+
 const formatAgo = (modifiedAtMs: number, now: number): string => `${fmtDuration(Math.max(0, now - modifiedAtMs))} ago`;
 
 const modifiedAtOf = (state: EvaluationFileState): number | undefined =>
@@ -141,7 +150,7 @@ const EvaluationBody = ({
                 {model.detail !== undefined && <Text dimColor>{model.detail}</Text>}
               </Box>
             )}
-            <EvaluationLines lines={model.lines.slice(offset, offset + bodyRows)} keyOffset={offset} />
+            <EvaluationLines lines={model.lines.slice(offset, offset + bodyRows)} keyOffset={offset} oneRowPerLine />
           </>
         )}
       </Box>
@@ -169,8 +178,14 @@ export const EvaluationOverlay = (): React.JSX.Element | null => {
 
   const target = ui.evaluationTarget;
   const state = useEvaluationFile(target, storage.dataRoot);
-  const model = buildBodyModel(state);
   const bodyRows = overlayBodyRows(term.rows);
+  // Wrap BEFORE windowing: `projectEvaluationLines` emits one entry per paragraph, and the
+  // scroll model below counts entries as terminal rows. See `wrap-document-rows.ts`.
+  const bodyColumns = overlayBodyColumns(term.columns);
+  const model = useMemo<EvaluationBodyModel>(() => {
+    const built = buildBodyModel(state);
+    return { ...built, lines: built.lines.flatMap((line) => wrapRow(line.text, bodyColumns).map(withText(line))) };
+  }, [state, bodyColumns]);
   const { offset } = useDocumentScroll(model.lines.length, bodyRows);
 
   // Every Hook above runs unconditionally; the null guard sits below them so Hook order is stable

--- a/src/application/ui/tui/components/evaluator-failure-panel.tsx
+++ b/src/application/ui/tui/components/evaluator-failure-panel.tsx
@@ -124,19 +124,27 @@ export const projectEvaluationLines = (parsed: ParsedEvaluation): readonly Evalu
  * cannot style the same model differently. `keyPrefix` disambiguates when the caller renders a
  * SLICE — row indices restart at 0 on every scroll otherwise.
  *
+ * `oneRowPerLine` is for the WINDOWING caller: it clips each row with `truncate-end` so a spec
+ * can never paint across two terminal rows and desync a row-count viewport. The overlay pairs it
+ * with a pre-wrap (`wrap-document-rows.ts`) so nothing is actually lost; a caller that renders
+ * the whole projection (the panel below) leaves it off and lets Ink reflow the prose.
+ *
  * @public
  */
 export const EvaluationLines = ({
   lines,
   keyOffset = 0,
+  oneRowPerLine = false,
 }: {
   readonly lines: readonly EvaluationLineSpec[];
   readonly keyOffset?: number;
+  readonly oneRowPerLine?: boolean;
 }): React.JSX.Element => (
   <Box flexDirection="column">
     {lines.map((line, idx) => (
       <Text
         key={`eval-line-${String(keyOffset + idx)}`}
+        {...(oneRowPerLine ? ({ wrap: 'truncate-end' } as const) : {})}
         {...(line.color !== undefined ? { color: line.color } : {})}
         {...(line.dim === true ? { dimColor: true } : {})}
         {...(line.bold === true ? { bold: true } : {})}

--- a/src/application/ui/tui/components/overlay-internals/wrap-document-rows.ts
+++ b/src/application/ui/tui/components/overlay-internals/wrap-document-rows.ts
@@ -1,0 +1,100 @@
+/**
+ * Hard-wrap helper shared by the read-only document overlays (`ProgressOverlay`,
+ * `EvaluationOverlay`).
+ *
+ * Both overlays window an on-disk artifact by ROW COUNT — they slice `lines[offset, offset +
+ * bodyRows]` and derive `maxOffset` from `lines.length`. That arithmetic is only sound when one
+ * array entry paints exactly one terminal row. It does not hold for the raw artifacts: an
+ * `evaluation.md` critique and a `progress.md` note are each written as ONE unwrapped paragraph,
+ * which Ink's default `wrap="wrap"` happily paints across 4–8 rows. The overlay then overflows
+ * the fixed-height app frame (garbling the closing border) while `maxOffset` stays 0, so
+ * `useDocumentScroll` early-returns on every keystroke and the clipped tail is unreachable.
+ *
+ * Wrapping here — before windowing — makes the two agree again, and unlike `truncate-end` alone
+ * it loses no prose (these overlays exist to READ prose and there is no horizontal scroll).
+ * `truncate-end` still rides on the `<Text>` as the belt-and-braces guarantee that a row we
+ * mis-measured (tabs, wide glyphs) can never spill onto a second line.
+ *
+ * Width is measured in code points, not display cells: the alternative is a `string-width`
+ * dependency we don't carry, and the `truncate-end` backstop already bounds the failure mode to
+ * "a wide-glyph row wraps a little early" rather than "the viewport arithmetic breaks".
+ */
+
+import { spacing } from '@src/application/ui/tui/theme/tokens.ts';
+
+/**
+ * Columns the overlay chrome eats before the body gets any: the outer `paddingX`, the rounded
+ * border, and the inner `paddingX` — each on both sides. Keep in step with the frame both
+ * overlays render (outer Box `paddingX={spacing.indent}` → bordered Box `paddingX={spacing.indent}`).
+ */
+export const OVERLAY_CHROME_COLUMNS = spacing.indent * 2 + 2 + spacing.indent * 2;
+
+/** Floor on the wrap width so a pathologically narrow terminal still wraps into something. */
+export const OVERLAY_MIN_BODY_COLUMNS = 20;
+
+/** Usable body width for an overlay row on a terminal of `termColumns` columns. */
+export const overlayBodyColumns = (termColumns: number): number =>
+  Math.max(OVERLAY_MIN_BODY_COLUMNS, termColumns - OVERLAY_CHROME_COLUMNS);
+
+/**
+ * Below this many usable columns a continuation indent costs more than it buys, so continuation
+ * rows start at column 0 instead of under the parent's indent.
+ */
+const MIN_CONTINUATION_WIDTH = 8;
+
+/** Chop a row that cannot be word-wrapped (leading whitespace alone exceeds the width). */
+const hardSplit = (text: string, width: number): readonly string[] => {
+  const rows: string[] = [];
+  for (let i = 0; i < text.length; i += width) rows.push(text.slice(i, i + width));
+  return rows;
+};
+
+/**
+ * Word-wrap one row to `width` columns. Continuation rows repeat the source row's leading
+ * whitespace so an indented finding stays visually attached to its heading. A single word longer
+ * than the width (a URL, a base64 blob) is chopped rather than allowed to overflow.
+ *
+ * Interior runs of spaces are preserved verbatim — evidence blocks use them for alignment.
+ * An empty row wraps to a single empty row, keeping the artifact's blank-line rhythm.
+ */
+export const wrapRow = (text: string, width: number): readonly string[] => {
+  if (width <= 0 || text.length <= width) return [text];
+
+  const leading = /^[ \t]*/.exec(text)?.[0] ?? '';
+  const firstWidth = width - leading.length;
+  if (firstWidth <= 0) return hardSplit(text, width);
+  const indent = leading.length + MIN_CONTINUATION_WIDTH <= width ? leading : '';
+
+  const rows: string[] = [];
+  let prefix = leading;
+  let avail = firstWidth;
+  let line = '';
+  const flush = (): void => {
+    rows.push(prefix + line);
+    prefix = indent;
+    avail = width - indent.length;
+    line = '';
+  };
+
+  for (const word of text.slice(leading.length).split(' ')) {
+    const candidate = line.length === 0 ? word : `${line} ${word}`;
+    if (candidate.length <= avail) {
+      line = candidate;
+      continue;
+    }
+    if (line.length > 0) flush();
+    let rest = word;
+    while (rest.length > avail) {
+      line = rest.slice(0, avail);
+      rest = rest.slice(avail);
+      flush();
+    }
+    line = rest;
+  }
+  if (line.length > 0 || rows.length === 0) rows.push(prefix + line);
+  return rows;
+};
+
+/** {@link wrapRow} over a whole document. */
+export const wrapRows = (rows: readonly string[], width: number): readonly string[] =>
+  rows.flatMap((row) => wrapRow(row, width));

--- a/src/application/ui/tui/components/progress-overlay.tsx
+++ b/src/application/ui/tui/components/progress-overlay.tsx
@@ -18,7 +18,7 @@
 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { resolveSprintDir } from '@src/integration/persistence/storage.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
@@ -34,6 +34,10 @@ import {
   overlayBodyRows,
   useDocumentScroll,
 } from '@src/application/ui/tui/components/overlay-internals/use-document-scroll.ts';
+import {
+  overlayBodyColumns,
+  wrapRows,
+} from '@src/application/ui/tui/components/overlay-internals/wrap-document-rows.ts';
 
 interface ProgressFile {
   readonly kind: 'ok';
@@ -53,6 +57,8 @@ interface ProgressFailed {
 }
 
 type ProgressState = ProgressFile | ProgressMissing | ProgressEmpty | ProgressFailed | { readonly kind: 'loading' };
+
+const EMPTY_LINES: readonly string[] = [];
 
 const formatAgo = (modifiedAtMs: number, now: number): string => {
   const elapsed = Math.max(0, now - modifiedAtMs);
@@ -166,7 +172,12 @@ const ProgressBody = ({
         {state.kind === 'ok' && (
           <Box flexDirection="column">
             {visibleLines.map((line, idx) => (
-              <Text key={`row-${String(offset + idx)}`}>{line.length === 0 ? ' ' : line}</Text>
+              // `truncate-end` is the backstop behind the pre-wrap: a row we mis-measured (tabs,
+              // wide glyphs) is clipped rather than allowed to spill onto a second terminal row
+              // and desync the row-count windowing above.
+              <Text key={`row-${String(offset + idx)}`} wrap="truncate-end">
+                {line.length === 0 ? ' ' : line}
+              </Text>
             ))}
           </Box>
         )}
@@ -201,9 +212,16 @@ export const ProgressOverlay = (): React.JSX.Element => {
   const state = useProgressFile(sprintId, storage.dataRoot);
 
   const bodyRows = overlayBodyRows(term.rows);
-  const lineCount = state.kind === 'ok' ? state.lines.length : 0;
+  // `progress.md` rows come off disk unwrapped — one note can be a whole paragraph. Wrap before
+  // windowing so the row count the scroll model uses is the row count Ink paints.
+  const bodyColumns = overlayBodyColumns(term.columns);
+  const lines = useMemo<readonly string[]>(
+    () => (state.kind === 'ok' ? wrapRows(state.lines, bodyColumns) : EMPTY_LINES),
+    [state, bodyColumns]
+  );
+  const lineCount = lines.length;
   const { offset } = useDocumentScroll(lineCount, bodyRows);
-  const visibleLines = state.kind === 'ok' ? state.lines.slice(offset, offset + bodyRows) : [];
+  const visibleLines = lines.slice(offset, offset + bodyRows);
 
   const sprintLabel =
     ui.focusedRunSprintLabel ?? selection.sprintLabel ?? (sprintId !== undefined ? String(sprintId) : '(no sprint)');

--- a/src/application/ui/tui/components/status-banner.tsx
+++ b/src/application/ui/tui/components/status-banner.tsx
@@ -19,7 +19,11 @@
  *    entry. Insertion order is the publish order; sort flows error → warn → info before
  *    render so urgency stays visually consistent regardless of when each emitter fired.
  *  - Up to `MAX_VISIBLE` (3) banners render; the rest collapse into a `… + N more` row.
- *  - `d` dismisses the topmost (most-urgent) banner. Dismissal is local to the TUI session —
+ *  - `d` dismisses the topmost (most-urgent) banner, and stands down while a prompt or overlay
+ *    holds the keyboard (`ui.modalOpen`) — the component is mounted in every `ViewShell`, so an
+ *    ungated `d` would fire mid-word inside a text prompt. Requires a `UiStateProvider` above
+ *    it for that reason (unlike the EventBus, which it tolerates being absent).
+ *  - Dismissal is local to the TUI session —
  *    the underlying state remains; if the emitter publishes the same id again the banner
  *    reappears. Re-display after dismiss requires a re-publish from the emitter (the bus
  *    has no replay), which matches the design intent: "I don't need to see this right now"
@@ -32,6 +36,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useDeps } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { useOverlayState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { glyphs, inkColors, spacing } from '@src/application/ui/tui/theme/tokens.ts';
 import type { BannerShowEvent } from '@src/business/observability/events.ts';
 
@@ -103,6 +108,7 @@ const upsert = (current: readonly ActiveBanner[], next: ActiveBanner): readonly 
 
 export const StatusBanner = (): React.JSX.Element | null => {
   const deps = useDeps();
+  const overlay = useOverlayState();
   const [banners, setBanners] = useState<readonly ActiveBanner[]>([]);
 
   useEffect(() => {
@@ -142,7 +148,15 @@ export const StatusBanner = (): React.JSX.Element | null => {
   // via `useInput`'s `isActive` option because the option flips the subscription itself, which
   // races with the first render where banners arrive and the keystroke can land on the same
   // tick. The in-handler check is cheap and avoids that race.
+  //
+  // `modalOpen` is the same stand-down every other keyboard owner honours (DESIGN-SYSTEM § 4.4):
+  // it folds in promptActive, so a `d` typed into an askText/askTextArea prompt is a character,
+  // not a dismissal — this banner sits inside every ViewShell next to PromptHost, and silently
+  // discarding a rate-limit / watchdog warning mid-word is exactly the visibility loss the
+  // banner exists to prevent. It also covers the help / progress / evaluation overlays, where
+  // the operator cannot see what they would be dismissing.
   useInput((input) => {
+    if (overlay.modalOpen) return;
     if (input === 'd' && sorted.length > 0) dismissTop();
   });
 

--- a/src/application/ui/tui/components/tasks-panel.tsx
+++ b/src/application/ui/tui/components/tasks-panel.tsx
@@ -21,7 +21,11 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
-import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+import {
+  type BucketedExecution,
+  isInFlightBucket,
+  type TaskBucket,
+} from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import type { SprintState, TaskOverlay } from '@src/application/ui/tui/components/tasks-projection.ts';
 import type { TaskEvaluation } from '@src/application/ui/tui/components/tasks-panel-internals/evaluation-row.tsx';
 import type { RecoveryContext } from '@src/domain/entity/attempt.ts';
@@ -173,7 +177,7 @@ export interface TasksPanelProps extends TaskOverlaySources {
 }
 
 interface TaskCardState {
-  /** Index of the first non-completed task in `bucketed.tasks`; `-1` when every task is done. */
+  /** Index of the first IN-FLIGHT task in `bucketed.tasks`; `-1` when none is running. */
   readonly activeTaskIdx: number;
   readonly activeTaskId: string | undefined;
   readonly expandedTaskIds: ReadonlySet<string>;
@@ -196,10 +200,12 @@ const useTaskCardState = (
   onFocusedCardChange: ((taskId: string | undefined) => void) | undefined,
   onExpandedCardChange: ((expanded: boolean) => void) | undefined
 ): TaskCardState => {
-  // The active (first non-completed) task — anchor for the `e` criteria hotkey AND the
-  // default card-cursor position. Recomputed each render so the `useInput` callback always
-  // sees the latest active id.
-  const activeTaskIdx = bucketed.tasks.findIndex((t) => t.status !== 'completed');
+  // The active (first in-flight) task — anchor for the `e` criteria hotkey AND the default
+  // card-cursor position. Recomputed each render so the `useInput` callback always sees the
+  // latest active id. Settled-but-not-completed buckets (failed / aborted / dependency-skipped)
+  // are BEHIND the cursor: a task blocked upstream sits early in the list and would otherwise
+  // hold the anchor for the whole run while later tasks actually execute.
+  const activeTaskIdx = bucketed.tasks.findIndex(isInFlightBucket);
   const activeTaskId = activeTaskIdx >= 0 ? bucketed.tasks[activeTaskIdx]?.id : undefined;
 
   // Per-task card expansion. The active (running) task auto-expands when it becomes active so

--- a/src/application/ui/tui/runtime/bucket-task-signals.ts
+++ b/src/application/ui/tui/runtime/bucket-task-signals.ts
@@ -19,7 +19,9 @@
  * per-task substep trace alone:
  *
  *  - any substep failed/aborted (terminally) → that status (last-wins for failed-vs-aborted)
- *  - last expected substep (`uninstall-skills-<id>`) recorded → `completed`
+ *  - the guarded body composite (`task-body-<id>`) recorded as `skipped` → `skipped`
+ *    (the dependency gate blocked the task upstream, so nothing inside the body ever ran)
+ *  - last expected substep (`uninstall-skills-<id>`) recorded as `completed` → `completed`
  *  - any substep recorded, but not yet `uninstall-skills` → `running`
  *  - no substeps recorded → `pending`
  *
@@ -49,6 +51,17 @@ export const isPerTaskLeaf = (name: string): boolean => TOP_LEVEL_TASK_REGEX.tes
  * terminal leaf override via {@link BucketOptions.terminalSubstepName}.
  */
 const DEFAULT_TERMINAL_SUBSTEP = 'uninstall-skills';
+
+/**
+ * Default name of the per-task subchain's GUARDED BODY composite. `guard` emits exactly one
+ * synthetic `skipped` trace entry named after its body, so `task-body-<taskId>` with status
+ * `skipped` is the single unambiguous marker that a task never ran at all (today: the dependency
+ * gate blocked it upstream). Guards nested INSIDE the body (`reproduce-guard`,
+ * `quarantine-blocked-diff-guard`) skip routinely on the happy path — only this one means the
+ * whole task was passed over. Flows whose body composite is named differently override via
+ * {@link BucketOptions.bodySubstepName}.
+ */
+const DEFAULT_BODY_SUBSTEP = 'task-body';
 
 export type TaskBucketStatus = TraceStatus | 'running' | 'pending';
 
@@ -320,16 +333,42 @@ const bucketSignals = (
  * Derive the task-level status from its substep trace. See module docstring for the algorithm.
  * `failed` / `aborted` win over later `completed` substeps (the task subchain short-circuits
  * on the first failure via `sequential`'s contract).
+ *
+ * A `skipped` BODY composite is checked next: the dependency gate blocks a task by transitioning
+ * it to `blocked upstream …` and letting the body guard skip the whole lifecycle, which leaves
+ * no failed/aborted entry and no terminal leaf. Without this branch the task read `running`
+ * forever and pinned the Execute header's active-task cursor for the rest of the run.
+ *
+ * The terminal check requires the terminal leaf to have COMPLETED — a skipped terminal entry
+ * (were `guard` ever changed to synthesise one entry per flattened leaf) must never read as a
+ * finished task.
  */
-const resolveStatusFromSubSteps = (subSteps: readonly TaskSubStep[], terminalSubstepName: string): TaskBucketStatus => {
+const resolveStatusFromSubSteps = (
+  subSteps: readonly TaskSubStep[],
+  terminalSubstepName: string,
+  bodySubstepName: string
+): TaskBucketStatus => {
   if (subSteps.length === 0) return 'pending';
   for (const sub of subSteps) {
     if (sub.status === 'aborted') return 'aborted';
     if (sub.status === 'failed') return 'failed';
   }
-  const lastSeen = subSteps.some((s) => s.leafName === terminalSubstepName);
+  if (subSteps.some((s) => s.leafName === bodySubstepName && s.status === 'skipped')) return 'skipped';
+  const lastSeen = subSteps.some((s) => s.leafName === terminalSubstepName && s.status === 'completed');
   return lastSeen ? 'completed' : 'running';
 };
+
+/**
+ * Is this bucket the one the operator is watching? `running` mid-task, `pending` in the brief
+ * transition window between tasks. Settled buckets — `completed`, but equally `failed` /
+ * `aborted` / `skipped` — sit BEHIND the cursor: the Execute header's active-task readout and
+ * the Tasks panel's active-card anchor both scan for the first in-flight bucket, and a blocked
+ * (skipped) task earlier in the list must not hold that cursor while later tasks actually run.
+ *
+ * @public
+ */
+export const isInFlightBucket = (bucket: { readonly status: TaskBucketStatus }): boolean =>
+  bucket.status === 'running' || bucket.status === 'pending';
 
 const firstFailureMessage = (subSteps: readonly TaskSubStep[]): string | undefined => {
   for (const sub of subSteps) {
@@ -364,6 +403,13 @@ export interface BucketOptions {
    */
   readonly terminalSubstepName?: string;
   /**
+   * Name of the per-task subchain's guarded BODY composite — when it appears in the trace with
+   * status `skipped` the task never ran and flips to `skipped`. Defaults to
+   * {@link DEFAULT_BODY_SUBSTEP} (`'task-body'`, the implement flow's composite). Same decoupling
+   * rationale as {@link terminalSubstepName}.
+   */
+  readonly bodySubstepName?: string;
+  /**
    * Tasks the launcher knows about up front (e.g. from `tasks.json`) — used to synthesise
    * `pending` buckets for ids that have NO trace entries yet. Without this hint, a chain that
    * fails before any per-task leaf runs (e.g. `setup-script-runner` aborts the chain) leaves
@@ -382,6 +428,7 @@ export const bucketTaskSignals = (
   opts: BucketOptions = {}
 ): BucketedExecution => {
   const terminalSubstepName = opts.terminalSubstepName ?? DEFAULT_TERMINAL_SUBSTEP;
+  const bodySubstepName = opts.bodySubstepName ?? DEFAULT_BODY_SUBSTEP;
   const { order, byId: windows } = buildTaskWindows(chainEvents);
   const subStepsByTask = collectSubSteps(trace);
   const { signalsByTask, evaluationsByTask, orphans } = bucketSignals(signals, windows);
@@ -413,7 +460,7 @@ export const bucketTaskSignals = (
 
   const tasks: TaskBucket[] = ids.map((id) => {
     const subSteps = subStepsByTask.get(id) ?? [];
-    const status = resolveStatusFromSubSteps(subSteps, terminalSubstepName);
+    const status = resolveStatusFromSubSteps(subSteps, terminalSubstepName, bodySubstepName);
     const errorMessage = firstFailureMessage(subSteps);
     const duration =
       status === 'completed' || status === 'failed' || status === 'aborted' ? totalDurationMs(subSteps) : undefined;

--- a/src/application/ui/tui/runtime/router.tsx
+++ b/src/application/ui/tui/runtime/router.tsx
@@ -26,7 +26,15 @@ export interface RouterApi {
   push(entry: ViewEntry): void;
   pop(): void;
   replace(entry: ViewEntry): void;
-  reset(entry?: ViewEntry): void;
+  /**
+   * Drop the whole stack and land on `entry`. The destination is REQUIRED — an optional
+   * "fall back to the launch entry" form used to exist, and both of its callers (`h` = Home,
+   * `D` = detach) meant Home. On a first-run session the launch entry is the welcome / create-
+   * project wizard, so the bare form silently re-mounted the first-run wizard (which then
+   * re-applied its AI preset over the user's Settings edits). Making the parameter required
+   * keeps that class of bug unrepresentable.
+   */
+  reset(entry: ViewEntry): void;
 }
 
 const RouterContext = createContext<RouterApi | undefined>(undefined);
@@ -67,12 +75,9 @@ export const RouterProvider = ({ initial, children }: RouterProviderProps): Reac
     setStack((s) => (s.length === 0 ? [entry] : [...s.slice(0, -1), entry]));
   }, []);
 
-  const reset = useCallback(
-    (entry?: ViewEntry) => {
-      setStack(() => [entry ?? initial]);
-    },
-    [initial]
-  );
+  const reset = useCallback((entry: ViewEntry) => {
+    setStack(() => [entry]);
+  }, []);
 
   const current = stack[stack.length - 1] ?? initial;
 

--- a/src/application/ui/tui/runtime/use-global-keys.ts
+++ b/src/application/ui/tui/runtime/use-global-keys.ts
@@ -222,7 +222,10 @@ const handleViewShortcut = (input: string, router: RouterApi, ui: UiStateApi): b
 
   switch (input) {
     case 'h':
-      if (router.current.id !== 'home') router.reset();
+      // Explicit destination — `reset` never infers one. On a first-run session the launch
+      // entry is the welcome wizard, and inferring it here sent `h` backwards into first-run
+      // setup instead of Home.
+      if (router.current.id !== 'home') router.reset({ id: 'home' });
       return true;
     case 'n':
       navigate('flows');

--- a/src/application/ui/tui/runtime/use-token-usage.ts
+++ b/src/application/ui/tui/runtime/use-token-usage.ts
@@ -72,7 +72,10 @@ const toUsage = (e: TokenUsageEvent): TokenUsage => ({
   ...(e.contextWindow !== undefined ? { contextWindow: e.contextWindow } : {}),
 });
 
-// Key by the chain runner id when present — that is the id the execute view looks up by.
+// Key by the chain runner id when present — that is the id the execute view looks up by. The
+// producer side stamps `chainSessionId` from `rootSessionId()`, so a spawn that ran inside a
+// nested per-task branch runner (parallel implement) still files under the HOST session rather
+// than a `task-<taskId>` key nothing looks up.
 // Provider adapters stamp `sessionId` with the AI CLI's own uuid (a disjoint id space), so keying
 // on it alone guarantees a miss. Legacy / one-shot events without a runner id fall back to
 // `sessionId` so they still resolve. Module-scoped so it stays referentially stable across

--- a/src/application/ui/tui/views/execute-view-internals/use-bucketed-tasks.ts
+++ b/src/application/ui/tui/views/execute-view-internals/use-bucketed-tasks.ts
@@ -23,6 +23,7 @@ import { useTaskRoundTracker } from '@src/application/ui/tui/runtime/use-task-ro
 import {
   type BucketedExecution,
   bucketTaskSignals,
+  isInFlightBucket,
   type TaskBucket,
 } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
@@ -49,23 +50,21 @@ export interface BucketedDerivation {
 const isCompletedBucket = (t: TaskBucket): boolean => t.status === 'completed';
 
 /**
- * The task in flight — `running` mid-task and `pending` in the brief transition window between
- * tasks. The per-task chain runs sequentially, so the FIRST non-completed task is always the one
- * the operator is watching; failed / aborted / skipped tasks are behind the cursor.
- */
-const isCurrentBucket = (t: TaskBucket): boolean => !isCompletedBucket(t);
-
-/**
  * Counters + the "what is happening right now" trio the header card reads, derived from the merged
  * bucket. Split out so the hook body stays a chain of memos rather than a wall of optional-chained
  * lookups.
+ *
+ * `tasksDone` deliberately counts ONLY `completed` buckets: a run that ends with a dependency-
+ * blocked task shows `2/3` (not green) because the third task genuinely did not get done and needs
+ * the operator. The CURSOR, by contrast, only tracks in-flight buckets ({@link isInFlightBucket}),
+ * so a settled-but-not-completed task never holds the "current task" readout hostage.
  */
 const summariseProgress = (
   bucketed: BucketedExecution | undefined,
   taskNames: ReadonlyMap<string, string> | undefined
 ): Omit<BucketedDerivation, 'bucketed'> => {
   const tasks = bucketed?.tasks ?? [];
-  const currentTaskIdx = tasks.findIndex(isCurrentBucket);
+  const currentTaskIdx = tasks.findIndex(isInFlightBucket);
   const currentTask = currentTaskIdx >= 0 ? tasks[currentTaskIdx] : undefined;
   const currentTaskName =
     currentTask !== undefined

--- a/src/application/ui/tui/views/execute-view-internals/use-execute-input.ts
+++ b/src/application/ui/tui/views/execute-view-internals/use-execute-input.ts
@@ -9,8 +9,8 @@
  * Key handling:
  *   - help / prompt overlays own the keyboard — early-return when active.
  *   - while running: `c` opens the cancel-scope picker (unless already open); `D` detaches
- *     (router.reset, runner continues in background). `r` is deliberately inert here — a
- *     stray keystroke must not navigate off a live run.
+ *     to Home (router.reset, runner continues in background). `r` is deliberately inert here —
+ *     a stray keystroke must not navigate off a live run.
  *   - when settled: Enter / Esc resets to Home. ALWAYS Home — never sprint-detail or a
  *     stack pop. A finished flow (refine / plan / implement / …) drops the user back on the
  *     Home card with their own project/sprint selection intact. Browsing a run must not
@@ -90,6 +90,9 @@ export const useExecuteInput = ({
       return;
     }
     if (input === 'c' && !cancelScopeOpen) setCancelScopeOpen(true);
-    if (input === 'D') router.reset();
+    // Detach: drop the run's view and land on Home — the same destination a settled run's
+    // Enter/Esc uses. Named explicitly; `reset` never infers a destination (a bare form used to
+    // re-mount the process's launch entry, i.e. the first-run wizard on a fresh install).
+    if (input === 'D') router.reset({ id: 'home' });
   });
 };

--- a/src/application/ui/tui/views/welcome-view.tsx
+++ b/src/application/ui/tui/views/welcome-view.tsx
@@ -16,8 +16,15 @@
  * locally (via `useUiState().claimEscape()`) so the global `router.pop()` handler doesn't also
  * fire and race the local continue. Every other branch (1 CLI, 2+ CLIs) still auto-routes.
  *
+ * The seed-FAILED branch arms the same gate (destination `home`). It has to: the error card
+ * names `esc`, Welcome is the router stack's root so the global `router.pop()` fall-through is a
+ * no-op there, and an unarmed gate left the advertised key doing nothing.
+ *
  * The welcome is read-only: an existing settings file means the user already set up readiness,
- * so the launch entry routes straight to home before this view ever mounts.
+ * so the launch entry routes straight to home before this view ever mounts. The seeding effect
+ * re-asserts that on DISK (`settingsRepo.exists()`) rather than trusting the launch decision —
+ * a re-mounted view gets a fresh component instance (and so a fresh in-memory guard), and
+ * re-seeding would replace the whole `ai` section over the user's own Settings edits.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -34,6 +41,7 @@ import { createSettingsApplyPresetFlow } from '@src/application/flows/settings-a
 import { detectInstalledProviders } from '@src/integration/system/detect-cli.ts';
 import type { PresetName } from '@src/business/settings/presets.ts';
 import type { AiProvider } from '@src/domain/entity/settings.ts';
+import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 
 type Step = 'detecting' | 'seeded' | 'error';
 
@@ -50,6 +58,18 @@ const pickPresetForDetected = (installed: ReadonlySet<AiProvider>): PresetName =
     return PRESET_FOR_PROVIDER[only!];
   }
   return 'mixed';
+};
+
+/**
+ * Where welcome hands the user off. After first-run setup the user still has no project, so walk
+ * them straight into the create-project wizard rather than dropping them on a home screen they
+ * can't use yet; a repo that already holds projects goes to home. Shared by the seeding path and
+ * the already-seeded short-circuit so both land in the same place.
+ */
+const resolveNextRoute = async (projectRepo: ProjectRepository): Promise<ViewEntry> => {
+  const projects = await projectRepo.list();
+  const needsProject = projects.ok && projects.value.length === 0;
+  return { id: needsProject ? 'create-project' : 'home' };
 };
 
 interface UseWelcomeSeedingResult {
@@ -83,13 +103,25 @@ const useWelcomeSeeding = (): UseWelcomeSeedingResult => {
   const [pendingRoute, setPendingRoute] = useState<ViewEntry | undefined>(undefined);
   // First-run seeding must execute exactly once, even if React re-runs the effect because a
   // parent re-render produced a fresh `deps` / `router` reference. Without this guard, the
-  // apply-preset flow would fire on every re-render, writing settings multiple times.
+  // apply-preset flow would fire on every re-render, writing settings multiple times. This ref
+  // covers ONE component instance; the `settingsRepo.exists()` check below is the durable,
+  // disk-backed half that also survives a re-mount.
   const seededRef = useRef(false);
 
   useEffect(() => {
     if (seededRef.current) return;
     seededRef.current = true;
     const seed = async (): Promise<void> => {
+      // Durable idempotence gate. A settings file on disk means first-run setup already
+      // happened, so re-seeding would replace the whole `ai` section (that is what
+      // `applyPreset` does) over whatever the user configured in Settings since. Route onward
+      // without probing PATH or writing anything. A storage error fails OPEN — a first run must
+      // never be blocked by an unreadable settings probe.
+      const already = await deps.settingsRepo.exists();
+      if (already.ok && already.value) {
+        router.reset(await resolveNextRoute(deps.projectRepo));
+        return;
+      }
       const installed = await detectInstalledProviders();
       const zeroCliDetected = installed.size === 0;
       setNoCliDetected(zeroCliDetected);
@@ -97,17 +129,18 @@ const useWelcomeSeeding = (): UseWelcomeSeedingResult => {
       const flow = createSettingsApplyPresetFlow({ settingsRepo: deps.settingsRepo });
       const result = await flow.execute({ input: { preset } });
       if (!result.ok) {
+        // Hold `home` as the pending route BEFORE flipping to the error step. The error card
+        // tells the user to press `esc`, and `pendingRoute` is what arms both the local escape
+        // handler and the `claimEscape` that keeps the global `router.pop()` (a no-op at the
+        // stack root) from racing it. Without it the advertised key does nothing at all.
+        setPendingRoute({ id: 'home' });
         setErrorMsg(result.error.error.message);
         setStep('error');
         return;
       }
       setChosenPreset(preset);
       setStep('seeded');
-      // After welcome, the user still has no project. Walk them straight into the create-
-      // project wizard rather than dropping them on a home screen they can't actually use yet.
-      const projects = await deps.projectRepo.list();
-      const needsProject = projects.ok && projects.value.length === 0;
-      const next: ViewEntry = { id: needsProject ? 'create-project' : 'home' };
+      const next = await resolveNextRoute(deps.projectRepo);
       if (zeroCliDetected) {
         setPendingRoute(next);
         return;
@@ -155,7 +188,9 @@ export const WelcomeView = (): React.JSX.Element => {
   return (
     <ViewShell title="Welcome to ralphctl" subtitle="first-run setup">
       <Box flexDirection="column">
-        <Card title="Seeding settings" tone="primary">
+        {/* One card wraps all three steps, so the tone is derived rather than a second card
+            added — DESIGN-SYSTEM § 5 wants an error state on an `error`-toned surface. */}
+        <Card title="Seeding settings" tone={step === 'error' ? 'error' : 'primary'}>
           <Box flexDirection="column" paddingX={spacing.indent}>
             {step === 'detecting' && <Spinner label="probing PATH for installed AI CLIs…" />}
             {step === 'seeded' &&

--- a/src/business/observability/events.ts
+++ b/src/business/observability/events.ts
@@ -185,8 +185,10 @@ export interface TokenUsageEvent {
    */
   readonly sessionId: string;
   /**
-   * The chain runner / session id this spawn ran under, read from `currentSessionId()` (the
-   * runner wraps every `element.execute()` in `runWithSession(id, …)`). This is the id the TUI
+   * The chain runner / session id this spawn ran under, read from `rootSessionId()` (the
+   * runner wraps every `element.execute()` in `runWithSession(id, …)`; the ROOT id is used
+   * because nested branch runners on the parallel implement path shadow the current one).
+   * This is the id the TUI
    * execute view looks up by, so subscribers that drive per-runner widgets (the TokenBudgetCard)
    * MUST key on `chainSessionId ?? sessionId` — the provider-uuid `sessionId` never matches a
    * runner id. Optional because one-shot spawns outside any chain scope (and legacy events) have

--- a/src/business/task/run-evaluator-turn.ts
+++ b/src/business/task/run-evaluator-turn.ts
@@ -7,6 +7,7 @@ import {
   recordRunningAttemptWarning,
 } from '@src/domain/entity/task-attempts.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
 import {
   computePlateauVerdict,
@@ -24,10 +25,12 @@ import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts'
  *
  * Decisions owned by this use case:
  *  - `callEvaluate` returned a recoverable error (the reviewer never produced a usable
- *     `signals.json` — wrong shape, wrong place, non-zero spawn exit) → `self-blocked` exit so
- *     the task settles as `blocked` (NOT `malformed`, which settle-attempt treats as done-with-
- *     warning and would mark an ungraded change `done`). Fatal errors (`Aborted`/`RateLimit`)
- *     propagate as `Result.error` to abort the whole run — see {@link isRecoverableTurnError}.
+ *     `signals.json` — wrong shape, wrong place) → `self-blocked` exit so the task settles as
+ *     `blocked` (NOT `malformed`, which settle-attempt treats as done-with-warning and would mark
+ *     an ungraded change `done`). A `ProcessCrash` (watchdog kill / spawn crash / non-zero exit
+ *     with no signals.json) is instead a `crashed` exit — a transient process death retried within
+ *     `maxAttempts`. Fatal errors (`Aborted`/`RateLimit`) propagate as `Result.error` to abort the
+ *     whole run — see {@link isRecoverableTurnError}.
  *  - No evaluation signal at all → `malformed` exit.
  *  - `evaluation.status === 'passed'` → `passed` exit.
  *  - `evaluation.status === 'malformed'` → `malformed` exit.
@@ -52,6 +55,10 @@ import { isRecoverableTurnError } from '@src/business/task/turn-error-policy.ts'
 export type EvaluatorTurnExit =
   | { readonly kind: 'passed' }
   | { readonly kind: 'self-blocked'; readonly reason: string }
+  // Transient process death (watchdog kill / spawn crash / non-zero exit with no signals.json) —
+  // retried within `maxAttempts` by finalize-gen-eval, NOT a terminal block. Mirrors the generator's
+  // member of the same name; both are members of `GenEvalExit`, which is what ctx carries.
+  | { readonly kind: 'crashed'; readonly reason: string }
   | { readonly kind: 'malformed'; readonly detail: string }
   // `source: 'threshold'` — this is the ONLY plateau detector this use case ever produces (the
   // loop-diversity / entropy detectors run downstream in `gen-eval-loop.ts`, outside the
@@ -159,10 +166,18 @@ const resolveCritique = (evaluation: EvaluationSignal): string | undefined => {
 
 /**
  * Handle a `callEvaluate` failure. Fatal errors (user abort, rate-limit-after-retries) must
- * abort the whole run — propagate. Everything else is a recoverable signals-contract failure:
- * self-block THIS task so it settles as `blocked` (the generator's work is NOT committed/
- * marked-done ungraded — commit is gated on no block reason). Routing to `malformed` instead
- * would mark the change done.
+ * abort the whole run — propagate. Everything else is recoverable but splits two ways by error
+ * TYPE, exactly as the generator's half does:
+ *
+ *  - a `ProcessCrash` (watchdog kill / spawn crash / non-zero exit with no signals.json) is a
+ *    TRANSIENT process death → a `crashed` exit, which finalize retries within `maxAttempts`
+ *    (then blocks at the cap) instead of terminally blocking after ONE attempt. The evaluator
+ *    spawns through the same headless provider, watchdog and spawn-exit ladder as the generator,
+ *    so it dies the same ways and deserves the same remedy.
+ *  - anything else is a genuine signals-contract failure (the reviewer never produced a usable
+ *    `signals.json` — wrong shape, wrong place) → self-block THIS task so it settles as `blocked`
+ *    (the generator's work is NOT committed/marked-done ungraded — commit is gated on no block
+ *    reason). Routing to `malformed` instead would mark the change done.
  */
 const handleEvaluateFailure = (
   err: DomainError,
@@ -172,6 +187,16 @@ const handleEvaluateFailure = (
   if (!isRecoverableTurnError(err)) {
     log.error('evaluate call failed (fatal — propagating)', { taskId: task.id, error: err.message });
     return Result.error(err);
+  }
+  if (err.code === ErrorCode.ProcessCrash) {
+    log.warn('evaluator process was killed before producing signals.json — retrying attempt', {
+      taskId: task.id,
+      error: err.message,
+    });
+    return Result.ok({
+      task,
+      exit: { kind: 'crashed', reason: `AI process was killed before producing signals.json: ${err.message}` },
+    });
   }
   log.warn('evaluator did not produce a valid signals.json — blocking task', {
     taskId: task.id,

--- a/src/domain/entity/task-lifecycle.ts
+++ b/src/domain/entity/task-lifecycle.ts
@@ -49,6 +49,9 @@ export const markTaskBlocked = (
  * carrying a top-of-ladder escalation stamp would `topped-out` immediately. The per-attempt history
  * still lives in `progress.md` and git; only the task's in-memory attempt ledger resets.
  *
+ * The one stamp a clean restart KEEPS is the permanent `bestOfNGranted` marker (the once-per-task
+ * gate); its transient `bestOfNGrantedCandidates` handshake is dropped — see the destructure below.
+ *
  * Distinct from {@link resetTaskToTodo} (crash recovery), which PRESERVES attempts because it
  * resumes mid-work rather than restarting. Upstream-blocked dependents re-armed by the unblock
  * cascade carry no attempts, so the reset is a no-op for them.
@@ -69,6 +72,14 @@ export const unblockTask = (task: Task): Result<TodoTask, InvalidStateError> => 
     // A clean restart drops the prior run's per-criterion verdicts too — a freshly-planned task
     // carries no k-of-N history; stale verdicts would mislead the next run's checklist.
     criteriaVerdicts: _verdicts,
+    // The best-of-N handshake is transient: it is meant to be consumed by the ATTEMPT it was issued
+    // for. A grant stamped but never consumed (the attempt was cancelled / self-blocked before
+    // `best-of-n-selection` cleared it) would otherwise ride onto a task with zero attempts and make
+    // the restarted run's FIRST attempt sample N candidate generator sessions — an unexpected N×
+    // spend on what the operator asked to be a fresh run. The PERMANENT `bestOfNGranted` marker is
+    // deliberately NOT stripped: it is the once-per-task gate `decideEscalation` reads, and clearing
+    // it would let repeated block/unblock cycles re-grant N sessions without bound.
+    bestOfNGrantedCandidates: _bestOfNCandidates,
     ...rest
   } = guard.value;
   void _reason;
@@ -78,6 +89,7 @@ export const unblockTask = (task: Task): Result<TodoTask, InvalidStateError> => 
   void _effort;
   void _evaluatorEffort;
   void _verdicts;
+  void _bestOfNCandidates;
   return Result.ok({ ...rest, status: 'todo', attempts: [] });
 };
 

--- a/src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts
+++ b/src/integration/ai/agents/_engine/filesystem-agent-definition-adapter.ts
@@ -117,9 +117,10 @@ const writeAllDefinitions = async (
 };
 
 /**
- * Best-effort, once-per-`sessionDir` attempt to append the wildcard exclude line to
- * `<sessionDir>/.git/info/exclude`. A non-git tree, a worktree, or a write-protected exclude
- * file all collapse to "warn and proceed" — the caller's install already succeeded regardless.
+ * Best-effort, once-per-`sessionDir` attempt to append the wildcard exclude line to the
+ * `info/exclude` of `<sessionDir>`'s common git dir (a linked worktree resolves to the main
+ * repo's `.git`). A non-git tree, an uninspectable `.git`, or a write-protected exclude file
+ * all collapse to "warn and proceed" — the caller's install already succeeded regardless.
  */
 const ensureGitExcludeOnce = async (
   sessionDir: AbsolutePath,
@@ -172,10 +173,10 @@ export const createFilesystemAgentDefinitionAdapter = (
       if (tracked.size > 0) installed.set(String(sessionDir), tracked);
       if (!written.ok) return written;
 
-      // Best-effort: append a single wildcard line to <sessionDir>/.git/info/exclude so every
-      // `ralphctl-*` agent definition we manage stays out of `git status`. A non-git tree, a
-      // worktree, or a write-protected `.git/info/exclude` all collapse to "warn and proceed" —
-      // the install itself already succeeded.
+      // Best-effort: append a single wildcard line to <sessionDir>'s common `.git/info/exclude`
+      // (linked worktrees included) so every `ralphctl-*` agent definition we manage stays out of
+      // `git status`. A non-git tree, an uninspectable `.git`, or a write-protected
+      // `info/exclude` all collapse to "warn and proceed" — the install already succeeded.
       await ensureGitExcludeOnce(sessionDir, excludeAttempted, excludePattern, deps.providerId, deps.logger);
 
       return Result.ok(undefined);

--- a/src/integration/ai/contract/_engine/signals/skill-suggestions/schema.ts
+++ b/src/integration/ai/contract/_engine/signals/skill-suggestions/schema.ts
@@ -2,15 +2,43 @@ import { z } from 'zod';
 import type { SkillSuggestionsSignal } from '@src/domain/signal.ts';
 import { IsoTimestampSchema } from '@src/integration/persistence/shared/value-schemas.ts';
 import type { Compatible } from '@src/integration/persistence/shared/codec-internal.ts';
+import { SkillNameSchema } from '@src/integration/ai/skills/_engine/skill.ts';
+
+/**
+ * Upper bound on suggestions the harness carries forward. Each surviving name costs the operator
+ * one blocking confirm prompt in the readiness offer leaf, so an unbounded list is a way for a
+ * runaway (or hostile) model to wall the operator in with prompts. A realistic round suggests a
+ * handful; 20 is far above that and still bounded.
+ *
+ * @public
+ */
+export const MAX_SKILL_SUGGESTIONS = 20;
 
 /**
  * Zod schema for the `skill-suggestions` AI signal — kebab-case skill names the AI
  * recommends linking into the agentic working directory. Empty `names` is the canonical
  * "no suggestions" state.
+ *
+ * `names` is the one AI-controlled string in this contract that becomes a filesystem path: the
+ * readiness offer leaf turns each accepted name into `<repo>/<parentDir>/skills/<name>/SKILL.md`.
+ * So the wire schema is the first containment boundary — every element must be a bare kebab-case
+ * identifier ({@link SkillNameSchema}), which rules out separators, `..`, absolute paths, and the
+ * embedded newline that would otherwise inject extra keys into the rendered YAML frontmatter.
+ *
+ * Out-of-shape names are DROPPED rather than failing the parse: the signal is advisory and the
+ * array parse is all-or-nothing, so one mis-cased suggestion would otherwise discard the whole
+ * readiness round (the context-file proposal included). Same leniency stance as the `timestamp`
+ * defaulting and the `body`/`text` alias in `validateSignalsFile`. The skills adapter re-validates
+ * the name at the mkdir/writeFile seam, so dropping here never becomes the only line of defence.
  */
 export const skillSuggestionsSignalSchema = z.object({
   type: z.literal('skill-suggestions'),
-  names: z.array(z.string()).readonly(),
+  names: z
+    .array(z.string())
+    .transform((names) =>
+      names.filter((name) => SkillNameSchema.safeParse(name).success).slice(0, MAX_SKILL_SUGGESTIONS)
+    )
+    .readonly(),
   timestamp: IsoTimestampSchema,
 });
 

--- a/src/integration/ai/prompts/_engine/bundled-templates.ts
+++ b/src/integration/ai/prompts/_engine/bundled-templates.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical inventory of every prompt asset shipped in the bundle — the names
+ * `TemplateLoader.load()` must be able to resolve on an installed package.
+ *
+ * Why this exists at all: `resolveTemplatesDir` (fs-template-loader.ts) probes for a `prompts/`
+ * directory beside the running module and falls back SILENTLY to the package root when it is
+ * missing, which is exactly how 0.15.0 shipped a bundle that served no templates. Nothing
+ * reachable from a non-interactive CLI command used to touch that resolver — `skills list` /
+ * `agents list` exercise their own copies of the probe, and `bundle-integrity` existence-checks
+ * the manifest through a third copy — so the dist smoke could stay green with every prompt
+ * unreadable. `ralphctl prompts list` walks this list through the real loader; a parity test pins
+ * the list against the on-disk `src/integration/ai/prompts/` tree so a new prompt cannot land
+ * without joining the gate.
+ *
+ * Names are loader names, not paths: a template resolves to `<dir>/<name>/template.md`, a partial
+ * to `<dir>/_partials/<name>.md`.
+ */
+
+/** Per-flow prompt templates — `<dir>/<name>/template.md`. */
+export const BUNDLED_PROMPT_TEMPLATES: readonly string[] = [
+  'apply-feedback',
+  'create-pr',
+  'detect-scripts',
+  'detect-skills',
+  'distill-learnings',
+  'evaluate',
+  'evaluate-continuation',
+  'ideate',
+  'implement',
+  'implement-continuation',
+  'plan',
+  'readiness',
+  'refine',
+  'reproduce',
+  'select-candidate',
+];
+
+/** Cross-cutting partials — `<dir>/_partials/<name>.md`. */
+export const BUNDLED_PROMPT_PARTIALS: readonly string[] = [
+  'conventions-agents-md',
+  'conventions-claude-md',
+  'conventions-copilot-instructions',
+  'decisions',
+  'harness-context',
+  'validation-checklist',
+];

--- a/src/integration/ai/prompts/readiness/template.md
+++ b/src/integration/ai/prompts/readiness/template.md
@@ -160,7 +160,8 @@ Do not invent stack claims without evidence.
 3. `verify-skill-proposal` — optional. Same shape as the setup skill but for verification (typecheck /
    lint / test). Omit entirely when the project has no canonical verify command.
 4. `skill-suggestions` — optional. `names` is a list of kebab-case bundled skill names to link (e.g.
-   `["typescript-strict"]`).
+   `["typescript-strict"]`). Each name becomes a directory name, so it must be lowercase alphanumeric
+   with single hyphens — no paths, no separators, no spaces. The harness silently drops any other name.
 5. `note` — optional. One short observation. MUST be the only signal emitted when the repo cannot be
    characterised.
 6. `learning` — optional. A durable insight worth recording beyond this session (e.g. a

--- a/src/integration/ai/providers/_engine/ai-session.ts
+++ b/src/integration/ai/providers/_engine/ai-session.ts
@@ -94,9 +94,11 @@ export interface AiSession {
    * application-layer construction site (which builds the session inside the runner's
    * `runWithSession` scope), then stamped onto the {@link TokenUsageEvent} the adapter
    * publishes post-spawn so subscribers (the TUI's TokenBudgetCard) can key spend by the
-   * runner id rather than the AI CLI's own per-spawn uuid. Provider-agnostic; the adapters
-   * never read `currentSessionId()` themselves — integration cannot import the application
-   * session helper. Unset → the adapter omits the field (legacy / out-of-scope callers).
+   * runner id rather than the AI CLI's own per-spawn uuid. It is the ROOT (outermost) runner
+   * id — a nested per-task branch runner must not re-key its spawns away from the session the
+   * TUI mounted. Provider-agnostic; the adapters never read the session scope themselves —
+   * integration cannot import the application session helper. Unset → the adapter omits the
+   * field (legacy / out-of-scope callers).
    */
   readonly chainSessionId?: string;
 }

--- a/src/integration/ai/providers/_engine/classify-spawn-exit.ts
+++ b/src/integration/ai/providers/_engine/classify-spawn-exit.ts
@@ -20,6 +20,25 @@ import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attem
 export const DEFAULT_RATE_LIMIT_RE = /rate.?limit|quota|\b429\b/i;
 
 /**
+ * NARROW rate-limit pattern, applied to `stdoutTail` ONLY — never to stderr, which keeps the
+ * adapter's own broad {@link DEFAULT_RATE_LIMIT_RE}-style pattern.
+ *
+ * Why two tiers: `stdoutTail` is ASSISTANT-GENERATED task output (claude's stream-json `result`
+ * body, codex's `agent_message` tail, copilot's body tail, opencode's `text` records). The broad
+ * pattern matches ordinary prose — "Implemented the rate limiter in src/throttle.ts", "retry logic
+ * for HTTP 429 responses", "increased the disk quota" — so any non-zero exit on a task ABOUT
+ * throttling (an idle-watchdog SIGTERM, say) was classified as a throttle, skipping the
+ * signals.json recovery branch and sleeping through the whole backoff schedule before failing.
+ *
+ * This tier matches only the vendors' actual throttle sentences, so a false positive needs the
+ * assistant to quote one verbatim. Bare `429`, bare `quota` and bare `rate limiter` are
+ * deliberately absent. Real shapes still covered: claude's "usage limit reached" / 5-hour window /
+ * `overloaded_error`, the API's `rate_limit_error`, and a JSON-quoted `"status": 429`.
+ */
+const STDOUT_RATE_LIMIT_RE =
+  /usage limit reached|rate.?limit exceeded|rate_limit_error|overloaded_error|\b5-hour limit\b|"status"\s*:\s*429/i;
+
+/**
  * Shared post-spawn classifier for the four headless AI provider adapters
  * (claude / codex / copilot / opencode). Inspects the child's exit, the abort signal, stderr, and the
  * presence of `signals.json`, and decides whether the attempt is a success, a rate-limit
@@ -55,10 +74,12 @@ export const DEFAULT_RATE_LIMIT_RE = /rate.?limit|quota|\b429\b/i;
  * handle the bad-content cases uniformly with the case where the AI just never wrote
  * signals.json at all.
  *
- * **Rate-limit wins over recovery.** If stderr matches the rate-limit regex, surface
- * `rate-limit` — backoff/retry is the right response even if a partial `signals.json` from
- * a previous attempt happens to be on disk (per-round outputDir means it shouldn't be, but
- * the precedence keeps the semantics safe under reuse).
+ * **Rate-limit on STDERR wins over recovery; on STDOUT it does not.** A throttle reported on
+ * stderr surfaces `rate-limit` even if a partial `signals.json` from a previous attempt happens to
+ * be on disk (per-round outputDir means it shouldn't be, but the precedence keeps the semantics
+ * safe under reuse). A match found only in `stdoutTail` is weaker evidence — that haystack is
+ * assistant prose — so a landed `signals.json` beats it: the envelope is proof the turn did its
+ * work, and discarding it to sleep through the backoff schedule is the worse error.
  *
  * **Retryable crash vs. non-retryable config error.** Two failure branches surface a
  * `ProcessCrashError` (a TRANSIENT process death worth retrying within the attempt budget):
@@ -76,12 +97,15 @@ export type ProviderName = 'claude-provider' | 'codex-provider' | 'copilot-provi
  *  - copilot:  `Error: Model "gpt-5.4-nano" from --model flag is not available.`
  *  - codex:    `model not found`
  *  - claude:   `unknown model`
- *  - opencode: NOT DETECTABLE HERE. An unreachable `provider/model` id exits 1 with EMPTY stderr
- *    and reports `{"type":"error","error":{"name":"UnknownError","data":{"message":"Unexpected
- *    server error. …"}}}` on stdout (verified against opencode v1.18.15) — neither output mode
- *    carries the word `model`, so this regex cannot match and the exit necessarily falls through
- *    to the retryable ProcessCrash branch. Widening the pattern would not help; the token simply
- *    isn't there.
+ *  - opencode: reports fatal CLI errors on a stdout `{"type":"error"}` record with EMPTY stderr,
+ *    so the adapter feeds that record's text as {@link ClassifySpawnExitInput.processErrorText}
+ *    and this regex scans it alongside stderr. Caveat: the wording observed for an unreachable
+ *    `provider/model` id on v1.18.15 is `UnknownError: Unexpected server error. …`, which carries
+ *    no `model` token and therefore still falls through to the retryable ProcessCrash branch —
+ *    now at least WITH that text in the message instead of `<empty stderr>`. The durable fix for
+ *    that case is a pre-flight check of the configured id against `opencode models`, not a looser
+ *    regex: the same generic wording is also what a transient upstream outage produces, so
+ *    treating it as a config error would convert a retryable blip into an immediate block.
  * Broad enough to catch phrasing drift (`model ... is not available`, `model not found`,
  * `unknown model`, `unsupported model`) yet anchored on the word `model` so it can't trip on
  * unrelated "not available" lines. Abort is classified first, so this regex never sees an
@@ -110,20 +134,32 @@ export interface ClassifySpawnExitInput {
   };
   readonly stderr: string;
   /**
-   * Matched against the rate-limit haystack to detect a 429 / quota throttle. The haystack is
-   * `stderr` plus any provider-parsed stdout error body the adapter passes via `stdoutTail`:
-   * Claude's `-p stream-json` mode reports quota errors in the stdout `result` envelope, not on
-   * stderr, so a stderr-only scan misses the most common real-world throttle shape. Producer of
-   * the regex is the adapter (per-provider wording differs).
+   * Matched against `stderr` ONLY to detect a 429 / quota throttle. Producer of the regex is the
+   * adapter (per-provider wording differs), and it can be broad because stderr carries the CLI's
+   * own diagnostics rather than model output. The stdout side uses the shared, narrow
+   * {@link STDOUT_RATE_LIMIT_RE} instead — see `stdoutTail`.
    */
   readonly rateLimitRe: RegExp;
   /**
-   * Provider-parsed stdout error / result body, concatenated onto `stderr` before the
-   * rate-limit regex runs. Lets a provider that surfaces quota messages in its stdout JSON
-   * envelope (claude stream-json `result`, copilot/codex result records) still trip the
-   * overnight backoff. Optional — adapters whose throttle wording always lands on stderr omit it.
+   * Provider-parsed stdout body tail, scanned with {@link STDOUT_RATE_LIMIT_RE} after `stderr`.
+   * Lets a provider that surfaces quota messages in its stdout JSON envelope (claude stream-json
+   * `result`, copilot/codex result records) still trip the overnight backoff. Optional — adapters
+   * whose throttle wording always lands on stderr omit it.
+   *
+   * This is ASSISTANT-GENERATED text, so it is used for exactly one thing (the narrow rate-limit
+   * tier) and never for the model-unavailable branch. Structured CLI error records belong in
+   * `processErrorText`, not here.
    */
   readonly stdoutTail?: string;
+  /**
+   * The CLI's own STRUCTURED error record, parsed off stdout by adapters whose fatal errors never
+   * reach stderr (opencode's `{"type":"error","error":{"name","data":{"message"}}}`). Used as the
+   * stderr fallback in the failure message — otherwise the only explanation the CLI produced is
+   * parsed and then dropped, leaving `process exited with code 1: <empty stderr>` — and scanned by
+   * the model-unavailable branch, which is safe here precisely because this is a CLI error record
+   * rather than model output.
+   */
+  readonly processErrorText?: string;
   /** Provider's best-effort captured session id, attached to `RateLimitError` when present. */
   readonly capturedSessionId?: string;
   readonly providerName: ProviderName;
@@ -144,9 +180,16 @@ export interface ClassifySpawnExitInput {
   readonly onSuccess: () => AttemptOutcome | Promise<AttemptOutcome>;
 }
 
-/** Shared `code=N (signal=S): <stderr tail>` prefix used by both non-zero-exit failure shapes. */
-const exitSummary = (exit: ClassifySpawnExitInput['exit'], stderr: string): string =>
-  `process exited with code ${String(exit.code)}${exit.signal !== null ? ` (signal=${exit.signal})` : ''}: ${stderr.trim() || '<empty stderr>'}`;
+/**
+ * Shared `code=N (signal=S): <stderr tail>` prefix used by both non-zero-exit failure shapes.
+ * Falls back to the provider-parsed `processErrorText` when the CLI wrote nothing to stderr —
+ * opencode puts its whole explanation on a stdout error record, so without the fallback the
+ * operator sees `<empty stderr>` and nothing else.
+ */
+const exitSummary = ({ exit, stderr, processErrorText }: ClassifySpawnExitInput): string => {
+  const detail = stderr.trim() || processErrorText?.trim() || '<empty stderr>';
+  return `process exited with code ${String(exit.code)}${exit.signal !== null ? ` (signal=${exit.signal})` : ''}: ${detail}`;
+};
 
 /**
  * The two branches that are decided BEFORE the exit code is even looked at. Returns `undefined`
@@ -223,103 +266,108 @@ export const classifySpawnFailure = (
 };
 
 /**
- * The two non-zero-exit branches that BEAT signals-recovery. Returns `undefined` when neither
- * applies and the exit should fall through to recovery. Pure and synchronous.
- *
- *  - **Rate-limit** wins over recovery because backoff/retry is the right response even if a
- *    partial `signals.json` from a previous attempt happens to be on disk. The haystack is
- *    stderr PLUS any provider-parsed stdout error body: claude's stream-json mode reports quota
- *    in stdout, not stderr, so a stderr-only scan misses the most common real-world throttle.
- *  - **Model unavailable** is a configuration failure, not recoverable work. It wins over
- *    recovery because a model-not-available exit means the run never produced valid work for
- *    this model; a stale signals.json must not mask the real cause. The actionable hint is
- *    folded into `.message` (not just the separate `.hint` field) so it survives unchanged
- *    through `run-generator-turn`'s blockedReason string and into the TUI without touching the
- *    render layer.
- *
- *    **stderr ONLY (unlike rate-limit).** The claude / codex / copilot CLIs report
- *    model-availability errors on stderr; opencode does NOT (see the note on
- *    `MODEL_UNAVAILABLE_RE` — empty stderr, a generic error record on stdout), so an opencode
- *    model-availability failure is classified as a retryable crash rather than a config error.
- *    Scanning `stdoutTail` to compensate would be a false-positive hazard: stdoutTail
- *    carries assistant-generated task output (Claude envelope body / Copilot event text / Codex
- *    agent message), where benign phrases like "the model is not available in TensorFlow" or
- *    "the model checkpoint was not found" appear in NORMAL responses and would be misclassified
- *    as a config failure. The rate-limit branch legitimately needs stdoutTail (claude reports
- *    quota in its stream-json result envelope); opencode's stdout error record is deliberately
- *    left unscanned for exactly the reason above — it carries no `model` token to anchor on, so
- *    scanning it would buy nothing and cost false positives.
+ * Which stream carried the rate-limit evidence — the two are NOT equally trustworthy, so the
+ * ladder treats them differently (stderr beats signals-recovery, stdout does not).
  */
-const classifyFailureExit = ({
-  exit,
-  stderr,
-  rateLimitRe,
-  stdoutTail,
-  capturedSessionId,
-  providerName,
-}: ClassifySpawnExitInput): AttemptOutcome | undefined => {
-  const rateLimitHaystack = stdoutTail !== undefined ? `${stderr}\n${stdoutTail}` : stderr;
-  if (rateLimitRe.test(rateLimitHaystack)) {
-    return {
-      kind: 'rate-limit',
-      error: new RateLimitError({
-        subCode: 'spawn-stderr',
-        message: `${providerName}: rate-limit detected in stderr (exit ${String(exit.code)})`,
-        ...(capturedSessionId !== undefined ? { sessionId: capturedSessionId } : {}),
-      }),
-    };
-  }
+type RateLimitSource = 'stderr' | 'stdout';
 
-  if (MODEL_UNAVAILABLE_RE.test(stderr)) {
-    const hint = 'model not available — it may not be on your plan or CLI version; pick another model in settings';
-    return {
-      kind: 'error',
-      error: new InvalidStateError({
-        entity: providerName,
-        currentState: `exit-${String(exit.code ?? 'null')}`,
-        attemptedAction: 'complete generation',
-        message: `${providerName}: ${exitSummary(exit, stderr)} — ${hint}`,
-        hint,
-      }),
-    };
-  }
-
+/**
+ * Rate-limit detection, two-tiered by haystack trustworthiness:
+ *
+ *  - **stderr** gets the adapter's own broad pattern — it is the CLI's diagnostic channel, so
+ *    "quota" / a bare `429` there really is a throttle.
+ *  - **stdoutTail** gets the shared, narrow {@link STDOUT_RATE_LIMIT_RE} — it is assistant prose,
+ *    where those same tokens appear in ordinary answers about throttling code.
+ *
+ * Returns the matching source, or `undefined` when neither tier matches.
+ */
+const detectRateLimit = ({ stderr, rateLimitRe, stdoutTail }: ClassifySpawnExitInput): RateLimitSource | undefined => {
+  if (rateLimitRe.test(stderr)) return 'stderr';
+  if (stdoutTail !== undefined && STDOUT_RATE_LIMIT_RE.test(stdoutTail)) return 'stdout';
   return undefined;
 };
 
 /**
- * The tail of the ladder, and the only branch that touches the filesystem.
- *
- *  - **Recovery** — signals.json is authoritative, so a non-zero exit with the envelope on disk
- *    preserves the work: the watchdog banner is cleared, the adapter's own success block runs,
- *    and `recoveredFromExit` is spliced in so the caller can tell it apart from a clean exit.
- *    Existence-check only; the downstream validator catches malformed content.
- *  - **Hard fail** — non-zero exit with no signals.json. This is the
- *    watchdog-SIGTERM-before-signals shape (idle-stdout kill of a wedged child): a TRANSIENT
- *    process death worth retrying, so it surfaces a RETRYABLE `ProcessCrash` (distinct from the
- *    non-retryable model-unavailable config error). The message text is unchanged from the
- *    historical per-adapter exit-N shape so logs / progress read the same.
+ * The rate-limit outcome. The message names the stream that matched: a `rate-limit` classification
+ * costs the operator the whole backoff schedule, so which haystack triggered it has to be
+ * readable from the log without re-running anything.
  */
-const recoverOrCrash = async ({
+const rateLimitOutcome = (
+  { exit, capturedSessionId, providerName }: ClassifySpawnExitInput,
+  source: RateLimitSource
+): AttemptOutcome => ({
+  kind: 'rate-limit',
+  error: new RateLimitError({
+    subCode: 'spawn-stderr',
+    message: `${providerName}: rate-limit detected in ${source} (exit ${String(exit.code)})`,
+    ...(capturedSessionId !== undefined ? { sessionId: capturedSessionId } : {}),
+  }),
+});
+
+/**
+ * **Model unavailable** is a configuration failure, not recoverable work. It wins over recovery
+ * because a model-not-available exit means the run never produced valid work for this model; a
+ * stale signals.json must not mask the real cause. The actionable hint is folded into `.message`
+ * (not just the separate `.hint` field) so it survives unchanged through `run-generator-turn`'s
+ * blockedReason string and into the TUI without touching the render layer.
+ *
+ * **Scans stderr + `processErrorText`, never `stdoutTail`.** Both of the former are the CLI's own
+ * diagnostics (claude / codex / copilot use stderr; opencode uses a structured stdout error
+ * record). `stdoutTail` is assistant-generated task output, where benign phrases like "the model
+ * is not available in TensorFlow" or "the model checkpoint was not found" appear in NORMAL
+ * responses and would be misclassified as a config failure.
+ */
+const classifyModelUnavailable = (input: ClassifySpawnExitInput): AttemptOutcome | undefined => {
+  const { exit, stderr, processErrorText, providerName } = input;
+  if (!MODEL_UNAVAILABLE_RE.test(stderr) && !MODEL_UNAVAILABLE_RE.test(processErrorText ?? '')) return undefined;
+
+  const hint = 'model not available — it may not be on your plan or CLI version; pick another model in settings';
+  return {
+    kind: 'error',
+    error: new InvalidStateError({
+      entity: providerName,
+      currentState: `exit-${String(exit.code ?? 'null')}`,
+      attemptedAction: 'complete generation',
+      message: `${providerName}: ${exitSummary(input)} — ${hint}`,
+      hint,
+    }),
+  };
+};
+
+/**
+ * Non-zero exit with no signals.json — the watchdog-SIGTERM-before-signals shape (idle-stdout kill
+ * of a wedged child). A TRANSIENT process death worth retrying, so it surfaces a RETRYABLE
+ * `ProcessCrash` (distinct from the non-retryable model-unavailable config error). The message
+ * text keeps the historical per-adapter exit-N shape so logs / progress read the same.
+ */
+const crashOutcome = (input: ClassifySpawnExitInput): AttemptOutcome => ({
+  kind: 'error',
+  error: new ProcessCrashError({
+    entity: input.providerName,
+    state: `exit-${String(input.exit.code ?? 'null')}`,
+    message: `${input.providerName}: ${exitSummary(input)}`,
+  }),
+});
+
+/**
+ * The only branch that touches the filesystem. `signals.json` is authoritative, so a non-zero exit
+ * with the envelope on disk preserves the work: the watchdog banner is cleared, the adapter's own
+ * success block runs, and `recoveredFromExit` is spliced in so the caller can tell it apart from a
+ * clean exit. Existence-check only; the downstream validator catches malformed content.
+ *
+ * Returns `undefined` when nothing landed, so the ladder can decide between the weaker
+ * (stdout-only) rate-limit evidence and a plain crash.
+ */
+const recoverIfSignalsLanded = async ({
   session,
   exit,
-  stderr,
   providerName,
   eventBus,
   watchdogBannerId,
   onSuccess,
-}: ClassifySpawnExitInput): Promise<AttemptOutcome> => {
+}: ClassifySpawnExitInput): Promise<AttemptOutcome | undefined> => {
   const exists = await pathExists(String(session.signalsFile));
-  if (!exists.ok || !exists.value) {
-    return {
-      kind: 'error',
-      error: new ProcessCrashError({
-        entity: providerName,
-        state: `exit-${String(exit.code ?? 'null')}`,
-        message: `${providerName}: ${exitSummary(exit, stderr)}`,
-      }),
-    };
-  }
+  if (!exists.ok || !exists.value) return undefined;
 
   eventBus.publish({
     type: 'log',
@@ -346,9 +394,18 @@ const recoverOrCrash = async ({
 };
 
 /**
- * The precedence ladder, in order: the two pre-exit branches (abort, spawn error) beat everything;
- * a clean exit hands straight to the adapter's success block; the two failure branches
- * (rate-limit, model unavailable) beat signals-recovery; everything else recovers-or-crashes.
+ * The precedence ladder, in order:
+ *
+ *  1. the two pre-exit branches (abort, spawn error) beat everything;
+ *  2. a clean exit hands straight to the adapter's success block;
+ *  3. a rate-limit found on **stderr** beats signals-recovery (the CLI itself said "throttled");
+ *  4. model-unavailable beats signals-recovery (a config error must not be masked by a stale
+ *     envelope);
+ *  5. signals-recovery beats a rate-limit found only in **stdoutTail** — a landed envelope is
+ *     proof the turn did its work, and that haystack is assistant prose;
+ *  6. otherwise a stdout-only rate-limit match still surfaces `rate-limit` (the real claude
+ *     stream-json throttle shape, which never lands an envelope);
+ *  7. everything else is a retryable crash.
  */
 export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<AttemptOutcome> => {
   const preExit = classifyPreExit(input);
@@ -356,8 +413,16 @@ export const classifySpawnExit = async (input: ClassifySpawnExitInput): Promise<
 
   if (input.exit.code === 0) return await input.onSuccess();
 
-  const failure = classifyFailureExit(input);
-  if (failure !== undefined) return failure;
+  const rateLimitSource = detectRateLimit(input);
+  if (rateLimitSource === 'stderr') return rateLimitOutcome(input, rateLimitSource);
 
-  return await recoverOrCrash(input);
+  const modelUnavailable = classifyModelUnavailable(input);
+  if (modelUnavailable !== undefined) return modelUnavailable;
+
+  const recovered = await recoverIfSignalsLanded(input);
+  if (recovered !== undefined) return recovered;
+
+  if (rateLimitSource !== undefined) return rateLimitOutcome(input, rateLimitSource);
+
+  return crashOutcome(input);
 };

--- a/src/integration/ai/providers/_engine/run-provider-attempt.ts
+++ b/src/integration/ai/providers/_engine/run-provider-attempt.ts
@@ -120,6 +120,13 @@ export interface ProviderAttemptInput {
   /** Returns the stdout body tail for the rate-limit haystack, or undefined to scan stderr only. */
   readonly getStdoutTail: () => string | undefined;
   /**
+   * Returns the CLI's own structured error record, for providers that report fatal errors on
+   * stdout with an EMPTY stderr (opencode). Feeds `classifySpawnExit`'s `processErrorText`, which
+   * uses it as the failure-message fallback and as a model-unavailable haystack. Omit for
+   * providers whose fatal errors land on stderr — the classifier already reads those.
+   */
+  readonly getProcessErrorText?: () => string | undefined;
+  /**
    * Returns the assistant body for `bodyFile` mirroring. Only called when `session.bodyFile`
    * is set. Forensic capture is best-effort across all providers — an unreadable body resolves to
    * an empty string rather than a failure Result, so it never discards an otherwise-recovered
@@ -304,6 +311,7 @@ export const runProviderAttempt = async (input: ProviderAttemptInput): Promise<A
 
   const sessionId = input.getSessionId();
   const stdoutTail = input.getStdoutTail();
+  const processErrorText = input.getProcessErrorText?.();
   return classifySpawnExit({
     session,
     // `spawnError` was previously dropped here, which left the classifier's spawn-error branch
@@ -312,6 +320,7 @@ export const runProviderAttempt = async (input: ProviderAttemptInput): Promise<A
     stderr: stderrTail.value(),
     rateLimitRe,
     ...(stdoutTail !== undefined && stdoutTail.length > 0 ? { stdoutTail } : {}),
+    ...(processErrorText !== undefined && processErrorText.length > 0 ? { processErrorText } : {}),
     ...(sessionId !== undefined ? { capturedSessionId: sessionId } : {}),
     providerName,
     eventBus,

--- a/src/integration/ai/providers/opencode/headless.ts
+++ b/src/integration/ai/providers/opencode/headless.ts
@@ -178,6 +178,10 @@ const runOpencodeAttempt = (
     flush: () => tracker.flush(),
     getSessionId: () => tracker.getSessionId(),
     getStdoutTail: () => tracker.getStdoutTail(),
+    // OpenCode is the one backend that reports fatal CLI errors on stdout with an EMPTY stderr, so
+    // without this the classifier's message reads `process exited with code 1: <empty stderr>` and
+    // the CLI's only explanation is parsed and then dropped on every attempt.
+    getProcessErrorText: () => tracker.getStreamError(),
     // The body comes off the stream rather than a tempfile, so it is always readable and never
     // needs the codex adapter's best-effort disk guard.
     getBody: () => Promise.resolve(Result.ok(tracker.getBody())),

--- a/src/integration/ai/providers/opencode/parse-stream.ts
+++ b/src/integration/ai/providers/opencode/parse-stream.ts
@@ -1,3 +1,4 @@
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import {
   FORENSIC_BODY_TAIL_CAP,
@@ -105,9 +106,10 @@ export const assistantText = (obj: Record<string, unknown>): string | undefined 
 /**
  * Diagnostic text for an `error` record: `{"type":"error","error":{"name":"UnknownError",
  * "data":{"message":"…"}}}`. An unreachable model id makes `opencode run` exit 1 with an EMPTY
- * stderr and puts its only explanation on this record, so folding it into the body / tail is what
- * keeps the `ProcessCrashError` message from reading `process exited with code 1: ` and nothing
- * else.
+ * stderr and puts its only explanation on this record. It is retained SEPARATELY from the body
+ * (see {@link OpencodeAttemptTracker.getStreamError}) because the classifier needs it as a
+ * structured CLI error — folding it only into the assistant tail would leave it indistinguishable
+ * from model output, which the classifier is not allowed to trust.
  */
 const streamErrorText = (obj: Record<string, unknown>): string | undefined => {
   if (stringField(obj, 'type') !== 'error') return undefined;
@@ -162,6 +164,21 @@ export const publishOpencodeStreamLineEvents = (eventBus: EventBus, obj: Record<
     publishAssistantEvent(eventBus, PROVIDER_NAME, assistantText(obj));
     return;
   }
+  if (type === 'error') {
+    // WARN, not debug: this record is the CLI's only account of a fatal failure (stderr is empty),
+    // and the attempt may be re-spawned several times before the budget blocks the task. Under the
+    // default log floor a debug event would hide every one of those explanations.
+    const text = streamErrorText(obj);
+    if (text !== undefined) {
+      eventBus.publish({
+        type: 'log',
+        level: 'warn',
+        message: `${PROVIDER_NAME}: CLI reported an error — ${text}`,
+        at: IsoTimestamp.now(),
+      });
+    }
+    return;
+  }
   if (type !== 'tool_use') return;
   const part = partOf(obj);
   if (part !== undefined) publishToolEvents(eventBus, part);
@@ -194,6 +211,12 @@ export interface OpencodeAttemptTracker {
   readonly getBody: () => string;
   /** Bounded assistant tail used as the rate-limit classifier's haystack. */
   readonly getStdoutTail: () => string | undefined;
+  /**
+   * Text of the last `error` record — the CLI's own structured explanation for an exit that
+   * carries nothing on stderr. Kept apart from {@link getStdoutTail} so the classifier can trust
+   * it (it is not model output) without trusting the assistant tail.
+   */
+  readonly getStreamError: () => string | undefined;
 }
 
 export const createOpencodeAttemptTracker = (eventBus: EventBus): OpencodeAttemptTracker => {
@@ -202,6 +225,7 @@ export const createOpencodeAttemptTracker = (eventBus: EventBus): OpencodeAttemp
   let outputTokens: number | undefined;
   let body = '';
   let assistantTail = '';
+  let streamError: string | undefined;
   const lineFeed = createCappedLineFeed<Record<string, unknown>>('opencode-stream', emitOpencodeLine);
 
   const onMeta = (update: OpencodeMetaUpdate): void => {
@@ -215,9 +239,13 @@ export const createOpencodeAttemptTracker = (eventBus: EventBus): OpencodeAttemp
 
   const onLine = (obj: Record<string, unknown>): void => {
     publishOpencodeStreamLineEvents(eventBus, obj);
-    // `error` records fold in alongside assistant prose: they are the CLI's only explanation for
-    // an exit-1 with empty stderr (see `streamErrorText`).
-    const text = assistantText(obj) ?? streamErrorText(obj);
+    // `error` records fold into the forensic body alongside assistant prose — they are the CLI's
+    // only explanation for an exit-1 with empty stderr — AND are retained separately so the
+    // classifier gets them as a structured error rather than as model output (see
+    // `streamErrorText`). Last one wins: the final error is the one that killed the run.
+    const errorText = streamErrorText(obj);
+    if (errorText !== undefined) streamError = errorText;
+    const text = assistantText(obj) ?? errorText;
     if (text === undefined) return;
     // Both accumulators are capped — an hours-long chatty session must not grow either without
     // bound (same OOM class the line-parse cap guards).
@@ -245,5 +273,6 @@ export const createOpencodeAttemptTracker = (eventBus: EventBus): OpencodeAttemp
     getOutputTokens: () => outputTokens,
     getBody: () => body,
     getStdoutTail: () => (assistantTail.length > 0 ? assistantTail : undefined),
+    getStreamError: () => streamError,
   };
 };

--- a/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
+++ b/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
@@ -27,7 +27,7 @@ import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { Logger } from '@src/business/observability/logger.ts';
 import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
-import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import { SkillNameSchema, type Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import type { SkillsAdapter } from '@src/integration/ai/skills/_engine/skills-port.ts';
 
 export interface FilesystemSkillsAdapterDeps {
@@ -61,6 +61,25 @@ const renderSkill = (skill: Skill): string => {
   return `${lines.join('\n')}\n\n${skill.content.replace(/\s+$/u, '')}\n`;
 };
 
+/**
+ * Containment gate — `skill.name` is used verbatim as a directory name, so `join(skillsDir,
+ * '../../../../tmp/pwned')` would land the write outside `sessionDir` entirely. On the bare path
+ * the name originates from AI output (the readiness `skill-suggestions` signal), which makes this
+ * adapter the last boundary before `mkdir` / `writeFile`. Re-validating against
+ * {@link SkillNameSchema} here — the same shape every on-disk skill already satisfies — keeps a
+ * future caller from reintroducing a model-controlled path, and rules out the embedded newline
+ * that would otherwise inject extra keys into {@link renderSkill}'s YAML frontmatter.
+ */
+const rejectUnsafeSkillName = (providerId: string, skillsDir: string, name: string): StorageError | undefined => {
+  if (SkillNameSchema.safeParse(name).success) return undefined;
+  return new StorageError({
+    subCode: 'schema-mismatch',
+    message: `${providerId}: refusing skill name ${JSON.stringify(name)} — skill names are used verbatim as a directory name and must be kebab-case (lowercase alphanumeric with single hyphens, 1-64 chars)`,
+    path: skillsDir,
+    hint: 'The name came from a skill source or AI output. Nothing was written; fix the skill name at its source.',
+  });
+};
+
 const tryRmdirIfEmpty = async (path: string): Promise<void> => {
   try {
     await rmdir(path);
@@ -81,6 +100,9 @@ const writeAllSkills = async (
   tracked: Set<string>
 ): Promise<Result<void, StorageError>> => {
   for (const skill of skills) {
+    const unsafe = rejectUnsafeSkillName(providerId, skillsDir, skill.name);
+    if (unsafe !== undefined) return Result.error(unsafe);
+
     const dst = join(skillsDir, skill.name);
     if (existsSync(dst)) continue; // project copy wins
 
@@ -103,9 +125,10 @@ const writeAllSkills = async (
 };
 
 /**
- * Best-effort, once-per-`sessionDir` attempt to append the wildcard exclude line to
- * `<sessionDir>/.git/info/exclude`. A non-git tree, a worktree, or a write-protected exclude
- * file all collapse to "warn and proceed" — the caller's install already succeeded regardless.
+ * Best-effort, once-per-`sessionDir` attempt to append the wildcard exclude line to the
+ * `info/exclude` of `<sessionDir>`'s common git dir (a linked worktree resolves to the main
+ * repo's `.git`). A non-git tree, an uninspectable `.git`, or a write-protected exclude file
+ * all collapse to "warn and proceed" — the caller's install already succeeded regardless.
  */
 const ensureGitExcludeOnce = async (
   sessionDir: AbsolutePath,
@@ -159,10 +182,10 @@ export const createFilesystemSkillsAdapter = (deps: FilesystemSkillsAdapterDeps)
       if (tracked.size > 0) installed.set(String(sessionDir), tracked);
       if (!written.ok) return written;
 
-      // Best-effort: append a single wildcard line to <sessionDir>/.git/info/exclude so
-      // every `ralphctl-*` skill we manage stays out of `git status`. A non-git tree, a
-      // worktree, or a write-protected `.git/info/exclude` all collapse to "warn and
-      // proceed" — the skill install itself already succeeded.
+      // Best-effort: append a single wildcard line to <sessionDir>'s common `.git/info/exclude`
+      // (linked worktrees included) so every `ralphctl-*` skill we manage stays out of
+      // `git status`. A non-git tree, an uninspectable `.git`, or a write-protected
+      // `info/exclude` all collapse to "warn and proceed" — the skill install already succeeded.
       await ensureGitExcludeOnce(sessionDir, excludeAttempted, excludePattern, deps.providerId, deps.logger);
 
       return Result.ok(undefined);
@@ -173,6 +196,9 @@ export const createFilesystemSkillsAdapter = (deps: FilesystemSkillsAdapterDeps)
       // `.git/info/exclude`, doesn't add to the manifest. The folder is deliberately
       // project-tracked so the operator commits it as a regular project asset.
       const skillsDir = join(String(sessionDir), skillsSubdir);
+      const unsafe = rejectUnsafeSkillName(deps.providerId, skillsDir, skill.name);
+      if (unsafe !== undefined) return Result.error(unsafe);
+
       const dst = join(skillsDir, skill.name);
       // Project-wins: a pre-existing `SKILL.md` at the destination is the operator's own.
       // Leave it alone (the readiness flow may run on a repo where these skills already

--- a/src/integration/io/git-exclude.ts
+++ b/src/integration/io/git-exclude.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import { Result } from '@src/domain/result.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
@@ -13,8 +13,10 @@ import { writeTextAtomic } from '@src/integration/io/fs.ts';
  *
  * Handles the three layouts git can present:
  *  - Plain repo:  `<repoRoot>/.git/info/exclude` exists (or its parent dir does).
- *  - Worktree:    `<repoRoot>/.git` is a FILE whose contents are `gitdir: <path>`. The
- *    real `info/exclude` lives under that resolved path.
+ *  - Linked worktree: `<repoRoot>/.git` is a FILE whose contents are `gitdir: <path>`, and
+ *    that gitdir carries a `commondir` pointer back to the main repo's `.git`. `info/` is a
+ *    COMMON path in git, so git reads `$GIT_COMMON_DIR/info/exclude` and never the
+ *    per-worktree copy — the wildcard must be written to the common dir or it has no effect.
  *  - Not a git repo / `.git` missing: there's no exclude file to write; return Ok and
  *    skip silently. The caller (skills install) wants best-effort behaviour here — a
  *    non-git working tree is a legitimate place to run ralphctl.
@@ -26,7 +28,9 @@ export const ensureGitExcludeWildcard = async (
   repoRoot: AbsolutePath,
   pattern: string
 ): Promise<Result<void, StorageError>> => {
-  const resolved = await resolveExcludePath(String(repoRoot));
+  const resolvedResult = await resolveExcludePath(String(repoRoot));
+  if (!resolvedResult.ok) return Result.error(resolvedResult.error);
+  const resolved = resolvedResult.value;
   if (resolved === undefined) return Result.ok(undefined);
 
   let existing = '';
@@ -58,23 +62,32 @@ export const ensureGitExcludeWildcard = async (
 };
 
 /**
- * Resolve the path of the writable `info/exclude` file for a working tree. Returns
- * `undefined` when no `.git` marker exists (the working tree isn't tracked by git) —
- * the caller treats that as a no-op rather than an error.
+ * Resolve the path of the `info/exclude` file git actually reads for a working tree. Yields
+ * `Ok(undefined)` when no `.git` marker exists (the working tree isn't tracked by git) — the
+ * caller treats that as a no-op rather than an error. Any other inspection failure (EACCES,
+ * ELOOP, EPERM …) comes back as an error Result: the whole module is best-effort, so it must
+ * never throw a raw Node errno error out of the `Result` envelope.
  */
-const resolveExcludePath = async (repoRoot: string): Promise<string | undefined> => {
+const resolveExcludePath = async (repoRoot: string): Promise<Result<string | undefined, StorageError>> => {
   const gitMarker = join(repoRoot, '.git');
   let stat;
   try {
     stat = await fs.stat(gitMarker);
   } catch (cause) {
-    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return undefined;
-    throw cause;
+    if (isNodeErrnoCode(cause, 'ENOENT') || isNodeErrnoCode(cause, 'ENOTDIR')) return Result.ok(undefined);
+    return Result.error(
+      new StorageError({
+        subCode: 'io',
+        message: `failed to inspect ${gitMarker}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        path: gitMarker,
+        cause,
+      })
+    );
   }
   if (stat.isDirectory()) {
-    return join(gitMarker, 'info', 'exclude');
+    return Result.ok(join(gitMarker, 'info', 'exclude'));
   }
-  if (!stat.isFile()) return undefined;
+  if (!stat.isFile()) return Result.ok(undefined);
 
   // Worktree: `.git` is a pointer file like `gitdir: /abs/path/.git/worktrees/<name>`.
   // The pointer's path may be relative to repoRoot; resolve accordingly.
@@ -82,13 +95,31 @@ const resolveExcludePath = async (repoRoot: string): Promise<string | undefined>
   try {
     pointer = await fs.readFile(gitMarker, 'utf8');
   } catch {
-    return undefined;
+    return Result.ok(undefined);
   }
   const match = /^gitdir:\s*(.+)\s*$/m.exec(pointer);
-  if (match === null) return undefined;
+  if (match === null) return Result.ok(undefined);
   const gitdir = match[1]!.trim();
-  const absoluteGitdir = isAbsolute(gitdir) ? gitdir : join(repoRoot, gitdir);
-  return join(absoluteGitdir, 'info', 'exclude');
+  const absoluteGitdir = isAbsolute(gitdir) ? gitdir : resolve(repoRoot, gitdir);
+  return Result.ok(join(await resolveCommonDir(absoluteGitdir), 'info', 'exclude'));
+};
+
+/**
+ * Map a gitdir to the git dir whose `info/` git consults. For a linked worktree that is the
+ * main repo's `.git`, named by the `commondir` file git writes into every worktree gitdir
+ * (content is a path, absolute or relative to the gitdir). Layouts without that file —
+ * submodules at `<super>/.git/modules/<name>`, any hand-rolled pointer — own their `info/`
+ * directly, so the gitdir itself is the answer.
+ */
+const resolveCommonDir = async (gitdir: string): Promise<string> => {
+  let commondir: string;
+  try {
+    commondir = await fs.readFile(join(gitdir, 'commondir'), 'utf8');
+  } catch {
+    return gitdir;
+  }
+  const trimmed = commondir.trim();
+  return trimmed.length === 0 ? gitdir : resolve(gitdir, trimmed);
 };
 
 const isNodeErrnoCode = (cause: unknown, code: string): boolean =>

--- a/src/integration/persistence/settings/json-settings-repository.ts
+++ b/src/integration/persistence/settings/json-settings-repository.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import type { ZodError } from 'zod';
 import { Result } from '@src/domain/result.ts';
 import type { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import { ParseError } from '@src/domain/value/error/parse-error.ts';
@@ -21,6 +22,23 @@ const SCHEMA_MISMATCH = 'schema-mismatch';
  * defaults — not to re-run a mutating command.
  */
 const REPAIR_HINT = 'fix or delete settings.json and re-run; a missing file falls back to defaults';
+
+/** Field-level issues enumerated in a validation message, capped so the line stays readable. */
+const MAX_REPORTED_ISSUES = 5;
+
+/**
+ * Compact, one-line rendering of a settings validation failure: `ai.provider: expected string,
+ * received number; …`. `ZodError.message` is a pretty-printed JSON dump of the whole issue array —
+ * 40+ lines for one bad field — and this message is surfaced verbatim by `settings show` and by the
+ * CLI's terminal error reporter, both of which need a line an operator can act on.
+ */
+const formatIssues = (error: ZodError): string => {
+  const shown = error.issues
+    .slice(0, MAX_REPORTED_ISSUES)
+    .map((issue) => `${issue.path.length > 0 ? issue.path.map(String).join('.') : '(root)'}: ${issue.message}`);
+  const hidden = error.issues.length - shown.length;
+  return hidden > 0 ? `${shown.join('; ')} (+${String(hidden)} more)` : shown.join('; ');
+};
 
 export interface JsonSettingsRepositoryDeps {
   /** Directory where the JSON file lives. Production: `<appRoot>/config/`. Tests: a tmp dir. */
@@ -86,7 +104,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
         return Result.error(
           new ParseError({
             subCode: SCHEMA_MISMATCH,
-            message: `settings at ${path} are invalid: ${parsed.error.message}`,
+            message: `settings at ${path} are invalid — ${formatIssues(parsed.error)}`,
             cause: parsed.error,
             hint: REPAIR_HINT,
           })
@@ -108,7 +126,7 @@ export const createJsonSettingsRepository = (deps: JsonSettingsRepositoryDeps): 
         return Result.error(
           new ParseError({
             subCode: SCHEMA_MISMATCH,
-            message: `settings validation failed before save: ${parsed.error.message}`,
+            message: `settings validation failed before save — ${formatIssues(parsed.error)}`,
             cause: parsed.error,
           })
         );

--- a/tests/e2e/cli/prompts.test.ts
+++ b/tests/e2e/cli/prompts.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
+import {
+  BUNDLED_PROMPT_PARTIALS,
+  BUNDLED_PROMPT_TEMPLATES,
+} from '@src/integration/ai/prompts/_engine/bundled-templates.ts';
+
+describe('ralphctl prompts list', () => {
+  let cli: CliHome;
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+  });
+
+  afterEach(async () => cli.cleanup());
+
+  it('loads every bundled template + partial through the real resolver', async () => {
+    const result = await runCliCaptured(cli, ['prompts', 'list']);
+
+    expect(result.exitCode).toBe(0);
+    for (const name of [...BUNDLED_PROMPT_TEMPLATES, ...BUNDLED_PROMPT_PARTIALS]) {
+      expect(result.stdout).toContain(name);
+    }
+    // One row per asset — the command loads each body, it does not just echo the inventory.
+    const rows = result.stdout.trimEnd().split('\n');
+    expect(rows).toHaveLength(BUNDLED_PROMPT_TEMPLATES.length + BUNDLED_PROMPT_PARTIALS.length);
+    for (const row of rows) expect(row).toMatch(/\s+\d+ bytes$/);
+  });
+
+  it('prints the flow name the dist smokes grep for at the start of a line', async () => {
+    const result = await runCliCaptured(cli, ['prompts', 'list']);
+
+    // `.github/workflows/{ci,release}.yml` assert `grep -q '^implement'` against this output.
+    expect(result.stdout).toMatch(/^implement\s/m);
+  });
+});

--- a/tests/e2e/cli/top-level-error.test.ts
+++ b/tests/e2e/cli/top-level-error.test.ts
@@ -1,0 +1,70 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type CliHome, createCliHome, runCliCaptured } from '@tests/e2e/cli/_harness.ts';
+import { RALPHCTL_DEBUG_TRACE_ENV } from '@src/application/bootstrap/wire.ts';
+
+/**
+ * The CLI's terminal error frame. `bootstrapCli`'s pre-flights (storage paths / roots / settings /
+ * bundle integrity) throw plain `Error`s, and uncaught they reach Node's crash handler — which on
+ * an installed package prints a source excerpt from the bundled `dist/cli-<hash>.mjs`, a full
+ * commander stack and a `Node.js v<x>` footer. `doctor` is the command an operator runs BECAUSE
+ * something is wrong, so it is the worst possible place for that output.
+ */
+describe('CLI top-level error handling', () => {
+  let cli: CliHome;
+
+  const writeSettings = async (body: string): Promise<void> => {
+    await fs.writeFile(join(String(cli.paths.configRoot), 'settings.json'), body, 'utf8');
+  };
+
+  beforeEach(async () => {
+    cli = await createCliHome();
+    delete process.env[RALPHCTL_DEBUG_TRACE_ENV];
+  });
+
+  afterEach(async () => {
+    delete process.env[RALPHCTL_DEBUG_TRACE_ENV];
+    await cli.cleanup();
+  });
+
+  it('reports a malformed settings.json as one actionable line, not a stack trace', async () => {
+    await writeSettings('not json at all');
+
+    const result = await runCliCaptured(cli, ['doctor']);
+
+    expect(result.exitCode).toBe(1);
+    const lines = result.stderr.trimEnd().split('\n');
+    expect(lines[0]).toMatch(/^ralphctl: settings: /);
+    expect(lines[0]).toContain('settings.json');
+    // No stack: no `at <frame>` lines and no Node crash banner.
+    expect(result.stderr).not.toMatch(/\n\s+at /);
+    expect(result.stderr).not.toContain('Node.js v');
+    // The repair is named, not just the fault.
+    expect(result.stderr).toContain(RALPHCTL_DEBUG_TRACE_ENV);
+  });
+
+  it('renders a schema-invalid settings.json as compact field-level issues', async () => {
+    await writeSettings(JSON.stringify({ schemaVersion: 1, ai: { provider: 12345 } }));
+
+    const result = await runCliCaptured(cli, ['doctor']);
+
+    expect(result.exitCode).toBe(1);
+    const firstLine = result.stderr.split('\n')[0] ?? '';
+    expect(firstLine).toContain('are invalid');
+    // The old message inlined `ZodError.message` — a pretty-printed JSON dump of every issue.
+    expect(firstLine).not.toContain('"code"');
+    expect(firstLine).toContain('fix or delete settings.json');
+  });
+
+  it('keeps the full stack behind RALPHCTL_DEBUG_TRACE', async () => {
+    await writeSettings('not json at all');
+    process.env[RALPHCTL_DEBUG_TRACE_ENV] = '1';
+
+    const result = await runCliCaptured(cli, ['doctor']);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/^ralphctl: settings: /);
+    expect(result.stderr).toMatch(/\n\s+at /);
+  });
+});

--- a/tests/e2e/flows/implement.test.ts
+++ b/tests/e2e/flows/implement.test.ts
@@ -2680,6 +2680,93 @@ describe('createImplementFlow — gen-eval loop', () => {
     expect(sprintRepo.current().status).toBe('active');
   });
 
+  it('EVALUATOR watchdog kill before signals.json: retries within maxAttempts, same as the generator half', async () => {
+    // The evaluator spawns through the same headless provider, the same idle-stdout watchdog and
+    // the same classify-spawn-exit ladder as the generator, so it dies the same ways. Before the
+    // fix its ProcessCrashError folded into a `self-blocked` exit, which terminally blocked the
+    // task after ONE attempt with the budget untouched — a manual `unblock` for a transient
+    // process death. It must now take the generator's `crashed` retry path instead.
+    const f = await buildFixture(1, 3); // maxAttempts = 3
+    tracking(f);
+    const sprintRepo = inMemorySprintRepo(f.sprint);
+    const taskRepo = inMemoryTaskRepo(f.tasks);
+
+    // Generator behaves normally (writes a valid signals.json); only the EVALUATOR crashes.
+    const generatorFake = createFakeAiProvider({ signals: { implement: [taskVerified('tests pass')] } });
+    let evalCalls = 0;
+    const crashingEvaluator: HeadlessAiProvider = {
+      async generate() {
+        evalCalls += 1;
+        return Result.error(
+          new ProcessCrashError({
+            entity: 'codex-provider',
+            state: 'exit-143',
+            message: 'codex-provider: process exited with code 143 (signal=SIGTERM): <empty stderr>',
+          })
+        );
+      },
+    };
+
+    const baseDeps = buildDeps(
+      sprintRepo.repo,
+      inMemoryExecutionRepo(f.execution).repo,
+      taskRepo.repo,
+      generatorFake,
+      f.dir,
+      makeCleanGit()
+    );
+    const deps: ImplementDeps = { ...baseDeps, generatorProvider: generatorFake, evaluatorProvider: crashingEvaluator };
+
+    const flow = createImplementFlow(deps, {
+      sprintId: f.sprint.id,
+      todoTasks: f.tasks,
+      repositories: FAKE_REPOSITORIES,
+      generatorProviderId: 'claude-code',
+      generatorModel: 'claude-opus-4-8',
+      evaluatorProviderId: 'openai-codex',
+      evaluatorModel: 'gpt-5.5',
+      progressFile: absolutePath(f.progressFile),
+      sprintDir: absolutePath(f.dir),
+      memoryRoot: FAKE_MEMORY_ROOT,
+      projectId: FAKE_PROJECT_ID,
+      projectSlug: FAKE_PROJECT_SLUG,
+    });
+
+    const runner = createRunner({
+      id: 'r-impl-eval-crash-retry',
+      element: flow,
+      initialCtx: { sprintId: f.sprint.id } satisfies ImplementCtx,
+    });
+    await runner.start();
+
+    expect(runner.status).toBe('completed');
+
+    const finalTask = taskRepo.tasks()[0];
+    // Blocked only at the CAP (budget branch of failCurrentAttempt) — not after one attempt, and
+    // NOT with the evaluator's own reason: a `crashed` exit deliberately leaves `lastBlockReason`
+    // unset, which is also what keeps the commit-task guard (keyed on that field) open so the
+    // generator's work still lands before the retry starts from it.
+    expect(finalTask?.status).toBe('blocked');
+    expect(finalTask?.attempts).toHaveLength(3);
+    if (finalTask?.status === 'blocked') {
+      expect(finalTask.blockedReason).toContain('attempt budget exhausted');
+      expect(finalTask.blockedReason).not.toContain('signals.json');
+    }
+
+    // The outer attempt loop genuinely re-entered: one start/settle pair + one evaluator spawn
+    // per attempt. A terminal block after attempt 1 would leave these at 1.
+    const startEntries = runner.trace.filter((e) => e.elementName === `start-attempt-${String(finalTask?.id)}`);
+    expect(startEntries).toHaveLength(3);
+    expect(evalCalls).toBe(3);
+
+    // Operator visibility: each failed attempt records the crash as a structured warning.
+    for (const attempt of finalTask?.attempts ?? []) {
+      expect(attempt.warning?.kind).toBe('crashed');
+    }
+
+    expect(sprintRepo.current().status).toBe('active');
+  });
+
   it('self-block fence: a genuine <task-blocked> STILL blocks after ONE attempt even with maxAttempts=3 (semantic self-blocks must not retry)', async () => {
     // Fence for the crash-retry change: only a ProcessCrash takes the retry path. A generator
     // <task-blocked> signal is a SEMANTIC self-block (the AI decided it cannot proceed) and must

--- a/tests/integration/ai/prompts/_engine/bundled-templates.test.ts
+++ b/tests/integration/ai/prompts/_engine/bundled-templates.test.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  BUNDLED_PROMPT_PARTIALS,
+  BUNDLED_PROMPT_TEMPLATES,
+} from '@src/integration/ai/prompts/_engine/bundled-templates.ts';
+import { createFsTemplateLoader } from '@src/integration/ai/prompts/_engine/fs-template-loader.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+
+const PROMPTS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'src',
+  'integration',
+  'ai',
+  'prompts'
+);
+
+/**
+ * Parity fence for the inventory `ralphctl prompts list` walks. The command is the only
+ * non-interactive surface that exercises the prompt-template resolver, and the CI + release dist
+ * smokes grep it — a prompt that is not in the inventory is a prompt outside that gate, so a new
+ * prompt directory must fail here rather than silently opt out.
+ */
+describe('bundled prompt inventory', () => {
+  it('matches the prompt directories on disk', async () => {
+    const entries = await fs.readdir(PROMPTS_DIR, { withFileTypes: true });
+    const onDisk = entries
+      .filter((d) => d.isDirectory() && !d.name.startsWith('_'))
+      .map((d) => d.name)
+      .sort();
+
+    expect([...BUNDLED_PROMPT_TEMPLATES].sort()).toEqual(onDisk);
+  });
+
+  it('matches the partials on disk', async () => {
+    const entries = await fs.readdir(join(PROMPTS_DIR, '_partials'), { withFileTypes: true });
+    const onDisk = entries
+      .filter((d) => d.isFile() && d.name.endsWith('.md'))
+      .map((d) => d.name.replace(/\.md$/, ''))
+      .sort();
+
+    expect([...BUNDLED_PROMPT_PARTIALS].sort()).toEqual(onDisk);
+  });
+
+  it('every listed name loads a non-empty body through the real loader', async () => {
+    const dir = AbsolutePath.parse(PROMPTS_DIR);
+    expect(dir.ok).toBe(true);
+    if (!dir.ok) return;
+    const loader = createFsTemplateLoader(dir.value);
+
+    for (const name of [...BUNDLED_PROMPT_TEMPLATES, ...BUNDLED_PROMPT_PARTIALS]) {
+      const body = await loader.load(name);
+      expect(body.ok, `failed to load '${name}'`).toBe(true);
+      if (body.ok) expect(body.value.trim().length, `'${name}' is empty`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
+++ b/tests/integration/ai/providers/_engine/classify-spawn-exit.test.ts
@@ -2,7 +2,11 @@ import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
-import { classifySpawnExit, type ProviderName } from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
+import {
+  DEFAULT_RATE_LIMIT_RE,
+  classifySpawnExit,
+  type ProviderName,
+} from '@src/integration/ai/providers/_engine/classify-spawn-exit.ts';
 import type { AttemptOutcome } from '@src/integration/ai/providers/_engine/attempt-outcome.ts';
 import type { AiSession } from '@src/integration/ai/providers/_engine/ai-session.ts';
 import type { ProviderOutput } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
@@ -326,8 +330,8 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
   it('rate-limit detected in stdoutTail (not stderr) when the provider reports quota on stdout', async () => {
     // FINDING 3 — claude's `-p stream-json` mode reports quota in the stdout result envelope, not
     // on stderr. The classifier must scan stderr + stdoutTail so the throttle trips the backoff.
+    // No signals.json here: the turn was throttled before it could land an envelope.
     const session = baseSession();
-    await writeSignalsFile(String(session.signalsFile));
     const outcome = await classifySpawnExit({
       session,
       exit: { code: 1, signal: null },
@@ -343,6 +347,61 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
     expect(outcome.kind).toBe('rate-limit');
     if (outcome.kind === 'rate-limit') {
       expect(outcome.error.sessionId).toBe('sess-stdout');
+      // The message names the stream that matched — a 36-minute backoff triggered by stdout must
+      // be diagnosable from the log alone.
+      expect(outcome.error.message).toContain('stdout');
+    }
+  });
+
+  it('benign assistant prose in stdoutTail does NOT trip the rate-limit branch (false-positive guard)', async () => {
+    // stdoutTail carries ASSISTANT-GENERATED task output. A task about throttling routinely says
+    // "rate limiter" / "429"; scanning it with the broad stderr pattern turned an ordinary
+    // watchdog SIGTERM into a ~36-minute backoff. Only the vendors' real throttle sentences are
+    // matched on stdout — the broad pattern stays scoped to stderr.
+    const session = baseSession();
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: '',
+      stdoutTail: 'Implemented the rate limiter in src/throttle.ts and modified 429 lines across 3 files',
+      rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.message).toContain('process exited with code 1');
+    }
+  });
+
+  it('signals-recovery beats a stdoutTail-only rate-limit match (landed envelope proves the turn worked)', async () => {
+    // A completed signals.json on disk is authoritative per the audit-[09] contract: the AI landed
+    // its work before the non-zero exit. Even a real throttle sentence quoted back in the assistant
+    // body must not discard it — stderr keeps its rate-limit-beats-recovery precedence, stdout does not.
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 143, signal: null },
+      stderr: '',
+      stdoutTail: 'I hit the usage limit reached banner while reading the docs, then finished the task',
+      rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(1);
+    expect(outcome.kind).toBe('success');
+    if (outcome.kind === 'success') {
+      expect(outcome.output.recoveredFromExit).toEqual({ code: 143, signal: null });
     }
   });
 
@@ -462,6 +521,63 @@ describe.each(PROVIDERS)('classifySpawnExit [%s]', (providerName) => {
       // Generic non-zero exit → the retryable hard-fail branch, and no model hint.
       expect(outcome.error).toBeInstanceOf(ProcessCrashError);
       expect(outcome.error.message).not.toContain('pick another model in settings');
+    }
+  });
+
+  it('surfaces processErrorText in the failure message when the CLI wrote nothing to stderr', async () => {
+    // opencode reports a fatal CLI error on a stdout `{"type":"error"}` record and leaves stderr
+    // EMPTY, so the crash message used to read `process exited with code 1: <empty stderr>` — the
+    // only explanation the CLI produced was parsed and then dropped.
+    const session = baseSession();
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: '',
+      processErrorText: 'UnknownError: Unexpected server error. Please try again.',
+      rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => okSuccess(session),
+    });
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.message).toContain('UnknownError: Unexpected server error');
+      expect(outcome.error.message).not.toContain('<empty stderr>');
+    }
+  });
+
+  it('model-unavailable wording in processErrorText is a NON-retryable config error', async () => {
+    // Unlike stdoutTail (assistant prose), processErrorText is the CLI's own STRUCTURED error
+    // record, so scanning it carries no false-positive risk. A provider that reports model
+    // unavailability there must reach the same non-retryable branch as the stderr-reporting CLIs
+    // instead of burning the whole attempt budget re-spawning the same misconfiguration.
+    const session = baseSession();
+    await writeSignalsFile(String(session.signalsFile));
+    let invoked = 0;
+    const outcome = await classifySpawnExit({
+      session,
+      exit: { code: 1, signal: null },
+      stderr: '',
+      processErrorText: 'ModelNotFoundError: model openrouter/nope-4 not found',
+      rateLimitRe: DEFAULT_RATE_LIMIT_RE,
+      providerName,
+      eventBus: createCapturingBus().bus,
+      watchdogBannerId: 'unused',
+      onSuccess: () => {
+        invoked += 1;
+        return okSuccess(session);
+      },
+    });
+    expect(invoked).toBe(0);
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') {
+      expect(outcome.error).toBeInstanceOf(InvalidStateError);
+      expect(outcome.error).not.toBeInstanceOf(ProcessCrashError);
+      expect(outcome.error.code).toBe('invalid-state');
+      expect(outcome.error.message).toContain('ModelNotFoundError');
+      expect(outcome.error.message).toContain('pick another model in settings');
     }
   });
 

--- a/tests/integration/ai/providers/opencode/opencode-provider.test.ts
+++ b/tests/integration/ai/providers/opencode/opencode-provider.test.ts
@@ -255,6 +255,28 @@ describe('createOpencodeProvider', () => {
     expect(calls[1]?.args).not.toContain('-s');
   });
 
+  it('surfaces the stdout error record in the failure message and as a warn log (empty stderr)', async () => {
+    // An unreachable / unauthenticated `provider/model` id makes `opencode run` exit 1 with an
+    // EMPTY stderr and its whole explanation on a stdout `{"type":"error"}` record. That text used
+    // to be parsed and dropped, leaving `process exited with code 1: <empty stderr>` — a failure
+    // an operator cannot act on, repeated for every attempt in the budget.
+    const errorLine =
+      '{"type":"error","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Please try again."}}}\n';
+    const { spawn } = makeSpawn([{ stdoutChunks: [errorLine], exitCode: 1 }]);
+    const bus = createCapturingBus();
+    // No signals.json — the CLI never got far enough to land one.
+    const result = await createOpencodeProvider({ rateLimitRetries: 0, eventBus: bus.bus, spawn }).generate(session());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain('UnknownError: Unexpected server error');
+    expect(result.error.message).not.toContain('<empty stderr>');
+    // …and the same explanation is visible per attempt at warn level, not buried at debug.
+    expect(
+      bus.logs.some((l) => l.level === 'warn' && l.message.includes('UnknownError: Unexpected server error'))
+    ).toBe(true);
+  });
+
   it('tolerates non-JSON banner lines interleaved with the stream', async () => {
     const sid = 'ses_noise';
     const { spawn } = makeSpawn([

--- a/tests/integration/ai/skills/_engine/bare-name-install.test.ts
+++ b/tests/integration/ai/skills/_engine/bare-name-install.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
 import { createClaudeSkillsAdapter } from '@src/integration/ai/skills/claude/adapter.ts';
 import { createCodexSkillsAdapter } from '@src/integration/ai/skills/codex/adapter.ts';
@@ -22,6 +23,20 @@ import { createCopilotSkillsAdapter } from '@src/integration/ai/skills/copilot/a
 
 const makeSession = async (): Promise<AbsolutePath> => {
   const dir = await mkdtemp(join(tmpdir(), 'bare-skills-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+/**
+ * Session dir nested one level inside a fresh tmp root, so a traversing skill name resolves to a
+ * path that is still unique to this test run — the escape assertions cannot be satisfied (or
+ * poisoned) by an artifact some other run left in the shared tmp dir.
+ */
+const makeNestedSession = async (): Promise<AbsolutePath> => {
+  const root = await mkdtemp(join(tmpdir(), 'bare-skills-root-'));
+  const dir = join(root, 'repo');
+  await mkdir(dir, { recursive: true });
   const parsed = AbsolutePath.parse(dir);
   if (!parsed.ok) throw new Error(parsed.error.message);
   return parsed.value;
@@ -109,6 +124,56 @@ describe('installBareSkill — claude adapter', () => {
 
     const exclude = await readFile(join(String(session), '.git/info/exclude'), 'utf-8');
     expect(exclude).toContain('.claude/skills/ralphctl-*');
+  });
+});
+
+/**
+ * Containment boundary — `skill.name` is used verbatim as a directory name, and on the bare
+ * path it originates from AI output (the readiness `skill-suggestions` signal). The adapter is
+ * the last gate before `mkdir` / `writeFile`, so a name that is not a bare kebab-case identifier
+ * must fail loudly and write nothing — inside or outside the session directory.
+ */
+describe('skills adapter — rejects names that are not bare kebab-case identifiers', () => {
+  // Traversal targets are asserted relative to the session dir, so every escaping name here must
+  // stay inside the per-run `makeNestedSession` root — otherwise a leftover from an earlier run
+  // (or from the pre-fix code, which really did write there) would mask a regression.
+  const hostileNames = ['../escape', '../../../escape-far', 'a/b', 'a\\b', '/etc/pwn', '..', '', 'Upper'];
+
+  it.each(hostileNames)('installBareSkill(%j) → StorageError, nothing written', async (name) => {
+    const session = await makeNestedSession();
+    const adapter = createClaudeSkillsAdapter();
+
+    const result = await adapter.installBareSkill(session, skill(name, '# pwned'));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(StorageError);
+    // Nothing landed anywhere — not under the session dir, not outside it.
+    expect(existsSync(join(String(session), '.claude/skills'))).toBe(false);
+    expect(existsSync(resolve(String(session), '.claude/skills', name))).toBe(false);
+  });
+
+  it('install (bundled path) rejects a traversing name and writes nothing', async () => {
+    const session = await makeNestedSession();
+    const adapter = createClaudeSkillsAdapter();
+
+    const result = await adapter.install(session, [skill('../../../escape-bundled', '# pwned')]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(StorageError);
+    expect(existsSync(resolve(String(session), '.claude/skills', '../../../escape-bundled'))).toBe(false);
+  });
+
+  it('install stops at the bad name — the valid skill before it is still installed', async () => {
+    const session = await makeNestedSession();
+    const adapter = createClaudeSkillsAdapter();
+
+    const result = await adapter.install(session, [skill('ralphctl-alignment', '# ok'), skill('../evil', '# pwned')]);
+
+    expect(result.ok).toBe(false);
+    expect(existsSync(join(String(session), '.claude/skills/ralphctl-alignment/SKILL.md'))).toBe(true);
+    expect(existsSync(resolve(String(session), '.claude/skills', '../evil'))).toBe(false);
   });
 });
 

--- a/tests/integration/application/flows/implement/nested-runner-token-usage-key.test.ts
+++ b/tests/integration/application/flows/implement/nested-runner-token-usage-key.test.ts
@@ -1,0 +1,85 @@
+/**
+ * End-to-end fence for the parallel implement token-usage hole, exercised through the REAL
+ * runners rather than bare `runWithSession` calls.
+ *
+ * Shape under test (mirrors `parallel-element.ts` → `wave-scheduler.ts` → `wave-branch.ts`): a
+ * host runner (`r-host`, the id the Execute view is mounted with) whose element spins up one
+ * nested branch runner per task (`task-<taskId>`). Every generator / evaluator spawn happens
+ * inside the BRANCH scope, so the `chainSessionId` the provider adapter stamps onto its
+ * `TokenUsageEvent` must still be the host id — `useTokenUsage(bus).get(hostId)` is a plain
+ * `Map.get`, and a branch-keyed entry can never be found.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { createRunner } from '@src/application/chain/run/runner.ts';
+import type { Element, ElementResult } from '@src/application/chain/element.ts';
+import { implementSession } from '@src/application/flows/implement/leaves/implement-session.ts';
+import { absolutePath } from '@tests/fixtures/domain.ts';
+import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
+
+const PROMPT = 'nested-runner prompt' as unknown as Prompt;
+const SANDBOX = absolutePath('/tmp/sandbox');
+const REPO = absolutePath('/tmp/repo');
+const SPRINT_DIR = absolutePath('/tmp/sprint');
+const SIGNALS = absolutePath('/tmp/sandbox/rounds/1/generator/signals.json');
+
+const TASKS = ['01933fbb-1111-7000-8000-000000000001', '01933fbb-2222-7000-8000-000000000002'] as const;
+
+/** Stands in for the generator leaf: builds the AiSession the provider adapter would consume. */
+const spawnLeaf = (record: (chainSessionId: string | undefined) => void): Element<undefined> => ({
+  name: 'generator',
+  async execute(): Promise<ElementResult<undefined>> {
+    const session = implementSession(SANDBOX, REPO, SPRINT_DIR, PROMPT, 'claude-opus-4-8', SIGNALS, 'generator');
+    record(session.chainSessionId);
+    return Result.ok({ ctx: undefined, trace: [] });
+  },
+});
+
+/** Stands in for `createParallelImplementElement`: one nested runner per task, run concurrently. */
+const fanOut = (record: (chainSessionId: string | undefined) => void): Element<undefined> => ({
+  name: 'implement-parallel',
+  async execute(): Promise<ElementResult<undefined>> {
+    await Promise.all(
+      TASKS.map(async (taskId) => {
+        const branch = createRunner<undefined>({
+          id: `task-${taskId}`,
+          element: spawnLeaf(record),
+          initialCtx: undefined,
+        });
+        await branch.start();
+      })
+    );
+    return Result.ok({ ctx: undefined, trace: [] });
+  },
+});
+
+describe('parallel implement — token-usage session key', () => {
+  it('stamps the HOST runner id on every branch spawn, not the per-branch runner id', async () => {
+    const stamped: Array<string | undefined> = [];
+    const host = createRunner<undefined>({
+      id: 'r-host',
+      element: fanOut((id) => stamped.push(id)),
+      initialCtx: undefined,
+    });
+
+    await host.start();
+
+    expect(host.status).toBe('completed');
+    expect(stamped).toHaveLength(TASKS.length);
+    expect(stamped.every((id) => id === 'r-host')).toBe(true);
+  });
+
+  it('still stamps the runner id on the serial path (no nesting)', async () => {
+    const stamped: Array<string | undefined> = [];
+    const runner = createRunner<undefined>({
+      id: 'r-serial',
+      element: spawnLeaf((id) => stamped.push(id)),
+      initialCtx: undefined,
+    });
+
+    await runner.start();
+
+    expect(stamped).toStrictEqual(['r-serial']);
+  });
+});

--- a/tests/integration/application/flows/implement/parallel-element.test.ts
+++ b/tests/integration/application/flows/implement/parallel-element.test.ts
@@ -211,6 +211,59 @@ describe('createParallelImplementElement — B4 abort durability gate', () => {
   });
 });
 
+describe('createParallelImplementElement — operator abort from INSIDE a branch', () => {
+  it('stops the schedule (no later wave), keeps the durable fold, and returns the operator AbortError verbatim', async () => {
+    // The operator answers "abort" at an in-branch prompt (e.g. the red-baseline gate in
+    // verify-execution): the branch chain returns an AbortError with the OUTER signal untouched.
+    // The whole run must stop — not carry on spending AI sessions on the remaining waves.
+    const t1 = makeTodoTask({ name: 't1' });
+    const t2 = makeTodoTask({ name: 't2' });
+    const t3 = makeTodoTask({ name: 't3' });
+    const log: string[] = [];
+    const persisted: Persisted = { tasks: undefined };
+    const lockLog: string[] = [];
+    const bus = stubBus([]);
+    const operatorAbort = new AbortError({
+      elementName: 'verify-execution',
+      reason: 'operator aborted sprint on broken baseline',
+    });
+
+    const abortingBranch: WaveBranch<ImplementCtx> = {
+      id: `task-${String(t2.id)}`,
+      element: {
+        name: `branch-${String(t2.id)}`,
+        async execute(): Promise<ElementResult<ImplementCtx>> {
+          log.push(`branch-${t2.name}`);
+          return Result.error({
+            error: operatorAbort,
+            trace: [{ elementName: 'verify-execution', status: 'aborted', durationMs: 0, error: operatorAbort }],
+          });
+        },
+      },
+    };
+
+    const branches = [[doneBranch(t1, log), abortingBranch], [doneBranch(t3, log)]];
+    const element = createParallelImplementElement(
+      plan(tagElement('implement-prologue', log), recordingEpilogue(log, persisted), [[t1, t2], [t3]]),
+      baseConfig({ buildWaves: () => branches }, recordingLocker(lockLog), bus)
+    );
+
+    const result = await element.execute(ctxWith([t1, t2, t3]));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // The operator's own AbortError, verbatim — reason string intact.
+    expect(result.error.error).toBe(operatorAbort);
+    // Wave 1 never launched.
+    expect(log).not.toContain(`branch-${t3.name}`);
+    // The epilogue still ran under the lock and recorded the fold that DID happen.
+    expect(log).toContain('epilogue');
+    expect(persisted.tasks?.find((t) => t.id === t1.id)?.status).toBe('done');
+    expect(persisted.tasks?.find((t) => t.id === t3.id)?.status).toBe('todo');
+    expect(lockLog).toEqual(['lock-acquire', 'lock-release']);
+  });
+});
+
 /** A branch that settles task `done`, then trips the abort controller so siblings get killed. */
 const completeThenAbort = (task: Task, log: string[], ac: AbortController): WaveBranch<ImplementCtx> => ({
   id: `task-${String(task.id)}`,

--- a/tests/integration/application/ui/tui/_harness.tsx
+++ b/tests/integration/application/ui/tui/_harness.tsx
@@ -11,7 +11,8 @@
 import React from 'react';
 import { afterEach } from 'vitest';
 import { cleanup, render } from 'ink-testing-library';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { RouterProvider, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
@@ -185,17 +186,33 @@ export const waitForViewReady = async (
   result: { lastFrame: () => string | undefined },
   extra?: (frame: string) => boolean
 ): Promise<void> => {
-  await waitFor(() => {
-    const frame = result.lastFrame() ?? '';
-    if (frame.length === 0) return false;
-    if (frame.includes('Loading…')) return false;
-    return extra ? extra(frame) : true;
-  });
+  await waitForPredicate(
+    () => {
+      const frame = result.lastFrame() ?? '';
+      if (frame.length === 0) return false;
+      if (frame.includes('Loading…')) return false;
+      return extra ? extra(frame) : true;
+    },
+    { label: 'the view became ready (non-empty frame, no "Loading…", extra predicate satisfied)' }
+  );
   // Flush one tick so any `useEffect` queued by the loading→ok commit (cursor / focus /
   // derived-state syncs) runs before the test sends its first keystroke. Without this the
   // input race described in (2) above resurfaces.
   await tick();
 };
+
+// eslint-disable-next-line no-control-regex
+const ANSI_SGR_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Strip SGR colour codes from a rendered frame.
+ *
+ * `vitest.config.ts` pins `FORCE_COLOR=0` for both projects, so frames are already plain and
+ * raw `expect(frame).toContain(...)` works. Use this wherever an assertion should hold under
+ * EITHER colour mode — layout / box-geometry checks that measure visible width, and anything a
+ * future ambient-colour change could split with escape sequences.
+ */
+export const stripAnsi = (frame: string): string => frame.replace(ANSI_SGR_PATTERN, '');
 
 /**
  * One-shot effect to seed selection from the harness opts. Lives inside the provider so

--- a/tests/integration/application/ui/tui/_keys.ts
+++ b/tests/integration/application/ui/tui/_keys.ts
@@ -31,21 +31,6 @@ export const tick = async (ms = 30): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-/**
- * Poll `predicate` until it returns true or `timeoutMs` elapses. Use this in place of a fixed
- * `tick(N)` when the test depends on an async settling step whose timing isn't bounded by a
- * single Ink render tick — e.g. waiting for a stubbed repo `findById` to resolve before the
- * view's `useInput` handler is responsive, or waiting for an async `openEditPrompt` to enqueue
- * a prompt after a keystroke. Cheap on the happy path (~10ms first poll), bounded on cold CI.
- */
-export const waitFor = async (
-  predicate: () => boolean,
-  opts: { timeoutMs?: number; intervalMs?: number } = {}
-): Promise<void> => {
-  const { timeoutMs = 1000, intervalMs = 10 } = opts;
-  const start = Date.now();
-  while (!predicate()) {
-    if (Date.now() - start >= timeoutMs) return;
-    await tick(intervalMs);
-  }
-};
+// Async waiters live in `_wait.ts` (`waitFor` / `waitForPredicate`) — this module is key bytes
+// plus `tick` only. A silent-on-timeout `waitFor` used to live here as well, under the same name
+// as `_wait.ts`'s throwing one; see the `_wait.ts` docstring for why that had to go.

--- a/tests/integration/application/ui/tui/_wait.ts
+++ b/tests/integration/application/ui/tui/_wait.ts
@@ -1,4 +1,20 @@
 /**
+ * The TUI suite's two async waiters. Both live here, under DISTINCT names, because they used to
+ * be two same-named `waitFor` exports in two modules with OPPOSITE timeout contracts — the
+ * `_keys.ts` one returned silently on expiry, so a test whose wait never came true carried on and
+ * asserted against whatever the frame happened to hold (or, when the wait WAS the assertion,
+ * passed vacuously). A timeout must always fail the test loudly:
+ *
+ *  - {@link waitFor}          — assertion form. Poll a check that throws (typically an `expect`)
+ *                               until it stops throwing; rethrows the last error on expiry.
+ *  - {@link waitForPredicate} — boolean form. Poll a predicate until it returns true; throws a
+ *                               named error on expiry.
+ *
+ * Both share the same ceiling, poll interval and post-condition settle, so the choice between
+ * them is purely about which callback shape reads better at the call site.
+ */
+
+/**
  * `waitFor` — poll a predicate until it stops throwing, with a timeout. Replaces the
  * wall-clock `tick(ms)` pattern that was the dominant source of TUI test flakes: under
  * heavy CPU contention from concurrent vitest forks, a literal `await tick(40)` often
@@ -47,4 +63,32 @@ export const waitFor = async (check: () => void | Promise<void>, opts: WaitForOp
   throw lastError instanceof Error
     ? lastError
     : new Error(`waitFor: condition never satisfied within ${String(timeout)}ms`);
+};
+
+/**
+ * `waitForPredicate` — the boolean-returning sibling of {@link waitFor}. Use it in place of a
+ * fixed `tick(N)` when the test depends on an async settling step whose timing isn't bounded by a
+ * single Ink render tick — e.g. waiting for a stubbed repo `findById` to resolve before the view's
+ * `useInput` handler is responsive, or waiting for an async `openEditPrompt` to enqueue a prompt
+ * after a keystroke.
+ *
+ * Expiry THROWS. Nothing downstream of a wait that never came true is trustworthy: the frame is
+ * still in its pre-settle state, so every following assertion is either misleading (it fails on
+ * the wrong thing) or vacuous (the wait was the only check). Naming the predicate that never went
+ * true is the useful failure — pass a `label` when the arrow alone won't identify it.
+ *
+ * Cheap on the happy path (evaluated once before the first sleep), bounded on cold CI.
+ */
+export const waitForPredicate = async (
+  predicate: () => boolean,
+  opts: WaitForOptions & { readonly label?: string } = {}
+): Promise<void> => {
+  const label = opts.label;
+  await waitFor(() => {
+    if (!predicate()) {
+      throw new Error(
+        `waitForPredicate: ${label ?? 'predicate'} never became true within ${String(opts.timeout ?? 3000)}ms`
+      );
+    }
+  }, opts);
 };

--- a/tests/integration/application/ui/tui/color-pin.test.tsx
+++ b/tests/integration/application/ui/tui/color-pin.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+
+/**
+ * Fence for the colour pin in `vitest.config.ts`.
+ *
+ * Every TUI assertion in this project is a plain-substring check against `lastFrame()`. Ink and
+ * chalk decide colour support from the worker's environment, so an ambient `FORCE_COLOR` (Claude
+ * Code exports `FORCE_COLOR=3`; several terminal wrappers and CI images do too) used to split
+ * those substrings with truecolor SGR codes and turn 27 assertions across 13 files red on a
+ * pristine tree. The `env: { FORCE_COLOR: '0' }` pin on both vitest projects makes the suite give
+ * the same answer for every developer, agent session and runner.
+ *
+ * Run this file with `FORCE_COLOR=3` exported — it must still pass.
+ */
+describe('vitest colour pin', () => {
+  it('pins FORCE_COLOR=0 in the worker regardless of the ambient shell', () => {
+    expect(process.env['FORCE_COLOR']).toBe('0');
+  });
+
+  it('renders a coloured Text with no escape sequences', () => {
+    const result = render(<Text color="red">plain</Text>);
+    const frame = result.lastFrame() ?? '';
+    result.unmount();
+
+    expect(frame).toBe('plain');
+    // eslint-disable-next-line no-control-regex
+    expect(frame).not.toMatch(/\x1b\[/);
+  });
+});

--- a/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
+++ b/tests/integration/application/ui/tui/components/breadcrumb.test.tsx
@@ -24,7 +24,7 @@ import { Breadcrumb } from '@src/application/ui/tui/components/breadcrumb.tsx';
 import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { UiStateProvider, useUiState, type FocusedRunCtx } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 // Hoisted size control — vi.hoisted so the variable exists when the mock factory is hoisted.
 const sizeRef = vi.hoisted(() => ({ columns: 100, rows: 24 }));
@@ -105,7 +105,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="stale-sprint" focusedRun={focusedRun} />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('run-project'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('run-project'));
 
     const frame = lastFrame() ?? '';
     // Project resolves from the focused run.
@@ -129,7 +129,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="stale-sprint" focusedRun={focusedRun} />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('run-sprint'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('run-sprint'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('run-project');
@@ -145,7 +145,7 @@ describe('Breadcrumb — right-side label coalescing', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="global-sprint" />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('global-sprint'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('global-sprint'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('global-project');
@@ -161,7 +161,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="global-project" globalSprintLabel="global-sprint" />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('[S]'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('[S]'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('[P]');
     expect(frame).toContain('[S]');
@@ -173,7 +173,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="my-project" globalSprintLabel="my-sprint" globalSprintStatus="active" />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('[ACTIVE]'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('[ACTIVE]'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('my-sprint');
     // StatusChip wraps the label in brackets and uppercases it.
@@ -186,7 +186,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
     const { lastFrame, unmount } = render(
       <Harness globalProjectLabel="my-project" globalSprintLabel="my-sprint" globalSprintStatus="active" />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('my-sprint'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('my-sprint'));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('my-sprint');
     // No chip at narrow width — avoids overflow on small terminals.
@@ -209,7 +209,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
         focusedRun={focusedRun}
       />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('run-sprint'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('run-sprint'));
     const frame = lastFrame() ?? '';
     // The focused run's sprint label shows but the global status chip must not leak through.
     expect(frame).toContain('run-sprint');
@@ -228,7 +228,7 @@ describe('Breadcrumb — sprint status chip (audit 1-A)', () => {
       const { lastFrame, unmount } = render(
         <Harness globalProjectLabel="p" globalSprintLabel="s" globalSprintStatus={status as SprintStatus} />
       );
-      await waitFor(() => (lastFrame() ?? '').includes(expected));
+      await waitForPredicate(() => (lastFrame() ?? '').includes(expected));
 
       expect(lastFrame() ?? '').toContain(expected);
       unmount();

--- a/tests/integration/application/ui/tui/components/document-overlay-wrapping.test.tsx
+++ b/tests/integration/application/ui/tui/components/document-overlay-wrapping.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Regression: the read-only document overlays window by ROW COUNT, but the artifacts they read
+ * are written one paragraph per line. Before the wrap fix a single long critique / progress note
+ * counted as ONE line while Ink painted it across a dozen terminal rows, so:
+ *
+ *   - `maxOffset` stayed 0 → `useDocumentScroll` early-returned on every keystroke and the
+ *     clipped tail was unreachable,
+ *   - the `lines X–Y of N` footer never appeared, and
+ *   - the overlay grew taller than the viewport it was supposed to fit inside.
+ *
+ * Both overlays get the same three assertions: the footer shows up, PgDn actually moves, and the
+ * painted frame stays inside the terminal's row budget.
+ *
+ * ink-testing-library's stdout reports 100 columns and no rows (so `useTerminalSize` falls back
+ * to 24) — the numbers below are derived from that, not hardcoded guesses.
+ */
+
+import { promises as fs } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import React, { useEffect } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { StoragePaths } from '@src/application/bootstrap/storage-paths.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { SprintId } from '@src/domain/value/id/sprint-id.ts';
+import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { StorageProvider } from '@src/application/ui/tui/runtime/storage-context.tsx';
+import { UiStateProvider, useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { EvaluationOverlay } from '@src/application/ui/tui/components/evaluation-overlay.tsx';
+import { ProgressOverlay } from '@src/application/ui/tui/components/progress-overlay.tsx';
+import type { EvaluationTarget } from '@src/application/ui/tui/runtime/evaluation-target.ts';
+import { PAGE_DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
+
+const SPRINT_ID_STR = '0193ed2b-1234-7abc-8def-0123456789ab';
+const TASK_ID = 'task-wrap-1';
+const ARTIFACT = 'rounds/1/evaluator/evaluation.md';
+
+/** ink-testing-library reports 100 columns and no rows; `useTerminalSize` floors rows at 24. */
+const TERMINAL_ROWS = 24;
+
+const absPath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`invalid path: ${p}`);
+  return r.value;
+};
+
+const parseSprintId = (): SprintId => {
+  const r = SprintId.parse(SPRINT_ID_STR);
+  if (!r.ok) throw new Error('invalid SprintId fixture');
+  return r.value;
+};
+
+const buildStorage = (dataRoot: string): StoragePaths => ({
+  appRoot: absPath(dataRoot),
+  dataRoot: absPath(dataRoot),
+  configRoot: absPath(dataRoot),
+  stateRoot: absPath(dataRoot),
+  locksRoot: absPath(dataRoot),
+  runsRoot: absPath(dataRoot),
+  memoryRoot: absPath(dataRoot),
+  operatorSkillsRoot: absPath(dataRoot),
+  operatorAgentDefinitionsRoot: absPath(dataRoot),
+});
+
+/** One unwrapped paragraph of `words` distinct tokens — the shape both artifacts are written in. */
+const paragraph = (prefix: string, words: number): string =>
+  Array.from({ length: words }, (_, i) => `${prefix}${String(i).padStart(3, '0')}`).join(' ');
+
+const tmpRoots: string[] = [];
+const makeTmpRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'ralphctl-overlay-wrap-'));
+  tmpRoots.push(root);
+  return root;
+};
+
+afterEach(async () => {
+  while (tmpRoots.length > 0) {
+    const root = tmpRoots.pop();
+    if (root !== undefined) await rm(root, { recursive: true, force: true });
+  }
+});
+
+const frameRows = (frame: string): number => frame.split('\n').length;
+
+/* ------------------------------------------------------------------ evaluation overlay */
+
+const evaluationTarget = (): EvaluationTarget => ({
+  sprintId: parseSprintId(),
+  taskId: TASK_ID,
+  taskLabel: 'wrap the critique',
+  attemptN: 1,
+  status: 'failed',
+  file: ARTIFACT,
+});
+
+const EvaluationOpener = (): React.JSX.Element | null => {
+  const ui = useUiState();
+  const open = ui.openEvaluation;
+  useEffect(() => {
+    open(evaluationTarget());
+  }, [open]);
+  return ui.evaluationTarget === undefined ? null : <EvaluationOverlay />;
+};
+
+const EvaluationHarness = ({ dataRoot }: { readonly dataRoot: string }): React.JSX.Element => (
+  <DepsProvider value={{} as unknown as AppDeps}>
+    <StorageProvider value={buildStorage(dataRoot)}>
+      <UiStateProvider>
+        <EvaluationOpener />
+      </UiStateProvider>
+    </StorageProvider>
+  </DepsProvider>
+);
+
+const writeEvaluation = async (dataRoot: string, critique: string): Promise<void> => {
+  const path = join(dataRoot, 'sprints', SPRINT_ID_STR, 'implement', TASK_ID, ARTIFACT);
+  await fs.mkdir(dirname(path), { recursive: true });
+  const body = ['# Evaluation — failed', '', '## Critique', '', critique, ''].join('\n');
+  await fs.writeFile(path, body, 'utf8');
+};
+
+describe('EvaluationOverlay — wrapped rows are windowed as rows', () => {
+  it('paginates and scrolls a single-paragraph critique instead of overflowing the viewport', async () => {
+    const dataRoot = await makeTmpRoot();
+    const critique = paragraph('crit', 200);
+    await writeEvaluation(dataRoot, critique);
+
+    const { stdin, lastFrame, unmount } = render(<EvaluationHarness dataRoot={dataRoot} />);
+    await waitForPredicate(() => (lastFrame() ?? '').includes('crit000'));
+    // Let the post-load render commit before typing: the scroll handler closes over the line
+    // count, so a keystroke racing the first painted frame would still see the loading state's 0.
+    await tick(30);
+
+    const top = lastFrame() ?? '';
+    // One logical critique line used to mean `maxOffset === 0`: no footer, no scrolling.
+    expect(top).toMatch(/lines 1[–-]/);
+    expect(frameRows(top)).toBeLessThanOrEqual(TERMINAL_ROWS);
+    // The wrap is a reflow, not a truncation — the head of the paragraph is intact.
+    expect(top).toContain('crit000 crit001');
+    // The tail is off-screen until the user scrolls to it.
+    expect(top).not.toContain('crit199');
+
+    stdin.write(PAGE_DOWN);
+    await waitForPredicate(() => !(lastFrame() ?? '').includes('crit000'));
+
+    const scrolled = lastFrame() ?? '';
+    expect(scrolled).not.toContain('crit000');
+    expect(scrolled).toMatch(/lines \d+[–-]/);
+    expect(frameRows(scrolled)).toBeLessThanOrEqual(TERMINAL_ROWS);
+
+    unmount();
+  });
+});
+
+/* -------------------------------------------------------------------- progress overlay */
+
+const SeedSprint = (): React.JSX.Element => {
+  const selection = useSelection();
+  const setSprint = selection.setSprint;
+  useEffect(() => {
+    setSprint(parseSprintId(), 'demo-sprint');
+  }, [setSprint]);
+  return selection.sprintId === undefined ? <Text>SEEDING</Text> : <ProgressOverlay />;
+};
+
+const ProgressHarness = ({ dataRoot }: { readonly dataRoot: string }): React.JSX.Element => (
+  <DepsProvider value={{} as unknown as AppDeps}>
+    <StorageProvider value={buildStorage(dataRoot)}>
+      <UiStateProvider>
+        <SelectionProvider>
+          <SeedSprint />
+        </SelectionProvider>
+      </UiStateProvider>
+    </StorageProvider>
+  </DepsProvider>
+);
+
+const writeProgress = async (dataRoot: string, body: string): Promise<void> => {
+  const dir = join(dataRoot, 'sprints', SPRINT_ID_STR);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(join(dir, 'progress.md'), body, 'utf8');
+};
+
+describe('ProgressOverlay — wrapped rows are windowed as rows', () => {
+  it('paginates and scrolls a single-paragraph note instead of overflowing the viewport', async () => {
+    const dataRoot = await makeTmpRoot();
+    await writeProgress(dataRoot, ['# Progress', '', paragraph('note', 200), ''].join('\n'));
+
+    const { stdin, lastFrame, unmount } = render(<ProgressHarness dataRoot={dataRoot} />);
+    await waitForPredicate(() => (lastFrame() ?? '').includes('note000'));
+    await tick(30);
+
+    const top = lastFrame() ?? '';
+    expect(top).toMatch(/lines 1[–-]/);
+    expect(frameRows(top)).toBeLessThanOrEqual(TERMINAL_ROWS);
+    expect(top).toContain('note000 note001');
+    expect(top).not.toContain('note199');
+
+    stdin.write(PAGE_DOWN);
+    await waitForPredicate(() => !(lastFrame() ?? '').includes('note000'));
+
+    const scrolled = lastFrame() ?? '';
+    expect(scrolled).not.toContain('note000');
+    expect(scrolled).toMatch(/lines \d+[–-]/);
+    expect(frameRows(scrolled)).toBeLessThanOrEqual(TERMINAL_ROWS);
+
+    unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/components/evaluation-overlay-degrade.test.tsx
+++ b/tests/integration/application/ui/tui/components/evaluation-overlay-degrade.test.tsx
@@ -34,7 +34,7 @@ import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.t
 import { EvaluationOverlay } from '@src/application/ui/tui/components/evaluation-overlay.tsx';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { EvaluationTarget } from '@src/application/ui/tui/runtime/evaluation-target.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const SPRINT_ID_STR = '0193ed2b-1234-7abc-8def-0123456789ab';
 const TASK_ID = 'task-eval-degrade';
@@ -145,9 +145,9 @@ const openAndWaitFor = async (
   marker: string
 ): Promise<{ readonly frame: string; readonly unmount: () => void }> => {
   const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={evaluationTarget} />);
-  await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+  await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
   stdin.write('v');
-  await waitFor(() => (lastFrame() ?? '').includes(marker));
+  await waitForPredicate(() => (lastFrame() ?? '').includes(marker));
   return { frame: lastFrame() ?? '', unmount };
 };
 

--- a/tests/integration/application/ui/tui/components/evaluation-overlay.test.tsx
+++ b/tests/integration/application/ui/tui/components/evaluation-overlay.test.tsx
@@ -29,7 +29,8 @@ import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
 import { EvaluationOverlay } from '@src/application/ui/tui/components/evaluation-overlay.tsx';
 import type { EvaluationTarget } from '@src/application/ui/tui/runtime/evaluation-target.ts';
-import { ESC, PAGE_DOWN, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC, PAGE_DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const SPRINT_ID_STR = '0193ed2b-1234-7abc-8def-0123456789ab';
 const TASK_ID = 'task-eval-1';
@@ -177,10 +178,10 @@ describe('EvaluationOverlay — open / close', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, CANONICAL);
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
 
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('The legacy migration path is untested.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('The legacy migration path is untested.'));
 
     const opened = lastFrame() ?? '';
     expect(opened).toContain('Evaluation');
@@ -199,12 +200,12 @@ describe('EvaluationOverlay — open / close', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, CANONICAL);
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('correctness: passed'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('correctness: passed'));
 
     stdin.write(ESC);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     expect(lastFrame() ?? '').not.toContain('esc · v to close');
     unmount();
   });
@@ -213,12 +214,12 @@ describe('EvaluationOverlay — open / close', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, CANONICAL);
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('correctness: passed'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('correctness: passed'));
 
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     expect(lastFrame() ?? '').not.toContain('correctness: passed');
     unmount();
   });
@@ -229,9 +230,9 @@ describe('EvaluationOverlay — empty / unreadable file', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, '   \n');
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('exists but is empty'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('exists but is empty'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('exists but is empty');
@@ -248,9 +249,9 @@ describe('EvaluationOverlay — empty / unreadable file', () => {
     // portable stand-in for the permission-denied case (chmod is a no-op under a root CI user).
     await fs.mkdir(artifactPath(dataRoot), { recursive: true });
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('Could not read the evaluation file.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Could not read the evaluation file.'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('Could not read the evaluation file.');
@@ -262,9 +263,9 @@ describe('EvaluationOverlay — empty / unreadable file', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, 'RAW-GARBAGE-LINE\nsecond raw line\n');
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('RAW-GARBAGE-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('RAW-GARBAGE-LINE'));
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('showing the raw file');
@@ -288,9 +289,9 @@ describe('EvaluationOverlay — windowing', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, hugeDocument());
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('HEAD-DIMENSION'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('HEAD-DIMENSION'));
 
     const top = lastFrame() ?? '';
     expect(top).toContain('HEAD-DIMENSION');
@@ -300,7 +301,7 @@ describe('EvaluationOverlay — windowing', () => {
     expect(top.split('\n').length).toBeLessThan(40);
 
     stdin.write(PAGE_DOWN);
-    await waitFor(() => !(lastFrame() ?? '').includes('HEAD-DIMENSION'));
+    await waitForPredicate(() => !(lastFrame() ?? '').includes('HEAD-DIMENSION'));
     expect(lastFrame() ?? '').toMatch(/lines \d+[–-]/);
 
     unmount();
@@ -310,9 +311,9 @@ describe('EvaluationOverlay — windowing', () => {
     const dataRoot = await makeTmpRoot();
     await writeArtifact(dataRoot, CANONICAL);
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} evaluationTarget={target()} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('v');
-    await waitFor(() => (lastFrame() ?? '').includes('correctness: passed'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('correctness: passed'));
     await tick(20);
     expect(lastFrame() ?? '').not.toMatch(/lines \d+[–-]/);
     unmount();

--- a/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
+++ b/tests/integration/application/ui/tui/components/progress-overlay.test.tsx
@@ -27,7 +27,8 @@ import { SelectionProvider, useSelection } from '@src/application/ui/tui/runtime
 import { RouterProvider } from '@src/application/ui/tui/runtime/router.tsx';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
 import { ProgressOverlay } from '@src/application/ui/tui/components/progress-overlay.tsx';
-import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const SPRINT_ID_STR = '0193ed2b-1234-7abc-8def-0123456789ab';
 
@@ -165,14 +166,14 @@ describe('ProgressOverlay — open / close', () => {
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     // Wait until the SeedSelection sentinel confirms the sprint selection effect committed.
     // Replaces the old `tick(50)` which raced the effect under full-suite load.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
 
     expect(lastFrame() ?? '').toContain('UNDERLYING_VIEW');
 
     stdin.write('g');
     // The overlay reads progress.md asynchronously; wait for the content to land rather than a
     // fixed tick, which races the disk read under load (caught '⠋ Loading…' on a busy box).
-    await waitFor(() => (lastFrame() ?? '').includes('First line of activity.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('First line of activity.'));
     const opened = lastFrame() ?? '';
     expect(opened).toContain('Progress');
     expect(opened).toContain('demo-sprint');
@@ -180,7 +181,7 @@ describe('ProgressOverlay — open / close', () => {
     expect(opened).not.toContain('UNDERLYING_VIEW');
 
     stdin.write(ESC);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     expect(lastFrame() ?? '').toContain('UNDERLYING_VIEW');
 
     unmount();
@@ -189,7 +190,7 @@ describe('ProgressOverlay — open / close', () => {
   it('`g` is a no-op on Home (no sprint loaded)', async () => {
     const dataRoot = await makeTmpRoot();
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={false} />);
-    await waitFor(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('UNDERLYING_VIEW'));
     stdin.write('g');
     await tick(30);
     // No overlay — underlying view still showing, no "Progress" title.
@@ -209,10 +210,10 @@ describe('ProgressOverlay — open / close', () => {
       <Harness dataRoot={dataRoot} withSprint={false} withFocusedRun={true} />
     );
     // Wait until the SeedSelection sentinel confirms the focused-run pin effect committed.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
 
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('Pinned run activity.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Pinned run activity.'));
     const opened = lastFrame() ?? '';
     expect(opened).toContain('Progress');
     expect(opened).toContain('pinned-run');
@@ -228,9 +229,9 @@ describe('ProgressOverlay — missing / empty file', () => {
     // No file written — overlay should NOT crash.
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     // Wait for the SEEDED sentinel before pressing 'g' so the effect has committed.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('No progress file yet')); // disk read + state flush
+    await waitForPredicate(() => (lastFrame() ?? '').includes('No progress file yet')); // disk read + state flush
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('No progress file yet');
@@ -243,9 +244,9 @@ describe('ProgressOverlay — missing / empty file', () => {
     await writeProgressFile(dataRoot, '');
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     // Wait for the SEEDED sentinel before pressing 'g' so the effect has committed.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('exists but is empty'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('exists but is empty'));
 
     expect(lastFrame() ?? '').toContain('exists but is empty');
     unmount();
@@ -271,9 +272,9 @@ describe('ProgressOverlay — scrolling', () => {
     await writeProgressFile(dataRoot, buildLongFile());
     const { stdin, lastFrame, unmount } = render(<Harness dataRoot={dataRoot} withSprint={true} />);
     // Wait for the SEEDED sentinel before pressing 'g' so the effect has committed.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('HEAD-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('HEAD-LINE'));
 
     // Initial: top of file visible, tail not.
     const top = lastFrame() ?? '';
@@ -292,12 +293,12 @@ describe('ProgressOverlay — scrolling', () => {
     }
     // After the PgDn loop, use a condition-based wait instead of a fixed tick so slow state
     // flushes under full-suite load cannot fail the clamp assertion.
-    await waitFor(() => (lastFrame() ?? '').includes('TAIL-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('TAIL-LINE'));
     const bottom = lastFrame() ?? '';
     expect(bottom).toContain('TAIL-LINE');
     // Bounds clamp — the bottom frame is stable across additional PgDns.
     stdin.write('\x1b[6~');
-    await waitFor(() => (lastFrame() ?? '').includes('TAIL-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('TAIL-LINE'));
     const stillBottom = lastFrame() ?? '';
     expect(stillBottom).toContain('TAIL-LINE');
 
@@ -307,12 +308,12 @@ describe('ProgressOverlay — scrolling', () => {
       await tick(15);
     }
     // Same pattern: condition-based wait after the PgUp loop.
-    await waitFor(() => (lastFrame() ?? '').includes('HEAD-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('HEAD-LINE'));
     const back = lastFrame() ?? '';
     expect(back).toContain('HEAD-LINE');
     // PgUp at the top clamps — one more press is a no-op.
     stdin.write('\x1b[5~');
-    await waitFor(() => (lastFrame() ?? '').includes('HEAD-LINE'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('HEAD-LINE'));
     expect(lastFrame() ?? '').toContain('HEAD-LINE');
 
     unmount();
@@ -375,25 +376,25 @@ describe('ProgressOverlay — cursor preservation (mounted children)', () => {
     await writeProgressFile(dataRoot, '# Progress\n\nSome content.');
     const { stdin, lastFrame, unmount } = render(<HarnessWithCursor dataRoot={dataRoot} />);
     // Wait for SEEDED sentinel before interacting.
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
 
     // Initial cursor position.
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:0'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:0'));
 
     // Move the cursor down twice (using 'j' — the CursorChild handles input === 'j').
     stdin.write('j');
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:1'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:1'));
     stdin.write('j');
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:2'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:2'));
 
     // Open the overlay — underlying view should be hidden (display:none in Ink output).
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('Some content.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Some content.'));
     expect(lastFrame() ?? '').not.toContain('CURSOR:');
 
     // Close the overlay — cursor must still be at 2 (view was mounted, not remounted).
     stdin.write(ESC);
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:'));
     expect(lastFrame() ?? '').toContain('CURSOR:2');
 
     unmount();
@@ -403,12 +404,12 @@ describe('ProgressOverlay — cursor preservation (mounted children)', () => {
     const dataRoot = await makeTmpRoot();
     await writeProgressFile(dataRoot, '# Progress\n\nSome content.');
     const { stdin, lastFrame, unmount } = render(<HarnessWithCursor dataRoot={dataRoot} />);
-    await waitFor(() => (lastFrame() ?? '').includes('SEEDED'));
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:0'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('SEEDED'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:0'));
 
     // Open the overlay.
     stdin.write('g');
-    await waitFor(() => (lastFrame() ?? '').includes('Some content.'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Some content.'));
 
     // 'j' is a list-navigation key; the hidden view gates on ui.modalOpen so it must ignore it.
     stdin.write('j');
@@ -416,7 +417,7 @@ describe('ProgressOverlay — cursor preservation (mounted children)', () => {
 
     // Close the overlay — cursor should still be at 0.
     stdin.write(ESC);
-    await waitFor(() => (lastFrame() ?? '').includes('CURSOR:'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('CURSOR:'));
     expect(lastFrame() ?? '').toContain('CURSOR:0');
 
     unmount();

--- a/tests/integration/application/ui/tui/components/status-banner-prompt-gate.test.tsx
+++ b/tests/integration/application/ui/tui/components/status-banner-prompt-gate.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Regression: `StatusBanner`'s `d` dismiss used to be the one ungated keyboard owner in the
+ * chrome. It is mounted inside every `ViewShell`, right next to `PromptHost`, so typing a sprint
+ * name / ticket title / refine answer containing the letter `d` silently threw away the topmost
+ * banner — including a rate-limit or watchdog warning the operator was meant to act on. The same
+ * keystroke also landed while the progress / evaluation / help overlay was up, dismissing banners
+ * the operator could not even see.
+ *
+ * Every other keyboard owner stands down under `ui.modalOpen` (DESIGN-SYSTEM § 4.4); these tests
+ * fence that this one does too, without losing the plain `d` dismiss when nothing is claimed.
+ */
+
+import React, { useEffect } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { UiStateProvider, useUiState } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { StatusBanner } from '@src/application/ui/tui/components/status-banner.tsx';
+import { TextPrompt } from '@src/application/ui/tui/prompts/text-prompt.tsx';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
+
+type Bus = ReturnType<typeof createInMemoryEventBus>;
+
+const BANNER_TEXT = 'Rate limit — waiting 30s';
+
+const publishBanner = (bus: Bus): void => {
+  bus.publish({ type: 'banner-show', id: 'rate-limit-1', tier: 'warn', message: BANNER_TEXT, at: IsoTimestamp.now() });
+};
+
+/** Holds a `claimPrompt()` token for as long as it is mounted — exactly what PromptHost does. */
+const ClaimingPrompt = ({ onSubmit }: { readonly onSubmit: (value: string) => void }): React.JSX.Element => {
+  const ui = useUiState();
+  useEffect(() => ui.claimPrompt(), [ui.claimPrompt]);
+  return <TextPrompt message="name" onSubmit={onSubmit} onCancel={() => undefined} />;
+};
+
+const Harness = ({
+  bus,
+  withPrompt,
+  onSubmit,
+}: {
+  readonly bus: Bus;
+  readonly withPrompt: boolean;
+  readonly onSubmit: (value: string) => void;
+}): React.JSX.Element => (
+  <DepsProvider value={{ eventBus: bus } as unknown as AppDeps}>
+    <UiStateProvider>
+      <StatusBanner />
+      {withPrompt && <ClaimingPrompt onSubmit={onSubmit} />}
+    </UiStateProvider>
+  </DepsProvider>
+);
+
+describe('StatusBanner — `d` stands down while a prompt owns the keyboard', () => {
+  it('keeps the banner and delivers the character when a claimed prompt is up', async () => {
+    const bus = createInMemoryEventBus();
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame, unmount } = render(<Harness bus={bus} withPrompt onSubmit={onSubmit} />);
+    await tick(50); // let the claim effect commit
+
+    publishBanner(bus);
+    await waitForPredicate(() => (lastFrame() ?? '').includes(BANNER_TEXT));
+
+    // One character per write — a real terminal delivers keystrokes individually, and the
+    // ungated handler only matched a bare `d` (a batched 'draft' write arrives as one input
+    // string and would have sailed past the bug).
+    for (const ch of 'draft') {
+      stdin.write(ch);
+      await tick();
+    }
+    stdin.write('\r');
+    await tick();
+
+    expect(onSubmit).toHaveBeenCalledWith('draft');
+    expect(lastFrame() ?? '').toContain(BANNER_TEXT);
+    unmount();
+  });
+
+  it('still dismisses on `d` when nothing has claimed the keyboard', async () => {
+    const bus = createInMemoryEventBus();
+    const { stdin, lastFrame, unmount } = render(<Harness bus={bus} withPrompt={false} onSubmit={() => undefined} />);
+
+    publishBanner(bus);
+    await waitForPredicate(() => (lastFrame() ?? '').includes(BANNER_TEXT));
+
+    stdin.write('d');
+    await waitForPredicate(() => !(lastFrame() ?? '').includes(BANNER_TEXT));
+
+    expect(lastFrame() ?? '').not.toContain(BANNER_TEXT);
+    unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/components/status-banner.test.tsx
+++ b/tests/integration/application/ui/tui/components/status-banner.test.tsx
@@ -26,15 +26,24 @@ import { describe, expect, it } from 'vitest';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
 import { StatusBanner } from '@src/application/ui/tui/components/status-banner.tsx';
+import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
 
+/**
+ * `UiStateProvider` is required, not decorative: the `d` handler stands down under
+ * `ui.modalOpen` so it cannot fire while a prompt or overlay owns the keyboard, and
+ * `useOverlayState` throws without a provider. Nothing here claims a prompt, so the gate is
+ * open and the dismiss cases below behave exactly as they did before.
+ */
 const renderBanner = (bus: ReturnType<typeof createInMemoryEventBus>): ReturnType<typeof render> => {
   const deps = { eventBus: bus } as unknown as AppDeps;
   return render(
     <DepsProvider value={deps}>
-      <StatusBanner />
+      <UiStateProvider>
+        <StatusBanner />
+      </UiStateProvider>
     </DepsProvider>
   );
 };

--- a/tests/integration/application/ui/tui/components/status-bar.test.tsx
+++ b/tests/integration/application/ui/tui/components/status-bar.test.tsx
@@ -12,7 +12,7 @@ import { StatusBar } from '@src/application/ui/tui/components/status-bar.tsx';
 import { useSystemStatus } from '@src/application/ui/tui/runtime/system-status-context.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { DoctorReport } from '@src/application/flows/doctor/ctx.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const reportRef = vi.hoisted(() => ({ current: undefined as DoctorReport | undefined }));
@@ -53,7 +53,7 @@ describe('StatusBar — doctor indicator', () => {
       hasFailures: false,
     };
     const { result } = renderView(<TriggerAndRender />, { deps, initial: { id: 'home' } });
-    await waitFor(() => (result.lastFrame() ?? '').includes('doctor ok'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('doctor ok'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('doctor ok');
     expect(frame).not.toContain('doctor warning');
@@ -67,7 +67,7 @@ describe('StatusBar — doctor indicator', () => {
       hasFailures: false,
     };
     const { result } = renderView(<TriggerAndRender />, { deps, initial: { id: 'home' } });
-    await waitFor(() => (result.lastFrame() ?? '').includes('doctor warning'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('doctor warning'));
     expect(result.lastFrame() ?? '').toContain('1 doctor warning');
   });
 });

--- a/tests/integration/application/ui/tui/components/tasks-panel-evaluation-open.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-evaluation-open.test.tsx
@@ -14,7 +14,8 @@ import { render } from 'ink-testing-library';
 import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
 import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import type { TaskEvaluation } from '@src/application/ui/tui/components/tasks-panel-internals/evaluation-row.tsx';
-import { ENTER, tick, UP, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, tick, UP } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const bucketed = (): BucketedExecution => ({
   tasks: [
@@ -52,10 +53,10 @@ describe("TasksPanel — `v` opens the focused card's evaluation", () => {
         ['task-live', { status: 'failed', attemptN: 2, file: 'rounds/3/evaluator/evaluation.md' }],
       ])
     );
-    await waitFor(() => (r.lastFrame() ?? '').includes('task-liv'));
+    await waitForPredicate(() => (r.lastFrame() ?? '').includes('task-liv'));
 
     r.stdin.write('v');
-    await waitFor(() => onOpenEvaluation.mock.calls.length === 1);
+    await waitForPredicate(() => onOpenEvaluation.mock.calls.length === 1);
     expect(onOpenEvaluation).toHaveBeenCalledWith('task-live');
     r.unmount();
   });
@@ -69,13 +70,13 @@ describe("TasksPanel — `v` opens the focused card's evaluation", () => {
         ['task-live', { status: 'failed', attemptN: 2, file: 'rounds/3/evaluator/evaluation.md' }],
       ])
     );
-    await waitFor(() => (r.lastFrame() ?? '').includes('task-liv'));
+    await waitForPredicate(() => (r.lastFrame() ?? '').includes('task-liv'));
 
     // Move the card cursor up onto the completed card, then read its verdict.
     r.stdin.write(UP);
     await tick(30);
     r.stdin.write('v');
-    await waitFor(() => onOpenEvaluation.mock.calls.length === 1);
+    await waitForPredicate(() => onOpenEvaluation.mock.calls.length === 1);
     expect(onOpenEvaluation).toHaveBeenCalledWith('task-done');
     r.unmount();
   });
@@ -87,7 +88,7 @@ describe("TasksPanel — `v` opens the focused card's evaluation", () => {
       onOpenEvaluation,
       evaluations([['task-done', { status: 'passed', attemptN: 1, file: 'rounds/1/evaluator/evaluation.md' }]])
     );
-    await waitFor(() => (r.lastFrame() ?? '').includes('task-liv'));
+    await waitForPredicate(() => (r.lastFrame() ?? '').includes('task-liv'));
 
     r.stdin.write('v');
     await tick(50);
@@ -100,7 +101,7 @@ describe("TasksPanel — `v` opens the focused card's evaluation", () => {
       undefined,
       evaluations([['task-live', { status: 'failed', attemptN: 2, file: 'rounds/3/evaluator/evaluation.md' }]])
     );
-    await waitFor(() => (r.lastFrame() ?? '').includes('task-liv'));
+    await waitForPredicate(() => (r.lastFrame() ?? '').includes('task-liv'));
     const before = r.lastFrame() ?? '';
     r.stdin.write('v');
     await tick(50);
@@ -122,7 +123,7 @@ describe("TasksPanel — `v` opens the focused card's evaluation", () => {
         onOpenEvaluation={onOpenEvaluation}
       />
     );
-    await waitFor(() => (r.lastFrame() ?? '').includes('AC-1'));
+    await waitForPredicate(() => (r.lastFrame() ?? '').includes('AC-1'));
 
     // `e` still toggles the criteria block and must NOT open the overlay.
     r.stdin.write('e');

--- a/tests/integration/application/ui/tui/components/tasks-panel-skipped-task.test.tsx
+++ b/tests/integration/application/ui/tui/components/tasks-panel-skipped-task.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * A dependency-blocked (bucket status `skipped`) task must render as skipped and must NOT hold
+ * the panel's active-card anchor: the anchor auto-expands the card the operator should be
+ * watching, and a task blocked upstream sits early in the list while later tasks actually run.
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+import { TasksPanel } from '@src/application/ui/tui/components/tasks-panel.tsx';
+import type { BucketedExecution, TaskBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+
+const BLOCKED = '01933fbb-0000-7000-8000-000000000001';
+const RUNNING = '01933fbb-0000-7000-8000-000000000002';
+
+const bucket = (id: string, status: TaskBucket['status'], subSteps: TaskBucket['subSteps']): TaskBucket => ({
+  id,
+  status,
+  subSteps,
+  evaluations: [],
+  signals: [],
+  genEvalRound: 0,
+});
+
+const bucketed: BucketedExecution = {
+  tasks: [
+    bucket(BLOCKED, 'skipped', [
+      { leafName: 'dependency-gate', status: 'completed', durationMs: 2 },
+      { leafName: 'task-body', status: 'skipped', durationMs: 0 },
+    ]),
+    bucket(RUNNING, 'running', [{ leafName: 'generator', status: 'completed', durationMs: 40 }]),
+  ],
+  orphanSignals: [],
+};
+
+const names = new Map([
+  [BLOCKED, 'Blocked upstream task'],
+  [RUNNING, 'Live task'],
+]);
+
+describe('TasksPanel — dependency-blocked task', () => {
+  it('labels the blocked task `skipped`, never `running`', () => {
+    const r = render(<TasksPanel bucketed={bucketed} running nameById={names} />);
+    const frame = r.lastFrame() ?? '';
+
+    expect(frame).toContain('Blocked upstream task');
+    expect(frame).toContain('skipped');
+    r.unmount();
+  });
+
+  it('anchors the auto-expanded active card on the running task, not the blocked one', () => {
+    const r = render(<TasksPanel bucketed={bucketed} running nameById={names} />);
+    const frame = r.lastFrame() ?? '';
+
+    // The active card is the only one expanded on first paint, so its sub-steps are visible
+    // while the blocked card's stay collapsed.
+    expect(frame).toContain('generator');
+    expect(frame).not.toContain('dependency-gate');
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/migration/migration-gate.test.tsx
+++ b/tests/integration/application/ui/tui/migration/migration-gate.test.tsx
@@ -14,7 +14,8 @@ import type { DataMigrationEngine } from '@src/integration/persistence/data-migr
 import type { DryRunReport, RenamePlan } from '@src/integration/persistence/data-migration/types.ts';
 import type { ApplyResult } from '@src/integration/persistence/data-migration/apply.ts';
 import { MigrationGate, type MigrationGateOutcome } from '@src/application/ui/tui/migration/migration-gate.tsx';
-import { ENTER, ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const ABS = (p: string): AbsolutePath => {
   const r = AbsolutePath.parse(p);
@@ -93,7 +94,7 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> =>
         reportWith({ planned: [plan('sprint', 's1'), plan('sprint', 's2'), plan('project', 'p1')] }),
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     const frame = r.lastFrame() ?? '';
     expect(frame).toContain('2 sprints');
     expect(frame).toContain('1 project');
@@ -105,7 +106,7 @@ describe('MigrationGate', () => {
     const { h, r } = mount({
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('n');
     await tick();
     expect(h.resolved).toEqual(['skipped']);
@@ -117,7 +118,7 @@ describe('MigrationGate', () => {
     const { h, r } = mount({
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write(ESC);
     await tick(60);
     expect(h.resolved).toEqual(['skipped']);
@@ -130,9 +131,9 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
       applyResult: { kind: 'ok', backupPath: '/bk', applied: [] },
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('m');
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     expect(h.apply).toHaveBeenCalledOnce();
     expect(h.resolved).toEqual(['migrated']);
     r.unmount();
@@ -143,9 +144,9 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
       applyResult: { kind: 'ok', backupPath: '/bk', applied: [] },
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write(ENTER);
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     expect(h.apply).toHaveBeenCalledOnce();
     expect(h.resolved).toEqual(['migrated']);
     r.unmount();
@@ -158,16 +159,16 @@ describe('MigrationGate', () => {
       applyResult: { kind: 'failed', backupPath: '/home/me/.ralphctl/data.backup-v1-2026', error: err, applied: [] },
       priorAppVersion: '0.11.4', // a real recorded prior version → the npm line is honest to print
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('m');
-    await waitFor(() => r.lastFrame()?.includes('Your data is safe') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('Your data is safe') === true);
     const frame = r.lastFrame() ?? '';
     expect(frame).toContain('/home/me/.ralphctl/data.backup-v1-2026');
     expect(frame).toContain('npm install -g ralphctl@0.11.4');
     expect(frame).toContain('your current version still reads');
     // Continue (Enter) → proceed into the app on the tolerant readers.
     r.stdin.write(ENTER);
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     expect(h.resolved).toEqual(['failed-continue']);
     r.unmount();
   });
@@ -179,9 +180,9 @@ describe('MigrationGate', () => {
       applyResult: { kind: 'failed', backupPath: '/bk', error: err, applied: [] },
       // priorAppVersion omitted → marker carries no lastWrittenByAppVersion (the v1→v2 first run).
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('m');
-    await waitFor(() => r.lastFrame()?.includes('Your data is safe') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('Your data is safe') === true);
     const frame = r.lastFrame() ?? '';
     // A wrong downgrade command would be actively harmful — the line must be absent entirely.
     expect(frame).not.toContain('npm install -g ralphctl@');
@@ -193,7 +194,7 @@ describe('MigrationGate', () => {
     const { h, r } = mount({
       dryRun: async (): Promise<DryRunReport> => reportWith(), // empty: brand-new install / already reconciled
     });
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     // The consent splash never rendered — the marker was stamped and the gate resolved straight through.
     expect(h.stampCurrent).toHaveBeenCalledOnce();
     expect(h.apply).not.toHaveBeenCalled();
@@ -208,11 +209,11 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
       applyResult: { kind: 'failed', backupPath: '/bk', error: err, applied: [] },
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('m');
-    await waitFor(() => r.lastFrame()?.includes('Your data is safe') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('Your data is safe') === true);
     r.stdin.write('q');
-    await waitFor(() => h.quit.mock.calls.length > 0);
+    await waitForPredicate(() => h.quit.mock.calls.length > 0);
     expect(h.quit).toHaveBeenCalledOnce();
     expect(h.resolved).toEqual([]);
     r.unmount();
@@ -223,11 +224,11 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> => reportWith({ planned: [plan('sprint', 's1')] }),
       applyResult: { kind: 'lock-held' },
     });
-    await waitFor(() => r.lastFrame()?.includes('renamed for readability') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('renamed for readability') === true);
     r.stdin.write('m');
-    await waitFor(() => r.lastFrame()?.includes('Another ralphctl is running') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('Another ralphctl is running') === true);
     r.stdin.write(ENTER);
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     expect(h.resolved).toEqual(['skipped']);
     r.unmount();
   });
@@ -237,11 +238,11 @@ describe('MigrationGate', () => {
       dryRun: async (): Promise<DryRunReport> =>
         reportWith({ problems: [{ name: 'abc', reason: 'collides with abc--slug' }] }),
     });
-    await waitFor(() => r.lastFrame()?.includes('collides with abc--slug') === true);
+    await waitForPredicate(() => r.lastFrame()?.includes('collides with abc--slug') === true);
     expect(r.lastFrame()).toContain('abc');
     // Any key continues; apply must never have been reached.
     r.stdin.write(ENTER);
-    await waitFor(() => h.resolved.length > 0);
+    await waitForPredicate(() => h.resolved.length > 0);
     expect(h.apply).not.toHaveBeenCalled();
     expect(h.resolved).toEqual(['skipped']);
     r.unmount();

--- a/tests/integration/application/ui/tui/prompts/multi-choice-initial-roundtrip.test.tsx
+++ b/tests/integration/application/ui/tui/prompts/multi-choice-initial-roundtrip.test.tsx
@@ -21,7 +21,8 @@ import { createInkInteractivePrompt } from '@src/application/ui/tui/prompts/ink-
 import { PromptHost } from '@src/application/ui/tui/prompts/prompt-host.tsx';
 import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
 import type { Choice } from '@src/business/interactive/prompt.ts';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const Host = ({ queue }: { readonly queue: ReturnType<typeof createPromptQueue> }): React.JSX.Element => (
   <UiStateProvider>
@@ -43,7 +44,7 @@ describe('askMultiChoice initial seeding through the real queue → PromptHost p
     const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
 
     const answer = interactive.askMultiChoice<string>('Skills for this run:', OPTIONS, { initial: ['a', 'c'] });
-    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Alpha'));
     await tick(50); // give useInput's subscription time to attach before the first keypress
 
     const frame = lastFrame() ?? '';
@@ -67,7 +68,7 @@ describe('askMultiChoice initial seeding through the real queue → PromptHost p
     const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
 
     const answer = interactive.askMultiChoice<string>('Pick:', OPTIONS, { initial: [] });
-    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Alpha'));
     await tick(50); // give useInput's subscription time to attach before the first keypress
 
     // select-all must not pull in the disabled Delta row.
@@ -88,7 +89,7 @@ describe('askMultiChoice initial seeding through the real queue → PromptHost p
     const { stdin, lastFrame, unmount } = render(<Host queue={queue} />);
 
     const answer = interactive.askMultiChoice<string>('Pick:', OPTIONS);
-    await waitFor(() => (lastFrame() ?? '').includes('Alpha'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('Alpha'));
     await tick(50); // give useInput's subscription time to attach before the first keypress
     expect(lastFrame() ?? '').toMatch(/\[ ]\s*Alpha/);
 

--- a/tests/integration/application/ui/tui/runtime/home-chord-destination.test.tsx
+++ b/tests/integration/application/ui/tui/runtime/home-chord-destination.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * `h` (global Home chord) and `D` (Execute-view detach) must land on the HOME view — never on
+ * whatever entry the process happened to boot with.
+ *
+ * The regression: `RouterProvider.reset()` used to fall back to its frozen `initial` prop when
+ * called with no argument, and both chords called it bare. On a first-run session `initial` is
+ * `{ id: 'welcome' }` (and `{ id: 'create-project' }` when settings exist but no project), so
+ * pressing `h` re-mounted the first-run wizard instead of going Home — and a fresh WelcomeView
+ * instance re-ran its PATH probe + apply-preset seed over whatever the user had just configured
+ * in Settings.
+ */
+
+import React, { useEffect } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import { DepsProvider } from '@src/application/ui/tui/runtime/deps-context.tsx';
+import { SessionsProvider } from '@src/application/ui/tui/runtime/sessions-context.tsx';
+import { SelectionProvider } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { UiStateProvider } from '@src/application/ui/tui/runtime/ui-state-context.tsx';
+import { HintsProvider } from '@src/application/ui/tui/runtime/use-view-hints.tsx';
+import { RouterProvider, useRouter, type ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
+import { useExecuteInput } from '@src/application/ui/tui/views/execute-view-internals/use-execute-input.ts';
+import type { SessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+
+const stubDeps = (): AppDeps => ({ eventBus: createInMemoryEventBus() }) as unknown as AppDeps;
+
+const emptyManager = (): SessionManager =>
+  ({
+    list: () => [],
+    get: () => undefined,
+    subscribe: () => () => undefined,
+  }) as unknown as SessionManager;
+
+const RouteProbe = ({ onRoute }: { readonly onRoute: (e: ViewEntry) => void }): React.JSX.Element => {
+  const router = useRouter();
+  useEffect(() => {
+    onRoute(router.current);
+  });
+  return <></>;
+};
+
+const GlobalKeysProbe = (): React.JSX.Element => {
+  useGlobalKeys();
+  return <></>;
+};
+
+/** Mounts the Execute view's own key handler in its RUNNING state, where `D` = detach. */
+const ExecuteInputProbe = (): React.JSX.Element => {
+  const router = useRouter();
+  useExecuteInput({
+    isRunning: true,
+    cancelScopeOpen: false,
+    setCancelScopeOpen: () => undefined,
+    modalOpen: false,
+    router,
+    hasPinnedSprint: false,
+    hasEvaluation: false,
+  });
+  return <></>;
+};
+
+const Harness = ({
+  initial,
+  onRoute,
+  probe,
+}: {
+  readonly initial: ViewEntry;
+  readonly onRoute: (e: ViewEntry) => void;
+  readonly probe: React.ReactNode;
+}): React.JSX.Element => (
+  <DepsProvider value={stubDeps()}>
+    <SessionsProvider value={emptyManager()}>
+      <SelectionProvider>
+        <UiStateProvider>
+          <HintsProvider>
+            <RouterProvider initial={initial}>
+              {(): React.JSX.Element => (
+                <>
+                  {probe}
+                  <RouteProbe onRoute={onRoute} />
+                </>
+              )}
+            </RouterProvider>
+          </HintsProvider>
+        </UiStateProvider>
+      </SelectionProvider>
+    </SessionsProvider>
+  </DepsProvider>
+);
+
+describe('Home destination chords', () => {
+  it('`h` lands on home from a first-run session whose launch entry was welcome', async () => {
+    let current: ViewEntry = { id: 'welcome' };
+    const { stdin, unmount } = render(
+      <Harness initial={current} onRoute={(e) => (current = e)} probe={<GlobalKeysProbe />} />
+    );
+    await tick(50);
+    stdin.write('h');
+    await tick();
+
+    expect(current.id).toBe('home');
+    unmount();
+  });
+
+  it('`h` lands on home when the launch entry was the create-project wizard', async () => {
+    let current: ViewEntry = { id: 'create-project' };
+    const { stdin, unmount } = render(
+      <Harness initial={current} onRoute={(e) => (current = e)} probe={<GlobalKeysProbe />} />
+    );
+    await tick(50);
+    stdin.write('h');
+    await tick();
+
+    expect(current.id).toBe('home');
+    unmount();
+  });
+
+  it('`D` (detach) lands on home rather than re-mounting the first-run launch entry', async () => {
+    let current: ViewEntry = { id: 'welcome' };
+    const { stdin, unmount } = render(
+      <Harness initial={current} onRoute={(e) => (current = e)} probe={<ExecuteInputProbe />} />
+    );
+    await tick(50);
+    stdin.write('D');
+    await tick();
+
+    expect(current.id).toBe('home');
+    unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/add-repository-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/add-repository-view.test.tsx
@@ -44,7 +44,8 @@ describe('AddRepositoryView — wizard e2e', () => {
       deps,
       initial: { id: 'add-repository', props: { projectId: project.id } },
     });
-    await waitForViewReady(result, (f) => f.includes('Repository path'));
+    // Match the prompt's literal copy — the path step is titled "Repository directory".
+    await waitForViewReady(result, (f) => f.includes('Repository directory'));
 
     // Step 1: path picker — use `t` typing overlay for determinism.
     result.stdin.write('t');

--- a/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/create-pr-view.test.tsx
@@ -22,7 +22,8 @@ import { createSprintExecution, setExecutionBranch } from '@src/domain/entity/sp
 import type { HeadlessAiProvider } from '@src/integration/ai/providers/_engine/headless-ai-provider.ts';
 import { DEFAULT_SETTINGS, defaultAiSettingsForProvider } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
-import { ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { absolutePath, makeReviewSprint } from '@tests/fixtures/domain.ts';
 import { emptySkillSource } from '@tests/fixtures/skills-fakes.ts';
@@ -190,7 +191,7 @@ describe('CreatePrView — provider rebuild + PATH gate', () => {
     await waitForViewReady(result, (f) => f.includes('Confirm'));
 
     result.stdin.write(ENTER);
-    await waitFor(() => factoryRef.calls.map((c) => c.flow).includes('createPr'));
+    await waitForPredicate(() => factoryRef.calls.map((c) => c.flow).includes('createPr'));
 
     expect(factoryRef.calls.map((c) => c.flow)).toContain('createPr');
   });
@@ -210,7 +211,7 @@ describe('CreatePrView — provider rebuild + PATH gate', () => {
     await waitForViewReady(result, (f) => f.includes('Confirm'));
 
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('copilot'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('copilot'));
 
     const frame = result.lastFrame() ?? '';
     // The gate's actionable message names the binary + the settings key — surfaced as the

--- a/tests/integration/application/ui/tui/views/create-project-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/create-project-view.test.tsx
@@ -37,7 +37,8 @@ describe('CreateProjectView — wizard e2e', () => {
     const deps: AppDeps = { projectRepo } as unknown as AppDeps;
 
     const { result } = renderView(<CreateProjectView />, { deps, initial: { id: 'create-project' } });
-    await waitForViewReady(result, (f) => f.includes('Display name'));
+    // Match the prompt's literal copy — the view renders "Project display name" (create-project-view.tsx:207).
+    await waitForViewReady(result, (f) => f.includes('Project display name'));
 
     // Step 1: display name.
     result.stdin.write('Mainline');

--- a/tests/integration/application/ui/tui/views/doctor-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/doctor-view.test.tsx
@@ -10,7 +10,7 @@ import { Result } from '@src/domain/result.ts';
 import { DoctorView } from '@src/application/ui/tui/views/doctor-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { DoctorReport, ProbeResult } from '@src/application/flows/doctor/ctx.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const reportRef = vi.hoisted(() => ({ current: undefined as DoctorReport | undefined }));
@@ -39,7 +39,7 @@ describe('DoctorView', () => {
       hasFailures: false,
     };
     const { result } = renderView(<DoctorView />, { deps, initial: { id: 'doctor' } });
-    await waitFor(() => /passed/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /passed/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).toMatch(/passed/);
     expect(frame).toContain('Storage');
@@ -50,7 +50,7 @@ describe('DoctorView', () => {
   it('publishes the r reload hint', async () => {
     reportRef.current = { probes: [], allPassed: true, hasFailures: false };
     const { result } = renderView(<DoctorView />, { deps, initial: { id: 'doctor' } });
-    await waitFor(() => (result.lastFrame() ?? '').includes('reload'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('reload'));
     expect(result.lastFrame() ?? '').toContain('reload');
   });
 
@@ -69,7 +69,7 @@ describe('DoctorView', () => {
       hasFailures: false,
     };
     const { result } = renderView(<DoctorView />, { deps, initial: { id: 'doctor' } });
-    await waitFor(() => (result.lastFrame() ?? '').includes('GitHub Copilot authenticated'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('GitHub Copilot authenticated'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('UNKNOWN');
     // The summary header tallies it as "1 unknown", not as a warning.

--- a/tests/integration/application/ui/tui/views/execute-view-internals/run-forensics.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view-internals/run-forensics.test.tsx
@@ -21,7 +21,8 @@ import { useRunForensics } from '@src/application/ui/tui/views/execute-view-inte
 import type { ForensicPath } from '@src/application/ui/shared/next-steps.ts';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 
 const SPRINT_ID = '01933fbb-2222-7000-8000-0000000000aa' as unknown as SprintId;
 
@@ -53,6 +54,35 @@ const mkSprintDir = async (): Promise<{ readonly dataRoot: AbsolutePath; readonl
   return { dataRoot: absPath(root), sprintDir };
 };
 
+/**
+ * Settle marker for the negative tests.
+ *
+ * `useRunForensics` seeds its state to `[]` and only fills it once an async `fs.stat` pass
+ * resolves inside `useEffect`, so the hook's EMPTY output is also its FIRST FRAME — waiting for
+ * "empty" is satisfied at t≈0, before the effect can possibly have run, and a regression that
+ * resolved a fabricated sprint dir one tick later would sail straight through. So each negative
+ * test renders this control alongside the probe under test: it is pinned at a sprint directory
+ * that really exists, does strictly MORE filesystem work than any negative case (resolve + four
+ * stats vs. zero or one), and its effect is scheduled by the same commit. Once `CONTROL:n` has
+ * appeared with n > 0 the negative case has definitively finished its own pass, and the whole
+ * `seen` history — not just the last frame — can be asserted empty.
+ */
+const ControlProbe = ({ dataRoot }: { readonly dataRoot: AbsolutePath }): React.JSX.Element => {
+  const forensics = useRunForensics({
+    enabled: true,
+    pinnedSprintId: SPRINT_ID,
+    flowId: 'implement',
+    dataRoot,
+    runsRoot: dataRoot,
+  });
+  return <Text>{`CONTROL:${String(forensics.length)}`}</Text>;
+};
+
+/** Grace beyond the control's settle, so a leak racing just behind it still lands in `seen`. */
+const SETTLE_GRACE_MS = 50;
+
+const controlSettled = (frame: string): boolean => /CONTROL:[1-9]/.test(frame);
+
 describe('useRunForensics', () => {
   it('lists only the artifacts that actually exist on disk', async () => {
     const { dataRoot, sprintDir } = await mkSprintDir();
@@ -71,7 +101,7 @@ describe('useRunForensics', () => {
         seen={seen}
       />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('progress.md'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('progress.md'));
     const labels = (seen.at(-1) ?? []).map((f) => f.label);
     // progress.md + the sprint dir itself; events.ndjson and the verify logs dir do not exist.
     expect(labels).toContain('progress.md');
@@ -95,23 +125,34 @@ describe('useRunForensics', () => {
         seen={seen}
       />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('events.ndjson'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('events.ndjson'));
     const labels = (seen.at(-1) ?? []).map((f) => f.label);
     expect(labels).toEqual(['progress.md', 'events.ndjson', 'verify logs', 'sprint dir']);
     unmount();
   });
 
   it('returns nothing when the run has no pinned sprint (the create-sprint case)', async () => {
-    const { dataRoot } = await mkSprintDir();
+    // `mkSprintDir()` puts a REAL `<root>/sprints/<SPRINT_ID>--demo-sprint` with a real
+    // progress.md on disk: a regression that guessed the pin from the ambient data root would
+    // find something to report, and every frame in `seen` would stop being empty.
+    const { dataRoot, sprintDir } = await mkSprintDir();
+    await fs.writeFile(join(sprintDir, 'progress.md'), '# progress\n', 'utf8');
     const seen: ForensicPath[][] = [];
     const { lastFrame, unmount } = render(
-      <Probe
-        args={{ enabled: true, pinnedSprintId: undefined, flowId: 'create-sprint', dataRoot, runsRoot: dataRoot }}
-        seen={seen}
-      />
+      <>
+        <Probe
+          args={{ enabled: true, pinnedSprintId: undefined, flowId: 'create-sprint', dataRoot, runsRoot: dataRoot }}
+          seen={seen}
+        />
+        <ControlProbe dataRoot={dataRoot} />
+      </>
     );
-    await waitFor(() => (lastFrame() ?? '').includes('NONE'));
-    expect(seen.at(-1)).toEqual([]);
+
+    await waitForPredicate(() => controlSettled(lastFrame() ?? ''), { label: 'the control probe settled' });
+    await tick(SETTLE_GRACE_MS);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((entries) => entries.length === 0)).toBe(true);
     unmount();
   });
 
@@ -120,33 +161,56 @@ describe('useRunForensics', () => {
     await fs.writeFile(join(sprintDir, 'progress.md'), '# progress\n', 'utf8');
     const seen: ForensicPath[][] = [];
     const { lastFrame, unmount } = render(
-      <Probe
-        args={{ enabled: false, pinnedSprintId: SPRINT_ID, flowId: 'implement', dataRoot, runsRoot: dataRoot }}
-        seen={seen}
-      />
+      <>
+        <Probe
+          args={{ enabled: false, pinnedSprintId: SPRINT_ID, flowId: 'implement', dataRoot, runsRoot: dataRoot }}
+          seen={seen}
+        />
+        <ControlProbe dataRoot={dataRoot} />
+      </>
     );
-    await waitFor(() => (lastFrame() ?? '').includes('NONE'));
-    expect(seen.at(-1)).toEqual([]);
+
+    // The control proves the artifacts ARE resolvable from this very root — so an empty list
+    // here can only come from the `enabled: false` gate, not from an unpopulated tmp dir.
+    await waitForPredicate(() => controlSettled(lastFrame() ?? ''), { label: 'the control probe settled' });
+    await tick(SETTLE_GRACE_MS);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((entries) => entries.length === 0)).toBe(true);
     unmount();
   });
 
   it('returns nothing when the sprint directory is gone', async () => {
+    // A sibling sprint exists under `sprints/` so the resolver has a real directory to scan and
+    // mis-match against — "empty because the tree is empty" would prove much less.
     const root = await mkdtemp(join(tmpdir(), 'ralphctl-forensics-empty-'));
+    const strangerDir = join(root, 'sprints', '01933fbb-9999-7000-8000-0000000000bb--other-sprint');
+    await fs.mkdir(strangerDir, { recursive: true });
+    await fs.writeFile(join(strangerDir, 'progress.md'), '# not ours\n', 'utf8');
+
+    const { dataRoot: controlRoot } = await mkSprintDir();
     const seen: ForensicPath[][] = [];
     const { lastFrame, unmount } = render(
-      <Probe
-        args={{
-          enabled: true,
-          pinnedSprintId: SPRINT_ID,
-          flowId: 'implement',
-          dataRoot: absPath(root),
-          runsRoot: absPath(root),
-        }}
-        seen={seen}
-      />
+      <>
+        <Probe
+          args={{
+            enabled: true,
+            pinnedSprintId: SPRINT_ID,
+            flowId: 'implement',
+            dataRoot: absPath(root),
+            runsRoot: absPath(root),
+          }}
+          seen={seen}
+        />
+        <ControlProbe dataRoot={controlRoot} />
+      </>
     );
-    await waitFor(() => (lastFrame() ?? '').includes('NONE'));
-    expect(seen.at(-1)).toEqual([]);
+
+    await waitForPredicate(() => controlSettled(lastFrame() ?? ''), { label: 'the control probe settled' });
+    await tick(SETTLE_GRACE_MS);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((entries) => entries.length === 0)).toBe(true);
     unmount();
   });
 
@@ -170,7 +234,7 @@ describe('useRunForensics', () => {
         seen={seen}
       />
     );
-    await waitFor(() => (lastFrame() ?? '').includes('run artifacts'));
+    await waitForPredicate(() => (lastFrame() ?? '').includes('run artifacts'));
     const entry = (seen.at(-1) ?? []).find((f) => f.label === 'run artifacts');
     expect(entry?.path).toBe(join(runsRoot, 'readiness'));
     unmount();

--- a/tests/integration/application/ui/tui/views/execute-view-internals/settled-next-steps.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view-internals/settled-next-steps.test.tsx
@@ -31,7 +31,8 @@ import {
   makeReviewSprint,
   makeTodoTask,
 } from '@tests/fixtures/domain.ts';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const SPRINT_ID = '01933fbb-3333-7000-8000-0000000000bb' as unknown as SprintId;
@@ -171,7 +172,7 @@ describe('Execute view — settled-run next steps', () => {
     });
     await waitForViewReady(result, (f) => f.includes('Implement — Rerun'));
     result.stdin.write('r');
-    await waitFor(() => routeIds().at(-1) === 'flows');
+    await waitForPredicate(() => routeIds().at(-1) === 'flows');
     expect(routeIds().at(-1)).toBe('flows');
     // A reset (not a push): Home is never routed through, and the run is off the stack.
     expect(routeIds()).not.toContain('home');
@@ -282,7 +283,7 @@ describe('Execute view — settled-run next steps', () => {
     emit?.({ type: 'completed' });
 
     await waitForViewReady(result, (f) => f.includes('Next steps'));
-    await waitFor(() => (result.lastFrame() ?? '').includes('run implement'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('run implement'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('run implement');
     expect(frame).not.toContain('run plan');

--- a/tests/integration/application/ui/tui/views/execute-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view.test.tsx
@@ -19,7 +19,8 @@ import type { TaskId } from '@src/domain/value/id/task-id.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
-import { ENTER, ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopEventBus: EventBus = {
@@ -161,7 +162,7 @@ describe('ExecuteView', () => {
     // fake runner. Re-render by re-registering a new sessions object isn't right either.
     // Instead: poke the view via tick — execute-view runs a setInterval(setNow, 1000) while
     // the session is running. Advance some time so the view re-renders.
-    await waitFor(() => /round 5/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /round 5/.test(result.lastFrame() ?? ''));
     const frame2 = result.lastFrame() ?? '';
     // The monotonic ref must hold the count at 5 even though only 2 generator entries remain
     // in the trace.
@@ -244,7 +245,7 @@ describe('ExecuteView', () => {
     });
     await waitForViewReady(result, (f) => f.includes('Refine — Done'));
     result.stdin.write(ENTER);
-    await waitFor(() => routeIds().includes('home'));
+    await waitForPredicate(() => routeIds().includes('home'));
     expect(routeIds()).toContain('home');
     expect(routeIds()).not.toContain('sprint-detail');
     result.unmount();
@@ -299,11 +300,11 @@ describe('ExecuteView', () => {
     // a fixed 30ms window, which showed up as a real ~1-in-8 flake here (always the pre-focus
     // sprintB value, never a corrupted one — confirms this is a "hasn't happened yet" race, not
     // a wrong-value bug).
-    await waitFor(() => seenSprintIds.at(-1) === sprintA);
+    await waitForPredicate(() => seenSprintIds.at(-1) === sprintA);
     expect(seenSprintIds.at(-1)).toBe(sprintA);
 
     result.stdin.write(ENTER);
-    await waitFor(() => routeEntries.some((e) => e.id === 'home'));
+    await waitForPredicate(() => routeEntries.some((e) => e.id === 'home'));
     expect(routeEntries.some((e) => e.id === 'sprint-detail')).toBe(false);
     // The converged selection (A) survives the exit — it is not reverted to the pre-focus pick.
     expect(seenSprintIds.at(-1)).toBe(sprintA);
@@ -363,7 +364,7 @@ describe('ExecuteView', () => {
     await waitForViewReady(result, (f) => f.includes('Implement — B'));
     // The seeded selection starts on A (the pre-focus pick) — `seenSprintIds` legitimately opens
     // with A; the fence is that it CONVERGES to B and stays there, not that A never appears.
-    await waitFor(() => seenSprintIds.at(-1) === sprintB);
+    await waitForPredicate(() => seenSprintIds.at(-1) === sprintB);
     expect(seenSprintIds.at(-1)).toBe(sprintB);
     result.unmount();
   });
@@ -410,7 +411,7 @@ describe('ExecuteView', () => {
     );
     await waitForViewReady(result, (f) => f.includes('Implement — No Persist'));
     // Converged in memory …
-    await waitFor(() => seenSprintIds.at(-1) === sprintA);
+    await waitForPredicate(() => seenSprintIds.at(-1) === sprintA);
     expect(seenSprintIds.at(-1)).toBe(sprintA);
     // … but never handed to the persistence callback.
     expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ sprintId: sprintA }));
@@ -540,9 +541,9 @@ describe('ExecuteView', () => {
     });
     await waitForViewReady(result, (f) => f.includes('Implement — Cancel'));
     result.stdin.write('c');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
     result.stdin.write('2');
-    await waitFor(() => findById.mock.calls.length > 0);
+    await waitForPredicate(() => findById.mock.calls.length > 0);
     expect(findById).toHaveBeenCalledWith(sprintA, TASK as unknown as TaskId);
     result.unmount();
   });
@@ -607,7 +608,7 @@ describe('ExecuteView', () => {
 
     // Open the overlay, then press `j` — the panel is muted, so the cursor stays put.
     result.stdin.write('c');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Cancel — pick a scope'));
     expect(result.lastFrame() ?? '').toContain('Cancel — pick a scope');
     result.stdin.write('j');
     await tick();
@@ -618,7 +619,7 @@ describe('ExecuteView', () => {
     await tick();
     expect(result.lastFrame() ?? '').not.toContain('Cancel — pick a scope');
     result.stdin.write('j');
-    await waitFor(() => cursorOnSecond(result.lastFrame() ?? ''));
+    await waitForPredicate(() => cursorOnSecond(result.lastFrame() ?? ''));
     expect(cursorOnSecond(result.lastFrame() ?? '')).toBe(true);
     result.unmount();
   });

--- a/tests/integration/application/ui/tui/views/flows-view.sprint-bound-launch.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.sprint-bound-launch.test.tsx
@@ -26,7 +26,8 @@ import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
 import { createSessionManager } from '@src/application/ui/tui/runtime/session-manager.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
-import { ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
@@ -127,7 +128,9 @@ describe('FlowsView — create-sprint launch does not pin the stale sprint', () 
     expect(focusedOnCreate()).toBe(true);
 
     result.stdin.write(ENTER);
-    await waitFor(() => sessions.list().some((s) => s.descriptor.flowId === 'create-sprint'), { timeoutMs: 3000 });
+    await waitForPredicate(() => sessions.list().some((s) => s.descriptor.flowId === 'create-sprint'), {
+      label: 'a create-sprint session was registered',
+    });
 
     const record = sessions.list().find((s) => s.descriptor.flowId === 'create-sprint');
     expect(record).toBeDefined();
@@ -137,7 +140,7 @@ describe('FlowsView — create-sprint launch does not pin the stale sprint', () 
     expect(record?.descriptor.pinnedSprintLabel).toBeUndefined();
 
     // The launch routed into the execute view.
-    await waitFor(() => routedIds.includes('execute'));
+    await waitForPredicate(() => routedIds.includes('execute'));
     expect(routedIds).toContain('execute');
   });
 });

--- a/tests/integration/application/ui/tui/views/flows-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/flows-view.test.tsx
@@ -15,7 +15,8 @@ import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repo
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
-import { DOWN, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const FIXED_PROJECT_ID = 'project-fixture-id' as unknown as ProjectId;
@@ -92,7 +93,7 @@ describe('FlowsView', () => {
   it('renders the no-project orientation regime on a fresh install', async () => {
     const { result } = renderView(<FlowsView />, { deps: emptyDeps, initial: { id: 'flows' } });
     // Wait for the async deps load + Ink render to settle; orientation card is always present.
-    await waitFor(() => /no project|pick one/i.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /no project|pick one/i.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     // The card should direct the user toward picking or creating a project.
     expect(frame).toMatch(/no project|pick one/i);
@@ -106,7 +107,7 @@ describe('FlowsView', () => {
     // hidden too; the user is meant to land here only after picking or creating a project.
     const { result } = renderView(<FlowsView />, { deps: emptyDeps, initial: { id: 'flows' } });
     // Anchor on the orientation card so absence assertions run on a fully-settled frame.
-    await waitFor(() => /no project|pick one/i.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /no project|pick one/i.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).not.toContain('Create sprint');
     expect(frame).not.toContain('Refine');
@@ -124,7 +125,7 @@ describe('FlowsView', () => {
       initial: { id: 'flows' },
       selection: { projectId: FIXED_PROJECT_ID }, // sprintId intentionally omitted
     });
-    await waitFor(() => /no sprint|create one|pick one/i.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /no sprint|create one|pick one/i.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).toMatch(/no sprint|create one|pick one/i);
     result.unmount();
@@ -140,7 +141,7 @@ describe('FlowsView', () => {
       initial: { id: 'flows' },
       selection: { projectId: FIXED_PROJECT_ID, sprintId: FIXED_SPRINT_ID },
     });
-    await waitFor(() => (result.lastFrame() ?? '').includes('Fixture Sprint'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Fixture Sprint'));
     const frame = result.lastFrame() ?? '';
     // Sprint name must appear in the orientation card.
     expect(frame).toContain('Fixture Sprint');
@@ -155,7 +156,7 @@ describe('FlowsView', () => {
 
   it('publishes the r reload-state hint', async () => {
     const { result } = renderView(<FlowsView />, { deps: emptyDeps, initial: { id: 'flows' } });
-    await waitFor(() => /reload/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /reload/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).toMatch(/reload/);
     result.unmount();
@@ -177,7 +178,7 @@ describe('FlowsView', () => {
     // rendered before asserting — a fixed tick can capture a pre-load frame under coverage.
     // New copy: Refine reason mentions "ticket" (add at least one), Plan reason mentions
     // "Refine and approve" — both contain "ticket".
-    await waitFor(() => /ticket/i.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /ticket/i.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     // At least one trigger reason should be visible — both Refine and Plan are dimmed.
     // Use a forgiving check: the reason text may be truncated on narrow test terminals.
@@ -198,7 +199,7 @@ describe('FlowsView', () => {
     // Wait for the async project + sprint load to settle so the sprint-scoped "Remove ticket" row
     // is rendered. This was the flake source: a fixed tick(40) under coverage instrumentation
     // could capture the frame before the load resolved, so the row was absent.
-    await waitFor(() => (result.lastFrame() ?? '').includes('Remove ticket'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'));
     const frame = result.lastFrame() ?? '';
     // The "Remove ticket" row should appear.
     expect(frame).toContain('Remove ticket');
@@ -227,11 +228,11 @@ describe('FlowsView — cost hints (manifest → menu threading)', () => {
       selection: { projectId: FIXED_PROJECT_ID, sprintId: FIXED_SPRINT_ID },
     });
     // Wait for the orientation card to settle so the view is interactive.
-    await waitFor(() => (result.lastFrame() ?? '').includes('Fixture Sprint'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Fixture Sprint'));
 
     // Press `v` to show all flows — this makes Ideate visible in the menu.
     result.stdin.write('v');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Ideate'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Ideate'));
 
     // Navigate down until the Ideate cost hint becomes visible (cursor lands on Ideate).
     const IDEATE_HINT = 'single AI session';

--- a/tests/integration/application/ui/tui/views/home-create-hotkey.test.tsx
+++ b/tests/integration/application/ui/tui/views/home-create-hotkey.test.tsx
@@ -19,7 +19,8 @@ import type { SprintExecutionRepository } from '@src/domain/repository/sprint/sp
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { makeProject } from '@tests/fixtures/domain.ts';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopVersionChecker = async (): Promise<null> => null;
@@ -99,7 +100,7 @@ describe('HomeView — + hotkey', () => {
 
     // Press '+' — should launch create-sprint.
     result.stdin.write('+');
-    await waitFor(() => routedIds.length > 0 && routedIds[routedIds.length - 1] !== 'home');
+    await waitForPredicate(() => routedIds.length > 0 && routedIds[routedIds.length - 1] !== 'home');
 
     // The router should have been asked to push the create-sprint execute view.
     // The implementer may route via 'execute' (after launching the runner) or navigate to

--- a/tests/integration/application/ui/tui/views/home-digit-hotkey.test.tsx
+++ b/tests/integration/application/ui/tui/views/home-digit-hotkey.test.tsx
@@ -28,7 +28,7 @@ import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
 import { NotFoundError } from '@src/domain/value/error/not-found-error.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { makeDraftSprint, makeProject } from '@tests/fixtures/domain.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const noopVersionChecker = async (): Promise<null> => null;
@@ -120,7 +120,7 @@ describe('HomeView — digit quick-switch hotkeys', () => {
 
     // '1' maps to the newest non-current recent sprint (Beta) — a real switch.
     result.stdin.write('1');
-    await waitFor(() => seenSprintIds.at(-1) === sprintB.id);
+    await waitForPredicate(() => seenSprintIds.at(-1) === sprintB.id);
 
     expect(seenSprintIds.at(-1)).toBe(sprintB.id);
     result.unmount();

--- a/tests/integration/application/ui/tui/views/implement-main-area.test.tsx
+++ b/tests/integration/application/ui/tui/views/implement-main-area.test.tsx
@@ -22,7 +22,8 @@ import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 
 const ts = (n: number): IsoTimestamp => new Date(Date.UTC(2026, 0, 1, 0, 0, n)).toISOString() as IsoTimestamp;
@@ -109,7 +110,7 @@ describe('ImplementMainArea — Esc collapse-before-pop', () => {
     const { result } = mount();
     await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
     // Confirm the second route + the live claim's precondition (card expanded) both settled.
-    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
 
     result.stdin.write(ESC);
     await tick(60);
@@ -126,7 +127,7 @@ describe('ImplementMainArea — Esc collapse-before-pop', () => {
   it('Esc with no expanded card pops the route as before', async () => {
     const { result } = mount();
     await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
-    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
 
     // First Esc collapses the auto-expanded card (releasing the claim).
     result.stdin.write(ESC);
@@ -136,7 +137,7 @@ describe('ImplementMainArea — Esc collapse-before-pop', () => {
 
     // Second Esc — no card expanded, no claim held — the global handler pops the route.
     result.stdin.write(ESC);
-    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:execute:1'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('ROUTE:execute:1'));
     expect(result.lastFrame() ?? '').toContain('ROUTE:execute:1');
 
     result.unmount();
@@ -145,7 +146,7 @@ describe('ImplementMainArea — Esc collapse-before-pop', () => {
   it('unmounting while expanded releases the claim (no stale claim blocking Esc elsewhere)', async () => {
     const { result } = mount();
     await waitForViewReady(result, (f) => f.includes(LIVE_SIGNAL_TEXT));
-    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('ROUTE:sessions:2'));
 
     // Unmount ImplementMainArea while its focused card is still expanded — the claim is live.
     result.stdin.write('u');
@@ -154,7 +155,7 @@ describe('ImplementMainArea — Esc collapse-before-pop', () => {
 
     // A leaked claim would swallow this Esc forever; the unmount cleanup must have released it.
     result.stdin.write(ESC);
-    await waitFor(() => (result.lastFrame() ?? '').includes('ROUTE:execute:1'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('ROUTE:execute:1'));
     expect(result.lastFrame() ?? '').toContain('ROUTE:execute:1');
 
     result.unmount();

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -14,7 +14,8 @@ import type { ProjectRepository } from '@src/domain/repository/project/project-r
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { FIXED_PROJECT_ID, makeProject, makeRepository, repositoryId, slug } from '@tests/fixtures/domain.ts';
-import { DOWN, ENTER, tick, UP, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, ENTER, tick, UP } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const fakeProjectRepo = (project: Project): ProjectRepository =>
@@ -291,7 +292,7 @@ describe('ProjectDetailView', () => {
     });
     await waitForViewReady(result);
     result.stdin.write(ENTER);
-    await waitFor(() => queue.head !== undefined);
+    await waitForPredicate(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     expect(queue.head?.message ?? '').toContain('Rename project');
   });

--- a/tests/integration/application/ui/tui/views/projects-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/projects-view.test.tsx
@@ -10,7 +10,7 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import { makeProject, makeRepository } from '@tests/fixtures/domain.ts';
-import { waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { ProjectId } from '@src/domain/value/id/project-id.ts';
@@ -113,7 +113,7 @@ describe('ProjectsView', () => {
     const { result, routeIds } = renderView(<ProjectsView />, { deps: stubDeps([]), initial: { id: 'projects' } });
     await waitForViewReady(result, (f) => f.includes('No projects yet'));
     result.stdin.write('c');
-    await waitFor(() => routeIds().includes('create-project'));
+    await waitForPredicate(() => routeIds().includes('create-project'));
     expect(routeIds()).toContain('create-project');
     result.unmount();
   });
@@ -139,13 +139,13 @@ describe('ProjectsView', () => {
     const { result } = renderView(<ProjectsView />, { deps, initial: { id: 'projects' }, queue });
     await waitForViewReady(result, (f) => f.includes('Old Label'));
     result.stdin.write('e');
-    await waitFor(() => queue.head !== undefined);
+    await waitForPredicate(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Old Label');
     }
     queue.resolveHead('New Label');
-    await waitFor(() => save.mock.calls.length > 0);
+    await waitForPredicate(() => save.mock.calls.length > 0);
     expect(save).toHaveBeenCalledTimes(1);
     expect(save.mock.calls[0]?.[0]?.displayName).toBe('New Label');
     result.unmount();

--- a/tests/integration/application/ui/tui/views/sessions-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sessions-view.test.tsx
@@ -19,7 +19,8 @@ import {
 } from '@src/application/ui/tui/runtime/session-manager.ts';
 import type { Runner } from '@src/application/chain/run/runner.ts';
 import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
-import { DOWN, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const emptyDeps: AppDeps = {} as unknown as AppDeps;
@@ -129,13 +130,13 @@ describe('SessionsView', () => {
 
     // Move the cursor onto the middle session (Bravo, id s-b).
     result.stdin.write(DOWN);
-    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
+    await waitForPredicate(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     // Reorder so the index that used to hold Bravo now holds a different session. The cursor
     // must follow the id (Bravo), not the old index-1 slot.
     setList([c, a, b]);
-    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
+    await waitForPredicate(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     result.unmount();
@@ -160,7 +161,7 @@ describe('SessionsView', () => {
 
     // Focus Bravo, then evict Bravo. The cursor snaps to a survivor (by prior index, clamped).
     result.stdin.write(DOWN);
-    await waitFor(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
+    await waitForPredicate(() => (focusedTitle(result.lastFrame() ?? '') ?? '').includes('Bravo'));
     expect(focusedTitle(result.lastFrame() ?? '')).toContain('Bravo');
 
     setList([a, c]);
@@ -172,7 +173,7 @@ describe('SessionsView', () => {
     // Enter must open the execute view for the session the cursor now sits on — not the evicted
     // one. The cursor landed on Charlie (prior index 1, clamped into the 2-item list).
     result.stdin.write('\r');
-    await waitFor(() => routed.length > 0);
+    await waitForPredicate(() => routed.length > 0);
     expect(routed.at(-1)).toBe('s-c');
 
     result.unmount();

--- a/tests/integration/application/ui/tui/views/settings-view.escalation-map.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.escalation-map.test.tsx
@@ -14,7 +14,8 @@ import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { ENTER, RIGHT, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, RIGHT, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 vi.mock('@src/integration/system/detect-cli.ts', async () => {
@@ -61,9 +62,9 @@ describe('SettingsView — escalation map editor', () => {
     const deps = { settingsRepo: repo } as unknown as AppDeps;
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
 
-    await waitFor(() => (result.lastFrame() ?? '').includes('Presets'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Presets'));
     await goToHarness(result.stdin);
-    await waitFor(() => (result.lastFrame() ?? '').includes('Escalation map'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Escalation map'));
 
     // The defaults summary is visible before any override exists.
     expect(result.lastFrame() ?? '').toContain('Effective ladder');
@@ -75,21 +76,21 @@ describe('SettingsView — escalation map editor', () => {
       await tick(15);
     }
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('step 1/2'));
 
     // Step 1 — first catalog entry is claude-haiku-4-5.
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('step 2/2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('step 2/2'));
     expect(result.lastFrame() ?? '').toContain('claude-haiku-4-5');
 
     // Step 2 — first compatible target is claude-sonnet-4-6.
     result.stdin.write(ENTER);
-    await waitFor(() => saved() !== undefined);
+    await waitForPredicate(() => saved() !== undefined);
 
     expect(saved()?.harness.escalationMap).toEqual({ 'claude-haiku-4-5': 'claude-sonnet-4-6' });
 
     // Back on the section: the override row + customised ladder render after the refresh.
-    await waitFor(() => (result.lastFrame() ?? '').includes('1 override'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('1 override'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('claude-haiku-4-5');
     expect(frame).toContain('(customised)');
@@ -101,20 +102,20 @@ describe('SettingsView — escalation map editor', () => {
     const deps = { settingsRepo: repo } as unknown as AppDeps;
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
 
-    await waitFor(() => (result.lastFrame() ?? '').includes('Presets'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Presets'));
     await goToHarness(result.stdin);
-    await waitFor(() => (result.lastFrame() ?? '').includes('Escalation map'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Escalation map'));
     for (let i = 0; i < 10; i += 1) {
       result.stdin.write('j');
       await tick(15);
     }
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('step 1/2'));
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('step 2/2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('step 2/2'));
 
     result.stdin.write(String.fromCharCode(27)); // esc
-    await waitFor(() => (result.lastFrame() ?? '').includes('step 1/2'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('step 1/2'));
 
     expect(saved()).toBeUndefined();
   });

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -11,7 +11,8 @@ import { SettingsView } from '@src/application/ui/tui/views/settings-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
 import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
-import { ENTER, RIGHT, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER, RIGHT, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 // Hoisted state holder — each test mutates this before rendering so the mocked
@@ -305,7 +306,7 @@ describe('SettingsView', () => {
     ): Promise<void> => {
       await goToSection(stdin, 'refine');
       stdin.write(ENTER);
-      await waitFor(() => (lastFrame() ?? '').includes('↑/↓ navigate · ↵ submit · esc cancel'));
+      await waitForPredicate(() => (lastFrame() ?? '').includes('↑/↓ navigate · ↵ submit · esc cancel'));
     };
 
     it("labels unavailable providers as '(not installed)' in the provider picker", async () => {

--- a/tests/integration/application/ui/tui/views/skills-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/skills-view.test.tsx
@@ -18,7 +18,8 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import { BUNDLED_SKILLS } from '@src/integration/ai/skills/_engine/registry.ts';
 import type { SkillCatalogEntry, SkillCatalogPort } from '@src/integration/ai/skills/_engine/skill-catalog-port.ts';
 import { SkillsView } from '@src/application/ui/tui/views/skills-view.tsx';
-import { DOWN, ENTER, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { DOWN, ENTER, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const abs = (p: string): AbsolutePath => {
@@ -153,7 +154,7 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('e');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Enable'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain(`Enable "${name}" for:`);
     // Refine is default-on: shown but disabled with an explanatory description.
@@ -171,9 +172,9 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('e');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Enable'));
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('enabled'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('enabled'));
 
     const listed = await catalog.list();
     expect(listed.ok).toBe(true);
@@ -195,7 +196,7 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes('hand-authored-thing'));
 
     result.stdin.write('e');
-    await waitFor(() => (result.lastFrame() ?? '').includes('nothing to enable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('nothing to enable'));
     expect(result.lastFrame() ?? '').not.toContain('Enable "hand-authored-thing" for:');
   });
 
@@ -208,11 +209,11 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('d');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Disable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Disable'));
     result.stdin.write(' '); // toggle Plan on
     await tick();
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('disabled'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('disabled'));
 
     const listed = await catalog.list();
     expect(listed.ok).toBe(true);
@@ -235,17 +236,17 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('d');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Disable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Disable'));
     result.stdin.write(' ');
     await tick();
     result.stdin.write(ENTER);
-    await waitFor(() => (result.lastFrame() ?? '').includes('permanently lost'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('permanently lost'));
     // The install must still be present — nothing happened until the confirm is answered.
     const midway = await catalog.list();
     expect(midway.ok && midway.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
 
     result.stdin.write('y');
-    await waitFor(() => (result.lastFrame() ?? '').includes('disabled'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('disabled'));
     const after = await catalog.list();
     expect(after.ok && after.value[0]?.installs).toEqual([]);
   });
@@ -275,7 +276,7 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(first.name));
 
     result.stdin.write('U');
-    await waitFor(() => (result.lastFrame() ?? '').includes('updated 1 skill'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('updated 1 skill'));
 
     const listed = await catalog.list();
     expect(listed.ok).toBe(true);
@@ -293,7 +294,7 @@ describe('SkillsView', () => {
       updateAll: vi.fn(),
     } as unknown as SkillCatalogPort;
     const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
-    await waitFor(() => (result.lastFrame() ?? '').includes('Failed to load'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Failed to load'));
     expect(result.lastFrame() ?? '').toContain('Failed to load the skill catalog.');
   });
 
@@ -317,7 +318,10 @@ describe('SkillsView', () => {
     result.stdin.write(DOWN);
     await tick();
     result.stdin.write('r');
-    await waitFor(() => (result.lastFrame() ?? '').includes(second.name));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes(second.name), {
+      label: `the reloaded catalog rendered '${second.name}'`,
+    });
+    expect(result.lastFrame() ?? '').toContain(second.name);
   });
 
   it('update (u): declining the overwrite confirm leaves the copy untouched', async () => {
@@ -335,13 +339,13 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('u');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Overwrite?'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Overwrite?'));
     // Nothing written until the confirm is answered.
     const midway = await catalog.list();
     expect(midway.ok && midway.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
 
     result.stdin.write('n');
-    await waitFor(() => !(result.lastFrame() ?? '').includes('Overwrite?'));
+    await waitForPredicate(() => !(result.lastFrame() ?? '').includes('Overwrite?'));
     const declined = await catalog.list();
     expect(declined.ok && declined.value[0]?.installs).toEqual([{ flow: 'plan', status: 'locally-modified' }]);
   });
@@ -361,9 +365,9 @@ describe('SkillsView', () => {
     await waitForViewReady(result, (f) => f.includes(name));
 
     result.stdin.write('u');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Overwrite?'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Overwrite?'));
     result.stdin.write('y');
-    await waitFor(() => (result.lastFrame() ?? '').includes('updated'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('updated'));
     const after = await catalog.list();
     expect(after.ok && after.value[0]?.installs).toEqual([{ flow: 'plan', status: 'in-sync' }]);
   });
@@ -376,7 +380,10 @@ describe('SkillsView', () => {
     const { result } = renderView(<SkillsView />, { deps: buildDeps(catalog), initial: { id: 'skills' } });
     await waitForViewReady(result, (f) => f.includes(name));
     result.stdin.write('u');
-    await waitFor(() => (result.lastFrame() ?? '').includes('already up to date'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('already up to date'), {
+      label: "the 'already up to date' notice rendered",
+    });
+    expect(result.lastFrame() ?? '').toContain('already up to date');
   });
 
   it('offers Create PR — its view / CLI compose a skill source directly, same as any mounting flow', async () => {
@@ -398,7 +405,7 @@ describe('SkillsView', () => {
     expect(frame).not.toContain('◌ pr');
 
     result.stdin.write('e');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Enable'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Enable'));
     const picker = result.lastFrame() ?? '';
     // Offered but disabled — it's already default-on for createPr, same treatment as any flow.
     expect(picker).toContain('Create PR');
@@ -455,7 +462,7 @@ describe('SkillsView', () => {
     expect(result.lastFrame() ?? '').toContain('◌ imp');
 
     result.stdin.write('c');
-    await waitFor(() => (result.lastFrame() ?? '').includes('■ imp'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('■ imp'));
 
     expect(current.ai.skills?.implement?.disabled).toEqual([]);
   });

--- a/tests/integration/application/ui/tui/views/sprint-detail-evaluation-open.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-evaluation-open.test.tsx
@@ -27,7 +27,8 @@ import type { Task } from '@src/domain/entity/task.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
 import { recordRunningAttemptEvaluation, startNextAttempt } from '@src/domain/entity/task-attempts.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeTodoTask } from '@tests/fixtures/domain.ts';
 
@@ -111,7 +112,7 @@ describe('SprintDetailView — `v` opens the focused task evaluation', () => {
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('v');
-    await waitFor(() => (result.lastFrame() ?? '').includes('TARGET:wire the migration'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('TARGET:wire the migration'));
 
     expect(result.lastFrame() ?? '').toContain('TARGET:wire the migration:1:failed:rounds/2/evaluator/evaluation.md');
     result.unmount();
@@ -125,7 +126,7 @@ describe('SprintDetailView — `v` opens the focused task evaluation', () => {
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('v');
-    await waitFor(() => (result.lastFrame() ?? '').includes('TARGET:legacy task'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('TARGET:legacy task'));
 
     // The chord still opens — the overlay owns the degrade, not the view.
     expect(result.lastFrame() ?? '').toContain('TARGET:legacy task:1:failed:no-file');

--- a/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-make-current.test.tsx
@@ -19,7 +19,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 
 const SPRINT_ID = 'sprint-make-current-id' as unknown as SprintId;
@@ -90,7 +91,7 @@ describe('SprintDetailView — m key makes current', () => {
     await waitForViewReady(result, (f) => f.includes('Make Current Sprint'));
 
     result.stdin.write('m');
-    await waitFor(() => setSprint.mock.calls.length === 1);
+    await waitForPredicate(() => setSprint.mock.calls.length === 1);
 
     expect(setSprint).toHaveBeenCalledTimes(1);
     const [calledId, calledLabel] = setSprint.mock.calls[0] as [SprintId | undefined, string | undefined];
@@ -139,7 +140,7 @@ describe('SprintDetailView — m key makes current', () => {
     await waitForViewReady(result, (f) => f.includes('Scoped Sprint'));
 
     result.stdin.write('n');
-    await waitFor(() => setSprint.mock.calls.length === 1);
+    await waitForPredicate(() => setSprint.mock.calls.length === 1);
 
     expect(setSprint).toHaveBeenCalledTimes(1);
     const [calledId, calledLabel] = setSprint.mock.calls[0] as [SprintId | undefined, string | undefined];

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.card-harmony.test.tsx
@@ -29,7 +29,7 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { renderView, stripAnsi, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const sizeRef = vi.hoisted(() => ({ columns: 120, rows: 40 }));
@@ -39,10 +39,6 @@ vi.mock('@src/application/ui/tui/runtime/use-terminal-size.ts', () => ({
 }));
 
 const FIXED_SPRINT_ID = 'sprint-fixture-id' as unknown as SprintId;
-
-// eslint-disable-next-line no-control-regex
-const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
-const stripAnsi = (s: string): string => s.replace(ANSI_ESCAPE_PATTERN, '');
 
 const makeSprint = (tickets: readonly unknown[]): Sprint =>
   ({

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -23,7 +23,8 @@ import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repo
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { ESC, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeApprovedTicket, makeDraftSprint } from '@tests/fixtures/domain.ts';
 
@@ -78,12 +79,12 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Expand the first ticket (cursor starts at idx 0).
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to the second ticket and expand it without collapsing the first.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
     const frame = result.lastFrame() ?? '';
     // Both expanded views render their per-ticket Requirements heading; if either card
@@ -102,12 +103,12 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Open card 0.
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to card 1 and open it.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
     // Move back to card 0 and toggle it closed.
     result.stdin.write('k');
     await tick(40);
@@ -130,11 +131,11 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Expand both cards.
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
     // Confirm pre-condition: both cards expanded.
     let frame = result.lastFrame() ?? '';
@@ -161,7 +162,7 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Expand only the first card.
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
 
     // Navigate cursor up and down across all three cards.
     result.stdin.write('j');
@@ -228,14 +229,14 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Open card 0 (alpha).
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move down twice to card 2 (charlie) and open it.
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('j');
     await tick(40);
     result.stdin.write('o');
-    await waitFor(() => (result.lastFrame() ?? '').includes('requirements for charlie card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for charlie card'));
 
     // Pre-condition: alpha and charlie expanded; bravo collapsed.
     let frame = result.lastFrame() ?? '';
@@ -251,9 +252,9 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     result.stdin.write('k');
     await tick(40);
     result.stdin.write('d');
-    await waitFor(() => (result.lastFrame() ?? '').includes('Remove ticket'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'));
     result.stdin.write('y');
-    await waitFor(() => {
+    await waitForPredicate(() => {
       const f = result.lastFrame() ?? '';
       return f.includes('alpha card') && f.includes('charlie card') && !f.includes('Loading');
     });

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
@@ -13,7 +13,8 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
@@ -179,10 +180,10 @@ describe('SprintDetailView — phase workspace', () => {
     await waitForViewReady(result, (f) => f.includes('wedged'));
     // Cursor starts at idx 0 (the ticket). Press 'j' once to land on the (one) task below.
     result.stdin.write('j');
-    await waitFor(() => (result.lastFrame() ?? '').includes('unbl'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('unbl'));
     result.stdin.write('u');
     // Give the async use case + reload a chance to settle.
-    await waitFor(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
@@ -222,17 +223,17 @@ describe('SprintDetailView — phase workspace', () => {
     await waitForViewReady(result, (f) => f.includes('Typo iin Title'));
     // Cursor starts on the ticket. Press 'e' → opens the field-picker choice.
     result.stdin.write('e');
-    await waitFor(() => queue.head !== undefined);
+    await waitForPredicate(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('choice');
     // Pick "title" (the first option for a pending ticket).
     queue.resolveHead('title');
-    await waitFor(() => queue.head?.kind === 'text');
+    await waitForPredicate(() => queue.head?.kind === 'text');
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Typo iin Title');
     }
     queue.resolveHead('Typo in Title');
-    await waitFor(() => save.mock.calls.length === 1);
+    await waitForPredicate(() => save.mock.calls.length === 1);
     expect(save).toHaveBeenCalledTimes(1);
     const saved = save.mock.calls[0]?.[0];
     expect(saved?.tickets?.[0]?.title).toBe('Typo in Title');
@@ -279,7 +280,7 @@ describe('SprintDetailView — phase workspace', () => {
     await waitForViewReady(result, (f) => f.includes('stuck-task'));
     // Cursor starts on the ticket; press 'j' to land on the blocked task.
     result.stdin.write('j');
-    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /unbl/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     // The 'u unblock' hint must appear in the status bar footer area. The terminal width used
     // by ink-testing-library may wrap the label across lines — match a prefix that survives
@@ -377,7 +378,7 @@ describe('SprintDetailView — phase workspace', () => {
     await waitForViewReady(result, (f) => f.includes('in-progress-stuck'));
     // Cursor starts on the ticket; press 'j' to land on the in_progress task.
     result.stdin.write('j');
-    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /unbl/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('in-progress-stuck');
     // The 'u unblock' hint must appear for in_progress tasks, same as for blocked.
@@ -435,9 +436,9 @@ describe('SprintDetailView — phase workspace', () => {
     await waitForViewReady(result, (f) => f.includes('crashed-task'));
     // Cursor starts on the ticket; press 'j' to land on the in_progress task.
     result.stdin.write('j');
-    await waitFor(() => /unbl/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /unbl/.test(result.lastFrame() ?? ''));
     result.stdin.write('u');
-    await waitFor(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('✓ unblocked'));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.windowing.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.windowing.test.tsx
@@ -23,7 +23,8 @@ import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repo
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 
 const sizeRef = vi.hoisted(() => ({ columns: 120, rows: 24 }));
@@ -111,7 +112,7 @@ describe('SprintDetailView — task-list windowing (M4 guard)', () => {
 
       await tick(8);
     }
-    await waitFor(() => (result.lastFrame() ?? '').includes('task-marker-19'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('task-marker-19'));
 
     const frame = result.lastFrame() ?? '';
     // The focused task (#19) must be inside the rendered window — the M4 regression would have it

--- a/tests/integration/application/ui/tui/views/sprints-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprints-view.test.tsx
@@ -16,7 +16,8 @@ import type { TaskRepository } from '@src/domain/repository/task/task-repository
 import type { Task } from '@src/domain/entity/task.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { ProjectId } from '@src/domain/value/id/project-id.ts';
-import { END, tick, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { END, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { createPromptQueue } from '@src/application/ui/tui/prompts/prompt-queue.ts';
 import { makeDraftSprint, makeTodoTask } from '@tests/fixtures/domain.ts';
@@ -122,7 +123,7 @@ describe('SprintsView', () => {
     const { result } = renderView(<SprintsView />, { deps: stubDeps([done]), initial: { id: 'sprints' } });
     await waitForViewReady(result, (f) => f.includes('Shipped Sprint'));
     result.stdin.write('e');
-    await waitFor(() => (result.lastFrame() ?? '').includes("done sprints can't be renamed"));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes("done sprints can't be renamed"));
     const frame = result.lastFrame() ?? '';
     // Someone who found `e` via `?` should learn why it's inert, not be left guessing.
     expect(frame).toContain("done sprints can't be renamed");
@@ -150,7 +151,7 @@ describe('SprintsView', () => {
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' }, queue });
     await waitForViewReady(result, (f) => f.includes('Mispeld Sprint'));
     result.stdin.write('e');
-    await waitFor(() => queue.head !== undefined);
+    await waitForPredicate(() => queue.head !== undefined);
     expect(queue.head?.kind).toBe('text');
     if (queue.head?.kind === 'text') {
       expect(queue.head.initial).toBe('Mispeld Sprint');
@@ -249,7 +250,7 @@ describe('SprintsView', () => {
     await waitForViewReady(result, (f) => f.includes('Recovery Sprint') && f.includes('unblock'));
     result.stdin.write('u');
     // The sequential unblock loop + feedback + task refresh complete when the toast lands.
-    await waitFor(() => /unblocked 1 task/.test(result.lastFrame() ?? ''));
+    await waitForPredicate(() => /unblocked 1 task/.test(result.lastFrame() ?? ''));
     const frame = result.lastFrame() ?? '';
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
@@ -297,7 +298,7 @@ describe('SprintsView', () => {
     const { result } = renderView(<SprintsView />, { deps, initial: { id: 'sprints' } });
     await waitForViewReady(result, (f) => f.includes('Crash Sprint') && f.includes('unblock'));
     result.stdin.write('u');
-    await waitFor(() => updateCalls.length === 1);
+    await waitForPredicate(() => updateCalls.length === 1);
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]?.status).toBe('todo');
     result.unmount();
@@ -359,7 +360,7 @@ describe('SprintsView', () => {
     expect(before).not.toContain('Sprint 01');
 
     result.stdin.write(END);
-    await waitFor(() => (result.lastFrame() ?? '').includes('Sprint 01'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Sprint 01'));
     const after = result.lastFrame() ?? '';
     // After End the window has scrolled to the bottom: the previously-hidden oldest sprint shows,
     // and the newest has scrolled off the top.

--- a/tests/integration/application/ui/tui/views/use-bucketed-tasks-blocked-cursor.test.tsx
+++ b/tests/integration/application/ui/tui/views/use-bucketed-tasks-blocked-cursor.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * The Execute header's "current task" cursor must move PAST a dependency-blocked task.
+ *
+ * A gate-blocked task traces `dependency-gate-<id>` (completed) + `task-body-<id>` (skipped) and
+ * nothing else. It used to bucket as `running` forever, and the cursor scan ("first non-completed
+ * task") pinned the header's active-task / current-substep readout on it for the rest of the run
+ * while the tasks that actually executed ran unnoticed underneath.
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { describe, expect, it } from 'vitest';
+import { createInMemoryEventBus } from '@src/integration/observability/in-memory-event-bus.ts';
+import type { Trace } from '@src/application/chain/trace.ts';
+import type { BucketedDerivation } from '@src/application/ui/tui/views/execute-view-internals/use-bucketed-tasks.ts';
+import { useBucketedTasks } from '@src/application/ui/tui/views/execute-view-internals/use-bucketed-tasks.ts';
+import type { SessionDescriptor } from '@src/application/ui/tui/runtime/session-manager.ts';
+
+const BLOCKED = '01933fbb-1111-7000-8000-000000000001';
+const RUNNING = '01933fbb-2222-7000-8000-000000000002';
+
+/** Task 1 blocked upstream by the dependency gate; task 2 mid gen-eval loop. */
+const TRACE: Trace = [
+  { elementName: `dependency-gate-${BLOCKED}`, status: 'completed', durationMs: 2 },
+  { elementName: `task-body-${BLOCKED}`, status: 'skipped', durationMs: 0 },
+  { elementName: `dependency-gate-${RUNNING}`, status: 'completed', durationMs: 2 },
+  { elementName: `generator-${RUNNING}`, status: 'completed', durationMs: 40 },
+];
+
+const descriptor: SessionDescriptor = {
+  id: 'r-1',
+  flowId: 'implement',
+  title: 'Implement — test',
+  status: 'running',
+  startedAt: 0,
+  trace: TRACE,
+  taskNames: new Map([
+    [BLOCKED, 'Blocked upstream task'],
+    [RUNNING, 'The task actually running'],
+  ]),
+};
+
+const Probe = ({
+  bus,
+  onState,
+}: {
+  readonly bus: ReturnType<typeof createInMemoryEventBus>;
+  readonly onState: (derivation: BucketedDerivation) => void;
+}): React.JSX.Element => {
+  const derivation = useBucketedTasks({ descriptor, chainEvents: [], signals: [], eventBus: bus });
+  onState(derivation);
+  return <Text>tasks={derivation.tasksTotal}</Text>;
+};
+
+describe('useBucketedTasks — dependency-blocked cursor', () => {
+  it('points the current-task readout at the running sibling, not the blocked task', () => {
+    const bus = createInMemoryEventBus();
+    let last: BucketedDerivation | undefined;
+    const r = render(<Probe bus={bus} onState={(d) => (last = d)} />);
+
+    expect(last?.bucketed?.tasks[0]?.status).toBe('skipped');
+    expect(last?.currentTask?.id).toBe(RUNNING);
+    expect(last?.currentTaskName).toBe('The task actually running');
+    expect(last?.currentSubStep).toBe('generator');
+    r.unmount();
+  });
+
+  it('reports no current task once every task has settled', () => {
+    const bus = createInMemoryEventBus();
+    let last: BucketedDerivation | undefined;
+    const settled: Trace = [
+      { elementName: `dependency-gate-${BLOCKED}`, status: 'completed', durationMs: 2 },
+      { elementName: `task-body-${BLOCKED}`, status: 'skipped', durationMs: 0 },
+      { elementName: `generator-${RUNNING}`, status: 'completed', durationMs: 40 },
+      { elementName: `uninstall-skills-${RUNNING}`, status: 'completed', durationMs: 3 },
+    ];
+    const Settled = (): React.JSX.Element => {
+      const derivation = useBucketedTasks({
+        descriptor: { ...descriptor, trace: settled },
+        chainEvents: [],
+        signals: [],
+        eventBus: bus,
+      });
+      last = derivation;
+      return <Text>x</Text>;
+    };
+    const r = render(<Settled />);
+
+    expect(last?.currentTask).toBeUndefined();
+    // Only the task that genuinely finished counts as done — the blocked one is not a pass.
+    expect(last?.tasksDone).toBe(1);
+    expect(last?.tasksTotal).toBe(2);
+    r.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/welcome-view-idempotence.test.tsx
+++ b/tests/integration/application/ui/tui/views/welcome-view-idempotence.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * WelcomeView seeding must be idempotent against DISK, not just against its own component
+ * instance. The old guard was a per-instance `useRef`, so any re-mount of the view (the `h` /
+ * `D` chords used to do exactly that on a first-run session) re-ran the PATH probe and
+ * re-applied the AI preset — `applyPreset` replaces the whole `ai` section, silently clobbering
+ * anything the user had just configured in Settings during the same session.
+ *
+ * The view's own header comment asserts the invariant: "an existing settings file means the
+ * user already set up readiness", so a mount that finds one must route onward without writing.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import type { AiProvider, Settings } from '@src/domain/entity/settings.ts';
+import { WelcomeView } from '@src/application/ui/tui/views/welcome-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { Project } from '@src/domain/entity/project.ts';
+import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
+import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { makeProject } from '@tests/fixtures/domain.ts';
+import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+
+const detectRef = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock('@src/integration/system/detect-cli.ts', () => ({
+  detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> => {
+    detectRef.calls += 1;
+    return new Set<AiProvider>(['claude-code']);
+  },
+  PROVIDER_BINARY: {
+    'claude-code': 'claude',
+    'github-copilot': 'copilot',
+    'openai-codex': 'codex',
+    opencode: 'opencode',
+  },
+}));
+
+const settingsRepoWith = (exists: boolean, save: (s: Settings) => void): SettingsRepository => ({
+  path: '/tmp/test-settings.json',
+  async exists() {
+    return Result.ok(exists);
+  },
+  async load() {
+    return Result.ok(DEFAULT_SETTINGS);
+  },
+  save: (async (s: Settings) => {
+    save(s);
+    return Result.ok(undefined);
+  }) as unknown as SettingsRepository['save'],
+});
+
+const fakeProjectRepo = (projects: readonly Project[]): ProjectRepository =>
+  ({
+    async list() {
+      return Result.ok(projects);
+    },
+  }) as unknown as ProjectRepository;
+
+describe('WelcomeView — disk-backed seed idempotence', () => {
+  it('never re-applies the preset when a settings file already exists', async () => {
+    detectRef.calls = 0;
+    const saved: Settings[] = [];
+    const deps: AppDeps = {
+      settingsRepo: settingsRepoWith(true, (s) => saved.push(s)),
+      projectRepo: fakeProjectRepo([makeProject()]),
+    } as unknown as AppDeps;
+
+    const routes: ViewEntry[] = [];
+    renderView(<WelcomeView />, { deps, initial: { id: 'welcome' }, onRoute: (e) => routes.push(e) });
+    await waitForPredicate(() => routes.at(-1)?.id === 'home');
+
+    expect(saved).toHaveLength(0);
+    expect(detectRef.calls).toBe(0);
+  });
+
+  it('still seeds (and routes on) when no settings file exists yet', async () => {
+    detectRef.calls = 0;
+    const saved: Settings[] = [];
+    const deps: AppDeps = {
+      settingsRepo: settingsRepoWith(false, (s) => saved.push(s)),
+      projectRepo: fakeProjectRepo([]),
+    } as unknown as AppDeps;
+
+    const routes: ViewEntry[] = [];
+    renderView(<WelcomeView />, { deps, initial: { id: 'welcome' }, onRoute: (e) => routes.push(e) });
+    await waitForPredicate(() => routes.at(-1)?.id === 'create-project');
+
+    expect(saved).toHaveLength(1);
+    // The seeding path probes PATH (the view's own probe plus the apply-preset flow's) — the
+    // exact count is an implementation detail, "at least once" is the behaviour under test.
+    expect(detectRef.calls).toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/application/ui/tui/views/welcome-view.error-escape.test.tsx
+++ b/tests/integration/application/ui/tui/views/welcome-view.error-escape.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Regression: the welcome error card advertises `esc`, so `esc` has to do something.
+ *
+ * The seeding hook only ever set `pendingRoute` on the SUCCESS + zero-CLI branch, which left the
+ * local escape handler (and the ↵/space dispatcher, and the `claimEscape` that keeps the global
+ * `router.pop()` out of the way) muted on the error branch. Welcome is the root of the router
+ * stack, so the fall-through `router.pop()` was a no-op too: the operator pressed the key the
+ * screen named and nothing happened at all.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { DEFAULT_SETTINGS } from '@src/business/settings/defaults.ts';
+import type { AiProvider } from '@src/domain/entity/settings.ts';
+import { WelcomeView } from '@src/application/ui/tui/views/welcome-view.tsx';
+import type { AppDeps } from '@src/application/bootstrap/wire.ts';
+import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
+import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
+import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
+import { ENTER, ESC } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
+import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+
+const detectRef = vi.hoisted(() => ({ installed: new Set<string>(['claude-code']) }));
+
+vi.mock('@src/integration/system/detect-cli.ts', () => ({
+  detectInstalledProviders: async (): Promise<ReadonlySet<AiProvider>> =>
+    new Set(detectRef.installed) as ReadonlySet<AiProvider>,
+  PROVIDER_BINARY: {
+    'claude-code': 'claude',
+    'github-copilot': 'copilot',
+    'openai-codex': 'codex',
+    opencode: 'opencode',
+  },
+}));
+
+/** A settings repo whose `save` always fails — the branch that renders the error card. */
+const failingDeps = (): AppDeps =>
+  ({
+    settingsRepo: {
+      path: '/tmp/test-settings.json',
+      async exists() {
+        return Result.ok(false);
+      },
+      async load() {
+        return Result.ok(DEFAULT_SETTINGS);
+      },
+      save: (async () =>
+        Result.error({
+          error: { message: 'disk full', code: 'storage-error' },
+        })) as unknown as SettingsRepository['save'],
+    } as unknown as SettingsRepository,
+    projectRepo: {
+      async list() {
+        return Result.ok([]);
+      },
+    } as unknown as ProjectRepository,
+  }) as unknown as AppDeps;
+
+const renderFailedWelcome = async (): Promise<{
+  readonly result: ReturnType<typeof renderView>['result'];
+  readonly routes: ViewEntry[];
+}> => {
+  const routes: ViewEntry[] = [];
+  const { result } = renderView(<WelcomeView />, {
+    deps: failingDeps(),
+    initial: { id: 'welcome' },
+    onRoute: (e) => routes.push(e),
+  });
+  await waitForViewReady(result, (f) => f.includes('Failed to save settings'));
+  return { result, routes };
+};
+
+describe("WelcomeView — the error card's escape hatch actually works", () => {
+  it('routes to home on esc', async () => {
+    const { result, routes } = await renderFailedWelcome();
+    expect(routes.at(-1)?.id).toBe('welcome');
+
+    result.stdin.write(ESC);
+    await waitForPredicate(() => routes.at(-1)?.id === 'home');
+
+    expect(routes.at(-1)?.id).toBe('home');
+    result.unmount();
+  });
+
+  it('routes to home on ↵ as well, so the hinted continue key is not a lie', async () => {
+    const { result, routes } = await renderFailedWelcome();
+
+    result.stdin.write(ENTER);
+    await waitForPredicate(() => routes.at(-1)?.id === 'home');
+
+    expect(routes.at(-1)?.id).toBe('home');
+    result.unmount();
+  });
+
+  it('keeps advertising esc while the gate is up', async () => {
+    const { result } = await renderFailedWelcome();
+
+    const frame = result.lastFrame() ?? '';
+    expect(frame).toContain('Failed to save settings');
+    expect(frame).toContain('Press esc to skip welcome');
+    result.unmount();
+  });
+});

--- a/tests/integration/application/ui/tui/views/welcome-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/welcome-view.test.tsx
@@ -13,7 +13,8 @@ import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { Project } from '@src/domain/entity/project.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import type { SettingsRepository } from '@src/domain/repository/settings/settings-repository.ts';
-import { ENTER, waitFor } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ENTER } from '@tests/integration/application/ui/tui/_keys.ts';
+import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
 import { makeProject } from '@tests/fixtures/domain.ts';
 import type { ViewEntry } from '@src/application/ui/tui/runtime/router.tsx';
@@ -155,7 +156,7 @@ describe('WelcomeView — first-run UX', () => {
     expect(routes.at(-1)?.id).toBe('welcome');
 
     result.stdin.write(ENTER);
-    await waitFor(() => routes.at(-1)?.id === 'create-project');
+    await waitForPredicate(() => routes.at(-1)?.id === 'create-project');
     expect(routes.at(-1)?.id).toBe('create-project');
     // The gate never re-triggers seeding — still exactly one save.
     expect(saved).toHaveLength(1);
@@ -194,7 +195,7 @@ describe('WelcomeView — first-run UX', () => {
       initial: { id: 'welcome' },
       onRoute: (e) => routes.push(e),
     });
-    await waitFor(() => routes.at(-1)?.id === 'home');
+    await waitForPredicate(() => routes.at(-1)?.id === 'home');
 
     expect(routes.at(-1)?.id).toBe('home');
     welcomeResult.unmount();

--- a/tests/integration/io/git-exclude-realgit.test.ts
+++ b/tests/integration/io/git-exclude-realgit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Real-git test for `ensureGitExcludeWildcard` against a LINKED WORKTREE.
+ *
+ * git resolves `info/exclude` through `$GIT_COMMON_DIR` (the main repo's `.git`), never through
+ * the per-worktree gitdir `<main>/.git/worktrees/<name>/`. A fabricated-gitdir unit test can only
+ * assert which path was written; it cannot prove the exclude actually takes effect. This test
+ * creates a REAL worktree, installs a `ralphctl-*` skill folder into it, and asserts
+ * `git status --porcelain` stays clean — the assertion that catches a wrong-path write, which is
+ * exactly how the parallel implement path was committing harness-authored skills into user PRs.
+ */
+
+import { promises as fs } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
+import { createFakeProject, type FakeProject } from '@tests/helpers/fake-project.ts';
+
+const PATTERN = '.claude/skills/ralphctl-*';
+
+const abs = (p: string): AbsolutePath => {
+  const parsed = AbsolutePath.parse(p);
+  if (!parsed.ok) throw new Error(`test setup: bad path ${p}`);
+  return parsed.value;
+};
+
+let project: FakeProject | undefined;
+let worktreePath: string | undefined;
+
+afterEach(async () => {
+  if (worktreePath !== undefined) await fs.rm(worktreePath, { recursive: true, force: true });
+  worktreePath = undefined;
+  await project?.cleanup();
+  project = undefined;
+});
+
+describe('ensureGitExcludeWildcard against a real linked worktree', () => {
+  it('writes to the common git dir so the pattern actually excludes inside the worktree', async () => {
+    project = await createFakeProject();
+    const parent = await realpath(await fs.mkdtemp(join(tmpdir(), 'ralphctl-wt-')));
+    worktreePath = join(parent, 'wt');
+    await project.git('worktree', 'add', '-q', '-b', 'wt-branch', worktreePath);
+
+    const result = await ensureGitExcludeWildcard(abs(worktreePath), PATTERN);
+    expect(result.ok).toBe(true);
+
+    // The line must land in the COMMON dir — that is the only file git consults.
+    const common = await fs.readFile(join(project.path, '.git/info/exclude'), 'utf8');
+    expect(common.split('\n').some((line) => line.trim() === PATTERN)).toBe(true);
+
+    // Behavioural proof: a harness-authored skill folder stays invisible to git in the worktree.
+    await fs.mkdir(join(worktreePath, '.claude/skills/ralphctl-foo'), { recursive: true });
+    await fs.writeFile(join(worktreePath, '.claude/skills/ralphctl-foo/SKILL.md'), '# skill\n', 'utf8');
+    // A second `-C` with an absolute path re-targets the fixture's repo-bound git helper.
+    const status = await project.git('-C', worktreePath, 'status', '--porcelain');
+    expect(status.trim()).toBe('');
+  });
+
+  it('still excludes in the main checkout after the worktree call (shared common dir)', async () => {
+    project = await createFakeProject();
+    const parent = await realpath(await fs.mkdtemp(join(tmpdir(), 'ralphctl-wt-')));
+    worktreePath = join(parent, 'wt');
+    await project.git('worktree', 'add', '-q', '-b', 'wt-branch', worktreePath);
+
+    await ensureGitExcludeWildcard(abs(worktreePath), PATTERN);
+    await fs.mkdir(join(project.path, '.claude/skills/ralphctl-foo'), { recursive: true });
+    await fs.writeFile(join(project.path, '.claude/skills/ralphctl-foo/SKILL.md'), '# skill\n', 'utf8');
+
+    const status = await project.git('status', '--porcelain');
+    expect(status.trim()).toBe('');
+  });
+});

--- a/tests/integration/scm/pull-request-creator.test.ts
+++ b/tests/integration/scm/pull-request-creator.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Adapter-level tests for `createPullRequestCreator`.
+ *
+ * The pure helpers (`parseRemoteHostname` / `detectPullRequestPlatform` / `parseUrlFromCliStdout`)
+ * are covered in `tests/unit/business/scm/pull-request-creator.test.ts`; every flow-level test
+ * injects a stub `PullRequestCreator` port. What is only reachable here is the adapter itself:
+ * the exact `gh pr create` / `glab mr create` argv, the `cwd` the child is spawned in, and the
+ * four `StorageError` paths (no origin, unknown host, non-zero exit, zero exit with no URL).
+ * Modelled on `issue-pusher.test.ts` — only the process boundary (`Spawn`) and the `GitRunner`
+ * transport are faked; the argv builders and error mapping run for real.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { Result } from '@src/domain/result.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { GitRunner, GitRunResult } from '@src/integration/io/git-runner.ts';
+import type { Spawn } from '@src/integration/io/spawn.ts';
+import { createPullRequestCreator } from '@src/integration/scm/pull-request-creator.ts';
+import type { PullRequestCreatorInput } from '@src/business/scm/pull-request-creator.ts';
+
+const absPath = (p: string): AbsolutePath => {
+  const r = AbsolutePath.parse(p);
+  if (!r.ok) throw new Error(`invalid path ${p}`);
+  return r.value;
+};
+
+const CWD = absPath('/repo');
+
+interface SpawnCall {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string | undefined;
+}
+
+interface ScriptedChild {
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly exitCode?: number;
+  /** Throw synchronously from `spawn` — models a missing binary. */
+  readonly throws?: Error;
+}
+
+const makeChild = (stdout: string, stderr: string, exitCode: number): ChildProcessWithoutNullStreams => {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+  const stdoutStream = new EventEmitter() as ChildProcessWithoutNullStreams['stdout'];
+  const stderrStream = new EventEmitter() as ChildProcessWithoutNullStreams['stderr'];
+  Object.assign(child, {
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    stdin: { end(): void {} },
+    kill(): boolean {
+      return true;
+    },
+  });
+  setImmediate(() => {
+    if (stdout) stdoutStream.emit('data', Buffer.from(stdout, 'utf8'));
+    if (stderr) stderrStream.emit('data', Buffer.from(stderr, 'utf8'));
+    setImmediate(() => child.emit('close', exitCode));
+  });
+  return child;
+};
+
+const scriptedSpawn = (scripted: ScriptedChild): { spawn: Spawn; calls: SpawnCall[] } => {
+  const calls: SpawnCall[] = [];
+  const spawn: Spawn = (command, args, options) => {
+    calls.push({ command, args: [...args], cwd: options.cwd });
+    if (scripted.throws) throw scripted.throws;
+    return makeChild(scripted.stdout ?? '', scripted.stderr ?? '', scripted.exitCode ?? 0);
+  };
+  return { spawn, calls };
+};
+
+/** `GitRunner` fake that answers `remote get-url origin` and records the argv it was asked for. */
+const gitRunnerWith = (
+  answer: Result<GitRunResult, StorageError>
+): { gitRunner: GitRunner; calls: Array<readonly string[]> } => {
+  const calls: Array<readonly string[]> = [];
+  const gitRunner: GitRunner = {
+    run: async (_cwd, args) => {
+      calls.push([...args]);
+      return answer;
+    },
+  };
+  return { gitRunner, calls };
+};
+
+const okRemote = (url: string): Result<GitRunResult, StorageError> =>
+  Result.ok({ stdout: `${url}\n`, stderr: '', exitCode: 0 });
+
+const INPUT: PullRequestCreatorInput = {
+  cwd: CWD,
+  branch: 'ralphctl/sprint-x',
+  base: 'main',
+  title: 'Add the thing',
+  body: 'Body text\nsecond line',
+  draft: false,
+};
+
+describe('createPullRequestCreator — argv', () => {
+  it('GitHub: builds the exact `gh pr create` argv and runs it inside the repo', async () => {
+    const { gitRunner, calls: gitCalls } = gitRunnerWith(okRemote('https://github.com/x/y.git'));
+    const { spawn, calls } = scriptedSpawn({ stdout: 'https://github.com/x/y/pull/7\n' });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ url: 'https://github.com/x/y/pull/7', platform: 'github' });
+    expect(gitCalls).toEqual([['remote', 'get-url', 'origin']]);
+    expect(calls).toEqual([
+      {
+        command: 'gh',
+        args: [
+          'pr',
+          'create',
+          '--base',
+          'main',
+          '--head',
+          'ralphctl/sprint-x',
+          '--title',
+          'Add the thing',
+          '--body',
+          'Body text\nsecond line',
+        ],
+        cwd: '/repo',
+      },
+    ]);
+  });
+
+  it('GitHub: appends --draft only when the input asks for a draft', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('git@github.com:x/y.git'));
+    const { spawn, calls } = scriptedSpawn({ stdout: 'https://github.com/x/y/pull/8\n' });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create({ ...INPUT, draft: true });
+
+    expect(r.ok).toBe(true);
+    expect(calls[0]?.args.at(-1)).toBe('--draft');
+  });
+
+  it('GitLab: builds the `glab mr create` argv with target/source-branch and --description', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://gitlab.com/foo/bar.git'));
+    const { spawn, calls } = scriptedSpawn({ stdout: 'https://gitlab.com/foo/bar/-/merge_requests/3\n' });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create({ ...INPUT, draft: true });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ url: 'https://gitlab.com/foo/bar/-/merge_requests/3', platform: 'gitlab' });
+    expect(calls).toEqual([
+      {
+        command: 'glab',
+        args: [
+          'mr',
+          'create',
+          '--target-branch',
+          'main',
+          '--source-branch',
+          'ralphctl/sprint-x',
+          '--title',
+          'Add the thing',
+          '--description',
+          'Body text\nsecond line',
+          '--draft',
+        ],
+        cwd: '/repo',
+      },
+    ]);
+  });
+
+  it('self-hosted GitLab host still dispatches to glab', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('git@gitlab.example.internal:team/project.git'));
+    const { spawn, calls } = scriptedSpawn({
+      stdout: 'https://gitlab.example.internal/team/project/-/merge_requests/1\n',
+    });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(true);
+    expect(calls[0]?.command).toBe('glab');
+  });
+
+  it('picks the URL line out of noisy CLI stdout', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://github.com/x/y.git'));
+    const { spawn } = scriptedSpawn({
+      stdout:
+        'Creating pull request for ralphctl/sprint-x into main\n\nhttps://github.com/x/y/pull/12\nWarning: draft\n',
+    });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.url).toBe('https://github.com/x/y/pull/12');
+  });
+});
+
+describe('createPullRequestCreator — failure paths', () => {
+  it('surfaces a non-zero CLI exit as a StorageError carrying the stderr text', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://github.com/x/y.git'));
+    const { spawn } = scriptedSpawn({ stderr: 'pull request already exists for branch\n', exitCode: 1 });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBeInstanceOf(StorageError);
+      expect(r.error.message).toBe('gh pr create failed: pull request already exists for branch');
+    }
+  });
+
+  it('names the platform noun in the failure message for gitlab too', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://gitlab.com/foo/bar.git'));
+    const { spawn } = scriptedSpawn({ stderr: '', exitCode: 2 });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('glab mr create failed: unknown error');
+  });
+
+  it('rejects a zero exit that emitted no URL', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://github.com/x/y.git'));
+    const { spawn } = scriptedSpawn({ stdout: '   \n\n', exitCode: 0 });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('gh pr create succeeded but emitted no URL');
+  });
+
+  it('tells the operator to install gh or glab when the host is neither', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://bitbucket.org/x/y.git'));
+    const { spawn, calls } = scriptedSpawn({});
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok)
+      expect(r.error.message).toMatch(/Unknown git host 'https:\/\/bitbucket\.org\/x\/y\.git' — install gh or glab/);
+    // No CLI is spawned once the host is unrecognised.
+    expect(calls).toEqual([]);
+  });
+
+  it('fails when `git remote get-url origin` exits non-zero', async () => {
+    const { gitRunner } = gitRunnerWith(Result.ok({ stdout: '', stderr: 'no such remote', exitCode: 2 }));
+    const { spawn, calls } = scriptedSpawn({});
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('git remote get-url origin failed: no such remote');
+    expect(calls).toEqual([]);
+  });
+
+  it('fails when the origin remote resolves to an empty string', async () => {
+    const { gitRunner } = gitRunnerWith(Result.ok({ stdout: '  \n', stderr: '', exitCode: 0 }));
+    const { spawn } = scriptedSpawn({});
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe("no 'origin' remote configured at /repo");
+  });
+
+  it('propagates a GitRunner transport error unchanged', async () => {
+    const transportError = new StorageError({ subCode: 'io', message: 'failed to spawn git: ENOENT' });
+    const { gitRunner } = gitRunnerWith(Result.error(transportError));
+    const { spawn } = scriptedSpawn({});
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe(transportError);
+  });
+
+  it('maps a missing platform CLI (spawn throws) to a StorageError', async () => {
+    const { gitRunner } = gitRunnerWith(okRemote('https://github.com/x/y.git'));
+    const { spawn } = scriptedSpawn({ throws: new Error('spawn gh ENOENT') });
+
+    const create = createPullRequestCreator({ gitRunner, spawn });
+    const r = await create(INPUT);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('gh not installed or failed to spawn');
+  });
+});

--- a/tests/unit/application/chain/run/runner.test.ts
+++ b/tests/unit/application/chain/run/runner.test.ts
@@ -233,7 +233,7 @@ describe('createRunner', () => {
     const abortThrower: Element<Ctx> = {
       name: 'raw-abort',
       async execute() {
-        throw new AbortError({ elementName: 'raw-abort' });
+        throw new AbortError({ elementName: 'raw-abort', reason: 'thrown from inside' });
       },
     };
     const events: Array<RunnerEvent<Ctx>> = [];
@@ -243,7 +243,59 @@ describe('createRunner', () => {
     await expect(runner.start()).resolves.toBeUndefined();
 
     expect(runner.status).toBe('aborted');
-    expect(events.at(-1)?.type).toBe('aborted');
+    const last = events.at(-1);
+    expect(last?.type).toBe('aborted');
+    // The chain-originated abort carries its error, so schedulers above can propagate it verbatim.
+    if (last?.type === 'aborted') expect(last.error?.message).toBe('thrown from inside');
+  });
+
+  it('carries the chain-returned AbortError on the aborted event (and on late replay)', async () => {
+    const abortReturner: Element<Ctx> = {
+      name: 'operator-abort',
+      async execute() {
+        const error = new AbortError({ elementName: 'verify-execution', reason: 'operator aborted on red baseline' });
+        return Result.error({ error, trace: [{ elementName: 'verify-execution', status: 'aborted', durationMs: 0 }] });
+      },
+    };
+    const events: Array<RunnerEvent<Ctx>> = [];
+    const runner = createRunner({ id: 'r-inner-abort', element: abortReturner, initialCtx: { trail: [] } });
+    runner.subscribe((e) => events.push(e));
+
+    await runner.start();
+
+    expect(runner.status).toBe('aborted');
+    const last = events.at(-1);
+    expect(last?.type).toBe('aborted');
+    if (last?.type === 'aborted') {
+      expect(last.error).toBeInstanceOf(AbortError);
+      expect(last.error?.message).toBe('operator aborted on red baseline');
+    }
+
+    // Late-subscriber replay is lossless — it carries the same error.
+    const replayed: Array<RunnerEvent<Ctx>> = [];
+    runner.subscribe((e) => replayed.push(e));
+    const replayedLast = replayed.at(-1);
+    expect(replayedLast?.type).toBe('aborted');
+    if (replayedLast?.type === 'aborted') expect(replayedLast.error).toBeInstanceOf(AbortError);
+  });
+
+  it('omits the error on a caller-driven abort mid-run', async () => {
+    const events: Array<RunnerEvent<Ctx>> = [];
+    const runner = createRunner({
+      id: 'r-caller-abort',
+      element: sequential<Ctx>('chain', [slowTag('a', 50), tag('b')]),
+      initialCtx: { trail: [] },
+    });
+    runner.subscribe((e) => events.push(e));
+
+    const startPromise = runner.start();
+    setTimeout(() => runner.abort('caller'), 5);
+    await startPromise;
+
+    const last = events.at(-1);
+    expect(last?.type).toBe('aborted');
+    // `abort()` is the caller's own doing — it is not a branch error to propagate upwards.
+    if (last?.type === 'aborted') expect(last.error).toBeUndefined();
   });
 
   it('unsubscribe stops further events', async () => {

--- a/tests/unit/application/chain/run/wave-scheduler.test.ts
+++ b/tests/unit/application/chain/run/wave-scheduler.test.ts
@@ -294,6 +294,63 @@ describe('runWaves — abort wins with bounded settle + cleanup', () => {
     expect(cleanups.sort()).toEqual(['b0', 'b1']);
   });
 
+  it("treats a branch's OWN AbortError as fatal: stops the schedule, folds nothing, returns it verbatim", async () => {
+    // The operator answers 'abort' at an in-branch prompt: the branch chain returns an AbortError
+    // while the OUTER signal is untouched. That must tear the whole schedule down — not be
+    // downgraded to "this one task did not settle" while later waves keep spending AI sessions.
+    const gauge = { count: 0, max: 0 };
+    const operatorAbort = new AbortError({
+      elementName: 'verify-execution',
+      reason: 'operator aborted sprint on broken baseline',
+    });
+    const cleanups: string[] = [];
+    const launched: string[] = [];
+
+    const track = (id: string, element: Element<Ctx>): WaveBranch<Ctx> => ({
+      id,
+      element: {
+        name: element.name,
+        async execute(ctx, signal, onTrace) {
+          launched.push(id);
+          return element.execute(ctx, signal, onTrace);
+        },
+      },
+    });
+
+    const waveOne: Array<WaveBranch<Ctx>> = [
+      track(
+        'aborting',
+        fakeElement({ name: 'aborting', gauge, settle: Promise.resolve(), error: () => operatorAbort })
+      ),
+      track(
+        'sibling',
+        fakeElement({
+          name: 'sibling',
+          gauge,
+          settle: new Promise<void>(() => {}),
+          onCleanup: () => cleanups.push('sibling'),
+        })
+      ),
+    ];
+    const waveTwo: Array<WaveBranch<Ctx>> = [
+      track('later', fakeElement({ name: 'later', gauge, settle: Promise.resolve() })),
+    ];
+
+    const merge = vi.fn(mergeConcat);
+    const result = await runWaves([waveOne, waveTwo], BASE, cfg({ merge }));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // The operator's own AbortError, verbatim — reason string intact for the TUI / chain.log.
+    expect(result.error.error).toBe(operatorAbort);
+    // In-flight siblings were killed and got to run their cleanup; the next wave never launched.
+    expect(cleanups).toEqual(['sibling']);
+    expect(launched).toEqual(['aborting', 'sibling']);
+    // Nothing folded: an abort short-circuit never reaches the reducer.
+    expect(merge).not.toHaveBeenCalled();
+    expect(gauge.count).toBe(0);
+  });
+
   it('never launches a branch when the outer signal is already aborted', async () => {
     const gauge = { count: 0, max: 0 };
     const ac = new AbortController();

--- a/tests/unit/application/flows/implement/leaves/entropy-check.test.ts
+++ b/tests/unit/application/flows/implement/leaves/entropy-check.test.ts
@@ -3,7 +3,11 @@ import { createInMemoryEventBus } from '@src/integration/observability/in-memory
 import { FIXED_NOW, makeInProgressTaskWithRunningAttempt } from '@tests/fixtures/domain.ts';
 import { entropyCheckLeaf, type EntropyCheckDeps } from '@src/application/flows/implement/leaves/entropy-check.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
-import type { PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
+import {
+  computePlateauVerdict,
+  windowIsHardStall,
+  type PlateauTurnRecord,
+} from '@src/business/task/plateau-detection.ts';
 import type { EvaluationSignal } from '@src/domain/signal.ts';
 
 const task = makeInProgressTaskWithRunningAttempt();
@@ -49,6 +53,15 @@ const rec = (opts: {
 const collapsedWindow = (hashes: readonly string[]): readonly PlateauTurnRecord[] =>
   hashes.map((hash) => rec({ hash, actionCounts: new Map([['change', 3]]) }));
 
+/**
+ * These tests exercise the leaf's OWN predicate in isolation, on ctx states hand-fed to
+ * `leaf.execute`. Read them alongside the subordination fence below and the composed-loop tests
+ * in `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` — in the real
+ * `gen-eval-turn` sequential the evaluator leaf runs two elements earlier on the SAME window, so a
+ * window this leaf would fire on has already produced a `source: 'threshold'` exit and the
+ * `alreadyExiting` short-circuit wins. The isolated firing cases below are the leaf's contract,
+ * NOT a claim that a `source: 'entropy'` exit is reachable through the composed loop.
+ */
 describe('entropyCheckLeaf', () => {
   /**
    * REGRESSION — the K=1 false positive. Before windowing, a SINGLE turn that emitted only one
@@ -211,5 +224,54 @@ describe('entropyCheckLeaf', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) return;
     expect(out.value.ctx.lastExit).toEqual({ kind: 'passed' });
+  });
+});
+
+/**
+ * SUBORDINATION FENCE — what the composed `gen-eval-turn` sequential actually presents to this
+ * leaf. The evaluator leaf runs two elements earlier and merges `computePlateauVerdict`'s exit
+ * onto `ctx.lastExit`; this leaf then re-reads the SAME window through `windowIsHardStall`. Both
+ * route through `classifyPlateauWindow`, so the two conditions the leaf needs — a hard-stalled
+ * window AND `lastExit === undefined` — are mutually exclusive by construction.
+ *
+ * These tests pin that mutual exclusion at the fixture level, so the day the subordination gate
+ * changes (either direction) the fixtures above stop silently describing an unreachable state.
+ * The end-to-end counterpart is the "attributes a genuine stall to the calibrated 'threshold'
+ * detector" case in `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts`.
+ */
+describe('entropyCheckLeaf — subordination to the calibrated predicate', () => {
+  const THRESHOLD = 3;
+
+  it('the very window the leaf fires on is one the evaluator already exited as a threshold plateau', () => {
+    const window = collapsedWindow(['h1', 'h1', 'h1']);
+    const current = window[window.length - 1];
+    expect(current).toBeDefined();
+    if (current === undefined) return;
+
+    // The leaf's own calibration gate opens …
+    expect(windowIsHardStall(window, { threshold: THRESHOLD })).toBe(true);
+    // … but only on a window the calibrated predicate — running TWO ELEMENTS EARLIER on the same
+    // history — has already ruled a plateau, which the evaluator leaf merges onto ctx.lastExit.
+    const verdict = computePlateauVerdict(window.slice(0, -1), current, { threshold: THRESHOLD });
+    expect(verdict.kind).toBe('plateau');
+  });
+
+  it('is a no-op on the ctx the loop really hands it — the threshold exit survives unre-attributed', async () => {
+    const leaf = entropyCheckLeaf(buildDeps({ maxTurns: 10, plateauThreshold: THRESHOLD }), task.id);
+    // Exactly what the evaluator leaf leaves behind on a stalled window: history appended AND a
+    // calibrated `source: 'threshold'` exit already set. Opted IN, so only the subordination gate
+    // can keep the leaf quiet here.
+    const ctx: ImplementCtx = {
+      ...baseCtx(),
+      genEvalTurn: THRESHOLD,
+      plateauHistory: collapsedWindow(['h1', 'h1', 'h1']),
+      lastExit: { kind: 'plateau', dimensions: ['correctness'], source: 'threshold' },
+    };
+
+    const out = await leaf.execute(ctx);
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.ctx.lastExit).toEqual({ kind: 'plateau', dimensions: ['correctness'], source: 'threshold' });
   });
 });

--- a/tests/unit/application/flows/implement/leaves/implement-session-nested-runner.test.ts
+++ b/tests/unit/application/flows/implement/leaves/implement-session-nested-runner.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `AiSession.chainSessionId` is the key the Execute view's token-usage map is read by
+ * (`useTokenUsage(bus).get(sessionId)` with the OUTER runner id). On the parallel implement path
+ * each task's subchain runs inside its own branch runner (`createRunner({ id: 'task-<taskId>' })`),
+ * which re-scopes the ambient session — so a session stamped from the innermost id filed every
+ * `token-usage` event under `task-<uuid>` and the header's token / context readout stayed blank
+ * for the entire run while the serial path (one runner) showed it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runWithSession } from '@src/application/session/session.ts';
+import { implementSession } from '@src/application/flows/implement/leaves/implement-session.ts';
+import { absolutePath } from '@tests/fixtures/domain.ts';
+import type { Prompt } from '@src/integration/ai/prompts/_engine/prompt-type.ts';
+
+const PROMPT = 'unit-test prompt body' as unknown as Prompt;
+const SANDBOX = absolutePath('/tmp/sandbox');
+const REPO = absolutePath('/tmp/repo');
+const SPRINT_DIR = absolutePath('/tmp/sprint');
+const SIGNALS = absolutePath('/tmp/sandbox/rounds/1/generator/signals.json');
+
+const build = (): ReturnType<typeof implementSession> =>
+  implementSession(SANDBOX, REPO, SPRINT_DIR, PROMPT, 'claude-opus-4-8', SIGNALS, 'generator');
+
+describe('implementSession — chainSessionId keying', () => {
+  it('omits chainSessionId outside any session scope', () => {
+    expect(build()).not.toHaveProperty('chainSessionId');
+  });
+
+  it('stamps the runner id on the serial path (single scope)', async () => {
+    await runWithSession('r-serial-1', () => {
+      expect(build().chainSessionId).toBe('r-serial-1');
+    });
+  });
+
+  it('stamps the HOST runner id from inside a parallel branch runner scope', async () => {
+    await runWithSession('r-host-1', async () => {
+      await runWithSession('task-01933fbb-1111-7000-8000-000000000001', () => {
+        expect(build().chainSessionId).toBe('r-host-1');
+      });
+    });
+  });
+});

--- a/tests/unit/application/flows/implement/leaves/loop-diversity-check.test.ts
+++ b/tests/unit/application/flows/implement/leaves/loop-diversity-check.test.ts
@@ -6,7 +6,11 @@ import {
   type LoopDiversityCheckDeps,
 } from '@src/application/flows/implement/leaves/loop-diversity-check.ts';
 import type { ImplementCtx } from '@src/application/flows/implement/ctx.ts';
-import type { PlateauTurnRecord } from '@src/business/task/plateau-detection.ts';
+import {
+  computePlateauVerdict,
+  windowIsHardStall,
+  type PlateauTurnRecord,
+} from '@src/business/task/plateau-detection.ts';
 import type { EvaluationSignal } from '@src/domain/signal.ts';
 
 const task = makeInProgressTaskWithRunningAttempt();
@@ -47,6 +51,15 @@ const recordFor = (
 const stalledWindow = (n: number): readonly PlateauTurnRecord[] =>
   Array.from({ length: n }, () => recordFor('correctness', { critique: RECYCLED, hash: 'h1' }));
 
+/**
+ * These tests exercise the leaf's OWN predicate in isolation, on ctx states hand-fed to
+ * `leaf.execute`. Read them alongside the subordination fence below and the composed-loop tests
+ * in `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts` — in the real
+ * `gen-eval-turn` sequential the evaluator leaf runs one element earlier on the SAME window, so a
+ * window this leaf would fire on has already produced a `source: 'threshold'` exit and the
+ * `alreadyExiting` short-circuit wins. The isolated firing cases below are the leaf's contract,
+ * NOT a claim that a `source: 'diversity'` exit is reachable through the composed loop.
+ */
 describe('loopDiversityCheckLeaf', () => {
   it('sets a diversity plateau exit when the window repeats an identical fingerprint over an unchanged tree', async () => {
     const leaf = loopDiversityCheckLeaf(buildDeps(10), task.id);
@@ -156,5 +169,53 @@ describe('loopDiversityCheckLeaf', () => {
     expect(out.ok).toBe(true);
     if (!out.ok) return;
     expect(out.value.ctx.lastExit).toBeUndefined();
+  });
+});
+
+/**
+ * SUBORDINATION FENCE — what the composed `gen-eval-turn` sequential actually presents to this
+ * leaf. The evaluator leaf runs one element earlier and merges `computePlateauVerdict`'s exit onto
+ * `ctx.lastExit`; this leaf then re-reads the SAME window through `windowIsHardStall`. Both route
+ * through `classifyPlateauWindow`, so the two conditions the leaf needs — a hard-stalled window
+ * AND `lastExit === undefined` — are mutually exclusive by construction.
+ *
+ * These tests pin that mutual exclusion at the fixture level, so the day the subordination gate
+ * changes (either direction) the fixtures above stop silently describing an unreachable state.
+ * The end-to-end counterpart is the "attributes a genuine stall to the calibrated 'threshold'
+ * detector" case in `tests/integration/application/flows/implement/leaves/gen-eval-loop.test.ts`.
+ */
+describe('loopDiversityCheckLeaf — subordination to the calibrated predicate', () => {
+  const THRESHOLD = 3;
+
+  it('the very window the leaf fires on is one the evaluator already exited as a threshold plateau', () => {
+    const window = stalledWindow(THRESHOLD);
+    const current = window[window.length - 1];
+    expect(current).toBeDefined();
+    if (current === undefined) return;
+
+    // The leaf's own gate opens …
+    expect(windowIsHardStall(window, { threshold: THRESHOLD })).toBe(true);
+    // … but only on a window the calibrated predicate — running ONE ELEMENT EARLIER on the same
+    // history — has already ruled a plateau, which the evaluator leaf merges onto ctx.lastExit.
+    const verdict = computePlateauVerdict(window.slice(0, -1), current, { threshold: THRESHOLD });
+    expect(verdict.kind).toBe('plateau');
+  });
+
+  it('is a no-op on the ctx the loop really hands it — the threshold exit survives unre-attributed', async () => {
+    const leaf = loopDiversityCheckLeaf(buildDeps(10, THRESHOLD), task.id);
+    // Exactly what the evaluator leaf leaves behind on a stalled window: history appended AND a
+    // calibrated `source: 'threshold'` exit already set.
+    const ctx: ImplementCtx = {
+      ...baseCtx(),
+      genEvalTurn: THRESHOLD,
+      plateauHistory: stalledWindow(THRESHOLD),
+      lastExit: { kind: 'plateau', dimensions: ['correctness'], source: 'threshold' },
+    };
+
+    const out = await leaf.execute(ctx);
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.value.ctx.lastExit).toEqual({ kind: 'plateau', dimensions: ['correctness'], source: 'threshold' });
   });
 });

--- a/tests/unit/application/flows/implement/leaves/post-task-verify.test.ts
+++ b/tests/unit/application/flows/implement/leaves/post-task-verify.test.ts
@@ -146,8 +146,9 @@ describe('postTaskVerifyLeaf', () => {
     expect(row?.outcome).toBe('success');
     expect(row?.exitCode).toBe(0);
     // Carry-baseline: a green post stamps `priorPostVerifyOutcome` onto ctx so the next
-    // task's pre-task-verify can short-circuit when the cwd matches + tree is clean.
-    expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'success' });
+    // task's pre-task-verify can short-circuit when the cwd matches + tree is clean. The legacy
+    // single-script path always covers the whole tree, so the carry is eligible.
+    expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'success', coveredAllGates: true });
   });
 
   it('marks verify-failed with exitCode + verbatim stderr when red (audit-[03] — no persistence-time clip)', async () => {
@@ -194,7 +195,7 @@ describe('postTaskVerifyLeaf', () => {
     // Carry-baseline still records the (cwd, outcome) pair — pre-task-verify only
     // short-circuits when the outcome is 'success', so a 'failed' carry just means the next
     // task's pre-verify will fall through to the real script.
-    expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'failed' });
+    expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'failed', coveredAllGates: true });
   });
 
   it('attribution truth table — pre=red, post=red → baseline-broken (preserve verdict, NO block)', async () => {
@@ -291,8 +292,8 @@ describe('postTaskVerifyLeaf', () => {
       // Pre-verify block reason survives untouched (the leaf must not clear it).
       expect(out.value.ctx.lastBlockReason).toBe(ctx.lastBlockReason);
       // Carry records outcome 'skipped' so the NEXT task's pre-verify carry (needs 'success')
-      // does not short-circuit the real script.
-      expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'skipped' });
+      // does not short-circuit the real script. No gate ran at all → not a full-tree baseline.
+      expect(out.value.ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'skipped', coveredAllGates: false });
     });
 
     it('turn-1 generator self-block (lastBlockReason set, genEvalTurn === 1) → does NOT short-circuit, runs the real script', async () => {
@@ -410,6 +411,32 @@ describe('postTaskVerifyLeaf', () => {
       const { runner, ran } = gateShell();
       await runGated({ gitRunner: footprintGit([]), shell: runner, preOutcome: 'success' });
       expect(ran()).toEqual(['test-web', 'test-api', 'lint-all']);
+    });
+
+    it('a DIFF-SCOPED green post is NOT carried as a full-tree green baseline', async () => {
+      // Headline regression. A scoped run's `outcome: 'success'` only means "every EXECUTED gate
+      // passed" — the gates outside the diff footprint never ran. Carrying that as a whole-tree
+      // green would let the NEXT task's pre-verify short-circuit to a synthetic green baseline it
+      // never measured, and a pre-existing red gate that task then touches reads as `regressed`:
+      // the harness blames the AI for a baseline it never broke, burns the retry budget and
+      // bypasses both the baseline-broken escape hatch and the operator's 'proceed' amnesty.
+      const { runner, ran } = gateShell();
+      const ctx = await runGated({
+        gitRunner: footprintGit(['apps/web-ui/src/App.tsx']),
+        shell: runner,
+        preOutcome: 'success',
+      });
+      expect(ran()).toEqual(['test-web', 'lint-all']); // the api gate never ran…
+      expect(ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'success', coveredAllGates: false });
+    });
+
+    it('the run-ALL fallback (empty footprint) IS carried as a full-tree green baseline', async () => {
+      // The complement of the case above: with no usable scope every gate executes, so a green
+      // aggregate really is whole-tree evidence and the next task may still short-circuit.
+      const { runner, ran } = gateShell();
+      const ctx = await runGated({ gitRunner: footprintGit([]), shell: runner, preOutcome: 'success' });
+      expect(ran()).toEqual(['test-web', 'test-api', 'lint-all']);
+      expect(ctx.priorPostVerifyOutcome).toEqual({ cwd: CWD, outcome: 'success', coveredAllGates: true });
     });
 
     it('post fail-fast: a red module gate stops before the catch-all runs', async () => {

--- a/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
+++ b/tests/unit/application/flows/implement/leaves/pre-task-verify.test.ts
@@ -605,7 +605,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       currentTaskId: task.id,
       tasks: [task],
       execution,
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -648,6 +648,98 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
     ).toBe(true);
   });
 
+  it('carried success from a DIFF-SCOPED post run (coveredAllGates false) → falls through, runs every gate', async () => {
+    // Headline regression: with structured gates the previous task's post-verify only ran the
+    // gates its diff footprint touched, so its green aggregate is NOT evidence the whole tree is
+    // green. Short-circuiting on it would synthesize a green baseline nothing measured — and a
+    // gate that was already red outside that footprint would then read as `regressed` on this
+    // task, blaming the AI, burning the retry budget and bypassing the baseline-broken amnesty.
+    const shell = countingShellRunner({ passed: true, exitCode: 0, output: 'OK' });
+    const git = cleanGitRunner();
+    const task = makeInProgressTaskWithRunningAttempt();
+    const execution = createSprintExecution({ sprintId: SPRINT_ID });
+    const ctx: ImplementCtx = {
+      sprintId: SPRINT_ID,
+      currentTask: task,
+      currentTaskId: task.id,
+      tasks: [task],
+      execution,
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success', coveredAllGates: false },
+    };
+    const repo = fakeTaskRepo();
+    const execRepo = fakeExecRepo();
+    const bus = createCapturingBus();
+    const leaf = preTaskVerifyLeaf(
+      {
+        shellScriptRunner: shell.runner,
+        taskRepo: repo,
+        sprintExecutionRepo: execRepo,
+        interactive: neverPrompt,
+        gitRunner: git.runner,
+        clock: () => FIXED_NOW,
+        eventBus: bus.bus,
+        logger: noopLogger,
+        environment: TTY_ENV,
+      },
+      {
+        cwd: CWD,
+        verifyGates: [
+          { pathPrefix: 'apps/web-ui', command: 'test-web' },
+          { pathPrefix: 'apps/api', command: 'test-api' },
+        ],
+      },
+      task.id
+    );
+
+    const out = await leaf.execute(ctx);
+    if (!out.ok) throw new Error(`expected ok: ${out.error.error.message}`);
+
+    // The real baseline ran — every gate (pre-verify is `all-run`, no scope), audit row appended.
+    expect(shell.callCount()).toBe(2);
+    expect(out.value.ctx.currentTask?.attempts.at(-1)?.verifyRuns?.[0]?.phase).toBe('pre');
+    expect(repo.updates).toHaveLength(1);
+    expect(out.value.ctx.lastPreVerifyOutcome).toBe('success');
+    expect(bus.events.some((e) => e.type === 'log' && e.message.includes('short-circuited'))).toBe(false);
+  });
+
+  it('carried success from a pre-flag ctx (coveredAllGates absent) → falls through rather than assuming coverage', async () => {
+    // Resume safety: a ctx written before the coverage flag existed carries no evidence of WHICH
+    // gates ran, so it demotes to running the real gate instead of silently keeping the old
+    // (unsound) short-circuit.
+    const shell = countingShellRunner({ passed: true, exitCode: 0, output: 'OK' });
+    const git = cleanGitRunner();
+    const task = makeInProgressTaskWithRunningAttempt();
+    const execution = createSprintExecution({ sprintId: SPRINT_ID });
+    const ctx: ImplementCtx = {
+      sprintId: SPRINT_ID,
+      currentTask: task,
+      currentTaskId: task.id,
+      tasks: [task],
+      execution,
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success' },
+    };
+    const leaf = preTaskVerifyLeaf(
+      {
+        shellScriptRunner: shell.runner,
+        taskRepo: fakeTaskRepo(),
+        sprintExecutionRepo: fakeExecRepo(),
+        interactive: neverPrompt,
+        gitRunner: git.runner,
+        clock: () => FIXED_NOW,
+        eventBus: createCapturingBus().bus,
+        logger: noopLogger,
+        environment: TTY_ENV,
+      },
+      { cwd: CWD, verifyScript: 'pnpm test' },
+      task.id
+    );
+
+    const out = await leaf.execute(ctx);
+    if (!out.ok) throw new Error(`expected ok: ${out.error.error.message}`);
+    expect(shell.callCount()).toBe(1);
+    expect(out.value.ctx.lastPreVerifyOutcome).toBe('success');
+  });
+
   it('carried success + same cwd + dirty tree → falls through to real script', async () => {
     const shell = countingShellRunner({ passed: true, exitCode: 0, output: 'OK' });
     const git = dirtyGitRunner();
@@ -659,7 +751,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       currentTaskId: task.id,
       tasks: [task],
       execution,
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -704,7 +796,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       currentTaskId: task.id,
       tasks: [task],
       execution,
-      priorPostVerifyOutcome: { cwd: otherCwd, outcome: 'success' },
+      priorPostVerifyOutcome: { cwd: otherCwd, outcome: 'success', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -748,7 +840,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       currentTaskId: task.id,
       tasks: [task],
       execution,
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'failed' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'failed', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -800,7 +892,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       tasks: [task],
       execution,
       // Outcome is 'skipped' — NOT 'success'. The short-circuit must not fire.
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'skipped' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'skipped', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -887,7 +979,7 @@ describe('preTaskVerifyLeaf — carry-baseline short-circuit', () => {
       currentTaskId: task.id,
       tasks: [task],
       execution,
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success', coveredAllGates: true },
     };
     const repo = fakeTaskRepo();
     const execRepo = fakeExecRepo();
@@ -1126,7 +1218,7 @@ describe('preTaskVerifyLeaf — fresh-setup short-circuit (T13)', () => {
     const task = makeInProgressTaskWithRunningAttempt();
     const ctx: ImplementCtx = {
       ...ctxFor(task, [FIXED_REPOSITORY_ID]),
-      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success' },
+      priorPostVerifyOutcome: { cwd: CWD, outcome: 'success', coveredAllGates: true },
     };
     const leaf = buildLeaf({
       shell,

--- a/tests/unit/application/flows/readiness/leaves/offer-skill-suggestions.test.ts
+++ b/tests/unit/application/flows/readiness/leaves/offer-skill-suggestions.test.ts
@@ -239,6 +239,27 @@ describe('offer-skill-suggestions leaf', () => {
     expect(adapter.bareInstalls.map((i) => i.skill.name)).toEqual(['a-skill', 'c-skill']);
   });
 
+  it('malformed suggestion → neither prompts nor installs (the confirm message is never a path)', async () => {
+    const adapter = recordingAdapter();
+    const prompt = scriptedPrompt([Result.ok(true), Result.ok(true), Result.ok(true), Result.ok(true)]);
+    const leaf = offerSkillSuggestionsLeaf(
+      { interactive: prompt, skillSource: fakeSource({}), skillsAdapter: adapter, logger: noopLogger },
+      TOOL
+    );
+
+    // The names ride in on AI output; anything that is not a bare kebab-case identifier would
+    // become a directory outside the repo (`join(skillsDir, '../../evil')`) or spoof the
+    // confirm message with an embedded newline. Both are dropped before the human gate.
+    const out = await leaf.execute(
+      ctxWith(['../../evil', '/etc/pwn', 'a/b', 'ralphctl-alignment\nallowed-tools: Bash', 'react-patterns'])
+    );
+
+    expect(out.ok).toBe(true);
+    expect(prompt.confirmMessages).toHaveLength(1);
+    expect(prompt.confirmMessages[0]).toContain('react-patterns');
+    expect(adapter.bareInstalls.map((i) => i.skill.name)).toEqual(['react-patterns']);
+  });
+
   it('propagates an AbortError from the confirm prompt (Ctrl-C aborts the chain)', async () => {
     const adapter = recordingAdapter();
     const prompt = scriptedPrompt([

--- a/tests/unit/application/session/root-session-id.test.ts
+++ b/tests/unit/application/session/root-session-id.test.ts
@@ -1,0 +1,63 @@
+/**
+ * `rootSessionId()` — the OUTERMOST runner id of the current scope.
+ *
+ * `currentSessionId()` is deliberately innermost-wins: per-branch logger / signal attribution
+ * depends on it. But the TUI's token-usage map is keyed by the id of the runner the Execute view
+ * was mounted with — the outer one. On the parallel implement path every generator / evaluator
+ * spawn runs inside a per-branch `createRunner({ id: 'task-<taskId>' })`, which re-scopes the ALS
+ * store, so a `chainSessionId` taken from `currentSessionId()` filed every event under a key the
+ * view never looks up: the header's token / context readout stayed blank for the whole run.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { currentSessionId, rootSessionId, runWithSession } from '@src/application/session/session.ts';
+
+describe('rootSessionId', () => {
+  it('is undefined outside any scope', () => {
+    expect(rootSessionId()).toBeUndefined();
+  });
+
+  it('equals the current id for a single (serial-path) scope', async () => {
+    await runWithSession('r-serial', async () => {
+      expect(rootSessionId()).toBe('r-serial');
+      expect(currentSessionId()).toBe('r-serial');
+    });
+  });
+
+  it('keeps the OUTER id while a nested branch runner shadows the current id', async () => {
+    await runWithSession('r-host', async () => {
+      await runWithSession('task-01933fbb', async () => {
+        expect(currentSessionId()).toBe('task-01933fbb');
+        expect(rootSessionId()).toBe('r-host');
+      });
+      expect(rootSessionId()).toBe('r-host');
+    });
+  });
+
+  it('survives arbitrary nesting depth (branch runner inside a sub-runner)', async () => {
+    await runWithSession('r-host', async () => {
+      await runWithSession('prologue', async () => {
+        await runWithSession('task-1', async () => {
+          expect(rootSessionId()).toBe('r-host');
+        });
+      });
+    });
+  });
+
+  it('resolves each concurrently interleaved branch to the SAME root but its own current id', async () => {
+    const observed: Array<{ current: string | undefined; root: string | undefined }> = [];
+    await runWithSession('r-host', async () => {
+      await Promise.all(
+        ['task-a', 'task-b', 'task-c'].map((id) =>
+          runWithSession(id, async () => {
+            await Promise.resolve();
+            observed.push({ current: currentSessionId(), root: rootSessionId() });
+          })
+        )
+      );
+    });
+
+    expect(observed.map((o) => o.current).sort()).toStrictEqual(['task-a', 'task-b', 'task-c']);
+    expect(observed.every((o) => o.root === 'r-host')).toBe(true);
+  });
+});

--- a/tests/unit/application/ui/tui/components/wrap-document-rows.test.ts
+++ b/tests/unit/application/ui/tui/components/wrap-document-rows.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The document overlays window by ROW COUNT, so their wrap helper owes one invariant above all
+ * others: every row it returns fits the requested width. Everything else here (indent carrying,
+ * long-word chopping, blank-row preservation) is about not making the artifact less readable
+ * while enforcing that invariant.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  OVERLAY_CHROME_COLUMNS,
+  overlayBodyColumns,
+  wrapRow,
+  wrapRows,
+} from '@src/application/ui/tui/components/overlay-internals/wrap-document-rows.ts';
+
+describe('wrapRow', () => {
+  it('leaves a row that already fits untouched', () => {
+    expect(wrapRow('short line', 40)).toEqual(['short line']);
+  });
+
+  it('preserves a blank row so the artifact keeps its rhythm', () => {
+    expect(wrapRow('', 40)).toEqual(['']);
+  });
+
+  it('wraps a long paragraph so every row fits the width', () => {
+    const paragraph = Array.from({ length: 60 }, (_, i) => `word${String(i).padStart(2, '0')}`).join(' ');
+    const rows = wrapRow(paragraph, 30);
+
+    expect(rows.length).toBeGreaterThan(1);
+    for (const row of rows) expect(row.length).toBeLessThanOrEqual(30);
+    // No prose is lost — the wrap is a reflow, not a truncation.
+    expect(rows.join(' ').split(/\s+/).filter(Boolean)).toEqual(paragraph.split(' '));
+  });
+
+  it('carries the leading indent onto continuation rows', () => {
+    const rows = wrapRow('    alpha beta gamma delta epsilon zeta eta theta', 20);
+
+    expect(rows.length).toBeGreaterThan(1);
+    for (const row of rows) expect(row.startsWith('    ')).toBe(true);
+  });
+
+  it('chops a single word longer than the width instead of overflowing', () => {
+    const rows = wrapRow(`prefix ${'x'.repeat(50)} suffix`, 20);
+
+    for (const row of rows) expect(row.length).toBeLessThanOrEqual(20);
+    expect(rows.join('')).toContain('x'.repeat(20));
+    expect(rows.at(-1)).toContain('suffix');
+  });
+
+  it('preserves interior runs of spaces used for alignment', () => {
+    const rows = wrapRow('    FAIL   tests/foo.test.ts', 40);
+
+    expect(rows).toEqual(['    FAIL   tests/foo.test.ts']);
+  });
+
+  it('falls back to a hard split when the leading whitespace alone exceeds the width', () => {
+    const rows = wrapRow(`${' '.repeat(12)}tail`, 10);
+
+    for (const row of rows) expect(row.length).toBeLessThanOrEqual(10);
+    expect(rows.join('')).toContain('tail');
+  });
+});
+
+describe('wrapRows / overlayBodyColumns', () => {
+  it('flattens a document so the row count matches what will be painted', () => {
+    const doc = ['one', 'alpha beta gamma delta', ''];
+    const rows = wrapRows(doc, 12);
+
+    expect(rows).toEqual(['one', 'alpha beta', 'gamma delta', '']);
+  });
+
+  it('subtracts the overlay chrome from the terminal width', () => {
+    expect(overlayBodyColumns(100)).toBe(100 - OVERLAY_CHROME_COLUMNS);
+  });
+
+  it('floors the width so a tiny terminal still wraps into something usable', () => {
+    expect(overlayBodyColumns(4)).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/application/ui/tui/runtime/bucket-task-signals-blocked-dependency.test.ts
+++ b/tests/unit/application/ui/tui/runtime/bucket-task-signals-blocked-dependency.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A dependency-blocked task must NOT read as `running` for the rest of the implement run.
+ *
+ * The per-task subchain is `sequential('task-<id>', [dependency-gate-<id>, guard('task-runnable-<id>',
+ * isTaskRunnable, sequential('task-body-<id>', […]))])`. `guard` emits exactly ONE synthetic trace
+ * entry, named after its BODY — so a gate-blocked task's only trace entries are
+ * `dependency-gate-<id>` (completed) and `task-body-<id>` (skipped). Neither is failed/aborted and
+ * neither is the terminal `uninstall-skills` leaf, so the bucket used to resolve `running` forever:
+ * the Execute header pinned its "active task" readout on a task that was `blocked` on disk.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Trace } from '@src/application/chain/trace.ts';
+import { bucketTaskSignals, isInFlightBucket } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
+
+const BLOCKED = '01933fbb-1111-7000-8000-000000000001';
+const SIBLING = '01933fbb-2222-7000-8000-000000000002';
+
+/** The exact trace shape the dependency gate + body guard produce for a blocked task. */
+const gateBlockedTrace = (taskId: string): Trace => [
+  { elementName: `dependency-gate-${taskId}`, status: 'completed', durationMs: 2 },
+  { elementName: `task-body-${taskId}`, status: 'skipped', durationMs: 0 },
+];
+
+describe('bucketTaskSignals — dependency-blocked task', () => {
+  it('resolves a gate-blocked task to `skipped`, not `running`', () => {
+    const result = bucketTaskSignals(gateBlockedTrace(BLOCKED), [], []);
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.id).toBe(BLOCKED);
+    expect(result.tasks[0]?.status).toBe('skipped');
+  });
+
+  it('keeps the blocked task behind the in-flight cursor while a sibling still runs', () => {
+    const trace: Trace = [
+      ...gateBlockedTrace(BLOCKED),
+      { elementName: `dependency-gate-${SIBLING}`, status: 'completed', durationMs: 2 },
+      { elementName: `generator-${SIBLING}`, status: 'completed', durationMs: 40 },
+    ];
+    const result = bucketTaskSignals(trace, [], []);
+
+    const inFlight = result.tasks.findIndex(isInFlightBucket);
+    expect(result.tasks[inFlight]?.id).toBe(SIBLING);
+    expect(result.tasks[inFlight]?.status).toBe('running');
+  });
+
+  it('does not treat a skipped sub-guard (reproduce / quarantine) as a skipped task', () => {
+    // Both guards live INSIDE the body and skip routinely on the happy path — only the
+    // `task-body` composite being skipped means the whole task never ran.
+    const trace: Trace = [
+      { elementName: `dependency-gate-${SIBLING}`, status: 'completed', durationMs: 2 },
+      { elementName: `reproduce-${SIBLING}`, status: 'skipped', durationMs: 0 },
+      { elementName: `generator-${SIBLING}`, status: 'completed', durationMs: 40 },
+      { elementName: `uninstall-skills-${SIBLING}`, status: 'completed', durationMs: 3 },
+    ];
+    const result = bucketTaskSignals(trace, [], []);
+
+    expect(result.tasks[0]?.status).toBe('completed');
+  });
+
+  it('never reads a SKIPPED terminal leaf as a completed task', () => {
+    const trace: Trace = [
+      { elementName: `dependency-gate-${BLOCKED}`, status: 'completed', durationMs: 2 },
+      { elementName: `uninstall-skills-${BLOCKED}`, status: 'skipped', durationMs: 0 },
+    ];
+    const result = bucketTaskSignals(trace, [], []);
+
+    expect(result.tasks[0]?.status).not.toBe('completed');
+  });
+
+  it('counts only genuinely in-flight buckets as current', () => {
+    expect(isInFlightBucket({ status: 'running' })).toBe(true);
+    expect(isInFlightBucket({ status: 'pending' })).toBe(true);
+    expect(isInFlightBucket({ status: 'skipped' })).toBe(false);
+    expect(isInFlightBucket({ status: 'failed' })).toBe(false);
+    expect(isInFlightBucket({ status: 'aborted' })).toBe(false);
+    expect(isInFlightBucket({ status: 'completed' })).toBe(false);
+  });
+});

--- a/tests/unit/business/task/run-evaluator-turn.test.ts
+++ b/tests/unit/business/task/run-evaluator-turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Result } from '@src/domain/result.ts';
 import { recordRunningAttemptVerification } from '@src/domain/entity/task-attempts.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
+import { ProcessCrashError } from '@src/domain/value/error/process-crash-error.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import { RateLimitError } from '@src/domain/value/error/rate-limit-error.ts';
 import type { EvaluationSignal, HarnessSignal } from '@src/domain/signal.ts';
@@ -267,6 +268,38 @@ describe('runEvaluatorTurnUseCase', () => {
         expect(result.value.exit.reason).toContain('signals.json not found in outputDir');
       }
       expect(result.value.task).toBe(task); // unchanged — no evaluation recorded
+    }
+  });
+
+  it('returns a CRASHED exit (not self-blocked) on a ProcessCrashError — the retry path', async () => {
+    // The evaluator spawns through the same headless provider, the same idle-stdout watchdog and
+    // the same classify-spawn-exit ladder as the generator, so a transient evaluator process death
+    // must route to `crashed` (finalize retries within maxAttempts) rather than `self-blocked`,
+    // which terminally blocks the task after ONE attempt with the budget untouched. Mirrors the
+    // generator-side split.
+    const task = verifiedTask();
+    const err = new ProcessCrashError({
+      entity: 'codex-provider',
+      state: 'exit-143',
+      message: 'codex-provider: process exited with code 143 (signal=SIGTERM): <empty stderr>',
+    });
+    const result = await runEvaluatorTurnUseCase({
+      task,
+      plateauThreshold: 2,
+      callEvaluate: async () => Result.error(err),
+      evaluationFile: EVAL_FILE,
+      logger: noopLogger,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.exit?.kind).toBe('crashed');
+      if (result.value.exit?.kind === 'crashed') {
+        expect(result.value.exit.reason).toContain('AI process was killed before producing signals.json');
+        expect(result.value.exit.reason).toContain('process exited with code 143 (signal=SIGTERM)');
+      }
+      expect(result.value.task).toBe(task); // unchanged — no evaluation recorded on a crash
+      // No evaluation signal survives a crashed turn, so the prior round's verdict cannot leak.
+      expect(result.value.evaluation).toBeUndefined();
     }
   });
 

--- a/tests/unit/domain/entity/task-lifecycle.test.ts
+++ b/tests/unit/domain/entity/task-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   unblockTask,
 } from '@src/domain/entity/task-lifecycle.ts';
 import {
+  recordTaskBestOfNGrant,
   recordTaskEffortEscalation,
   recordTaskEscalation,
   recordTaskEvaluatorEffortEscalation,
@@ -95,6 +96,30 @@ describe('unblockTask — clean restart (drops block fields, resets budget + esc
     expect((back.value as unknown as Record<string, unknown>)['escalatedToEvaluatorEffort']).toBeUndefined();
     // The cap itself (a planning field) survives — only the consumed budget resets.
     expect(back.value.maxAttempts).toBe(3);
+  });
+
+  it('drops the unconsumed best-of-N handshake but KEEPS the permanent grant marker', () => {
+    // Arrange: a task whose best-of-N grant was stamped but never consumed (the attempt aborted /
+    // self-blocked before `best-of-n-selection` cleared the handshake), then blocked.
+    const inProgress = makeInProgressTaskWithRunningAttempt();
+    const granted = recordTaskBestOfNGrant(inProgress, 3);
+    if (!granted.ok) throw granted.error;
+    const blocked = markTaskBlocked(granted.value, 'cancelled by operator', 'own');
+    if (!blocked.ok) throw blocked.error;
+    expect(blocked.value.bestOfNGrantedCandidates).toBe(3); // precondition: handshake survives the block
+
+    // Act
+    const back = unblockTask(blocked.value);
+
+    // Assert: the transient handshake is meant to be consumed by the attempt it was issued for, so a
+    // clean restart with zero attempts must not re-enter the best-of-N composite and burn N sessions.
+    expect(back.ok).toBe(true);
+    if (!back.ok) return;
+    expect(back.value.attempts).toHaveLength(0);
+    expect((back.value as unknown as Record<string, unknown>)['bestOfNGrantedCandidates']).toBeUndefined();
+    // The PERMANENT marker survives — it is the once-per-task gate `decideEscalation` reads; clearing
+    // it would let repeated block/unblock cycles re-grant N candidate sessions without bound.
+    expect(back.value.bestOfNGranted).toBe(true);
   });
 
   it('drops criteriaVerdicts so stale k-of-N verdicts do not mislead the next run', () => {

--- a/tests/unit/integration/ai/contract/_engine/signal-schemas.test.ts
+++ b/tests/unit/integration/ai/contract/_engine/signal-schemas.test.ts
@@ -13,7 +13,10 @@ import { setupScriptSignalSchema } from '@src/integration/ai/contract/_engine/si
 import { verifyScriptSignalSchema } from '@src/integration/ai/contract/_engine/signals/verify-script/schema.ts';
 import { setupSkillProposalSignalSchema } from '@src/integration/ai/contract/_engine/signals/setup-skill-proposal/schema.ts';
 import { verifySkillProposalSignalSchema } from '@src/integration/ai/contract/_engine/signals/verify-skill-proposal/schema.ts';
-import { skillSuggestionsSignalSchema } from '@src/integration/ai/contract/_engine/signals/skill-suggestions/schema.ts';
+import {
+  MAX_SKILL_SUGGESTIONS,
+  skillSuggestionsSignalSchema,
+} from '@src/integration/ai/contract/_engine/signals/skill-suggestions/schema.ts';
 import { contextCompactedSignalSchema } from '@src/integration/ai/contract/_engine/signals/context-compacted/schema.ts';
 import { prContentSignalSchema } from '@src/integration/ai/contract/_engine/signals/pr-content/schema.ts';
 
@@ -328,5 +331,54 @@ describe('signal schemas (happy-path parses)', () => {
         timestamp: ts,
       }).success
     ).toBe(true);
+  });
+});
+
+/**
+ * `skill-suggestions.names` is the one AI-controlled string that becomes a directory name on the
+ * operator's disk (`<repo>/<parentDir>/skills/<name>/SKILL.md` via the readiness offer leaf), so
+ * the wire schema is the first containment boundary: anything that is not a bare kebab-case
+ * identifier is dropped at parse time rather than failing the whole round.
+ */
+describe('skill-suggestions names — path-traversal containment at the wire', () => {
+  const parseNames = (names: readonly string[]): readonly string[] | undefined => {
+    const parsed = skillSuggestionsSignalSchema.safeParse({ type: 'skill-suggestions', names, timestamp: ts });
+    return parsed.success ? parsed.data.names : undefined;
+  };
+
+  const hostile = [
+    '../evil',
+    '../../../../tmp/pwned',
+    'a/b',
+    'a\\b',
+    '/etc/cron.d/pwn',
+    '~/evil',
+    '.',
+    '..',
+    '',
+    '   ',
+    'ralphctl-alignment\nallowed-tools: Bash',
+    'Réact-patterns',
+    'react⁄patterns',
+    'react patterns',
+    'UPPER-case',
+    '.hidden',
+    'a'.repeat(65),
+  ];
+
+  it.each(hostile)('drops the hostile name %j', (name) => {
+    expect(parseNames([name])).toEqual([]);
+  });
+
+  it('keeps well-formed names and drops only the hostile ones (one bad name never fails the round)', () => {
+    expect(parseNames(['ralphctl-alignment', '../evil', 'react-patterns', '/abs'])).toEqual([
+      'ralphctl-alignment',
+      'react-patterns',
+    ]);
+  });
+
+  it('caps the list so a runaway model cannot queue unbounded install prompts', () => {
+    const many = Array.from({ length: MAX_SKILL_SUGGESTIONS + 10 }, (_, i) => `skill-${i}`);
+    expect(parseNames(many)).toHaveLength(MAX_SKILL_SUGGESTIONS);
   });
 });

--- a/tests/unit/integration/io/git-exclude.test.ts
+++ b/tests/unit/integration/io/git-exclude.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
 
 const makeRoot = async (): Promise<AbsolutePath> => {
@@ -66,6 +67,53 @@ describe('ensureGitExcludeWildcard', () => {
 
     const content = await readFile(join(String(root), '.git/info/exclude'), 'utf8');
     expect(content).toBe(`  ${PATTERN}  \n`);
+  });
+
+  it('follows the worktree commondir pointer — git only reads the COMMON info/exclude', async () => {
+    const main = await makeRoot();
+    const gitdir = join(String(main), '.git/worktrees/wt');
+    await mkdir(join(gitdir, 'info'), { recursive: true });
+    await mkdir(join(String(main), '.git/info'), { recursive: true });
+    // git writes `commondir` into every linked-worktree gitdir, relative to that gitdir.
+    await writeFile(join(gitdir, 'commondir'), '../..\n', 'utf8');
+
+    const worktree = await makeRoot();
+    await writeFile(join(String(worktree), '.git'), `gitdir: ${gitdir}\n`, 'utf8');
+
+    const result = await ensureGitExcludeWildcard(worktree, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const common = await readFile(join(String(main), '.git/info/exclude'), 'utf8');
+    expect(common).toBe(`${PATTERN}\n`);
+    // The per-worktree gitdir copy is the file git ignores — it must stay untouched.
+    await expect(readFile(join(gitdir, 'info/exclude'), 'utf8')).rejects.toThrow();
+  });
+
+  it('accepts an absolute commondir path', async () => {
+    const main = await makeRoot();
+    const gitdir = await mkdtemp(join(tmpdir(), 'wt-gitdir-'));
+    await mkdir(join(String(main), '.git/info'), { recursive: true });
+    await writeFile(join(gitdir, 'commondir'), `${join(String(main), '.git')}\n`, 'utf8');
+
+    const worktree = await makeRoot();
+    await writeFile(join(String(worktree), '.git'), `gitdir: ${gitdir}\n`, 'utf8');
+
+    const result = await ensureGitExcludeWildcard(worktree, PATTERN);
+    expect(result.ok).toBe(true);
+
+    const common = await readFile(join(String(main), '.git/info/exclude'), 'utf8');
+    expect(common).toBe(`${PATTERN}\n`);
+  });
+
+  it('returns an error Result instead of throwing when .git cannot be inspected', async () => {
+    const root = await makeRoot();
+    // A self-referential symlink makes stat() fail with ELOOP — neither ENOENT nor ENOTDIR.
+    await symlink('.git', join(String(root), '.git'));
+
+    const result = await ensureGitExcludeWildcard(root, PATTERN);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toBeInstanceOf(StorageError);
   });
 
   it('resolves the worktree pointer file (.git is a file containing gitdir:)', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,17 @@ export default defineConfig({
         test: {
           name: 'tui',
           include: ['tests/integration/application/ui/tui/**/*.test.{ts,tsx}'],
+          // Colour is PINNED, not inherited. Ink/chalk decide colour support from the worker's
+          // env, and every TUI assertion is a plain-substring check against `lastFrame()` — with
+          // an ambient `FORCE_COLOR` (Claude Code exports `FORCE_COLOR=3`; several terminal
+          // wrappers and CI images do too) chalk splits those substrings with truecolor SGR codes
+          // and 27 assertions across 13 files fail on a pristine tree. The suite must give the
+          // same answer for every developer, agent session and runner, so the gate stays
+          // trustworthy. `NO_COLOR` is deliberately NOT set here: chalk lets FORCE_COLOR win
+          // anyway, and `useNoColor()` reads NO_COLOR to swap in the shape-glyph fallback —
+          // pinning it suite-wide would silently run every test through the fallback path and
+          // neuter `tasks-panel-no-color.test.tsx`, which sets it per-test on purpose.
+          env: { FORCE_COLOR: '0' },
           pool: 'forks',
           // One file at a time within this project; non-TUI tests still parallelise.
           fileParallelism: false,
@@ -66,6 +77,8 @@ export default defineConfig({
           name: 'default',
           include: ['tests/**/*.test.{ts,tsx}'],
           exclude: ['tests/integration/application/ui/tui/**'],
+          // Same colour pin as the `tui` project — CLI-output assertions are plain-substring too.
+          env: { FORCE_COLOR: '0' },
           pool: 'forks',
           // E2E tests under `tests/e2e/cli/` spawn real child processes (git / gh / glab /
           // provider CLIs) inside the in-process CLI run, and pay full module-import cost on


### PR DESCRIPTION
Pre-release hardening batch from a full-repo maintenance audit: 8 auditor roles (correctness, TUI/display, chain framework, provider adapters, release gates, test integrity, security, docs drift) produced 51 findings, deduplicated to 47; every must/should candidate was adversarially re-verified against the code before implementation. 28 verified findings are fixed here; 19 lower-severity ones were filed as issues #288–#306.

## Must-fixes
- **Chain**: an in-branch operator abort no longer degrades to a no-op that keeps launching waves — it stops scheduling, kills in-flight siblings, and propagates the AbortError verbatim
- **Providers**: rate-limit detection no longer matches assistant prose (a "429" in conversation could discard a landed `signals.json` and sleep ~36 min); landed signals now beat stdout evidence; unreachable OpenCode model ids fail fast instead of burning the attempt budget
- **Security**: worktree `.git/info/exclude` now resolves the common git dir (bundled skills were being committed); AI-supplied `skill-suggestions` names are sanitized against path traversal at the contract boundary
- **TUI**: `router.reset` requires an explicit entry — first-run `h`/`D` no longer bounce to Welcome and re-stamp the AI preset; document overlays hard-wrap before windowing so wrapped critiques scroll correctly
- **Test gate**: vitest pins `FORCE_COLOR=0` — `pnpm test` was reporting 27 false failures whenever the caller's shell exported FORCE_COLOR

## Should-fixes
- Diff-scoped post-verify success no longer recorded as a full-tree green baseline (false `regressed` blocks)
- Evaluator process crashes retry within `maxAttempts` instead of terminally blocking the task; `unblockTask` clears best-of-N grant stamps
- Blocked tasks bucket as skipped instead of rendering active; parallel runs show token usage (root-session keying); Welcome esc hint works; status-banner dismiss gated while prompts own the keyboard
- CLI top-level error handler (one-line errors, stack behind debug env); release workflow packs + installs the tarball before publish; CI exercises the bundled-prompt resolver via new `ralphctl prompts list`
- One loud `waitFor` contract across the TUI suite (exposed and fixed 2 silently-dead tests); real coverage for `pull-request-creator`; forensics negative tests await loaded state; entropy-check fixtures match the real loop composition
- Docs drift: four-backend counts, contributor guide, data-model fields, implementFlow trace, README CLI reference, playbook scenarios for the Unreleased features

## Verification
- `pnpm typecheck` / `pnpm lint` / `pnpm test` all green — 607 files / 5890 tests (+18 files, +131 tests), passing **with `FORCE_COLOR=3` exported** (previously 27 false failures)
- `pnpm build`, `pnpm deadcode`, `pnpm format:check` clean; every fix ships with a regression test written to fail first

https://claude.ai/code/session_01PHikH4LdejozJdjzTzhPes