### PR TITLE
fix(skills): strict-YAML-safe frontmatter for installed skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,12 @@ to [Semantic Versioning](https://semver.org/).
   with long wrapped lines scrolls instead of overflowing the viewport; the Welcome error state's
   `esc` hint now works; and the status banner's `d` dismiss no longer fires while a prompt owns the
   keyboard.
+- **Copilot loads every installed ralphctl skill again.** The bundled `ralphctl-alignment` skill's
+  frontmatter description contained an unquoted `: `, which Copilot's strict YAML parser rejects
+  ("mapping values are not allowed in this context") — the skill failed to load in Copilot sessions.
+  The description is fixed, the installer now quotes any frontmatter value a strict YAML parser
+  would reject unquoted (round-tripping cleanly through ralphctl's own reader), and a test gate
+  checks every bundled skill against the strict rules so this class of break cannot ship again.
 - **CLI errors are one line, not a stack.** A malformed `settings.json` (or any unexpected failure)
   prints `ralphctl: <message>` with a debug-env hint instead of dumping a raw Node stack from the
   minified bundle.

--- a/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
+++ b/src/integration/ai/skills/_engine/filesystem-skills-adapter.ts
@@ -49,14 +49,26 @@ export interface FilesystemSkillsAdapterDeps {
 }
 
 /**
+ * Downstream CLIs parse the installed frontmatter with STRICT YAML parsers — Copilot rejects an
+ * unquoted plain scalar containing `: ` outright ("mapping values are not allowed in this
+ * context"). Values that are safe plain scalars stay unquoted to keep the files human-readable;
+ * anything else is double-quoted with YAML escapes, which `parseSimpleYaml` unescapes on read.
+ */
+const yamlValue = (value: string): string =>
+  /^[A-Za-z0-9]/u.test(value) && !value.includes(': ') && !value.includes(' #') && !/[\s:]$/u.test(value)
+    ? value
+    : `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+
+/**
  * Render the canonical Skill back into Markdown with frontmatter — Agent Skills spec
  * (`name`, `description`, plus optional `license` / `compatibility` / `allowed-tools`).
+ * `name` renders bare: it is schema-fenced to kebab-case, which is always a safe plain scalar.
  */
 const renderSkill = (skill: Skill): string => {
-  const lines = ['---', `name: ${skill.name}`, `description: ${skill.description}`];
-  if (skill.license !== undefined) lines.push(`license: ${skill.license}`);
-  if (skill.compatibility !== undefined) lines.push(`compatibility: ${skill.compatibility}`);
-  if (skill.allowedTools !== undefined) lines.push(`allowed-tools: ${skill.allowedTools}`);
+  const lines = ['---', `name: ${skill.name}`, `description: ${yamlValue(skill.description)}`];
+  if (skill.license !== undefined) lines.push(`license: ${yamlValue(skill.license)}`);
+  if (skill.compatibility !== undefined) lines.push(`compatibility: ${yamlValue(skill.compatibility)}`);
+  if (skill.allowedTools !== undefined) lines.push(`allowed-tools: ${yamlValue(skill.allowedTools)}`);
   lines.push('---');
   return `${lines.join('\n')}\n\n${skill.content.replace(/\s+$/u, '')}\n`;
 };

--- a/src/integration/ai/skills/_engine/frontmatter.ts
+++ b/src/integration/ai/skills/_engine/frontmatter.ts
@@ -36,9 +36,11 @@ export const splitFrontmatter = (raw: string): { readonly frontmatter: string; r
 };
 
 /**
- * Naive YAML key:value parser — keys are simple identifiers, values are strings or single-quoted
- * strings without escapes. Frontmatter we control is always this shape, so a full YAML parser
- * is overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
+ * Naive YAML key:value parser — keys are simple identifiers, values are plain strings,
+ * double-quoted strings with `\"` / `\\` escapes (the shape the skills adapter's renderer
+ * emits for values a strict YAML parser would reject unquoted), or single-quoted strings
+ * without escapes. Frontmatter we control is always this shape, so a full YAML parser is
+ * overkill (and adds a dep). Multiline / nested YAML is rejected via schema validation.
  *
  * @public
  */
@@ -51,8 +53,9 @@ export const parseSimpleYaml = (input: string): Record<string, string> => {
     if (colon === -1) continue;
     const key = stripped.slice(0, colon).trim();
     let value = stripped.slice(colon + 1).trim();
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-    else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"'))
+      value = value.slice(1, -1).replace(/\\(["\\])/gu, '$1');
+    else if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
     result[key] = value;
   }
   return result;

--- a/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
+++ b/src/integration/ai/skills/bundled/ralphctl-alignment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralphctl-alignment
-description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output: restate the input back to the user, surface assumptions, name non-goals, and agree before you write. For an input that is still a raw, unshaped idea needing multiple candidate directions before one is chosen, run the ralphctl-idea-refinement skill first when it is installed in this session; alignment then confirms whichever direction comes out of it.
+description: Cross-phase skill — establish a shared understanding of what will and will not be done before producing output. Restate the input back to the user, surface assumptions, name non-goals, and agree before you write. For an input that is still a raw, unshaped idea needing multiple candidate directions before one is chosen, run the ralphctl-idea-refinement skill first when it is installed in this session; alignment then confirms whichever direction comes out of it.
 ---
 
 # Alignment

--- a/tests/integration/ai/skills/_engine/frontmatter-strict-yaml.test.ts
+++ b/tests/integration/ai/skills/_engine/frontmatter-strict-yaml.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import type { Skill } from '@src/integration/ai/skills/_engine/skill.ts';
+import { parseSimpleYaml, splitFrontmatter } from '@src/integration/ai/skills/_engine/frontmatter.ts';
+import { createCopilotSkillsAdapter } from '@src/integration/ai/skills/copilot/adapter.ts';
+
+/**
+ * Installed SKILL.md frontmatter is read back by the downstream CLIs' STRICT YAML parsers —
+ * Copilot rejects an unquoted plain scalar containing `: ` with "mapping values are not allowed
+ * in this context" and refuses to load the skill. ralphctl's own reader is deliberately naive
+ * and tolerated such values, which is exactly how one shipped: this suite pins the contract
+ * from the strict consumer's side, for both the render path (adapter install) and the bundled
+ * sources that are copied verbatim.
+ */
+
+/**
+ * The strict-YAML rules a flat `key: value` frontmatter line must satisfy for the downstream
+ * parsers: a value is either quoted, or a plain scalar that contains no `: ` / ` #`, does not
+ * start with an indicator character, and does not end with `:` or whitespace.
+ */
+const isStrictSafeLine = (line: string): boolean => {
+  const match = /^(?<key>[a-z][a-z-]*): (?<value>.*)$/u.exec(line);
+  if (!match?.groups) return false;
+  const value = match.groups['value'] ?? '';
+  if (/^"(?:[^"\\]|\\.)*"$/u.test(value)) return true;
+  if (/^'[^']*'$/u.test(value)) return true;
+  return /^[A-Za-z0-9]/u.test(value) && !value.includes(': ') && !value.includes(' #') && !/[\s:]$/u.test(value);
+};
+
+const makeSession = async (): Promise<AbsolutePath> => {
+  const dir = await mkdtemp(join(tmpdir(), 'strict-yaml-skills-'));
+  const parsed = AbsolutePath.parse(dir);
+  if (!parsed.ok) throw new Error(parsed.error.message);
+  return parsed.value;
+};
+
+const install = async (skill: Skill): Promise<string> => {
+  const session = await makeSession();
+  const adapter = createCopilotSkillsAdapter();
+  const result = await adapter.install(session, [skill]);
+  expect(result.ok).toBe(true);
+  return readFile(join(String(session), '.github/skills', skill.name, 'SKILL.md'), 'utf-8');
+};
+
+describe('renderSkill — strict-YAML-safe frontmatter for downstream parsers', () => {
+  it('quotes a description containing ": " (the exact shape Copilot rejected unquoted)', async () => {
+    const description =
+      'Cross-phase skill — do the thing before producing output: restate, surface assumptions, agree.';
+    const raw = await install({ name: 'ralphctl-colon-desc', description, content: '# body' });
+
+    const { frontmatter } = splitFrontmatter(raw);
+    for (const line of frontmatter.split('\n'))
+      expect(line, `unsafe frontmatter line: ${line}`).toSatisfy(isStrictSafeLine);
+    // Round-trip: ralphctl's own reader recovers the original description from the quoted form.
+    expect(parseSimpleYaml(frontmatter)['description']).toBe(description);
+  });
+
+  it('escapes embedded double quotes and backslashes, and round-trips them', async () => {
+    const description = 'Use "quoted" phrases: even with a back\\slash.';
+    const raw = await install({ name: 'ralphctl-quote-desc', description, content: '# body' });
+
+    const { frontmatter } = splitFrontmatter(raw);
+    for (const line of frontmatter.split('\n'))
+      expect(line, `unsafe frontmatter line: ${line}`).toSatisfy(isStrictSafeLine);
+    expect(parseSimpleYaml(frontmatter)['description']).toBe(description);
+  });
+
+  it('leaves a safe plain-scalar description unquoted (files stay human-readable)', async () => {
+    const description = 'Plain description — em-dashes, commas, and even mid:colons are fine unquoted.';
+    const raw = await install({ name: 'ralphctl-plain-desc', description, content: '# body' });
+
+    expect(raw).toContain(`description: ${description}`);
+  });
+
+  it('quotes the optional license / compatibility / allowed-tools values when unsafe', async () => {
+    const raw = await install({
+      name: 'ralphctl-optional-keys',
+      description: 'safe',
+      content: '# body',
+      license: 'MIT: see LICENSE',
+      compatibility: 'claude, copilot',
+      allowedTools: 'Read, Grep: no writes',
+    });
+
+    const { frontmatter } = splitFrontmatter(raw);
+    for (const line of frontmatter.split('\n'))
+      expect(line, `unsafe frontmatter line: ${line}`).toSatisfy(isStrictSafeLine);
+    const parsed = parseSimpleYaml(frontmatter);
+    expect(parsed['license']).toBe('MIT: see LICENSE');
+    expect(parsed['allowed-tools']).toBe('Read, Grep: no writes');
+  });
+});
+
+describe('bundled skill sources — frontmatter parses under strict YAML', () => {
+  it('every src/integration/ai/skills/bundled/*/SKILL.md is strict-safe as authored', async () => {
+    // The catalog enable path copies these files VERBATIM (no re-render), so the sources
+    // themselves must already satisfy the strict consumers — quoting in the renderer alone
+    // does not cover them.
+    const bundledDir = join(process.cwd(), 'src/integration/ai/skills/bundled');
+    const entries = await readdir(bundledDir, { withFileTypes: true });
+    const skillDirs = entries.filter((entry) => entry.isDirectory());
+    expect(skillDirs.length).toBeGreaterThan(0);
+
+    for (const dir of skillDirs) {
+      const raw = await readFile(join(bundledDir, dir.name, 'SKILL.md'), 'utf-8');
+      const { frontmatter } = splitFrontmatter(raw);
+      expect(frontmatter, `${dir.name}/SKILL.md has no frontmatter`).not.toBe('');
+      for (const line of frontmatter.split('\n'))
+        expect(line, `${dir.name}/SKILL.md unsafe frontmatter line: ${line}`).toSatisfy(isStrictSafeLine);
+    }
+  });
+});

--- a/tests/unit/integration/ai/skills/frontmatter.test.ts
+++ b/tests/unit/integration/ai/skills/frontmatter.test.ts
@@ -74,6 +74,18 @@ describe('parseSimpleYaml', () => {
   it('skips lines with no colon', () => {
     expect(parseSimpleYaml('not a kv line\na: 1')).toEqual({ a: '1' });
   });
+
+  it('unescapes \\" and \\\\ inside a double-quoted value (the renderer emits this shape)', () => {
+    expect(parseSimpleYaml('a: "say \\"hi\\": a back\\\\slash"')).toEqual({ a: 'say "hi": a back\\slash' });
+  });
+
+  it('leaves single-quoted values verbatim — no escape handling', () => {
+    expect(parseSimpleYaml("a: 'no \\\" unescaping here'")).toEqual({ a: 'no \\" unescaping here' });
+  });
+
+  it('treats a lone quote character as a plain value, not an empty quoted string', () => {
+    expect(parseSimpleYaml('a: "\nb: \'')).toEqual({ a: '"', b: "'" });
+  });
 });
 
 describe('errorCode', () => {


### PR DESCRIPTION
Copilot refused to load the installed `ralphctl-alignment` skill: `failed to parse YAML frontmatter: mapping values are not allowed in this context at line 2 column 124`. Root cause is two-layered:

1. The bundled skill's `description` contained an unquoted `: ` ("…before producing output: restate…") — invalid as a YAML plain scalar. ralphctl's deliberately naive frontmatter reader tolerated it; Copilot's strict parser does not.
2. `renderSkill` interpolated every frontmatter value unquoted, so *any* future description with a colon-space would break the same way in downstream strict parsers.

Fixes:
- Reword the `ralphctl-alignment` description (colon → sentence break) so the source file stays a plain scalar
- `renderSkill` now quotes any value a strict YAML parser would reject unquoted (safe plain scalars stay bare for readability); `parseSimpleYaml` unescapes the double-quoted form so the round-trip is lossless
- New strict-YAML test gate: every bundled `SKILL.md` frontmatter must satisfy the strict rules (proven to fail on the pre-fix content), plus renderer round-trip tests for colons, embedded quotes, backslashes, and the optional `license`/`compatibility`/`allowed-tools` keys

Verify gate green: typecheck, lint, 608 files / 5898 tests.

Note for existing checkouts: the broken file in a downstream repo's `.github/skills/` heals on the next ralphctl run — skills are reinstalled per task and the run replaces the saved copy.

https://claude.ai/code/session_01PHikH4LdejozJdjzTzhPes