### PR TITLE
Refactor + documentation ticket batch (#293, #297, #305, #306)

### DIFF
--- a/.claude/agent-memory/designer/MEMORY.md
+++ b/.claude/agent-memory/designer/MEMORY.md
@@ -71,6 +71,10 @@
 
 - [project_outcome_report_card_2026-08-14.md](project_outcome_report_card_2026-08-14.md) — Sprint outcome-report card: hosted in SprintDetailView's Body (review/done gate), minimal metric set, hasAttemptData empty-fallback gotcha
 
+## Design-System Drift Fixes
+
+- [project_design_system_drift_297.md](project_design_system_drift_297.md) — #297: focusBar/barFilled/barEmpty/unknownGlyph tokens, breakpoints in use-responsive-layout, `↑/↓`-only hint strips, joinCounts separator; DESIGN-SYSTEM §2.2 table still owed (Aug 2026)
+
 ## Working Agreements
 
 - [feedback_no_git_when_told_none.md](feedback_no_git_when_told_none.md) — "NO git commands of any kind" means literally zero, including read-only log/diff/show/status — not just mutating ones

--- a/.claude/agent-memory/designer/project_design_system_drift_297.md
+++ b/.claude/agent-memory/designer/project_design_system_drift_297.md
@@ -1,0 +1,34 @@
+---
+name: design-system-drift-297
+description: Ticket #297 fixes — new glyph tokens (focusBar/barFilled/barEmpty/unknownGlyph), breakpoint tokens in use-responsive-layout, j/k dropped from hint strips, joinCounts separator; plus owed DESIGN-SYSTEM.md §2.2 doc update
+metadata:
+  type: project
+---
+
+Ticket #297 (2026-08-19, branch `feature/refactor-docs-tickets`) closed four design-system departures.
+Decisions worth keeping:
+
+- **`glyphs.focusBar` is U+258D (left three-eighths block), not U+258E.** The sprint-picker focus rail
+  literal was `▍`. An initial token test asserted `0x258e` and failed — pin `0x258d`.
+- **`glyphs.unknownGlyph = '?'` is deliberately colourless.** `evaluator-failure-panel.tsx`'s
+  `VERDICT_PRESENTATION.unknown` must keep `color` ABSENT so `dimensionRows` falls through to
+  `{ dim: true }`. Adding a colour would report an undetermined verdict as pass/fail.
+- **`token-budget-card.tsx` still renders a bare `'?'`** for a missing token count (a placeholder for an
+  absent number, not a status glyph). Intentionally NOT switched to `unknownGlyph` — different meaning.
+- **Hint strips advertise `↑/↓` only** (DESIGN-SYSTEM §6.4). `useViewKeys` sites take `keys: ['↑', '↓']`
+  (joined to `↑/↓`); `useViewHints` sites take `keys: '↑/↓'`. `listMoveHint` is NOT spread into either —
+  `useViewKeys`'s `keys` array holds literal input strings the dispatcher matches, and the already-correct
+  views write the literal. `project-detail-view` and `settings-view` label the same hint `navigate`, so
+  `move` is not the single label — only the keys spelling converged.
+- **`outcome-card.tsx` `joinCounts` now emits `label N · label N`** (bullet as separator), matching every
+  sibling line in that card. The old `label ·N  label ·N` form had no design-system basis.
+
+**Why:** theme/tokens.ts is the single source of visual truth; inline glyphs and raw column numbers
+defeat it.
+
+**How to apply:** reuse these tokens rather than re-inlining. Two inline `█` remain at
+`prompts/text-prompt.tsx` and `prompts/text-area-prompt.tsx` as the caret block — a different semantic;
+a `caretBlock` token is the proposed follow-up.
+
+**OWED FOLLOW-UP:** `.claude/docs/DESIGN-SYSTEM.md` §2.2's glyph table does not yet list the four new
+tokens (that file was outside the ticket's owned-files list). Add them the next time that doc is touched.

--- a/.claude/agent-memory/docs-keeper/MEMORY.md
+++ b/.claude/agent-memory/docs-keeper/MEMORY.md
@@ -16,5 +16,7 @@
   OpenCode paragraphs mix headless (`--auto`) and interactive (`buildOpencodeEnv` config grant) — don't conflate
 - [reference_provider_fanout_registries.md](reference_provider_fanout_registries.md) — Provider fan-out is
   `Record<AiProvider,…>` tables, not switches; regenerate the list by grep, never hand-maintain
+- [reference_mermaid_validation_entities.md](reference_mermaid_validation_entities.md) — `&lt;`/`&gt;` entities
+  inside mermaid blocks are a REAL parse error (GitHub included) — use raw `<angle brackets>`; 01-flow-lifecycle.md still broken
 - [reference_entity_symbol_names_drift.md](reference_entity_symbol_names_drift.md) — ARCHITECTURE § Data Models
   entity mutator/field names rot silently; table of the 2026-08-18 renames

--- a/.claude/agent-memory/docs-keeper/reference_mermaid_validation_entities.md
+++ b/.claude/agent-memory/docs-keeper/reference_mermaid_validation_entities.md
@@ -1,0 +1,28 @@
+---
+name: reference-mermaid-validation-entities
+description: HTML entities (&lt;/&gt;) inside mermaid blocks are a REAL parse error — mermaid's own parser rejects them, GitHub included; always use raw <angle brackets> in diagram bodies
+metadata:
+  type: reference
+---
+
+HTML entities (`&lt;` / `&gt;`) inside mermaid participant aliases or message text are a **hard parse
+error in mermaid itself** (verified against mermaid 11.15 `mermaid.parse()` on 2026-08-19: the `;` in
+the entity terminates the statement). GitHub renders mermaid with the same parser, so an entity-bearing
+diagram shows as a parse error there too — an earlier conclusion that "GitHub handles the entities
+fine" and mmdc's rejection was a false alarm was **wrong** and was corrected in review.
+
+**How to apply:** use RAW angle brackets inside mermaid blocks — `participant Disk as <outputDir>/`,
+`read implement/<taskId>/rounds/<N>/...` — mermaid accepts them (02-sprint-lifecycle.md's raw `<id>`
+always parsed). `04-ai-session-data-flow.md` was fixed this way; **`01-flow-lifecycle.md` still uses
+entities and still fails to parse — open follow-up.** Entities remain fine in surrounding prose.
+
+Validating an edit: extract the fenced block and run mermaid's real parser, e.g.
+`npm i mermaid` in a scratch dir, then `mermaid.parse(text)` in node — a parse-OK there is the signal
+GitHub will render it. `mmdc` needs a browser but agrees with `parse()` on validity.
+
+Other conventions these files establish (match them, don't invent): `<br/>` for participant line
+breaks, `·` middot as an inline separator, `-->>` dashed for replies, `X->>X` for self-messages, and no
+backticks inside mermaid text — the surrounding prose uses backticks, the diagram body never does.
+Style fence is `.claude/docs/diagrams/README.md` § Conventions: plain syntax, no themes/classDef.
+
+Related: [[reference-step-trace-locations]], [[project-high-drift-areas]].

--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -134,4 +134,5 @@
   ImplementLayout's wide (>=140 col) branch entirely — thread + A/B both branches
 - [project_release_gate_seams.md](project_release_gate_seams.md) — release/CI gates: vitest FORCE_COLOR pin (never
   add NO_COLOR), `npm init -y --prefix` writes into CWD (nearly corrupted package.json pre-publish), runCli's
-  reportFatal terminal frame (AbortError handled not re-thrown), `prompts list` as the prompt-resolver dist gate
+  reportFatal terminal frame (AbortError handled not re-thrown), `prompts list` as the prompt-resolver dist gate,
+  pre-release tag glob + npm `--tag next` as one inseparable change (#305)

--- a/.claude/agent-memory/implementer/project_chain_runner_containment_boundary.md
+++ b/.claude/agent-memory/implementer/project_chain_runner_containment_boundary.md
@@ -15,6 +15,14 @@ so an un-caught throw becomes an unhandled rejection that on Node 24 kills the p
 with the runner stuck in 'running' and no terminal event. It also falsifies the wave scheduler's
 documented "start() never rejects" invariant.
 
+**Widened surface (ticket #293, 2026-08-19):** `leaf`'s `isDomainError` used to accept any `Error`
+with a _string_ `code`, which matched every Node errno error (EACCES/ELOOP/ENOENT) and laundered
+adapter I/O failures into the domain channel with a bogus code. It is now exact membership in
+`Object.values(ErrorCode)` (a `Set<unknown>` — `Array.includes()` rejects an `unknown` arg because
+`ErrorCode` is an `as const` object, not a TS enum). Accepted trade-off: an errno throw now emits NO
+trace entry and unwinds here, so the TUI rail names the ROOT element instead of the failing leaf.
+That is the same shape a `TypeError` throw already had; don't "fix" it by loosening the predicate.
+
 **How to apply:** On catch, synthesize an `InvalidStateError` carrying cause message + stack (hint),
 set status='failed', emit 'failed'. CRITICAL: a raw-thrown `AbortError` (code === ErrorCode.Aborted)
 must travel the abort path (status='aborted', emit 'aborted') NOT the synthesized-failure path — same

--- a/.claude/agent-memory/implementer/project_release_gate_seams.md
+++ b/.claude/agent-memory/implementer/project_release_gate_seams.md
@@ -1,11 +1,12 @@
 ---
 name: release-gate-seams
-description: Release/CI gate seams — vitest FORCE_COLOR pin, CLI terminal error frame, npm-pack prefix trap, and the prompts-list resolver gate
+description: Release/CI gate seams — vitest FORCE_COLOR pin, CLI terminal error frame, npm-pack prefix trap, prompts-list resolver gate, and the pre-release tag/dist-tag pair
 metadata:
   type: project
 ---
 
-Four seams around the release/CI gates (hardened 2026-08-18, branch `chore/maintenance-hardening`).
+Five seams around the release/CI gates (hardened 2026-08-18, branch `chore/maintenance-hardening`;
+seam 5 added 2026-08-19 for #305).
 
 **1. Colour is PINNED in `vitest.config.ts`, per project (`env: { FORCE_COLOR: '0' }`).**
 **Why:** every TUI assertion is a plain-substring check on `lastFrame()`; an ambient `FORCE_COLOR`
@@ -43,3 +44,19 @@ prompt assets are unreadable (verified empirically). `prompts list` loads every 
 **How to apply:** the inventory is `_engine/bundled-templates.ts`, fenced against the on-disk tree
 by `tests/integration/ai/prompts/_engine/bundled-templates.test.ts` — a new prompt dir must join
 the list or that test fails. `ci.yml` + `release.yml` grep `^implement` from its output.
+
+**5. The pre-release tag glob and the npm `--tag` are ONE change, never separable.**
+**Why:** Actions ref filters full-match and `[0-9]+` cannot express an optional suffix, so
+`release.yml` needs a second literal pattern (`'v[0-9]+.[0-9]+.[0-9]+-*'`) or a `v0.20.0-rc.1` push
+creates no run at all — silently, no error (that was #305; the `prerelease:` expression had been dead
+since it was written). But widening the trigger alone is a live regression: `pnpm publish` had no
+`--tag`, so an rc would land on `latest`, and `compareVersions`
+(`src/business/version/version-check.ts`) strips pre-release suffixes on the _documented_ assumption
+that `latest` is always stable — every stable user would be nagged to install the rc.
+**How to apply:** the version step emits `npm_tag` (`next` when the version contains `-`, else
+`latest`) and publish consumes it. The tag/version guard, changelog gate and pack smoke are all
+string-based and already pre-release-safe — a pre-release still needs `package.json#version` and a
+literal `## [0.20.0-rc.1]` changelog heading; that friction is deliberate. Fenced by
+`tests/unit/ci/release-workflow.test.ts`, which also fences the PERFORMANCE.md release-procedure
+prose against the workflow (the drift class #305 itself was). Untested until a real pre-release is
+cut — if the glob still does not fire, fall back to one permissive `'v[0-9]+.[0-9]+.[0-9]+*'`.

--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -53,19 +53,20 @@ Rules:
 
 Canonical set. If a view needs a symbol not in this list, **add it to `glyphs` first** (and document it here).
 
-| Group           | Tokens                                                                                               |
-| --------------- | ---------------------------------------------------------------------------------------------------- |
-| Phase / status  | `phaseDone ■`, `phaseActive ◆`, `phasePending ◇`, `phaseDisabled ◌`                                  |
-| Cursors         | `actionCursor ▸`, `selectMarker ›`                                                                   |
-| Disclosure      | `disclosureCollapsed ▸`, `disclosureExpanded ▾` (collapsible rows, e.g. Tasks-panel commit messages) |
-| Section markers | `badge ▣`, `sectionRule ━`                                                                           |
-| State           | `check ✓`, `cross ✗`, `warningGlyph ⚠`, `infoGlyph i`, `modified ✎`                                  |
-| Bullets         | `bullet ·`, `inlineDot ·`, `emDash —`, `arrowRight →`, `activityArrow ↳`, `refresh ↻`                |
-| Separators      | `pipe │`                                                                                             |
-| Motion          | `spinner` (braille frames `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`)                                                              |
-| Clip markers    | `clipEllipsis …`, `collapseExpand ▼ more`                                                            |
-| Overflow cues   | `moreAbove ▴`, `moreBelow ▾` (windowed-list `OverflowRow` "N more" rows)                             |
-| Personality     | `quoteRail ┃`                                                                                        |
+| Group           | Tokens                                                                                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase / status  | `phaseDone ■`, `phaseActive ◆`, `phasePending ◇`, `phaseDisabled ◌`                                                                                         |
+| Cursors         | `actionCursor ▸`, `selectMarker ›`, `focusBar ▍` (picker focus rail)                                                                                        |
+| Disclosure      | `disclosureCollapsed ▸`, `disclosureExpanded ▾` (collapsible rows, e.g. Tasks-panel commit messages)                                                        |
+| Section markers | `badge ▣`, `sectionRule ━`                                                                                                                                  |
+| State           | `check ✓`, `cross ✗`, `warningGlyph ⚠`, `infoGlyph i`, `modified ✎`, `unknownGlyph ?` (undetermined verdict, never tinted), `stethoscope ✚` (footer doctor) |
+| Bullets         | `bullet ·`, `inlineDot ·`, `emDash —`, `arrowRight →`, `activityArrow ↳`, `refresh ↻`                                                                       |
+| Separators      | `pipe │`                                                                                                                                                    |
+| Motion          | `spinner` (braille frames `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`), `busyDot ●` (gen-eval busy indicator)                                                                              |
+| Meters          | `barFilled █`, `barEmpty ░` (fixed-width progress meters — ratio reads by density alone)                                                                    |
+| Clip markers    | `clipEllipsis …`, `collapseExpand ▼ more`                                                                                                                   |
+| Overflow cues   | `moreAbove ▴`, `moreBelow ▾` (windowed-list `OverflowRow` "N more" rows)                                                                                    |
+| Personality     | `quoteRail ┃`                                                                                                                                               |
 
 Do not mix glyph families (no `✔` from one set and `✓` from another). No emoji in TUI surfaces.
 

--- a/.claude/docs/DESIGN-SYSTEM.md
+++ b/.claude/docs/DESIGN-SYSTEM.md
@@ -56,7 +56,7 @@ Canonical set. If a view needs a symbol not in this list, **add it to `glyphs` f
 | Group           | Tokens                                                                                                                                                      |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Phase / status  | `phaseDone ■`, `phaseActive ◆`, `phasePending ◇`, `phaseDisabled ◌`                                                                                         |
-| Cursors         | `actionCursor ▸`, `selectMarker ›`, `focusBar ▍` (picker focus rail)                                                                                        |
+| Cursors         | `actionCursor ▸`, `selectMarker ›`, `focusBar ▍` (picker focus rail), `caretBlock █` (text-input caret — same char as `barFilled`, separate role)           |
 | Disclosure      | `disclosureCollapsed ▸`, `disclosureExpanded ▾` (collapsible rows, e.g. Tasks-panel commit messages)                                                        |
 | Section markers | `badge ▣`, `sectionRule ━`                                                                                                                                  |
 | State           | `check ✓`, `cross ✗`, `warningGlyph ⚠`, `infoGlyph i`, `modified ✎`, `unknownGlyph ?` (undetermined verdict, never tinted), `stethoscope ✚` (footer doctor) |

--- a/.claude/docs/PERFORMANCE.md
+++ b/.claude/docs/PERFORMANCE.md
@@ -356,9 +356,15 @@ For the installed binary instead of `pnpm dev`, set the same flags yourself:
 
 ## Release procedure
 
-GitHub Actions auto-publishes on tags `v[0-9]+.[0-9]+.[0-9]+`. Tag must match
-`package.json#version`; `CHANGELOG.md` needs a `## [X.Y.Z]` section (the literal-prefix extractor surfaces
-it). NPM publish uses `--provenance`. Pre-releases are tags containing `-`.
+GitHub Actions auto-publishes on tags `v[0-9]+.[0-9]+.[0-9]+` and `v[0-9]+.[0-9]+.[0-9]+-*` (ref filters
+full-match, so the pre-release glob is a separate pattern). Tag must match `package.json#version`;
+`CHANGELOG.md` needs a `## [X.Y.Z]` section (the literal-prefix extractor surfaces it). NPM publish uses
+`--provenance`. Pre-releases are tags containing `-`, e.g. `v0.20.0-rc.1` — the full suffix must appear in
+both `package.json#version` and the changelog heading (`## [0.20.0-rc.1]`); they publish under the `next`
+dist-tag, never `latest`, and are flagged `prerelease` on the GitHub Release. `next` is not moved
+automatically afterwards — once the matching stable ships, run `npm dist-tag add ralphctl@X.Y.Z next`
+(or `npm dist-tag rm ralphctl next`) so `next` never serves a superseded pre-release, and check
+`npm dist-tag ls ralphctl` still points `latest` at the last stable.
 
 ## References
 

--- a/.claude/docs/diagrams/01-flow-lifecycle.md
+++ b/.claude/docs/diagrams/01-flow-lifecycle.md
@@ -12,8 +12,8 @@ sequenceDiagram
     actor User
     participant UI as TUI menu / CLI command
     participant Registry as registry.ts
-    participant Launch as launch/&lt;flow&gt;.ts
-    participant Factory as flows/&lt;flow&gt;/flow.ts
+    participant Launch as launch/<flow>.ts
+    participant Factory as flows/<flow>/flow.ts
     participant Runner as chain/run/runner.ts
     participant Bridge as observability/chain-runner-bridge.ts
     participant Bus as EventBus
@@ -25,7 +25,7 @@ sequenceDiagram
 
     UI->>Launch: launchXxx(ctx)
     Launch->>Factory: createXxxFlow(deps, opts)
-    Factory-->>Launch: Element&lt;TCtx&gt;
+    Factory-->>Launch: Element<TCtx>
 
     Launch->>Runner: createRunner({ id, element, initialCtx })
     Runner->>Runner: runWithSession(id, …)

--- a/.claude/docs/diagrams/03-task-lifecycle.md
+++ b/.claude/docs/diagrams/03-task-lifecycle.md
@@ -28,7 +28,7 @@ sequenceDiagram
         Harness->>Repo: read validated signals
         Harness->>Ev: spawn (prompt.md, outputDir)
         Ev-->>Harness: writes signals.json (only)
-        Note over Harness,Ev: harness renders evaluation.md sidecar post-spawn
+        Note over Harness,Ev: harness renders evaluation.md sidecar post-spawn<br/>(read back later by CLI task evaluation / TUI v overlay — see 04)
         Harness->>Task: append attempt + evaluation
         alt evaluator passed
             Harness->>Repo: post-task verify

--- a/.claude/docs/diagrams/04-ai-session-data-flow.md
+++ b/.claude/docs/diagrams/04-ai-session-data-flow.md
@@ -9,10 +9,11 @@ writes one file (`signals.json`), the harness validates + projects.
 ```mermaid
 sequenceDiagram
     participant Leaf as Chain leaf
-    participant Prompt as &lt;leaf&gt;.contract.ts<br/>+ prompt template
-    participant Disk as &lt;outputDir&gt;/
+    participant Prompt as <leaf>.contract.ts<br/>+ prompt template
+    participant Disk as <outputDir>/
     participant AI as AI provider (headless / interactive)
     participant Bus as EventBus + sink
+    participant Ops as operator surface<br/>(CLI task evaluation · TUI v overlay)
 
     Leaf->>Prompt: render with placeholders + outputContractSection
     Prompt-->>Leaf: Prompt object
@@ -30,7 +31,25 @@ sequenceDiagram
         Leaf->>Disk: renderSidecars (commit-message.txt · evaluation.md · …)
         Leaf->>Bus: fan-out each validated signal
     end
+    Note over Leaf,Disk: sidecars are operator UX only — no downstream leaf reads one back
+
+    Ops->>Disk: later — read implement/<taskId>/rounds/<N>/evaluator/evaluation.md<br/>(path off Attempt.evaluation.file in tasks.json)
+    Disk-->>Ops: markdown
+    Ops->>Ops: TUI overlay only — parseEvaluationMarkdown → ParsedEvaluation<br/>(the CLI streams the markdown verbatim)
 ```
+
+## Reading evaluation.md back
+
+`evaluation.md` is the one sidecar with readers. The evaluator contract's sole sidecar rule renders it
+via `renderEvaluationMarkdown`, and the leaf stamps its workspace-relative path
+(`roundEvaluationRelativePath`) onto `Attempt.evaluation.file` in `tasks.json`. Two operator surfaces
+read it back later — `ralphctl task evaluation <taskId>` and the TUI `v` overlay — both resolving the
+path through `latestRecordedEvaluation` + `evaluationArtifactSprintPath`. Only the TUI overlay parses
+with `parseEvaluationMarkdown`; the CLI streams the artifact byte-for-byte so it can be piped into a
+pager or a diff. The round trip is deliberately lossy — per-criterion verdicts are never
+rendered, and `applicable: false` collapses onto the literal word `n/a` — pinned by
+`tests/integration/ai/contract/evaluation-markdown-roundtrip.test.ts`. No chain leaf reads a sidecar;
+downstream leaves take their signals from ctx.
 
 ## The wrapper shape on disk
 
@@ -54,12 +73,19 @@ verbatim; the adapter only mirrors raw body for forensic capture.
 
 ## Where each piece lives
 
-| Concern              | Path                                                             |
-| -------------------- | ---------------------------------------------------------------- |
-| Per-kind Zod schemas | `src/integration/ai/contract/_engine/signals/<kind>/schema.ts`   |
-| Validation reader    | `src/integration/ai/contract/_engine/validate-signals-file.ts`   |
-| Sidecar renderer     | `src/integration/ai/contract/_engine/render-sidecars.ts`         |
-| Per-leaf contract    | `src/application/flows/<flow>/leaves/<leaf>.contract.ts`         |
-| Prompt section       | `src/integration/ai/contract/_engine/render-contract-section.ts` |
+| Concern                | Path                                                                                    |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| Per-kind Zod schemas   | `src/integration/ai/contract/_engine/signals/<kind>/schema.ts`                          |
+| Validation reader      | `src/integration/ai/contract/_engine/validate-signals-file.ts`                          |
+| Sidecar renderer       | `src/integration/ai/contract/_engine/render-sidecars.ts`                                |
+| Per-leaf contract      | `src/application/flows/<flow>/leaves/<leaf>.contract.ts`                                |
+| Prompt section         | `src/integration/ai/contract/_engine/render-contract-section.ts`                        |
+| Evaluation renderer    | `src/integration/ai/contract/_engine/render-evaluation-markdown.ts`                     |
+| Recorded artifact path | `src/application/flows/implement/leaves/round-artifacts.ts`                             |
+| Evaluation parser      | `src/business/task/parse-evaluation-md.ts`                                              |
+| Artifact path resolver | `src/business/task/evaluation-artifact.ts`                                              |
+| CLI reader surface     | `src/application/ui/cli/commands/task.ts`                                               |
+| TUI reader surface     | `src/application/ui/tui/components/evaluation-overlay-internals/use-evaluation-file.ts` |
 
-The audit-[09] contract is implemented under `src/integration/ai/contract/_engine/` (see the table above).
+The audit-[09] contract is implemented under `src/integration/ai/contract/_engine/` (see the table above);
+the per-leaf contracts and the read-back surfaces live outside it.

--- a/.claude/docs/diagrams/README.md
+++ b/.claude/docs/diagrams/README.md
@@ -3,13 +3,13 @@
 Sequence and data-flow diagrams for the current architecture. GitHub renders Mermaid natively
 in markdown previews — no toolchain required.
 
-| #   | Diagram                                              | What it shows                                                                            |
-| --- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| 00  | [Chain framework](./00-chain-framework.md)           | One chain run end to end: runner → session → element → event bus.                        |
-| 01  | [Flow lifecycle](./01-flow-lifecycle.md)             | From a TUI click / CLI subcommand to a running chain.                                    |
-| 02  | [Sprint lifecycle](./02-sprint-lifecycle.md)         | One sprint's user-action timeline: create → plan → implement → review → close.           |
-| 03  | [Task lifecycle](./03-task-lifecycle.md)             | One task's per-attempt timeline: preflight → generator-evaluator loop → verify → commit. |
-| 04  | [AI session data flow](./04-ai-session-data-flow.md) | The audit-[09] file-based contract: prompt in, `signals.json` out, sidecars rendered.    |
+| #   | Diagram                                              | What it shows                                                                                                                                          |
+| --- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 00  | [Chain framework](./00-chain-framework.md)           | One chain run end to end: runner → session → element → event bus.                                                                                      |
+| 01  | [Flow lifecycle](./01-flow-lifecycle.md)             | From a TUI click / CLI subcommand to a running chain.                                                                                                  |
+| 02  | [Sprint lifecycle](./02-sprint-lifecycle.md)         | One sprint's user-action timeline: create → plan → implement → review → close.                                                                         |
+| 03  | [Task lifecycle](./03-task-lifecycle.md)             | One task's per-attempt timeline: preflight → generator-evaluator loop → verify → commit.                                                               |
+| 04  | [AI session data flow](./04-ai-session-data-flow.md) | The audit-[09] file-based contract: prompt in, `signals.json` out, sidecars rendered — and `evaluation.md` read back by the CLI/TUI operator surfaces. |
 
 ## Conventions
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -51,7 +51,8 @@ Group the surviving commit subjects by conventional-commit prefix into `### Adde
 `CHANGELOG.md` (edit only — don't commit yet; the release commit in step 5 picks it up).
 
 **If the filtered `git log` is also empty,** there's nothing user-facing to release — stop and tell the user. Don't
-promote an empty section; `release.yml` would fall back to a raw `git log` dump and ship noise.
+promote an empty section; `release.yml` hard-fails on a missing or empty `## [<version>]` section (there is no
+fallback), so the workflow would die after the tag is already public.
 
 **If the original `## [Unreleased]` had content,** skip the draft — the user already wrote what they want. Proceed.
 
@@ -81,7 +82,14 @@ branch if anything looks off.
 
    Use today's UTC date in ISO format (`date -u +%Y-%m-%d`). Keep the existing entries where they are — they belong
    under the new dated heading by virtue of position. The heading format is **load-bearing**: `release.yml` extracts the
-   GitHub Release body by `awk`-ing for `## [<version>]`, and a typo there silently falls back to a `git log` blob.
+   GitHub Release body by `awk`-ing for `## [<version>]`, and a typo there fails the workflow — after the tag is
+   already public.
+
+   **Pre-release versions** (`1.0.0-rc.1`): the full suffix must appear in both `package.json#version` and the
+   changelog heading (`## [1.0.0-rc.1]`). The workflow publishes hyphenated versions under the `next` npm dist-tag
+   (never `latest`) and flags the GitHub Release `prerelease`. After the matching stable ships later, run
+   `npm dist-tag add ralphctl@X.Y.Z next` (or `npm dist-tag rm ralphctl next`) so `next` never serves a superseded
+   rc — see the release procedure in `.claude/docs/PERFORMANCE.md`.
 
 4. **Local gate.** Run the project's full check sequence (same as the `verify` skill):
 
@@ -168,7 +176,7 @@ branch if anything looks off.
 - **Tag the merge commit, not the release-branch tip:** The published artifact must match what's actually on `main`.
   Tagging the merge commit guarantees `git checkout v<version>` shows the same tree `main` had at release time.
 - **One source of truth for release notes:** The workflow extracts `## [<version>] - <YYYY-MM-DD>` from `CHANGELOG.md`.
-  Match the format exactly; otherwise the GitHub Release body silently falls back to a raw `git log` dump (still works,
-  but noisy).
+  Match the format exactly; a missing or empty section fails the workflow (the old raw-`git log` fallback was removed
+  on purpose — a commit-subject dump is not release notes).
 - **Admin bypass is loud, on purpose:** Each release surfaces the bypass via `--admin` rather than relying on auto-merge
   with weakened protections. The protections stay strict; the bypass is invoked explicitly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,13 @@ name: Release
 
 on:
   push:
+    # Two patterns, not one: Actions ref filters FULL-match the ref name, and the `[0-9]+` glob
+    # syntax cannot express an optional suffix — so a single stable pattern silently matches no
+    # pre-release tag at all (no run, no error). The second entry is what makes `v0.20.0-rc.1`
+    # fire, and with it the `prerelease:` expression at the bottom of this file.
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: write
@@ -43,9 +48,20 @@ jobs:
             exit 1
           fi
 
-      - name: Extract version from tag
+      # `npm_tag` keeps a pre-release OFF the `latest` dist-tag: `latest` is what a bare
+      # `npm i ralphctl` resolves to, and `compareVersions` in
+      # src/business/version/version-check.ts strips pre-release suffixes on the documented
+      # assumption that `latest` is always stable — publishing an rc there would nag every
+      # stable user to "update" to it.
+      - name: Extract version and npm dist-tag from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          case "$VERSION" in
+            *-*) echo "npm_tag=next" >> "$GITHUB_OUTPUT" ;;
+            *) echo "npm_tag=latest" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       # No git-log fallback: a commit-subject dump is not release notes, and silently
       # substituting one hid the real defect (nobody wrote the changelog section) until after
@@ -53,8 +69,12 @@ jobs:
       # because they have separate fixes.
       - name: Extract and validate changelog section
         id: changelog
+        # VERSION goes through `env`, not `${{ }}` inside `run:` — the widened `-*` tag glob
+        # admits shell metacharacters into the ref name, and template interpolation would paste
+        # them straight into the script body.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
             echo "::error file=CHANGELOG.md::No '## [${VERSION}]' heading in CHANGELOG.md — write the release notes before tagging."
             exit 1
@@ -131,6 +151,8 @@ jobs:
       - name: Verify npm pack installs correctly
         env:
           RALPHCTL_HOME: ${{ runner.temp }}/ralphctl-pack-smoke
+          # Via `env`, not `${{ }}` in the script — see the changelog step.
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           TARBALL=$(pnpm pack --pack-destination /tmp 2>/dev/null | tail -1)
           SMOKE=/tmp/ralphctl-release-smoke
@@ -139,7 +161,7 @@ jobs:
           npm install --prefix "$SMOKE" "$TARBALL"
           BIN="$SMOKE"/node_modules/.bin/ralphctl
           version=$("$BIN" --version)
-          printf '%s\n' "$version" | grep -qF "${{ steps.version.outputs.version }}"
+          printf '%s\n' "$version" | grep -qF "$VERSION"
           skills=$("$BIN" skills list)
           printf '%s\n' "$skills" | grep -q '^ralphctl-alignment'
           agents=$("$BIN" agents list)
@@ -148,7 +170,7 @@ jobs:
           printf '%s\n' "$prompts" | grep -q '^implement'
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --provenance
+        run: pnpm publish --no-git-checks --provenance --tag "${{ steps.version.outputs.npm_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,9 @@ See [ARCHITECTURE.md](./.claude/docs/ARCHITECTURE.md) for the full technical ref
 ## Releasing
 
 Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml),
-which triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+`. To cut a release:
+which triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+` (stable) or `v[0-9]+.[0-9]+.[0-9]+-*`
+(pre-release, e.g. `v0.20.0-rc.1` — published under the `next` dist-tag and marked `prerelease`
+on the GitHub Release). To cut a release:
 
 1. Bump `package.json#version` to `X.Y.Z`
 2. Move `## [Unreleased]` to `## [X.Y.Z] - <date>` in `CHANGELOG.md`

--- a/src/application/chain/build/leaf.ts
+++ b/src/application/chain/build/leaf.ts
@@ -1,6 +1,7 @@
 import { Result } from '@src/domain/result.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
 
 import { checkAborted, type Element, type ElementResult } from '@src/application/chain/element.ts';
 import type { TraceEntry } from '@src/application/chain/trace.ts';
@@ -97,5 +98,18 @@ export const leaf = <TCtx, UInput, UOutput>(
   };
 };
 
+/**
+ * Every real error class in `domain/value/error/` assigns `readonly code = ErrorCode.*`, so exact
+ * membership in this table is the discriminator. `Set<unknown>` (not `ReadonlySet<ErrorCode>`) so
+ * `.has()` accepts the unknown-typed `code` without a cast.
+ */
+const DOMAIN_ERROR_CODES = new Set<unknown>(Object.values(ErrorCode));
+
+/**
+ * Accepting any Error with a *string* `code` matched every Node errno error (EACCES, ELOOP,
+ * ENOENT …), laundering adapter I/O failures into the domain-error channel with a bogus code.
+ * Keep this an exact-membership check — a non-domain throw is a programmer bug and must
+ * re-propagate to the runner, which is the containment boundary for those.
+ */
 const isDomainError = (cause: unknown): cause is DomainError =>
-  cause instanceof Error && typeof (cause as { code?: unknown }).code === 'string';
+  cause instanceof Error && DOMAIN_ERROR_CODES.has((cause as { code?: unknown }).code);

--- a/src/application/ui/tui/components/evaluator-failure-panel.tsx
+++ b/src/application/ui/tui/components/evaluator-failure-panel.tsx
@@ -72,7 +72,7 @@ const VERDICT_PRESENTATION: Record<ParsedDimensionVerdict, { readonly glyph: str
   passed: { glyph: glyphs.check, color: inkColors.success },
   failed: { glyph: glyphs.cross, color: inkColors.error },
   'n/a': { glyph: glyphs.bullet },
-  unknown: { glyph: '?' },
+  unknown: { glyph: glyphs.unknownGlyph },
 };
 
 const clip = (text: string): string =>

--- a/src/application/ui/tui/components/token-budget-card.tsx
+++ b/src/application/ui/tui/components/token-budget-card.tsx
@@ -56,7 +56,7 @@ const BAR_WIDTH = 10;
 /** Render an ASCII progress bar of the configured width — filled-blocks for used, light-shade for remaining. */
 const renderBar = (filled: number): string => {
   const clamped = Math.max(0, Math.min(BAR_WIDTH, Math.round(filled)));
-  return `${'█'.repeat(clamped)}${'░'.repeat(BAR_WIDTH - clamped)}`;
+  return `${glyphs.barFilled.repeat(clamped)}${glyphs.barEmpty.repeat(BAR_WIDTH - clamped)}`;
 };
 
 /**

--- a/src/application/ui/tui/prompts/select-prompt.tsx
+++ b/src/application/ui/tui/prompts/select-prompt.tsx
@@ -130,7 +130,7 @@ export const SelectPrompt = ({
         </Text>
       )}
       {footer !== undefined && <Text dimColor>{footer}</Text>}
-      <Text dimColor>↑/↓ navigate · ↵ submit · esc cancel</Text>
+      <Text dimColor>↑/↓ move · ↵ submit · esc cancel</Text>
     </Box>
   );
 };

--- a/src/application/ui/tui/prompts/text-area-prompt.tsx
+++ b/src/application/ui/tui/prompts/text-area-prompt.tsx
@@ -379,7 +379,7 @@ const TextAreaRow = ({
         <Text>{line.slice(0, cursorCol)}</Text>
         {caretOn ? (
           <>
-            <Text color={inkColors.highlight}>█</Text>
+            <Text color={inkColors.highlight}>{glyphs.caretBlock}</Text>
             <Text>{line.slice(cursorCol + 1)}</Text>
           </>
         ) : (

--- a/src/application/ui/tui/prompts/text-prompt.tsx
+++ b/src/application/ui/tui/prompts/text-prompt.tsx
@@ -220,7 +220,7 @@ export const TextPrompt = ({
         <Text>{beforeCursor}</Text>
         {caretOn ? (
           <>
-            <Text color={inkColors.highlight}>█</Text>
+            <Text color={inkColors.highlight}>{glyphs.caretBlock}</Text>
             <Text>{afterCursor}</Text>
           </>
         ) : (

--- a/src/application/ui/tui/theme/tokens.ts
+++ b/src/application/ui/tui/theme/tokens.ts
@@ -34,6 +34,9 @@ export const glyphs = {
   actionCursor: '▸',
   selectMarker: '›',
   bullet: '·',
+  // Left focus rail printed beside the focused picker row (sprint picker today). A partial block
+  // (U+258D) reads as a solid gutter mark without filling the whole cell like `▉` would.
+  focusBar: '▍',
   // Disclosure carets for collapsible rows (Tasks-panel commit-message rows today).
   // Right-pointing → collapsed, down-pointing → expanded — folded in from the stray
   // `COLLAPSED_DISCLOSURE` / `EXPANDED_DISCLOSURE` pair that used to live next to
@@ -54,6 +57,9 @@ export const glyphs = {
   cross: '✗',
   warningGlyph: '⚠',
   infoGlyph: 'i',
+  // Verdict / state the parser could not determine. Deliberately shape-only (never tinted) so it
+  // reads apart from `check` / `cross` / `bullet` even under NO_COLOR.
+  unknownGlyph: '?',
   // Skill-catalog "locally edited" marker — distinct shape from `warningGlyph` (an upstream
   // update is available) and `cross` (removed/broken) so the three states read apart even
   // without colour (NO_COLOR / accessibility).
@@ -61,6 +67,10 @@ export const glyphs = {
   // Health marker — footer doctor indicator. Monochrome medical cross, tinted by probe status;
   // renders without color so it survives NO_COLOR (no emoji).
   stethoscope: '✚',
+  // Progress bar — filled / remaining cells of a fixed-width meter (TokenBudgetCard context bar).
+  // Full block vs. light shade so the ratio reads by density alone, without colour.
+  barFilled: '█',
+  barEmpty: '░',
   // Loading (braille spinner frames)
   spinner: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const,
   // Personality rail

--- a/src/application/ui/tui/theme/tokens.ts
+++ b/src/application/ui/tui/theme/tokens.ts
@@ -71,6 +71,9 @@ export const glyphs = {
   // Full block vs. light shade so the ratio reads by density alone, without colour.
   barFilled: '█',
   barEmpty: '░',
+  // Text-input cursor (text / text-area prompts). Same character as `barFilled` but a separate
+  // token on purpose — a caret and a meter cell are different roles, and either may diverge.
+  caretBlock: '█',
   // Loading (braille spinner frames)
   spinner: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const,
   // Personality rail

--- a/src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts
+++ b/src/application/ui/tui/views/execute-view-internals/use-responsive-layout.ts
@@ -3,9 +3,9 @@
  * compact-two / single — into a single readonly record alongside the derived row caps and
  * column widths every regime needs.
  *
- *   ≥180 cols (xl+):  three-column — fluid-width rail + flex Tasks + fixed context column.
- *   140–179 cols   :  two-column — fixed RAIL_WIDTH rail + flex Tasks.
- *   100–139 cols   :  compact two-column — glyph-only rail.
+ *   ≥180 cols (xl) :  three-column — fluid-width rail + flex Tasks + fixed context column.
+ *   140–179 (lg)   :  two-column — fixed RAIL_WIDTH rail + flex Tasks.
+ *   100–139 (md)   :  compact two-column — glyph-only rail.
  *   <100 cols      :  single-column stack.
  *
  * Pulling the breakpoint logic out of the view keeps the orchestrator focused on hook
@@ -20,15 +20,6 @@ import {
   resolveRailWidth,
 } from '@src/application/ui/tui/theme/tokens.ts';
 
-const TWO_COL_BREAKPOINT = 140;
-const THREE_COL_BREAKPOINT = 180;
-/**
- * Below this width the Flow Steps section collapses to four rows in single-column mode AND
- * the two-column layout disappears entirely (we never render the rail on a <100 col terminal
- * — the stream column wouldn't have room left). At 100-139 cols a *compact* rail variant
- * (status glyphs only, no labels) is rendered instead of the labelled rail used at ≥140 cols.
- */
-const NARROW_FLOW_STEPS_BREAKPOINT = 100;
 const NARROW_FLOW_STEPS_ROWS = 4;
 
 export interface ResponsiveLayout {
@@ -88,9 +79,15 @@ interface UseResponsiveLayoutInput {
 }
 
 export const useResponsiveLayout = ({ columns, rows, isRunning }: UseResponsiveLayoutInput): ResponsiveLayout => {
-  const threeColumn = columns >= THREE_COL_BREAKPOINT;
-  const twoColumn = !threeColumn && columns >= TWO_COL_BREAKPOINT;
-  const compactTwoColumn = !threeColumn && !twoColumn && columns >= NARROW_FLOW_STEPS_BREAKPOINT;
+  const threeColumn = columns >= breakpoints.xl;
+  const twoColumn = !threeColumn && columns >= breakpoints.lg;
+  /*
+   * Below `md` the Flow Steps section collapses to four rows in single-column mode AND
+   * the two-column layout disappears entirely (we never render the rail on a <100 col terminal
+   * — the stream column wouldn't have room left). At 100-139 cols a *compact* rail variant
+   * (status glyphs only, no labels) is rendered instead of the labelled rail used at ≥140 cols.
+   */
+  const compactTwoColumn = !threeColumn && !twoColumn && columns >= breakpoints.md;
   const singleColumn = !threeColumn && !twoColumn && !compactTwoColumn;
 
   const baseFlowStepsRows = isRunning ? Math.max(8, rows - 22) : 16;
@@ -110,7 +107,7 @@ export const useResponsiveLayout = ({ columns, rows, isRunning }: UseResponsiveL
   // NOTE: <140 cols intentionally falls back to the legacy ExecuteLayout (three/two/compact/single
   // column grid). This is the accepted behaviour for the v0.7.0 redesign gate — do not add a
   // sidebar-only collapse mode for the 100-139 col band without a new design decision.
-  const sidebarLayout = columns >= TWO_COL_BREAKPOINT;
+  const sidebarLayout = columns >= breakpoints.lg;
   // 2/5 of terminal width — gives the sidebar room for the baseline card (which can be wide),
   // task names, and flow-step labels; the main area (flexGrow) keeps the remaining 3/5.
   // Floor at 34 so the sidebar remains legible at the 140-col entry point. No upper cap —

--- a/src/application/ui/tui/views/pick-sprint-internals/row-views.tsx
+++ b/src/application/ui/tui/views/pick-sprint-internals/row-views.tsx
@@ -105,7 +105,7 @@ export const PickerRowList = ({
 const CreateRowView = ({ focused }: { readonly focused: boolean }): React.JSX.Element => (
   <Box flexDirection="column" paddingX={spacing.indent}>
     <Box>
-      <Text color={focused ? inkColors.primary : inkColors.rule}>{focused ? '▍' : ' '}</Text>
+      <Text color={focused ? inkColors.primary : inkColors.rule}>{focused ? glyphs.focusBar : ' '}</Text>
       <Text>
         {' '}
         <Text color={focused ? inkColors.primary : inkColors.highlight} bold>
@@ -151,7 +151,7 @@ const SprintRowView = ({
   return (
     <Box flexDirection="column" paddingX={spacing.indent}>
       <Box>
-        <Text color={focused ? inkColors.primary : inkColors.rule}>{focused ? '▍' : ' '}</Text>
+        <Text color={focused ? inkColors.primary : inkColors.rule}>{focused ? glyphs.focusBar : ' '}</Text>
         <Text>
           {' '}
           <Text color={focused ? inkColors.primary : inkColors.muted} bold={focused}>

--- a/src/application/ui/tui/views/pick-sprint-view.tsx
+++ b/src/application/ui/tui/views/pick-sprint-view.tsx
@@ -258,7 +258,7 @@ export const PickSprintView = (): React.JSX.Element => {
     usePickerRows(deps, selection);
 
   useViewHints([
-    { keys: '↑/↓/j/k', label: 'move' },
+    { keys: '↑/↓', label: 'move' },
     { keys: '↵', label: 'use sprint' },
     { keys: 't', label: 'toggle scope' },
     { keys: 'f', label: hideDone ? 'show done' : 'hide done' },

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -327,7 +327,7 @@ interface ProjectDetailHintsArgs {
 const useProjectDetailHints = ({ project, selectionProjectId, focused }: ProjectDetailHintsArgs): void => {
   const focusedRepo = focused?.kind === 'repo';
   useViewHints([
-    { keys: '↑/↓', label: 'navigate' },
+    { keys: '↑/↓', label: 'move' },
     { keys: '↵', label: 'confirm/select' },
     // Surface the `m` chord only while the viewed project is not already current — once they
     // match the action is a no-op and the hint adds noise (mirrors sprint-detail).

--- a/src/application/ui/tui/views/project-detail-view.tsx
+++ b/src/application/ui/tui/views/project-detail-view.tsx
@@ -327,7 +327,7 @@ interface ProjectDetailHintsArgs {
 const useProjectDetailHints = ({ project, selectionProjectId, focused }: ProjectDetailHintsArgs): void => {
   const focusedRepo = focused?.kind === 'repo';
   useViewHints([
-    { keys: '↑/↓/j/k', label: 'navigate' },
+    { keys: '↑/↓', label: 'navigate' },
     { keys: '↵', label: 'confirm/select' },
     // Surface the `m` chord only while the viewed project is not already current — once they
     // match the action is a no-op and the hint adds noise (mirrors sprint-detail).

--- a/src/application/ui/tui/views/projects-view.tsx
+++ b/src/application/ui/tui/views/projects-view.tsx
@@ -248,7 +248,7 @@ const projectsKeyBindings = ({
   setFeedback,
   reload,
 }: ProjectsKeysInput): readonly ViewKeyBinding[] => [
-  { keys: ['↑', '↓', 'j', 'k'], hint: 'move' },
+  { keys: ['↑', '↓'], hint: 'move' },
   { keys: ['↵'], hint: 'open' },
   {
     keys: ['m'],

--- a/src/application/ui/tui/views/sessions-view.tsx
+++ b/src/application/ui/tui/views/sessions-view.tsx
@@ -163,7 +163,7 @@ export const SessionsView = (): React.JSX.Element => {
 
   useViewKeys(
     [
-      { keys: ['↑', '↓', 'j', 'k'], hint: 'move' },
+      { keys: ['↑', '↓'], hint: 'move' },
       { keys: ['↵'], hint: 'open' },
       {
         keys: ['c'],

--- a/src/application/ui/tui/views/settings-view.tsx
+++ b/src/application/ui/tui/views/settings-view.tsx
@@ -3,7 +3,7 @@
  * render-side render is factored into sibling files; this file's only responsibility is to
  * wire those pieces together with the EventBus + dependency-injected flow factories.
  *
- * `←/→` switch sections; `↑/↓` navigate fields inside the active section; `↵/e` mounts the
+ * `←/→` switch sections; `↑/↓` move between fields inside the active section; `↵/e` mounts the
  * prompt appropriate to the field's type (SelectPrompt for enums + model catalogs, TextPrompt
  * for numbers / free-text strings). Most routes funnel through `applySettingsKey` (validation)
  * → `settingsSet` use-case (persistence) so the TUI and `ralphctl settings set` share a
@@ -448,7 +448,7 @@ export const SettingsView = (): React.JSX.Element => {
 
   useViewHints([
     { keys: '←/→', label: 'section' },
-    { keys: '↑/↓', label: 'navigate' },
+    { keys: '↑/↓', label: 'move' },
     { keys: '↵/e', label: 'edit' },
   ]);
 
@@ -494,7 +494,7 @@ export const SettingsView = (): React.JSX.Element => {
     settings === undefined ? null : renderFieldValue(activeFields, cursor, key);
 
   return (
-    <ViewShell title="Settings" subtitle="←/→ section · ↑/↓ navigate · ↵ edit · esc cancel">
+    <ViewShell title="Settings" subtitle="←/→ section · ↑/↓ move · ↵ edit · esc cancel">
       <SettingsViewBody
         helpOpen={ui.helpOpen}
         pendingPreset={pendingPreset}

--- a/src/application/ui/tui/views/skills-view.tsx
+++ b/src/application/ui/tui/views/skills-view.tsx
@@ -8,7 +8,7 @@
  * `skills-view-internals/skill-row.tsx`.
  *
  * Local keys:
- *   ↑/↓/j/k   move the focus cursor (windowed list)
+ *   ↑/↓       move the focus cursor (windowed list — `useListWindow` also accepts the j/k alias)
  *   e         enable the focused skill for picked flows (multi-select, recommendedFor preselected)
  *   d         disable the focused skill for picked flows (multi-select over currently-installed flows)
  *   u         update the focused skill from the bundle (confirms first if it would overwrite a
@@ -237,7 +237,7 @@ const skillsKeyBindings = ({
   canClearOptOut,
   reload,
 }: SkillsKeysInput): readonly ViewKeyBinding[] => [
-  { keys: ['↑', '↓', 'j', 'k'], hint: 'move' },
+  { keys: ['↑', '↓'], hint: 'move' },
   {
     keys: ['e'],
     hint: 'enable',

--- a/src/application/ui/tui/views/sprint-detail-internals/detail-body.tsx
+++ b/src/application/ui/tui/views/sprint-detail-internals/detail-body.tsx
@@ -145,7 +145,9 @@ interface BuildDetailHintsArgs {
 }
 
 /**
- * Build the local footer-hint list. Every hint shares one source of truth with its handler via
+ * Build the local footer-hint list. Labels stay terse on purpose: the rendered strip must fit
+ * a 100-column terminal on ONE line — an overflowing strip makes Yoga distribute the deficit
+ * across every footer cell, mangling the whole status bar. Every hint shares one source of truth with its handler via
  * `enabledWhen`: the `a`/`d` ticket-CRUD chords are gated on `ticketsEditable` (draft only), so
  * the hints must hide on a non-draft sprint or the footer would advertise keys that do nothing.
  * `m` (mark-current) and `u` (unblock) follow the same declarative gate rather than conditional
@@ -156,13 +158,13 @@ const buildDetailHints = (args: BuildDetailHintsArgs): readonly ViewHint[] => {
   return [
     { keys: '↑/↓', label: 'move' },
     { keys: 'n', label: 'flows' },
-    { keys: '↵/o', label: inDetail ? 'expand/collapse' : 'expand' },
+    { keys: '↵/o', label: inDetail ? 'toggle' : 'expand' },
     // `esc/q` collapses all expanded cards; only shown while in detail mode so the hint
     // doesn't compete with the global `esc → back` behavior when nothing is expanded.
-    { keys: 'esc/q', label: 'collapse all', enabledWhen: inDetail },
-    { keys: 'a', label: 'add ticket', enabledWhen: ticketsEditable },
-    { keys: 'e', label: 'edit field', enabledWhen: canEdit },
-    { keys: 'd', label: 'remove ticket', enabledWhen: ticketsEditable },
+    { keys: 'esc/q', label: 'collapse', enabledWhen: inDetail },
+    { keys: 'a', label: 'add', enabledWhen: ticketsEditable },
+    { keys: 'e', label: 'edit', enabledWhen: canEdit },
+    { keys: 'd', label: 'remove', enabledWhen: ticketsEditable },
     // Surface the `m` chord only when this sprint is not already the current one — once
     // they match, the action is a no-op and the hint adds noise. Suppressed while a
     // stuck task is focused so the `u unblock` hint (a more urgent operator action)

--- a/src/application/ui/tui/views/sprint-detail-internals/detail-body.tsx
+++ b/src/application/ui/tui/views/sprint-detail-internals/detail-body.tsx
@@ -154,7 +154,7 @@ interface BuildDetailHintsArgs {
 const buildDetailHints = (args: BuildDetailHintsArgs): readonly ViewHint[] => {
   const { inDetail, ticketsEditable, canEdit, sprint, currentSprintId, focusedStuckTask, focusedEvaluatedTask } = args;
   return [
-    { keys: '↑/↓/j/k', label: 'move' },
+    { keys: '↑/↓', label: 'move' },
     { keys: 'n', label: 'flows' },
     { keys: '↵/o', label: inDetail ? 'expand/collapse' : 'expand' },
     // `esc/q` collapses all expanded cards; only shown while in detail mode so the hint

--- a/src/application/ui/tui/views/sprint-detail-internals/outcome-card.tsx
+++ b/src/application/ui/tui/views/sprint-detail-internals/outcome-card.tsx
@@ -51,11 +51,14 @@ const RUNG_LABEL: Readonly<Record<EscalationRung, string>> = {
 
 const pct = (rate: number): string => `${String(Math.round(rate * 100))}%`;
 
-/** `a • b • c` — the card's one-line list idiom, built from the theme's bullet. */
+/**
+ * One-line `label count` list, separated by the theme bullet — the same separator idiom every
+ * sibling line in this card uses (`regressionLine`, `outcomeMixLine`, `rungFields`).
+ */
 const joinCounts = (entries: ReadonlyArray<readonly [string, number]>): string | undefined => {
   const nonzero = entries.filter(([, count]) => count > 0);
   if (nonzero.length === 0) return undefined;
-  return nonzero.map(([label, count]) => `${label} ${glyphs.bullet}${String(count)}`).join('  ');
+  return nonzero.map(([label, count]) => `${label} ${String(count)}`).join(` ${glyphs.bullet} `);
 };
 
 /**

--- a/src/application/ui/tui/views/sprints-view.tsx
+++ b/src/application/ui/tui/views/sprints-view.tsx
@@ -366,7 +366,7 @@ const sprintsKeyBindings = ({
   const { setFeedback } = actions;
   const focusedDone = focusedSprint?.status === 'done';
   return [
-    { keys: ['↑', '↓', 'j', 'k'], hint: 'move' },
+    { keys: ['↑', '↓'], hint: 'move' },
     { keys: ['↵'], hint: 'open' },
     {
       keys: ['c'],

--- a/tests/integration/application/ui/tui/components/evaluator-failure-panel.test.tsx
+++ b/tests/integration/application/ui/tui/components/evaluator-failure-panel.test.tsx
@@ -21,6 +21,7 @@ import {
   projectEvaluationLines,
 } from '@src/application/ui/tui/components/evaluator-failure-panel.tsx';
 import { parseEvaluationMarkdown, type ParsedEvaluation } from '@src/business/task/parse-evaluation-md.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import type { BucketedExecution } from '@src/application/ui/tui/runtime/bucket-task-signals.ts';
 import type { EvaluationSignal } from '@src/domain/signal.ts';
 import type { IsoTimestamp } from '@src/domain/value/iso-timestamp.ts';
@@ -97,6 +98,20 @@ describe('EvaluatorFailurePanel — per-dimension render', () => {
     // Dim, so it carries no success/error colour at all.
     expect(docs?.color).toBeUndefined();
     expect(docs?.dim).toBe(true);
+  });
+
+  it('renders an `unknown` dimension with the themed unknown glyph and no colour', () => {
+    // A dimension heading with no ` — verdict` tail parses to `unknown`. The glyph comes from the
+    // theme (never an inline literal) and, like `n/a`, must stay uncoloured so the panel does not
+    // report an undetermined verdict as a failure.
+    const parsed = parseEvaluationMarkdown(
+      ['# Evaluation — failed', '', '## Dimensions', '', '### flakiness', '', 'could not tell', ''].join('\n')
+    );
+    const row = projectEvaluationLines(parsed).find((l) => l.text.includes('flakiness:'));
+    expect(row?.text).toContain('flakiness: unknown');
+    expect(row?.text.startsWith(glyphs.unknownGlyph)).toBe(true);
+    expect(row?.color).toBeUndefined();
+    expect(row?.dim).toBe(true);
   });
 
   it('surfaces a dimension whose fenced execution evidence was recorded', () => {

--- a/tests/integration/application/ui/tui/components/token-budget-card.test.tsx
+++ b/tests/integration/application/ui/tui/components/token-budget-card.test.tsx
@@ -15,8 +15,14 @@
 import { render } from 'ink-testing-library';
 import { describe, expect, it } from 'vitest';
 import { TokenBudgetCard } from '@src/application/ui/tui/components/token-budget-card.tsx';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 
 const SESSION = '019e46d1-5f16-7db9-af55-67c3c703d438';
+
+/** Any progress-bar cell — built from the tokens so the assertion follows a glyph swap. */
+const BAR_CELL = new RegExp(`[${glyphs.barFilled}${glyphs.barEmpty}]`, 'u');
+/** A completely full 10-cell bar (the card's BAR_WIDTH) — used as a negative assertion. */
+const FULL_BAR = new RegExp(`${glyphs.barFilled}{10}`, 'u');
 
 describe('TokenBudgetCard', () => {
   it('renders the empty state when no usage data is supplied', () => {
@@ -56,7 +62,7 @@ describe('TokenBudgetCard', () => {
     // Context group: live-derived occupancy = 9.1k + 50k = 59.1k against the 200k window.
     expect(frame).toContain('59.1k');
     expect(frame).toContain('200k');
-    expect(frame).toMatch(/[█░]/);
+    expect(frame).toMatch(BAR_CELL);
     // 59100 / 200000 = 29.55% ⇒ 30%.
     expect(frame).toContain('30%');
   });
@@ -124,7 +130,7 @@ describe('TokenBudgetCard', () => {
     expect(frame).toContain('cumulative');
     expect(frame).toContain('240k');
     expect(frame).not.toContain('100%');
-    expect(frame).not.toMatch(/█{10}/);
+    expect(frame).not.toMatch(FULL_BAR);
     // The Usage row still shows the raw throughput values.
     expect(frame).toContain('180k');
     expect(frame).toContain('5k');
@@ -147,7 +153,7 @@ describe('TokenBudgetCard', () => {
     // Context used = input only = 40000 ⇒ 40k, 20% (output excluded), bar renders.
     expect(frame).toContain('40k');
     expect(frame).toContain('20%');
-    expect(frame).toMatch(/[█░]/);
+    expect(frame).toMatch(BAR_CELL);
     expect(frame).not.toContain('cumulative');
     expect(frame).not.toContain('cache hit');
   });

--- a/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/pick-sprint-view.test.tsx
@@ -19,6 +19,7 @@ import type { Sprint } from '@src/domain/entity/sprint.ts';
 import type { ProjectRepository } from '@src/domain/repository/project/project-repository.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import { useSelection } from '@src/application/ui/tui/runtime/selection-context.tsx';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { END, HOME, PAGE_DOWN, PAGE_UP, tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { waitFor } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView } from '@tests/integration/application/ui/tui/_harness.tsx';
@@ -219,6 +220,8 @@ describe('PickSprintView', () => {
     expect(frame).toContain('beta sprint one');
     expect(frame).toContain('3 sprints');
     expect(frame).toContain('all projects');
+    // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
+    expect(frame).not.toContain('j/k');
     // Current project (Alpha) appears before Beta in the rendered output.
     expect(frame.indexOf('Alpha Project')).toBeLessThan(frame.indexOf('Beta Project'));
   });
@@ -341,7 +344,7 @@ describe('PickSprintView', () => {
     await tick(30);
     // Press j again — there's no further sprint, cursor stays put.
     result.stdin.write('j');
-    // The focus marker (▍) precedes whichever sprint is focused; assert beta sprint shows
+    // The focus marker (glyphs.focusBar) precedes whichever sprint is focused; assert beta sprint shows
     // the focused-line marker (focused rows print a "↳ N tickets" hint, headers do not).
     await waitFor(() => expect(result.lastFrame() ?? '').toContain('↳ 0 tickets'));
   });
@@ -404,10 +407,10 @@ describe('PickSprintView', () => {
     expect(frame).toContain('⚠');
   });
 
-  // The focus marker (▍) precedes the focused row's label on the same rendered line. Returns the
+  // The focus marker (glyphs.focusBar) precedes the focused row's label on the same rendered line. Returns the
   // trimmed line carrying the marker so a test can assert which row is currently focused without
   // depending on absolute screen coordinates.
-  const focusedLine = (frame: string): string => frame.split('\n').find((line) => line.includes('▍')) ?? '';
+  const focusedLine = (frame: string): string => frame.split('\n').find((line) => line.includes(glyphs.focusBar)) ?? '';
 
   // 30 sprints in one project, named picksprint-01..30 with id counters that sort (descending,
   // newest-first) so the rendered top→bottom order is picksprint-30 … picksprint-01. Comfortably

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -69,7 +69,7 @@ describe('ProjectDetailView', () => {
     result.unmount();
   });
 
-  it('advertises the navigate / select / edit hints the view actually responds to', async () => {
+  it('advertises the move / select / edit hints the view actually responds to', async () => {
     const project = makeTwoRepoProject();
     const { result } = renderView(<ProjectDetailView />, {
       deps: stubDeps(project),
@@ -78,7 +78,7 @@ describe('ProjectDetailView', () => {
     await waitForViewReady(result);
     const frame = result.lastFrame() ?? '';
     // Previously-omitted keys the view handles must be advertised (audit L17).
-    expect(frame).toContain('navigate');
+    expect(frame).toContain('move');
     expect(frame).toContain('confirm/select');
     expect(frame).toContain('edit field');
     // DESIGN-SYSTEM §6.4 — the j/k alias stays bound but is never advertised per-view.

--- a/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/project-detail-view.test.tsx
@@ -81,6 +81,8 @@ describe('ProjectDetailView', () => {
     expect(frame).toContain('navigate');
     expect(frame).toContain('confirm/select');
     expect(frame).toContain('edit field');
+    // DESIGN-SYSTEM §6.4 — the j/k alias stays bound but is never advertised per-view.
+    expect(frame).not.toContain('j/k');
     result.unmount();
   });
 

--- a/tests/integration/application/ui/tui/views/projects-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/projects-view.test.tsx
@@ -54,6 +54,8 @@ describe('ProjectsView', () => {
     expect(frame).toContain('Demo Project');
     expect(frame).toContain('demo-proj');
     expect(frame).toContain('1 project(s)');
+    // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
+    expect(frame).not.toContain('j/k');
     result.unmount();
   });
 

--- a/tests/integration/application/ui/tui/views/sessions-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sessions-view.test.tsx
@@ -112,6 +112,8 @@ describe('SessionsView', () => {
     expect(frame).toContain('refine');
     expect(frame).toContain('running');
     expect(frame).toContain('1 session(s)');
+    // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
+    expect(frame).not.toContain('j/k');
     result.unmount();
   });
 

--- a/tests/integration/application/ui/tui/views/settings-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/settings-view.test.tsx
@@ -140,12 +140,12 @@ describe('SettingsView', () => {
     result.unmount();
   });
 
-  it('exposes ←/→ section, ↑/↓ navigate, ↵/e edit hints', async () => {
+  it('exposes ←/→ section, ↑/↓ move, ↵/e edit hints', async () => {
     const { result } = renderView(<SettingsView />, { deps, initial: { id: 'settings' } });
     await waitForViewReady(result, (f) => f.includes('section'));
     const frame = result.lastFrame() ?? '';
     expect(frame).toContain('section');
-    expect(frame).toContain('navigate');
+    expect(frame).toContain('move');
     expect(frame).toContain('edit');
     result.unmount();
   });
@@ -260,10 +260,10 @@ describe('SettingsView', () => {
       result.stdin.write('j');
       await tick(20);
       result.stdin.write(ENTER);
-      await waitForViewReady(result, (f) => f.includes('↑/↓ navigate · ↵ submit · esc cancel'));
+      await waitForViewReady(result, (f) => f.includes('↑/↓ move · ↵ submit · esc cancel'));
       const frame = result.lastFrame() ?? '';
       // SelectPrompt always renders the navigation legend below its option list.
-      expect(frame).toContain('↑/↓ navigate · ↵ submit · esc cancel');
+      expect(frame).toContain('↑/↓ move · ↵ submit · esc cancel');
       // TextPrompt's hint row carries the `←/→ cursor · home/end edge` suffix; its absence
       // confirms the active editor is the SelectPrompt, not a free-text input.
       expect(frame).not.toContain('←/→ cursor · home/end edge');
@@ -306,7 +306,7 @@ describe('SettingsView', () => {
     ): Promise<void> => {
       await goToSection(stdin, 'refine');
       stdin.write(ENTER);
-      await waitForPredicate(() => (lastFrame() ?? '').includes('↑/↓ navigate · ↵ submit · esc cancel'));
+      await waitForPredicate(() => (lastFrame() ?? '').includes('↑/↓ move · ↵ submit · esc cancel'));
     };
 
     it("labels unavailable providers as '(not installed)' in the provider picker", async () => {

--- a/tests/integration/application/ui/tui/views/skills-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/skills-view.test.tsx
@@ -122,6 +122,8 @@ describe('SkillsView', () => {
     expect(frame).toContain('◌ ref');
     // No opt-in copies exist anywhere — the hint should point at the enable key + folder.
     expect(frame).toContain('no opt-in copies yet');
+    // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
+    expect(frame).not.toContain('j/k');
   });
 
   it('shows the "(manual)" tag for a phase-folder entry with no matching bundled skill', async () => {

--- a/tests/integration/application/ui/tui/views/sprint-detail-outcome-card.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-outcome-card.test.tsx
@@ -109,6 +109,11 @@ describe('OutcomeReportCard — the regression / failure taxonomy', () => {
     expect(frame).toContain('Warnings');
     expect(frame).toContain('budget-exhausted');
     expect(frame).toContain('plateau');
+    // Count follows its label; the theme bullet SEPARATES entries rather than prefixing counts
+    // (the `label ·N  label ·N` form the docstring never described is gone).
+    expect(frame).toContain('budget-exhausted 1');
+    expect(frame).toContain('plateau 1');
+    expect(frame).not.toMatch(/·\d/u);
   });
 
   it('names the abort cause only when an attempt actually aborted', () => {

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -22,8 +22,9 @@ import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import type { SprintRepository } from '@src/domain/repository/sprint/sprint-repository.ts';
 import type { TaskRepository } from '@src/domain/repository/task/task-repository.ts';
 import type { Task } from '@src/domain/entity/task.ts';
+import { glyphs } from '@src/application/ui/tui/theme/tokens.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
-import { ESC, tick } from '@tests/integration/application/ui/tui/_keys.ts';
+import { ESC } from '@tests/integration/application/ui/tui/_keys.ts';
 import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { noopLogger } from '@tests/fixtures/noop-logger.ts';
 import { makeApprovedTicket, makeDraftSprint } from '@tests/fixtures/domain.ts';
@@ -68,6 +69,18 @@ const stubReadOnlyDeps = (sprint: Sprint, tasks: readonly Task[]): AppDeps =>
 
 const initial: ViewEntry = { id: 'sprint-detail', props: { sprintId: FIXED_SPRINT_ID } };
 
+/**
+ * Wait until the focus cursor lands on card #N (1-based). `ListCard` prefixes the focused card's
+ * index label with `glyphs.actionCursor`, so `▸ #N` in the frame IS the cursor position. A blind
+ * `tick(40)` here was the flake: under a slow CI fork the keystroke could land after the tick, and
+ * the following `o` then toggled the WRONG card — leaving the next predicate permanently false.
+ */
+const waitForCursorOn = async (result: { lastFrame: () => string | undefined }, index: number): Promise<void> => {
+  await waitForPredicate(() => (result.lastFrame() ?? '').includes(`${glyphs.actionCursor} #${String(index)}`), {
+    label: `cursor on card #${String(index)}`,
+  });
+};
+
 describe('SprintDetailView — per-card expand/collapse', () => {
   it('opens two cards independently — both remain expanded', async () => {
     const sprint = makeSprintWithTickets([
@@ -82,7 +95,7 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to the second ticket and expand it without collapsing the first.
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('o');
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
@@ -106,14 +119,16 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move to card 1 and open it.
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('o');
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
     // Move back to card 0 and toggle it closed.
     result.stdin.write('k');
-    await tick(40);
+    await waitForCursorOn(result, 1);
     result.stdin.write('o');
-    await tick(40);
+    await waitForPredicate(() => !(result.lastFrame() ?? '').includes('requirements for alpha card'), {
+      label: 'alpha card collapsed',
+    });
 
     const frame = result.lastFrame() ?? '';
     // Card 0's requirements heading should be gone; card 1's must remain.
@@ -133,7 +148,7 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     result.stdin.write('o');
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('o');
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for bravo card'));
 
@@ -144,7 +159,13 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // One Esc must clear the entire openIds set.
     result.stdin.write(ESC);
-    await tick(40);
+    await waitForPredicate(
+      () => {
+        const f = result.lastFrame() ?? '';
+        return !f.includes('requirements for alpha card') && !f.includes('requirements for bravo card');
+      },
+      { label: 'both cards collapsed after esc' }
+    );
 
     frame = result.lastFrame() ?? '';
     expect(frame).not.toContain('requirements for alpha card');
@@ -166,13 +187,13 @@ describe('SprintDetailView — per-card expand/collapse', () => {
 
     // Navigate cursor up and down across all three cards.
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 3);
     result.stdin.write('k');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('k');
-    await tick(40);
+    await waitForCursorOn(result, 1);
 
     const frame = result.lastFrame() ?? '';
     // The alpha card must remain expanded throughout cursor movement; the others must not
@@ -232,11 +253,13 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for alpha card'));
     // Move down twice to card 2 (charlie) and open it.
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('j');
-    await tick(40);
+    await waitForCursorOn(result, 3);
     result.stdin.write('o');
-    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for charlie card'));
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('requirements for charlie card'), {
+      label: 'charlie card expanded',
+    });
 
     // Pre-condition: alpha and charlie expanded; bravo collapsed.
     let frame = result.lastFrame() ?? '';
@@ -250,14 +273,21 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     // briefly flips the view to a Loading spinner while the new bundle resolves, so we poll
     // until the cards are back before asserting.
     result.stdin.write('k');
-    await tick(40);
+    await waitForCursorOn(result, 2);
     result.stdin.write('d');
-    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'));
-    result.stdin.write('y');
-    await waitForPredicate(() => {
-      const f = result.lastFrame() ?? '';
-      return f.includes('alpha card') && f.includes('charlie card') && !f.includes('Loading');
+    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'), {
+      label: 'remove-ticket confirm mounted',
     });
+    result.stdin.write('y');
+    // The remove + reload round-trips the repo stub and remounts the card list — the slowest
+    // settle in this file, so it gets headroom beyond the default ceiling for instrumented CI.
+    await waitForPredicate(
+      () => {
+        const f = result.lastFrame() ?? '';
+        return f.includes('alpha card') && f.includes('charlie card') && !f.includes('Loading');
+      },
+      { label: 'cards back after remove-ticket reload', timeout: 10_000 }
+    );
 
     frame = result.lastFrame() ?? '';
     // The two surviving cards (alpha + charlie) keep their expansion; bravo is gone from the

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -275,9 +275,17 @@ describe('SprintDetailView — per-card expand/collapse', () => {
     result.stdin.write('k');
     await waitForCursorOn(result, 2);
     result.stdin.write('d');
-    await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'), {
-      label: 'remove-ticket confirm mounted',
-    });
+    // This wait has failed CI-only in the past with no local repro — on timeout, surface the
+    // actual frame so the failure is diagnosable from the CI log alone.
+    try {
+      await waitForPredicate(() => (result.lastFrame() ?? '').includes('Remove ticket'), {
+        label: 'remove-ticket confirm mounted',
+      });
+    } catch (err) {
+      throw new Error(`${String(err)}\n--- frame at timeout ---\n${result.lastFrame() ?? '(no frame)'}`, {
+        cause: err,
+      });
+    }
     result.stdin.write('y');
     // The remove + reload round-trips the repo stub and remounts the card list — the slowest
     // settle in this file, so it gets headroom beyond the default ceiling for instrumented CI.

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.per-card-toggle.test.tsx
@@ -282,9 +282,23 @@ describe('SprintDetailView — per-card expand/collapse', () => {
         label: 'remove-ticket confirm mounted',
       });
     } catch (err) {
-      throw new Error(`${String(err)}\n--- frame at timeout ---\n${result.lastFrame() ?? '(no frame)'}`, {
-        cause: err,
-      });
+      // Frame-history forensics: `frames` holds every write since mount. Whether the confirm
+      // EVER appeared separates "d was processed, then something reset" from "d never landed",
+      // and the tail shows whether Ink kept rendering (spinner advancing) or stalled.
+      const frames = result.frames;
+      const confirmSeen = frames.findIndex((f) => f.includes('Remove ticket'));
+      const bravoLastSeen = frames.map((f) => f.includes('bravo card')).lastIndexOf(true);
+      const tail = frames
+        .slice(-4)
+        .map((f, i) => `--- frame[len-${String(4 - i)}] (${String(f.length)} chars) ---\n${f}`)
+        .join('\n');
+      throw new Error(
+        `${String(err)}\n` +
+          `frames total: ${String(frames.length)}; ` +
+          `'Remove ticket' first seen in frame: ${String(confirmSeen)}; ` +
+          `'bravo card' last seen in frame: ${String(bravoLastSeen)}\n${tail}`,
+        { cause: err }
+      );
     }
     result.stdin.write('y');
     // The remove + reload round-trips the repo stub and remounts the card list — the slowest

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
@@ -458,6 +458,8 @@ describe('SprintDetailView — phase workspace', () => {
     // The hint strip advertises the ticket add/remove chords only while they are wired up.
     expect(frame).toContain('add ticket');
     expect(frame).toContain('remove ticket');
+    // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
+    expect(frame).not.toContain('j/k');
     result.unmount();
   });
 

--- a/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprint-detail-view.test.tsx
@@ -453,11 +453,11 @@ describe('SprintDetailView — phase workspace', () => {
       tickets: [{ id: 't1' as never, title: 'first', status: 'pending' } as never],
     });
     const { result } = renderView(<SprintDetailView />, { deps: stubDeps(sprint, []), initial });
-    await waitForViewReady(result, (f) => f.includes('add ticket'));
+    await waitForViewReady(result, (f) => f.includes('a add'));
     const frame = result.lastFrame() ?? '';
     // The hint strip advertises the ticket add/remove chords only while they are wired up.
-    expect(frame).toContain('add ticket');
-    expect(frame).toContain('remove ticket');
+    expect(frame).toContain('a add');
+    expect(frame).toContain('d remove');
     // DESIGN-SYSTEM §6.4 — arrows only in the per-view hint strip; j/k stays bound but unadvertised.
     expect(frame).not.toContain('j/k');
     result.unmount();
@@ -473,8 +473,8 @@ describe('SprintDetailView — phase workspace', () => {
     const frame = result.lastFrame() ?? '';
     // Ticket CRUD is draft-only; on an active sprint the chords do nothing, so the footer must
     // not advertise them — the hint shares one source of truth with the gated handler.
-    expect(frame).not.toContain('add ticket');
-    expect(frame).not.toContain('remove ticket');
+    expect(frame).not.toContain('a add');
+    expect(frame).not.toContain('d remove');
     result.unmount();
   });
 

--- a/tests/integration/application/ui/tui/views/sprints-view.test.tsx
+++ b/tests/integration/application/ui/tui/views/sprints-view.test.tsx
@@ -103,6 +103,10 @@ describe('SprintsView', () => {
     expect(frame).toContain('c create');
     expect(frame).toContain('d delete');
     expect(frame).toContain('e rename');
+    // DESIGN-SYSTEM §6.4 — arrows are the advertised move keys; the j/k alias lives in the help
+    // overlay's Lists section only and must never be repeated in a per-view hint strip.
+    expect(frame).toContain('↑/↓ move');
+    expect(frame).not.toContain('j/k');
     result.unmount();
   });
 

--- a/tests/unit/application/chain/leaf-precondition-trace.test.ts
+++ b/tests/unit/application/chain/leaf-precondition-trace.test.ts
@@ -5,12 +5,17 @@
  * step broke) while the surrounding `sequential` marks the steps after it `skipped`.
  *
  * Any OTHER throw is a programmer bug and must re-propagate untouched — the runner, not the leaf,
- * is the containment boundary for those.
+ * is the containment boundary for those. Node errno errors (EACCES, ELOOP …) are the motivating
+ * non-domain case: they carry a string `code` too, and must never be laundered into the
+ * domain-error channel just because an adapter threw one instead of returning `Result.error`.
  */
 
 import { describe, expect, it } from 'vitest';
 
 import { Result } from '@src/domain/result.ts';
+import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import type { DomainError } from '@src/domain/value/error/domain-error.ts';
+import type { ErrorCode } from '@src/domain/value/error/error-code.ts';
 import { InvalidStateError } from '@src/domain/value/error/invalid-state-error.ts';
 import { leaf } from '@src/application/chain/build/leaf.ts';
 import { sequential } from '@src/application/chain/build/sequential.ts';
@@ -123,5 +128,94 @@ describe('leaf precondition throws', () => {
     });
 
     await expect(element.execute(CTX)).rejects.toThrow('merge exploded');
+  });
+
+  it('re-propagates a Node errno error from input() — a string `code` is not a domain code', async () => {
+    const emitted: TraceEntry[] = [];
+    const element = leaf<Ctx, unknown, Ctx>('errno-projector', {
+      useCase: {
+        async execute() {
+          return Result.ok(CTX);
+        },
+      },
+      input: () => {
+        throw errno('EACCES: permission denied', 'EACCES');
+      },
+      output: (c) => c,
+    });
+
+    await expect(element.execute(CTX, undefined, (e) => emitted.push(e))).rejects.toThrow('EACCES: permission denied');
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('re-propagates a Node errno error thrown by the use case (the adapter-I/O shape)', async () => {
+    const emitted: TraceEntry[] = [];
+    const element = leaf<Ctx, Ctx, Ctx>('install-skills', {
+      useCase: {
+        async execute() {
+          throw errno('ELOOP: too many symbolic links', 'ELOOP');
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    await expect(element.execute(CTX, undefined, (e) => emitted.push(e))).rejects.toThrow(
+      'ELOOP: too many symbolic links'
+    );
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('still turns a real DomainError thrown by the use case into a failed entry', async () => {
+    const element = leaf<Ctx, Ctx, Ctx>('save-sprint', {
+      useCase: {
+        async execute() {
+          throw new InvalidStateError({ entity: 'sprint', currentState: 'draft', attemptedAction: 'save' });
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const result = await element.execute(CTX);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.error).toBeInstanceOf(InvalidStateError);
+    expect(result.error.trace[0]?.status).toBe('failed');
+    expect(result.error.trace[0]?.elementName).toBe('save-sprint');
+  });
+
+  it('still turns an AbortError thrown by the use case into an aborted entry', async () => {
+    const element = leaf<Ctx, Ctx, Ctx>('long-step', {
+      useCase: {
+        async execute() {
+          throw new AbortError({ elementName: 'long-step' });
+        },
+      },
+      input: (c) => c,
+      output: (_c, o) => o,
+    });
+
+    const result = await element.execute(CTX);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error.error).toBeInstanceOf(AbortError);
+    expect(result.error.trace[0]?.status).toBe('aborted');
+  });
+});
+
+/** A Node-shaped errno error: a real `Error` carrying a string `code` that is not an `ErrorCode`. */
+const errno = (message: string, code: string): Error => Object.assign(new Error(message), { code });
+
+describe('DomainError code registry', () => {
+  it('every DomainError class assigns a registered ErrorCode (compile-time fence)', () => {
+    // The exact-membership predicate in leaf.ts makes this correspondence load-bearing: a new
+    // error class with an unregistered `code` literal would compile, satisfy the union, and then
+    // silently re-throw past the leaf instead of tracing as `failed`. This line makes that a
+    // typecheck failure instead.
+    const fence: Exclude<DomainError['code'], ErrorCode> extends never ? true : never = true;
+    expect(fence).toBe(true);
   });
 });

--- a/tests/unit/application/ui/tui/theme/tokens.test.ts
+++ b/tests/unit/application/ui/tui/theme/tokens.test.ts
@@ -51,6 +51,22 @@ describe('glyphs.clipMarkers (audit-[03])', () => {
   });
 });
 
+describe('glyphs — design-system tokens for former inline glyphs (#297)', () => {
+  it('exposes the picker focus rail as U+258D (left three-eighths block)', () => {
+    expect(glyphs.focusBar).toHaveLength(1);
+    expect(glyphs.focusBar.codePointAt(0)).toBe(0x258d);
+  });
+
+  it('exposes the progress-bar cells as U+2588 / U+2591 (full block / light shade)', () => {
+    expect(glyphs.barFilled.codePointAt(0)).toBe(0x2588);
+    expect(glyphs.barEmpty.codePointAt(0)).toBe(0x2591);
+  });
+
+  it('exposes the unknown-verdict glyph as a plain ASCII question mark', () => {
+    expect(glyphs.unknownGlyph).toBe('?');
+  });
+});
+
 describe('resolveRailWidth', () => {
   it('returns the fixed RAIL_WIDTH below the xl breakpoint', () => {
     // sm / md / lg all share the fixed value — the two-column layout has no context column to

--- a/tests/unit/ci/release-workflow.test.ts
+++ b/tests/unit/ci/release-workflow.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = fileURLToPath(new URL('../../../.github/workflows/release.yml', import.meta.url));
+const WORKFLOW_TEXT = readFileSync(WORKFLOW_PATH, 'utf8');
+
+const PERFORMANCE_DOC_PATH = fileURLToPath(new URL('../../../.claude/docs/PERFORMANCE.md', import.meta.url));
+const PERFORMANCE_DOC_TEXT = readFileSync(PERFORMANCE_DOC_PATH, 'utf8');
+
+describe('release workflow tag triggers', () => {
+  it('triggers on both the stable and the pre-release tag glob', () => {
+    // Actions ref filters full-match, and `[0-9]+` cannot express an optional suffix — so the
+    // pre-release path needs its own pattern. Dropping it makes `v0.20.0-rc.1` a silent no-op.
+    expect(WORKFLOW_TEXT).toContain("- 'v[0-9]+.[0-9]+.[0-9]+'");
+    expect(WORKFLOW_TEXT).toContain("- 'v[0-9]+.[0-9]+.[0-9]+-*'");
+  });
+
+  it('routes a hyphenated version to the `next` npm dist-tag', () => {
+    expect(WORKFLOW_TEXT).toContain('*-*) echo "npm_tag=next" >> "$GITHUB_OUTPUT" ;;');
+    expect(WORKFLOW_TEXT).toContain('*) echo "npm_tag=latest" >> "$GITHUB_OUTPUT" ;;');
+  });
+
+  it('publishes under the computed dist-tag rather than defaulting to `latest`', () => {
+    // Without `--tag`, npm puts a pre-release on `latest`, which a bare `npm i ralphctl`
+    // resolves to and which `compareVersions` assumes is always stable.
+    expect(WORKFLOW_TEXT).toContain(
+      'pnpm publish --no-git-checks --provenance --tag "${{ steps.version.outputs.npm_tag }}"'
+    );
+  });
+
+  it('keeps the now-live prerelease flag on the GitHub Release', () => {
+    expect(WORKFLOW_TEXT).toContain("prerelease: ${{ contains(github.ref_name, '-') }}");
+  });
+});
+
+describe('release procedure documentation', () => {
+  it('documents the pre-release glob and an example tag the workflow accepts', () => {
+    // Doc/workflow drift is the exact defect this test fences: the doc used to promise a
+    // pre-release path the trigger rejected. Assertions stay loose so prose edits do not thrash.
+    expect(PERFORMANCE_DOC_TEXT).toContain('v[0-9]+.[0-9]+.[0-9]+-*');
+    expect(PERFORMANCE_DOC_TEXT).toContain('v0.20.0-rc.1');
+  });
+});

--- a/tests/unit/integration/io/git-exclude.test.ts
+++ b/tests/unit/integration/io/git-exclude.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
+import { ErrorCode } from '@src/domain/value/error/error-code.ts';
 import { StorageError } from '@src/domain/value/error/storage-error.ts';
 import { ensureGitExcludeWildcard } from '@src/integration/io/git-exclude.ts';
 
@@ -114,6 +115,12 @@ describe('ensureGitExcludeWildcard', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     expect(result.error).toBeInstanceOf(StorageError);
+    // The raw errno ('ELOOP') must NOT become the error code — it is a Node code, not a domain one.
+    expect(result.error.code).toBe(ErrorCode.Storage);
+    expect(result.error.subCode).toBe('io');
+    expect(result.error.path?.endsWith('/.git')).toBe(true);
+    // …but it stays reachable on `.cause` so the failure is still diagnosable from a logger.warn.
+    expect((result.error.cause as { code?: unknown } | undefined)?.code).toBe('ELOOP');
   });
 
   it('resolves the worktree pointer file (.git is a file containing gitdir:)', async () => {


### PR DESCRIPTION
## Summary

Implements the four open `refactor` / `documentation` tickets, plus the follow-ups surfaced by review.

- **Closes #293** — `isDomainError` now requires exact `ErrorCode` membership, so Node errno throws (EACCES/ELOOP) are no longer laundered into the domain-error channel; compile-time fence pins the `DomainError`↔`ErrorCode` correspondence. The git-exclude `Result` conversion itself had already shipped in `1be3ae69`; its ELOOP test is hardened here (real self-referential symlink, no fs mocks).
- **Closes #297** — design-system drift: new `glyphs.focusBar` / `barFilled` / `barEmpty` / `unknownGlyph` tokens replace the inline unicode at all four call sites; responsive breakpoints come from tokens (values identical — layout byte-identical); `j/k` dropped from seven per-view hint strips (bindings still work); `joinCounts` output matches its docstring; DESIGN-SYSTEM §2.2 table updated.
- **Closes #305** — pre-release tag path is now live: second trigger glob `v[0-9]+.[0-9]+.[0-9]+-*` + `pnpm publish --tag` (`next` for hyphenated versions — without it an rc would land on `latest`). `VERSION` passed via `env` rather than run-body interpolation. PERFORMANCE.md + CONTRIBUTING.md updated; drift-fence test pins workflow + prose. Note: the glob can only be proven by pushing a tag — make the first real pre-release a throwaway rc and check `npm dist-tag ls ralphctl` after. If it doesn't fire, fallback is a single `v[0-9]+.[0-9]+.[0-9]+*` glob.
- **Closes #306** — AI-session data-flow diagram documents the evaluation.md read-back (only the TUI overlay parses; the CLI streams verbatim). Mermaid `&lt;/&gt;` entities replaced with raw brackets — they were a real parse error on GitHub, not an mmdc quirk.
- **Follow-ups from review**: 01-flow-lifecycle.md entity fix (all 5 diagrams verified with `mermaid.parse()`), diagrams README + 03 read-back mentions, release skill pre-release path + removed-fallback corrections, `glyphs.caretBlock` for the prompt carets, hint label unified to `move` across the four `navigate` stragglers.

#220 (loop GIF) is deliberately not in this batch — it needs a live recording session.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` (zero warnings) · `pnpm test` (6066 tests / 618 files) — green locally
- [x] `pnpm format:check` clean
- [x] All 5 mermaid diagrams parse via `mermaid.parse()` (mermaid 11)
- [x] Opus reviewer pass over the combined diff — both major findings fixed, nits applied
- [ ] CI green

https://claude.ai/code/session_01PHikH4LdejozJdjzTzhPes