### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-21
+
 ### Added
 
 - **`ralphctl runs stats` — the harness outcome rollup.** A read-only report over the sprint data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, OpenAI Codex, and OpenCode across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.20.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.20.0]`

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green

https://claude.ai/code/session_01PHikH4LdejozJdjzTzhPes