### PR TITLE
chore: migrate haiku presets to sonnet-5 + test hygiene

### DIFF
--- a/.claude/agent-memory/implementer/seams_model_catalog_refresh.md
+++ b/.claude/agent-memory/implementer/seams_model_catalog_refresh.md
@@ -38,6 +38,20 @@ NOT reachable by grepping for the changed slugs.
 catalog file → `RETIRED_MODEL_REMAPS` in `src/domain/entity/settings.ts` → fingerprint → the two remap
 test files → AI-SETTINGS.md → CHANGELOG.
 
+## The inverse case: a preset-only model migration
+
+Retiring a model from the curated presets WITHOUT touching the catalog (e.g. the Haiku 4.5 →
+Sonnet 5-at-`low` move) does **not** trip the fingerprint gate — that gate hashes catalog ids, not
+preset rows. The real fences live in `tests/unit/business/settings/presets.test.ts`: the
+`retiring cheap tier` set (add the slug there so the matrices can't regress onto it), the
+per-family readiness assertion, and the per-preset matrix blocks. `presets.ts` also carries prose
+in three docstrings (economic "cheap tier", fast-family "not haiku", the hoisted-const comment)
+that no test guards. `.claude/docs/AI-SETTINGS.md` restates the same prose and also goes stale.
+
+When a cheap-tier MODEL disappears, the cost intent has to move into the effort column: pin
+`effort: 'low'` on each migrated row, because an absent effort inherits the preset's global (`high`
+on economic / strong-gate) and silently raises spend.
+
 Touchpoints that usually need NO change: `escalation-map.ts` (rungs name only claude/gpt slugs),
 `context-window.ts` (Copilot/Codex windows are deliberately omitted — the CLIs don't surface them),
 `suspended-models.ts` (empty by design, kept as a kill-switch mechanism), `effort.ts`,

--- a/.claude/docs/AI-SETTINGS.md
+++ b/.claude/docs/AI-SETTINGS.md
@@ -110,8 +110,12 @@ additionally carries `opencode-only`. The families:
   climbs to the flagship on plateau via the escalation ladder (`escalateOnPlateau` stamped `true`). The
   Codex variant (`gpt-5.6-terra` gen → `gpt-5.6-sol` gate) has the narrowest gap of the family.
 - **fast** (`mixed-fast`, `claude-fast`, `copilot-fast`, `codex-fast`) — cheapest viable tier at `low`
-  effort across the board. Implement uses sonnet/mini (not haiku — too weak to author code reliably); light
-  flows drop further. This is the only family with `escalateOnPlateau` stamped **`false`** — a plateau
+  effort across the board; the family differentiates by EFFORT rather than by model. Implement stays on a
+  code-capable tier (sonnet / the cheapest 5.6 tier), never a sub-coding model — too weak to author code
+  reliably. `claude-fast` is uniformly sonnet across every row (Haiku 4.5 is retiring with no Haiku 5
+  successor, so it left every preset default — see the Claude Code catalog note below) and buys its speed
+  entirely from `low` effort; the gpt-side light flows (refine/readiness/ideate/createPr) additionally drop
+  a model tier further. This is the only family with `escalateOnPlateau` stamped **`false`** — a plateau
   settles (done-with-warning) rather than climbing the ladder, which is what keeps the family genuinely
   cheap and predictable.
 - **frontier** (`mixed-frontier`, `claude-frontier`, `copilot-frontier`, `codex-frontier`) — flagship
@@ -125,7 +129,9 @@ strong-gate / frontier all stamp it `true`; fast stamps it `false`. The rest of 
 `escalationMap`, `plateauThreshold`, …) plus all other top-level settings keys are preserved verbatim.
 
 **Model-tier ordering.** The ladders each family relies on are grounded in SWE-bench rankings (June
-2026 data): Claude haiku < sonnet < opus < fable; GPT mini < 5.4 < 5.5 < 5.6 (luna < terra < sol). These
+2026 data): Claude sonnet < opus < fable (Haiku 4.5 sits below sonnet but is no longer part of any preset
+ladder — it faces an Anthropic retirement horizon with no Haiku 5 successor, see the **fast** family note
+above); GPT mini < 5.4 < 5.5 < 5.6 (luna < terra < sol). These
 orderings explain why the cheap-to-strong tier progressions are wired the way they are — not as
 guaranteed scores (OpenAI stopped publishing SWE-bench Verified after contamination concerns, and
 results swing significantly with scaffolding). Treat this as relative-ordering rationale, not a
@@ -139,6 +145,8 @@ every `ai` row plus `harness.escalateOnPlateau` in one transaction; subsequent p
 
 - Claude Code — `claude-haiku-4-5` / `claude-sonnet-4-6` / `claude-sonnet-5` / `claude-opus-4-8` /
   `claude-opus-5` (verified against Claude Code v2.1.197; `claude-sonnet-5` requires v2.1.197+;
+  `claude-haiku-4-5` stays in the catalog for manual selection only — it left every preset default
+  ahead of its Anthropic retirement horizon, which has no Haiku 5 successor;
   `claude-opus-5` ships at the same price as Opus 4.8 — vendor-stated drop-in). `claude-opus-5` is the
   Opus 4.8 successor and the **default Opus** across presets, the new-install defaults, and the
   escalation ladder; `claude-opus-4-8` is kept alongside it (both Active at Anthropic) so pinned 4.8

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -598,7 +598,7 @@ const reservedSignalsPath: Linter.RuleEntry = [
 
 export default [
   {
-    ignores: ['dist/**', 'node_modules/**', '.claude/worktrees/**'],
+    ignores: ['dist/**', 'node_modules/**', '.claude/worktrees/**', 'coverage/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/business/settings/presets.ts
+++ b/src/business/settings/presets.ts
@@ -76,8 +76,8 @@ export const isPresetName = (raw: string): raw is PresetName => (PRESET_NAMES as
 
 // Provider and model identifiers referenced across the preset matrices below, hoisted so each
 // literal appears once. The dash vs dot spelling is provider-specific and load-bearing:
-// claude-code uses the dash form (`claude-opus-5`, `claude-sonnet-5` → OPUS / SONNET / HAIKU)
-// while github-copilot uses the dotted form (`claude-…-4.8` → COPILOT_OPUS / COPILOT_SONNET). Do
+// claude-code uses the dash form (`claude-opus-5`, `claude-sonnet-5` → OPUS / SONNET) while
+// github-copilot uses the dotted form (`claude-…-4.8` → COPILOT_OPUS / COPILOT_SONNET). Do
 // not normalise one into the other. Sonnet 5 is the default Sonnet for Claude Code; Copilot's
 // curated presets stay on Sonnet 4.6 (its slug collides with the Claude-Code id — see escalation-map).
 // `COPILOT_OPUS` deliberately stays `claude-opus-4.8` — `claude-opus-5` is plan-gated on Copilot
@@ -97,7 +97,10 @@ const OPENCODE_BIG = 'opencode/big-pickle';
 const OPENCODE_MINI = 'opencode/deepseek-v4-flash-free';
 const OPUS = 'claude-opus-5';
 const SONNET = 'claude-sonnet-5';
-const HAIKU = 'claude-haiku-4-5';
+// No HAIKU constant: `claude-haiku-4-5` faces an Anthropic retirement horizon (not before
+// 2026-10-15) with no Haiku 5 successor, so every cheap-flow claude row moved to SONNET pinned at
+// `low` effort — Claude Code's designated cheap tier. Haiku stays in the catalog as a manually
+// selectable model; what left is the curated preset defaults.
 const COPILOT_OPUS = 'claude-opus-4.8';
 const COPILOT_SONNET = 'claude-sonnet-4.6';
 const GPT_5_6_SOL = 'gpt-5.6-sol';
@@ -220,12 +223,15 @@ const CODEX_ONLY: AiSettings = {
  * when a task plateaus — so most tasks finish on the cheaper tier and only the genuinely hard
  * ones pay flagship token rates. Global `ai.effort` is stamped to `high` like the standard
  * presets; per-row efforts mirror the standard presets (`plan` / `implement` heavy, `readiness`
- * `medium`, `refine` / `ideate` inherit global). Implement.generator and implement.evaluator
- * share the same row — splitting roles is an explicit per-row edit, not a preset.
+ * `medium`, `refine` / `ideate` inherit global) — EXCEPT on `claude-economic`, where the cheap
+ * tier is a model already used elsewhere in the matrix, so the saving has to live in the effort
+ * column instead: its light rows pin `low` explicitly. Implement.generator and
+ * implement.evaluator share the same row — splitting roles is an explicit per-row edit, not a preset.
  *
  * `refine` / `readiness` / `createPr` drop to the cheap tier across all four; `ideate` drops a
  * tier too, in every family including `codex-economic` — the GPT-5.6 family's `terra` tier is
- * the intermediate tier the cheap-ideation row needed.
+ * the intermediate tier the cheap-ideation row needed. On `claude-economic` "cheap tier" means
+ * sonnet pinned at `low`, since Haiku 4.5 is retiring with no Haiku 5 successor (see SONNET).
  *
  * This is also the one family that pins `harness.bestOfNCandidates` to `0` (see {@link PRESETS}).
  * The shipped default is `2` — a stuck task samples two candidates at the top of the ladder — but
@@ -247,15 +253,18 @@ const MIXED_ECONOMIC: AiSettings = {
 
 const CLAUDE_ECONOMIC: AiSettings = {
   effort: 'high',
-  refine: { provider: CLAUDE, model: HAIKU },
+  // Claude's cheap tier is sonnet-at-`low`, not a smaller model — see the note on SONNET. Effort
+  // is pinned on every light row: unset would inherit this preset's global `high` and undo the
+  // saving the row exists for.
+  refine: { provider: CLAUDE, model: SONNET, effort: 'low' },
   plan: { provider: CLAUDE, model: SONNET, effort: 'high' },
   implement: {
     generator: { provider: CLAUDE, model: SONNET, effort: 'high' },
     evaluator: { provider: CLAUDE, model: SONNET, effort: 'high' },
   },
-  readiness: { provider: CLAUDE, model: HAIKU, effort: 'medium' },
+  readiness: { provider: CLAUDE, model: SONNET, effort: 'low' },
   ideate: { provider: CLAUDE, model: SONNET },
-  createPr: { provider: CLAUDE, model: HAIKU },
+  createPr: { provider: CLAUDE, model: SONNET, effort: 'low' },
 };
 
 const COPILOT_ECONOMIC: AiSettings = {
@@ -308,9 +317,10 @@ const CLAUDE_STRONG_GATE: AiSettings = {
     // Strong gate: opus from the first round, never cheapened.
     evaluator: { provider: CLAUDE, model: OPUS, effort: 'xhigh' },
   },
-  readiness: { provider: CLAUDE, model: HAIKU, effort: 'medium' },
+  // Cheap light flows: sonnet pinned at `low` (see CLAUDE_ECONOMIC) — never inheriting global `high`.
+  readiness: { provider: CLAUDE, model: SONNET, effort: 'low' },
   ideate: { provider: CLAUDE, model: SONNET },
-  createPr: { provider: CLAUDE, model: HAIKU },
+  createPr: { provider: CLAUDE, model: SONNET, effort: 'low' },
 };
 
 /**
@@ -377,11 +387,14 @@ const CODEX_STRONG_GATE: AiSettings = {
  * quality. This is the only family with `escalateOnPlateau` stamped OFF — a plateau here settles
  * (done-with-warning) rather than climbing the ladder, because the whole point is to stay cheap.
  *
- * Implement deliberately uses sonnet / gpt-mini, NOT haiku: haiku (and the codex nano tier) is
- * too weak to author code reliably, so the cheapest model that can still complete a task gates
- * the implement rows even in the fast family. Light flows (refine / readiness / ideate / createPr)
- * drop further — `codex-fast`'s light flows leave `effort` unset so they inherit the family's
- * global `low`; Codex no longer has a below-`low` rung (`minimal` was retired).
+ * Implement deliberately uses a code-capable tier (sonnet / the cheapest 5.6 tier), NOT a
+ * sub-coding model: haiku and the codex nano tier are too weak to author code reliably, so the
+ * cheapest model that can still complete a task gates the implement rows even in the fast family.
+ * The gpt-side light flows (refine / readiness / ideate / createPr) drop a model tier further;
+ * the claude-side ones cannot — Haiku 4.5 is retiring with no successor (see SONNET), so
+ * `claude-fast` is uniformly sonnet and buys its speed entirely from `low` effort, which the
+ * family stamps globally AND pins per row. `codex-fast`'s light flows leave `effort` unset so
+ * they inherit the family's global `low`; Codex no longer has a below-`low` rung (`minimal` was retired).
  */
 const MIXED_FAST: AiSettings = {
   effort: 'low',
@@ -392,21 +405,21 @@ const MIXED_FAST: AiSettings = {
     evaluator: { provider: CLAUDE, model: SONNET, effort: 'low' },
   },
   readiness: { provider: COPILOT, model: GPT_5_6_LUNA, effort: 'low' },
-  ideate: { provider: CLAUDE, model: HAIKU },
+  ideate: { provider: CLAUDE, model: SONNET, effort: 'low' },
   createPr: { provider: CODEX, model: GPT_5_6_LUNA },
 };
 
 const CLAUDE_FAST: AiSettings = {
   effort: 'low',
-  refine: { provider: CLAUDE, model: HAIKU },
+  refine: { provider: CLAUDE, model: SONNET, effort: 'low' },
   plan: { provider: CLAUDE, model: SONNET, effort: 'low' },
   implement: {
     generator: { provider: CLAUDE, model: SONNET, effort: 'low' },
     evaluator: { provider: CLAUDE, model: SONNET, effort: 'low' },
   },
-  readiness: { provider: CLAUDE, model: HAIKU, effort: 'low' },
-  ideate: { provider: CLAUDE, model: HAIKU },
-  createPr: { provider: CLAUDE, model: HAIKU },
+  readiness: { provider: CLAUDE, model: SONNET, effort: 'low' },
+  ideate: { provider: CLAUDE, model: SONNET, effort: 'low' },
+  createPr: { provider: CLAUDE, model: SONNET, effort: 'low' },
 };
 
 const COPILOT_FAST: AiSettings = {

--- a/tests/e2e/cli/demo.test.ts
+++ b/tests/e2e/cli/demo.test.ts
@@ -24,19 +24,23 @@ const loadSeededAi = async (homeDirStr: string): Promise<AiSettings> => {
 
 describe('ralphctl demo', () => {
   let cli: CliHome;
+  let demoParent: string;
   let demoHome: string;
 
   beforeEach(async () => {
     // `createCliHome` gives us a scratch RALPHCTL_HOME for the harness to point commander's
     // own bootstrap at (unused by `demo`, which takes an explicit `--home`), plus a fresh
-    // sibling directory for the sandbox itself.
+    // sibling directory for the sandbox itself. `demoHome` is a child of `demoParent` (`demo`
+    // refuses to seed into an existing, unmarked directory) — cleanup removes the mkdtemp'd
+    // parent, not just the child, or the parent leaks on every run.
     cli = await createCliHome();
-    demoHome = join(await fs.mkdtemp(join(tmpdir(), 'ralphctl-demo-e2e-')), 'sandbox');
+    demoParent = await fs.mkdtemp(join(tmpdir(), 'ralphctl-demo-e2e-'));
+    demoHome = join(demoParent, 'sandbox');
   });
 
   afterEach(async () => {
     await cli.cleanup();
-    await fs.rm(demoHome, { recursive: true, force: true });
+    await fs.rm(demoParent, { recursive: true, force: true });
   });
 
   it('seeds a project + three sprints readable through the fs repositories', async () => {

--- a/tests/integration/application/ui/tui/views/execute-view-internals/run-forensics.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view-internals/run-forensics.test.tsx
@@ -10,11 +10,9 @@
  */
 
 import { promises as fs } from 'node:fs';
-import { mkdtemp } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
 import { useRunForensics } from '@src/application/ui/tui/views/execute-view-internals/use-run-forensics.ts';
@@ -23,6 +21,7 @@ import { AbsolutePath } from '@src/domain/value/absolute-path.ts';
 import type { SprintId } from '@src/domain/value/id/sprint-id.ts';
 import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
 
 const SPRINT_ID = '01933fbb-2222-7000-8000-0000000000aa' as unknown as SprintId;
 
@@ -31,6 +30,22 @@ const absPath = (p: string): AbsolutePath => {
   if (!r.ok) throw new Error(`invalid path ${p}`);
   return r.value;
 };
+
+const cleanups: Array<() => Promise<void>> = [];
+
+/** Allocates a tmp root and registers it for teardown — every test in this file routes through here. */
+const nextTmpRoot = async (): Promise<AbsolutePath> => {
+  const { root, cleanup } = await makeTmpRoot();
+  cleanups.push(cleanup);
+  return root;
+};
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup !== undefined) await cleanup();
+  }
+});
 
 interface ProbeArgs {
   readonly enabled: boolean;
@@ -48,10 +63,10 @@ const Probe = ({ args, seen }: { readonly args: ProbeArgs; readonly seen: Forens
 };
 
 const mkSprintDir = async (): Promise<{ readonly dataRoot: AbsolutePath; readonly sprintDir: string }> => {
-  const root = await mkdtemp(join(tmpdir(), 'ralphctl-forensics-'));
-  const sprintDir = join(root, 'sprints', `${String(SPRINT_ID)}--demo-sprint`);
+  const dataRoot = await nextTmpRoot();
+  const sprintDir = join(String(dataRoot), 'sprints', `${String(SPRINT_ID)}--demo-sprint`);
   await fs.mkdir(sprintDir, { recursive: true });
-  return { dataRoot: absPath(root), sprintDir };
+  return { dataRoot, sprintDir };
 };
 
 /**
@@ -183,8 +198,8 @@ describe('useRunForensics', () => {
   it('returns nothing when the sprint directory is gone', async () => {
     // A sibling sprint exists under `sprints/` so the resolver has a real directory to scan and
     // mis-match against — "empty because the tree is empty" would prove much less.
-    const root = await mkdtemp(join(tmpdir(), 'ralphctl-forensics-empty-'));
-    const strangerDir = join(root, 'sprints', '01933fbb-9999-7000-8000-0000000000bb--other-sprint');
+    const root = await nextTmpRoot();
+    const strangerDir = join(String(root), 'sprints', '01933fbb-9999-7000-8000-0000000000bb--other-sprint');
     await fs.mkdir(strangerDir, { recursive: true });
     await fs.writeFile(join(strangerDir, 'progress.md'), '# not ours\n', 'utf8');
 
@@ -197,8 +212,8 @@ describe('useRunForensics', () => {
             enabled: true,
             pinnedSprintId: SPRINT_ID,
             flowId: 'implement',
-            dataRoot: absPath(root),
-            runsRoot: absPath(root),
+            dataRoot: root,
+            runsRoot: root,
           }}
           seen={seen}
         />
@@ -217,8 +232,8 @@ describe('useRunForensics', () => {
   it('points a one-shot flow at its runs directory, never at a fabricated run id', async () => {
     // `<runsRoot>/<flowId>/<run-id>/` — the run-id segment is generated inside the chain and
     // never reaches the descriptor, so the hook stops one level up and names `ralphctl runs list`.
-    const root = await mkdtemp(join(tmpdir(), 'ralphctl-forensics-runs-'));
-    const runsRoot = join(root, 'runs');
+    const root = await nextTmpRoot();
+    const runsRoot = join(String(root), 'runs');
     await fs.mkdir(join(runsRoot, 'readiness'), { recursive: true });
 
     const seen: ForensicPath[][] = [];
@@ -228,7 +243,7 @@ describe('useRunForensics', () => {
           enabled: true,
           pinnedSprintId: undefined,
           flowId: 'readiness',
-          dataRoot: absPath(root),
+          dataRoot: root,
           runsRoot: absPath(runsRoot),
         }}
         seen={seen}

--- a/tests/integration/application/ui/tui/views/execute-view-internals/settled-next-steps.test.tsx
+++ b/tests/integration/application/ui/tui/views/execute-view-internals/settled-next-steps.test.tsx
@@ -10,10 +10,8 @@
  */
 
 import { promises as fs } from 'node:fs';
-import { mkdtemp } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ExecuteView } from '@src/application/ui/tui/views/execute-view.tsx';
 import type { AppDeps } from '@src/application/bootstrap/wire.ts';
 import type { EventBus } from '@src/business/observability/event-bus.ts';
@@ -34,6 +32,7 @@ import {
 import { tick } from '@tests/integration/application/ui/tui/_keys.ts';
 import { waitForPredicate } from '@tests/integration/application/ui/tui/_wait.ts';
 import { renderView, waitForViewReady } from '@tests/integration/application/ui/tui/_harness.tsx';
+import { makeTmpRoot } from '@tests/fixtures/tmp-root.ts';
 
 const SPRINT_ID = '01933fbb-3333-7000-8000-0000000000bb' as unknown as SprintId;
 const PROJECT_ID = 'project-settled-next' as unknown as ProjectId;
@@ -83,6 +82,15 @@ const depsWithSprint = (sprint: unknown): AppDeps =>
       findBySprintId: vi.fn().mockResolvedValue({ ok: true, value: [] }),
     },
   }) as unknown as AppDeps;
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup !== undefined) await cleanup();
+  }
+});
 
 describe('Execute view — settled-run next steps', () => {
   it('offers BOTH flows visible at review, not the create-pr the old Home card advised', async () => {
@@ -202,8 +210,9 @@ describe('Execute view — settled-run next steps', () => {
   });
 
   it('renders the post-mortem block with the paths a failed run actually left behind', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'ralphctl-settled-'));
-    const sprintDir = join(root, 'sprints', `${String(SPRINT_ID)}--demo-sprint`);
+    const { root, cleanup } = await makeTmpRoot();
+    cleanups.push(cleanup);
+    const sprintDir = join(String(root), 'sprints', `${String(SPRINT_ID)}--demo-sprint`);
     await fs.mkdir(sprintDir, { recursive: true });
     await fs.writeFile(join(sprintDir, 'progress.md'), '# progress\n', 'utf8');
 
@@ -221,7 +230,7 @@ describe('Execute view — settled-run next steps', () => {
       deps: depsWithSprint(makeReviewSprint()),
       initial: { id: 'execute', props: { sessionId: 'r-settled-forensics' } },
       sessions,
-      storage: storageAt(root),
+      storage: storageAt(String(root)),
     });
     await waitForViewReady(result, (f) => f.includes('Post-mortem'));
     const frame = result.lastFrame() ?? '';

--- a/tests/integration/persistence/settings/json-settings-repository.test.ts
+++ b/tests/integration/persistence/settings/json-settings-repository.test.ts
@@ -368,6 +368,30 @@ describe('JsonSettingsRepository', () => {
     expect(onDisk.ai['plan']).toEqual({ provider: 'github-copilot', model: retired });
   });
 
+  it('load silently strips a legacy settings.developer section (removed in 4bd412aa)', async () => {
+    const path = join(String(configRoot), SETTINGS_FILE_NAME);
+    // Every shipped user's settings.json still carries this section from before
+    // `settings.developer` (and its one flag, `showEvaluatorFailureUI`) was removed wholesale —
+    // the schema strips unknown keys by default, so load must succeed rather than reject the file.
+    const legacyWithDeveloper = {
+      ...DEFAULT_SETTINGS,
+      developer: { showEvaluatorFailureUI: true },
+    };
+    await fs.writeFile(path, `${JSON.stringify(legacyWithDeveloper, null, 2)}\n`);
+
+    const repo = createJsonSettingsRepository({ configRoot });
+    const loaded = await repo.load();
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+    expect(loaded.value).not.toHaveProperty('developer');
+
+    // A subsequent save() must not resurrect the stripped key on disk.
+    const saved = await repo.save(loaded.value);
+    expect(saved.ok).toBe(true);
+    const onDisk = JSON.parse(await fs.readFile(path, 'utf8')) as Record<string, unknown>;
+    expect(onDisk).not.toHaveProperty('developer');
+  });
+
   it('load rejects a settings file from a newer ralphctl version', async () => {
     const path = join(String(configRoot), SETTINGS_FILE_NAME);
     const future = { ...DEFAULT_SETTINGS, schemaVersion: CURRENT_SCHEMA_VERSION + 1 };

--- a/tests/integration/version/npm-version-checker.test.ts
+++ b/tests/integration/version/npm-version-checker.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -30,8 +30,8 @@ describe('createNpmVersionChecker', () => {
   beforeEach(async () => {
     stateRoot = await makeStateRoot();
   });
-  afterEach(() => {
-    // tmpdir cleanup is best-effort across the suite; leave it to the OS.
+  afterEach(async () => {
+    await rm(String(stateRoot), { recursive: true, force: true });
   });
 
   it('reports an update when registry latest > current', async () => {

--- a/tests/unit/business/settings/presets.test.ts
+++ b/tests/unit/business/settings/presets.test.ts
@@ -229,9 +229,12 @@ describe('presets', () => {
   it('no preset row references a retiring cheap tier', () => {
     // `gpt-5.4-mini` retires 2026-08-31 and `gpt-5-mini` is the generation below it; both were
     // replaced by `gpt-5.6-luna`, which is catalogued on BOTH openai-codex and github-copilot.
+    // `claude-haiku-4-5` joins them: Anthropic has announced a retirement horizon (not before
+    // 2026-10-15) with no Haiku 5 successor, so every cheap-flow slot that used to sit on it now
+    // sits on `claude-sonnet-5` at `low` effort — Claude Code's designated cheap tier.
     // The ids stay in the catalogs (an operator may still pin one until the shutoff) — what this
     // fences is the curated matrices shipping a row that stops spawning on a known date.
-    const retiring = new Set(['gpt-5.4-mini', 'gpt-5-mini']);
+    const retiring = new Set(['gpt-5.4-mini', 'gpt-5-mini', 'claude-haiku-4-5']);
     for (const preset of PRESET_NAMES) {
       const out = applyPreset(preset, DEFAULT_SETTINGS);
       for (const flow of FLOW_IDS) {
@@ -243,14 +246,41 @@ describe('presets', () => {
     }
   });
 
-  it('claude-only routes readiness to Sonnet 5 — haiku stays in the cheaper families', () => {
-    // The standard family's story is "the best model per flow purpose"; haiku under-reads a repo
-    // during readiness inventory. The economic / strong-gate / fast families keep haiku there
-    // deliberately, so this assertion is paired with the negative below.
+  it('every claude family routes readiness to Sonnet 5 — the cheap families separate by EFFORT, not by model', () => {
+    // Haiku 4.5 is on a retirement horizon with no successor, so the cheap claude families moved
+    // their light flows onto sonnet at `low` effort rather than a weaker model. The cost intent
+    // survives in the effort column: standard reads a repo at `medium`, the cheap families at
+    // `low`. `low` is pinned EXPLICITLY on those rows — leaving effort unset would inherit the
+    // global (`high` for economic / strong-gate) and silently raise the bill.
     expect(applyPreset('claude-only', DEFAULT_SETTINGS).ai.readiness.model).toBe('claude-sonnet-5');
     expect(applyPreset('claude-only', DEFAULT_SETTINGS).ai.readiness.effort).toBe('medium');
     for (const preset of ['claude-economic', 'claude-strong-gate', 'claude-fast'] as const) {
-      expect(applyPreset(preset, DEFAULT_SETTINGS).ai.readiness.model, preset).toBe('claude-haiku-4-5');
+      const out = applyPreset(preset, DEFAULT_SETTINGS);
+      expect(out.ai.readiness.model, preset).toBe('claude-sonnet-5');
+      expect(out.ai.readiness.effort, preset).toBe('low');
+    }
+  });
+
+  it('every migrated cheap-flow row pins effort explicitly so it cannot inherit a pricier global', () => {
+    // The rows that used to be haiku: refine / readiness / createPr on claude-economic and
+    // claude-fast, readiness / createPr on claude-strong-gate, ideate on mixed-fast + claude-fast.
+    const cheapClaudeRows: ReadonlyArray<[PresetName, 'refine' | 'readiness' | 'ideate' | 'createPr']> = [
+      ['claude-economic', 'refine'],
+      ['claude-economic', 'readiness'],
+      ['claude-economic', 'createPr'],
+      ['claude-strong-gate', 'readiness'],
+      ['claude-strong-gate', 'createPr'],
+      ['mixed-fast', 'ideate'],
+      ['claude-fast', 'refine'],
+      ['claude-fast', 'readiness'],
+      ['claude-fast', 'ideate'],
+      ['claude-fast', 'createPr'],
+    ];
+    for (const [preset, flow] of cheapClaudeRows) {
+      const row = applyPreset(preset, DEFAULT_SETTINGS).ai[flow];
+      expect(row.provider, `${preset}/${flow}`).toBe('claude-code');
+      expect(row.model, `${preset}/${flow}`).toBe('claude-sonnet-5');
+      expect(row.effort, `${preset}/${flow}`).toBe('low');
     }
   });
 
@@ -437,11 +467,12 @@ describe('presets', () => {
         expect(out.ai.refine.effort).toBeUndefined();
         expect(out.ai.plan.model).toBe('claude-opus-5');
         expect(out.ai.plan.effort).toBe('xhigh');
-        expect(out.ai.readiness.model).toBe('claude-haiku-4-5');
-        expect(out.ai.readiness.effort).toBe('medium');
+        expect(out.ai.readiness.model).toBe('claude-sonnet-5');
+        expect(out.ai.readiness.effort).toBe('low');
         expect(out.ai.ideate.model).toBe('claude-sonnet-5');
         expect(out.ai.ideate.effort).toBeUndefined();
-        expect(out.ai.createPr.model).toBe('claude-haiku-4-5');
+        expect(out.ai.createPr.model).toBe('claude-sonnet-5');
+        expect(out.ai.createPr.effort).toBe('low');
       });
 
       it('splits a cheap sonnet generator against a strong opus evaluator (same provider, different model)', () => {


### PR DESCRIPTION
## Summary
- Migrate haiku preset rows to sonnet-5 at low effort (presets.ts + AI-SETTINGS.md)
- Fix temp-dir leaks in tests and add coverage for legacy `settings.developer` load
- Record agent memory from the preset migration

## Test plan
- `pnpm verify` (typecheck + lint + test)