### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-24
+
+### Changed
+
+- **Curated Claude presets no longer default to Haiku 4.5.** Haiku 4.5 faces an Anthropic retirement
+  horizon with no Haiku 5 successor, so every cheap-flow row that pinned it — `refine`, `readiness`,
+  `createPr` (and `ideate` where it applied) across `claude-economic`, `claude-strong-gate`,
+  `claude-fast`, and `mixed-fast` — now runs Sonnet 5 pinned at `low` effort, Claude Code's designated
+  cheap tier. The effort is pinned explicitly rather than inherited, so the light rows keep the saving
+  they exist for. Haiku stays fully selectable as a model; what changed is the curated preset defaults.
+  Existing `settings.ai` files are untouched — only newly applied presets pick up the new rows.
+
 ## [0.20.0] - 2026-08-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralphctl",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Agent harness for long-running AI coding tasks — orchestrates Claude Code, GitHub Copilot, OpenAI Codex, and OpenCode across repositories",
   "homepage": "https://github.com/lukas-grigis/ralphctl",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.21.0
- Promote `## [Unreleased]` CHANGELOG section to `## [0.21.0]`

Shipped change: curated Claude presets migrate their cheap-flow rows off Haiku 4.5 onto Sonnet 5 pinned at `low` effort.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` — green locally
- [ ] CI green