### PR TITLE
fix(tui): Grok interactive TTY handoff via Ink suspendTerminal

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "24"
-pnpm = "10"
+node = "26"
+pnpm = "11"

--- a/src/application/ui/shared/ink-host.ts
+++ b/src/application/ui/shared/ink-host.ts
@@ -80,6 +80,13 @@ export interface InkHostDeps {
    * starting ralphctl gives the operator a clean screen and exiting restores their scrollback.
    */
   readonly alternateScreen?: boolean;
+  /**
+   * Invoked after `runInTerminal` exists and BEFORE the first `render()`. Launch installs the
+   * unmount fallback here so {@link TerminalHandoff} can replace it on mount. Calling
+   * `setRunInTerminal` *after* `createInkHost` clobbers suspend and sends every interactive
+   * CLI (Claude, Copilot, Codex, OpenCode, Grok) down the unmount path Grok cannot survive.
+   */
+  readonly beforeMount?: (runInTerminal: RunInTerminal) => void;
 }
 
 export interface InkHost {
@@ -101,7 +108,7 @@ export const createInkHost = (deps: InkHostDeps): InkHost => {
     return render(deps.renderElement(), { alternateScreen });
   };
 
-  let instance: InkInstance = renderOnce();
+  let instance!: InkInstance;
   let pausing: Promise<void> | undefined;
 
   const runInTerminal: RunInTerminal = async (fn) => {
@@ -124,6 +131,9 @@ export const createInkHost = (deps: InkHostDeps): InkHost => {
       release?.();
     }
   };
+
+  deps.beforeMount?.(runInTerminal);
+  instance = renderOnce();
 
   const waitForShutdown = async (): Promise<void> => {
     try {

--- a/src/application/ui/shared/ink-host.ts
+++ b/src/application/ui/shared/ink-host.ts
@@ -5,25 +5,47 @@
  * Lifecycle:
  *   - `render()` is called with `alternateScreen: true` so the wordmark + chrome appear on a
  *     fresh buffer; on unmount Ink automatically restores the user's original screen.
- *   - `runInTerminal(fn)` performs a *real* unmount before invoking `fn`: the React tree is
- *     torn down, the alternate screen is exited, and `fn` runs against the user's primary
- *     terminal. When `fn` resolves we `render()` a *freshly built* App element — `renderElement()`
- *     is called again so the new tree mounts with the latest seed (e.g. the in-session sprint
- *     selection), not a frozen launch-time element.
+ *   - `runInTerminal(fn)` is the fallback handoff used before the React tree mounts
+ *     (`TerminalHandoff` swaps in Ink's `suspendTerminal` once `App` is up). The fallback
+ *     unmounts, restores TTY modes a nested TUI expects, runs `fn`, then remounts a freshly
+ *     built App element.
  *   - `waitForShutdown()` keeps the launcher alive across these pause/resume cycles. Each
  *     pause unmounts the current Ink instance, which would normally resolve
  *     `waitUntilExit()` and let the process drop the TUI; the host loop instead checks
  *     whether a pause is in flight and re-awaits the next instance.
  *
- * Why a full unmount rather than `instance.clear()`: while `fn` runs the user owns the
- * terminal. If we left the React tree mounted, any bus/state update would cause Ink to
- * write to stdout and clobber the AI session's UI. Tearing the tree down severs every
- * subscription cleanly.
+ * Production interactive sessions go through Ink's `suspendTerminal` (see `TerminalHandoff`)
+ * rather than this unmount path: Grok's pager cannot attach after a full unmount (no
+ * `pager started` in its log; stderr `Device not configured`). The fallback remains for
+ * the window before App mounts and for tests that drive the host directly.
  */
 import type { ReactElement } from 'react';
 import { type Instance as InkInstance, render } from 'ink';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { RunInTerminal } from '@src/integration/io/run-in-terminal.ts';
+
+/** Restore cooked TTY + leave alt-screen / kitty / bracketed-paste so a nested TUI can attach. */
+const restoreTerminalForChild = (): void => {
+  if (process.stdin.isTTY) {
+    try {
+      process.stdin.setRawMode(false);
+    } catch {
+      // Best-effort: a non-TTY or already-cooked stdin must not fail the handoff.
+    }
+    try {
+      process.stdin.ref();
+    } catch {
+      // `ref` is missing on some test fakes.
+    }
+  }
+  if (!process.stdout.isTTY) return;
+  try {
+    // kitty keyboard off, leave alt-screen, show cursor, bracketed paste off.
+    process.stdout.write('\x1b[<u\x1b[?1049l\x1b[?25h\x1b[?2004l');
+  } catch {
+    // Best-effort: a closed stdout must not crash the host.
+  }
+};
 
 /**
  * DEC private mode 2004 — bracketed paste. With it on, the terminal wraps pasted content in
@@ -93,6 +115,7 @@ export const createInkHost = (deps: InkHostDeps): InkHost => {
     // The user owns the terminal while `fn` runs — turn bracketed paste off so a paste into the
     // AI session isn't wrapped in markers. `renderOnce()` re-enables it when the TUI remounts.
     setBracketedPaste(false);
+    restoreTerminalForChild();
     try {
       return await fn();
     } finally {

--- a/src/application/ui/shared/launch/refine.ts
+++ b/src/application/ui/shared/launch/refine.ts
@@ -11,8 +11,8 @@ import type { LaunchResult } from '@src/application/ui/shared/launcher.ts';
 import { checkCli } from '@src/application/ui/shared/launch/check-cli.ts';
 
 // HITL approval — runs AFTER the AI proposes refined requirements and BEFORE the ticket
-// transitions. `runInTerminal` resolves before we get here, so Ink has remounted and
-// `<PromptHost>` is subscribed by the time we enqueue the choice. Cancel = reject.
+// transitions. `runInTerminal` resolves before we get here: Ink's `suspendTerminal` has
+// resumed (tree stayed mounted, PromptHost still subscribed). Cancel = reject.
 //
 // The reviewer picks from up to four options. Two terminate the loop, two iterate:
 //   - Approve         → terminal; persist the current body locally.

--- a/src/application/ui/tui/App.tsx
+++ b/src/application/ui/tui/App.tsx
@@ -27,6 +27,7 @@ import { HintsProvider, useSuppressGlobalHints } from '@src/application/ui/tui/r
 import { SelectionProvider, type SelectionSeed } from '@src/application/ui/tui/runtime/selection-context.tsx';
 import { SystemStatusProvider } from '@src/application/ui/tui/runtime/system-status-context.tsx';
 import { LogLevelProvider } from '@src/application/ui/tui/runtime/log-level-context.tsx';
+import { TerminalHandoff } from '@src/application/ui/tui/runtime/terminal-handoff.tsx';
 import { renderView } from '@src/application/ui/tui/views/view-registry.tsx';
 import { globalKeys } from '@src/application/ui/tui/runtime/keyboard-map.ts';
 import { useGlobalKeys } from '@src/application/ui/tui/runtime/use-global-keys.ts';
@@ -83,6 +84,7 @@ export const App = ({
   onSelectionChange,
 }: AppProps): React.JSX.Element => (
   <DepsProvider value={deps}>
+    <TerminalHandoff />
     <StorageProvider value={storage}>
       <BusesProvider value={buses}>
         <SessionsProvider value={sessions}>

--- a/src/application/ui/tui/launch.ts
+++ b/src/application/ui/tui/launch.ts
@@ -548,8 +548,13 @@ export const launchTui = async (options: LaunchTuiOptions = {}): Promise<void> =
     }
     return React.createElement(App, appProps());
   };
-  const host = createInkHost({ renderElement });
-  setRunInTerminal(host.runInTerminal);
+  const host = createInkHost({
+    renderElement,
+    // Fallback first, then App's TerminalHandoff swaps in suspendTerminal. Installing
+    // *after* render used to clobber that swap and send Claude/Copilot/Codex/OpenCode/Grok
+    // down the full-unmount path.
+    beforeMount: setRunInTerminal,
+  });
   try {
     await host.waitForShutdown();
   } finally {

--- a/src/application/ui/tui/runtime/run-in-terminal.ts
+++ b/src/application/ui/tui/runtime/run-in-terminal.ts
@@ -1,17 +1,19 @@
 import { passthroughRunInTerminal, type RunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
 
 /**
- * Module-level holder for the active `runInTerminal`. The TUI bootstrap (`launchTui`) swaps
- * this from the passthrough default to an Ink-aware variant after the Ink instance exists —
- * Ink doesn't expose pause/resume via hooks, so the swap happens out-of-band.
- *
- * Views and the launcher read through {@link useRunInTerminal} which closes over the ref so
+ * Module-level holder for the active `runInTerminal`. The TUI bootstrap (`launchTui`) installs
+ * the host's unmount-based fallback; {@link TerminalHandoff} then swaps in Ink's
+ * `suspendTerminal` (the supported child-process handoff) once the React tree is mounted.
+ * Views and the launcher read through {@link getRunInTerminal}, which closes over the ref so
  * the binding stays stable across renders.
  */
 const ref: { current: RunInTerminal } = { current: passthroughRunInTerminal };
 
-export const setRunInTerminal = (next: RunInTerminal): void => {
+/** Install `next` and return the previous handler so callers can restore on unmount. */
+export const setRunInTerminal = (next: RunInTerminal): RunInTerminal => {
+  const previous = ref.current;
   ref.current = next;
+  return previous;
 };
 
 export const getRunInTerminal = (): RunInTerminal => (fn) => ref.current(fn);

--- a/src/application/ui/tui/runtime/terminal-handoff.tsx
+++ b/src/application/ui/tui/runtime/terminal-handoff.tsx
@@ -1,0 +1,29 @@
+/**
+ * Registers Ink's `suspendTerminal` as the live `runInTerminal` implementation.
+ *
+ * Full unmount/remount (the host fallback) exits the alternate screen and disables kitty
+ * keyboard protocol, but it does not pause input the way Ink's supported handoff does —
+ * Grok's pager then dies during TUI init (`Device not configured` / no `pager started`).
+ * `suspendTerminal` is the API Ink documents for `$EDITOR` / `less` / nested TUIs: raw mode
+ * off, kitty off, alt-screen exited, Ink writes paused, then restored after the child exits.
+ */
+
+import { useLayoutEffect } from 'react';
+import { useApp } from 'ink';
+import { setRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
+
+export const TerminalHandoff = (): null => {
+  const { suspendTerminal } = useApp();
+  useLayoutEffect(() => {
+    const previous = setRunInTerminal(<T,>(fn: () => Promise<T>): Promise<T> => {
+      const box: { value?: T } = {};
+      return suspendTerminal(async () => {
+        box.value = await fn();
+      }).then(() => box.value as T);
+    });
+    return () => {
+      setRunInTerminal(previous);
+    };
+  }, [suspendTerminal]);
+  return null;
+};

--- a/src/application/ui/tui/runtime/terminal-handoff.tsx
+++ b/src/application/ui/tui/runtime/terminal-handoff.tsx
@@ -15,11 +15,12 @@ import { setRunInTerminal } from '@src/application/ui/tui/runtime/run-in-termina
 export const TerminalHandoff = (): null => {
   const { suspendTerminal } = useApp();
   useLayoutEffect(() => {
-    const previous = setRunInTerminal(<T,>(fn: () => Promise<T>): Promise<T> => {
+    const previous = setRunInTerminal(async <T,>(fn: () => Promise<T>): Promise<T> => {
       const box: { value?: T } = {};
-      return suspendTerminal(async () => {
+      await suspendTerminal(async () => {
         box.value = await fn();
-      }).then(() => box.value as T);
+      });
+      return box.value as T;
     });
     return () => {
       setRunInTerminal(previous);

--- a/tests/unit/application/ui/shared/ink-host.test.ts
+++ b/tests/unit/application/ui/shared/ink-host.test.ts
@@ -104,4 +104,21 @@ describe('createInkHost rebuilds the element on resume', () => {
     // Resume remounted a freshly built element rather than reusing the first.
     expect(renderElement).toHaveBeenCalledTimes(2);
   });
+
+  it('calls beforeMount with runInTerminal before the first render so TerminalHandoff can replace it', () => {
+    const order: string[] = [];
+    const beforeMount = vi.fn((runInTerminal: (fn: () => Promise<string>) => Promise<string>) => {
+      order.push('beforeMount');
+      expect(typeof runInTerminal).toBe('function');
+    });
+    createInkHost({
+      renderElement: () => {
+        order.push('render');
+        return React.createElement(React.Fragment);
+      },
+      beforeMount,
+    });
+    expect(beforeMount).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['beforeMount', 'render']);
+  });
 });

--- a/tests/unit/application/ui/tui/runtime/terminal-handoff.test.tsx
+++ b/tests/unit/application/ui/tui/runtime/terminal-handoff.test.tsx
@@ -63,4 +63,69 @@ describe('TerminalHandoff', () => {
     await getRunInTerminal()(async () => 'x');
     expect(via).toBe('previous');
   });
+
+  it('replaces a fallback installed before mount so every interactive CLI uses suspend, not unmount', async () => {
+    let via = '';
+    const fallback = async <T,>(fn: () => Promise<T>): Promise<T> => {
+      via = 'fallback';
+      return fn();
+    };
+    setRunInTerminal(fallback);
+
+    const r = render(
+      <>
+        <TerminalHandoff />
+        <Text>handoff-alive</Text>
+      </>
+    );
+    await flush();
+
+    const result = await getRunInTerminal()(async () => {
+      via = 'suspend';
+      return 'from-child';
+    });
+    expect(via).toBe('suspend');
+    expect(result).toBe('from-child');
+    expect(r.lastFrame()).toContain('handoff-alive');
+    r.unmount();
+  });
+
+  it('propagates a child error and still leaves the Ink tree mounted for the next CLI', async () => {
+    const r = render(
+      <>
+        <TerminalHandoff />
+        <Text>handoff-alive</Text>
+      </>
+    );
+    await flush();
+
+    await expect(
+      getRunInTerminal()(async () => {
+        throw new Error('interactive-claude: session exited with code 1');
+      })
+    ).rejects.toThrow('interactive-claude: session exited with code 1');
+    expect(r.lastFrame()).toContain('handoff-alive');
+
+    const again = await getRunInTerminal()(async () => 'second-session');
+    expect(again).toBe('second-session');
+    expect(r.lastFrame()).toContain('handoff-alive');
+    r.unmount();
+  });
+
+  it('runs sequential handoffs (refine ticket A then B, or plan after refine)', async () => {
+    const r = render(
+      <>
+        <TerminalHandoff />
+        <Text>handoff-alive</Text>
+      </>
+    );
+    await flush();
+
+    const first = await getRunInTerminal()(async () => 'ticket-a');
+    const second = await getRunInTerminal()(async () => 'ticket-b');
+    expect(first).toBe('ticket-a');
+    expect(second).toBe('ticket-b');
+    expect(r.lastFrame()).toContain('handoff-alive');
+    r.unmount();
+  });
 });

--- a/tests/unit/application/ui/tui/runtime/terminal-handoff.test.tsx
+++ b/tests/unit/application/ui/tui/runtime/terminal-handoff.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Ink 7's `suspendTerminal` is the supported way to hand a TTY to a child process. The previous
+ * host path fully unmounted the tree (and remounted after), which left Grok's pager unable to
+ * attach — refine-with-grok spawned, logged early startup, then died before `pager started`.
+ *
+ * This pins: while TerminalHandoff is mounted, `getRunInTerminal` runs the callback without
+ * tearing the Ink tree down.
+ */
+
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TerminalHandoff } from '@src/application/ui/tui/runtime/terminal-handoff.tsx';
+import { getRunInTerminal, setRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
+import { passthroughRunInTerminal } from '@src/application/ui/shared/run-in-terminal.ts';
+
+const flush = async (): Promise<void> => {
+  await new Promise((res) => setTimeout(res, 5));
+};
+
+afterEach(() => {
+  setRunInTerminal(passthroughRunInTerminal);
+});
+
+describe('TerminalHandoff', () => {
+  it('runs getRunInTerminal without unmounting the Ink tree', async () => {
+    const r = render(
+      <>
+        <TerminalHandoff />
+        <Text>handoff-alive</Text>
+      </>
+    );
+    await flush();
+
+    expect(r.lastFrame()).toContain('handoff-alive');
+
+    let ran = false;
+    await getRunInTerminal()(async () => {
+      ran = true;
+      // Tree must still be mounted mid-handoff — unmount/remount would blank the frame.
+      expect(r.lastFrame()).toContain('handoff-alive');
+      return 'ok';
+    });
+
+    expect(ran).toBe(true);
+    expect(r.lastFrame()).toContain('handoff-alive');
+    r.unmount();
+  });
+
+  it('restores the previous runInTerminal on unmount', async () => {
+    let via = '';
+    const previous = async <T,>(fn: () => Promise<T>): Promise<T> => {
+      via = 'previous';
+      return fn();
+    };
+    setRunInTerminal(previous);
+
+    const r = render(<TerminalHandoff />);
+    await flush();
+    r.unmount();
+    await flush();
+
+    await getRunInTerminal()(async () => 'x');
+    expect(via).toBe('previous');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Refine with Grok spawned then died before the pager started (`Device not configured` / no `pager started`), so nothing was saved.

Ink was handing the TTY over by fully unmounting. Grok's pager cannot attach after that. Switch interactive sessions to Ink 7's `suspendTerminal` (the supported nested-TUI handoff), and install that swap *before* first render so Claude / Copilot / Codex / OpenCode / Grok all take it — a post-mount `setRunInTerminal` was clobbering the swap.

Also bumps local `mise.toml` to node 26 / pnpm 11. CI still pins Node 24 via `setup-node`.

## How to test

- Refine (or plan / ideate) with Grok: TUI should take over, not flash back to ralphctl.
- Same flows with Claude / Copilot / Codex / OpenCode still hand off and return to the TUI.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] Added/updated tests if applicable