### PR TITLE
fix(tui): make the Grok interactive handoff work, and drop what didn't

### DIFF
--- a/src/application/ui/shared/ink-host.ts
+++ b/src/application/ui/shared/ink-host.ts
@@ -7,7 +7,7 @@
  *     fresh buffer; on unmount Ink automatically restores the user's original screen.
  *   - `runInTerminal(fn)` is the fallback handoff used before the React tree mounts
  *     (`TerminalHandoff` swaps in Ink's `suspendTerminal` once `App` is up). The fallback
- *     unmounts, restores TTY modes a nested TUI expects, runs `fn`, then remounts a freshly
+ *     unmounts, runs {@link releaseTerminalForChild}, runs `fn`, then remounts a freshly
  *     built App element.
  *   - `waitForShutdown()` keeps the launcher alive across these pause/resume cycles. Each
  *     pause unmounts the current Ink instance, which would normally resolve
@@ -22,30 +22,8 @@
 import type { ReactElement } from 'react';
 import { type Instance as InkInstance, render } from 'ink';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { releaseTerminalForChild } from '@src/application/ui/shared/release-terminal-for-child.ts';
 import type { RunInTerminal } from '@src/integration/io/run-in-terminal.ts';
-
-/** Restore cooked TTY + leave alt-screen / kitty / bracketed-paste so a nested TUI can attach. */
-const restoreTerminalForChild = (): void => {
-  if (process.stdin.isTTY) {
-    try {
-      process.stdin.setRawMode(false);
-    } catch {
-      // Best-effort: a non-TTY or already-cooked stdin must not fail the handoff.
-    }
-    try {
-      process.stdin.ref();
-    } catch {
-      // `ref` is missing on some test fakes.
-    }
-  }
-  if (!process.stdout.isTTY) return;
-  try {
-    // kitty keyboard off, leave alt-screen, show cursor, bracketed paste off.
-    process.stdout.write('\x1b[<u\x1b[?1049l\x1b[?25h\x1b[?2004l');
-  } catch {
-    // Best-effort: a closed stdout must not crash the host.
-  }
-};
 
 /**
  * DEC private mode 2004 — bracketed paste. With it on, the terminal wraps pasted content in
@@ -119,10 +97,10 @@ export const createInkHost = (deps: InkHostDeps): InkHost => {
     const current = instance;
     current.unmount();
     await current.waitUntilExit();
-    // The user owns the terminal while `fn` runs — turn bracketed paste off so a paste into the
-    // AI session isn't wrapped in markers. `renderOnce()` re-enables it when the TUI remounts.
-    setBracketedPaste(false);
-    restoreTerminalForChild();
+    // The user owns the terminal while `fn` runs. `releaseTerminalForChild` turns bracketed paste
+    // off as part of the same sequence, so a paste into the AI session isn't wrapped in markers;
+    // `renderOnce()` re-enables it when the TUI remounts.
+    releaseTerminalForChild();
     try {
       return await fn();
     } finally {

--- a/src/application/ui/shared/release-terminal-for-child.ts
+++ b/src/application/ui/shared/release-terminal-for-child.ts
@@ -1,0 +1,69 @@
+/**
+ * Best-effort terminal-mode reset before a nested interactive CLI (`grok` / `claude` / …) takes
+ * over the terminal. Shared by both handoff paths so the suspend path and the pre-mount unmount
+ * fallback leave the terminal in the same state.
+ *
+ * Ink's `suspendTerminal` already exits the alt-screen, drops raw mode, and restores bracketed
+ * paste through its own refcount. What it does not reset are modes Ink never set and therefore
+ * does not know about:
+ *
+ *   1. Mouse reporting. `ScrollRegion` enables SGR mouse tracking for wheel scrolling; left on,
+ *      the child's terminal floods its stdin with CSI sequences instead of keystrokes.
+ *   2. Kitty keyboard protocol and cursor visibility, when something other than Ink enabled them.
+ *   3. A synchronized-update region opened by a previous occupant of the terminal. ESU is
+ *      idempotent when no region is open, so sending it unconditionally is free insurance.
+ *      (Ink itself cannot leave one open — it writes BSU and ESU synchronously inside a single
+ *      function body, and `beginSuspend` flushes its throttled writers before pausing.)
+ *
+ * `process.stdin` is deliberately NOT touched here. Ink's `pauseInput` / `resumeInput` pair owns
+ * raw mode and its own listener across a suspension, and reaching into the shared stream from
+ * outside that pair breaks consumers Ink does not know about — `removeAllListeners('data')`
+ * detached `ScrollRegion`'s wheel handler permanently, because under `suspendTerminal` the React
+ * tree stays mounted and its effect cleanup never re-runs.
+ *
+ * Known gap: nothing re-enables mouse reporting when the child exits, so wheel scrolling stays off
+ * for the rest of the session. Re-arming it belongs in `ScrollRegion` on a resume signal.
+ *
+ * Writes go through `writeSync` on the stdout fd when available so the sequences reach the
+ * terminal before the child is spawned — an async `stdout.write` can still be queued when the
+ * child's first capability query goes out.
+ */
+
+import { writeSync } from 'node:fs';
+
+const RELEASE_STDOUT =
+  // End sync region (idempotent if none open), mouse reporting off, kitty off, leave alt-screen,
+  // show cursor, bracketed paste off.
+  // Soft-reset (CSI !p) deliberately omitted — it can leave iTerm in a state where a nested
+  // Grok never reaches pager started.
+  '\x1b[?2026l' +
+  '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1015l\x1b[?1006l\x1b[?1004l' +
+  '\x1b[<u\x1b[?1049l\x1b[?25h\x1b[?2004l';
+
+const writeRelease = (): void => {
+  const fd = process.stdout.fd;
+  if (typeof fd === 'number' && fd >= 0) {
+    writeSync(fd, RELEASE_STDOUT);
+    return;
+  }
+  process.stdout.write(RELEASE_STDOUT);
+};
+
+export const releaseTerminalForChild = (): void => {
+  if (process.stdin.isTTY) {
+    try {
+      // Cooked mode so Ctrl-C reaches the child's process group. Idempotent under Ink's suspend,
+      // which has already done this; load-bearing on the unmount path, where no Ink instance is
+      // left to do it.
+      process.stdin.setRawMode(false);
+    } catch {
+      // Non-TTY fakes / already-cooked stdin must not fail the handoff.
+    }
+  }
+  if (!process.stdout.isTTY) return;
+  try {
+    writeRelease();
+  } catch {
+    // Closed stdout / fd-less test fakes must not crash the host.
+  }
+};

--- a/src/application/ui/tui/runtime/terminal-handoff.tsx
+++ b/src/application/ui/tui/runtime/terminal-handoff.tsx
@@ -1,15 +1,19 @@
 /**
  * Registers Ink's `suspendTerminal` as the live `runInTerminal` implementation.
  *
- * Full unmount/remount (the host fallback) exits the alternate screen and disables kitty
- * keyboard protocol, but it does not pause input the way Ink's supported handoff does —
- * Grok's pager then dies during TUI init (`Device not configured` / no `pager started`).
- * `suspendTerminal` is the API Ink documents for `$EDITOR` / `less` / nested TUIs: raw mode
- * off, kitty off, alt-screen exited, Ink writes paused, then restored after the child exits.
+ * `suspendTerminal` is the API Ink documents for `$EDITOR` / `less` / nested TUIs: raw mode off,
+ * kitty off, alt-screen exited, Ink writes flushed then paused, and all of it restored after the
+ * child exits — with the React tree left mounted throughout. The host's unmount/remount fallback
+ * tears the tree down instead and is only reachable before `App` mounts.
+ *
+ * {@link releaseTerminalForChild} runs inside the suspension for the modes Ink never set and so
+ * cannot restore — mouse reporting above all, which otherwise floods the child's stdin with CSI
+ * sequences. It deliberately leaves `process.stdin` to Ink's own pause/resume pair.
  */
 
 import { useLayoutEffect } from 'react';
 import { useApp } from 'ink';
+import { releaseTerminalForChild } from '@src/application/ui/shared/release-terminal-for-child.ts';
 import { setRunInTerminal } from '@src/application/ui/tui/runtime/run-in-terminal.ts';
 
 export const TerminalHandoff = (): null => {
@@ -18,6 +22,7 @@ export const TerminalHandoff = (): null => {
     const previous = setRunInTerminal(async <T,>(fn: () => Promise<T>): Promise<T> => {
       const box: { value?: T } = {};
       await suspendTerminal(async () => {
+        releaseTerminalForChild();
         box.value = await fn();
       });
       return box.value as T;

--- a/src/business/task/escalation-map.ts
+++ b/src/business/task/escalation-map.ts
@@ -261,10 +261,12 @@ const claudeEffortRung = (model: string, currentEffort: string | undefined): str
  *   - **github-copilot** — fixed target {@link EFFORT_ESCALATION_TARGET} (`high`); `unset` counts as
  *     escalatable (its CLI default sits ~medium), and `high | xhigh | max` are spent. Non-OpenAI
  *     models' effort semantics are opaque, so Copilot stays conservative rather than climbing further.
- *   - **openai-codex** — fixed target {@link CODEX_EFFORT_ESCALATION_TARGET} (`xhigh`, universal
- *     across the codex catalog since the vocabulary change); `unset` and a legacy `minimal` (retired,
- *     pre-migration) count as escalatable, and `xhigh | max | ultra` are spent. `model` plays no role
- *     on either the Copilot or Codex path.
+ *   - **openai-codex** and **xai-grok** — fixed target {@link CODEX_EFFORT_ESCALATION_TARGET}
+ *     (`xhigh`, universal across the codex catalog since the vocabulary change, and the top rung
+ *     Grok's `--reasoning-effort` accepts); `unset` and a legacy `minimal` (retired, pre-migration)
+ *     count as escalatable, and `xhigh | max | ultra` are spent. `model` plays no role on the
+ *     Copilot, Codex, or Grok path — they are the fallthrough once the two model-aware providers
+ *     above have been handled.
  *
  * `currentEffort` is the resolved per-flow effort (`resolveEffort`/`resolveEffortForRow`), or
  * `undefined` for the CLI default. Pure; no I/O.
@@ -283,9 +285,6 @@ export const nextEffortRung = (
     return EFFORT_ESCALATION_TARGET;
   }
   // openai-codex and xai-grok: xhigh is universal; max/ultra are already above it.
-  if (provider === 'openai-codex' || provider === 'xai-grok') {
-    if (currentEffort !== undefined && CODEX_EFFORT_AT_OR_ABOVE_TARGET.has(currentEffort)) return undefined;
-    return CODEX_EFFORT_ESCALATION_TARGET;
-  }
-  return undefined;
+  if (currentEffort !== undefined && CODEX_EFFORT_AT_OR_ABOVE_TARGET.has(currentEffort)) return undefined;
+  return CODEX_EFFORT_ESCALATION_TARGET;
 };

--- a/src/integration/ai/providers/grok/interactive.ts
+++ b/src/integration/ai/providers/grok/interactive.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { InteractiveProviderDeps } from '@src/integration/ai/providers/_engine/interactive-provider-deps.ts';
 import { createInteractiveProvider } from '@src/integration/ai/providers/_engine/run-interactive-session.ts';
@@ -7,15 +9,28 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
  * Interactive `grok` adapter. Spawns the Grok Build CLI with `stdio: 'inherit'` so the user sees
  * Grok's TUI directly.
  *
- *   grok --no-auto-update --cwd <cwd> -m <model> --permission-mode acceptEdits
- *        [--effort <level>] [-s <uuid>] <pointer at promptFile>
+ *   grok --no-auto-update --cwd <cwd> --sandbox off --no-alt-screen
+ *        --leader-socket <tmp>/ralphctl-grok-<id>.sock -m <model>
+ *        --permission-mode acceptEdits [--effort <level>] [-s <uuid>] <pointer at promptFile>
  *
- * `-s` (grok 1.0.5) sets the id of the session about to start — Claude's `--session-id`, not the
+ * `-s` (grok 1.0.13) sets the id of the session about to start — Claude's `--session-id`, not the
  * resume flag. The harness pre-generates it so it can mirror `sessionId.txt` for later re-attach;
  * resume of an existing session is the headless adapter's `-r <id>`.
  *
  * `--prompt-file` is deliberately omitted — it forces headless. The prompt slot is a positional
  * pointer from `buildPromptPointer`, never the body.
+ *
+ * `--leader-socket` is the one Grok-specific piece of session isolation. Grok's agent runs behind
+ * a leader process reached over `~/.grok/leader.sock` by default, and it kills discovered leaders
+ * at startup (`leader.startup_kill`); sharing that socket lets a harness-launched session and a
+ * long-lived interactive Grok the user already has open tear each other down. A per-session path
+ * keeps them apart. It is derived from the session id the engine already generates rather than
+ * from a staged temp directory: the path is the only thing needed, Grok binds the socket itself,
+ * and the short `<id>` suffix keeps the name clear of the 104-byte macOS `sun_path` limit even
+ * under a long `TMPDIR`.
+ *
+ * `--no-alt-screen` keeps Grok inline after Ink's `suspendTerminal` has already left the
+ * alternate screen.
  *
  * Grok has no `--add-dir`. `--sandbox off` is forced so extra roots (and `outputFile` outside
  * cwd) stay reachable — a named over-grant rather than an InvalidStateError (same posture as
@@ -23,6 +38,17 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
  *
  * Docs: https://docs.x.ai/build/overview
  */
+
+/**
+ * Per-session leader socket path. Keyed off the engine's session id so no state has to be threaded
+ * from `run` into `buildArgs`; the tail is enough to be unique per session while staying short
+ * (`/var/folders/…/T/` already spends ~48 of the 104 bytes a unix socket path may occupy). The pid
+ * fallback cannot be reached while `supportsSessionId` is true, and keeps concurrent harnesses
+ * apart rather than collapsing them onto one shared path if it ever is.
+ */
+const leaderSocketFor = (sessionId: string | undefined): string =>
+  join(tmpdir(), `ralphctl-grok-${(sessionId ?? String(process.pid)).slice(-8)}.sock`);
+
 export const createInteractiveGrokProvider = (deps: InteractiveProviderDeps): InteractiveAiProvider =>
   createInteractiveProvider(
     {
@@ -37,6 +63,9 @@ export const createInteractiveGrokProvider = (deps: InteractiveProviderDeps): In
         String(input.cwd),
         '--sandbox',
         'off',
+        '--no-alt-screen',
+        '--leader-socket',
+        leaderSocketFor(sessionId),
         '-m',
         input.model,
         '--permission-mode',

--- a/tests/integration/ai/providers/grok/interactive.test.ts
+++ b/tests/integration/ai/providers/grok/interactive.test.ts
@@ -12,6 +12,12 @@ const PROMPT_FILE = absolutePath('/tmp/grok-prompt.md');
 const OUTPUT_FILE = absolutePath('/tmp/grok-output.md');
 const CWD = absolutePath('/tmp/grok-interactive-cwd');
 
+const leaderSocketOf = (args: readonly string[]): string => {
+  const idx = args.indexOf('--leader-socket');
+  expect(idx).toBeGreaterThanOrEqual(0);
+  return args[idx + 1]!;
+};
+
 describe('createInteractiveGrokProvider', () => {
   it('rejects a model outside the Grok catalog with InvalidStateError', async () => {
     const cap = createCapturingBus();
@@ -37,8 +43,7 @@ describe('createInteractiveGrokProvider', () => {
       model: GROK_MODELS[0]!,
     });
     emitExit(0);
-    const result = await runPromise;
-    expect(result.ok).toBe(true);
+    expect((await runPromise).ok).toBe(true);
 
     expect(calls).toHaveLength(1);
     expect(calls[0]!.command).toBe('grok');
@@ -50,6 +55,7 @@ describe('createInteractiveGrokProvider', () => {
     expect(args).toContain(GROK_MODELS[0]!);
     expect(args).toContain('--permission-mode');
     expect(args).toContain('acceptEdits');
+    expect(args).toContain('--no-alt-screen');
     const sandboxIdx = args.indexOf('--sandbox');
     expect(sandboxIdx).toBeGreaterThanOrEqual(0);
     expect(args[sandboxIdx + 1]).toBe('off');
@@ -57,9 +63,36 @@ describe('createInteractiveGrokProvider', () => {
     expect(args).not.toContain('--prompt-file');
     expect(args).not.toContain('-r');
     expect(args).not.toContain('-p');
+    // The pointer names the caller's real prompt file — the body never rides argv.
     expect(args.at(-1)).toContain(String(PROMPT_FILE));
     expect(args).not.toContain(STUB_PROMPT);
     expect(calls[0]!.cwd).toBe(String(CWD));
+  });
+
+  it('gives each session its own --leader-socket so it never shares ~/.grok/leader.sock', async () => {
+    // Grok kills discovered leaders at startup; a shared socket lets a harness session and the
+    // user's own long-lived Grok tear each other down.
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
+    const provider = createInteractiveGrokProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+    const input = { cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: GROK_MODELS[0]! };
+
+    const first = provider.run(input);
+    emitExit(0);
+    await first;
+    const second = provider.run(input);
+    emitExit(0);
+    await second;
+
+    const socketA = leaderSocketOf(calls[0]!.args);
+    const socketB = leaderSocketOf(calls[1]!.args);
+    expect(socketA).not.toBe(socketB);
+    expect(socketA).not.toContain('.grok/leader.sock');
+    for (const socket of [socketA, socketB]) {
+      expect(socket).toMatch(/ralphctl-grok-.*\.sock$/);
+      // macOS caps a unix socket path (`sun_path`) at 104 bytes — a longer one fails to bind.
+      expect(Buffer.byteLength(socket)).toBeLessThan(104);
+    }
   });
 
   it('forwards the resolved effort as --effort <level>, and omits it when unset', async () => {

--- a/tests/unit/application/ui/shared/release-terminal-for-child.test.ts
+++ b/tests/unit/application/ui/shared/release-terminal-for-child.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Pins the terminal-mode reset that runs before every interactive AI handoff — the modes Ink
+ * never set and therefore cannot restore on its own. Leaving mouse reporting on floods the
+ * child's stdin with CSI sequences instead of keystrokes; refine-with-Grok hung after
+ * `leader.startup_kill` with a blank screen and no Ctrl-C. See `release-terminal-for-child.ts`.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { releaseTerminalForChild } from '@src/application/ui/shared/release-terminal-for-child.ts';
+
+describe('releaseTerminalForChild', () => {
+  const originalStdin = process.stdin;
+  const originalStdout = process.stdout;
+
+  const stubStdin = (overrides: Record<string, unknown> = {}): Record<string, unknown> => {
+    const stdin = { isTTY: true, setRawMode: vi.fn(), ...overrides };
+    Object.defineProperty(process, 'stdin', { value: stdin, configurable: true });
+    return stdin;
+  };
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+    Object.defineProperty(process, 'stdout', { value: originalStdout, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('writes ESU + mouse-off + kitty-off + leave-alt-screen + show-cursor + bracketed-paste-off on a TTY stdout', () => {
+    const write = vi.fn();
+    // No `fd` → falls back to async write (writeSync needs a real descriptor).
+    Object.defineProperty(process, 'stdout', {
+      value: { isTTY: true, write },
+      configurable: true,
+    });
+    stubStdin();
+
+    releaseTerminalForChild();
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const payload = write.mock.calls[0]![0] as string;
+    expect(payload).toContain('\x1b[?2026l'); // end synchronized update
+    expect(payload).not.toContain('\x1b[!p'); // soft-reset omitted (breaks nested Grok on iTerm)
+    expect(payload).toContain('\x1b[?1000l'); // mouse reporting off
+    expect(payload).toContain('\x1b[?1006l'); // SGR mouse reporting off
+    expect(payload).toContain('\x1b[<u'); // kitty keyboard off
+    expect(payload).toContain('\x1b[?1049l'); // leave alt-screen
+    expect(payload).toContain('\x1b[?25h'); // show cursor
+    expect(payload).toContain('\x1b[?2004l'); // bracketed paste off
+  });
+
+  it('cooks stdin so Ctrl-C reaches the child, and leaves the stream itself to Ink', () => {
+    // Ink's pauseInput/resumeInput pair owns the stdin listener across a suspension. Detaching
+    // listeners here took `ScrollRegion`'s wheel handler with it — the React tree stays mounted
+    // under suspendTerminal, so its effect cleanup never re-attaches.
+    const stdin = stubStdin({
+      pause: vi.fn(),
+      read: vi.fn(() => null),
+      removeAllListeners: vi.fn(),
+    });
+    Object.defineProperty(process, 'stdout', {
+      value: { isTTY: false, write: vi.fn() },
+      configurable: true,
+    });
+
+    releaseTerminalForChild();
+
+    expect(stdin['setRawMode']).toHaveBeenCalledWith(false);
+    expect(stdin['removeAllListeners']).not.toHaveBeenCalled();
+    expect(stdin['pause']).not.toHaveBeenCalled();
+    expect(stdin['read']).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op write on non-TTY stdout and still cooks a TTY stdin', () => {
+    const write = vi.fn();
+    Object.defineProperty(process, 'stdout', {
+      value: { isTTY: false, write },
+      configurable: true,
+    });
+    const stdin = stubStdin();
+
+    releaseTerminalForChild();
+
+    expect(write).not.toHaveBeenCalled();
+    expect(stdin['setRawMode']).toHaveBeenCalledWith(false);
+  });
+
+  it('survives a stdin that cannot leave raw mode', () => {
+    stubStdin({
+      setRawMode: vi.fn(() => {
+        throw new Error('not a tty');
+      }),
+    });
+    const write = vi.fn();
+    Object.defineProperty(process, 'stdout', { value: { isTTY: true, write }, configurable: true });
+
+    expect(() => {
+      releaseTerminalForChild();
+    }).not.toThrow();
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Makes the interactive Grok handoff work, and removes the layers of terminal hardening that turned out not to be doing anything.

### The evidence

Grok's own log (`~/.grok/logs/unified.jsonl`) shows a stalled launch dying between `leader.startup_kill.done` and `startup phase: config_load` — **before its pager exists at all**. 18 of 54 interactive launches (~33%) died there. That rules out the whole "leftover escape sequences break Grok's TUI init" theory the previous round was built on: the TUI never starts.

What *is* at that phase is Grok's leader process. It reaches `~/.grok/leader.sock` by default and kills every leader it discovers at startup, so a harness-launched session and a long-lived interactive Grok tear each other down. Hence a per-session `--leader-socket`.

Verified on a real PTY with the full production path (`createInkHost` + `TerminalHandoff` + the real adapter): reaches `pager started` every run.

## Changes

**`fix(tui)`** — both handoff paths share one `releaseTerminalForChild`, resetting only the modes Ink never set and so cannot restore (mouse reporting above all; left on, the child's terminal floods its stdin with CSI sequences instead of keystrokes).

`process.stdin` is now left to Ink's `pauseInput`/`resumeInput` pair. Reaching into the shared stream from outside it broke a consumer Ink doesn't know about: `removeAllListeners('data')` detached `ScrollRegion`'s wheel handler permanently, because under `suspendTerminal` the React tree stays mounted and its effect cleanup never re-runs.

Dropped the stdout Proxy that stripped synchronized-update markers. Ink 7.1.1 writes BSU only as a standalone `stdout.write(bsu)`, never embedded in a frame, and `beginSuspend` flushes its throttled writers before pausing — the race it defended against cannot occur. Its only real effect was disabling Ink's tearing prevention app-wide. ESU is still emitted unconditionally as free insurance.

**`fix(providers)`** — per-session `--leader-socket` plus `--no-alt-screen`, derived from the session id the engine already generates instead of from a staged temp directory. Staging the prompt bought ~50 characters against a 32 KB argv budget and cost: a red conformance suite, a double read of the prompt, a pre-flight retargeted onto a file this process had just written, a lost log breadcrumb, and ~5ms of dead time inside the suspend window.

**`refactor(task)`** — unreachable branch in `nextEffortRung`.

## Verification

`typecheck` · `lint` · `format:check` · `deadcode` · `test` all green.

The shared `interactive-port-conformance` suite was **red for `xai-grok`** on the previous state (6 tests timing out at 15s each) because the adapter did async filesystem work before delegating. It now passes alongside the other four backends, and that suite runs in **0.7s instead of 90s**. Full suite: 6210 tests, ~100s faster.

## Follow-ups (not in scope here)

- Nothing re-enables mouse reporting when the child exits, so wheel scrolling stays off for the rest of the session. Belongs in `ScrollRegion` on a resume signal.
- The "AGENTS.md + skills" readiness probe is now cloned three times (codex / opencode / grok); same for the attempt tracker (opencode / grok) and `PROVIDER_LABEL` (two copies).
- The `ink-host` unmount fallback looks unreachable in production now that `beforeMount` installs before `render()`.