### PR TITLE
feat(providers): always write a Grok interactive debug log

### DIFF
--- a/src/integration/ai/providers/grok/interactive.ts
+++ b/src/integration/ai/providers/grok/interactive.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { InteractiveProviderDeps } from '@src/integration/ai/providers/_engine/interactive-provider-deps.ts';
 import { createInteractiveProvider } from '@src/integration/ai/providers/_engine/run-interactive-session.ts';
@@ -36,8 +36,26 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
  * cwd) stay reachable — a named over-grant rather than an InvalidStateError (same posture as
  * the headless adapter).
  *
+ * `--debug-file` is unconditional, and interactive is the surface that needs it most: with
+ * `stdio: 'inherit'` the harness hands the child the terminal and can observe NOTHING about it —
+ * no stdout to parse, no exit detail beyond a code. When a session hangs, the only account of
+ * what happened is Grok's own. `~/.grok/logs/unified.jsonl` is not a substitute: it stops dead at
+ * the last line the process managed to emit, so a stall there has to be inferred from what is
+ * MISSING, which produced two confidently wrong root causes for the black-screen hang before this
+ * landed. The debug log records `startup phase phase=<name>` transitions directly and names the
+ * phase instead.
+ *
+ * Not behind a flag on purpose. The hang is intermittent (~1 in 3 launches), so a switch the
+ * operator has to set BEFORE a session that may or may not hang collects evidence exactly when it
+ * is not needed. Size works in the same direction: a stalled startup writes ~24 KB and stops,
+ * while the ~600 KB a long healthy session produces is the case nobody needs to read. Both land
+ * beside the session's other artifacts and are pruned with the rest of the unit.
+ *
  * Docs: https://docs.x.ai/build/overview
  */
+
+/** Name of the per-session Grok debug log, dropped beside `outputFile` / `sessionId.txt`. */
+const DEBUG_LOG_FILENAME = 'grok-debug.log';
 
 /**
  * Per-session leader socket path. Keyed off the engine's session id so no state has to be threaded
@@ -70,6 +88,8 @@ export const createInteractiveGrokProvider = (deps: InteractiveProviderDeps): In
         input.model,
         '--permission-mode',
         'acceptEdits',
+        '--debug-file',
+        join(dirname(String(input.outputFile)), DEBUG_LOG_FILENAME),
         ...(input.effort !== undefined ? ['--effort', input.effort] : []),
         ...(sessionId !== undefined ? ['-s', sessionId] : []),
         promptArg,

--- a/tests/integration/ai/providers/grok/interactive.test.ts
+++ b/tests/integration/ai/providers/grok/interactive.test.ts
@@ -69,6 +69,30 @@ describe('createInteractiveGrokProvider', () => {
     expect(calls[0]!.cwd).toBe(String(CWD));
   });
 
+  it('writes a per-session debug log beside outputFile, so a hung session leaves an account', async () => {
+    // `stdio: 'inherit'` means the harness can observe nothing about the child. When an interactive
+    // session hangs, Grok's own debug log is the only record of which startup phase it stopped in.
+    const cap = createCapturingBus();
+    const { spawn, calls, emitExit } = makeInteractiveSpawn();
+    const provider = createInteractiveGrokProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
+
+    const runPromise = provider.run({
+      cwd: CWD,
+      promptFile: PROMPT_FILE,
+      outputFile: OUTPUT_FILE,
+      model: GROK_MODELS[0]!,
+    });
+    emitExit(0);
+    await runPromise;
+
+    const args = calls[0]!.args;
+    const idx = args.indexOf('--debug-file');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('/tmp/grok-debug.log');
+    // `--debug` is deliberately NOT passed — it also changes what Grok puts on screen.
+    expect(args).not.toContain('--debug');
+  });
+
   it('gives each session its own --leader-socket so it never shares ~/.grok/leader.sock', async () => {
     // Grok kills discovered leaders at startup; a shared socket lets a harness session and the
     // user's own long-lived Grok tear each other down.


### PR DESCRIPTION
## Why

The interactive surface has no observability at all. `stdio: 'inherit'` hands the child the terminal, so there is no stdout to parse and no exit detail beyond a code. When a session hangs, the only account of what happened is Grok's own.

`~/.grok/logs/unified.jsonl` is not a substitute — it stops dead at the last line the process managed to emit, so a stall has to be inferred from what is **missing**. That approach produced two confidently wrong root causes for the black-screen hang (a shared leader socket in #325, then the folder-trust prompt) before this landed. Neither fixed it; the hang reproduces on current `main`.

`--debug-file` records `startup phase phase=<name>` transitions directly:

```
startup phase phase=config_load
startup phase phase=managed_policy
startup phase phase=bootstrap
startup phase phase=model_catalog
startup phase phase=worker_spawn
startup phase phase=acp_initialize
startup phase phase=eager_auth
startup phase phase=app_init
startup phase phase=session_create
```

A hung run stops partway through that list and names the phase, instead of leaving us to guess from an absence.

## Decisions

**Not behind a flag.** The hang is intermittent (~1 in 3 launches), so a switch the operator must set *before* a session that may or may not hang collects evidence exactly when it isn't needed.

**Size works in the same direction.** A stalled startup writes ~24KB and stops; the ~600KB a long healthy session produces is the case nobody needs to read. Measured, not estimated. The log lands beside `outputFile` / `sessionId.txt` and is pruned with the rest of the unit.

**`--debug` is deliberately not passed** alongside `--debug-file` — it also changes what Grok puts on screen, and the point is to observe the hang, not perturb it.

## Verification

`typecheck` · `lint` · `format:check` · `deadcode` · `test` (6211) all green.

Verified end-to-end through the real production path (`createInkHost` + `TerminalHandoff` + the real adapter on a PTY): the log lands at `<unitDir>/grok-debug.log` and contains the full phase sequence above.

## Status of the underlying bug

Still open. A bare PTY has not reproduced the hang in ~17 attempts across every variable I can control — fresh untrusted cwd, a `.grok/skills` tree present, the exact real refinement unit dir. Only the user's iTerm2 with the ralphctl TUI holding the tty reproduces it. This PR is the instrument, not the fix.