### PR TITLE
fix(providers): stop forcing a per-session Grok leader socket

### DIFF
--- a/src/integration/ai/providers/grok/interactive.ts
+++ b/src/integration/ai/providers/grok/interactive.ts
@@ -1,4 +1,3 @@
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { InteractiveAiProvider } from '@src/integration/ai/providers/_engine/interactive-ai-provider.ts';
 import type { InteractiveProviderDeps } from '@src/integration/ai/providers/_engine/interactive-provider-deps.ts';
@@ -9,8 +8,7 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
  * Interactive `grok` adapter. Spawns the Grok Build CLI with `stdio: 'inherit'` so the user sees
  * Grok's TUI directly.
  *
- *   grok --no-auto-update --cwd <cwd> --sandbox off
- *        --leader-socket <tmp>/ralphctl-grok-<id>.sock -m <model>
+ *   grok --no-auto-update --cwd <cwd> --sandbox off -m <model>
  *        --permission-mode acceptEdits --debug-file <unitDir>/grok-debug.log
  *        [--effort <level>] [-s <uuid>] <pointer at promptFile>
  *
@@ -20,15 +18,6 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
  *
  * `--prompt-file` is deliberately omitted — it forces headless. The prompt slot is a positional
  * pointer from `buildPromptPointer`, never the body.
- *
- * `--leader-socket` is the one Grok-specific piece of session isolation. Grok's agent runs behind
- * a leader process reached over `~/.grok/leader.sock` by default, and it kills discovered leaders
- * at startup (`leader.startup_kill`); sharing that socket lets a harness-launched session and a
- * long-lived interactive Grok the user already has open tear each other down. A per-session path
- * keeps them apart. It is derived from the session id the engine already generates rather than
- * from a staged temp directory: the path is the only thing needed, Grok binds the socket itself,
- * and the short `<id>` suffix keeps the name clear of the 104-byte macOS `sun_path` limit even
- * under a long `TMPDIR`.
  *
  * Grok has no `--add-dir`. `--sandbox off` is forced so extra roots (and `outputFile` outside
  * cwd) stay reachable — a named over-grant rather than an InvalidStateError (same posture as
@@ -55,16 +44,6 @@ import { isGrokModel } from '@src/domain/value/settings-models/grok.ts';
 /** Name of the per-session Grok debug log, dropped beside `outputFile` / `sessionId.txt`. */
 const DEBUG_LOG_FILENAME = 'grok-debug.log';
 
-/**
- * Per-session leader socket path. Keyed off the engine's session id so no state has to be threaded
- * from `run` into `buildArgs`; the tail is enough to be unique per session while staying short
- * (`/var/folders/…/T/` already spends ~48 of the 104 bytes a unix socket path may occupy). The pid
- * fallback cannot be reached while `supportsSessionId` is true, and keeps concurrent harnesses
- * apart rather than collapsing them onto one shared path if it ever is.
- */
-const leaderSocketFor = (sessionId: string | undefined): string =>
-  join(tmpdir(), `ralphctl-grok-${(sessionId ?? String(process.pid)).slice(-8)}.sock`);
-
 export const createInteractiveGrokProvider = (deps: InteractiveProviderDeps): InteractiveAiProvider =>
   createInteractiveProvider(
     {
@@ -79,8 +58,6 @@ export const createInteractiveGrokProvider = (deps: InteractiveProviderDeps): In
         String(input.cwd),
         '--sandbox',
         'off',
-        '--leader-socket',
-        leaderSocketFor(sessionId),
         '-m',
         input.model,
         '--permission-mode',

--- a/tests/integration/ai/providers/grok/interactive.test.ts
+++ b/tests/integration/ai/providers/grok/interactive.test.ts
@@ -12,12 +12,6 @@ const PROMPT_FILE = absolutePath('/tmp/grok-prompt.md');
 const OUTPUT_FILE = absolutePath('/tmp/grok-output.md');
 const CWD = absolutePath('/tmp/grok-interactive-cwd');
 
-const leaderSocketOf = (args: readonly string[]): string => {
-  const idx = args.indexOf('--leader-socket');
-  expect(idx).toBeGreaterThanOrEqual(0);
-  return args[idx + 1]!;
-};
-
 describe('createInteractiveGrokProvider', () => {
   it('rejects a model outside the Grok catalog with InvalidStateError', async () => {
     const cap = createCapturingBus();
@@ -59,6 +53,10 @@ describe('createInteractiveGrokProvider', () => {
     expect(sandboxIdx).toBeGreaterThanOrEqual(0);
     expect(args[sandboxIdx + 1]).toBe('off');
     expect(args).not.toContain('--always-approve');
+    // No `--leader-socket`: Grok's default `~/.grok/leader.sock` is the configuration that
+    // demonstrably starts. Forcing a per-session socket makes Grok stand up a fresh leader and
+    // was the one flag present in every hung session and absent from every healthy one.
+    expect(args).not.toContain('--leader-socket');
     expect(args).not.toContain('--prompt-file');
     expect(args).not.toContain('-r');
     expect(args).not.toContain('-p');
@@ -90,32 +88,6 @@ describe('createInteractiveGrokProvider', () => {
     expect(args[idx + 1]).toBe('/tmp/grok-debug.log');
     // `--debug` is deliberately NOT passed — it also changes what Grok puts on screen.
     expect(args).not.toContain('--debug');
-  });
-
-  it('gives each session its own --leader-socket so it never shares ~/.grok/leader.sock', async () => {
-    // Grok kills discovered leaders at startup; a shared socket lets a harness session and the
-    // user's own long-lived Grok tear each other down.
-    const cap = createCapturingBus();
-    const { spawn, calls, emitExit } = makeInteractiveSpawn();
-    const provider = createInteractiveGrokProvider({ eventBus: cap.bus, spawn, readFile: stubReadFile });
-    const input = { cwd: CWD, promptFile: PROMPT_FILE, outputFile: OUTPUT_FILE, model: GROK_MODELS[0]! };
-
-    const first = provider.run(input);
-    emitExit(0);
-    await first;
-    const second = provider.run(input);
-    emitExit(0);
-    await second;
-
-    const socketA = leaderSocketOf(calls[0]!.args);
-    const socketB = leaderSocketOf(calls[1]!.args);
-    expect(socketA).not.toBe(socketB);
-    expect(socketA).not.toContain('.grok/leader.sock');
-    for (const socket of [socketA, socketB]) {
-      expect(socket).toMatch(/ralphctl-grok-.*\.sock$/);
-      // macOS caps a unix socket path (`sun_path`) at 104 bytes — a longer one fails to bind.
-      expect(Buffer.byteLength(socket)).toBeLessThan(104);
-    }
   });
 
   it('forwards the resolved effort as --effort <level>, and omits it when unset', async () => {


### PR DESCRIPTION
## Why

Grok runs its agent behind a **leader process** reached over a unix socket. Left alone it uses `~/.grok/leader.sock` and finds-or-starts a leader the way any normal invocation does. `--leader-socket` points it at a path nothing is listening on, so it has to stand up a fresh leader instead.

Two facts line up:

- **Every hung session had this flag.** A manual `grok` in the same unit directory, in the same terminal, with no flags at all, starts fine.
- **`leader.startup_kill` is the last line every hung process logs** before it stops — leader territory, and before its own `config_load` or debug-log init.

The flag was added in #325 to fix that hang, on a theory (a harness session and the user's own open Grok killing each other's leader) that was never confirmed and did not fix anything. Removing it puts the harness back on the configuration that demonstrably starts.

## Also settled along the way

The folder-trust theory is **conclusively dead**, and not by assertion: `~/.grok/trusted_folders.toml` was last written Aug 28, contains only the repo root, and a manual run in the untrusted unit directory today neither prompted nor wrote to it.

Ruled out on the live hung process this round:
- ralphctl holding it up — `SIGSTOP` on the parent for 20s changed nothing
- a `.claude/` directory in cwd — reproduced that exact shape, grok started fine
- `--debug-file` (#326) — it never even reaches the point where grok opens the log, so it cannot see this class of hang

## Honesty about confidence

This is correlation, not proof. Nothing has reproduced the hang outside the reporter's terminal in ~22 attempts. But an unjustified flag that appears in 100% of failures and 0% of successes has to go regardless of whether it turns out to be the cause.

## Verification

`typecheck` · `lint` · `format:check` · `deadcode` · `test` (6200) all green.