### PR TITLE
fix(tui): release stdin before handing the terminal to an interactive child

### DIFF
--- a/.claude/docs/INTERACTIVE-HANDOFF-HANG.md
+++ b/.claude/docs/INTERACTIVE-HANDOFF-HANG.md
@@ -1,6 +1,9 @@
 # Interactive handoff — the black-screen hang
 
-**Status:** root cause confirmed 2026-09-04. **Fix not yet implemented.** Read this before touching
+**Status:** root cause confirmed 2026-09-04, **fixed 2026-09-05** — `releaseStdinForChild` in
+`src/application/ui/shared/stdin-handoff.ts`, awaited by `runInTerminal` in
+`src/application/ui/shared/ink-host.ts`. Driven through the real host in a real iTerm window, Grok
+reached its pager in 0 of 8 launches before the fix and 8 of 8 after it. Read this before touching
 the interactive TTY handoff or re-investigating the hang; it cost several days and six wrong root
 causes, all of which are listed below so nobody pays for them twice.
 
@@ -8,7 +11,7 @@ causes, all of which are listed below so nobody pays for them twice.
 
 An interactive AI session (seen with Grok, but the mechanism is provider-agnostic) is launched from
 the TUI. The screen goes black and stays black. The child process is alive at 0% CPU, blocked in
-`kevent`, and never draws anything. Ctrl-C does nothing. Roughly 1 launch in 3.
+`kevent`, and never draws anything. Ctrl-C does nothing.
 
 For Grok specifically, `~/.grok/logs/unified.jsonl` shows the process stopping after
 `leader.startup_kill.done` and never reaching `startup phase: config_load`. It freezes before it
@@ -16,7 +19,7 @@ opens its own debug log, so `--debug-file` cannot see this class of hang.
 
 ## Root cause
 
-**A parent process that is holding `process.stdin` open eats the terminal's reply to the child's
+**A parent process that is still reading `process.stdin` eats the terminal's reply to the child's
 capability queries, and the child blocks forever waiting for an answer that already went somewhere
 else.**
 
@@ -30,49 +33,109 @@ On startup an interactive CLI writes terminal queries and waits for the reply. G
 
 The terminal answers by writing bytes back into the tty's input buffer. Parent and child share that
 file descriptor, so **whoever reads first wins**. A shell never competes — it waits in `waitpid`
-while a foreground child runs. A Node parent with an active `data` listener and a resumed stdin
-does compete, and wins often enough to hang the child about half the time.
+while a foreground child runs. A Node parent whose tty handle is still in its reading state does
+compete, and wins often enough to hang the child.
+
+"Still reading" is the subtle part. **Unmounting Ink does not release stdin.** Ink's teardown
+removes its `readable` listener, drops raw mode and calls `unref()` — and after all of that the
+handle is still reading. Measured on Node 26 through `process.stdin._handle.reading`:
+
+| State                                            | `_handle.reading` |
+| ------------------------------------------------ | ----------------- |
+| never touched                                    | `false`           |
+| Ink armed (`readable` listener + raw mode)       | `true`            |
+| after Ink-style teardown (listener off, raw off) | **`true`**        |
+| after `pause()` + one tick                       | `false`           |
+| after a `read()` on an EMPTY buffer              | **`true` again**  |
+
+What actually stops the fd read is Node core: `process.stdin` carries a `'pause'` listener that calls
+`readStop()` on the handle one tick later. `pause()` only emits `'pause'` when it is a real state
+transition — and it is a documented no-op while a `readable` listener is attached, with the stream
+only forgetting that listener's paused state on the tick after it is removed.
 
 This also explains why it is invisible in CI or under a bare pty: nothing there answers a
-capability query, so the child's timeout path fires and it carries on. It needs a **real terminal
-emulator that actually replies**.
+capability query, so the child's timeout path fires and it carries on. It needs something that
+**actually replies**.
 
-### The measurement
+### The measurements
 
-Four arms, run strictly sequentially in a real iTerm window, 8 repetitions each, scored on whether
-Grok reached `pager started`:
+All arms strictly sequential, one experiment at a time.
 
-| Arm                                                     | Result              |
-| ------------------------------------------------------- | ------------------- |
-| launched from the shell                                 | 8/8 PASS            |
-| Node, plain `spawn` with `stdio: 'inherit'`             | 8/8 PASS            |
-| **Node holding stdin (`resume()` + a `data` listener)** | **4 HANG / 4 PASS** |
-| **Node releasing stdin before the spawn**               | **8/8 PASS**        |
+**1. Original arms (2026-09-04), plain Node, real iTerm window, 8 repetitions each, scored on Grok
+reaching `pager started`:**
 
-"Releasing" means: detach the listeners, `pause()`, and drain whatever is already buffered.
+| Arm                                                   | Result              |
+| ----------------------------------------------------- | ------------------- |
+| launched from the shell                               | 8/8 PASS            |
+| Node, plain `spawn` with `stdio: 'inherit'`           | 8/8 PASS            |
+| **Node holding stdin (`resume()` + `data` listener)** | **4 HANG / 4 PASS** |
+| **Node releasing stdin before the spawn**             | **8/8 PASS**        |
 
-## The fix, and the trap in it
+**2. Production host (2026-09-05), the real `createInkHost` with a `ScrollRegion` mounted,
+`runInTerminal(() => spawn('grok', …, { stdio: 'inherit' }))`, real iTerm window, 8 repetitions
+each, scored by Grok pid on `pager started`:**
 
-`releaseTerminalForChild` used to do exactly that release. It was **deleted in #327** because
-`removeAllListeners('data')` permanently detached `ScrollRegion`'s mouse-wheel handler — under the
-old `suspendTerminal` handoff the React tree stayed mounted, so the effect cleanup that re-attaches
-it never ran. Deleting the release removed a real fix to cure a real side effect.
+| Tree                                | `_handle.reading` at spawn | Result       |
+| ----------------------------------- | -------------------------- | ------------ |
+| `main` without the release          | `true` (0 listeners)       | **0/8 PASS** |
+| with `releaseStdinForChild` awaited | `false`                    | **8/8 PASS** |
 
-The correct shape is **release, then restore**:
+The baseline is worse than the plain-Node arm because the host's unmount leaves the handle in
+exactly the state above: no consumer, still reading, so the very first reply is buffered by us.
 
-- Before the spawn: capture the current `data` / `readable` listeners, remove those specific
-  handlers (not `removeAllListeners`, which reaches into consumers you do not own), `pause()`, and
-  drain the buffer.
-- After the child exits: re-attach exactly the handlers that were removed and resume.
+**3. Release-sequence variants (2026-09-05), parent/child Node race under a pty that answers
+DA1, 18 runs per variant across reply latencies of 0 / 10 / 30 ms:**
+
+| Variant                                            | parent stole the reply |
+| -------------------------------------------------- | ---------------------- |
+| held (Ink-style teardown, nothing else)            | 6/18                   |
+| remove listeners → `pause()` synchronously         | **8/18**               |
+| remove listeners → one event-loop turn → `pause()` | **0/18**               |
+
+The synchronous variant is the one three independent reviewers approved; it never emitted
+`'pause'`, so the handle kept reading. Only the measurement caught it.
+
+## The fix
+
+`releaseStdinForChild` in `src/application/ui/shared/stdin-handoff.ts` is **release, then
+restore**, and it is `async` on purpose:
+
+- Before the spawn: capture the current `data` / `readable` listeners via `rawListeners()` (so
+  `once()` wrappers survive), remove exactly those handlers with `removeListener`, drain only while
+  `readableLength > 0`, let one event-loop turn pass, `pause()`, let one more turn pass so Node's
+  `readStop` has run, then resolve. **Spawn after the `await`.**
+- After the child exits: re-attach exactly the handlers that were removed, in order, and `resume()`
+  only if the stream had been flowing. The returned restore function is idempotent.
+
+`ink-host.ts` awaits the release after `await current.waitUntilExit()` — so Ink's own teardown has
+already run — and before `fn()`; the restore runs in the `finally` before the Ink remount. Both ends
+of that ordering are load-bearing.
+
+Three implementation traps, each measured:
+
+- **`read()` on an empty buffer restarts the handle.** A "drain until `read()` returns null" loop
+  re-arms the tty and reintroduces the bug. Only read while `readableLength > 0`.
+- **`pause()` right after removing a `readable` listener is a no-op.** See table 3. The settle turn
+  is what makes `pause()` a real transition. Under the current unmount handoff Ink removed its
+  listener ticks earlier, so the naive version happens to work there — the settle exists so the next
+  handoff mechanism does not silently bring the hang back.
+- **`removeAllListeners` reaches into consumers you do not own.** It used to be the release, and it
+  was deleted in #327 because it permanently detached `ScrollRegion`'s mouse-wheel handler — under
+  the old `suspendTerminal` handoff the React tree stayed mounted, so the effect cleanup that
+  re-attaches it never ran. Deleting the release removed a real fix to cure a real side effect.
+  `tests/unit/application/ui/shared/stdin-handoff.test.ts` spies on both removal methods, so a
+  "simplification" back to it fails there rather than in production.
 
 Under the current unmount/remount handoff the tree is torn down anyway, so `ScrollRegion` is not at
-risk — but the restore must exist regardless, because the handoff mechanism has already changed
-twice and the next change must not silently reintroduce the bug.
+risk — but the restore exists regardless, because the handoff mechanism has already changed twice.
 
 Do **not** substitute any of these; each was measured and does not work:
 
-- A settle delay between teardown and spawn — 3 HANG / 1 PASS identically at 0ms, 150ms and 400ms.
+- A wall-clock settle delay between teardown and spawn — 3 HANG / 1 PASS identically at 0ms, 150ms
+  and 400ms. (The two event-loop turns inside the helper are not this: they let Node's own stream
+  bookkeeping run, they do not wait for the race to resolve itself.)
 - Opening fresh `/dev/tty` descriptors instead of inheriting — **8/8 HANG**, deterministically worse.
+- Ink's unmount alone — table 2, 0/8.
 
 ## Refuted — do not re-investigate
 
@@ -95,8 +158,9 @@ cannot say anything about the race.
 
 ## Reproducing it
 
-A bare pty will not reproduce this — it answers no queries. You need a real terminal, driven
-programmatically:
+Two instruments, with different reach.
+
+**A real terminal, driven programmatically** — the only oracle for Grok itself:
 
 ```bash
 osascript -e 'tell application "iTerm"
@@ -105,27 +169,48 @@ osascript -e 'tell application "iTerm"
 end tell'
 ```
 
-Score each run by whether the child reached its "TUI is up" log line — for Grok:
+Score each run by whether the child reached its "TUI is up" log line, matched on the child's pid so
+concurrent sessions cannot be mistaken for each other — for Grok:
 
 ```bash
-before=$(grep -c '"msg":"pager started"' ~/.grok/logs/unified.jsonl)
-# … launch, wait, kill …
-after=$(grep -c '"msg":"pager started"' ~/.grok/logs/unified.jsonl)
+grep '"pid":'"$pid"',' ~/.grok/logs/unified.jsonl | grep -c '"msg":"pager started"'
 ```
 
-Two rules, both learned the hard way:
+The highest-fidelity experiment mounts the real `createInkHost` (with a `ScrollRegion`, so both of
+Ink's listener kinds are present), calls `runInTerminal(() => spawn('grok', […], { stdio:
+'inherit' }))`, snapshots `process.stdin` (`_handle.reading`, `listenerCount('data' | 'readable')`,
+`readableLength`) at mount, at spawn and after restore, and kills Grok after ~12 s. That is what
+produced table 2; the run-to-run snapshot is what shows whether the release actually happened.
 
-- **One experiment at a time.** A watchdog doing `pkill -n -x grok` will kill a concurrent
+**A pty that answers queries** — a Python `pty.fork()` master that watches the child's output for
+`ESC[c` / `ESC[>q` / `ESC[?u` and writes the reply a real terminal would into the slave's input
+queue. It reproduces the parent-steals-the-reply race deterministically for a Node child (table 3)
+and needs no GUI, so it is the right tool for A/B-ing the release sequence. It does **not**
+reproduce the hang for Grok — Grok wins that race in a pty every time (8/8) — so it cannot replace
+the real terminal for the end-to-end score.
+
+Rules, all learned the hard way:
+
+- **One experiment at a time.** A watchdog doing `pkill -x grok` will kill a concurrent
   experiment's child and score both arms as false hangs.
 - **Never redirect the child's stdout**, and never background it in a script without reattaching
   stdin — POSIX gives an asynchronous list `/dev/null` for stdin, which alone stops the TUI from
   starting and scores every arm a false hang.
+- **A harness script must live inside the repo tree** (e.g. `scripts/`) so `react` / `ink` resolve;
+  run it with `tsx --tsconfig <root>/tsconfig.json` so `@src/*` resolves too.
+- **iTerm's `create window` can hang** when the app has a modal up (a dead-session window left by a
+  previous `exit` is enough). Run `osascript` in the background with a timeout and poll for the
+  result file instead of trusting the AppleScript call to return.
 
 ## Related
 
-- `src/application/ui/shared/ink-host.ts` — the unmount/remount handoff (restored in #327).
-- `src/integration/ai/providers/_engine/run-interactive-session.ts` — where the child is spawned.
-- Branch `fix/spawn-context-probe` (unmerged) — writes `<unitDir>/spawn-context.json` immediately
-  before every interactive spawn, recording stdin listener counts, stream state and the terminal
-  size. That is the instrument that made the stdin listener counts visible; it is worth landing
-  alongside the fix.
+- `src/application/ui/shared/stdin-handoff.ts` — the release/restore helper, plus its unit test at
+  `tests/unit/application/ui/shared/stdin-handoff.test.ts`.
+- `src/application/ui/shared/ink-host.ts` — the unmount/remount handoff (restored in #327); awaits
+  the release around `fn()` in `runInTerminal`.
+- `src/integration/ai/providers/_engine/run-interactive-session.ts` — where the child is spawned. It
+  writes `<unitDir>/spawn-context.json` immediately before every interactive spawn, recording stdin
+  listener counts, stream state and the terminal size. That probe is the instrument that made the
+  stdin listener counts visible; it ships alongside the fix.
+- Any _new_ caller that spawns an interactive child from a process that has touched stdin has to
+  release it the same way — the hang is not specific to the TUI or to Grok.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ to [Semantic Versioning](https://semver.org/).
   sharing `~/.grok/leader.sock`: Grok kills every leader process it discovers at startup, so
   a shared socket lets a harness run and a Grok you already have open tear each other down.
 
+### Fixed
+
+- **Interactive sessions no longer hang on a black screen after the TUI hands over the terminal.**
+  Seen with Grok but provider-agnostic: an interactive CLI queries the terminal for its capabilities
+  on startup and blocks until the reply arrives, and ralphctl — whose stdin handle was still reading
+  after Ink unmounted — swallowed that reply about half the time (every time through the production
+  host). The TUI now releases `process.stdin` before spawning the child and restores it afterwards.
+  Measured in a real iTerm window through the real host: 0 of 8 launches reached Grok's pager before,
+  8 of 8 after. Every interactive spawn also drops a `spawn-context.json` beside the session's other
+  artifacts recording the stdin state it was handed, so a future hang can be diagnosed from disk.
+  Full writeup in `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`.
+
 ## [0.21.0] - 2026-08-24
 
 ### Changed

--- a/src/application/ui/shared/ink-host.ts
+++ b/src/application/ui/shared/ink-host.ts
@@ -6,10 +6,11 @@
  *   - `render()` is called with `alternateScreen: true` so the wordmark + chrome appear on a
  *     fresh buffer; on unmount Ink automatically restores the user's original screen.
  *   - `runInTerminal(fn)` performs a *real* unmount before invoking `fn`: the React tree is
- *     torn down, the alternate screen is exited, and `fn` runs against the user's primary
- *     terminal. When `fn` resolves we `render()` a *freshly built* App element — `renderElement()`
- *     is called again so the new tree mounts with the latest seed (e.g. the in-session sprint
- *     selection), not a frozen launch-time element.
+ *     torn down, the alternate screen is exited, `process.stdin` is released (see
+ *     `stdin-handoff.ts`), and `fn` runs against the user's primary terminal. When `fn` settles we
+ *     restore stdin and `render()` a *freshly built* App element — `renderElement()` is called
+ *     again so the new tree mounts with the latest seed (e.g. the in-session sprint selection),
+ *     not a frozen launch-time element.
  *   - `waitForShutdown()` keeps the launcher alive across these pause/resume cycles. Each
  *     pause unmounts the current Ink instance, which would normally resolve
  *     `waitUntilExit()` and let the process drop the TUI; the host loop instead checks
@@ -23,6 +24,7 @@
 import type { ReactElement } from 'react';
 import { type Instance as InkInstance, render } from 'ink';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
+import { releaseStdinForChild } from '@src/application/ui/shared/stdin-handoff.ts';
 import type { RunInTerminal } from '@src/integration/io/run-in-terminal.ts';
 
 /**
@@ -90,18 +92,25 @@ export const createInkHost = (deps: InkHostDeps): InkHost => {
     const current = instance;
     current.unmount();
     await current.waitUntilExit();
-    // KNOWN BUG, not yet fixed — see `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`. Nothing here
-    // releases `process.stdin` before the child is spawned. A parent still holding it wins the
-    // race for the terminal's reply to the child's capability queries, and the child then waits
-    // for an answer that went somewhere else: a black screen, ~1 launch in 3. Measured at
-    // 4 hangs / 8 runs with stdin held, 0 / 8 once released. The fix is release-then-restore;
-    // read the doc before reaching for `removeAllListeners`, which is what broke ScrollRegion.
+    // Hand `process.stdin` over before the child is spawned. Unmounting Ink is not enough: the tty
+    // handle is left reading, so the terminal's reply to the child's capability queries lands in
+    // this process's buffer and the child hangs waiting for an answer that went somewhere else —
+    // measured through this very host in a real iTerm window at 0 / 8 launches reaching Grok's
+    // pager without the release, 8 / 8 with it. The release is awaited because Node stops reading
+    // the fd a tick after `pause()`, and the child must not be spawned before that. Ordering is
+    // load-bearing on both sides: release only after `waitUntilExit()` so Ink's own teardown has
+    // already run, and restore in the `finally` BEFORE `renderOnce()` so the remounting tree finds
+    // the stream exactly as it left it. See `.claude/docs/INTERACTIVE-HANDOFF-HANG.md` and
+    // `stdin-handoff.ts` — in particular before reaching for `removeAllListeners`, which is what
+    // broke ScrollRegion.
+    const restoreStdin = await releaseStdinForChild();
     // The user owns the terminal while `fn` runs — turn bracketed paste off so a paste into the
     // AI session isn't wrapped in markers. `renderOnce()` re-enables it when the TUI remounts.
     setBracketedPaste(false);
     try {
       return await fn();
     } finally {
+      restoreStdin();
       instance = renderOnce();
       pausing = undefined;
       release?.();

--- a/src/application/ui/shared/stdin-handoff.ts
+++ b/src/application/ui/shared/stdin-handoff.ts
@@ -1,0 +1,121 @@
+/**
+ * Release `process.stdin` before an interactive child CLI (`grok` / `claude` / …) takes over the
+ * terminal, and hand back a restore function that re-attaches the consumers it detached.
+ *
+ * Why this exists — the short version, full writeup in `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`:
+ * on startup an interactive CLI asks the terminal about its capabilities (DA1 `ESC[c`, XTVERSION,
+ * kitty keyboard) and blocks until the terminal answers. The answer is written back into the tty's
+ * input buffer, which parent and child share, so whoever reads first wins. A shell never competes
+ * (it sits in `waitpid`); a Node parent still reading stdin does, and the child then waits forever
+ * for a reply that landed in our buffer — a black screen. Driven through the real `createInkHost`
+ * in a real iTerm window, Grok reached its pager in 0 of 8 launches before this helper and 8 of 8
+ * with it.
+ *
+ * Unmounting Ink is NOT enough. Measured on Node 26 in a real iTerm window, reading
+ * `process.stdin._handle.reading` across states:
+ *
+ *   - never touched                                      → reading = false
+ *   - Ink-style armed (`readable` listener + raw mode)    → reading = true
+ *   - after Ink-style teardown (listener off, raw off)    → reading = TRUE  ← still stealing bytes
+ *   - after `pause()` + one tick                          → reading = false, DA1 reply not captured
+ *
+ * What actually stops the fd read is Node core: `process.stdin` carries a `'pause'` listener that
+ * calls `readStop()` on the handle one tick later. So the whole job of this helper is to make
+ * `pause()` EMIT `'pause'`, and `pause()` only emits when the stream is not already in the paused
+ * state — which is why the order below is capture → remove → drain → settle → `pause()` → settle.
+ *
+ * Three traps, each measured:
+ *
+ *   1. **`read()` on an empty buffer restarts the handle.** A "drain until read() returns null"
+ *      loop re-arms the tty (`reading` back to `true`) and reintroduces the exact bug it was
+ *      meant to fix. Only ever read while `readableLength > 0`.
+ *   2. **`removeAllListeners()` reaches into consumers you do not own.** That is how #327 broke
+ *      `ScrollRegion`'s mouse-wheel handler — permanently, because the effect cleanup that would
+ *      have re-attached it never ran. Remove exactly the handlers captured here, via
+ *      `rawListeners()` so `once()` wrappers survive as `once` listeners, and put them back.
+ *   3. **`pause()` is a documented no-op while a `'readable'` listener is attached**, and Node only
+ *      forgets that listener's paused state on the next tick after it is removed. A synchronous
+ *      remove-then-`pause()` therefore emits nothing and leaves the handle reading: in a pty that
+ *      answers capability queries, that variant let the parent steal the reply in 8 of 18 runs,
+ *      the settled variant in 0 of 18. Under the current unmount handoff Ink has already removed
+ *      its listener ticks earlier, so the naive version happens to work there — the settle exists
+ *      so the next handoff mechanism does not silently bring the hang back.
+ *
+ * Anything already buffered when the handoff starts is dropped on purpose: those bytes are stale
+ * keystrokes and mouse reports aimed at a TUI that no longer exists, and leaving them in place
+ * would feed them to the child as if the user had typed them.
+ *
+ * Do not extend this with raw-mode changes (Ink owns raw mode on both unmount and remount),
+ * wall-clock settle delays before the spawn, or a fresh `/dev/tty` descriptor — all three were
+ * measured and are non-fixes; the `/dev/tty` variant is deterministically worse (8/8 hangs). The
+ * two `settle()` turns here are event-loop turns that let Node's own stream bookkeeping run, not
+ * delays that hope the race resolves itself.
+ */
+import type { Readable } from 'node:stream';
+
+/** Events whose listeners actively pull bytes out of the stream and must step aside. */
+const HANDOFF_EVENTS = ['data', 'readable'] as const;
+
+type StdinListener = (...args: unknown[]) => void;
+
+interface CapturedListener {
+  readonly event: (typeof HANDOFF_EVENTS)[number];
+  readonly listener: StdinListener;
+}
+
+/**
+ * One macrotask turn — enough for every `process.nextTick` the stream internals queued (the
+ * `readable`-listener bookkeeping after `removeListener`, and `process.stdin`'s `readStop` after
+ * `'pause'`) to have run.
+ */
+const settle = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * Detach every `data` / `readable` consumer, drop what is already buffered, and pause the stream so
+ * Node stops reading the fd. Resolves only once that has taken effect — spawn the child after the
+ * `await`, not before.
+ *
+ * Pair every release with its own restore before releasing again: a second release would capture an
+ * empty listener set, so the first restore function is the only thing that can put the original
+ * consumers back.
+ *
+ * @param stdin The stream to release; defaults to the process's real stdin.
+ * @returns An idempotent restore function that re-attaches exactly the listeners that were removed
+ *   (in their original order) and resumes the stream only if it had been flowing. Call it after the
+ *   child exits and before anything remounts a TUI on top of the same stream. It restores whether
+ *   the stream is flowing, not Node's flowing/paused/pristine tri-state — the first `pause()` makes
+ *   `readableFlowing === null` unreachable for the rest of the stream's life, and with it the
+ *   auto-resume that `on('data', …)` would otherwise trigger. No caller here depends on that
+ *   distinction; one that did would have to re-arm the stream itself.
+ */
+export const releaseStdinForChild = async (stdin: Readable = process.stdin): Promise<() => void> => {
+  const wasFlowing = stdin.readableFlowing === true;
+  const captured: readonly CapturedListener[] = HANDOFF_EVENTS.flatMap((event) =>
+    (stdin.rawListeners(event) as StdinListener[]).map((listener) => ({ event, listener }))
+  );
+
+  for (const { event, listener } of captured) stdin.removeListener(event, listener);
+
+  // Trap 1: never read an empty buffer — that restarts the tty handle.
+  while (stdin.readableLength > 0) {
+    if (stdin.read() === null) break;
+  }
+
+  // Trap 3: let the `readable`-listener bookkeeping run so `pause()` below is a real transition
+  // (and therefore emits `'pause'`) rather than the documented no-op.
+  await settle();
+  stdin.pause();
+  // Node's `process.stdin` stops reading the fd from its `'pause'` listener on the NEXT tick. Do not
+  // hand the terminal over until that has happened, or the spawn can still race it.
+  await settle();
+
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    for (const { event, listener } of captured) stdin.on(event, listener);
+    // `on('data', …)` does not auto-resume a stream that was explicitly paused, so the resume has
+    // to be deliberate — and only when the caller's stream was flowing to begin with.
+    if (wasFlowing) stdin.resume();
+  };
+};

--- a/src/integration/ai/providers/_engine/run-interactive-session.ts
+++ b/src/integration/ai/providers/_engine/run-interactive-session.ts
@@ -60,10 +60,13 @@ import { uuidv7 } from '@src/domain/value/uuid7.ts';
  * `interactiveAi.run(...)` in `runInTerminal(...)`. Keeping the adapter pure means it behaves the
  * same under the TUI, the plain CLI, and tests.
  *
- * Handing over the terminal is the caller's job, and it is currently incomplete: whoever spawns an
- * interactive session must release `process.stdin` first, or the child can hang on a black screen
- * waiting for a terminal reply the parent swallowed. See
- * `.claude/docs/INTERACTIVE-HANDOFF-HANG.md` — confirmed root cause, measured, fix not yet landed.
+ * Handing over the terminal is the caller's job. The TUI host does it: `runInTerminal` in
+ * `src/application/ui/shared/ink-host.ts` releases `process.stdin` (detach the `data` / `readable`
+ * consumers, drain what is buffered, `pause()`) before `fn` runs and restores it afterwards. Any
+ * NEW caller that spawns an interactive child from a process that has touched stdin must do the
+ * same — reuse `releaseStdinForChild` from `src/application/ui/shared/stdin-handoff.ts`. Skip it
+ * and the parent wins the race for the terminal's reply to the child's capability queries, and the
+ * child hangs on a black screen. See `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`.
  */
 export interface InteractiveSessionContext {
   /**

--- a/src/integration/ai/providers/_engine/run-interactive-session.ts
+++ b/src/integration/ai/providers/_engine/run-interactive-session.ts
@@ -20,6 +20,7 @@ import {
 import { buildPromptPointer } from '@src/integration/ai/providers/_engine/prompt-pointer.ts';
 import { persistSessionIdFile } from '@src/integration/ai/providers/_engine/persist-session-id.ts';
 import { attachAbortKill } from '@src/integration/ai/providers/_engine/abort-kill.ts';
+import { recordSpawnContext } from '@src/integration/ai/providers/_engine/spawn-context-probe.ts';
 import { validateModel } from '@src/integration/ai/providers/_engine/validate-model.ts';
 import { AbortError } from '@src/domain/value/error/abort-error.ts';
 import type { DomainError } from '@src/domain/value/error/domain-error.ts';
@@ -338,6 +339,17 @@ export const createInteractiveProvider = (
           ...(sessionId !== undefined ? { sessionId } : {}),
         },
         at: IsoTimestamp.now(),
+      });
+
+      // Last observable moment: `stdio: 'inherit'` hands the terminal to the child, after which
+      // the harness sees nothing. Synchronous, so a child that freezes instantly cannot outrun it.
+      recordSpawnContext({
+        providerName: spec.providerName,
+        command,
+        args,
+        cwd: String(input.cwd),
+        outputFile: String(input.outputFile),
+        envOverrides: env.value,
       });
 
       const spawned = spawnSession(spawnFn, command, args, String(input.cwd), env.value);

--- a/src/integration/ai/providers/_engine/spawn-context-probe.ts
+++ b/src/integration/ai/providers/_engine/spawn-context-probe.ts
@@ -1,0 +1,146 @@
+/**
+ * A snapshot of what the harness is about to hand an interactive CLI, written to disk in the
+ * instant before the spawn.
+ *
+ * Why this exists: an interactive session is spawned `stdio: 'inherit'`, so the harness gives the
+ * child its terminal and can observe nothing afterwards. When a child freezes during its own
+ * startup there is no stdout to read, no exit code, and — as the Grok black-screen hang showed —
+ * not necessarily any log from the child either, because it can freeze before it opens one.
+ *
+ * A bisect established that the argv is not the difference: the exact command the harness builds,
+ * run by hand from a shell in the same directory, starts every time. What is left is the spawn
+ * CONTEXT — the environment, the state of the three standard streams, and what the parent has
+ * left attached to stdin. This file records that, and nothing else can outrun it: the write is
+ * synchronous and happens before `spawn` is called, so even a child that hangs instantly still
+ * leaves a complete account of the conditions it was handed.
+ *
+ * It is written for every interactive backend, not just the one that misbehaves — the whole point
+ * is to be able to diff a healthy Claude spawn against a frozen Grok one.
+ *
+ * SECRETS: environment VALUES are not written. Provider credentials, tokens and API keys live in
+ * the environment this process inherits, and this file lands in the sprint data directory, so only
+ * the sorted list of variable NAMES is recorded plus the values of {@link SAFE_ENV_KEYS} — the
+ * terminal- and runtime-describing variables that are the point of the exercise and carry no
+ * secrets. A name list is enough to spot a variable that is present in one spawn and absent in
+ * another, which is the comparison this is for.
+ *
+ * Best-effort throughout: a diagnostic must never be the reason a session fails to start.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/** Basename of the snapshot, dropped beside `outputFile` and the session-id mirror. */
+export const SPAWN_CONTEXT_FILENAME = 'spawn-context.json';
+
+/**
+ * Environment variables whose VALUES are safe to record and worth comparing: they describe the
+ * terminal, the locale, and the Node runtime. Everything outside this list contributes its name
+ * only. Deliberately conservative — a variable earns a place here by being useless to an attacker
+ * and useful in a diff.
+ */
+const SAFE_ENV_KEYS: readonly string[] = [
+  'TERM',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'COLORTERM',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'SHELL',
+  'SHLVL',
+  'NODE_ENV',
+  'NODE_OPTIONS',
+  'COLUMNS',
+  'LINES',
+  'CI',
+  'FORCE_COLOR',
+  'NO_COLOR',
+  'TMPDIR',
+];
+
+interface StreamSnapshot {
+  readonly isTTY: boolean;
+  readonly columns?: number;
+  readonly rows?: number;
+}
+
+const snapshotOutput = (stream: NodeJS.WriteStream): StreamSnapshot => ({
+  isTTY: stream.isTTY === true,
+  ...(typeof stream.columns === 'number' ? { columns: stream.columns } : {}),
+  ...(typeof stream.rows === 'number' ? { rows: stream.rows } : {}),
+});
+
+/**
+ * What the parent still has attached to stdin. This is the half that matters most: the child is
+ * about to read the same file descriptor, and anything the parent has left listening competes for
+ * the bytes a terminal sends back in reply to the child's capability queries.
+ */
+const snapshotStdin = (): Record<string, unknown> => {
+  const stdin = process.stdin as NodeJS.ReadStream & { isRaw?: boolean };
+  const safe = <T>(read: () => T): T | 'unavailable' => {
+    try {
+      return read();
+    } catch {
+      return 'unavailable' as const;
+    }
+  };
+  return {
+    isTTY: stdin.isTTY === true,
+    isRaw: stdin.isRaw ?? null,
+    isPaused: safe(() => stdin.isPaused()),
+    readableFlowing: stdin.readableFlowing ?? null,
+    // A non-zero count here means the parent is still consuming the child's terminal.
+    listeners: {
+      data: safe(() => stdin.listenerCount('data')),
+      readable: safe(() => stdin.listenerCount('readable')),
+      keypress: safe(() => stdin.listenerCount('keypress')),
+    },
+  };
+};
+
+export interface SpawnContextInput {
+  readonly providerName: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  /** The snapshot lands in this file's directory, beside the session's other artifacts. */
+  readonly outputFile: string;
+  /** Environment overrides the adapter declared, if any — recorded by name only, same as the rest. */
+  readonly envOverrides?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Write the snapshot. Synchronous on purpose — an `await` here would let the spawn race the write
+ * on a child that freezes immediately, and it previously broke the shared interactive-port
+ * conformance suite, whose contract is that `run()` reaches `spawn` without yielding.
+ */
+export const recordSpawnContext = (input: SpawnContextInput): void => {
+  try {
+    const env = process.env;
+    const snapshot = {
+      at: new Date().toISOString(),
+      provider: input.providerName,
+      command: input.command,
+      args: input.args,
+      cwd: input.cwd,
+      node: { version: process.version, pid: process.pid, ppid: process.ppid, platform: process.platform },
+      stdout: snapshotOutput(process.stdout),
+      stderr: snapshotOutput(process.stderr),
+      stdin: snapshotStdin(),
+      env: {
+        note: 'values are recorded only for terminal/runtime variables; everything else is names only',
+        values: Object.fromEntries(SAFE_ENV_KEYS.filter((k) => env[k] !== undefined).map((k) => [k, env[k]] as const)),
+        names: Object.keys(env).sort(),
+        overrideNames: Object.keys(input.envOverrides ?? {}).sort(),
+      },
+    };
+    writeFileSync(
+      join(dirname(input.outputFile), SPAWN_CONTEXT_FILENAME),
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      'utf8'
+    );
+  } catch {
+    // A diagnostic must never be the reason a session fails to start.
+  }
+};

--- a/tests/unit/application/ui/shared/ink-host.test.ts
+++ b/tests/unit/application/ui/shared/ink-host.test.ts
@@ -17,8 +17,31 @@ const mockInstance = {
   cleanup: vi.fn(),
 };
 
+/**
+ * Ordering log shared by the `ink` and `stdin-handoff` mocks. `vi.hoisted` so it exists by the
+ * time the hoisted mock factories close over it.
+ */
+const { order, releaseStdinForChild, restoreStdin } = vi.hoisted(() => {
+  const log: string[] = [];
+  const restore = vi.fn(() => {
+    log.push('restore');
+  });
+  const release = vi.fn(async () => {
+    log.push('release');
+    return restore;
+  });
+  return { order: log, releaseStdinForChild: release, restoreStdin: restore };
+});
+
+vi.mock('@src/application/ui/shared/stdin-handoff.ts', () => ({
+  releaseStdinForChild,
+}));
+
 vi.mock('ink', () => ({
-  render: vi.fn(() => mockInstance),
+  render: vi.fn(() => {
+    order.push('render');
+    return mockInstance;
+  }),
 }));
 
 const { createInkHost } = await import('@src/application/ui/shared/ink-host.ts');
@@ -103,5 +126,61 @@ describe('createInkHost rebuilds the element on resume', () => {
 
     // Resume remounted a freshly built element rather than reusing the first.
     expect(renderElement).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The stdin handoff only works in one order: release AFTER Ink's teardown has finished (so we do
+ * not fight its own listener removal), before the child runs, and restore BEFORE the remount so
+ * the fresh tree finds the stream as it left it. See `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`.
+ */
+describe('createInkHost stdin handoff ordering', () => {
+  beforeEach(() => {
+    order.length = 0;
+    releaseStdinForChild.mockClear();
+    restoreStdin.mockClear();
+    mockInstance.unmount.mockReset();
+    mockInstance.unmount.mockImplementation(() => {
+      order.push('unmount');
+    });
+    mockInstance.waitUntilExit.mockReset();
+    mockInstance.waitUntilExit.mockImplementation(async () => {
+      order.push('wait-exit');
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeHost = () => {
+    const host = createInkHost({ renderElement: () => React.createElement(React.Fragment) });
+    order.length = 0; // Drop the initial mount's `render`.
+    return host;
+  };
+
+  it('releases stdin after the unmount completes and restores it before the remount', async () => {
+    const host = makeHost();
+
+    await host.runInTerminal(async () => {
+      order.push('fn');
+      return 'done';
+    });
+
+    expect(order).toEqual(['unmount', 'wait-exit', 'release', 'fn', 'restore', 'render']);
+    expect(releaseStdinForChild).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores stdin before remounting even when fn throws', async () => {
+    const host = makeHost();
+
+    await expect(
+      host.runInTerminal(async () => {
+        order.push('fn');
+        throw new Error('session failed');
+      })
+    ).rejects.toThrow('session failed');
+
+    expect(order).toEqual(['unmount', 'wait-exit', 'release', 'fn', 'restore', 'render']);
   });
 });

--- a/tests/unit/application/ui/shared/stdin-handoff.test.ts
+++ b/tests/unit/application/ui/shared/stdin-handoff.test.ts
@@ -1,0 +1,194 @@
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { releaseStdinForChild } from '@src/application/ui/shared/stdin-handoff.ts';
+
+/**
+ * The interactive handoff hangs when the parent keeps reading stdin — the terminal's reply to the
+ * child's capability queries lands in our buffer instead of the child's
+ * (`.claude/docs/INTERACTIVE-HANDOFF-HANG.md`). These tests pin the release sequence and the three
+ * traps that make a naive version worse than nothing: `read()` on an empty buffer restarts the tty
+ * handle, `removeAllListeners()` detaches consumers we do not own (that is how #327 broke
+ * ScrollRegion's wheel handler), and `pause()` is a documented no-op while a `readable` listener is
+ * attached — so it has to run after Node has forgotten that listener, or it never emits `'pause'`,
+ * which is the event `process.stdin` stops reading the fd from.
+ *
+ * A real `Readable` is used rather than a hand-rolled fake so `readableLength`, `readableFlowing`,
+ * `isPaused()` and the auto-resume semantics of `on('data')` behave exactly as they do on the real
+ * `process.stdin`.
+ */
+const makeStdin = (): Readable => new Readable({ read() {} });
+
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+describe('releaseStdinForChild', () => {
+  it('removes only the data/readable listeners and leaves other consumers attached', async () => {
+    const stdin = makeStdin();
+    const onData = vi.fn();
+    const onReadable = vi.fn();
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    stdin.on('data', onData);
+    stdin.on('readable', onReadable);
+    stdin.on('end', onEnd);
+    stdin.on('error', onError);
+
+    await releaseStdinForChild(stdin);
+
+    expect(stdin.listeners('data')).toEqual([]);
+    expect(stdin.listeners('readable')).toEqual([]);
+    expect(stdin.listeners('end')).toEqual([onEnd]);
+    expect(stdin.listeners('error')).toEqual([onError]);
+  });
+
+  it('detaches by handler identity — never removeAllListeners, which is how #327 broke ScrollRegion', async () => {
+    const stdin = makeStdin();
+    const first = vi.fn();
+    const second = vi.fn();
+    const onReadable = vi.fn();
+    stdin.on('data', first);
+    stdin.on('data', second);
+    stdin.on('readable', onReadable);
+    const removeListener = vi.spyOn(stdin, 'removeListener');
+    const removeAllListeners = vi.spyOn(stdin, 'removeAllListeners');
+
+    await releaseStdinForChild(stdin);
+
+    // The net listener count is identical either way, so assert the call shape itself: a future
+    // "simplification" back to removeAllListeners must fail here rather than in production.
+    expect(removeAllListeners).not.toHaveBeenCalled();
+    expect(removeListener.mock.calls).toEqual([
+      ['data', first],
+      ['data', second],
+      ['readable', onReadable],
+    ]);
+  });
+
+  it('re-attaches exactly the removed listeners, in their original order', async () => {
+    const stdin = makeStdin();
+    const first = vi.fn();
+    const second = vi.fn();
+    const onReadable = vi.fn();
+    stdin.on('data', first);
+    stdin.on('data', second);
+    stdin.on('readable', onReadable);
+
+    const restore = await releaseStdinForChild(stdin);
+    restore();
+
+    expect(stdin.listeners('data')).toEqual([first, second]);
+    expect(stdin.listeners('readable')).toEqual([onReadable]);
+  });
+
+  it('pauses the stream so the child wins the race for the terminal reply', async () => {
+    const stdin = makeStdin();
+    stdin.on('data', vi.fn());
+    expect(stdin.isPaused()).toBe(false);
+
+    await releaseStdinForChild(stdin);
+
+    expect(stdin.isPaused()).toBe(true);
+  });
+
+  it('never calls read() when nothing is buffered — read() on an empty buffer re-arms the handle', async () => {
+    const stdin = makeStdin();
+    stdin.on('readable', vi.fn());
+    // `on('readable')` schedules Node's own `read(0)` for the next tick; let it run first so the spy
+    // sees only what the helper does.
+    await flush();
+    const read = vi.spyOn(stdin, 'read');
+
+    await releaseStdinForChild(stdin);
+
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('drains bytes that were already buffered so the child does not inherit stale input', async () => {
+    const stdin = makeStdin();
+    stdin.push('stale keystrokes');
+    expect(stdin.readableLength).toBeGreaterThan(0);
+
+    await releaseStdinForChild(stdin);
+
+    expect(stdin.readableLength).toBe(0);
+  });
+
+  it('resumes on restore when the stream was flowing', async () => {
+    const stdin = makeStdin();
+    stdin.on('data', vi.fn());
+    const resume = vi.spyOn(stdin, 'resume');
+
+    const restore = await releaseStdinForChild(stdin);
+    restore();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(stdin.isPaused()).toBe(false);
+  });
+
+  it('leaves a non-flowing stream paused on restore', async () => {
+    const stdin = makeStdin();
+    stdin.on('readable', vi.fn());
+    const resume = vi.spyOn(stdin, 'resume');
+
+    const restore = await releaseStdinForChild(stdin);
+    restore();
+
+    expect(resume).not.toHaveBeenCalled();
+    expect(stdin.isPaused()).toBe(true);
+  });
+
+  it('is idempotent — a second restore does not duplicate listeners or resume again', async () => {
+    const stdin = makeStdin();
+    const onData = vi.fn();
+    stdin.on('data', onData);
+    const resume = vi.spyOn(stdin, 'resume');
+
+    const restore = await releaseStdinForChild(stdin);
+    restore();
+    restore();
+
+    expect(stdin.listeners('data')).toEqual([onData]);
+    expect(resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves a once() listener as a once listener across release/restore', async () => {
+    const stdin = makeStdin();
+    const onceData = vi.fn();
+    stdin.once('data', onceData);
+
+    const restore = await releaseStdinForChild(stdin);
+    restore();
+
+    stdin.push('a');
+    stdin.push('b');
+    await flush();
+
+    expect(onceData).toHaveBeenCalledTimes(1);
+    expect(stdin.listeners('data')).toEqual([]);
+  });
+
+  it("emits 'pause' even when a readable listener was attached — that event is what stops the fd read", async () => {
+    // Node's `process.stdin` calls `readStop()` from a `'pause'` listener, and `pause()` only emits
+    // while the stream is not already in the readable-listener paused state. A synchronous
+    // remove-then-pause never emits here; the settle turn inside the helper is what makes it fire.
+    const stdin = makeStdin();
+    stdin.on('readable', vi.fn());
+    const onPause = vi.fn();
+    stdin.on('pause', onPause);
+
+    await releaseStdinForChild(stdin);
+
+    expect(onPause).toHaveBeenCalledTimes(1);
+    expect(stdin.readableFlowing).toBe(false);
+  });
+
+  it("emits 'pause' exactly once when the stream was flowing through a data listener", async () => {
+    const stdin = makeStdin();
+    stdin.on('data', vi.fn());
+    const onPause = vi.fn();
+    stdin.on('pause', onPause);
+
+    await releaseStdinForChild(stdin);
+
+    expect(onPause).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/integration/ai/providers/_engine/spawn-context-probe.test.ts
+++ b/tests/unit/integration/ai/providers/_engine/spawn-context-probe.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The snapshot is written into the sprint data directory, so the property that matters most is
+ * that it never carries a credential out of the environment. The rest pins the fields a hung
+ * session is diagnosed from.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  SPAWN_CONTEXT_FILENAME,
+  recordSpawnContext,
+} from '@src/integration/ai/providers/_engine/spawn-context-probe.ts';
+
+interface SnapshotShape {
+  readonly at: string;
+  readonly provider: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly stdout: { readonly isTTY: boolean };
+  readonly stderr: { readonly isTTY: boolean };
+  readonly stdin: { readonly listeners: Record<string, unknown> };
+  readonly env: { readonly overrideNames: readonly string[] };
+}
+
+describe('recordSpawnContext', () => {
+  const dirs: string[] = [];
+  const makeDir = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-context-test-'));
+    dirs.push(dir);
+    return dir;
+  };
+
+  const record = (dir: string, overrides: Record<string, string> | undefined = undefined): SnapshotShape => {
+    recordSpawnContext({
+      providerName: 'interactive-grok',
+      command: 'grok',
+      args: ['--no-auto-update', '--cwd', dir],
+      cwd: dir,
+      outputFile: join(dir, 'output.md'),
+      envOverrides: overrides,
+    });
+    return JSON.parse(readFileSync(join(dir, SPAWN_CONTEXT_FILENAME), 'utf8')) as SnapshotShape;
+  };
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('never writes an environment value outside the terminal/runtime allowlist', () => {
+    const secret = 'sk-do-not-persist-this-0123456789';
+    process.env['SPAWN_PROBE_FAKE_TOKEN'] = secret;
+    try {
+      const dir = makeDir();
+      record(dir);
+      const text = readFileSync(join(dir, SPAWN_CONTEXT_FILENAME), 'utf8');
+      expect(text).not.toContain(secret);
+      // The NAME is kept — that is what makes a present-in-one-spawn-absent-in-another diff work.
+      expect(text).toContain('SPAWN_PROBE_FAKE_TOKEN');
+    } finally {
+      delete process.env['SPAWN_PROBE_FAKE_TOKEN'];
+    }
+  });
+
+  it('records the argv, cwd and stream state a frozen session is diagnosed from', () => {
+    const dir = makeDir();
+    const snapshot = record(dir);
+
+    expect(snapshot.provider).toBe('interactive-grok');
+    expect(snapshot.command).toBe('grok');
+    expect(snapshot.args).toContain('--no-auto-update');
+    expect(snapshot.cwd).toBe(dir);
+    expect(typeof snapshot.at).toBe('string');
+    expect(snapshot.stdout).toHaveProperty('isTTY');
+    expect(snapshot.stderr).toHaveProperty('isTTY');
+    // The listener counts are the point: a non-zero one means the parent still competes for the
+    // terminal the child is about to read.
+    expect(snapshot.stdin.listeners).toHaveProperty('data');
+    expect(snapshot.stdin.listeners).toHaveProperty('readable');
+  });
+
+  it('records env overrides by name only', () => {
+    const dir = makeDir();
+    const snapshot = record(dir, { OPENCODE_CONFIG_CONTENT: '{"secret":"nope"}' });
+
+    expect(snapshot.env.overrideNames).toEqual(['OPENCODE_CONFIG_CONTENT']);
+    expect(readFileSync(join(dir, SPAWN_CONTEXT_FILENAME), 'utf8')).not.toContain('nope');
+  });
+
+  it('stays silent when the target directory does not exist — a diagnostic never fails a session', () => {
+    expect(() => {
+      recordSpawnContext({
+        providerName: 'interactive-grok',
+        command: 'grok',
+        args: [],
+        cwd: '/nope',
+        outputFile: '/nope/does/not/exist/output.md',
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Fixes the black-screen hang when the TUI hands the terminal to an interactive AI CLI (seen with Grok, but provider-agnostic). Also lands the spawn-context probe from `fix/spawn-context-probe`.

## Why it hung

Ink's unmount removes its `readable` listener and drops raw mode, but Node's tty handle stays in its reading state. The terminal's reply to the child's capability queries (DA1 / XTVERSION / kitty) therefore lands in ralphctl's stdin buffer, and the child waits forever.

## The fix

`releaseStdinForChild` (`src/application/ui/shared/stdin-handoff.ts`), awaited by `runInTerminal` in `ink-host.ts` after Ink's teardown and restored before the remount:

capture `data`/`readable` listeners → remove exactly those → drain only while `readableLength > 0` → one event-loop turn → `pause()` → one more turn → resolve. Restore re-attaches the same listeners in order and resumes only if the stream was flowing.

It is async on purpose. `pause()` is a documented no-op while a `readable` listener is attached, and Node forgets that state one tick after removal; Node stops reading the fd from a `'pause'` listener on `process.stdin`, also one tick later. A synchronous remove-then-pause never emits `'pause'` and leaves the handle reading.

## Measurements

| Experiment | Result |
| --- | --- |
| Real `createInkHost` + ScrollRegion, real iTerm, Grok, **main** | **0 / 8** reached `pager started` (`_handle.reading` true at spawn) |
| Same, **this branch** | **8 / 8** (`_handle.reading` false at spawn, Ink listeners re-armed after restore) |
| Parent/child Node race under a query-answering pty, sync remove+pause | parent stole the reply 8 / 18 |
| Same, settled remove → tick → pause | 0 / 18 |

Full writeup with the trap list and reproduction recipe: `.claude/docs/INTERACTIVE-HANDOFF-HANG.md`.

## Not covered

An end-to-end run through the real `ralphctl` TUI (refine/plan → Grok) was not driven; the harness exercises the identical host + spawn path (`runInTerminal` → `spawn(…, { stdio: 'inherit' })`).

## Verify

`pnpm typecheck && pnpm lint && pnpm test` green (6218 tests), `pnpm deadcode` and `pnpm format:check` clean.
